### PR TITLE
Move #[cfg(..)] into functions to reduce signature duplication

### DIFF
--- a/mullvad-daemon/src/cache.rs
+++ b/mullvad-daemon/src/cache.rs
@@ -3,16 +3,17 @@ use {ErrorKind, Result, ResultExt};
 use std::fs;
 use std::path::PathBuf;
 
-#[cfg(target_os = "linux")]
 pub fn get_cache_dir() -> Result<PathBuf> {
-    let dir = PathBuf::from("/var/cache/mullvad-daemon");
-    fs::create_dir_all(&dir).chain_err(|| ErrorKind::NoCacheDir)?;
-    Ok(dir)
-}
-
-#[cfg(any(target_os = "macos", windows))]
-pub fn get_cache_dir() -> Result<PathBuf> {
-    use mullvad_metadata::APP_INFO;
-    ::app_dirs::app_root(::app_dirs::AppDataType::UserCache, &APP_INFO)
-        .chain_err(|| ErrorKind::NoCacheDir)
+    #[cfg(target_os = "linux")]
+    {
+        let dir = PathBuf::from("/var/cache/mullvad-daemon");
+        fs::create_dir_all(&dir).chain_err(|| ErrorKind::NoCacheDir)?;
+        Ok(dir)
+    }
+    #[cfg(any(target_os = "macos", windows))]
+    {
+        use mullvad_metadata::APP_INFO;
+        ::app_dirs::app_root(::app_dirs::AppDataType::UserCache, &APP_INFO)
+            .chain_err(|| ErrorKind::NoCacheDir)
+    }
 }

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -134,12 +134,13 @@ impl Formatter {
     }
 }
 
-#[cfg(not(windows))]
 fn escape_newlines(text: String) -> String {
-    text
-}
-
-#[cfg(windows)]
-fn escape_newlines(text: String) -> String {
-    text.replace("\n", LINE_SEPARATOR)
+    #[cfg(not(windows))]
+    {
+        text
+    }
+    #[cfg(windows)]
+    {
+        text.replace("\n", LINE_SEPARATOR)
+    }
 }

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -862,26 +862,25 @@ fn run() -> Result<()> {
     run_platform(config)
 }
 
-#[cfg(windows)]
 fn run_platform(config: cli::Config) -> Result<()> {
-    if config.run_as_service {
-        system_service::run()
-    } else {
-        if config.register_service {
-            let install_result =
-                system_service::install_service().chain_err(|| "Unable to install the service");
-            if install_result.is_ok() {
-                println!("Installed the service.");
-            }
-            install_result
+    #[cfg(windows)]
+    {
+        if config.run_as_service {
+            system_service::run()
         } else {
-            run_standalone(config)
+            if config.register_service {
+                let install_result =
+                    system_service::install_service().chain_err(|| "Unable to install the service");
+                if install_result.is_ok() {
+                    println!("Installed the service.");
+                }
+                install_result
+            } else {
+                run_standalone(config)
+            }
         }
     }
-}
-
-#[cfg(not(windows))]
-fn run_platform(config: cli::Config) -> Result<()> {
+    #[cfg(not(windows))]
     run_standalone(config)
 }
 
@@ -935,14 +934,15 @@ fn get_resource_dir() -> PathBuf {
     }
 }
 
-#[cfg(unix)]
 fn running_as_admin() -> bool {
-    let uid = unsafe { libc::getuid() };
-    uid == 0
-}
-
-#[cfg(windows)]
-fn running_as_admin() -> bool {
-    // TODO: Check if user is administrator correctly on Windows.
-    true
+    #[cfg(unix)]
+    {
+        let uid = unsafe { libc::getuid() };
+        uid == 0
+    }
+    #[cfg(windows)]
+    {
+        // TODO: Check if user is administrator correctly on Windows.
+        true
+    }
 }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -86,18 +86,19 @@ impl Settings {
         serde_json::to_writer_pretty(file, self).chain_err(|| ErrorKind::WriteError(path))
     }
 
-    #[cfg(unix)]
     fn get_settings_path() -> Result<PathBuf> {
-        let dir = PathBuf::from("/etc/mullvad-daemon");
-        ::std::fs::create_dir_all(&dir).chain_err(|| ErrorKind::DirectoryError)?;
-        Ok(dir.join(SETTINGS_FILE))
-    }
+        #[cfg(unix)]
+        let dir = {
+            let dir = PathBuf::from("/etc/mullvad-daemon");
+            ::std::fs::create_dir_all(&dir).chain_err(|| ErrorKind::DirectoryError)?;
+            dir
+        };
+        #[cfg(windows)]
+        let dir = ::app_dirs::app_root(
+            ::app_dirs::AppDataType::UserConfig,
+            &mullvad_metadata::APP_INFO,
+        ).chain_err(|| ErrorKind::DirectoryError)?;
 
-    #[cfg(windows)]
-    fn get_settings_path() -> Result<PathBuf> {
-        use mullvad_metadata::APP_INFO;
-        let dir = ::app_dirs::app_root(::app_dirs::AppDataType::UserConfig, &APP_INFO)
-            .chain_err(|| ErrorKind::DirectoryError)?;
         Ok(dir.join(SETTINGS_FILE))
     }
 

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -291,16 +291,17 @@ mod tests {
     struct TestProcessHandle(i32);
 
     impl ProcessHandle for TestProcessHandle {
-        #[cfg(unix)]
         fn wait(&self) -> io::Result<ExitStatus> {
-            use std::os::unix::process::ExitStatusExt;
-            Ok(ExitStatus::from_raw(self.0))
-        }
-
-        #[cfg(windows)]
-        fn wait(&self) -> io::Result<ExitStatus> {
-            use std::os::windows::process::ExitStatusExt;
-            Ok(ExitStatus::from_raw(self.0 as u32))
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                Ok(ExitStatus::from_raw(self.0))
+            }
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::ExitStatusExt;
+                Ok(ExitStatus::from_raw(self.0 as u32))
+            }
         }
 
         fn kill(&self) -> io::Result<()> {


### PR DESCRIPTION
This is a bit of a style question, so including all three of you to leave comments if you would like to.

I recently learned that putting conditional compilation guards can be done on stable Rust on whole blocks anywhere in code. Not just entire methods/functions. I think doing this instead of duplicating function signatures is good. Less duplicated code to keep in sync etc. This PR does not convert all instances where this pattern is applicable. I just picked some of them to be able to showcase this and see what you think.

I think it looks a slight bit awkward at first when not used to it. But I want to discuss this potential first awkwardness vs the reduced function signature duplication with you and see what you think.

As you can see in `settings.rs`, it can also be used to further reduce duplication of code that are the same in all implementations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/202)
<!-- Reviewable:end -->
