### PR TITLE
Switch to global windows temp directory on windows

### DIFF
--- a/mullvad-cli/src/rpc.rs
+++ b/mullvad-cli/src/rpc.rs
@@ -40,7 +40,10 @@ lazy_static! {
 #[cfg(not(unix))]
 lazy_static! {
     /// The path to the file where we read the RPC address
-    static ref RPC_ADDRESS_FILE_PATH: PathBuf = ::std::env::temp_dir().join(".mullvad_rpc_address");
+    static ref RPC_ADDRESS_FILE_PATH: PathBuf = {
+        let windows_directory = ::std::env::var_os("WINDIR").unwrap();
+        PathBuf::from(windows_directory).join("Temp").join(".mullvad_rpc_address")
+    };
 }
 
 fn read_rpc_address() -> Result<(String, String)> {

--- a/mullvad-daemon/src/rpc_address_file.rs
+++ b/mullvad-daemon/src/rpc_address_file.rs
@@ -24,7 +24,10 @@ lazy_static! {
 #[cfg(not(unix))]
 lazy_static! {
     /// The path to the file where we write the RPC connection info
-    static ref RPC_ADDRESS_FILE_PATH: PathBuf = ::std::env::temp_dir().join(".mullvad_rpc_address");
+    static ref RPC_ADDRESS_FILE_PATH: PathBuf = {
+        let windows_directory = ::std::env::var_os("WINDIR").unwrap();
+        PathBuf::from(windows_directory).join("Temp").join(".mullvad_rpc_address")
+    };
 }
 
 

--- a/mullvad-daemon/tests/common/mod.rs
+++ b/mullvad-daemon/tests/common/mod.rs
@@ -35,7 +35,10 @@ mod platform_specific {
     pub static DAEMON_EXECUTABLE_PATH: &str = r"..\target\debug\mullvad-daemon.exe";
 
     pub fn rpc_file_path() -> PathBuf {
-        ::std::env::temp_dir().join(".mullvad_rpc_address")
+        let windows_directory = ::std::env::var_os("WINDIR").unwrap();
+        PathBuf::from(windows_directory)
+            .join("Temp")
+            .join(".mullvad_rpc_address")
     }
 }
 


### PR DESCRIPTION
Checklist for a PR:

* [ ] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

Changes current rpc file location to `C:\Windows\Temp` (`C:\Windows` part is obtained via environment variable `WINDIR`) instead of `std::env::temp_dir()` which often refers to local temp directory and is inconsistent when running the daemon under different users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/116)
<!-- Reviewable:end -->
