### PR TITLE
Test RPC address file creation on daemon start-up

### DIFF
--- a/mullvad-daemon/tests/common/mod.rs
+++ b/mullvad-daemon/tests/common/mod.rs
@@ -1,0 +1,63 @@
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+pub struct DaemonInstance {
+    process: Child,
+    output: BufReader<ChildStdout>,
+}
+
+impl DaemonInstance {
+    pub fn new() -> Self {
+        let mut process = Command::new("target/debug/mullvad-daemon")
+            .stdout(Stdio::piped())
+            .current_dir("..")
+            .args(&["--resource-dir", "dist-assets"])
+            .spawn()
+            .expect("failed to start daemon");
+        let output = BufReader::new(process.stdout.take().expect("missing daemon stdout"));
+
+        DaemonInstance { process, output }
+    }
+
+    pub fn output(&mut self) -> String {
+        let mut bytes = Vec::new();
+        self.output
+            .read_to_end(&mut bytes)
+            .expect("failed to read daemon stdout");
+        String::from_utf8_lossy(&bytes).to_string()
+    }
+
+    pub fn expect(&mut self, pattern: &'static str, timeout: Duration) {
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            thread::sleep(timeout);
+            if rx.try_recv().is_err() {
+                panic!("timeout while searching for {:?}", pattern);
+            }
+        });
+
+        self.search_in_stdout(pattern);
+        let _ = tx.send(());
+    }
+
+    fn search_in_stdout(&mut self, pattern: &str) {
+        let mut line = String::new();
+
+        while !line.contains(pattern) {
+            self.output
+                .read_line(&mut line)
+                .expect("failed to read line from daemon stdout");
+            println!("{:?}", line);
+        }
+    }
+}
+
+impl Drop for DaemonInstance {
+    fn drop(&mut self) {
+        self.process.kill().expect("failed to kill daemon process");
+    }
+}

--- a/mullvad-daemon/tests/startup.rs
+++ b/mullvad-daemon/tests/startup.rs
@@ -1,0 +1,31 @@
+extern crate libc;
+
+mod common;
+
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::time::Duration;
+
+use common::DaemonInstance;
+
+#[test]
+fn rpc_info_file_permissions() {
+    let rpc_file = Path::new("/tmp/.mullvad_rpc_address");
+
+    let _ = fs::remove_file(&rpc_file);
+    assert!(!rpc_file.exists());
+
+    let mut daemon = DaemonInstance::new();
+
+    daemon.expect(
+        "Mullvad management interface listening on",
+        Duration::from_secs(10),
+    );
+    assert!(rpc_file.exists());
+
+    let uid = unsafe { libc::getuid() };
+    let metadata = fs::metadata(&rpc_file).expect("failed to inspect RPC address file");
+    assert_eq!(metadata.uid(), uid);
+    assert_eq!(metadata.mode() & 0o022, 0);
+}


### PR DESCRIPTION
This is an early attempt at implementing a test for the RPC address file creation. I originally wanted to test multiple-daemons to see if only the first one would keep running, but I thought it might be better to start with something simpler and gradually complicate it.

Feedback and suggestions welcome. I wrote this as an integration test, but other ways of testing can be discussed.

TODO:
* [ ] Make it cross platform (currently Unix specific);
* [ ] See if it's possible/desirable to test as administrator.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user. **This is not visible to the user.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/91)
<!-- Reviewable:end -->
