### PR TITLE
Refine HeaderBar styles

### DIFF
--- a/app/components/HeaderBar.js
+++ b/app/components/HeaderBar.js
@@ -49,11 +49,9 @@ export default class HeaderBar extends Component {
           : null}
 
         {this.props.showSettings ?
-          <View style={styles.headerbar__settings}>
-            <Button onPress={ this.props.onSettings } testName="headerbar__settings">
-              <Img style={ styles.headerbar__settings } source='icon-settings'/>
-            </Button>
-          </View>
+          <Button style={ styles.headerbar__settings } onPress={ this.props.onSettings } testName="headerbar__settings">
+            <Img source='icon-settings' style={ styles.headerbar__settings_icon } />
+          </Button>
           : null}
       </View>
     );

--- a/app/components/HeaderBarStyles.js
+++ b/app/components/HeaderBarStyles.js
@@ -1,69 +1,62 @@
 // @flow
-import { Styles } from 'reactxp';
+import { createTextStyles, createViewStyles } from '../lib/styles';
 
-const styles = {
-  headerbar:
-  Styles.createViewStyle({
-    paddingTop: 12,
-    paddingBottom: 12,
-    paddingLeft: 12,
-    paddingRight: 12,
-    backgroundColor: '#294D73',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+export default {
+  ...createViewStyles({
+    headerbar: {
+      paddingTop: 12,
+      paddingBottom: 12,
+      paddingLeft: 12,
+      paddingRight: 12,
+      backgroundColor: '#294D73',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    headerbar__hidden: {
+      paddingTop: 24,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+    },
+    headerbar__darwin: {
+      paddingTop: 24,
+    },
+    headerbar__style_defaultDark: {
+      backgroundColor: '#192E45',
+    },
+    headerbar__style_error: {
+      backgroundColor: '#D0021B',
+    },
+    headerbar__style_success: {
+      backgroundColor: '#44AD4D',
+    },
+    headerbar__container: {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    headerbar__logo: {
+      height: 50,
+      width: 50,
+    },
+    headerbar__settings: {
+      padding: 0
+    },
+    headerbar__settings_icon: {
+      width: 24,
+      height: 24,
+    },
   }),
-  headerbar__hidden:
-  Styles.createViewStyle({
-    paddingTop: 24,
-    paddingBottom: 0,
-    paddingLeft: 0,
-    paddingRight: 0,
-  }),
-  headerbar__darwin: Styles.createViewStyle({
-    paddingTop: 24,
-  }),
-  headerbar__style_defaultDark:
-  Styles.createViewStyle({
-    backgroundColor: '#192E45',
-  }),
-  headerbar__style_error:
-  Styles.createViewStyle({
-    backgroundColor: '#D0021B',
-  }),
-  headerbar__style_success:
-  Styles.createViewStyle({
-    backgroundColor: '#44AD4D',
-  }),
-  headerbar__container:
-  Styles.createViewStyle({
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-  }),
-  headerbar__title:
-  Styles.createTextStyle({
-    fontFamily: 'DINPro',
-    fontSize: 24,
-    fontWeight: '900',
-    lineHeight: 30,
-    letterSpacing: -0.5,
-    color: 'rgba(255,255,255,0.6)',
-    marginLeft: 8,
-  }),
-  headerbar__logo:
-  Styles.createViewStyle({
-    height: 50,
-    width: 50,
-  }),
-  headerbar__settings: {
-    padding: 0
-  },
-  headerbar__settings_icon:
-  Styles.createViewStyle({
-    width: 24,
-    height: 24,
-  }),
+  ...createTextStyles({
+    headerbar__title: {
+      fontFamily: 'DINPro',
+      fontSize: 24,
+      fontWeight: '900',
+      lineHeight: 30,
+      letterSpacing: -0.5,
+      color: 'rgba(255,255,255,0.6)',
+      marginLeft: 8,
+    }
+  })
 };
-
-module.exports = styles;

--- a/app/components/HeaderBarStyles.js
+++ b/app/components/HeaderBarStyles.js
@@ -56,14 +56,14 @@ const styles = {
     height: 50,
     width: 50,
   }),
-  headerbar__settings:
+  headerbar__settings: {
+    padding: 0
+  },
+  headerbar__settings_icon:
   Styles.createViewStyle({
     width: 24,
     height: 24,
-    backgroundColor: 'transparent',
-    marginLeft: -6, //Because of button.css, when removed remove this
-    marginTop: -1, //Because of button.css, when removed remove this
-  })
+  }),
 };
 
 module.exports = styles;


### PR DESCRIPTION
This PR refines the settings button styles in HeaderBar. It works perfectly fine on the web without negative margins and I see that RX resets padding and margin for `<Button>` in that particular configuration. I suspect it forgets to do so in certain scenarios...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10)
<!-- Reviewable:end -->
