### PR TITLE
Make default state in wfpctl permit network comms

### DIFF
--- a/wfpctl/src/extras/cli/commands/wfpctl/policy.cpp
+++ b/wfpctl/src/extras/cli/commands/wfpctl/policy.cpp
@@ -55,6 +55,12 @@ Policy::Policy(MessageSink messageSink)
 
 	m_dispatcher.addSubcommand
 	(
+		L"netblocked",
+		std::bind(&Policy::processNetBlocked, this)
+	);
+
+	m_dispatcher.addSubcommand
+	(
 		L"reset",
 		std::bind(&Policy::processReset, this)
 	);
@@ -137,6 +143,15 @@ void Policy::processConnected(const KeyValuePairs &arguments)
 		GetArgumentValue(arguments, L"tunnel").c_str(),
 		GetArgumentValue(arguments, L"dns").c_str()
 	);
+
+	m_messageSink((success
+		? L"Successfully applied policy."
+		: L"Failed to apply policy."));
+}
+
+void Policy::processNetBlocked()
+{
+	auto success = Wfpctl_ApplyPolicyNetBlocked();
 
 	m_messageSink((success
 		? L"Successfully applied policy."

--- a/wfpctl/src/extras/cli/commands/wfpctl/policy.h
+++ b/wfpctl/src/extras/cli/commands/wfpctl/policy.h
@@ -28,6 +28,7 @@ private:
 
 	void processConnecting(const KeyValuePairs &arguments);
 	void processConnected(const KeyValuePairs &arguments);
+	void processNetBlocked();
 	void processReset();
 };
 

--- a/wfpctl/src/wfpctl/wfpcontext.h
+++ b/wfpctl/src/wfpctl/wfpcontext.h
@@ -15,8 +15,11 @@ public:
 
 	bool applyPolicyConnecting(const WfpctlSettings &settings, const WfpctlRelay &relay);
 	bool applyPolicyConnected(const WfpctlSettings &settings, const WfpctlRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *primaryDns);
+	bool applyPolicyNetBlocked();
 
 	bool reset();
+
+	using Ruleset = std::vector<std::unique_ptr<rules::IFirewallRule> >;
 
 private:
 
@@ -24,10 +27,6 @@ private:
 	WfpContext &operator=(const WfpContext &) = delete;
 
 	bool applyBaseConfiguration();
-
-	using Ruleset = std::vector<std::unique_ptr<rules::IFirewallRule> >;
-
-	void appendSettingsRules(Ruleset &ruleset, const WfpctlSettings &settings);
 	bool applyRuleset(const Ruleset &ruleset);
 
 	std::unique_ptr<SessionController> m_sessionController;

--- a/wfpctl/src/wfpctl/wfpctl.cpp
+++ b/wfpctl/src/wfpctl/wfpctl.cpp
@@ -147,6 +147,36 @@ Wfpctl_ApplyPolicyConnected(
 WFPCTL_LINKAGE
 bool
 WFPCTL_API
+Wfpctl_ApplyPolicyNetBlocked(
+)
+{
+	if (nullptr == g_wfpContext)
+	{
+		return false;
+	}
+
+	try
+	{
+		return g_wfpContext->applyPolicyNetBlocked();
+	}
+	catch (std::exception &err)
+	{
+		if (nullptr != g_ErrorSink)
+		{
+			g_ErrorSink(err.what(), g_ErrorContext);
+		}
+
+		return false;
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+WFPCTL_LINKAGE
+bool
+WFPCTL_API
 Wfpctl_Reset()
 {
 	if (nullptr == g_wfpContext)

--- a/wfpctl/src/wfpctl/wfpctl.def
+++ b/wfpctl/src/wfpctl/wfpctl.def
@@ -1,7 +1,9 @@
 LIBRARY wfpctl
 EXPORTS
-            Wfpctl_ApplyPolicyConnected
-            Wfpctl_ApplyPolicyConnecting
-            Wfpctl_Deinitialize
-            Wfpctl_Initialize
-            Wfpctl_Reset
+
+Wfpctl_Initialize
+Wfpctl_Deinitialize
+Wfpctl_ApplyPolicyConnecting
+Wfpctl_ApplyPolicyConnected
+Wfpctl_ApplyPolicyNetBlocked
+Wfpctl_Reset

--- a/wfpctl/src/wfpctl/wfpctl.h
+++ b/wfpctl/src/wfpctl/wfpctl.h
@@ -86,7 +86,7 @@ Wfpctl_Deinitialize();
 //
 // ApplyPolicyConnecting:
 //
-// Apply restrictions in the firewall that blocks all traffic, except:
+// Apply restrictions in the firewall that block all traffic, except:
 // - What is specified by settings
 // - Communication with the relay server
 //
@@ -102,7 +102,7 @@ Wfpctl_ApplyPolicyConnecting(
 //
 // ApplyPolicyConnected:
 //
-// Apply restrictions in the firewall that blocks all traffic, except:
+// Apply restrictions in the firewall that block all traffic, except:
 // - What is specified by settings
 // - Communication with the relay server
 // - Non-DNS traffic inside the VPN tunnel
@@ -124,6 +124,18 @@ Wfpctl_ApplyPolicyConnected(
 	const WfpctlRelay &relay,
 	const wchar_t *tunnelInterfaceAlias,
 	const wchar_t *primaryDns
+);
+
+//
+// ApplyPolicyNetBlocked:
+//
+// Apply restrictions in the firewall that block all traffic.
+//
+extern "C"
+WFPCTL_LINKAGE
+bool
+WFPCTL_API
+Wfpctl_ApplyPolicyNetBlocked(
 );
 
 //


### PR DESCRIPTION
When moving the net blocking code into an explicit policy, I did not want to call it just "Blocked". The other policies are named with the app in mind, so calling the new policy "Blocked" would imply that it's blocking the app?

I would prefer to rename the other policies to "AppConnecting" and "AppConnected", but this is not a priority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/122)
<!-- Reviewable:end -->
