### PR TITLE
Only run one instance of daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add details to mullvad CLI interface error for when it doesn't trust the RPC file.
 - Warn if daemon is running as a non-root user.
 - Include the last two OpenVPN logs in problem reports instead of only the last.
+- Prevent two instances of the daemon to run at the same time.
 
 ### Fixed
 - Fix a bug in account input field that advanced the cursor to the end regardless its prior

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -84,6 +84,9 @@ use std::fs;
 
 error_chain!{
     errors {
+        DaemonIsAlreadyRunning {
+            description("Another instance of the daemon is already running")
+        }
         /// The client is in the wrong state for the requested operation. Optimally the code should
         /// be written in such a way so such states can't exist.
         InvalidState {
@@ -284,6 +287,11 @@ impl Daemon {
         event_tx: IntoSender<TunnelCommand, DaemonEvent>,
         require_auth: bool,
     ) -> Result<ManagementInterfaceServer> {
+        ensure!(
+            !rpc_info::is_another_instance_running(),
+            ErrorKind::DaemonIsAlreadyRunning
+        );
+
         let shared_secret = if require_auth {
             Some(uuid::Uuid::new_v4().to_string())
         } else {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -211,6 +211,11 @@ impl Daemon {
         resource_dir: PathBuf,
         require_auth: bool,
     ) -> Result<Self> {
+        ensure!(
+            !rpc_uniqueness_check::is_another_instance_running(),
+            ErrorKind::DaemonIsAlreadyRunning
+        );
+
         let (rpc_handle, http_handle, tokio_remote) =
             mullvad_rpc::event_loop::create(|core| {
                 let handle = core.handle();
@@ -288,11 +293,6 @@ impl Daemon {
         event_tx: IntoSender<TunnelCommand, DaemonEvent>,
         require_auth: bool,
     ) -> Result<ManagementInterfaceServer> {
-        ensure!(
-            !rpc_uniqueness_check::is_another_instance_running(),
-            ErrorKind::DaemonIsAlreadyRunning
-        );
-
         let shared_secret = if require_auth {
             Some(uuid::Uuid::new_v4().to_string())
         } else {

--- a/mullvad-daemon/src/rpc_address_file.rs
+++ b/mullvad-daemon/src/rpc_address_file.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 error_chain! {
     errors {
         WriteFailed(path: PathBuf) {
-            description("Failed to write RCP connection info to file")
+            description("Failed to write RPC connection info to file")
             display("Failed to write RPC connection info to {}", path.to_string_lossy())
         }
         RemoveFailed(path: PathBuf) {

--- a/mullvad-daemon/src/rpc_info.rs
+++ b/mullvad-daemon/src/rpc_info.rs
@@ -37,9 +37,12 @@ lazy_static! {
 /// Tries to connect to another daemon and perform a simple RPC call. If it fails, assumes the
 /// other daemon has stopped.
 pub fn is_another_instance_running() -> bool {
-    let rpc_file_exists = RPC_ADDRESS_FILE_PATH.as_path().exists();
-
-    rpc_file_exists && other_daemon_responds()
+    if let Err(message) = call_other_daemon() {
+        info!("{}; assuming it has stopped", message);
+        false
+    } else {
+        true
+    }
 }
 
 /// Writes down the RPC connection info to some API to a file.
@@ -69,15 +72,6 @@ pub fn remove() -> Result<()> {
         }
     } else {
         Ok(())
-    }
-}
-
-fn other_daemon_responds() -> bool {
-    if let Err(message) = call_other_daemon() {
-        info!("{}; assuming it has stopped", message);
-        false
-    } else {
-        true
     }
 }
 

--- a/mullvad-daemon/src/rpc_info.rs
+++ b/mullvad-daemon/src/rpc_info.rs
@@ -1,6 +1,10 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::result;
+
+use mullvad_types::states::DaemonState;
+use talpid_ipc::WsIpcClient;
 
 error_chain! {
     errors {
@@ -28,8 +32,21 @@ lazy_static! {
 }
 
 
+/// Checks if there is another instance of the daemon running.
+///
+/// Tries to connect to another daemon and perform a simple RPC call. If it fails, assumes the
+/// other daemon has stopped.
+pub fn is_another_instance_running() -> bool {
+    let rpc_file_exists = RPC_ADDRESS_FILE_PATH.as_path().exists();
+
+    rpc_file_exists && other_daemon_responds()
+}
+
 /// Writes down the RPC connection info to some API to a file.
 pub fn write(rpc_address: &str, shared_secret: &str) -> Result<()> {
+    // Remove any existent RPC address file first
+    let _ = remove();
+
     open_file(RPC_ADDRESS_FILE_PATH.as_path())
         .and_then(|mut file| write!(file, "{}\n{}\n", rpc_address, shared_secret))
         .chain_err(|| ErrorKind::WriteFailed(RPC_ADDRESS_FILE_PATH.to_owned()))?;
@@ -44,6 +61,36 @@ pub fn write(rpc_address: &str, shared_secret: &str) -> Result<()> {
 pub fn remove() -> Result<()> {
     fs::remove_file(RPC_ADDRESS_FILE_PATH.as_path())
         .chain_err(|| ErrorKind::RemoveFailed(RPC_ADDRESS_FILE_PATH.to_owned()))
+}
+
+fn other_daemon_responds() -> bool {
+    if let Err(message) = call_other_daemon() {
+        info!("{}; assuming it has stopped", message);
+        false
+    } else {
+        true
+    }
+}
+
+fn call_other_daemon() -> result::Result<(), String> {
+    let method = "get_state";
+    let args: [u8; 0] = [];
+    let address = read_rpc_file().map_err(|_| "Failed to read RPC address file of other daemon")?;
+    // TODO: Authenticate with server
+    let mut rpc_client =
+        WsIpcClient::new(address).map_err(|_| "Failed to connect to other daemon")?;
+    let _: DaemonState = rpc_client
+        .call(method, &args)
+        .map_err(|_| "Failed to execute RPC call to other daemon")?;
+    Ok(())
+}
+
+fn read_rpc_file() -> io::Result<String> {
+    let file = File::open(RPC_ADDRESS_FILE_PATH.as_path())?;
+    let mut reader = BufReader::new(file);
+    let mut address = String::new();
+    reader.read_line(&mut address)?;
+    Ok(address)
 }
 
 fn open_file(path: &Path) -> io::Result<File> {

--- a/mullvad-daemon/src/rpc_uniqueness_check.rs
+++ b/mullvad-daemon/src/rpc_uniqueness_check.rs
@@ -1,0 +1,34 @@
+use std::result;
+
+use mullvad_types::states::DaemonState;
+use talpid_ipc::WsIpcClient;
+
+use rpc_address_file;
+
+
+/// Checks if there is another instance of the daemon running.
+///
+/// Tries to connect to another daemon and perform a simple RPC call. If it fails, assumes the
+/// other daemon has stopped.
+pub fn is_another_instance_running() -> bool {
+    if let Err(message) = call_other_daemon() {
+        info!("{}; assuming it has stopped", message);
+        false
+    } else {
+        true
+    }
+}
+
+fn call_other_daemon() -> result::Result<(), String> {
+    let method = "get_state";
+    let args: [u8; 0] = [];
+    let address =
+        rpc_address_file::read().map_err(|_| "Failed to read RPC address file of other daemon")?;
+    // TODO: Authenticate with server
+    let mut rpc_client =
+        WsIpcClient::new(address).map_err(|_| "Failed to connect to other daemon")?;
+    let _: DaemonState = rpc_client
+        .call(method, &args)
+        .map_err(|_| "Failed to execute RPC call to other daemon")?;
+    Ok(())
+}


### PR DESCRIPTION
Before the RPC server is started, check if there is already another
instance of the daemon running. If there is, and it appears to be
responding correctly, don't start the daemon again.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/87)
<!-- Reviewable:end -->
