### PR TITLE
Adding a way to pass `--mssfix` parameter to OpenVPN's subprocess.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Add support for passing the `--mssfix` argument to OpenVPN tunnels.
 - Add `--disable-rpc-auth` flag to daemon to make it accept unauthorized control.
 - Add colors to terminal output on macOS and Linux.
 - Add details to mullvad CLI interface error for when it doesn't trust the RPC file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Add `tunnel` subcommand to manage tunnel specific options in the CLI.
 - Add support for passing the `--mssfix` argument to OpenVPN tunnels.
 - Add `--disable-rpc-auth` flag to daemon to make it accept unauthorized control.
 - Add colors to terminal output on macOS and Linux.

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -22,6 +22,10 @@ pub use self::shutdown::Shutdown;
 mod lan;
 pub use self::lan::Lan;
 
+mod tunnel;
+pub use self::tunnel::Tunnel;
+
+
 /// Returns a map of all available subcommands with their name as key.
 pub fn get_commands() -> HashMap<&'static str, Box<Command>> {
     let commands: Vec<Box<Command>> = vec![
@@ -32,6 +36,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<Command>> {
         Box::new(Shutdown),
         Box::new(Relay),
         Box::new(Lan),
+        Box::new(Tunnel),
     ];
     let mut map = HashMap::new();
     for cmd in commands {

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -53,7 +53,7 @@ impl Command for Relay {
                                     .index(4)
                                     .default_value("udp")
                                     .possible_values(&["udp", "tcp"]),
-                            ),
+                            )
                     )
                     .subcommand(
                         clap::SubCommand::with_name("location")

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -53,7 +53,7 @@ impl Command for Relay {
                                     .index(4)
                                     .default_value("udp")
                                     .possible_values(&["udp", "tcp"]),
-                            )
+                            ),
                     )
                     .subcommand(
                         clap::SubCommand::with_name("location")

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -1,0 +1,95 @@
+use {Command, Result};
+use clap;
+
+use rpc;
+use talpid_types::net::{OpenVpnTunnelOptions, TunnelOptions};
+
+pub struct Tunnel;
+
+impl Command for Tunnel {
+    fn name(&self) -> &'static str {
+        "tunnel"
+    }
+
+    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
+        clap::SubCommand::with_name(self.name())
+            .about("Manage tunnel specific options")
+            .setting(clap::AppSettings::SubcommandRequired)
+            .subcommand(
+                clap::SubCommand::with_name("openvpn")
+                    .about("Manage options for OpenVPN tunnels")
+                    .setting(clap::AppSettings::SubcommandRequired)
+                    .subcommand(
+                        clap::SubCommand::with_name("set")
+                            .subcommand(
+                                clap::SubCommand::with_name("mssfix").arg(
+                                    clap::Arg::with_name("mssfix")
+                                        .help(
+                                            "Sets the optional  mssfix parameter. \
+                                             Set an empty string to clear it.",
+                                        )
+                                        .required(true),
+                                ),
+                            )
+                            .setting(clap::AppSettings::SubcommandRequired),
+                    )
+                    .subcommand(
+                        clap::SubCommand::with_name("get")
+                            .help("Retrieves the current setting for mssfix"),
+                    ),
+            )
+    }
+
+    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(openvpn_matches) = matches.subcommand_matches("openvpn") {
+            Self::handle_openvpn_cmd(openvpn_matches)
+        } else {
+            unreachable!("No tunnel command given")
+        }
+    }
+}
+
+impl Tunnel {
+    fn handle_openvpn_cmd(matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(set_matches) = matches.subcommand_matches("set") {
+            Self::set_openvpn_option(set_matches)
+        } else if let Some(_) = matches.subcommand_matches("get") {
+            let openvpn_options = Self::get_tunnel_options()?.openvpn;
+            Self::print_openvpn_tunnel_options(&openvpn_options);
+            Ok(())
+        } else {
+            unreachable!("Unrecognized subcommand");
+        }
+    }
+
+    fn set_openvpn_option(matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(mssfix_args) = matches.subcommand_matches("mssfix") {
+            let mssfix_str = mssfix_args.value_of("mssfix").unwrap();
+            let mssfix: Option<u16> = if mssfix_str == "" {
+                None
+            } else {
+                Some(mssfix_str.parse()?)
+            };
+
+            rpc::call("set_openvpn_mssfix", &[mssfix])
+                .map(|_: ()| println!("mssfix parameter updated"))
+        } else {
+            unreachable!("Invalid option passed to 'openvpn set'");
+        }
+    }
+
+    fn get_tunnel_options() -> Result<TunnelOptions> {
+        rpc::call("get_tunnel_options", &[] as &[u8; 0])
+    }
+
+    fn print_openvpn_tunnel_options(options: &OpenVpnTunnelOptions) {
+        println!("OpenVPN tunnel options");
+        println!(
+            "\tmssfix: {}",
+            options
+                .mssfix
+                .map(|v| v.to_string())
+                .unwrap_or("UNSET".to_string())
+        );
+    }
+}

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -29,6 +29,7 @@ use std::io;
 error_chain! {
     foreign_links {
         Io(io::Error);
+        ParseIntError(::std::num::ParseIntError);
     }
 }
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -4,6 +4,7 @@ use app_dirs;
 
 use mullvad_types::relay_constraints::{Constraint, LocationConstraint, RelayConstraints,
                                        RelaySettings, RelaySettingsUpdate};
+use talpid_types::net::TunnelOptions;
 
 use std::fs::File;
 use std::io;
@@ -37,6 +38,9 @@ pub struct Settings {
     relay_settings: RelaySettings,
     /// If the app should allow communication with private (LAN) networks.
     allow_lan: bool,
+    /// Options that should be applied to tunnels of a specific type regardless of where the relays
+    /// might be located.
+    tunnel_options: TunnelOptions,
 }
 
 impl Default for Settings {
@@ -48,6 +52,7 @@ impl Default for Settings {
                 tunnel: Constraint::Any,
             }),
             allow_lan: false,
+            tunnel_options: TunnelOptions::default(),
         }
     }
 }
@@ -148,5 +153,18 @@ impl Settings {
         } else {
             Ok(false)
         }
+    }
+
+    pub fn set_openvpn_mssfix(&mut self, openvpn_mssfix: Option<u16>) -> Result<bool> {
+        if self.tunnel_options.openvpn.mssfix != openvpn_mssfix {
+            self.tunnel_options.openvpn.mssfix = openvpn_mssfix;
+            self.save().map(|_| true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn get_tunnel_options(&self) -> &TunnelOptions {
+        &self.tunnel_options
     }
 }

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -39,6 +39,7 @@ pub struct OpenVpnCommand {
     crl: Option<PathBuf>,
     plugin: Option<(PathBuf, Vec<String>)>,
     log: Option<PathBuf>,
+    tunnel_options: net::OpenVpnTunnelOptions,
 }
 
 impl OpenVpnCommand {
@@ -54,6 +55,7 @@ impl OpenVpnCommand {
             crl: None,
             plugin: None,
             log: None,
+            tunnel_options: net::OpenVpnTunnelOptions::default(),
         }
     }
 
@@ -106,6 +108,12 @@ impl OpenVpnCommand {
         duct::cmd(&self.openvpn_bin, self.get_arguments()).unchecked()
     }
 
+    /// Sets extra options
+    pub fn set_tunnel_options(&mut self, tunnel_options: &net::OpenVpnTunnelOptions) -> &mut Self {
+        self.tunnel_options = *tunnel_options;
+        self
+    }
+
     /// Returns all arguments that the subprocess would be spawned with.
     pub fn get_arguments(&self) -> Vec<OsString> {
         let mut args: Vec<OsString> = Self::base_arguments().iter().map(OsString::from).collect();
@@ -136,6 +144,11 @@ impl OpenVpnCommand {
         if let Some(ref path) = self.log {
             args.push(OsString::from("--log"));
             args.push(OsString::from(path))
+        }
+
+        if let Some(mssfix) = self.tunnel_options.mssfix {
+            args.push(OsString::from("--mssfix"));
+            args.push(OsString::from(mssfix.to_string()));
         }
 
         args.extend(Self::security_arguments().iter().map(OsString::from));

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -12,7 +12,8 @@ use std::io::{self, Write};
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 
-use talpid_types::net::{Endpoint, TunnelEndpoint, TunnelEndpointData};
+use talpid_types::net::{Endpoint, OpenVpnTunnelOptions, TunnelEndpoint, TunnelEndpointData,
+                        TunnelOptions};
 
 /// A module for all OpenVPN related tunnel management.
 pub mod openvpn;
@@ -113,6 +114,7 @@ impl TunnelMonitor {
     /// on tunnel state changes.
     pub fn new<L>(
         tunnel_endpoint: TunnelEndpoint,
+        tunnel_options: &TunnelOptions,
         account_token: &str,
         log: Option<&Path>,
         resource_dir: &Path,
@@ -129,6 +131,7 @@ impl TunnelMonitor {
             .chain_err(|| ErrorKind::CredentialsWriteError)?;
         let cmd = Self::create_openvpn_cmd(
             tunnel_endpoint.to_endpoint(),
+            &tunnel_options.openvpn,
             user_pass_file.as_ref(),
             log,
             resource_dir,
@@ -156,6 +159,7 @@ impl TunnelMonitor {
 
     fn create_openvpn_cmd(
         remote: Endpoint,
+        options: &OpenVpnTunnelOptions,
         user_pass_file: &Path,
         log: Option<&Path>,
         resource_dir: &Path,
@@ -166,6 +170,7 @@ impl TunnelMonitor {
         }
         cmd.remote(remote)
             .user_pass(user_pass_file)
+            .set_tunnel_options(&options)
             .ca(resource_dir.join("ca.crt"))
             .crl(resource_dir.join("crl.pem"));
         if let Some(log) = log {

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -125,3 +125,22 @@ impl Error for TransportProtocolParseError {
         "Not a valid transport protocol"
     }
 }
+
+/// TunnelOptions holds optional settings for tunnels, that are to be applied to any tunnel of the
+/// appropriate type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TunnelOptions {
+    /// openvpn holds OpenVPN specific tunnel options.
+    pub openvpn: OpenVpnTunnelOptions,
+}
+
+
+/// OpenVpnTunnelOptions contains options for an openvpn tunnel that should be applied irrespective
+/// of the relay parameters - i.e. have nothing to do with the particular OpenVPN server, but do
+/// affect the connection.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct OpenVpnTunnelOptions {
+    /// Optional argument for openvpn to try and limit TCP packet size,
+    /// as discussed [here](https://openvpn.net/archive/openvpn-users/2003-11/msg00154.html)
+    pub mssfix: Option<u16>,
+}


### PR DESCRIPTION
I've added some minor changes to the daemon to support optionally passing an extra parameter to the openvpn client that would _inform_ TCP sessions about what their maximum packet sizes should be. The 2 RPCs serve to both set and get the parameters value.

Do tell me if I should also add this change to the changelog. 

I'm not entirely certain if the best thing to do here _isn't_ going with a more generic way of setting custom arguments. I'm also not certain if validating the MTU size is done in the right place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/95)
<!-- Reviewable:end -->
