### PR TITLE
Format code with newer rustfmt

### DIFF
--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -1,5 +1,5 @@
-use {Command, Result};
 use clap;
+use {Command, Result};
 
 use mullvad_types::account::{AccountData, AccountToken};
 use rpc;

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -1,6 +1,6 @@
-use {Command, Result};
 use clap;
 use rpc;
+use {Command, Result};
 
 pub struct Lan;
 

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -1,6 +1,6 @@
-use {Command, Result, ResultExt};
 use clap;
 use std::str::FromStr;
+use {Command, Result, ResultExt};
 
 use mullvad_types::CustomTunnelEndpoint;
 use mullvad_types::relay_constraints::{Constraint, LocationConstraint, OpenVpnConstraints,

--- a/mullvad-cli/src/cmds/shutdown.rs
+++ b/mullvad-cli/src/cmds/shutdown.rs
@@ -1,5 +1,5 @@
-use {Command, Result};
 use clap;
+use {Command, Result};
 
 use rpc;
 

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -1,5 +1,5 @@
-use {Command, Result};
 use clap;
+use {Command, Result};
 
 use rpc;
 use talpid_types::net::{OpenVpnTunnelOptions, TunnelOptions};

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -20,8 +20,8 @@ extern crate serde;
 extern crate talpid_ipc;
 extern crate talpid_types;
 
-mod rpc;
 mod cmds;
+mod rpc;
 
 
 use std::io;

--- a/mullvad-cli/src/rpc.rs
+++ b/mullvad-cli/src/rpc.rs
@@ -1,5 +1,5 @@
-use {Result, ResultExt};
 use serde;
+use {Result, ResultExt};
 
 use std::fs::{File, Metadata};
 use std::io::{BufRead, BufReader};

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -47,8 +47,8 @@ mod geoip;
 mod logging;
 mod management_interface;
 mod relays;
-mod rpc_uniqueness_check;
 mod rpc_address_file;
+mod rpc_uniqueness_check;
 mod settings;
 mod shutdown;
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1,9 +1,9 @@
 use error_chain;
 
 use error_chain::ChainedError;
-use jsonrpc_core::{Error, ErrorCode, MetaIoHandler, Metadata};
-use jsonrpc_core::futures::{future, sync, Future};
 use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
+use jsonrpc_core::futures::{future, sync, Future};
+use jsonrpc_core::{Error, ErrorCode, MetaIoHandler, Metadata};
 use jsonrpc_macros::pubsub;
 use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, SubscriptionId};
 use jsonrpc_ws_server;
@@ -19,8 +19,8 @@ use serde;
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::sync::{Arc, Mutex, RwLock};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 use talpid_core::mpsc::IntoSender;
 use talpid_ipc;
 use talpid_types::net::TunnelOptions;

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -19,8 +19,8 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-use rand::{self, Rng, ThreadRng};
 use rand::distributions::{IndependentSample, Range};
+use rand::{self, Rng, ThreadRng};
 use tokio_timer::{TimeoutError, Timer};
 
 

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -1,9 +1,9 @@
-use futures::{future, Future, Stream};
 use futures::sync::{mpsc, oneshot};
+use futures::{future, Future, Stream};
 
 use hyper;
-use hyper::{Request, StatusCode, Uri};
 use hyper::client::Client;
+use hyper::{Request, StatusCode, Uri};
 use hyper_tls::HttpsConnector;
 use native_tls;
 

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 use std::process::ExitStatus;
-use std::sync::{mpsc, Arc};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 


### PR DESCRIPTION
Ok, so travis started failing because of newer rustfmt. Here I just corrected formatting. Rustfmt finally sorts `use` and `mod` :yay:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/106)
<!-- Reviewable:end -->
