### PR TITLE
Update problem report log paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix log newline characters on Windows.
 - Mullvad CLI can now be used with daemon instance that doesn't have the `--disable-rpc-auth`
   flag set.
+- Place log files in a directory where the GUI running as a non-privileged user can access.
 
 
 ## [2018.1] - 2018-03-01

--- a/app/main.js
+++ b/app/main.js
@@ -81,9 +81,11 @@ const appDelegate = {
     case 'darwin':
       // macOS: ~/Library/Logs/{appname}
       return path.join(app.getPath('home'), 'Library/Logs', appDirectoryName);
+    case 'win32':
+      // Windows: %ALLUSERSPROFILE%\{appname}
+      return path.join(process.env.ALLUSERSPROFILE, appDirectoryName);
     default:
       // Linux: ~/.config/{appname}/logs
-      // Windows: ~\AppData\Roaming\{appname}\logs
       return path.join(app.getPath('userData'), 'logs');
     }
   },

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -95,6 +95,10 @@ error_chain!{
         NoCacheDir {
             description("Unable to create cache directory")
         }
+        #[cfg(windows)]
+        NoLogDir {
+            description("Unable to create log directory")
+        }
         DaemonIsAlreadyRunning {
             description("Another instance of the daemon is already running")
         }

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -1,7 +1,8 @@
 #![cfg(windows)]
 
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::fs;
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
@@ -9,15 +10,17 @@ use std::{env, io, thread};
 
 use cli;
 use error_chain::ChainedError;
-use windows_service::service::{ServiceAccess, ServiceControl, ServiceControlAccept,
-                               ServiceErrorControl, ServiceExitCode, ServiceInfo,
-                               ServiceStartType, ServiceState, ServiceStatus, ServiceType};
-use windows_service::service_control_handler::{self, ServiceControlHandlerResult,
-                                               ServiceStatusHandle};
+use windows_service::service::{
+    ServiceAccess, ServiceControl, ServiceControlAccept, ServiceErrorControl, ServiceExitCode,
+    ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
+};
+use windows_service::service_control_handler::{
+    self, ServiceControlHandlerResult, ServiceStatusHandle,
+};
 use windows_service::service_dispatcher;
 use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
 
-use super::{get_resource_dir, Daemon, DaemonShutdownHandle, Result, ResultExt};
+use super::{get_resource_dir, Daemon, DaemonShutdownHandle, ErrorKind, Result, ResultExt};
 
 static SERVICE_NAME: &'static str = "MullvadVPN";
 static SERVICE_DISPLAY_NAME: &'static str = "Mullvad VPN Service";
@@ -214,21 +217,26 @@ pub fn install_service() -> Result<()> {
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)
         .chain_err(|| "Unable to connect to service manager")?;
     service_manager
-        .create_service(get_service_info(), ServiceAccess::empty())
+        .create_service(get_service_info()?, ServiceAccess::empty())
         .map(|_| ())
         .chain_err(|| "Unable to create a service")
 }
 
-fn get_service_info() -> ServiceInfo {
-    let windows_directory = ::std::env::var_os("WINDIR").unwrap();
-    let service_log_file = PathBuf::from(&windows_directory)
-        .join("Temp")
-        .join("mullvad-service.log");
-    let tunnel_log_file = PathBuf::from(&windows_directory)
-        .join("Temp")
-        .join("mullvad-openvpn.log");
+fn get_service_info() -> Result<ServiceInfo> {
+    let program_data_directory_string =
+        ::std::env::var_os("ALLUSERSPROFILE").ok_or_else(|| ErrorKind::NoLogDir)?;
+    let program_data_directory = Path::new(&program_data_directory_string);
+    let log_directory = program_data_directory.join("Mullvad VPN");
+    let service_log_file = log_directory.join("backend.log");
+    let tunnel_log_file = log_directory.join("openvpn.log");
 
-    ServiceInfo {
+    if let Err(error) = fs::create_dir(log_directory) {
+        if error.kind() != io::ErrorKind::AlreadyExists {
+            return Err(error).chain_err(|| ErrorKind::NoLogDir);
+        }
+    }
+
+    Ok(ServiceInfo {
         name: OsString::from(SERVICE_NAME),
         display_name: OsString::from(SERVICE_DISPLAY_NAME),
         service_type: SERVICE_TYPE,
@@ -245,5 +253,5 @@ fn get_service_info() -> ServiceInfo {
         ],
         account_name: None, // run as System
         account_password: None,
-    }
+    })
 }


### PR DESCRIPTION
This change moves the log files generated by the Windows service to `%ALLUSERSPROFILE%\Mullvad VPN`, which is a directory that doesn't have the same access restrictions as `%WINDIR%\Temp`.

`app-dirs` wasn't used in the Rust part of the code because the path would have been `%ALLUSERSPROFILE%\Mullvad\mullvad-daemon`, which would require changes to the GUI part. Manually creating the path seemed like the most compatible way to do it on both platforms.

Checklist for a PR:

* [*] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.
