### PR TITLE
Explicitly setting file permissions for the RPC address file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ env:
   global:
     - MACOSX_DEPLOYMENT_TARGET="10.7"
 
+git:
+  submodules: false
+
+before_install:
+  - git submodule update --init
+
 matrix:
   include:
     - language: node_js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
   - rustc -Vv
   - rustc --print cfg
   - cargo -V
-  - git submodule update --init --recursive
+  - git submodule update --init
 
 # This is the "test phase", tweak it as you see fit
 test_script:

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -41,6 +41,7 @@ simple-signal = "1.1"
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"
 windows-service = "0.1"
+winapi = "0.3"
 
 [dev-dependencies]
 assert_matches = "1.0"


### PR DESCRIPTION
Previously, we did not explicitly set any access restrictions on the RPC address file, so I've set them now. @mvd-ows please tell me if this isn't doing what I think it's doing, but after comparing the behaviour between the current master and a build with these changes, the file permissions remain the same, and a regular user cannot change the existing file either way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/188)
<!-- Reviewable:end -->
