### PR TITLE
Specify line height in px instead of a ratio in SupportStyles

### DIFF
--- a/app/components/SupportStyles.js
+++ b/app/components/SupportStyles.js
@@ -211,7 +211,7 @@ export default Object.assign(createViewStyles({
   support__no_email_warning: {
     fontFamily: 'Open Sans',
     fontSize: 13,
-    lineHeight: 1.3,
+    lineHeight: 16,
 
     color: 'rgba(255,255,255,0.8)',
   },


### PR DESCRIPTION
It seems that I got some weird results when rebasing the email confirmation PR. The line height is now interpreted as px and 1.3px is not very high :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/50)
<!-- Reviewable:end -->
