### PR TITLE
Add flag to allow not printing timestamps to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 - Daemon now fetches latest app versions and verifies whether the current
   version is supported.
 - Add `version` subcommand in the CLI to show information about current versions.
+- Add a flag to daemon to print log entries to standard output without timestamps.
 
 ### Changed
 - Change all occurrences of "MullvadVPN" into "Mullvad VPN", this affects

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub tunnel_log_file: Option<PathBuf>,
     pub resource_dir: Option<PathBuf>,
     pub require_auth: bool,
+    pub log_stdout_timestamps: bool,
 }
 
 pub fn get_config() -> Config {
@@ -26,6 +27,7 @@ pub fn get_config() -> Config {
     let tunnel_log_file = matches.value_of_os("tunnel_log_file").map(PathBuf::from);
     let resource_dir = matches.value_of_os("resource_dir").map(PathBuf::from);
     let require_auth = !matches.is_present("disable_rpc_auth");
+    let log_stdout_timestamps = !matches.is_present("disable_stdout_timestamps");
 
     Config {
         log_level,
@@ -33,6 +35,7 @@ pub fn get_config() -> Config {
         tunnel_log_file,
         resource_dir,
         require_auth,
+        log_stdout_timestamps,
     }
 }
 
@@ -73,4 +76,9 @@ fn create_app() -> App<'static, 'static> {
                 .long("disable-rpc-auth")
                 .help("Don't require authentication on the RPC management interface."),
         )
+        .arg(
+            Arg::with_name("disable_stdout_timestamps")
+            .long("disable-stdout-timestamps")
+            .help("Don't log timestamps when logging to stdout, useful when running as a systemd service")
+            )
 }

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -40,24 +40,36 @@ const COLORS: ColoredLevelConfig = ColoredLevelConfig {
     trace: Color::Black,
 };
 
-pub const DATE_TIME_FORMAT_STR: &str = "%Y-%m-%d %H:%M:%S%.3f";
+pub const DATE_TIME_FORMAT_STR: &str = "[%Y-%m-%d %H:%M:%S%.3f]";
 
-pub fn init_logger(log_level: log::LevelFilter, log_file: Option<&PathBuf>) -> Result<()> {
+pub fn init_logger(
+    log_level: log::LevelFilter,
+    log_file: Option<&PathBuf>,
+    output_timestamp: bool,
+) -> Result<()> {
     let mut top_dispatcher = fern::Dispatch::new().level(log_level);
     for silenced_crate in SILENCED_CRATES {
         top_dispatcher = top_dispatcher.level_for(*silenced_crate, log::LevelFilter::Warn);
     }
 
+    let stdout_formatter = Formatter {
+        output_timestamp: output_timestamp,
+        output_color: true,
+    };
     let stdout_dispatcher = fern::Dispatch::new()
-        .format(move |out, message, record| format_log_message(out, message, record, true))
+        .format(move |out, message, record| stdout_formatter.output_msg(out, message, record))
         .chain(io::stdout());
     top_dispatcher = top_dispatcher.chain(stdout_dispatcher);
 
     if let Some(ref log_file) = log_file {
+        let file_formatter = Formatter {
+            output_timestamp: true,
+            output_color: false,
+        };
         let f = fern::log_file(log_file)
             .chain_err(|| ErrorKind::WriteFileError(log_file.to_path_buf()))?;
         let file_dispatcher = fern::Dispatch::new()
-            .format(|out, message, record| format_log_message(out, message, record, false))
+            .format(move |out, message, record| file_formatter.output_msg(out, message, record))
             .chain(f);
         top_dispatcher = top_dispatcher.chain(file_dispatcher);
     }
@@ -65,28 +77,41 @@ pub fn init_logger(log_level: log::LevelFilter, log_file: Option<&PathBuf>) -> R
     Ok(())
 }
 
-fn format_log_message(
-    out: fern::FormatCallback,
-    message: &fmt::Arguments,
-    record: &log::Record,
-    color_output: bool,
-) {
-    let timestamp = chrono::Local::now().format(DATE_TIME_FORMAT_STR);
-    if color_output && cfg!(not(windows)) {
+#[derive(Default, Debug)]
+struct Formatter {
+    pub output_timestamp: bool,
+    pub output_color: bool,
+}
+
+impl Formatter {
+    fn get_timetsamp_fmt(&self) -> &str {
+        if self.output_timestamp {
+            DATE_TIME_FORMAT_STR
+        } else {
+            &""
+        }
+    }
+
+    fn get_record_level(&self, level: log::Level) -> Box<fmt::Display> {
+        if self.output_color && cfg!(not(windows)) {
+            Box::new(COLORS.color(level))
+        } else {
+            Box::new(level)
+        }
+    }
+
+    pub fn output_msg(
+        &self,
+        out: fern::FormatCallback,
+        message: &fmt::Arguments,
+        record: &log::Record,
+    ) {
         out.finish(format_args!(
-            "[{}][{}][{}] {}",
-            timestamp,
+            "{}[{}][{}] {}",
+            chrono::Local::now().format(self.get_timetsamp_fmt()),
             record.target(),
-            COLORS.color(record.level()),
+            self.get_record_level(record.level()),
             message,
-        ))
-    } else {
-        out.finish(format_args!(
-            "[{}][{}][{}] {}",
-            timestamp,
-            record.target(),
-            record.level(),
-            message
         ))
     }
 }

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -849,8 +849,11 @@ quick_main!(run);
 
 fn run() -> Result<()> {
     let config = cli::get_config();
-    logging::init_logger(config.log_level, config.log_file.as_ref())
-        .chain_err(|| "Unable to initialize logger")?;
+    logging::init_logger(
+        config.log_level,
+        config.log_file.as_ref(),
+        config.log_stdout_timestamps,
+    ).chain_err(|| "Unable to initialize logger")?;
     log_version();
 
     if !running_as_admin() {


### PR DESCRIPTION
Add a flag to daemon to print log entries to standard output without timestamps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/128)
<!-- Reviewable:end -->
