### PR TITLE
Update windows-security to 0.0.2 which ships prebuilt binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "optionalDependencies": {
     "nseventmonitor": "git+https://github.com/mullvad/NSEventMonitor.git#0.0.6",
-    "windows-security": "git+https://github.com/mullvad/windows-security.git#0.0.1"
+    "windows-security": "git+https://github.com/mullvad/windows-security.git#0.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8083,11 +8083,12 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-"windows-security@git+https://github.com/mullvad/windows-security.git#0.0.1":
-  version "0.0.1"
-  resolved "git+https://github.com/mullvad/windows-security.git#c6f62c0bc3f34f473f22f778b96ab3c1371809f5"
+"windows-security@git+https://github.com/mullvad/windows-security.git#0.0.2":
+  version "0.0.2"
+  resolved "git+https://github.com/mullvad/windows-security.git#469d33767de2a52e9bf10f06f2d90024438d2084"
   dependencies:
     bindings "^1.3.0"
+    node-pre-gyp "^0.6.39"
 
 winston@*:
   version "2.4.0"


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

This tiny PR updates to v. 0.0.2 of windows-security package that ships prebuilt binaries. See releases here: https://github.com/pronebird/windows-security/releases

This should fix any pending issues building the client on Windows and should remove Visual Studio from the requirements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/92)
<!-- Reviewable:end -->
