### PR TITLE
Change path of RPC connection info file on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-ipc-client 0.1.0",
+ "mullvad-metadata 0.1.0",
  "mullvad-rpc 0.1.0",
  "mullvad-types 0.1.0",
  "os_pipe 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -789,10 +790,18 @@ name = "mullvad-ipc-client"
 version = "0.1.0"
 dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mullvad-metadata 0.1.0",
  "mullvad-types 0.1.0",
  "serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
+]
+
+[[package]]
+name = "mullvad-metadata"
+version = "0.1.0"
+dependencies = [
+ "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "windows-service",
     "mullvad-cli",
     "mullvad-ipc-client",
+    "mullvad-metadata",
     "mullvad-types",
     "mullvad-rpc",
     "talpid-openvpn-plugin",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -28,6 +28,7 @@ tokio-timer = "0.1"
 regex = "0.2"
 
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
+mullvad-metadata = { path = "../mullvad-metadata" }
 mullvad-types = { path = "../mullvad-types" }
 mullvad-rpc = { path = "../mullvad-rpc" }
 talpid-core = { path = "../talpid-core" }

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -36,6 +36,7 @@ extern crate tokio_timer;
 extern crate uuid;
 
 extern crate mullvad_ipc_client;
+extern crate mullvad_metadata;
 extern crate mullvad_rpc;
 extern crate mullvad_types;
 extern crate talpid_core;
@@ -59,7 +60,6 @@ mod shutdown;
 mod system_service;
 mod version;
 
-use app_dirs::AppInfo;
 use error_chain::ChainedError;
 use futures::Future;
 use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
@@ -67,6 +67,7 @@ use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
 use management_interface::{BoxFuture, ManagementInterfaceServer, TunnelCommand};
 use mullvad_rpc::{AccountsProxy, AppVersionProxy, HttpHandle};
 
+use mullvad_metadata::APP_INFO;
 use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
 use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
@@ -133,14 +134,6 @@ lazy_static! {
     static ref MAX_RELAY_CACHE_AGE: Duration = Duration::from_secs(3600);
     static ref RELAY_CACHE_UPDATE_TIMEOUT: Duration = Duration::from_millis(3000);
 }
-
-static APP_INFO: AppInfo = AppInfo {
-    name: crate_name!(),
-    author: "Mullvad",
-};
-
-#[cfg(windows)]
-static PRODUCT_NAME: &str = "Mullvad VPN";
 
 
 /// All events that can happen in the daemon. Sent from various threads and exposed interfaces.
@@ -940,7 +933,7 @@ fn get_resource_dir() -> PathBuf {
 }
 
 fn get_cache_dir() -> Result<PathBuf> {
-    app_dirs::app_root(app_dirs::AppDataType::UserCache, &::APP_INFO)
+    app_dirs::app_root(app_dirs::AppDataType::UserCache, &APP_INFO)
         .chain_err(|| ErrorKind::NoCacheDir)
 }
 

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -10,6 +10,7 @@ use std::{env, io, thread};
 
 use cli;
 use error_chain::ChainedError;
+use mullvad_metadata::PRODUCT_NAME;
 use windows_service::service::{
     ServiceAccess, ServiceControl, ServiceControlAccept, ServiceErrorControl, ServiceExitCode,
     ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
@@ -226,7 +227,7 @@ fn get_service_info() -> Result<ServiceInfo> {
     let program_data_directory_string =
         ::std::env::var_os("ALLUSERSPROFILE").ok_or_else(|| ErrorKind::NoLogDir)?;
     let program_data_directory = Path::new(&program_data_directory_string);
-    let log_directory = program_data_directory.join(::PRODUCT_NAME);
+    let log_directory = program_data_directory.join(PRODUCT_NAME);
     let service_log_file = log_directory.join("backend.log");
     let tunnel_log_file = log_directory.join("openvpn.log");
 

--- a/mullvad-ipc-client/Cargo.toml
+++ b/mullvad-ipc-client/Cargo.toml
@@ -11,3 +11,6 @@ mullvad-types = { path = "../mullvad-types" }
 serde = "1.0"
 talpid-ipc = { path = "../talpid-ipc" }
 talpid-types = { path = "../talpid-types" }
+
+[target.'cfg(windows)'.dependencies]
+mullvad-metadata = { path = "../mullvad-metadata" }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -227,12 +227,14 @@ mod platform_specific {
 mod platform_specific {
     use super::*;
 
-    pub fn rpc_file_path() -> Result<PathBuf> {
-        let windows_directory =
-            ::std::env::var_os("WINDIR").ok_or_else(|| ErrorKind::UnknownRpcFilePath)?;
+    static PRODUCT_NAME: &str = "Mullvad VPN";
 
-        Ok(PathBuf::from(windows_directory)
-            .join("Temp")
+    pub fn rpc_file_path() -> Result<PathBuf> {
+        let shared_data_directory =
+            ::std::env::var_os("ALLUSERSPROFILE").ok_or_else(|| ErrorKind::UnknownRpcFilePath)?;
+
+        Ok(PathBuf::from(shared_data_directory)
+            .join(PRODUCT_NAME)
             .join(".mullvad_rpc_address"))
     }
 

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -225,9 +225,11 @@ mod platform_specific {
 
 #[cfg(windows)]
 mod platform_specific {
+    extern crate mullvad_metadata;
+
     use super::*;
 
-    static PRODUCT_NAME: &str = "Mullvad VPN";
+    use self::mullvad_metadata::PRODUCT_NAME;
 
     pub fn rpc_file_path() -> Result<PathBuf> {
         let shared_data_directory =

--- a/mullvad-metadata/Cargo.toml
+++ b/mullvad-metadata/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mullvad-metadata"
+version = "0.1.0"
+authors = ["Mullvad VPN <admin@mullvad.net>", "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>"]
+description = "Mullvad VPN application metadata"
+license = "GPL-3.0"
+
+[dependencies]
+app_dirs = "1.2"

--- a/mullvad-metadata/src/lib.rs
+++ b/mullvad-metadata/src/lib.rs
@@ -1,0 +1,10 @@
+extern crate app_dirs;
+
+use app_dirs::AppInfo;
+
+pub const PRODUCT_NAME: &str = "Mullvad VPN";
+
+pub const APP_INFO: AppInfo = AppInfo {
+    name: PRODUCT_NAME,
+    author: "Mullvad",
+};


### PR DESCRIPTION
This PR changes the location of the RPC connection info file on Windows to the common `C:\ProgramData\Mullvad VPN` directory. This should fix some problems relating to the GUI not being able to access the RPC connection info file.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user. **Affects only Windows version, which hasn't been publicly released yet.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/162)
<!-- Reviewable:end -->
