### PR TITLE
Add flow annotations to createXXXStyles

### DIFF
--- a/app/lib/styles.js
+++ b/app/lib/styles.js
@@ -1,6 +1,10 @@
+// @flow
+
 import { Styles } from 'reactxp';
 
-export function createViewStyles(styles: { [string]: Object }) {
+type ExtractReturnType = (*) => Object;
+
+export function createViewStyles<T: { [string]: Object }>(styles: T): $ObjMap<T, ExtractReturnType> {
   const viewStyles = {};
   for (const style of Object.keys(styles)) {
     viewStyles[style] = Styles.createViewStyle(styles[style]);
@@ -8,7 +12,7 @@ export function createViewStyles(styles: { [string]: Object }) {
   return viewStyles;
 }
 
-export function createTextStyles(styles: { [string]: Object }) {
+export function createTextStyles<T: { [string]: Object }>(styles: T): $ObjMap<T, ExtractReturnType> {
   const textStyles = {};
   for (const style of Object.keys(styles)) {
     textStyles[style] = Styles.createTextStyle(styles[style]);


### PR DESCRIPTION
This PR adds Flow annotations for `createViewStyles` and `createTextStyles` helpers using `$ObjMap<T, F>` to rewrite the return type while retaining the original keys.

Please see https://flow.org/en/docs/types/utilities/#toc-objmap for more information.

Sample:

```
const superStyle = createViewStyles({
  settings: {
    backgroundColor: 'red',
  },
  omg: {
    backgroundColor: 'blue',
  },
});
```

Flow output:

```
$ flow type-at-pos app/components/Settings.js 15 7
{omg: Object, settings: Object}
```

You can see that the created style retains the same keys but transforms the value of each key to opaque `Object`. Since the style ID is somewhat a private implementation detail of RX I deduce the compiled style type to `Object`.

The point of that improvement is to be able to access the same keys after the Style is compiled, this enables better QA and allows for autocompletion to properly function in the IDE of your choice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11)
<!-- Reviewable:end -->
