### PR TITLE
Add a vocabulary section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ preserving features. The crates having `mullvad` in their name on the other hand
   Rust crates.
 - **mullvad-daemon/** - Main Rust crate building the daemon binary.
 
+
+## Vocabulary
+
+Explanations for some common words used in the documentation and code in this repository.
+
+- **App** - This entire product (everything in this repository) is the "Mullvad VPN App", or App for
+  short.
+  - **Daemon** - Refers to the `mullvad-daemon` Rust program. This headless program exposes a
+    management interface that can be used to control the daemon
+  - **Frontend** - Term used for any program or component that connects to the daemon management
+    interface and allows a user to control the daemon.
+    - **GUI** - The Electron + React program that is a graphical frontend for the Mullvad VPN App.
+    - **CLI** - The Rust program named `mullvad` that is a terminal based frontend for the Mullvad
+      VPN app.
+
+
 ## Quirks
 
 - If you want to modify babel-configurations please note that `BABEL_ENV=development` must be used


### PR DESCRIPTION
Adding a vocabulary of common terms to the readme. My intention is that the vocabulary should include words that by themselves and without context could mean virtually anything, so we need to give them definitions in the context of our product.

We have changed words used for different components over the history of this project and both the code and the documentation is probably still wrong in many places. We also use different words when talking to each other and it can quite easily cause confusion. So my plan was to debate and discuss this vocabulary and get it merged. Then we can refer to this and try to stick to the defined words when we code and when we talk to each other.

Adding the entire team as assignees since it's important that we are all synced and up to date with what words we use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/101)
<!-- Reviewable:end -->
