### PR TITLE
Move cache dir

### DIFF
--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -1,6 +1,5 @@
 extern crate serde_json;
 
-use app_dirs::{self, AppDataType};
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;
@@ -55,8 +54,8 @@ impl AccountHistory {
         }
     }
 
-    pub fn get_accounts(&self) -> Vec<AccountToken> {
-        self.accounts.clone()
+    pub fn get_accounts(&self) -> &[AccountToken] {
+        &self.accounts
     }
 
     /// Add account token to the account history removing duplicate entries
@@ -97,8 +96,7 @@ impl AccountHistory {
     }
 
     fn get_path() -> Result<PathBuf> {
-        let dir = app_dirs::app_root(AppDataType::UserCache, &::APP_INFO)
-            .chain_err(|| ErrorKind::DirectoryError)?;
+        let dir = ::cache::get_cache_dir().chain_err(|| ErrorKind::DirectoryError)?;
         Ok(dir.join(ACCOUNT_HISTORY_FILE))
     }
 }

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -2,7 +2,7 @@ extern crate serde_json;
 
 use std::fs::File;
 use std::io;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 use mullvad_types::account::AccountToken;
 
@@ -26,32 +26,42 @@ static ACCOUNT_HISTORY_FILE: &str = "account-history.json";
 static ACCOUNT_HISTORY_LIMIT: usize = 3;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
-#[serde(default)]
 pub struct AccountHistory {
     accounts: Vec<AccountToken>,
+    #[serde(skip)]
+    cache_path: PathBuf,
 }
 
 impl AccountHistory {
-    /// Loads account history from file. If no file is present it returns the defaults.
-    pub fn load(cache_dir: &Path) -> Result<AccountHistory> {
-        let history_path = cache_dir.join(ACCOUNT_HISTORY_FILE);
-        match File::open(&history_path) {
-            Ok(file) => {
+    /// Returns a new empty `AccountHistory` ready to load from, or save to, the given cache dir.
+    pub fn new(cache_dir: &Path) -> AccountHistory {
+        AccountHistory {
+            accounts: Vec::new(),
+            cache_path: cache_dir.join(ACCOUNT_HISTORY_FILE),
+        }
+    }
+
+    /// Loads account history from file. If no file is present this does nothing.
+    pub fn load(&mut self) -> Result<()> {
+        match File::open(&self.cache_path).map(io::BufReader::new) {
+            Ok(mut file) => {
                 info!(
                     "Loading account history from {}",
-                    history_path.display()
+                    &self.cache_path.display()
                 );
-                Self::parse(&mut io::BufReader::new(file))
+                self.accounts = Self::parse(&mut file)?.accounts;
+                Ok(())
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-                info!(
-                    "No account history file at {}, using defaults",
-                    history_path.display()
-                );
-                Ok(AccountHistory::default())
+                info!("No account history file at {}", &self.cache_path.display());
+                Ok(())
             }
-            Err(e) => Err(e).chain_err(|| ErrorKind::ReadError(history_path)),
+            Err(e) => Err(e).chain_err(|| ErrorKind::ReadError(self.cache_path.clone())),
         }
+    }
+
+    fn parse(file: &mut impl io::Read) -> Result<AccountHistory> {
+        serde_json::from_reader(file).chain_err(|| ErrorKind::ParseError)
     }
 
     pub fn get_accounts(&self) -> &[AccountToken] {
@@ -59,7 +69,7 @@ impl AccountHistory {
     }
 
     /// Add account token to the account history removing duplicate entries
-    pub fn add_account_token(&mut self, account_token: AccountToken, cache_dir: &Path) -> Result<()> {
+    pub fn add_account_token(&mut self, account_token: AccountToken) -> Result<()> {
         self.accounts
             .retain(|existing_token| existing_token != &account_token);
         self.accounts.push(account_token);
@@ -71,27 +81,24 @@ impl AccountHistory {
                 .split_off(num_accounts - ACCOUNT_HISTORY_LIMIT);
         }
 
-        self.save(cache_dir)
+        self.save()
     }
 
     /// Remove account token from the account history
-    pub fn remove_account_token(&mut self, account_token: AccountToken, cache_dir: &Path) -> Result<()> {
+    pub fn remove_account_token(&mut self, account_token: AccountToken) -> Result<()> {
         self.accounts
             .retain(|existing_token| existing_token != &account_token);
-        self.save(cache_dir)
+        self.save()
     }
 
     /// Serializes the account history and saves it to the file it was loaded from.
-    fn save(&self, cache_dir: &Path) -> Result<()> {
-        let path = cache_dir.join(ACCOUNT_HISTORY_FILE);
+    fn save(&self) -> Result<()> {
+        debug!("Writing account history to {}", self.cache_path.display());
+        let file = File::create(&self.cache_path)
+            .map(io::BufWriter::new)
+            .chain_err(|| ErrorKind::WriteError(self.cache_path.clone()))?;
 
-        debug!("Writing account history to {}", path.display());
-        let file = File::create(&path).chain_err(|| ErrorKind::WriteError(path.clone()))?;
-
-        serde_json::to_writer_pretty(io::BufWriter::new(file), self).chain_err(|| ErrorKind::WriteError(path))
-    }
-
-    fn parse(file: &mut impl io::Read) -> Result<AccountHistory> {
-        serde_json::from_reader(file).chain_err(|| ErrorKind::ParseError)
+        serde_json::to_writer_pretty(file, self)
+            .chain_err(|| ErrorKind::WriteError(self.cache_path.clone()))
     }
 }

--- a/mullvad-daemon/src/cache.rs
+++ b/mullvad-daemon/src/cache.rs
@@ -1,0 +1,18 @@
+use {ErrorKind, Result, ResultExt};
+
+use std::fs;
+use std::path::PathBuf;
+
+#[cfg(target_os = "linux")]
+pub fn get_cache_dir() -> Result<PathBuf> {
+    let dir = PathBuf::from("/var/cache/mullvad-daemon");
+    fs::create_dir_all(&dir).chain_err(|| ErrorKind::NoCacheDir)?;
+    Ok(dir)
+}
+
+#[cfg(any(target_os = "macos", windows))]
+pub fn get_cache_dir() -> Result<PathBuf> {
+    use mullvad_metadata::APP_INFO;
+    ::app_dirs::app_root(::app_dirs::AppDataType::UserCache, &APP_INFO)
+        .chain_err(|| ErrorKind::NoCacheDir)
+}

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub log_file: Option<PathBuf>,
     pub tunnel_log_file: Option<PathBuf>,
     pub resource_dir: Option<PathBuf>,
+    pub cache_dir: Option<PathBuf>,
     pub log_stdout_timestamps: bool,
     pub run_as_service: bool,
     pub register_service: bool,
@@ -27,6 +28,7 @@ pub fn get_config() -> Config {
     let log_file = matches.value_of_os("log_file").map(PathBuf::from);
     let tunnel_log_file = matches.value_of_os("tunnel_log_file").map(PathBuf::from);
     let resource_dir = matches.value_of_os("resource_dir").map(PathBuf::from);
+    let cache_dir = matches.value_of_os("cache_dir").map(PathBuf::from);
     let log_stdout_timestamps = !matches.is_present("disable_stdout_timestamps");
 
     let run_as_service = cfg!(windows) && matches.is_present("run_as_service");
@@ -37,6 +39,7 @@ pub fn get_config() -> Config {
         log_file,
         tunnel_log_file,
         resource_dir,
+        cache_dir,
         log_stdout_timestamps,
         run_as_service,
         register_service,
@@ -74,6 +77,13 @@ fn create_app() -> App<'static, 'static> {
                 .takes_value(true)
                 .value_name("DIR")
                 .help("Uses the given directory to read needed resources, such as certificates."),
+        )
+        .arg(
+            Arg::with_name("cache_dir")
+                .long("cache-dir")
+                .takes_value(true)
+                .value_name("DIR")
+                .help("Uses the given directory to read and write cache."),
         )
         .arg(
             Arg::with_name("disable_stdout_timestamps")

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -237,7 +237,8 @@ impl Daemon {
         let rpc_handle = rpc_handle.chain_err(|| "Unable to create RPC client")?;
         let http_handle = http_handle.chain_err(|| "Unable to create HTTP client")?;
 
-        let relay_selector = Self::create_relay_selector(rpc_handle.clone(), &resource_dir);
+        let relay_selector =
+            Self::create_relay_selector(rpc_handle.clone(), &resource_dir, &cache_dir);
 
         let (tx, rx) = mpsc::channel();
         let management_interface_broadcaster = Self::start_management_interface(tx.clone())?;
@@ -273,8 +274,9 @@ impl Daemon {
     fn create_relay_selector(
         rpc_handle: mullvad_rpc::HttpHandle,
         resource_dir: &Path,
+        cache_dir: &Path,
     ) -> relays::RelaySelector {
-        let mut relay_selector = relays::RelaySelector::new(rpc_handle, &resource_dir);
+        let mut relay_selector = relays::RelaySelector::new(rpc_handle, &resource_dir, cache_dir);
         if let Ok(elapsed) = relay_selector.get_last_updated().elapsed() {
             if elapsed > *MAX_RELAY_CACHE_AGE {
                 if let Err(e) = relay_selector.update(*RELAY_CACHE_UPDATE_TIMEOUT) {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -48,6 +48,7 @@ extern crate talpid_types;
 extern crate windows_service;
 
 mod account_history;
+mod cache;
 mod cli;
 mod geoip;
 mod logging;
@@ -67,7 +68,6 @@ use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
 use management_interface::{BoxFuture, ManagementInterfaceServer, TunnelCommand};
 use mullvad_rpc::{AccountsProxy, AppVersionProxy, HttpHandle};
 
-use mullvad_metadata::APP_INFO;
 use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
 use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
@@ -223,7 +223,7 @@ impl Daemon {
             ErrorKind::DaemonIsAlreadyRunning
         );
 
-        let cache_dir = get_cache_dir()?;
+        let cache_dir = cache::get_cache_dir()?;
         let mut rpc_manager = mullvad_rpc::MullvadRpcFactory::with_cache_dir(&cache_dir);
 
         let (rpc_handle, http_handle, tokio_remote) =
@@ -921,11 +921,6 @@ fn get_resource_dir() -> PathBuf {
             PathBuf::from(".")
         }
     }
-}
-
-fn get_cache_dir() -> Result<PathBuf> {
-    app_dirs::app_root(app_dirs::AppDataType::UserCache, &APP_INFO)
-        .chain_err(|| ErrorKind::NoCacheDir)
 }
 
 #[cfg(unix)]

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -20,8 +20,10 @@ use serde;
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
+
 use talpid_core::mpsc::IntoSender;
 use talpid_ipc;
 use talpid_types::net::TunnelOptions;
@@ -210,11 +212,12 @@ impl ManagementInterfaceServer {
     pub fn start<T>(
         tunnel_tx: IntoSender<TunnelCommand, T>,
         shared_secret: String,
+        cache_dir: PathBuf,
     ) -> talpid_ipc::Result<Self>
     where
         T: From<TunnelCommand> + 'static + Send,
     {
-        let rpc = ManagementInterface::new(tunnel_tx, shared_secret);
+        let rpc = ManagementInterface::new(tunnel_tx, shared_secret, cache_dir);
         let subscriptions = rpc.subscriptions.clone();
 
         let mut io = PubSubHandler::default();
@@ -284,14 +287,16 @@ struct ManagementInterface<T: From<TunnelCommand> + 'static + Send> {
     subscriptions: Arc<ActiveSubscriptions>,
     tx: Mutex<IntoSender<TunnelCommand, T>>,
     shared_secret: String,
+    cache_dir: PathBuf,
 }
 
 impl<T: From<TunnelCommand> + 'static + Send> ManagementInterface<T> {
-    pub fn new(tx: IntoSender<TunnelCommand, T>, shared_secret: String) -> Self {
+    pub fn new(tx: IntoSender<TunnelCommand, T>, shared_secret: String, cache_dir: PathBuf) -> Self {
         ManagementInterface {
             subscriptions: Default::default(),
             tx: Mutex::new(tx),
             shared_secret,
+            cache_dir,
         }
     }
 
@@ -439,8 +444,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
 
         if let Some(new_account_token) = account_token {
-            if let Err(e) = AccountHistory::load().and_then(|mut account_history| {
-                account_history.add_account_token(new_account_token)
+            if let Err(e) = AccountHistory::load(&self.cache_dir).and_then(|mut account_history| {
+                account_history.add_account_token(new_account_token, &self.cache_dir)
             }) {
                 error!(
                     "Unable to add an account into the account history: {}",
@@ -556,7 +561,7 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_account_history");
         try_future!(self.check_auth(&meta));
         Box::new(future::result(
-            AccountHistory::load()
+            AccountHistory::load(&self.cache_dir)
                 .map(|account_history| account_history.get_accounts().to_vec())
                 .map_err(|error| {
                     error!("Unable to get account history: {}", error.display_chain());
@@ -573,8 +578,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("remove_account_from_history");
         try_future!(self.check_auth(&meta));
         Box::new(future::result(
-            AccountHistory::load()
-                .and_then(|mut account_history| account_history.remove_account_token(account_token))
+            AccountHistory::load(&self.cache_dir)
+                .and_then(|mut history| history.remove_account_token(account_token, &self.cache_dir))
                 .map_err(|error| {
                     error!(
                         "Unable to remove account from history: {}",

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -557,7 +557,7 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         try_future!(self.check_auth(&meta));
         Box::new(future::result(
             AccountHistory::load()
-                .map(|account_history| account_history.get_accounts())
+                .map(|account_history| account_history.get_accounts().to_vec())
                 .map_err(|error| {
                     error!("Unable to get account history: {}", error.display_chain());
                     Error::internal_error()

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -1,4 +1,3 @@
-use app_dirs;
 use chrono::{DateTime, Local};
 use error_chain::ChainedError;
 use futures::Future;
@@ -335,8 +334,7 @@ impl RelaySelector {
     }
 
     fn get_cache_path() -> Result<PathBuf> {
-        let dir = app_dirs::app_root(app_dirs::AppDataType::UserCache, &::APP_INFO)
-            .chain_err(|| ErrorKind::RelayCacheError)?;
+        let dir = ::cache::get_cache_dir().chain_err(|| ErrorKind::RelayCacheError)?;
         Ok(dir.join("relays.json"))
     }
 }

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -23,6 +23,7 @@ use rand::distributions::{IndependentSample, Range};
 use rand::{self, Rng, ThreadRng};
 use tokio_timer::{TimeoutError, Timer};
 
+const RELAYS_FILENAME: &str = "relays.json";
 
 error_chain! {
     errors {
@@ -46,13 +47,15 @@ pub struct RelaySelector {
     last_updated: SystemTime,
     rng: ThreadRng,
     rpc_client: RelayListProxy<HttpHandle>,
+    cache_path: PathBuf,
 }
 
 impl RelaySelector {
     /// Returns a new `RelaySelector` backed by relays cached on disk. Use the `update` method
     /// to refresh the relay list from the internet.
-    pub fn new(rpc_handle: HttpHandle, resource_dir: &Path) -> Self {
-        let (last_updated, relay_list) = match Self::read_cached_relays(resource_dir) {
+    pub fn new(rpc_handle: HttpHandle, resource_dir: &Path, cache_dir: &Path) -> Self {
+        let cache_path = cache_dir.join(RELAYS_FILENAME);
+        let (last_updated, relay_list) = match Self::read_cached_relays(&cache_path, resource_dir) {
             Ok(value) => value,
             Err(error) => {
                 let error = error.chain_err(|| "Unable to load cached relays");
@@ -72,6 +75,7 @@ impl RelaySelector {
             last_updated,
             rng: rand::thread_rng(),
             rpc_client: RelayListProxy::new(rpc_handle),
+            cache_path,
         }
     }
 
@@ -257,7 +261,7 @@ impl RelaySelector {
             .relay_list()
             .map_err(|e| Error::with_chain(e, ErrorKind::DownloadError));
         let relay_list = Timer::default().timeout(download_future, timeout).wait()?;
-        if let Err(e) = Self::cache_relays(&relay_list) {
+        if let Err(e) = self.cache_relays(&relay_list) {
             error!("Unable to save relays to cache: {}", e.display_chain());
         }
         let (locations, relays) = Self::process_relay_list(relay_list);
@@ -297,16 +301,21 @@ impl RelaySelector {
     }
 
     /// Write a `RelayList` to the cache file.
-    fn cache_relays(relays: &RelayList) -> Result<()> {
-        let file = File::create(Self::get_cache_path()?).chain_err(|| ErrorKind::RelayCacheError)?;
-        serde_json::to_writer_pretty(file, relays).chain_err(|| ErrorKind::SerializationError)
+    fn cache_relays(&self, relays: &RelayList) -> Result<()> {
+        debug!("Writing relays cache to {}", self.cache_path.display());
+        let file = File::create(&self.cache_path).chain_err(|| ErrorKind::RelayCacheError)?;
+        serde_json::to_writer_pretty(io::BufWriter::new(file), relays)
+            .chain_err(|| ErrorKind::SerializationError)
     }
 
     /// Try to read the relays, first from cache and if that fails from the `resource_dir`.
-    fn read_cached_relays(resource_dir: &Path) -> Result<(SystemTime, RelayList)> {
-        match Self::get_cache_path().and_then(Self::read_relays) {
+    fn read_cached_relays(
+        cache_path: &Path,
+        resource_dir: &Path,
+    ) -> Result<(SystemTime, RelayList)> {
+        match Self::read_relays(cache_path) {
             Ok(value) => Ok(value),
-            Err(read_cache_error) => match Self::read_relays(resource_dir.join("relays.json")) {
+            Err(read_cache_error) => match Self::read_relays(resource_dir.join(RELAYS_FILENAME)) {
                 Ok(value) => Ok(value),
                 Err(read_resource_error) => Err(read_cache_error.chain_err(|| read_resource_error)),
             },
@@ -331,10 +340,5 @@ impl RelaySelector {
         let file = File::open(path)?;
         let last_modified = file.metadata()?.modified()?;
         Ok((last_modified, file))
-    }
-
-    fn get_cache_path() -> Result<PathBuf> {
-        let dir = ::cache::get_cache_dir().chain_err(|| ErrorKind::RelayCacheError)?;
-        Ok(dir.join("relays.json"))
     }
 }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -95,7 +95,8 @@ impl Settings {
 
     #[cfg(windows)]
     fn get_settings_path() -> Result<PathBuf> {
-        let dir = ::app_dirs::app_root(::app_dirs::AppDataType::UserConfig, &::APP_INFO)
+        use mullvad_metadata::APP_INFO;
+        let dir = ::app_dirs::app_root(::app_dirs::AppDataType::UserConfig, &APP_INFO)
             .chain_err(|| ErrorKind::DirectoryError)?;
         Ok(dir.join(SETTINGS_FILE))
     }

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -72,8 +72,12 @@ fn run_service(_arguments: Vec<OsString>) -> Result<()> {
         .set_pending_start(Duration::from_secs(1))
         .unwrap();
 
-    let resource_dir = get_resource_dir();
-    let daemon = Daemon::new(config.tunnel_log_file, resource_dir)
+    let resource_dir = config.resource_dir.unwrap_or_else(|| get_resource_dir());
+    let cache_dir = match config.cache_dir {
+        Some(cache_dir) => cache_dir,
+        None => ::cache::get_cache_dir()?,
+    };
+    let daemon = Daemon::new(config.tunnel_log_file, resource_dir, cache_dir)
         .chain_err(|| "Unable to initialize daemon")?;
     let shutdown_handle = daemon.shutdown_handle();
 

--- a/mullvad-daemon/tests/common/mod.rs
+++ b/mullvad-daemon/tests/common/mod.rs
@@ -46,7 +46,9 @@ impl DaemonRunner {
             DAEMON_EXECUTABLE_PATH,
             "-v",
             "--resource-dir",
-            "dist-assets"
+            "./dist-assets",
+            "--cache-dir",
+            "./"
         ).dir("..")
             .stderr_to_stdout()
             .stdout_handle(writer)

--- a/mullvad-rpc/src/cached_dns_resolver.rs
+++ b/mullvad-rpc/src/cached_dns_resolver.rs
@@ -351,7 +351,7 @@ mod tests {
         let address = cache.resolve();
 
         assert_eq!(address, fallback_address);
-        let cache_file_path = cache_dir.join("api_ip_address.txt");
+        let cache_file_path = cache_dir.join(::API_IP_CACHE_FILENAME);
         assert!(!cache_file_path.exists());
     }
 
@@ -365,7 +365,7 @@ mod tests {
     }
 
     fn write_invalid_address(dir: &Path) -> PathBuf {
-        let file_path = dir.join("api_ip_address.txt");
+        let file_path = dir.join(::API_IP_CACHE_FILENAME);
         let mut file = File::create(&file_path).unwrap();
 
         writeln!(file, "400.30.12.9").unwrap();
@@ -374,7 +374,7 @@ mod tests {
     }
 
     fn write_address(dir: &Path, address: IpAddr) -> PathBuf {
-        let file_path = dir.join("api_ip_address.txt");
+        let file_path = dir.join(::API_IP_CACHE_FILENAME);
         let mut file = File::create(&file_path).unwrap();
 
         writeln!(file, "{}", address).unwrap();
@@ -391,7 +391,7 @@ mod tests {
     }
 
     fn get_cached_address(cache_dir: &Path) -> String {
-        let cache_file_path = cache_dir.join("api_ip_address.txt");
+        let cache_file_path = cache_dir.join(::API_IP_CACHE_FILENAME);
 
         assert!(cache_file_path.exists());
 
@@ -408,9 +408,8 @@ mod tests {
         cache_dir: &Path,
         fallback_address: Option<IpAddr>,
     ) -> CachedDnsResolver<MockDnsResolver> {
-        let hostname = "dummy.host".to_owned();
-        let filename = "api_ip_address.txt";
-        let cache_file = cache_dir.join(filename);
+        let hostname = String::from("dummy.host");
+        let cache_file = cache_dir.join(::API_IP_CACHE_FILENAME);
         let fallback_address = fallback_address.unwrap_or(IpAddr::from([10, 0, 109, 91]));
 
         CachedDnsResolver::with_dns_resolver(mock_resolver, hostname, cache_file, fallback_address)

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -52,9 +52,9 @@ use cached_dns_resolver::CachedDnsResolver;
 mod https_client_with_sni;
 use https_client_with_sni::HttpsClientWithSni;
 
-static API_HOST: &str = "api.mullvad.net";
-static RPC_TIMEOUT: Duration = Duration::from_secs(5);
-static API_IP_CACHE_FILENAME: &str = "api_ip_address.txt";
+const API_HOST: &str = "api.mullvad.net";
+const RPC_TIMEOUT: Duration = Duration::from_secs(5);
+pub const API_IP_CACHE_FILENAME: &str = "api-ip-address.txt";
 lazy_static! {
     static ref API_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(193, 138, 219, 46));
 }


### PR DESCRIPTION
Moving the cache to `/var/cache/mullvad-daemon/` on Linux. Keeping it where it is on macOS since `/var/cache` does not exist there. Not adding to changelog because Linux is not released yet.

Renaming `api_ip_address.txt` to `api-ip-address.txt` since that is the naming standard we have for `account-history.json`. This feature has not been released yet, so we can freely rename it without worrying about migration or anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/173)
<!-- Reviewable:end -->
