### PR TITLE
Replace scrollIntoViewIfNeeded with standard scrollTop and scrollLeft

### DIFF
--- a/app/components/Accordion.js
+++ b/app/components/Accordion.js
@@ -24,17 +24,22 @@ export default class Accordion extends React.Component<AccordionProps, Accordion
   _containerElement: ?HTMLElement;
   _contentElement: ?HTMLElement;
 
+  constructor(props: AccordionProps) {
+    super(props);
+
+    // set the initial height if it's known
+    if(props.height !== 'auto') {
+      this.state = {
+        computedHeight: props.height
+      };
+    }
+  }
+
   componentDidMount() {
     const containerElement = this._containerElement;
     if(!containerElement) {
       throw new Error('containerElement cannot be null');
     }
-
-    // update initial state
-    if(this.props.height !== Accordion.defaultProps.height) {
-      this._updateHeight();
-    }
-
     containerElement.addEventListener('transitionend', this._onTransitionEnd);
   }
 

--- a/app/components/CustomScrollbars.js
+++ b/app/components/CustomScrollbars.js
@@ -20,6 +20,8 @@ type State = {
   showScrollIndicators: boolean,
 };
 
+type ScrollPosition = 'top' | 'bottom' | 'middle';
+
 export default class CustomScrollbars extends React.Component<Props, State> {
   static defaultProps = {
     autoHide: true,
@@ -34,6 +36,28 @@ export default class CustomScrollbars extends React.Component<Props, State> {
   _scrollableElement: ?HTMLElement;
   _thumbElement: ?HTMLElement;
   _autoHideTimer: ?TimeoutID;
+
+  scrollTo(x: number, y: number) {
+    const scrollable = this._scrollableElement;
+    if(scrollable) {
+      scrollable.scrollLeft = x;
+      scrollable.scrollTop = y;
+    }
+  }
+
+  scrollToElement(child: HTMLElement, scrollPosition: ScrollPosition) {
+    const scrollable = this._scrollableElement;
+    if(scrollable) {
+      // throw if child is not a descendant of scroll view
+      if(!scrollable.contains(child)) {
+        throw new Error('Cannot scroll to an element which is not a descendant of CustomScrollbars.');
+      }
+
+      const scrollTop = this._computeScrollTop(scrollable, child, scrollPosition);
+
+      this.scrollTo(0, scrollTop);
+    }
+  }
 
   componentDidMount() {
     this._updateScrollbarsHelper({
@@ -115,6 +139,22 @@ export default class CustomScrollbars extends React.Component<Props, State> {
     if(this._autoHideTimer) {
       clearTimeout(this._autoHideTimer);
       this._autoHideTimer = null;
+    }
+  }
+
+  _computeScrollTop(scrollable: HTMLElement, child: HTMLElement, scrollPosition: ScrollPosition) {
+    switch(scrollPosition) {
+    case 'top':
+      return child.offsetTop;
+
+    case 'bottom':
+      return child.offsetTop - (scrollable.offsetHeight - child.clientHeight);
+
+    case 'middle':
+      return child.offsetTop - ((scrollable.offsetHeight - child.clientHeight) * 0.5);
+
+    default:
+      throw new Error(`Unknown enum type for ScrollPosition: ${ scrollPosition }`);
     }
   }
 

--- a/app/components/SelectLocation.js
+++ b/app/components/SelectLocation.js
@@ -23,6 +23,7 @@ type State = {
 
 export default class SelectLocation extends React.Component<SelectLocationProps, State> {
   _selectedCell: ?HTMLElement;
+  _scrollView: ?CustomScrollbars;
 
   state = {
     expanded: [],
@@ -48,13 +49,10 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
   componentDidMount() {
     // restore scroll to selected cell
     const cell = this._selectedCell;
-    if(cell) {
-      // this is non-standard webkit method but it works great!
-      if(typeof(cell.scrollIntoViewIfNeeded) !== 'function') {
-        console.warn('HTMLElement.scrollIntoViewIfNeeded() is not available anymore! Please replace it with viable alternative.');
-        return;
-      }
-      cell.scrollIntoViewIfNeeded(true);
+    const scrollView = this._scrollView;
+
+    if(scrollView && cell) {
+      scrollView.scrollToElement(cell, 'middle');
     }
   }
 
@@ -70,7 +68,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
                 <h2 className="select-location__title">Select location</h2>
               </div>
 
-              <CustomScrollbars autoHide={ true }>
+              <CustomScrollbars autoHide={ true } ref={ (ref) => this._scrollView = ref }>
                 <div>
                   <div className="select-location__subtitle">
                     While connected, your real location is masked with a private and secure location in the selected region


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

A non-standard WebKit extension `scrollIntoViewIfNeeded` has been a nice shortcut and served us very well for over a year up until the moment we rewrote the view transitions using ReactXP.

This PR aims to:

1. Fix the issue of using a non-standard extension that's likely won't work on mobile.
2. Fix side effects that this function causes on Desktop when used with ReactXP animations. (PR #64)
3. Fix for Accordion which now sets the right height upon initialization and avoids extra `setState` upon mount when requested to be rendered with the fixed size or collapsed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/69)
<!-- Reviewable:end -->
