### PR TITLE
Add a paths section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,46 @@ Explanations for some common words used in the documentation and code in this re
       VPN app.
 
 
+## File paths used by Mullvad VPN app
+
+A list of file paths written to and read from by the various components of the Mullvad VPN app
+
+### Daemon
+
+#### Settings
+
+| Platform | Path |
+|----------|------|
+| Linux | /root/.config/mullvad-daemon/settings.json |
+| macOS | ~/Library/Application Support/mullvad-daemon/settings.json |
+| Windows | C:/ProgramData/Mullvad/mullvad-daemon/settings.json |
+
+#### Logs
+
+| Platform | Path |
+|----------|------|
+| Linux | <When running as system service log is collected by syslog?> |
+| macOS | ~/Library/Logs/Mullvad VPN/ |
+| Windows | C:/ProgramData/Mullvad VPN/ |
+
+#### Cache
+
+The daemon caches relay server list and DNS lookups etc. These cache files are stored inside
+
+| Platform | Path |
+|----------|------|
+| Linux | /root/.cache/mullvad-daemon/ |
+| macOS | ~/Library/Caches/mullvad-daemon/ |
+| Windows | C:/ProgramData/ |
+
+#### RPC address file
+
+| Platform | Path |
+|----------|------|
+| Linux | /tmp/.mullvad_rpc_address |
+| macOS | /tmp/.mullvad_rpc_address |
+| Windows | C:/ProgramData/Mullvad VPN/.mullvad_rpc_address |
+
 ## Quirks
 
 - If you want to modify babel-configurations please note that `BABEL_ENV=development` must be used


### PR DESCRIPTION
Trying to make it easy to overview where the product saves and reads files. This list is not yet complete. Might need your help to finish it.

Since we are in the process of updating these paths some of these might be wrong. For the paths we are discussing right now I tried to use the paths that we are changing to, not the ones we are using now.

What paths are there in the GUI app that I did not add. It only writes a log, right? It does not read or write any settings or cache or anything I hope? And if that is true and the log path is the same as the daemon, then we can remove the `### daemon` header and just explain the paths of the entire product in one section.