### PR TITLE
Format with rustfmt 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         # Install and run rustfmt on nightly only until rustfmt.toml settings are stabilized.
         - rustup component add rustfmt-preview
         - rustfmt --version
-        - cargo fmt -- --write-mode=check --unstable-features
+        - cargo fmt -- --check --unstable-features
 
     - language: rust
       rust: beta

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -215,7 +215,9 @@ impl Relay {
 fn parse_port_constraint(raw_port: &str) -> Result<Constraint<u16>> {
     match raw_port.to_lowercase().as_str() {
         "any" => Ok(Constraint::Any),
-        port => Ok(Constraint::Only(u16::from_str(port).chain_err(|| "Invalid port")?)),
+        port => Ok(Constraint::Only(
+            u16::from_str(port).chain_err(|| "Invalid port")?
+        )),
     }
 }
 

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -70,7 +70,8 @@ impl AccountHistory {
 
         let num_accounts = self.accounts.len();
         if num_accounts > ACCOUNT_HISTORY_LIMIT {
-            self.accounts = self.accounts
+            self.accounts = self
+                .accounts
                 .split_off(num_accounts - ACCOUNT_HISTORY_LIMIT);
         }
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -459,7 +459,8 @@ impl Daemon {
         tx: OneshotSender<BoxFuture<AccountData, mullvad_rpc::Error>>,
         account_token: AccountToken,
     ) {
-        let rpc_call = self.accounts_proxy
+        let rpc_call = self
+            .accounts_proxy
             .get_expiry(account_token)
             .map(|expiry| AccountData { expiry });
         Self::oneshot_send(tx, Box::new(rpc_call), "account data")
@@ -501,7 +502,8 @@ impl Daemon {
         tx: OneshotSender<BoxFuture<AppVersionInfo, mullvad_rpc::Error>>,
     ) {
         let current_version = version::current().to_owned();
-        let fut = self.version_proxy
+        let fut = self
+            .version_proxy
             .latest_app_version()
             .join(
                 self.version_proxy
@@ -698,7 +700,8 @@ impl Daemon {
                 self.tunnel_endpoint = Some(tunnel_endpoint);
             }
             RelaySettings::Normal(constraints) => {
-                let (relay, tunnel_endpoint) = self.relay_selector
+                let (relay, tunnel_endpoint) = self
+                    .relay_selector
                     .get_tunnel_endpoint(&constraints)
                     .chain_err(|| ErrorKind::NoRelay)?;
                 self.tunnel_endpoint = Some(tunnel_endpoint);
@@ -706,7 +709,8 @@ impl Daemon {
             }
         }
 
-        let account_token = self.settings
+        let account_token = self
+            .settings
             .get_account_token()
             .ok_or(ErrorKind::InvalidSettings("No account token"))?;
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -406,7 +406,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_account_data");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetAccountData(tx, account_token))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetAccountData(tx, account_token))
             .and_then(|_| rx.map_err(|_| Error::internal_error()))
             .and_then(|rpc_future| {
                 rpc_future.map_err(|error: mullvad_rpc::Error| {
@@ -424,7 +425,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_relay_locations");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetRelayLocations(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetRelayLocations(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -437,9 +439,9 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("set_account");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future =
-            self.send_command_to_daemon(TunnelCommand::SetAccount(tx, account_token.clone()))
-                .and_then(|_| rx.map_err(|_| Error::internal_error()));
+        let future = self
+            .send_command_to_daemon(TunnelCommand::SetAccount(tx, account_token.clone()))
+            .and_then(|_| rx.map_err(|_| Error::internal_error()));
 
         if let Some(new_account_token) = account_token {
             if let Err(e) = AccountHistory::load().and_then(|mut account_history| {
@@ -459,7 +461,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_account");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetAccount(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetAccount(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -474,7 +477,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         let (tx, rx) = sync::oneshot::channel();
 
         let message = TunnelCommand::UpdateRelaySettings(tx, constraints_update);
-        let future = self.send_command_to_daemon(message)
+        let future = self
+            .send_command_to_daemon(message)
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -483,7 +487,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_relay_settings");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetRelaySettings(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetRelaySettings(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -492,7 +497,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("allow_lan");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::SetAllowLan(tx, allow_lan))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::SetAllowLan(tx, allow_lan))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -501,7 +507,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_allow_lan");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetAllowLan(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetAllowLan(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -528,7 +535,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_state");
         try_future!(self.check_auth(&meta));
         let (state_tx, state_rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetState(state_tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetState(state_tx))
             .and_then(|_| state_rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -537,7 +545,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_current_location");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetCurrentLocation(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetCurrentLocation(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -589,7 +598,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("set_openvpn_mssfix");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::SetOpenVpnMssfix(tx, mssfix))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::SetOpenVpnMssfix(tx, mssfix))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
 
         Box::new(future)
@@ -599,7 +609,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
         trace!("get_tunnel_options");
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetTunnelOptions(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetTunnelOptions(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }
@@ -607,7 +618,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
     fn get_current_version(&self, meta: Self::Metadata) -> BoxFuture<String, Error> {
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetCurrentVersion(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetCurrentVersion(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
 
         Box::new(future)
@@ -616,7 +628,8 @@ impl<T: From<TunnelCommand> + 'static + Send> ManagementInterfaceApi for Managem
     fn get_version_info(&self, meta: Self::Metadata) -> BoxFuture<version::AppVersionInfo, Error> {
         try_future!(self.check_auth(&meta));
         let (tx, rx) = sync::oneshot::channel();
-        let future = self.send_command_to_daemon(TunnelCommand::GetVersionInfo(tx))
+        let future = self
+            .send_command_to_daemon(TunnelCommand::GetVersionInfo(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()))
             .and_then(|version_future| {
                 version_future.map_err(|error| {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -135,7 +135,8 @@ impl RelaySelector {
         &mut self,
         constraints: &RelayConstraints,
     ) -> Option<(Relay, TunnelEndpoint)> {
-        let matching_relays: Vec<Relay> = self.relays
+        let matching_relays: Vec<Relay> = self
+            .relays
             .iter()
             .filter_map(|relay| Self::matching_relay(relay, constraints))
             .collect();
@@ -252,7 +253,8 @@ impl RelaySelector {
     /// Downloads the latest relay list and caches it. This operation is blocking.
     pub fn update(&mut self, timeout: Duration) -> Result<()> {
         info!("Downloading list of relays...");
-        let download_future = self.rpc_client
+        let download_future = self
+            .rpc_client
             .relay_list()
             .map_err(|e| Error::with_chain(e, ErrorKind::DownloadError));
         let relay_list = Timer::default().timeout(download_future, timeout).wait()?;

--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -104,7 +104,8 @@ impl<T: Connect> Service for HttpsConnectorWithSni<T> {
 
     fn call(&self, uri: Uri) -> Self::Future {
         let is_https = uri.scheme() == Some("https");
-        let maybe_host = self.sni_hostname
+        let maybe_host = self
+            .sni_hostname
             .as_ref()
             .map(String::as_str)
             .or_else(|| uri.host())

--- a/talpid-core/src/firewall/linux/dns.rs
+++ b/talpid-core/src/firewall/linux/dns.rs
@@ -95,7 +95,8 @@ impl State {
     fn desired_config(&self) -> Config {
         let mut config = self.backup.clone();
 
-        config.nameservers = self.desired_dns
+        config.nameservers = self
+            .desired_dns
             .iter()
             .map(|&address| ScopedIp::from(address))
             .collect();

--- a/talpid-core/src/firewall/macos/mod.rs
+++ b/talpid-core/src/firewall/macos/mod.rs
@@ -240,7 +240,8 @@ impl PacketFilter {
 
     fn remove_rules(&mut self) -> Result<()> {
         // remove_anchor() does not deactivate active rules
-        Ok(self.pf
+        Ok(self
+            .pf
             .flush_rules(ANCHOR_NAME, pfctl::RulesetKind::Filter)?)
     }
 

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -79,14 +79,17 @@ impl TunnelEvent {
     ) -> Option<TunnelEvent> {
         match *event {
             OpenVpnPluginEvent::Up => {
-                let interface = env.get("dev")
+                let interface = env
+                    .get("dev")
                     .expect("No \"dev\" in tunnel up event")
                     .to_owned();
-                let ip = env.get("ifconfig_local")
+                let ip = env
+                    .get("ifconfig_local")
                     .expect("No \"ifconfig_local\" in tunnel up event")
                     .parse()
                     .expect("Tunnel IP not in valid format");
-                let gateway = env.get("route_vpn_gateway")
+                let gateway = env
+                    .get("route_vpn_gateway")
                     .expect("No \"route_vpn_gateway\" in tunnel up event")
                     .parse()
                     .expect("Tunnel gateway IP not in valid format");

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -66,7 +66,8 @@ impl<C: OpenVpnBuilder> OpenVpnMonitor<C> {
             event_server::start(on_event).chain_err(|| ErrorKind::EventDispatcherError)?;
 
         cmd.plugin(plugin_path, vec![event_dispatcher.address().to_owned()]);
-        let child = cmd.start()
+        let child = cmd
+            .start()
             .chain_err(|| ErrorKind::ChildProcessError("Failed to start"))?;
 
         Ok(OpenVpnMonitor {

--- a/windows-service/examples/simple_service.rs
+++ b/windows-service/examples/simple_service.rs
@@ -366,11 +366,13 @@ mod simple_service {
             | ServiceState::PausePending
             | ServiceState::ContinuePending => ServiceControlAccept::empty(),
             ServiceState::Running => {
-                ServiceControlAccept::STOP | ServiceControlAccept::PAUSE_CONTINUE
+                ServiceControlAccept::STOP
+                    | ServiceControlAccept::PAUSE_CONTINUE
                     | ServiceControlAccept::SHUTDOWN
             }
             ServiceState::Paused => {
-                ServiceControlAccept::STOP | ServiceControlAccept::PAUSE_CONTINUE
+                ServiceControlAccept::STOP
+                    | ServiceControlAccept::PAUSE_CONTINUE
                     | ServiceControlAccept::SHUTDOWN
             }
             ServiceState::StopPending | ServiceState::Stopped => ServiceControlAccept::empty(),


### PR DESCRIPTION
The new version of rustfmt dropped and both the formatting and the CLI syntax changed.

When it comes to formatting more or less the only difference seems to be that the code `foo.bar().baz()` was previously formatted as:
```rust
foo.bar()
    .baz()
```
But is now:
```rust
foo
    .bar()
    .baz()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/177)
<!-- Reviewable:end -->
