### PR TITLE
Macos system service, initial support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Line wrap the file at 100 chars.                                              Th
   resolution of the Mullvad API server hostname fails.
 - Manage firewall rules on Windows depending on connection state.
 - Improve account token hint to be the same length as an expected token.
+- The macOS installer is changed from dmg to pkg format.
+- The backend daemon is installed as a launchd daemon and started on macOS on install.
 
 ### Fixed
 - Fix a bug in account input field that advanced the cursor to the end regardless its prior

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -eu
+
+LOG_DIR=/var/log/mullvad-daemon
+
+mkdir -p $LOG_DIR
+exec 2>&1 > $LOG_DIR/install.log
+
+INSTALL_DIR=$2
+DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"
+
+DAEMON_PLIST=$(cat <<-EOM
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+        <dict>
+                <key>Label</key>
+                <string>net.mullvad.daemon</string>
+
+                <key>ProgramArguments</key>
+                <array>
+                        <string>$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-daemon</string>
+                        <string>-v</string>
+                        <string>--log</string>
+                        <string>$LOG_DIR/daemon.log</string>
+                        <string>--tunnel-log</string>
+                        <string>$LOG_DIR/openvpn.log</string>
+                </array>
+
+                <key>UserName</key>
+                <string>root</string>
+
+                <key>RunAtLoad</key>
+                <true/>
+
+                <key>KeepAlive</key>
+                <true/>
+
+                <key>StandardErrorPath</key>
+                <string>$LOG_DIR/stderr.log</string>
+        </dict>
+</plist>
+EOM
+)
+
+launchctl unload -w $DAEMON_PLIST_PATH
+echo "$DAEMON_PLIST" > $DAEMON_PLIST_PATH
+launchctl load -w $DAEMON_PLIST_PATH

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,19 +27,8 @@ files:
   - build/
   - node_modules/
 
-dmg:
-  contents:
-    - type: link
-      path: /Applications
-      x: 410
-      y: 150
-    - type: file
-      x: 130
-      y: 150
-
 mac:
-  target:
-    - dmg
+  target: pkg
   artifactName: MullvadVPN-${version}.${ext}
   category: public.app-category.tools
   extendInfo:
@@ -55,6 +44,10 @@ mac:
       to: .
     - from: ./client-binaries/mac/include/openvpn
       to: ./openvpn-binaries/openvpn
+
+pkg:
+  allowAnywhere: false
+  allowCurrentUserHome: false
 
 win:
   target:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-runtime": "^6.22.0",
     "d3-geo-projection": "^2.3.2",
     "electron-log": "^2.2.8",
-    "electron-sudo": "https://github.com/mullvad/electron-sudo.git",
     "history": "^4.6.1",
     "jsonrpc-lite": "^1.2.3",
     "mkdirp": "^0.5.1",
@@ -31,7 +30,6 @@
     "reactxp": "^1.1.0-rc.2",
     "redux": "^3.0.0",
     "redux-thunk": "^2.2.0",
-    "shell-escape": "^0.2.0",
     "uuid": "^3.0.1",
     "validated": "^1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,7 +1396,7 @@ bluebird-lst@^1.0.5:
   dependencies:
     bluebird "^3.5.1"
 
-bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1:
+bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -2785,13 +2785,6 @@ electron-publish@19.55.2:
     chalk "^2.3.0"
     fs-extra-p "^4.5.0"
     mime "^2.2.0"
-
-"electron-sudo@https://github.com/mullvad/electron-sudo.git":
-  version "4.0.12"
-  resolved "https://github.com/mullvad/electron-sudo.git#f71134f86541b15359f4813715d721818fb2b1f4"
-  dependencies:
-    babel-runtime "^6.18.0"
-    bluebird "^3.4.6"
 
 electron-window@^0.8.0:
   version "0.8.1"
@@ -6999,10 +6992,6 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-
-shell-escape@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/shell-escape/-/shell-escape-0.2.0.tgz#68fd025eb0490b4f567a027f0bf22480b5f84133"
 
 shell-quote@1.6.1, shell-quote@^1.6.1:
   version "1.6.1"


### PR DESCRIPTION
This PR adds two things

1. Support for disabling coloring of the stdout log. Useful since by default the macOS service log will be created by `launchd` forwarding stdout to a file, and we don't want color escape codes there. I suspect this might be equally useful on Linux with systemd, but I don't know.

2. Add an initial `lunchd` plist definition file to run the daemon as a system daemon on macOS. Just adding this file does nothing, it's mostly a way to get started. This can be tested by copying the file to `/Library/LaunchDaemons/` and started with `sudo launchctl load -w /Library/LaunchDaemons/net.mullvad.daemon.plist`

Things to think about here:
* Log paths. This topic is hot at the moment and we have several PRs discussing it. This should not be merged until we reach some conclusion on that over at https://github.com/mullvad/mullvadvpn-app/pull/161
* Hardcoded binary path. This forces the app to be installed in the default location. Probably true for most people, but should not have to be a requirement
* How to install the plist? We should probably switch to a pkg installer instead of a dmg image. That way I think we can execute code in the install step. Maybe this allows us to generate the plist and set the correct path as well.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/164)
<!-- Reviewable:end -->
