### PR TITLE
Create RPC connection information file parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix log newline characters on Windows.
 - Mullvad CLI can now be used with daemon instance that doesn't have the `--disable-rpc-auth`
   flag set.
+- If necessary, create parent directories for RPC connection info file.
 
 
 ## [2018.1] - 2018-03-01

--- a/mullvad-daemon/src/rpc_address_file.rs
+++ b/mullvad-daemon/src/rpc_address_file.rs
@@ -27,7 +27,7 @@ error_chain! {
     }
 }
 
-/// Writes down the RPC connection info to some API to a file.
+/// Writes down the RPC connection info to the RPC file.
 pub fn write(rpc_address: &str, shared_secret: &str) -> Result<()> {
     // Avoids opening an existing file owned by another user and writing sensitive data to it.
     remove()?;


### PR DESCRIPTION
This PR ensures that the parent directories for the RPC connection information file are created before the RPC file is created.

There's also a minor comment tweak for the changed function.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/172)
<!-- Reviewable:end -->
