### PR TITLE
Move api ip to global and some simplification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.3.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "jsonrpc-client-http 0.3.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-types 0.1.0",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -411,7 +411,7 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
             .and_then(|rpc_future| {
                 rpc_future.map_err(|error: mullvad_rpc::Error| {
                     error!(
-                        "Unable to get account data from master: {}",
+                        "Unable to get account data from API: {}",
                         error.display_chain()
                     );
                     Self::map_rpc_error(error)
@@ -621,7 +621,7 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
             .and_then(|version_future| {
                 version_future.map_err(|error| {
                     error!(
-                        "Unable to get version data from master: {}",
+                        "Unable to get version data from API: {}",
                         error.display_chain()
                     );
                     Self::map_rpc_error(error)

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -11,6 +11,7 @@ error-chain = "0.11"
 futures = "0.1.15"
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs" }
 jsonrpc-client-http = { git = "https://github.com/mullvad/jsonrpc-client-rs" }
+lazy_static = "1.0"
 serde_json = "1.0"
 tokio-core = "0.1"
 hyper = "0.11"

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -14,11 +14,7 @@ mod win {
             _ => panic!("uncrecognized target: {}", target),
         };
 
-        let mut lib_dir = manifest_dir();
-        lib_dir.push(WFP_BUILD_DIR);
-        lib_dir.push(&target_dir);
-
-        lib_dir
+        manifest_dir().join(WFP_BUILD_DIR).join(&target_dir)
     }
 
     fn manifest_dir() -> PathBuf {


### PR DESCRIPTION
This PR does a few things.

* Avoid having a variable `mut` when just building it immutably worked
* Remove all mentions of the word "master". This is an old term and I don't think we should have it in this code base. I prefer to refer to our API as just the "api" or "Mullvad api".
* Move the hardcoded API IP to a global constant right next to the domain name. In order to make it more visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/143)
<!-- Reviewable:end -->
