### PR TITLE
Clipboard from reactxp

### DIFF
--- a/app/redux/connection/actions.js
+++ b/app/redux/connection/actions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { clipboard } from 'electron';
+import { Clipboard } from 'reactxp';
 
 import type { Backend } from '../../lib/backend';
 import type { ReduxThunk } from '../store';
@@ -12,7 +12,7 @@ const copyIPAddress = (): ReduxThunk => {
   return (_, getState) => {
     const { connection: { clientIp } } = getState();
     if(clientIp) {
-      clipboard.writeText(clientIp);
+      Clipboard.setText(clientIp);
     }
   };
 };


### PR DESCRIPTION
This moves the Clipboard handling to reactxp. Please test as i have no possibility to check if it works on macOS, otherwise we just move it to platform.js to enable multi-platform use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/29)
<!-- Reviewable:end -->
