### PR TITLE
Redact possible account numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix a bug in account input field that advanced the cursor to the end regardless its prior
   position.
+- Redact all 16 digit numbers from problem report logs. Extra safety against accidentally sending
+  account numbers.
 
 
 ## [2018.1] - 2018-03-01

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -205,11 +205,15 @@ impl ProblemReport {
     }
 
     fn redact(&self, input: &str) -> String {
-        let mut out = self.redact_home_dir(input);
-
+        let mut out = self.redact_account_number(input);
+        out = self.redact_home_dir(&out);
         out = self.redact_network_info(&out);
-
         self.redact_custom_strings(out)
+    }
+
+    fn redact_account_number(&self, input: &str) -> String {
+        let re = Regex::new("\\d{16}").unwrap();
+        re.replace_all(input, "[REDACTED ACCOUNT NUMBER]").to_string()
     }
 
     fn redact_home_dir(&self, input: &str) -> String {

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -10,19 +10,19 @@
 extern crate clap;
 #[macro_use]
 extern crate error_chain;
-extern crate regex;
 #[macro_use]
 extern crate lazy_static;
+extern crate regex;
 
 extern crate mullvad_rpc;
 
 use error_chain::ChainedError;
 use regex::Regex;
 
+use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::env;
-use std::borrow::Cow;
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -198,11 +198,9 @@ impl ProblemReport {
     /// Attach file log to this report. This method uses the error chain instead of log
     /// contents if error occurred when reading log file.
     pub fn add_log(&mut self, path: &Path) {
-        let content = self.redact(
-            &read_file_lossy(path, LOG_MAX_READ_BYTES)
-                .chain_err(|| ErrorKind::ReadLogError(path.to_path_buf()))
-                .unwrap_or_else(|e| e.display_chain().to_string()),
-        );
+        let content = self.redact(&read_file_lossy(path, LOG_MAX_READ_BYTES)
+            .chain_err(|| ErrorKind::ReadLogError(path.to_path_buf()))
+            .unwrap_or_else(|e| e.display_chain().to_string()));
         let path = self.redact(&path.to_string_lossy());
         self.logs.push((path, content));
     }

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -196,15 +196,15 @@ impl ProblemReport {
     /// contents if error occurred when reading log file.
     pub fn add_log(&mut self, path: &Path) {
         let content = self.redact(
-            read_file_lossy(path, LOG_MAX_READ_BYTES)
+            &read_file_lossy(path, LOG_MAX_READ_BYTES)
                 .chain_err(|| ErrorKind::ReadLogError(path.to_path_buf()))
                 .unwrap_or_else(|e| e.display_chain().to_string()),
         );
-        let path = self.redact(path.to_string_lossy().into_owned());
+        let path = self.redact(&path.to_string_lossy());
         self.logs.push((path, content));
     }
 
-    fn redact(&self, input: String) -> String {
+    fn redact(&self, input: &str) -> String {
         let mut out = self.redact_home_dir(input);
 
         out = self.redact_network_info(&out);
@@ -212,10 +212,10 @@ impl ProblemReport {
         self.redact_custom_strings(out)
     }
 
-    fn redact_home_dir(&self, input: String) -> String {
+    fn redact_home_dir(&self, input: &str) -> String {
         match env::home_dir() {
             Some(home) => input.replace(home.to_string_lossy().as_ref(), "~"),
-            None => input,
+            None => input.to_owned(),
         }
     }
 

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -401,14 +401,14 @@ mod tests {
 
     fn assert_redacts_ipv4(input: &str) {
         let report = ProblemReport::new(vec![]);
-        let actual = report.redact(format!("pre {} post", input));
+        let actual = report.redact(&format!("pre {} post", input));
         assert_eq!("pre [REDACTED] post", actual);
     }
 
     #[test]
     fn does_not_redact_localhost_ipv4() {
         let report = ProblemReport::new(vec![]);
-        let res = report.redact("127.0.0.1".to_owned());
+        let res = report.redact("127.0.0.1");
         assert_eq!("127.0.0.1", res);
     }
 
@@ -430,27 +430,27 @@ mod tests {
     #[test]
     fn doesnt_redact_not_ipv6() {
         let report = ProblemReport::new(vec![]);
-        let actual = report.redact(format!("[talpid_core::firewall]"));
+        let actual = report.redact("[talpid_core::firewall]");
         assert_eq!("[talpid_core::firewall]", actual);
     }
 
     fn assert_redacts_ipv6(input: &str) {
         let report = ProblemReport::new(vec![]);
-        let actual = report.redact(format!("pre {} post", input));
+        let actual = report.redact(&format!("pre {} post", input));
         assert_eq!("pre [REDACTED] post", actual);
     }
 
     #[test]
     fn test_does_not_redact_localhost_ipv6() {
         let report = ProblemReport::new(vec![]);
-        let res = report.redact("::1".to_owned());
+        let res = report.redact("::1");
         assert_eq!("::1", res);
     }
 
     #[test]
     fn test_does_not_redact_time() {
         let report = ProblemReport::new(vec![]);
-        let res = report.redact("09:47:59".to_owned());
+        let res = report.redact("09:47:59");
         assert_eq!("09:47:59", res);
     }
 }


### PR DESCRIPTION
Main feature of this PR is that I redact all 16 digit numbers from the problem report. This is yet another best effort attempt to avoid sending account numbers. The vast majority of our account tokens are 16 digit numbers and all newly created accounts are. This will very unlikely redact something we actually need from the logs and it will redact account numbers not in our history.

Apart from that I realized we had a lot of redact functions being `fn(String) -> String` and caused unnecessary allocation. Not a high priority fix since it worked well. But it was easy to replace with `&str` and `Cow<str>` to reduce allocation. No benchmarking has been performed so I can't prove it did any good. But I highly doubt it became worse.

Also compile regular expressions into lazy statics. So they are only compiled once.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/81)
<!-- Reviewable:end -->
