### PR TITLE
Simplify firewall interface

### DIFF
--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -1,13 +1,12 @@
 use super::{Firewall, SecurityPolicy};
 
-/// alias used to instantiate firewall implementation
-pub type ConcreteFirewall = Netfilter;
-
 error_chain!{}
 
 /// The Linux implementation for the `Firewall` trait.
 pub struct Netfilter;
-impl Firewall<Error> for Netfilter {
+impl Firewall for Netfilter {
+    type Error = Error;
+
     fn new() -> Result<Self> {
         Ok(Netfilter)
     }

--- a/talpid-core/src/firewall/macos/mod.rs
+++ b/talpid-core/src/firewall/macos/mod.rs
@@ -19,9 +19,6 @@ error_chain! {
     }
 }
 
-/// alias used to instantiate firewall implementation
-pub type ConcreteFirewall = PacketFilter;
-
 const ANCHOR_NAME: &'static str = "mullvad";
 
 /// The macOS firewall implementation. Acting as converter between the `Firewall` trait API
@@ -32,7 +29,9 @@ pub struct PacketFilter {
     dns_monitor: DnsMonitor,
 }
 
-impl Firewall<Error> for PacketFilter {
+impl Firewall for PacketFilter {
+    type Error = Error;
+
     fn new() -> Result<Self> {
         Ok(PacketFilter {
             pf: pfctl::PfCtl::new()?,

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -1,13 +1,12 @@
 use super::{Firewall, SecurityPolicy};
 
-/// alias used to instantiate firewall implementation
-pub type ConcreteFirewall = WindowsFirewall;
-
 error_chain!{}
 
 /// The Windows implementation for the `Firewall` trait.
 pub struct WindowsFirewall;
-impl Firewall<Error> for WindowsFirewall {
+impl Firewall for WindowsFirewall {
+    type Error = Error;
+
     fn new() -> Result<Self> {
         Ok(WindowsFirewall)
     }


### PR DESCRIPTION
When going to implement the Linux firewall I realized our exposed interface was more complicated than it had to be. There is no need for the top level `FirewallProxy` since we can just re-export the implementing struct under that name and any user of the type `firewall::FirewallProxy` won't know the difference. Also gets rid of one level of errors. No need to have the very generic errors in the firewall module, the re-exported `FirewallProxy` will throw the platform specific errors directly.

Also, the error fits better as an associated type than a generic. A generic should be used when the **user** of that type decides the type. Such as `Vec<T>`, the code for `Vec` has no idea what `T` is and should not care. But for `WindowsFirewall` for example, the error type is not determined by the user of the struct, it's determined by `WindowsFirewall` itself.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/75)
<!-- Reviewable:end -->
