### PR TITLE
Fix Linux install scripts to not crash on uninstall

### DIFF
--- a/linux/install_script.sh
+++ b/linux/install_script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux
 systemctl enable mullvad-daemon.service
 systemctl start mullvad-daemon.service

--- a/linux/install_script.sh
+++ b/linux/install_script.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 systemctl enable mullvad-daemon.service
 systemctl start mullvad-daemon.service

--- a/linux/uninstall_script.sh
+++ b/linux/uninstall_script.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
-set -eux
+#!/usr/bin/env bash
+set -ux
 systemctl stop mullvad-daemon.service
 systemctl disable mullvad-daemon.service
+exit 0

--- a/linux/uninstall_script.sh
+++ b/linux/uninstall_script.sh
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
-set -ux
-systemctl stop mullvad-daemon.service
-systemctl disable mullvad-daemon.service
-exit 0
+set -eu
+function remove_systemd_unit {
+  systemctl stop mullvad-daemon.service
+  systemctl disable mullvad-daemon.service
+}
+
+function remove_logs_and_cache {
+  rm -rf /var/log/mullvad-daemon/
+  rm -rf /var/cache/mullvad-daemon/
+}
+
+function remove_config {
+  rm -rf /etc/mullvad-daemon
+}
+
+# checking what kind of an action is taking place
+case $@ in
+  # apt purge passes "purge"
+  "purge")
+    remove_logs_and_cache
+    remove_config
+    ;;
+  # apt remove passes "remove"
+  "remove")
+    remove_systemd_unit
+    ;;
+  # yum remove passes a 0
+  "0")
+    remove_logs_and_cache
+    remove_systemd_unit
+    remove_config
+    ;;
+esac

--- a/linux/uninstall_script.sh
+++ b/linux/uninstall_script.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 set -eu
+
 function remove_systemd_unit {
-  systemctl stop mullvad-daemon.service
-  systemctl disable mullvad-daemon.service
+  systemctl stop mullvad-daemon.service || \
+    echo "Failed to stop mullvad-daemon service"
+  systemctl disable mullvad-daemon.service || \
+    echo "Failed to disable mullvad-daemon service"
 }
 
 function remove_logs_and_cache {
-  rm -rf /var/log/mullvad-daemon/
-  rm -rf /var/cache/mullvad-daemon/
+  rm -rf /var/log/mullvad-daemon/ || \
+    echo "Failed to remove mullvad-daemon logs"
+  rm -rf /var/cache/mullvad-daemon/ || \
+    echo "Failed to remove mullvad-daemon cache"
 }
 
 function remove_config {
-  rm -rf /etc/mullvad-daemon
+  rm -rf /etc/mullvad-daemon || \
+    echo "Failed to remove mullvad-daemon config"
 }
 
 # checking what kind of an action is taking place


### PR DESCRIPTION
I get problems when trying to run `sudo apt purge mullvad-vpn`. Basically the uninstall script exits with a non-zero exit code when running for the second time. I have no idea why the purge would run it twice, but the second time `systemctl stop mullvad-daemon.service` exits with exit code 5 as the service does not exist (removed on the first run).

This is on Debian 9. See if you can reproduce it and if you know any way to make it run the uninstall script only once.

This hack makes it work, but it's not very nice, since it's basically just ignoring any errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/167)
<!-- Reviewable:end -->
