### PR TITLE
Change from to_string_lossy() to display() on paths

### DIFF
--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -14,11 +14,11 @@ error_chain! {
         }
         ReadError(path: PathBuf) {
             description("Unable to read account history file")
-            display("Unable to read account history from {}", path.to_string_lossy())
+            display("Unable to read account history from {}", path.display())
         }
         WriteError(path: PathBuf) {
             description("Unable to write account history file")
-            display("Unable to write account history to {}", path.to_string_lossy())
+            display("Unable to write account history to {}", path.display())
         }
         ParseError {
             description("Malformed account history")
@@ -41,16 +41,13 @@ impl AccountHistory {
         let history_path = Self::get_path()?;
         match File::open(&history_path) {
             Ok(mut file) => {
-                info!(
-                    "Loading account history from {}",
-                    history_path.to_string_lossy()
-                );
+                info!("Loading account history from {}", history_path.display());
                 Self::parse(&mut file)
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
                 info!(
                     "No account history file at {}, using defaults",
-                    history_path.to_string_lossy()
+                    history_path.display()
                 );
                 Ok(AccountHistory::default())
             }
@@ -89,7 +86,7 @@ impl AccountHistory {
     fn save(&self) -> Result<()> {
         let path = Self::get_path()?;
 
-        debug!("Writing account history to {}", path.to_string_lossy());
+        debug!("Writing account history to {}", path.display());
         let file = File::create(&path).chain_err(|| ErrorKind::WriteError(path.clone()))?;
 
         serde_json::to_writer_pretty(file, self).chain_err(|| ErrorKind::WriteError(path))

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -57,11 +57,11 @@ error_chain!{
     errors {
         WriteReportError(path: PathBuf) {
             description("Error writing the problem report file")
-            display("Error writing the problem report file: {}", path.to_string_lossy())
+            display("Error writing the problem report file: {}", path.display())
         }
         ReadLogError(path: PathBuf) {
             description("Error reading the contents of log file")
-            display("Error reading the contents of log file: {}", path.to_string_lossy())
+            display("Error reading the contents of log file: {}", path.display())
         }
         RpcError {
             description("Error during RPC call")

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -319,7 +319,7 @@ impl RelaySelector {
     fn read_relays<P: AsRef<Path>>(path: P) -> Result<(SystemTime, RelayList)> {
         debug!(
             "Trying to read relays cache from {}",
-            path.as_ref().to_string_lossy()
+            path.as_ref().display()
         );
         let (last_modified, file) =
             Self::read_file(path.as_ref()).chain_err(|| ErrorKind::RelayCacheError)?;

--- a/mullvad-daemon/src/rpc_address_file.rs
+++ b/mullvad-daemon/src/rpc_address_file.rs
@@ -13,16 +13,16 @@ error_chain! {
             description("Failed to create directory for RPC connection info file")
             display(
                 "Failed to create directory for RPC connection info file: {}",
-                path.to_string_lossy(),
+                path.display(),
             )
         }
         WriteFailed(path: PathBuf) {
             description("Failed to write RPC connection info to file")
-            display("Failed to write RPC connection info to {}", path.to_string_lossy())
+            display("Failed to write RPC connection info to {}", path.display())
         }
         RemoveFailed(path: PathBuf) {
             description("Failed to remove file")
-            display("Failed to remove {}", path.to_string_lossy())
+            display("Failed to remove {}", path.display())
         }
     }
 }
@@ -43,10 +43,7 @@ pub fn write(rpc_address: &str, shared_secret: &str) -> Result<()> {
         .and_then(|mut file| write!(file, "{}\n{}\n", rpc_address, shared_secret))
         .chain_err(|| ErrorKind::WriteFailed(file_path.clone()))?;
 
-    debug!(
-        "Wrote RPC connection info to {}",
-        file_path.to_string_lossy()
-    );
+    debug!("Wrote RPC connection info to {}", file_path.display());
     Ok(())
 }
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -62,13 +62,13 @@ impl Settings {
         let settings_path = Self::get_settings_path()?;
         match File::open(&settings_path) {
             Ok(file) => {
-                info!("Loading settings from {}", settings_path.to_string_lossy());
+                info!("Loading settings from {}", settings_path.display());
                 Self::read_settings(&mut io::BufReader::new(file))
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
                 info!(
                     "No settings file at {}, using defaults",
-                    settings_path.to_string_lossy()
+                    settings_path.display()
                 );
                 Ok(Settings::default())
             }
@@ -80,7 +80,7 @@ impl Settings {
     fn save(&self) -> Result<()> {
         let path = Self::get_settings_path()?;
 
-        debug!("Writing settings to {}", path.to_string_lossy());
+        debug!("Writing settings to {}", path.display());
         let file = File::create(&path).chain_err(|| ErrorKind::WriteError(path.clone()))?;
 
         serde_json::to_writer_pretty(file, self).chain_err(|| ErrorKind::WriteError(path))

--- a/talpid-core/src/mktemp.rs
+++ b/talpid-core/src/mktemp.rs
@@ -35,7 +35,7 @@ impl Drop for TempFile {
             if e.kind() != io::ErrorKind::NotFound {
                 error!(
                     "Unable to remove temp file {}: {:?}",
-                    self.path.to_string_lossy(),
+                    self.path.display(),
                     e
                 );
             }

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -205,7 +205,7 @@ impl TunnelMonitor {
         path.push(library);
 
         if path.exists() {
-            debug!("Using OpenVPN plugin at {}", path.to_string_lossy());
+            debug!("Using OpenVPN plugin at {}", path.display());
             Ok(path)
         } else {
             Err(ErrorKind::PluginNotFound.into())
@@ -253,7 +253,7 @@ impl TunnelMonitor {
         let temp_file = mktemp::TempFile::new();
         debug!(
             "Writing user-pass credentials to {}",
-            temp_file.as_ref().to_string_lossy()
+            temp_file.as_ref().display()
         );
         let mut file = fs::File::create(&temp_file)?;
         Self::set_user_pass_file_permissions(&file)?;

--- a/windows-service/examples/simple_service.rs
+++ b/windows-service/examples/simple_service.rs
@@ -74,7 +74,7 @@ mod simple_service {
             }
             OpenLogFile(path: PathBuf) {
                 description("Unable to open log file for writing")
-                display("Unable to open log file for writing: {}", path.to_string_lossy())
+                display("Unable to open log file for writing: {}", path.display())
             }
             InitLogger {
                 description("Cannot initialize logger")


### PR DESCRIPTION
There is a `display()` method on the `Path`/`PathBuf` types. We should probably use that when the goal is to print a display representation of the path. It's also shorter which makes some log macro calls into oneliners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/174)
<!-- Reviewable:end -->
