### PR TITLE
Add transform-builtin-extend babel plugin to allow extending Error class

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,10 +2,10 @@
   "env": {
     "electron": {
       "presets": ["es2015", "stage-0", "react"],
-      "plugins": ["transform-runtime", "inline-react-svg"]
+      "plugins": ["transform-runtime", "inline-react-svg", ["babel-plugin-transform-builtin-extend", { "globals": ["Error"] }]]
     },
     "development": {
-      "presets": ["react-native"]
+      "presets": ["react-native", ["babel-plugin-transform-builtin-extend", { "globals": ["Error"] }]]
     }
   }
 }

--- a/app/lib/backend.js
+++ b/app/lib/backend.js
@@ -40,6 +40,8 @@ export class BackendError extends Error {
 
   static localizedMessage(type: ErrorType, cause: ?Error): string {
 
+    // TODO: since instanceof now works, BackendError can be replaced by a set
+    // of specific error types
     switch(type) {
     case 'NO_CREDIT':
       return 'Buy more time, so you can continue using the internet securely';

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "repository": "https://github.com/mullvad/mullvadvpn-app",
   "license": "GPL-3.0",
   "dependencies": {
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-runtime": "^6.22.0",
     "d3-geo-projection": "^2.3.2",
     "electron-log": "^2.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,6 +749,13 @@ babel-plugin-transform-async-to-generator@^6.24.1:
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-builtin-extend@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz#5e96fecf58b8fa1ed74efcad88475b2af3c9116e"
+  dependencies:
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
+
 babel-plugin-transform-class-constructor-call@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz#80dc285505ac067dcb8d6c65e2f6f11ab7765ef9"
@@ -1236,14 +1243,14 @@ babel-register@^6.24.1, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.15.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.15.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:


### PR DESCRIPTION
The root cause for not displaying the window on startup when the app can't _autologin_ is that the error handling code was trying to assert `e instanceof BackendError` before displaying the window. Since `BackendError` extends `Error`, by default any instance of `BackendError` will have the class metadata of `Error`, or so I understand it. To fix this, I've added a babel plugins that enables the behaviour we expect, as instructed by @pronebird.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/134)
<!-- Reviewable:end -->
