### PR TITLE
Add verbosity level to OpenVPN arguments

### DIFF
--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -28,6 +28,7 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--sndbuf", "1048576"],
     &["--fast-io"],
     &["--cipher", "AES-256-CBC"],
+    &["--verb", "3"],
 ];
 
 static ALLOWED_TLS_CIPHERS: &[&str] = &[


### PR DESCRIPTION
Richard requested that we make OpenVPN slightly more verbose. It will likely help support debug some type of issues. The default verbosity is quite quiet.

Does not feel like a change worth mentioning in the changelog to me.

Checklist for a PR:

* [ ] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/203)
<!-- Reviewable:end -->
