### PR TITLE
Upgrade rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         # Install and run rustfmt on nightly only until rustfmt.toml settings are stabilized.
         - rustup component add rustfmt-preview
         - rustfmt --version
-        - cargo fmt -- --write-mode=diff
+        - cargo fmt -- --write-mode=diff --unstable-features
 
     - language: rust
       rust: beta

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,4 @@
 # Activation of features, almost objectively better ;)
-reorder_imports = true
-reorder_imported_names = true
-reorder_imports_in_group = true
 use_try_shorthand = true
 condense_wildcard_suffixes = true
 normalize_comments = true


### PR DESCRIPTION
Saw in a Travis build for one of your PRs that rustfmt complained about an invalid rustfmt option. I looked it up and both `reorder_imported_names` and `reorder_imports_in_group` don't exist any more. Also `reorder_imports` is now `true` by default, so no need to set it. I guess the more specific `reorder_imports_*` settings are now automatically activated by the more generic `reorder_imports` setting.

Then I also added `--unstable-features` to the formatting arguments. My understanding is that otherwise it will ignore the unstable features we have active in our config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/130)
<!-- Reviewable:end -->
