### PR TITLE
Read the backend security state when starting to talk to the backend

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -28,6 +28,7 @@ ipcRenderer.on('backend-info', async (_event, args) => {
   try {
     await backend.autologin();
     await backend.fetchRelaySettings();
+    await backend.fetchSecurityState();
     await backend.connect();
   } catch (e) {
     if(e instanceof BackendError) {


### PR DESCRIPTION
Should fix https://trello.com/c/SmyARVkA/65-fe-behaves-strange-if-the-tunnel-is-up-when-the-fe-starts

The idea is that when we find a backend to connect to we ask it for it's security state (e.g. ` { state: 'securing', target_state: 'secure'}`) and dispatch the corresponding connection state (`disconnected`, `connecting` or `connected`) . This should put the app in the correct state and thus avoid the bug mentioned in the trello card. It can unnecessarily call `backend.connect` if the state is `connected`, but that's a noop on the backend and we will move the autconnect logic from the FE to the BE in a few months :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/17)
<!-- Reviewable:end -->
