### PR TITLE
Default to empty RelayList if reading from file fails

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -229,7 +229,7 @@ impl Daemon {
         let rpc_handle = rpc_handle.chain_err(|| "Unable to create RPC client")?;
         let http_handle = http_handle.chain_err(|| "Unable to create HTTP client")?;
 
-        let relay_selector = Self::create_relay_selector(rpc_handle.clone(), &resource_dir)?;
+        let relay_selector = Self::create_relay_selector(rpc_handle.clone(), &resource_dir);
 
         let (tx, rx) = mpsc::channel();
         let management_interface_broadcaster =
@@ -266,9 +266,8 @@ impl Daemon {
     fn create_relay_selector(
         rpc_handle: mullvad_rpc::HttpHandle,
         resource_dir: &Path,
-    ) -> Result<relays::RelaySelector> {
-        let mut relay_selector = relays::RelaySelector::new(rpc_handle, &resource_dir)
-            .chain_err(|| "Unable to initialize relay list cache")?;
+    ) -> relays::RelaySelector {
+        let mut relay_selector = relays::RelaySelector::new(rpc_handle, &resource_dir);
         if let Ok(elapsed) = relay_selector.get_last_updated().elapsed() {
             if elapsed > *MAX_RELAY_CACHE_AGE {
                 if let Err(e) = relay_selector.update(*RELAY_CACHE_UPDATE_TIMEOUT) {
@@ -276,7 +275,7 @@ impl Daemon {
                 }
             }
         }
-        Ok(relay_selector)
+        relay_selector
     }
 
     // Starts the management interface and spawns a thread that will process it.

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -10,6 +10,14 @@ pub struct RelayList {
     pub countries: Vec<RelayListCountry>,
 }
 
+impl RelayList {
+    pub fn empty() -> Self {
+        Self {
+            countries: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RelayListCountry {
     pub name: String,


### PR DESCRIPTION
This is a suggestion. I'm not 100% convinced myself that this is the best solution yet though. The problem I'm trying to solve is that requiring `relays.json` to be present in the exe dir when running makes it slightly harder to do development. Also there is some proposed code that creates this file in unit tests, which is harder than I feel it should have to be.

So I implemented this change. That does not require a `relays.json` in the install dir any longer. If it fails finding it (and no cache file) it now, instead of returns an error, returns an empty relay list (reasonable default) and the Unix epoch as it's made up modification time (stand in for "really old cache")

I will add it to the changelog if you think this is a change that should be merged.

This is what the daemon prints on start with this new code if both the cache and the install dir relays are missing:
```
[2018-03-27 10:13:15.624][mullvad_daemon::relays][DEBUG] Trying to read relays cache from /root/.cache/mullvad-daemon/relays.json
[2018-03-27 10:13:15.624][mullvad_daemon::relays][DEBUG] Trying to read relays cache from /home/user/src/mullvadvpn-app/target/debug/relays.json
[2018-03-27 10:13:15.625][mullvad_daemon::relays][ERROR] Error: Unable to load cached relays
Caused by: Error with relay cache on disk
Caused by: No such file or directory (os error 2)

[2018-03-27 10:13:15.625][mullvad_daemon::relays][INFO] Initialized with 0 cached relays from 1970-01-01 01:00:00.000
[2018-03-27 10:13:15.626][mullvad_daemon::relays][INFO] Downloading list of relays...
[2018-03-27 10:13:16.583][mullvad_daemon::relays][INFO] Downloaded relay inventory has 178 relays
```

Checklist for a PR:

* [ ] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/107)
<!-- Reviewable:end -->
