### PR TITLE
Add system state backup to talpid core.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "system-configuration 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
+ "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -33,3 +33,6 @@ tokio-core = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "0.3"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -1,5 +1,7 @@
 use talpid_types::net::Endpoint;
 
+mod system_state;
+
 
 /// A enum that describes firewall rules strategy
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/talpid-core/src/firewall/system_state.rs
+++ b/talpid-core/src/firewall/system_state.rs
@@ -1,0 +1,64 @@
+//! A writer for a blob that would persistently store the system state. Useful
+//! for when the application of a secuirty policy proves to be persistent across
+//! reboots
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::slice;
+
+const STATE_BACKUP_FILENAME: &str = "system_state_backup";
+
+/// This struct is responsible for saving a binary blob to disk. The binary blob is intended to
+/// store system state that should be resotred when the security policy is reset.
+pub struct SystemStateWriter {
+    /// Full path to the system state backup file
+    pub backup_path: Box<Path>,
+}
+
+impl SystemStateWriter {
+    /// Creates a new SystemStateWriter which will use a file in the cache directory to store system
+    /// state that has to be restored.
+    pub fn new<P: AsRef<Path>>(cache_dir: P) -> Self {
+        let backup_path = cache_dir
+            .as_ref()
+            .join(STATE_BACKUP_FILENAME)
+            .into_boxed_path();
+        Self { backup_path }
+    }
+
+    /// Writes a binary blob representing the system state to the backup location before any
+    /// security policies are applied.
+    pub fn write_backup(&self, data: &[u8]) -> io::Result<()> {
+        fs::write(&self.backup_path, &data)
+    }
+
+    /// Tries to read a previously saved backup and deletes it after reading it if it exists.
+    pub fn consume_state_backup(&self) -> io::Result<Option<Vec<u8>>> {
+        match fs::read(&self.backup_path) {
+            Ok(blob) => {
+                if let Err(e) = self.remove_state_file() {
+                    error!("Failed to remove system state backup: {}", e)
+                };
+                Ok(Some(blob))
+            }
+            Err(e) => match e.kind() {
+                io::ErrorKind::NotFound => Ok(None),
+                _ => Err(e),
+            },
+        }
+    }
+
+    /// Removes a previously created state backup if it exists.
+    pub fn remove_state_file(&self) -> io::Result<()> {
+        match fs::remove_file(&self.backup_path) {
+            Err(e) => {
+                if e.kind() != io::ErrorKind::NotFound {
+                    Err(e)
+                } else {
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+}


### PR DESCRIPTION
I've added the code that will be used by the _Firewall_ trait implementors on Linux and Windows and some tests. Whilst it will only be used to store the DNS servers used by the system when a tunnel is not connected, I chose to not call it _DNSServerListBackup_ as this code really doesn't have to care about what it stores.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/204)
<!-- Reviewable:end -->
