### PR TITLE
Add disable auth flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,25 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Added
+- Add `--disable-rpc-auth` flag to daemon to make it accept unauthorized control.
 
+### Fixed
+- Fix a bug in account input field that advanced the cursor to the end regardless its prior
+  position.
+
+
+## [2018.1] - 2018-03-01
 ### Changed
-- Redact all account numbers in the account number history from problem reports instead of only the currently logged in one.
+- Redact all account numbers in the account number history from problem reports instead of only the
+  currently logged in one.
 
 ### Fixed
 - Increase a timeout for problem report collection to fix a timeout error on slower machines.
 - Fix a memory leak in the problem report collection routine.
-- Fix an issue when viewing a problem report brought up a dialog to choose the application to open the file.
-- Fix a bug in account input field that advanced the cursor to the end regardless its prior position.
+- Fix an issue when viewing a problem report brought up a dialog to choose the application to open
+  the file.
+
 
 ## [2018.1-beta10] - 2018-02-13
 ### Added

--- a/app/lib/backend.js
+++ b/app/lib/backend.js
@@ -72,7 +72,7 @@ export type IpcCredentials = {
 };
 export function parseIpcCredentials(data: string): ?IpcCredentials {
   const [connectionString, sharedSecret] = data.split('\n', 2);
-  if(connectionString && sharedSecret) {
+  if(connectionString && sharedSecret !== undefined) {
     return {
       connectionString,
       sharedSecret,

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub log_file: Option<PathBuf>,
     pub tunnel_log_file: Option<PathBuf>,
     pub resource_dir: Option<PathBuf>,
+    pub require_auth: bool,
 }
 
 pub fn get_config() -> Config {
@@ -22,12 +23,14 @@ pub fn get_config() -> Config {
     let log_file = matches.value_of_os("log_file").map(PathBuf::from);
     let tunnel_log_file = matches.value_of_os("tunnel_log_file").map(PathBuf::from);
     let resource_dir = matches.value_of_os("resource_dir").map(PathBuf::from);
+    let require_auth = !matches.is_present("disable_rpc_auth");
 
     Config {
         log_level,
         log_file,
         tunnel_log_file,
         resource_dir,
+        require_auth,
     }
 }
 
@@ -50,14 +53,14 @@ fn create_app() -> App<'static, 'static> {
                 .long("log")
                 .takes_value(true)
                 .value_name("PATH")
-                .help("Activates file logging to the given path"),
+                .help("Activates file logging to the given path."),
         )
         .arg(
             Arg::with_name("tunnel_log_file")
                 .long("tunnel-log")
                 .takes_value(true)
                 .value_name("PATH")
-                .help("Save log from tunnel implementation process to this file path"),
+                .help("Save log from tunnel implementation process to this file path."),
         )
         .arg(
             Arg::with_name("resource_dir")
@@ -65,5 +68,10 @@ fn create_app() -> App<'static, 'static> {
                 .takes_value(true)
                 .value_name("DIR")
                 .help("Uses the given directory to read needed resources, such as certificates."),
+        )
+        .arg(
+            Arg::with_name("disable_rpc_auth")
+                .long("disable-rpc-auth")
+                .help("Don't require authentication on the RPC management interface."),
         )
 }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -183,7 +183,7 @@ pub struct ManagementInterfaceServer {
 impl ManagementInterfaceServer {
     pub fn start<T>(
         tunnel_tx: IntoSender<TunnelCommand, T>,
-        shared_secret: String,
+        shared_secret: Option<String>,
     ) -> talpid_ipc::Result<Self>
     where
         T: From<TunnelCommand> + 'static + Send,
@@ -256,11 +256,11 @@ impl EventBroadcaster {
 struct ManagementInterface<T: From<TunnelCommand> + 'static + Send> {
     subscriptions: Arc<ActiveSubscriptions>,
     tx: Mutex<IntoSender<TunnelCommand, T>>,
-    shared_secret: String,
+    shared_secret: Option<String>,
 }
 
 impl<T: From<TunnelCommand> + 'static + Send> ManagementInterface<T> {
-    pub fn new(tx: IntoSender<TunnelCommand, T>, shared_secret: String) -> Self {
+    pub fn new(tx: IntoSender<TunnelCommand, T>, shared_secret: Option<String>) -> Self {
         ManagementInterface {
             subscriptions: Default::default(),
             tx: Mutex::new(tx),
@@ -330,7 +330,7 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterface<T> {
     }
 
     fn check_auth(&self, meta: &Meta) -> Result<(), Error> {
-        if meta.authenticated.load(Ordering::SeqCst) {
+        if self.shared_secret.is_none() || meta.authenticated.load(Ordering::SeqCst) {
             trace!("auth success");
             Ok(())
         } else {
@@ -354,13 +354,18 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
     type Metadata = Meta;
 
     fn auth(&self, meta: Self::Metadata, shared_secret: String) -> BoxFuture<(), Error> {
-        let authenticated = shared_secret == self.shared_secret;
-        meta.authenticated.store(authenticated, Ordering::SeqCst);
-        debug!("authenticated: {}", authenticated);
-        if authenticated {
-            Box::new(future::ok(()))
+        if let Some(ref self_shared_secret) = self.shared_secret {
+            let authenticated = &shared_secret == self_shared_secret;
+            meta.authenticated.store(authenticated, Ordering::SeqCst);
+            debug!("authenticated: {}", authenticated);
+            if authenticated {
+                Box::new(future::ok(()))
+            } else {
+                Box::new(future::err(Error::internal_error()))
+            }
         } else {
-            Box::new(future::err(Error::internal_error()))
+            warn!("Ignoring auth call since authentication is disabled");
+            Box::new(future::ok(()))
         }
     }
 

--- a/mullvad-daemon/src/rpc_info.rs
+++ b/mullvad-daemon/src/rpc_info.rs
@@ -31,7 +31,7 @@ lazy_static! {
 /// Writes down the RPC connection info to some API to a file.
 pub fn write(rpc_address: &str, shared_secret: &str) -> Result<()> {
     open_file(RPC_ADDRESS_FILE_PATH.as_path())
-        .and_then(|mut file| write!(file, "{}\n{}", rpc_address, shared_secret))
+        .and_then(|mut file| write!(file, "{}\n{}\n", rpc_address, shared_secret))
         .chain_err(|| ErrorKind::WriteFailed(RPC_ADDRESS_FILE_PATH.to_owned()))?;
 
     debug!(


### PR DESCRIPTION
Finally adding a flag to make it possible to control the daemon over RPC without the authorization. This will make the CLI work again. Will make it much easier to test stuff.

Also relevant for people who want to deploy the app on a server or similar environment where there are no hostile apps to protect against. The auth is mainly to protect against rouge websites controlling the app from within a browser.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/83)
<!-- Reviewable:end -->
