### PR TITLE
Only allow a single instance of the front-end

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -555,4 +555,22 @@ const appDelegate = {
 
 };
 
+try {
+  // This callback is guaranteed to be excuted after 'ready' events have been
+  // sent to the app.
+  const notFirstInstance = app.makeSingleInstance((_args, _workingDirectory) => {
+    log.debug('Another instance was spawned, showing window');
+    const window = appDelegate._window;
+    if (window != null) {
+      appDelegate._showWindow(window, appDelegate._tray);
+    }
+  });
+
+  if (notFirstInstance) {
+    log.info('Another instance already exists, shutting down');
+    app.exit();
+  }
+} catch (e) {
+  log.error('Failed to check if another instance is running: ', e);
+}
 appDelegate.setup();


### PR DESCRIPTION
I've added a callback and a guard on startup of the frontend app to ensure that only a single instance of the front end is ever run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/147)
<!-- Reviewable:end -->
