### PR TITLE
Add usage of credentials to Mullvad RPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix OpenVPN warning about usage of AES-256-CBC cipher.
 - Fix "Out of time" screen status icon position.
 - Fix log newline characters on Windows.
+- Mullvad CLI can now be used with daemon instance that doesn't have the `--disable-rpc-auth`
+  flag set.
 
 
 ## [2018.1] - 2018-03-01

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -50,7 +50,7 @@ impl Command for Account {
 
 impl Account {
     fn set(&self, token: Option<AccountToken>) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         rpc.set_account(token.clone())?;
         if let Some(token) = token {
             println!("Mullvad account \"{}\" set", token);
@@ -61,7 +61,7 @@ impl Account {
     }
 
     fn get(&self) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         let account_token = rpc.get_account()?;
         if let Some(account_token) = account_token {
             println!("Mullvad account: {}", account_token);

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -17,7 +17,7 @@ impl Command for Connect {
     }
 
     fn run(&self, _matches: &clap::ArgMatches) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         rpc.connect()?;
         Ok(())
     }

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -17,7 +17,7 @@ impl Command for Disconnect {
     }
 
     fn run(&self, _matches: &clap::ArgMatches) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         rpc.disconnect()?;
         Ok(())
     }

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -43,14 +43,14 @@ impl Command for Lan {
 
 impl Lan {
     fn set(&self, allow_lan: bool) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         rpc.set_allow_lan(allow_lan)?;
         println!("Changed local network sharing setting");
         Ok(())
     }
 
     fn get(&self) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         let allow_lan = rpc.get_allow_lan()?;
         println!(
             "Local network sharing setting: {}",

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -3,12 +3,14 @@ use std::str::FromStr;
 use {Command, Result, ResultExt};
 
 use mullvad_ipc_client::DaemonRpcClient;
-use mullvad_types::relay_constraints::{Constraint, LocationConstraint, OpenVpnConstraints,
-                                       RelayConstraintsUpdate, RelaySettingsUpdate,
-                                       TunnelConstraints};
+use mullvad_types::relay_constraints::{
+    Constraint, LocationConstraint, OpenVpnConstraints, RelayConstraintsUpdate,
+    RelaySettingsUpdate, TunnelConstraints,
+};
 use mullvad_types::CustomTunnelEndpoint;
-use talpid_types::net::{OpenVpnEndpointData, TransportProtocol, TunnelEndpointData,
-                        WireguardEndpointData};
+use talpid_types::net::{
+    OpenVpnEndpointData, TransportProtocol, TunnelEndpointData, WireguardEndpointData,
+};
 
 pub struct Relay;
 
@@ -113,7 +115,7 @@ impl Command for Relay {
 
 impl Relay {
     fn update_constraints(&self, update: RelaySettingsUpdate) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         rpc.update_relay_settings(update)?;
         println!("Relay constraints updated");
         Ok(())
@@ -183,7 +185,7 @@ impl Relay {
     }
 
     fn get(&self) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         let constraints = rpc.get_relay_settings()?;
         println!("Current constraints: {:#?}", constraints);
 
@@ -191,7 +193,7 @@ impl Relay {
     }
 
     fn list(&self, _matches: &clap::ArgMatches) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         let mut locations = rpc.get_relay_locations()?;
         locations.countries.sort_by(|c1, c2| c1.name.cmp(&c2.name));
         for mut country in locations.countries {

--- a/mullvad-cli/src/cmds/shutdown.rs
+++ b/mullvad-cli/src/cmds/shutdown.rs
@@ -15,7 +15,7 @@ impl Command for Shutdown {
     }
 
     fn run(&self, _matches: &clap::ArgMatches) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         rpc.shutdown()?;
         Ok(())
     }

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -17,7 +17,7 @@ impl Command for Status {
     }
 
     fn run(&self, _matches: &clap::ArgMatches) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         let state = rpc.get_state()?;
         print!("Tunnel status: ");
         match (state.state, state.target_state) {

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -71,7 +71,7 @@ impl Tunnel {
                 Some(mssfix_str.parse()?)
             };
 
-            let rpc = DaemonRpcClient::new()?;
+            let mut rpc = DaemonRpcClient::new()?;
             rpc.set_openvpn_mssfix(mssfix)?;
             println!("mssfix parameter updated");
             Ok(())
@@ -81,7 +81,7 @@ impl Tunnel {
     }
 
     fn get_tunnel_options() -> Result<TunnelOptions> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         Ok(rpc.get_tunnel_options()?)
     }
 

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -16,7 +16,7 @@ impl Command for Version {
     }
 
     fn run(&self, _: &clap::ArgMatches) -> Result<()> {
-        let rpc = DaemonRpcClient::new()?;
+        let mut rpc = DaemonRpcClient::new()?;
         let current_version = rpc.get_current_version()?;
         println!("Current version: {}", current_version);
         let version_info = rpc.get_version_info()?;

--- a/mullvad-daemon/src/rpc_uniqueness_check.rs
+++ b/mullvad-daemon/src/rpc_uniqueness_check.rs
@@ -9,7 +9,7 @@ use mullvad_ipc_client::DaemonRpcClient;
 /// other daemon has stopped.
 pub fn is_another_instance_running() -> bool {
     match DaemonRpcClient::new() {
-        Ok(client) => match client.get_state() {
+        Ok(mut client) => match client.get_state() {
             Ok(_) => true,
             Err(error) => {
                 let chained_error = error.chain_err(|| {

--- a/mullvad-daemon/tests/common/mod.rs
+++ b/mullvad-daemon/tests/common/mod.rs
@@ -99,7 +99,7 @@ impl DaemonRunner {
     fn request_clean_shutdown(&mut self, _: &mut duct::Handle) -> bool {
         use self::mullvad_ipc_client::DaemonRpcClient;
 
-        if let Ok(rpc_client) = DaemonRpcClient::new() {
+        if let Ok(mut rpc_client) = DaemonRpcClient::new() {
             rpc_client.shutdown().is_ok()
         } else {
             false

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -95,6 +95,10 @@ impl DaemonRpcClient {
             .chain_err(|| ErrorKind::ReadRpcFileError(file_path_string()))
     }
 
+    pub fn auth(&self, credentials: &str) -> Result<()> {
+        self.call("auth", &[credentials])
+    }
+
     pub fn connect(&self) -> Result<()> {
         self.call("connect", &NO_ARGS)
     }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -168,7 +168,7 @@ impl DaemonRpcClient {
         A: Serialize,
         O: for<'de> Deserialize<'de>,
     {
-        let mut rpc_client = WsIpcClient::connect(self.address.clone())
+        let mut rpc_client = WsIpcClient::connect(&self.address)
             .chain_err(|| ErrorKind::StartRpcClient(self.address.clone()))?;
 
         rpc_client

--- a/talpid-ipc/src/client.rs
+++ b/talpid-ipc/src/client.rs
@@ -180,8 +180,8 @@ pub struct WsIpcClient {
 }
 
 impl WsIpcClient {
-    pub fn connect(server_id: ::IpcServerId) -> Result<Self> {
-        let url = url::Url::parse(&server_id).chain_err(|| "Unable to parse server_id as url")?;
+    pub fn connect(server_id: &::IpcServerId) -> Result<Self> {
+        let url = url::Url::parse(server_id).chain_err(|| "Unable to parse server_id as url")?;
         let active_request = Arc::new(Mutex::new(None));
         let sender = Self::open_websocket(url, active_request.clone())?;
 

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -36,7 +36,7 @@ fn can_call_rpcs_on_server() {
 
     let (server, rx) = create_server();
     let server_id = server.address().to_owned();
-    let mut client = create_client(server_id);
+    let mut client = create_client(&server_id);
 
     let _result: () = client.call("foo", &[97]).unwrap();
     assert_eq!(Ok(97), rx.recv_timeout(Duration::from_millis(500)));
@@ -51,12 +51,12 @@ fn can_call_rpcs_on_server() {
 #[test]
 #[should_panic]
 fn ipc_client_invalid_url() {
-    create_client("INVALID ID".to_owned());
+    create_client(&"INVALID ID".to_owned());
 }
 
 #[test]
 fn ipc_client_bad_connection() {
-    let mut client = create_client("ws://127.0.0.1:9876".to_owned());
+    let mut client = create_client(&"ws://127.0.0.1:9876".to_owned());
     let result: Result<(), _> = client.call("invalid_method", &[0]);
     assert_matches!(result, Err(_));
 }
@@ -71,6 +71,6 @@ fn create_server() -> (talpid_ipc::IpcServer, mpsc::Receiver<i64>) {
     (server, rx)
 }
 
-fn create_client(id: talpid_ipc::IpcServerId) -> talpid_ipc::WsIpcClient {
+fn create_client(id: &talpid_ipc::IpcServerId) -> talpid_ipc::WsIpcClient {
     talpid_ipc::WsIpcClient::connect(id).unwrap()
 }

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -66,7 +66,7 @@ fn openvpn_open(
 
     let core_server_id = parse_args(&args)?;
     info!("Connecting back to talpid core at {}", core_server_id);
-    let processor = EventProcessor::new(core_server_id).chain_err(|| ErrorKind::InitHandleFailed)?;
+    let processor = EventProcessor::new(&core_server_id).chain_err(|| ErrorKind::InitHandleFailed)?;
 
     Ok((INTERESTING_EVENTS.to_vec(), processor))
 }

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -18,7 +18,7 @@ pub struct EventProcessor {
 }
 
 impl EventProcessor {
-    pub fn new(server_id: IpcServerId) -> Result<EventProcessor> {
+    pub fn new(server_id: &IpcServerId) -> Result<EventProcessor> {
         trace!("Creating EventProcessor");
         let ipc_client =
             WsIpcClient::connect(server_id).chain_err(|| "Unable to create IPC client")?;


### PR DESCRIPTION
This PR updates `mullvad-ipc-client` to reuse the WebSocket JSON-RPC connection and to attempt to authenticate the connection using the credentials read from the Mullvad RPC information file.

The CLI is updated to use mutable instances of the `DaemonRpcClient`, but its the changes inside `DaemonRpcClient` that now allow `mullvad-cli` to connect to a daemon using credentials. The same is true for the integration tests and the daemon instance when it tries to connect to itself.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/155)
<!-- Reviewable:end -->
