### PR TITLE
Metadata in problemreport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Fixed
+- Fixed bug where problem report tool would redact some things in the logs which were not IPv6
+  addresses, but looked like ones.
 
 
 ## [2018.1-beta8] - 2018-01-09

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -28,7 +28,7 @@ fn main() {
 // if it was able to obtain it, otherwise an empty string.
 fn commit_info() -> String {
     match (commit_description(), commit_date()) {
-        (Some(hash), Some(date)) => format!("({} {})", hash.trim(), date),
+        (Some(hash), Some(date)) => format!("{} {}", hash.trim(), date),
         _ => String::new(),
     }
 }

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -334,11 +334,10 @@ fn collect_metadata() -> HashMap<String, String> {
 }
 
 fn daemon_version() -> String {
-    format!(
-        "v{} {}",
-        env!("CARGO_PKG_VERSION"),
-        include_str!(concat!(env!("OUT_DIR"), "/git-commit-info.txt"))
-    )
+    String::from(include_str!(concat!(
+        env!("OUT_DIR"),
+        "/git-commit-info.txt"
+    )))
 }
 
 #[cfg(target_os = "linux")]

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -226,7 +226,7 @@ impl ProblemReport {
 
     fn redact_network_info(&self, input: &str) -> String {
         let combined_pattern = format!(
-            "\\b{}|{}|{}\\b",
+            "\\b({}|{}|{})\\b",
             self.build_ipv4_regex(),
             self.build_ipv6_regex(),
             self.build_mac_regex()
@@ -376,7 +376,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_redacts_ipv4() {
+    fn redacts_ipv4() {
         assert_redacts_ipv4("1.2.3.4");
         assert_redacts_ipv4("10.127.0.1");
         assert_redacts_ipv4("192.168.1.1");
@@ -392,14 +392,14 @@ mod tests {
     }
 
     #[test]
-    fn test_does_not_redact_localhost_ipv4() {
+    fn does_not_redact_localhost_ipv4() {
         let report = ProblemReport::new(vec![]);
         let res = report.redact("127.0.0.1".to_owned());
         assert_eq!("127.0.0.1", res);
     }
 
     #[test]
-    fn test_redacts_ipv6() {
+    fn redacts_ipv6() {
         assert_redacts_ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
         assert_redacts_ipv6("2001:db8:85a3:0:0:8a2e:370:7334");
         assert_redacts_ipv6("2001:db8:85a3::8a2e:370:7334");
@@ -411,6 +411,13 @@ mod tests {
         assert_redacts_ipv6("2001:db8::1:0:0:1");
         assert_redacts_ipv6("0::0");
         assert_redacts_ipv6("0:0:0:0::1");
+    }
+
+    #[test]
+    fn doesnt_redact_not_ipv6() {
+        let report = ProblemReport::new(vec![]);
+        let actual = report.redact(format!("[talpid_core::firewall]"));
+        assert_eq!("[talpid_core::firewall]", actual);
     }
 
     fn assert_redacts_ipv6(input: &str) {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -789,9 +789,8 @@ fn init_logger(log_level: log::LogLevelFilter, log_file: Option<&PathBuf>) -> Re
 
 fn log_version() {
     info!(
-        "Starting {} v{} {}",
+        "Starting {} {}",
         env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION"),
         include_str!(concat!(env!("OUT_DIR"), "/git-commit-info.txt"))
     )
 }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -24,6 +24,8 @@ pub use jsonrpc_client_http::{Error as HttpError, HttpHandle};
 use mullvad_types::account::AccountToken;
 use mullvad_types::relay_list::RelayList;
 
+use std::collections::HashMap;
+
 
 static MASTER_API_URI: &str = "https://api.mullvad.net/rpc/";
 
@@ -37,7 +39,13 @@ jsonrpc_client!(pub struct AccountsProxy {
 });
 
 jsonrpc_client!(pub struct ProblemReportProxy {
-    pub fn problem_report(&mut self, email: &str, message: &str, log: &str) -> RpcRequest<()>;
+    pub fn problem_report(
+        &mut self,
+        email: &str,
+        message: &str,
+        log: &str,
+        metadata: &HashMap<String, String>)
+        -> RpcRequest<()>;
 });
 
 impl ProblemReportProxy<HttpHandle> {


### PR DESCRIPTION
* Fixes the bug where `\b` around IPv6 addresses is not respected. Add regression test.
* Removes `test_` from test names (Since the module is named `tests` it will print `test tests::redacts_ipv4 ... ok` when running anyway)
* Renames the concept of `system_info` to `metadata` and include it as last parameter to master, which uses this structured data to extract some info about the report.
* Removes the `v0.1.0` part of backend information. Since we never bump this version anyway it's quite useless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/22)
<!-- Reviewable:end -->
