### PR TITLE
Add initial Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+Checklist for a PR:
+
+* [ ] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.


### PR DESCRIPTION
I guess updating the changelog is not done because all of us forgets it, not because we don't think it's a good idea?

Since Github supports issue and PR templates (https://github.com/blog/2111-issue-and-pull-request-templates) we can use this to remind ourselves of things like this. For now the changelog was the only thing I could think of that it's good to remember when creating a PR. Anything else?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/57)
<!-- Reviewable:end -->
