### PR TITLE
Silence tokio_reactor

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -27,6 +27,7 @@ const SILENCED_CRATES: &[&str] = &[
     "rpc",
     "tokio_core",
     "tokio_proto",
+    "tokio_reactor",
     "jsonrpc_ws_server",
     "ws",
     "mio",


### PR DESCRIPTION
I guess this was pulled in with my previous `cargo update` PR. Anyway, now the new dependency `tokio_reactor` spits out a lot of stuff on the `DEBUG` log level that we probably don't care about. So adding it to the list of silenced crates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/163)
<!-- Reviewable:end -->
