### PR TITLE
Fix the path to talpid_openvpn_plugin

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -67,7 +67,7 @@ win:
       to: .
     - from: ./target/release/mullvad-daemon.exe
       to: .
-    - from: ./target/release/libtalpid_openvpn_plugin.dll
+    - from: ./target/release/talpid_openvpn_plugin.dll
       to: .
 
 linux:


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

The binary on Windows does not contain the "lib" prefix, so the correct filename should be `talpid_openvpn_plugin.dll`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/71)
<!-- Reviewable:end -->
