### PR TITLE
Remove --disable-rpc-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add `tunnel` subcommand to manage tunnel specific options in the CLI.
 - Add support for passing the `--mssfix` argument to OpenVPN tunnels.
-- Add `--disable-rpc-auth` flag to daemon to make it accept unauthorized control.
 - Add colors to terminal output on macOS and Linux.
 - Add details to mullvad CLI interface error for when it doesn't trust the RPC file.
 - Warn if daemon is running as a non-root user.
@@ -61,8 +60,6 @@ Line wrap the file at 100 chars.                                              Th
 - Fix OpenVPN warning about usage of AES-256-CBC cipher.
 - Fix "Out of time" screen status icon position.
 - Fix log newline characters on Windows.
-- Mullvad CLI can now be used with daemon instance that doesn't have the `--disable-rpc-auth`
-  flag set.
 - If necessary, create parent directories for RPC connection info file.
 
 

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -10,7 +10,6 @@ pub struct Config {
     pub log_file: Option<PathBuf>,
     pub tunnel_log_file: Option<PathBuf>,
     pub resource_dir: Option<PathBuf>,
-    pub require_auth: bool,
     pub log_stdout_timestamps: bool,
     pub run_as_service: bool,
     pub register_service: bool,
@@ -28,7 +27,6 @@ pub fn get_config() -> Config {
     let log_file = matches.value_of_os("log_file").map(PathBuf::from);
     let tunnel_log_file = matches.value_of_os("tunnel_log_file").map(PathBuf::from);
     let resource_dir = matches.value_of_os("resource_dir").map(PathBuf::from);
-    let require_auth = !matches.is_present("disable_rpc_auth");
     let log_stdout_timestamps = !matches.is_present("disable_stdout_timestamps");
 
     let run_as_service = cfg!(windows) && matches.is_present("run_as_service");
@@ -39,7 +37,6 @@ pub fn get_config() -> Config {
         log_file,
         tunnel_log_file,
         resource_dir,
-        require_auth,
         log_stdout_timestamps,
         run_as_service,
         register_service,
@@ -77,11 +74,6 @@ fn create_app() -> App<'static, 'static> {
                 .takes_value(true)
                 .value_name("DIR")
                 .help("Uses the given directory to read needed resources, such as certificates."),
-        )
-        .arg(
-            Arg::with_name("disable_rpc_auth")
-                .long("disable-rpc-auth")
-                .help("Don't require authentication on the RPC management interface."),
         )
         .arg(
             Arg::with_name("disable_stdout_timestamps")

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -73,7 +73,7 @@ fn run_service(_arguments: Vec<OsString>) -> Result<()> {
         .unwrap();
 
     let resource_dir = get_resource_dir();
-    let daemon = Daemon::new(config.tunnel_log_file, resource_dir, config.require_auth)
+    let daemon = Daemon::new(config.tunnel_log_file, resource_dir)
         .chain_err(|| "Unable to initialize daemon")?;
     let shutdown_handle = daemon.shutdown_handle();
 

--- a/mullvad-daemon/tests/common/mod.rs
+++ b/mullvad-daemon/tests/common/mod.rs
@@ -45,7 +45,6 @@ impl DaemonRunner {
         let process = cmd!(
             DAEMON_EXECUTABLE_PATH,
             "-v",
-            "--disable-rpc-auth",
             "--resource-dir",
             "dist-assets"
         ).dir("..")


### PR DESCRIPTION
This was briefly discussed but never promoted to a card. Now I had some time so I ripped it out.

The `--disable-rpc-auth` was only added to make it possible to use the CLI. We would never have recommended it to end users, it was mostly just for internal debugging. Now when the CLI can work without disabling auth I don't see any reason to support disabling auth to begin with. Also simplifies the code a bit.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/176)
<!-- Reviewable:end -->
