### PR TITLE
Upgrade react xp to 0.51.8

### DIFF
--- a/app/components/Preferences.js
+++ b/app/components/Preferences.js
@@ -21,7 +21,7 @@ export default class Preferences extends Component {
         <Header hidden={ true } style={ 'defaultDark' } />
         <Container>
           <View style={ styles.preferences }>
-            <Button style={ styles.preferences__close } cursor='default' onPress={ this.props.onClose } testName='closeButton'>
+            <Button style={ styles.preferences__close } onPress={ this.props.onClose } testName='closeButton'>
               <View style={ styles.preferences__close_content }>
                 <Img style={ styles.preferences__close_icon } source="icon-back" />
                 <Text style={ styles.preferences__close_title }>Settings</Text>

--- a/app/components/styled/Button.js
+++ b/app/components/styled/Button.js
@@ -7,18 +7,10 @@ const defaultStyle = ReactXP.Styles.createViewStyle({
   cursor: 'default',
 });
 
-type Props = {
-  style?: Object | Array<any>;
-  cursor?: string;
-};
-
-export function Button(props: Props) {
-  const { style, cursor, ...rest } = props;
+export function Button(props: Object) {
+  const { style, ...rest } = props;
 
   const concreteStyle = ReactXP.Styles.combine([defaultStyle, style]);
 
-  // Can be removed when we upgrade to ReactXP 0.51
-  const concreteCursor = cursor || concreteStyle.cursor || 'default';
-
-  return <ReactXP.Button style={concreteStyle} cursor={concreteCursor} {...rest} />;
+  return <ReactXP.Button style={concreteStyle} {...rest} />;
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-router-redux": "5.0.0-alpha.6",
     "react-simple-maps": "^0.10.1",
     "react-transition-group": "^1.2.0",
-    "reactxp": "^0.51.1",
+    "reactxp": "^0.51.8",
     "redux": "^3.0.0",
     "redux-thunk": "^2.2.0",
     "shell-escape": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,16 +90,20 @@
   version "8.9.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.9.1.tgz#5a329d73a97f3c5a626dfe0ed8c0b831fee5357a"
 
-"@types/react-dom@^16.0.0":
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.3.tgz#8accad7eabdab4cca3e1a56f5ccb57de2da0ff64"
+"@types/react-dom@^16.0.3":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.4.tgz#2e8fd45f5443780ed49bf2cdd9809e6091177a7d"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.0.0":
+"@types/react@*":
   version "16.0.31"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.31.tgz#5285da62f3ac62b797f6d0729a1d6181f3180c3e"
+
+"@types/react@^16.0.36":
+  version "16.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.38.tgz#76617433ea10274505f60bb86eddfdd0476ffdc2"
 
 abbrev@1:
   version "1.1.1"
@@ -4105,9 +4109,9 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.19, iconv-lite@^0.4.8, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ifvisible.js@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ifvisible.js/-/ifvisible.js-1.0.6.tgz#52eb151ce89c56f15316226462e892d1f8451261"
+ifvisible@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ifvisible/-/ifvisible-1.1.0.tgz#a47768028c7c256368b16eaf3312e6898280215c"
 
 ignore@^3.3.3:
   version "3.3.7"
@@ -6304,15 +6308,15 @@ react@^16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-reactxp@^0.51.1:
-  version "0.51.3"
-  resolved "https://registry.yarnpkg.com/reactxp/-/reactxp-0.51.3.tgz#3762a87ec7709a6a35ebbefd02164e1a71409af1"
+reactxp@^0.51.8:
+  version "0.51.8"
+  resolved "https://registry.yarnpkg.com/reactxp/-/reactxp-0.51.8.tgz#e8ef1eaaa6fef35040f411a7b11193dc98f96a6e"
   dependencies:
     "@types/lodash" "^4.14.78"
-    "@types/react" "^16.0.0"
-    "@types/react-dom" "^16.0.0"
+    "@types/react" "^16.0.36"
+    "@types/react-dom" "^16.0.3"
     assert "^1.3.0"
-    ifvisible.js "^1.0.6"
+    ifvisible "^1.1.0"
     lodash "^4.17.1"
     prop-types "^15.5.9"
     rebound "^0.0.13"


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

This PR upgrades ReactXP to 0.51.8 and removes the use of no longer available `cursor` prop from Buttons.

The newer version of ReactXP is also needed for the upcoming PR by @anderklander

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/67)
<!-- Reviewable:end -->
