### PR TITLE
Add windows security check for RPC file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ matrix:
         # FIXME: Flow throws error for optional dependencies
         # missing from node_modules on unsupported platforms
         # see: https://github.com/facebook/flow/issues/4171
-        - NSEVENTMON_INDEX_JS=node_modules/nseventmonitor/index.js;
-          if [ ! -f $NSEVENTMON_INDEX_JS ]; then
-            echo "Installing a stub for NSEventMonitor..";
-            mkdir -p `dirname $NSEVENTMON_INDEX_JS`;
-            echo "module.exports = {};" > $NSEVENTMON_INDEX_JS;
-          fi
+        - OPTIONAL_DEPS=('nseventmonitor' 'windows-security');
+          for MODULE in ${OPTIONAL_DEPS[@]}; do
+            FILE="node_modules/$MODULE/index.js";
+            if [ ! -f $FILE ]; then
+              echo "Installing a stub for $MODULE..";
+              mkdir -p `dirname $FILE`;
+              echo "module.exports = {};" > $FILE;
+            fi
+          done
       before_script: &node_before_script
         - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
       script: &node_script

--- a/app/lib/rpc-file-security.js
+++ b/app/lib/rpc-file-security.js
@@ -1,0 +1,32 @@
+// @flow
+
+import fs from 'fs';
+
+export function canTrustRpcAddressFile(path: string): boolean {
+  const platform = process.platform;
+  switch(platform) {
+  case 'win32':
+    return isOwnedByLocalSystem(path);
+  case 'darwin':
+  case 'linux':
+    return isOwnedAndOnlyWritableByRoot(path);
+  default:
+    throw new Error(`Unknown platform: ${platform}`);
+  }
+}
+
+function isOwnedAndOnlyWritableByRoot(path: string): boolean {
+  const stat = fs.statSync(path);
+  const isOwnedByRoot = stat.uid === 0;
+  const isOnlyWritableByOwner = (stat.mode & parseInt('022', 8)) === 0;
+
+  return isOwnedByRoot && isOnlyWritableByOwner;
+}
+
+function isOwnedByLocalSystem(path: string): boolean {
+  const winsec = require('windows-security');
+  const ownerSid = winsec.getFileOwnerSid(path, null);
+  const isWellKnownSid = winsec.isWellKnownSid(ownerSid, winsec.WellKnownSid.LocalSystemSid);
+
+  return isWellKnownSid;
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "optionalDependencies": {
     "nseventmonitor": "git+https://github.com/pronebird/NSEventMonitor.git#0.0.6",
+    "windows-security": "git+https://github.com/pronebird/windows-security.git#0.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "validated": "^1.1.0"
   },
   "optionalDependencies": {
-    "nseventmonitor": "git+https://github.com/pronebird/NSEventMonitor.git#0.0.5"
+    "nseventmonitor": "git+https://github.com/pronebird/NSEventMonitor.git#0.0.6",
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
- This PR adds the RPC file security check for Windows. As discussed with @mvd-ows we think it's good enough to check if the file is owned by Local System which is basically a highly privileged account that we will be using for running the mullvad-daemon as a service. 

- The `windows-security` extension in Node.js has been reviewed by @mvd-ows @DMarby earlier this week but if you wish to glance at it please follow the link: https://github.com/pronebird/windows-security.git

- Minor update to NSEventMonitor which which now runs in `electron-mocha` environment + fixed tests for macOS 10.13 and few minor changes, but good to keep the mullvad app up to date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/58)
<!-- Reviewable:end -->
