### PR TITLE
Rename TunnelParameters to TunnelEndpointData

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -9,8 +9,8 @@ use mullvad_types::relay_constraints::{Constraint, LocationConstraint, OpenVpnCo
 use mullvad_types::relay_list::RelayList;
 
 use rpc;
-use talpid_types::net::{OpenVpnParameters, TransportProtocol, TunnelParameters,
-                        WireguardParameters};
+use talpid_types::net::{OpenVpnEndpointData, TransportProtocol, TunnelEndpointData,
+                        WireguardEndpointData};
 
 pub struct Relay;
 
@@ -135,11 +135,11 @@ impl Relay {
         let host = value_t!(matches.value_of("host"), String).unwrap_or_else(|e| e.exit());
         let port = value_t!(matches.value_of("port"), u16).unwrap_or_else(|e| e.exit());
         let tunnel = match matches.value_of("tunnel").unwrap() {
-            "openvpn" => TunnelParameters::OpenVpn(OpenVpnParameters {
+            "openvpn" => TunnelEndpointData::OpenVpn(OpenVpnEndpointData {
                 port,
                 protocol: value_t!(matches.value_of("protocol"), TransportProtocol).unwrap(),
             }),
-            "wireguard" => TunnelParameters::Wireguard(WireguardParameters { port }),
+            "wireguard" => TunnelEndpointData::Wireguard(WireguardEndpointData { port }),
             _ => unreachable!("Invalid tunnel protocol"),
         };
         self.update_constraints(RelaySettingsUpdate::CustomTunnelEndpoint(

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -11,7 +11,7 @@ use mullvad_types::relay_list::{Relay, RelayList, RelayTunnels};
 
 use serde_json;
 
-use talpid_types::net::{TransportProtocol, TunnelEndpoint, TunnelParameters};
+use talpid_types::net::{TransportProtocol, TunnelEndpoint, TunnelEndpointData};
 
 use std::fs::File;
 use std::io;
@@ -234,11 +234,11 @@ impl RelaySelector {
         }
     }
 
-    fn get_random_tunnel(&mut self, tunnels: &RelayTunnels) -> Option<TunnelParameters> {
+    fn get_random_tunnel(&mut self, tunnels: &RelayTunnels) -> Option<TunnelEndpointData> {
         self.rng
             .choose(&tunnels.openvpn)
             .cloned()
-            .map(|openvpn_endpoint| TunnelParameters::OpenVpn(openvpn_endpoint))
+            .map(|openvpn_endpoint| TunnelEndpointData::OpenVpn(openvpn_endpoint))
     }
 
     /// Downloads the latest relay list and caches it. This operation is blocking.

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, ToSocketAddrs};
 
-use talpid_types::net::{TunnelEndpoint, TunnelParameters};
+use talpid_types::net::{TunnelEndpoint, TunnelEndpointData};
 
 error_chain!{
     errors {
@@ -14,7 +14,7 @@ error_chain!{
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CustomTunnelEndpoint {
     pub host: String,
-    pub tunnel: TunnelParameters,
+    pub tunnel: TunnelEndpointData,
 }
 
 impl CustomTunnelEndpoint {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -3,7 +3,7 @@ use location::{CityCode, CountryCode};
 
 use std::fmt;
 
-use talpid_types::net::{OpenVpnParameters, TransportProtocol, WireguardParameters};
+use talpid_types::net::{OpenVpnEndpointData, TransportProtocol, WireguardEndpointData};
 
 
 pub trait Match<T> {
@@ -107,8 +107,8 @@ pub enum TunnelConstraints {
     Wireguard(WireguardConstraints),
 }
 
-impl Match<OpenVpnParameters> for TunnelConstraints {
-    fn matches(&self, endpoint: &OpenVpnParameters) -> bool {
+impl Match<OpenVpnEndpointData> for TunnelConstraints {
+    fn matches(&self, endpoint: &OpenVpnEndpointData) -> bool {
         match *self {
             TunnelConstraints::OpenVpn(ref constraints) => constraints.matches(endpoint),
             _ => false,
@@ -116,8 +116,8 @@ impl Match<OpenVpnParameters> for TunnelConstraints {
     }
 }
 
-impl Match<WireguardParameters> for TunnelConstraints {
-    fn matches(&self, endpoint: &WireguardParameters) -> bool {
+impl Match<WireguardEndpointData> for TunnelConstraints {
+    fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
         match *self {
             TunnelConstraints::Wireguard(ref constraints) => constraints.matches(endpoint),
             _ => false,
@@ -131,8 +131,8 @@ pub struct OpenVpnConstraints {
     pub protocol: Constraint<TransportProtocol>,
 }
 
-impl Match<OpenVpnParameters> for OpenVpnConstraints {
-    fn matches(&self, endpoint: &OpenVpnParameters) -> bool {
+impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
+    fn matches(&self, endpoint: &OpenVpnEndpointData) -> bool {
         self.port.matches(&endpoint.port) && self.protocol.matches(&endpoint.protocol)
     }
 }
@@ -142,8 +142,8 @@ pub struct WireguardConstraints {
     pub port: Constraint<u16>,
 }
 
-impl Match<WireguardParameters> for WireguardConstraints {
-    fn matches(&self, endpoint: &WireguardParameters) -> bool {
+impl Match<WireguardEndpointData> for WireguardConstraints {
+    fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
         self.port.matches(&endpoint.port)
     }
 }

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -2,7 +2,7 @@ use location::{CityCode, CountryCode, Location};
 
 use std::net::Ipv4Addr;
 
-use talpid_types::net::{OpenVpnParameters, WireguardParameters};
+use talpid_types::net::{OpenVpnEndpointData, WireguardEndpointData};
 
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -44,6 +44,6 @@ pub struct Relay {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RelayTunnels {
-    pub openvpn: Vec<OpenVpnParameters>,
-    pub wireguard: Vec<WireguardParameters>,
+    pub openvpn: Vec<OpenVpnEndpointData>,
+    pub wireguard: Vec<WireguardEndpointData>,
 }

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -12,7 +12,7 @@ use std::io::{self, Write};
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 
-use talpid_types::net::{Endpoint, TunnelEndpoint, TunnelParameters};
+use talpid_types::net::{Endpoint, TunnelEndpoint, TunnelEndpointData};
 
 /// A module for all OpenVPN related tunnel management.
 pub mod openvpn;
@@ -122,8 +122,8 @@ impl TunnelMonitor {
         L: Fn(TunnelEvent) + Send + Sync + 'static,
     {
         match tunnel_endpoint.tunnel {
-            TunnelParameters::OpenVpn(_) => (),
-            TunnelParameters::Wireguard(_) => bail!(ErrorKind::UnsupportedTunnelProtocol),
+            TunnelEndpointData::OpenVpn(_) => (),
+            TunnelEndpointData::Wireguard(_) => bail!(ErrorKind::UnsupportedTunnelProtocol),
         }
         let user_pass_file = Self::create_user_pass_file(account_token)
             .chain_err(|| ErrorKind::CredentialsWriteError)?;

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TunnelEndpoint {
     pub address: IpAddr,
-    pub tunnel: TunnelParameters,
+    pub tunnel: TunnelEndpointData,
 }
 
 impl TunnelEndpoint {
@@ -21,40 +21,42 @@ impl TunnelEndpoint {
     }
 }
 
+/// TunnelEndpointData contains data required to connect to a given tunnel endpoint.
+/// Different endpoint types can require different types of data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
-pub enum TunnelParameters {
+pub enum TunnelEndpointData {
     /// Extra parameters for an OpenVPN tunnel endpoint.
     #[serde(rename = "openvpn")]
-    OpenVpn(OpenVpnParameters),
+    OpenVpn(OpenVpnEndpointData),
     /// Extra parameters for a Wireguard tunnel endpoint.
     #[serde(rename = "wireguard")]
-    Wireguard(WireguardParameters),
+    Wireguard(WireguardEndpointData),
 }
 
-impl TunnelParameters {
+impl TunnelEndpointData {
     pub fn port(&self) -> u16 {
         match *self {
-            TunnelParameters::OpenVpn(metadata) => metadata.port,
-            TunnelParameters::Wireguard(metadata) => metadata.port,
+            TunnelEndpointData::OpenVpn(metadata) => metadata.port,
+            TunnelEndpointData::Wireguard(metadata) => metadata.port,
         }
     }
 
     pub fn transport_protocol(&self) -> TransportProtocol {
         match *self {
-            TunnelParameters::OpenVpn(metadata) => metadata.protocol,
-            TunnelParameters::Wireguard(_) => TransportProtocol::Udp,
+            TunnelEndpointData::OpenVpn(metadata) => metadata.protocol,
+            TunnelEndpointData::Wireguard(_) => TransportProtocol::Udp,
         }
     }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct OpenVpnParameters {
+pub struct OpenVpnEndpointData {
     pub port: u16,
     pub protocol: TransportProtocol,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct WireguardParameters {
+pub struct WireguardEndpointData {
     pub port: u16,
 }
 


### PR DESCRIPTION
This is small refactoring - `TunnelParameters` and it's enumerations have been renamed to `TunnelEndpointData` as to not be confused with upcoming `TunnelOptions`. I am open to discussions about whether this is the best way to represent different kinds of tunnel endpoints, maybe `TunnelEndpoint` should deal with the multiplicity of tunnel types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/99)
<!-- Reviewable:end -->
