### PR TITLE
Remove beta and nightly builds from macOS on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
 
     # Backend macOS
     - language: rust
-      rust: nightly
+      rust: stable
       os: osx
       cache: cargo
 
@@ -48,35 +48,19 @@ matrix:
       script: &rust_script
         - cargo build --verbose
         - cargo test --verbose
-        # Format only on nightly, since that is where rustfmt-nightly compiles
-        - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-            export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
-            && ./format.sh --write-mode=diff;
-          else
-            echo "Not checking formatting on this build";
-          fi
-
-    - language: rust
-      rust: stable
-      os: osx
-      cache: cargo
-      before_script: *rust_before_script
-      script: *rust_script
-
-    - language: rust
-      rust: beta
-      os: osx
-      cache: cargo
-      before_script: *rust_before_script
-      script: *rust_script
 
     # Backend Linux
     - language: rust
-      rust: stable
+      rust: nightly
       os: linux
       cache: cargo
       before_script: *rust_before_script
-      script: *rust_script
+      script:
+        - cargo build --verbose
+        - cargo test --verbose
+        # Format only on nightly, since that is where rustfmt-nightly compiles
+        - export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
+        - ./format.sh --write-mode=diff;
 
     - language: rust
       rust: beta
@@ -86,7 +70,7 @@ matrix:
       script: *rust_script
 
     - language: rust
-      rust: nightly
+      rust: stable
       os: linux
       cache: cargo
       before_script: *rust_before_script


### PR DESCRIPTION
Removed beta and nightly testing on macOS. Would be nice to have. But not worth the quite long extra wait.

Also simplified the nightly formatting exception so it does not require the bash-if, instead it's just explicitly included in the `script` part of the nightly build only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/24)
<!-- Reviewable:end -->
