### PR TITLE
Adjust logging levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Add `--disable-rpc-auth` flag to daemon to make it accept unauthorized control.
+- Add colors to terminal output on macOS and Linux.
 
 ### Fixed
 - Fix a bug in account input field that advanced the cursor to the end regardless its prior

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,10 +276,11 @@ dependencies = [
 
 [[package]]
 name = "fern"
-version = "0.4.4"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -324,6 +345,14 @@ dependencies = [
 name = "httparse"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hyper"
@@ -515,6 +544,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -615,7 +649,7 @@ dependencies = [
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-types 0.1.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
@@ -632,14 +666,14 @@ dependencies = [
  "clap 2.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fern 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fern 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
  "jsonrpc-macros 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
  "jsonrpc-pubsub 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
  "jsonrpc-ws-server 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-rpc 0.1.0",
  "mullvad-types 0.1.0",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,7 +700,7 @@ dependencies = [
  "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-http 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-types 0.1.0",
  "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -679,7 +713,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-types 0.1.0",
@@ -871,6 +905,11 @@ dependencies = [
 [[package]]
 name = "pkg-config"
 version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quick-error"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1140,7 +1179,7 @@ dependencies = [
  "jsonrpc-macros 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pfctl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1161,7 +1200,7 @@ dependencies = [
  "jsonrpc-core 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
  "jsonrpc-macros 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
  "jsonrpc-ws-server 7.1.1 (git+https://github.com/paritytech/jsonrpc?tag=v7.1.1)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1172,9 +1211,9 @@ dependencies = [
 name = "talpid-openvpn-plugin"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
 ]
@@ -1193,6 +1232,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1414,6 +1461,14 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wincolor"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws"
 version = "0.7.1"
 source = "git+https://github.com/tomusdrw/ws-rs#f8306a798b7541d64624299a83a2c934f173beed"
@@ -1462,6 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.29.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f4a2b3bb7ef3c672d7c13d15613211d5a6976b6892c598b0fcb5d40765f19c2"
+"checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
@@ -1473,9 +1529,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum duct 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8c553d79f40e74f7f611e49bf3429b6760cff79596b61818291c27cc0b18549d"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f3cc21490995c841d68e00276eba02071ebb269ec24011d5728bd00eabd39e31"
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
-"checksum fern 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0056c78f45f1964d627d7a12f37786e3ae04ba74fb848ec65230217fca80d128"
+"checksum fern 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "50475651fccc56343c766e4d1889428ea753308a977e1315db358ada28cc8c9d"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -1485,6 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum globset 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90d069fe6beb9be359ef505650b3f73228c5591a3c4b1f32be2f4f44459ffa3a"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum hyper 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)" = "856a5eb897fbc26890ddf8760ad4bbfc6bd777233522d9c48379ca9563d40517"
 "checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
@@ -1503,6 +1561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
@@ -1535,6 +1594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pfctl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "926afe7bf541b9a8f6156272ebe4ad3d3a1bf6eb31303ac1a6ab13a706ea30f6"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
@@ -1570,6 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum system-configuration-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d8b463ff8bb4585b46e3e23f44dd41b3f52d0ad09b6b9cf03aae55c74d74cff"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
+"checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
@@ -1598,6 +1659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
 "checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
+"checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
 "checksum ws 0.7.1 (git+https://github.com/tomusdrw/ws-rs)" = "<none>"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 clap = "2.20"
 error-chain = "0.11"
 lazy_static = "1.0"
-log = "0.3"
+log = "0.4"
 env_logger = "0.4"
 serde = "1.0"
 

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -11,11 +11,11 @@ app_dirs = "1.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.25"
 error-chain = "0.11"
-fern = "0.4"
+fern = { version = "0.5", features = ["colored"] }
 futures = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-log = "0.3"
+log = "0.4"
 jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", tag = "v7.1.1" }
 jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc", tag = "v7.1.1" }
 jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc", tag = "v7.1.1" }

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -4,7 +4,7 @@ use log;
 use std::path::PathBuf;
 
 pub struct Config {
-    pub log_level: log::LogLevelFilter,
+    pub log_level: log::LevelFilter,
     pub log_file: Option<PathBuf>,
     pub tunnel_log_file: Option<PathBuf>,
     pub resource_dir: Option<PathBuf>,
@@ -16,9 +16,9 @@ pub fn get_config() -> Config {
     let matches = app.get_matches();
 
     let log_level = match matches.occurrences_of("v") {
-        0 => log::LogLevelFilter::Info,
-        1 => log::LogLevelFilter::Debug,
-        _ => log::LogLevelFilter::Trace,
+        0 => log::LevelFilter::Info,
+        1 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
     };
     let log_file = matches.value_of_os("log_file").map(PathBuf::from);
     let tunnel_log_file = matches.value_of_os("tunnel_log_file").map(PathBuf::from);

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -1,0 +1,55 @@
+extern crate fern;
+
+use chrono;
+use log;
+
+use std::io;
+use std::path::PathBuf;
+
+error_chain! {
+    errors {
+        WriteFileError(path: PathBuf) {
+            description("Unable to open log file for writing")
+            display("Unable to open log file for writing: {}", path.to_string_lossy())
+        }
+    }
+    foreign_links {
+        SetLoggerError(log::SetLoggerError);
+    }
+}
+
+pub const DATE_TIME_FORMAT_STR: &str = "%Y-%m-%d %H:%M:%S%.3f";
+
+pub fn init_logger(log_level: log::LogLevelFilter, log_file: Option<&PathBuf>) -> Result<()> {
+    let silenced_crates = [
+        "jsonrpc_core",
+        "tokio_core",
+        "tokio_proto",
+        "jsonrpc_ws_server",
+        "ws",
+        "mio",
+        "hyper",
+    ];
+    let mut config = fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{}][{}][{}] {}",
+                chrono::Local::now().format(DATE_TIME_FORMAT_STR),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .level(log_level)
+        .chain(io::stdout());
+    for silenced_crate in &silenced_crates {
+        config = config.level_for(*silenced_crate, log::LogLevelFilter::Warn);
+    }
+    if let Some(ref log_file) = log_file {
+        let f = fern::log_file(log_file)
+            .chain_err(|| ErrorKind::WriteFileError(log_file.to_path_buf()))?;
+        config = config.chain(f);
+    }
+    config.apply()?;
+    Ok(())
+}

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -1,8 +1,10 @@
 extern crate fern;
 
+use self::fern::colors::{Color, ColoredLevelConfig};
 use chrono;
 use log;
 
+use std::fmt;
 use std::io;
 use std::path::PathBuf;
 
@@ -18,40 +20,73 @@ error_chain! {
     }
 }
 
+const SILENCED_CRATES: &[&str] = &[
+    "jsonrpc_core",
+    // jsonrpc_core does some logging under the "rpc" target as well.
+    "rpc",
+    "tokio_core",
+    "tokio_proto",
+    "jsonrpc_ws_server",
+    "ws",
+    "mio",
+    "hyper",
+];
+
+const COLORS: ColoredLevelConfig = ColoredLevelConfig {
+    error: Color::Red,
+    warn: Color::Yellow,
+    info: Color::Green,
+    debug: Color::Blue,
+    trace: Color::Black,
+};
+
 pub const DATE_TIME_FORMAT_STR: &str = "%Y-%m-%d %H:%M:%S%.3f";
 
-pub fn init_logger(log_level: log::LogLevelFilter, log_file: Option<&PathBuf>) -> Result<()> {
-    let silenced_crates = [
-        "jsonrpc_core",
-        // jsonrpc_core does some logging under the "rpc" target as well.
-        "rpc",
-        "tokio_core",
-        "tokio_proto",
-        "jsonrpc_ws_server",
-        "ws",
-        "mio",
-        "hyper",
-    ];
-    let mut config = fern::Dispatch::new()
-        .format(|out, message, record| {
-            out.finish(format_args!(
-                "[{}][{}][{}] {}",
-                chrono::Local::now().format(DATE_TIME_FORMAT_STR),
-                record.target(),
-                record.level(),
-                message
-            ))
-        })
-        .level(log_level)
-        .chain(io::stdout());
-    for silenced_crate in &silenced_crates {
-        config = config.level_for(*silenced_crate, log::LogLevelFilter::Warn);
+pub fn init_logger(log_level: log::LevelFilter, log_file: Option<&PathBuf>) -> Result<()> {
+    let mut top_dispatcher = fern::Dispatch::new().level(log_level);
+    for silenced_crate in SILENCED_CRATES {
+        top_dispatcher = top_dispatcher.level_for(*silenced_crate, log::LevelFilter::Warn);
     }
+
+    let stdout_dispatcher = fern::Dispatch::new()
+        .format(move |out, message, record| format_log_message(out, message, record, true))
+        .chain(io::stdout());
+    top_dispatcher = top_dispatcher.chain(stdout_dispatcher);
+
     if let Some(ref log_file) = log_file {
         let f = fern::log_file(log_file)
             .chain_err(|| ErrorKind::WriteFileError(log_file.to_path_buf()))?;
-        config = config.chain(f);
+        let file_dispatcher = fern::Dispatch::new()
+            .format(|out, message, record| format_log_message(out, message, record, false))
+            .chain(f);
+        top_dispatcher = top_dispatcher.chain(file_dispatcher);
     }
-    config.apply()?;
+    top_dispatcher.apply()?;
     Ok(())
+}
+
+fn format_log_message(
+    out: fern::FormatCallback,
+    message: &fmt::Arguments,
+    record: &log::Record,
+    color_output: bool,
+) {
+    let timestamp = chrono::Local::now().format(DATE_TIME_FORMAT_STR);
+    if color_output && cfg!(not(windows)) {
+        out.finish(format_args!(
+            "[{}][{}][{}] {}",
+            timestamp,
+            record.target(),
+            COLORS.color(record.level()),
+            message,
+        ))
+    } else {
+        out.finish(format_args!(
+            "[{}][{}][{}] {}",
+            timestamp,
+            record.target(),
+            record.level(),
+            message
+        ))
+    }
 }

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -23,6 +23,8 @@ pub const DATE_TIME_FORMAT_STR: &str = "%Y-%m-%d %H:%M:%S%.3f";
 pub fn init_logger(log_level: log::LogLevelFilter, log_file: Option<&PathBuf>) -> Result<()> {
     let silenced_crates = [
         "jsonrpc_core",
+        // jsonrpc_core does some logging under the "rpc" target as well.
+        "rpc",
         "tokio_core",
         "tokio_proto",
         "jsonrpc_ws_server",

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -54,10 +54,10 @@ impl RelaySelector {
     pub fn new(rpc_handle: HttpHandle, resource_dir: &Path) -> Result<Self> {
         let (last_updated, relay_list) = Self::read_cached_relays(resource_dir)?;
         let (locations, relays) = Self::process_relay_list(relay_list);
-        debug!(
+        info!(
             "Initialized with {} cached relays from {}",
             relays.len(),
-            DateTime::<Local>::from(last_updated).format(::DATE_TIME_FORMAT_STR)
+            DateTime::<Local>::from(last_updated).format(::logging::DATE_TIME_FORMAT_STR)
         );
         Ok(RelaySelector {
             locations,
@@ -243,7 +243,7 @@ impl RelaySelector {
 
     /// Downloads the latest relay list and caches it. This operation is blocking.
     pub fn update(&mut self, timeout: Duration) -> Result<()> {
-        info!("Downloading list of relays");
+        info!("Downloading list of relays...");
         let download_future = self.rpc_client
             .relay_list()
             .map_err(|e| Error::with_chain(e, ErrorKind::DownloadError));
@@ -252,7 +252,7 @@ impl RelaySelector {
             error!("Unable to save relays to cache: {}", e.display_chain());
         }
         let (locations, relays) = Self::process_relay_list(relay_list);
-        debug!("Downloaded relay inventory has {} relays", relays.len());
+        info!("Downloaded relay inventory has {} relays", relays.len());
         self.locations = locations;
         self.relays = relays;
         self.last_updated = SystemTime::now();

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -16,6 +16,6 @@ tokio-core = "0.1"
 hyper = "0.11"
 hyper-tls = "0.1"
 native-tls = "0.1"
-log = "0.3"
+log = "0.4"
 
 mullvad-types = { path = "../mullvad-types" }

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -10,6 +10,6 @@ chrono = { version = "0.4", features = ["serde"] }
 serde_derive = "1.0"
 serde = "1.0"
 error-chain = "0.11"
-log = "0.3"
+log = "0.4"
 
 talpid-types = { path = "../talpid-types" }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -11,7 +11,7 @@ error-chain = "0.11"
 jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", tag = "v7.1.1" }
 jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc", tag = "v7.1.1" }
 lazy_static = "1.0"
-log = "0.3"
+log = "0.4"
 uuid = { version = "0.5", features = ["v4"] }
 shell-escape = "0.1"
 

--- a/talpid-core/src/process/unix.rs
+++ b/talpid-core/src/process/unix.rs
@@ -25,7 +25,7 @@ impl HandleKillExt for duct::Handle {
             debug!("Child process exited from SIGTERM");
             Ok(())
         } else {
-            debug!("Child process did not exit from SIGTERM, sending SIGKILL");
+            warn!("Child process did not exit from SIGTERM, sending SIGKILL");
             self.kill()
         }
     }

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -262,7 +262,7 @@ mod event_server {
             event: OpenVpnPluginEvent,
             env: HashMap<String, String>,
         ) -> Result<(), Error> {
-            debug!("OpenVPN event {:?}", event);
+            trace!("OpenVPN event {:?}", event);
             (self.on_event)(event, env);
             Ok(())
         }

--- a/talpid-ipc/Cargo.toml
+++ b/talpid-ipc/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 error-chain = "0.11"
 serde = "1.0"
 serde_json = "1.0"
-log = "0.3"
+log = "0.4"
 jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", tag = "v7.1.1" }
 jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc", tag = "v7.1.1" }
 ws = { git = "https://github.com/tomusdrw/ws-rs" }

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 error-chain = "0.11"
-log = "0.3"
-env_logger = "0.4"
+log = "0.4"
+env_logger = "0.5"
 
 openvpn-plugin = { version = "0.3", features = ["serde", "log"] }
 talpid-ipc = { path = "../talpid-ipc" }

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -61,7 +61,7 @@ fn openvpn_open(
     args: Vec<CString>,
     _env: HashMap<CString, CString>,
 ) -> Result<(Vec<OpenVpnPluginEvent>, EventProcessor)> {
-    env_logger::init().chain_err(|| "Failed to bootstrap logging system")?;
+    env_logger::init();
     debug!("Initializing plugin");
 
     let core_server_id = parse_args(&args)?;


### PR DESCRIPTION
Did something I have wanted to do for a long time: Move the logging initializing to it's own module. `main.rs` is way too bloated anyway.

Also adjusted a few logging levels to what I felt was more appropriate levels. The main thing I wanted to get rid of was the `DEBUG` level logging of all jsonrpc responses. They are super verbose and feels much more like `TRACE` level to me. But I realized that was done in the `jsonrpc-core` crate, and not ours. So I could not directly adjust the level, but I could silence that crate a bit more.

Checklist for a PR:

* [ ] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/76)
<!-- Reviewable:end -->
