### PR TITLE
Add preinstall script for macOS that removes old MullvadVPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add `version` subcommand in the CLI to show information about current versions.
 - Add a flag to daemon to print log entries to standard output without timestamps.
 - Filter out and ignore DNS lookup results for api.mullvad.net that are bogus (private etc.)
+- Make the macOS pkg installer locate and uninstall any 2018.1 version of the app before installing
+  itself.
 
 ### Changed
 - Change all occurrences of "MullvadVPN" into "Mullvad VPN", this affects

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -5,7 +5,9 @@ set -eu
 LOG_DIR=/var/log/mullvad-daemon
 
 mkdir -p $LOG_DIR
-exec 2>&1 > $LOG_DIR/install.log
+exec 2>&1 > $LOG_DIR/postinstall.log
+
+echo "Running postinstall at $(date)"
 
 INSTALL_DIR=$2
 DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eux
+
+LOG_DIR=/var/log/mullvad-daemon
+
+mkdir -p $LOG_DIR
+exec 2>&1 > $LOG_DIR/preinstall.log
+
+echo "Running preinstall at $(date)"
+
+OLD_INSTALL_DIR="/Applications/MullvadVPN.app"
+
+if [ -d "$OLD_INSTALL_DIR" ]; then
+    echo "Found old Mullvad VPN install at $OLD_INSTALL_DIR. Stopping and uninstalling"
+    pkill MullvadVPN || true
+    pkill mullvad-daemon || true
+    rm -rf "$OLD_INSTALL_DIR"
+fi
+


### PR DESCRIPTION
The `2018.1` release had the product name `MullvadVPN` without a space. We have now added a space. Thus the install location will change from `/Applications/MullvadVPN.app` to `/Applications/Mullvad VPN.app`. It would be quite dirty to have two versions installed, so we want to make users get rid of the old one as soon as possible.

This preinstall script will look for such old versions, stop them and remove them. Optimally would be if this also removed or migrated the old logs. But the problem is that they are located under `/Users/<username>/Library/Logs` and this script is running as `root`, so we have no idea what `<username>` to look under. I guess having old logs laying around is not too bad. If we really want to get rid of them we could make the GUI find and remove them on startup since it runs as the normal user. But that feels out of scope for this PR.

I'm thinking we should keep this hook present in `2018.2` and maybe `2018.3`, then we can likely remove it, since the majority of users will have upgraded by then. We'll see how it plays out.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.
