### PR TITLE
Fix transition container remounting

### DIFF
--- a/app/components/TransitionContainer.js
+++ b/app/components/TransitionContainer.js
@@ -187,11 +187,12 @@ export default class TransitionContainer extends Component<TransitionContainerPr
       <View style={{flex:1}}>
 
         { previousChildren &&
-          (<Animated.View style={[this.state.animationStyles.style, previousChildrenAnimation]}>
+          (<Animated.View key={ previousChildren && previousChildren.key }
+            style={[this.state.animationStyles.style, previousChildrenAnimation]}>
             { previousChildren }
           </Animated.View>) }
 
-        <Animated.View style={[this.state.animationStyles.style, childrenAnimation]}>
+        <Animated.View key={ children.key } style={[this.state.animationStyles.style, childrenAnimation]}>
           { children }
         </Animated.View>
 

--- a/app/components/TransitionContainer.js
+++ b/app/components/TransitionContainer.js
@@ -16,6 +16,11 @@ type State = {
     dimensions: Types.Dimensions,
 };
 
+const transitionContainerStyle = Styles.createViewStyle({
+  flex: 1,
+  position: 'relative'
+});
+
 export default class TransitionContainer extends Component<TransitionContainerProps, State> {
 
   constructor(props: TransitionContainerProps) {
@@ -184,7 +189,7 @@ export default class TransitionContainer extends Component<TransitionContainerPr
     const { children } = this.props;
     const { previousChildren, childrenAnimation, previousChildrenAnimation } = this.state;
     return (
-      <View style={{flex:1}}>
+      <View style={[ transitionContainerStyle ]}>
 
         { previousChildren &&
           (<Animated.View key={ previousChildren && previousChildren.key }


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

I concluded that `autoFocus` was the cause of broken transitions. For whatever reason it used to work with `react-transition-group`. I can reproduce the same issue if I swap RX animations for CSS transitions directly in the `TransitionContainer`.

Besides in the conversation with ReactXP team it seems that the solution using keys to avoid re-mount is pretty much what they do too and it works. So I'm bringing this solution back into our codebase in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/78)
<!-- Reviewable:end -->
