### PR TITLE
Rename winfw lib dir and make cargo detect changes

### DIFF
--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -39,7 +39,9 @@ fn main() {
     use std::path::PathBuf;
     use win::*;
 
-    let winfw_dir = env::var_os("WINFW_INCLUDE_DIR")
+    const WINFW_LIB_DIR_VAR: &str = "WINFW_LIB_DIR";
+    println!("cargo:rerun-if-env-changed={}", WINFW_LIB_DIR_VAR);
+    let winfw_dir = env::var_os(WINFW_LIB_DIR_VAR)
         .map(PathBuf::from)
         .unwrap_or_else(default_winfw_output_dir);
 


### PR DESCRIPTION
The `cargo:rerun-if-env-changed=` trick I learned from `openssl-sys` (https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/main.rs#L48) makes it easy to change where to point to and re-run without having to `cargo clean` and restart everything.

Also renamed the variable from `INCLUDE` to `LIB`. In our other crates, and in other people's crates `LIB` is usually used to mean the libraries folder and `INCLUDE` for headers. `openssl-sys` (https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/main.rs#L56) is a good example again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/226)
<!-- Reviewable:end -->
