### PR TITLE
Consolidate log paths

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ esac
 # Remove binaries. To make sure it is rebuilt with the stable toolchain and the latest changes.
 cargo +stable clean
 
-echo "Compiling Rust backend in release mode with $RUSTC_VERSION..."
+echo "Compiling mullvad-daemon in release mode with $RUSTC_VERSION..."
 cargo +stable build --release
 
 

--- a/linux/mullvad-daemon.service
+++ b/linux/mullvad-daemon.service
@@ -3,7 +3,7 @@ Description=Mullvad VPN daemon
 Wants=network.target
 
 [Service]
-ExecStart="/opt/Mullvad VPN/resources/mullvad-daemon" --disable-stdout-timestamps
+ExecStart="/opt/Mullvad VPN/resources/mullvad-daemon" --disable-stdout-timestamps --log /var/log/mullvad-daemon/daemon.log --tunnel-log /var/log/mullvad-daemon/openvpn.log
 
 [Install]
 WantedBy=multi-user.target

--- a/linux/mullvad-daemon.service
+++ b/linux/mullvad-daemon.service
@@ -3,7 +3,7 @@ Description=Mullvad VPN daemon
 Wants=network.target
 
 [Service]
-ExecStart="/opt/Mullvad VPN/resources/mullvad-daemon" --disable-stdout-timestamps --log /var/log/mullvad-daemon/daemon.log --tunnel-log /var/log/mullvad-daemon/openvpn.log
+ExecStart="/opt/Mullvad VPN/resources/mullvad-daemon" -v --disable-stdout-timestamps --log /var/log/mullvad-daemon/daemon.log --tunnel-log /var/log/mullvad-daemon/openvpn.log
 
 [Install]
 WantedBy=multi-user.target

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -228,7 +228,7 @@ fn get_service_info() -> Result<ServiceInfo> {
         ::std::env::var_os("ALLUSERSPROFILE").ok_or_else(|| ErrorKind::NoLogDir)?;
     let program_data_directory = Path::new(&program_data_directory_string);
     let log_directory = program_data_directory.join(PRODUCT_NAME);
-    let service_log_file = log_directory.join("backend.log");
+    let service_log_file = log_directory.join("daemon.log");
     let tunnel_log_file = log_directory.join("openvpn.log");
 
     if let Err(error) = fs::create_dir(log_directory) {


### PR DESCRIPTION
* Move linux logs to `/var/log/mullvad-daemon`.
* Rename Windows daemon log to `daemon.log` so it becomes the same on all platforms.
* Make the daemon create its logging dir.

All these changes were present in #161. But I want that PR to be an umbrella PR for consolidating paths in general. So I felt like it would be faster to get this merged if I moved it to a separate PR. The README PR can be merged after all paths have been fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/166)
<!-- Reviewable:end -->
