### PR TITLE
Remove rustfmt 0.3.8 requirement and re-format with 0.4.1

### DIFF
--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -345,10 +345,12 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterface<T> {
 /// If it is `Ok(val)`, evaluates to `val`.
 /// If it is `Err(e)` it early returns `Box<Future>` where the future will result in `e`.
 macro_rules! try_future {
-    ($result:expr) => (match $result {
-        ::std::result::Result::Ok(val) => val,
-        ::std::result::Result::Err(e) => return Box::new(future::err(e)),
-    });
+    ($result: expr) => {
+        match $result {
+            ::std::result::Result::Ok(val) => val,
+            ::std::result::Result::Err(e) => return Box::new(future::err(e)),
+        }
+    };
 }
 
 impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for ManagementInterface<T> {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,3 @@
-required_version = "0.3.8"
-
 # Activation of features, almost objectively better ;)
 reorder_imports = true
 reorder_imported_names = true

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -32,7 +32,7 @@ pub use self::errors::*;
 
 
 #[cfg(unix)]
-lazy_static!{
+lazy_static! {
     static ref OPENVPN_DIE_TIMEOUT: Duration = Duration::from_secs(2);
 }
 


### PR DESCRIPTION
Turned out the `required_version` was an exact requirement, not a lower bound. So having to maintain it became a burden. Travis will make sure we always use the latest anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/103)
<!-- Reviewable:end -->
