### PR TITLE
Update native addons that serve electron binaries (along with node binaries) via node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "validated": "^1.1.0"
   },
   "optionalDependencies": {
-    "nseventmonitor": "git+https://github.com/mullvad/NSEventMonitor.git#0.0.6",
-    "windows-security": "git+https://github.com/mullvad/windows-security.git#0.0.2"
+    "nseventmonitor": "git+https://github.com/mullvad/NSEventMonitor.git#0.0.7",
+    "windows-security": "git+https://github.com/mullvad/windows-security.git#0.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,10 +1363,6 @@ binaryextensions@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-1.0.1.tgz#1e637488b35b58bda5f4774bf96a5212a8c90755"
 
-bindings@^1.2.1, bindings@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
-
 bl@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.1.tgz#cac328f7bee45730d404b692203fcb590e172d5e"
@@ -5526,11 +5522,11 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-"nseventmonitor@git+https://github.com/mullvad/NSEventMonitor.git#0.0.6":
-  version "0.0.6"
-  resolved "git+https://github.com/mullvad/NSEventMonitor.git#a67e14daa07e14577595e34aad2be81182c3f4f0"
+"nseventmonitor@git+https://github.com/mullvad/NSEventMonitor.git#0.0.7":
+  version "0.0.7"
+  resolved "git+https://github.com/mullvad/NSEventMonitor.git#7c4b5bc86154e00140196fef3b5b45066283b74e"
   dependencies:
-    bindings "^1.2.1"
+    node-pre-gyp "^0.6.39"
 
 nth-check@~1.0.0, nth-check@~1.0.1:
   version "1.0.1"
@@ -8083,11 +8079,10 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-"windows-security@git+https://github.com/mullvad/windows-security.git#0.0.2":
-  version "0.0.2"
-  resolved "git+https://github.com/mullvad/windows-security.git#469d33767de2a52e9bf10f06f2d90024438d2084"
+"windows-security@git+https://github.com/mullvad/windows-security.git#0.0.3":
+  version "0.0.3"
+  resolved "git+https://github.com/mullvad/windows-security.git#154e52a995184f6817c260b7f58166734453ac95"
   dependencies:
-    bindings "^1.3.0"
     node-pre-gyp "^0.6.39"
 
 winston@*:


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

There is a little funny situation here, when we install deps via terminal we use node and all binaries are resolved against it, however once we run the app with electron we are in electron environment with their own node so we need to resolve the binaries once again. 

I think what node-pre-gyp does is basically it pulls all the binaries and puts them in different folders. Then it picks the right binary based on environment.

The new binaries can be seen on the Github Releases pages:

1. https://github.com/mullvad/NSEventMonitor/releases/0.0.7
2. https://github.com/mullvad/windows-security/releases/tag/0.0.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/94)
<!-- Reviewable:end -->
