### PR TITLE
Move extern crate libc into talpid-core root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "windows-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -11,7 +11,6 @@ duct = "0.10"
 error-chain = "0.11"
 jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", tag = "v8.0.1" }
 jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc", tag = "v8.0.1" }
-libc = "0.2.20"
 log = "0.4"
 os_pipe = "0.6"
 uuid = { version = "0.6", features = ["v4"] }
@@ -32,6 +31,7 @@ core-foundation = "0.5"
 tokio-core = "0.1"
 
 [target.'cfg(windows)'.dependencies]
+libc = "0.2.20"
 widestring = "0.3"
 
 [dev-dependencies]

--- a/talpid-core/src/firewall/windows/mod.rs
+++ b/talpid-core/src/firewall/windows/mod.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 extern crate widestring;
 
 use super::{Firewall, SecurityPolicy};
@@ -137,7 +136,7 @@ impl WindowsFirewall {
 #[allow(non_snake_case)]
 mod ffi {
 
-    use super::libc;
+    extern crate libc;
     use super::{ErrorKind, Result};
     use std::ffi::CStr;
     use std::os::raw::c_char;

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -12,7 +12,6 @@
 
 extern crate atty;
 extern crate duct;
-
 #[macro_use]
 extern crate log;
 

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -1,5 +1,4 @@
 use duct;
-extern crate libc;
 extern crate os_pipe;
 
 use super::stoppable_process::StoppableProcess;

--- a/talpid-core/src/process/stoppable_process.rs
+++ b/talpid-core/src/process/stoppable_process.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 use std::io;
 use std::thread;
 use std::time::{Duration, Instant};


### PR DESCRIPTION
I realized two of the `extern crate libc`s were unused. Seems like unused `extern crate`s does not generate warnings. I removed them and moved the remaining usage of libc into only Windows.

The lockfile change has nothing with the `libc` change to do. That is just because the PR before this one forgot to update it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/225)
<!-- Reviewable:end -->
