### PR TITLE
Update login error when there's no daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix OpenVPN warning about usage of AES-256-CBC cipher.
 - Fix "Out of time" screen status icon position.
 - If necessary, create parent directories for RPC connection info file and tunnel log.
+- Fix error message when attempting to login when the daemon isn't running .
 
 
 ## [2018.1] - 2018-03-01

--- a/app/lib/backend.js
+++ b/app/lib/backend.js
@@ -11,7 +11,7 @@ import type { ReduxStore } from '../redux/store';
 import type { AccountToken, BackendState, RelaySettingsUpdate } from './ipc-facade';
 import type { ConnectionState } from '../redux/connection/reducers';
 
-export type ErrorType = 'NO_CREDIT' | 'NO_INTERNET' | 'INVALID_ACCOUNT' | 'NO_ACCOUNT' | 'COMMUNICATION_FAILURE' | 'UNKNOWN_ERROR' ;
+export type ErrorType = 'NO_CREDIT' | 'NO_INTERNET' | 'NO_DAEMON' | 'INVALID_ACCOUNT' | 'NO_ACCOUNT' | 'COMMUNICATION_FAILURE' | 'UNKNOWN_ERROR' ;
 
 export class BackendError extends Error {
   type: ErrorType;
@@ -51,6 +51,8 @@ export class BackendError extends Error {
       return 'Invalid account number';
     case 'NO_ACCOUNT':
       return 'No account was set';
+    case 'NO_DAEMON':
+      return 'Could not connect to the Mullvad daemon';
     case 'COMMUNICATION_FAILURE':
       return 'api.mullvad.net is blocked, please check your firewall';
     case 'UNKNOWN_ERROR': {
@@ -194,6 +196,10 @@ export class Backend {
   }
 
   _rpcErrorToBackendError(e) {
+    if (e instanceof BackendError) {
+      return e;
+    }
+
     const isJsonRpcError = e.hasOwnProperty('code');
     if (isJsonRpcError) {
       switch(e.code) {
@@ -525,7 +531,7 @@ export class Backend {
       }
       return this._authenticationPromise;
     } else {
-      return Promise.reject(new Error('Missing authentication credentials.'));
+      return Promise.reject(new BackendError('NO_DAEMON'));
     }
   }
 


### PR DESCRIPTION
This is a simple change to show a clearer error message when the RPC credentials aren't set.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/184)
<!-- Reviewable:end -->
