### PR TITLE
Bump OpenVPN buffer sizes to 999999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Line wrap the file at 100 chars.                                              Th
   directories.
 - Replaced previously bundled OpenVPN 2.4.4 with statically linked 2.4.6 version containing
   Mullvad patches for faster connect and other improvements.
+- Increase the OpenVPN receive and send buffers from 524288 to 1048576 bytes (1MiB).
 
 #### macOS
 - The installer changed from dmg to pkg format.

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -24,8 +24,8 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--connect-retry-max", "1"],
     &["--comp-lzo"],
     &["--remote-cert-tls", "server"],
-    &["--rcvbuf", "524288"],
-    &["--sndbuf", "524288"],
+    &["--rcvbuf", "1048576"],
+    &["--sndbuf", "1048576"],
     &["--fast-io"],
     &["--cipher", "AES-256-CBC"],
 ];


### PR DESCRIPTION
Richard made a performance test with the following results:
```
524288 - se-mma-005: 180, 190, 200, 190, 180, 200.
999999 - se-mma-005: 330, 260, 390, 390, 390, 390,
0      - se-mma-005: 330, 270, 400, 370, 340, 360
```
which clearly indicates that increasing the buffer yields better performance. This is of course subject to many factors. But we don't think it will decrease performance for anyone (?)

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/199)
<!-- Reviewable:end -->
