### PR TITLE
Filter out obviously invalid API IPs from DNS results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Line wrap the file at 100 chars.                                              Th
   version is supported.
 - Add `version` subcommand in the CLI to show information about current versions.
 - Add a flag to daemon to print log entries to standard output without timestamps.
+- Filter out and ignore DNS lookup results for api.mullvad.net that are bogus (private etc.)
 
 ### Changed
 - Change all occurrences of "MullvadVPN" into "Mullvad VPN", this affects


### PR DESCRIPTION
Censoring can sometimes be very primitive. There are known cases where DNS is poisoned with private IPs. So to work around that we ignore any DNS lookup results for `api.mullvad.net` that are obviously not correct (being private, unspecified or loopback)

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/144)
<!-- Reviewable:end -->
