### PR TITLE
Don't keep PF state for LAN firewall rules

### DIFF
--- a/talpid-core/src/firewall/macos/mod.rs
+++ b/talpid-core/src/firewall/macos/mod.rs
@@ -194,7 +194,6 @@ impl PacketFilter {
             let mut rule_builder = pfctl::FilterRuleBuilder::default();
             rule_builder
                 .action(pfctl::FilterRuleAction::Pass)
-                .keep_state(pfctl::StatePolicy::Keep)
                 .quick(true)
                 .af(pfctl::AddrFamily::Ipv4)
                 .from(pfctl::Ip::from(IpNetwork::V4(*net)));


### PR DESCRIPTION
It seems that existing connections over LAN continue to work after allow LAN sharing is disabled. This must be because we keep the states and never flush them. At some point we probably need to look into flushing states anyway. But for now we can simply make the LAN rules not keep any state since we don't need them. Thus the connections should be blocked instantly after the rule is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/14)
<!-- Reviewable:end -->
