### PR TITLE
Fix DOM selection in account input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Increase a timeout for problem report collection to fix a timeout error on slower machines.
 - Fix a memory leak in the problem report collection routine.
 - Fix an issue when viewing a problem report brought up a dialog to choose the application to open the file.
+- Fix a bug in account input field that advanced the cursor to the end regardless its prior position.
 
 ## [2018.1-beta10] - 2018-02-13
 ### Added

--- a/app/components/AccountInput.js
+++ b/app/components/AccountInput.js
@@ -85,7 +85,7 @@ export default class AccountInput extends React.Component<AccountInputProps, Acc
         onKeyDown={ this.onKeyDown }
         onPaste={ this.onPaste }
         onCut={ this.onCut }
-        ref={ this.onRef } />
+        ref={ (ref) => this.onRef(ref) } />
     );
   }
 

--- a/app/components/AccountInput.js
+++ b/app/components/AccountInput.js
@@ -295,7 +295,7 @@ export default class AccountInput extends React.Component<AccountInputProps, Acc
     }
   }
 
-  onRef = (ref: ?HTMLInputElement) => {
+  onRef(ref: ?HTMLInputElement) {
     this._ref = ref;
     if(!ref) { return; }
 


### PR DESCRIPTION
There is been a subtle bug related to the move away from ::operator
towards arrow function.

See https://github.com/mullvad/mullvadvpn-app/commit/398cab0730b40a6c98687d9be54d12446eda4a08#diff-c710bb1d123ea3b116c1967675c8c7e6L96

`::` operator used to transpile to `function.bind(this, ...)` which produced a new function each time, however since the move to arrow function the function is now cached and `ref={}` does not bother to call it on each render.

This PR remedies this by giving a new function to `ref` on each render and consistently managing the DOM selection range.

Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/82)
<!-- Reviewable:end -->
