### PR TITLE
Upgrade rustfmt to 0.3.6 and move version

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -7,12 +7,11 @@ set -u
 
 VERSION=`grep "required_version" rustfmt.toml | cut -f2 -d'"'`
 CMD="rustfmt"
-INSTALL_CMD="cargo install --vers $VERSION --force rustfmt-nightly"
+INSTALL_CMD="cargo +nightly install --vers $VERSION --force rustfmt-nightly"
 
 case "$(uname -s)" in
     Linux*)     export LD_LIBRARY_PATH=$(rustc +nightly --print sysroot)/lib;;
     Darwin*)    export DYLD_LIBRARY_PATH=$(rustc +nightly --print sysroot)/lib;;
-    *)          echo "Unsupported platform"; exit 1
 esac
 
 function correct_rustfmt() {

--- a/format.sh
+++ b/format.sh
@@ -5,7 +5,7 @@
 
 set -u
 
-VERSION="0.3.5"
+VERSION=`grep "required_version" rustfmt.toml | cut -f2 -d'"'`
 CMD="rustfmt"
 INSTALL_CMD="cargo install --vers $VERSION --force rustfmt-nightly"
 
@@ -37,5 +37,5 @@ else
     shift
 fi
 
-echo "Formatting..."
+echo "Formatting with $VERSION..."
 cargo +nightly fmt -- "$@"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+required_version = "0.3.6"
+
 # Activation of features, almost objectively better ;)
 reorder_imports = true
 reorder_imported_names = true


### PR DESCRIPTION
Upgrade rustfmt. Not strictly needed as the old one still builds. But I wanted to move the version out. This allows us to create a similar windows `format.bat` without duplicating the version. Plus having it in `rustfmt.toml` makes it harder to accidentally run an older version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/39)
<!-- Reviewable:end -->
