### PR TITLE
Test authentication in Talpid OpenVPN plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ matrix:
         - rustup component add rustfmt-preview
         - rustfmt --version
         - cargo fmt -- --check --unstable-features
-        - ./integration-tests.sh
 
     - language: rust
       rust: beta
@@ -62,7 +61,6 @@ matrix:
       script: &rust_linux_script
         - cargo build --verbose
         - cargo test --verbose
-        - ./integration-tests.sh
 
     - language: rust
       rust: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,9 @@ dependencies = [
  "mullvad-paths 0.1.0",
  "mullvad-types 0.1.0",
  "notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_pipe 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "talpid-ipc 0.1.0",
  "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ "$UID" -ne 0 ]; then
+    echo "WARNING: Not running as root, some tests may fail" >&2
+fi
+
 MULLVAD_DIR="$(cd "$(dirname "$0")"; pwd -P)"
 
 pushd "$MULLVAD_DIR"

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -6,7 +6,7 @@ pushd "$MULLVAD_DIR"
 
 cargo build \
     && cd mullvad-tests \
-    && cargo test --features "integration-tests"
+    && cargo test --features "integration-tests" -- --test-threads=1
 
 RESULT="$?"
 popd

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -14,7 +14,9 @@ mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-types = { path = "../mullvad-types" }
 notify = "4.0"
+openvpn-plugin = { version = "0.3", features = ["serde"] }
 os_pipe = "0.6"
+talpid-ipc = { path = "../talpid-ipc" }
 tempfile = "3.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -278,16 +278,29 @@ impl Drop for DaemonRunner {
 }
 
 pub struct MockOpenVpnPluginRpcClient {
+    credentials: String,
     rpc: WsIpcClient,
 }
 
 impl MockOpenVpnPluginRpcClient {
-    pub fn with_address(address: String) -> Result<Self, String> {
+    pub fn new(address: String, credentials: String) -> Result<Self, String> {
         let rpc = WsIpcClient::connect(&address).map_err(|error| {
             format!("Failed to create Mock OpenVPN plugin RPC client: {}", error)
         })?;
 
-        Ok(MockOpenVpnPluginRpcClient { rpc })
+        Ok(MockOpenVpnPluginRpcClient { rpc, credentials })
+    }
+
+    pub fn authenticate(&mut self) -> Result<bool, String> {
+        self.rpc
+            .call("authenticate", &[&self.credentials])
+            .map_err(|error| format!("Failed to authenticate mock OpenVPN IPC client: {}", error))
+    }
+
+    pub fn authenticate_with(&mut self, credentials: &str) -> Result<bool, String> {
+        self.rpc
+            .call("authenticate", &[credentials])
+            .map_err(|error| format!("Failed to authenticate mock OpenVPN IPC client: {}", error))
     }
 
     pub fn up(&mut self) -> Result<(), String> {

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -7,9 +7,12 @@ extern crate libc;
 extern crate mullvad_ipc_client;
 extern crate mullvad_paths;
 extern crate notify;
+extern crate openvpn_plugin;
 extern crate os_pipe;
+extern crate talpid_ipc;
 extern crate tempfile;
 
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -17,10 +20,12 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use self::mullvad_ipc_client::DaemonRpcClient;
-use self::notify::{op, RawEvent, RecursiveMode, Watcher};
-use self::os_pipe::{pipe, PipeReader};
-use self::tempfile::TempDir;
+use mullvad_ipc_client::DaemonRpcClient;
+use notify::{op, RawEvent, RecursiveMode, Watcher};
+use openvpn_plugin::types::OpenVpnPluginEvent;
+use os_pipe::{pipe, PipeReader};
+use talpid_ipc::WsIpcClient;
+use tempfile::TempDir;
 
 use self::platform_specific::*;
 
@@ -269,5 +274,39 @@ impl Drop for DaemonRunner {
         }
 
         let _ = fs::remove_file(&self.rpc_address_file);
+    }
+}
+
+pub struct MockOpenVpnPluginRpcClient {
+    rpc: WsIpcClient,
+}
+
+impl MockOpenVpnPluginRpcClient {
+    pub fn with_address(address: String) -> Result<Self, String> {
+        let rpc = WsIpcClient::connect(&address).map_err(|error| {
+            format!("Failed to create Mock OpenVPN plugin RPC client: {}", error)
+        })?;
+
+        Ok(MockOpenVpnPluginRpcClient { rpc })
+    }
+
+    pub fn up(&mut self) -> Result<(), String> {
+        let mut env: HashMap<String, String> = HashMap::new();
+
+        env.insert("dev".to_owned(), "dummy".to_owned());
+        env.insert("ifconfig_local".to_owned(), "10.0.0.10".to_owned());
+        env.insert("route_vpn_gateway".to_owned(), "10.0.0.1".to_owned());
+
+        self.send_event(OpenVpnPluginEvent::Up, env)
+    }
+
+    fn send_event(
+        &mut self,
+        event: OpenVpnPluginEvent,
+        env: HashMap<String, String>,
+    ) -> Result<(), String> {
+        self.rpc
+            .call("openvpn_event", &(event, env))
+            .map_err(|error| format!("Failed to send mock OpenVPN event {:?}: {}", event, error))
     }
 }

--- a/mullvad-tests/tests/connection.rs
+++ b/mullvad-tests/tests/connection.rs
@@ -4,12 +4,20 @@ extern crate mullvad_ipc_client;
 extern crate mullvad_tests;
 extern crate mullvad_types;
 
-use std::fs;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::Path;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use mullvad_tests::{wait_for_file_write_finish, DaemonRunner};
+use mullvad_tests::{wait_for_file_write_finish, DaemonRunner, MockOpenVpnPluginRpcClient};
 use mullvad_types::states::{DaemonState, SecurityState, TargetState};
+
+#[cfg(target_os = "linux")]
+const OPENVPN_PLUGIN_NAME: &str = "libtalpid_openvpn_plugin.so";
+
+#[cfg(windows)]
+const OPENVPN_PLUGIN_NAME: &str = "talpid_openvpn_plugin.dll";
 
 const CONNECTING_STATE: DaemonState = DaemonState {
     state: SecurityState::Unsecured,
@@ -62,14 +70,70 @@ fn changes_to_connecting_state() {
     rpc_client.set_account(Some("123456".to_owned())).unwrap();
     rpc_client.connect().unwrap();
 
-    assert_state_event(state_events, CONNECTING_STATE);
+    assert_state_event(&state_events, CONNECTING_STATE);
     assert_eq!(rpc_client.get_state().unwrap(), CONNECTING_STATE);
 }
 
-fn assert_state_event(receiver: mpsc::Receiver<DaemonState>, expected_state: DaemonState) {
+#[test]
+fn ignores_event_from_unauthorized_connection_from_openvpn_plugin() {
+    let mut daemon = DaemonRunner::spawn();
+    let mut rpc_client = daemon.rpc_client().unwrap();
+    let openvpn_args_file = daemon.mock_openvpn_args_file();
+    let state_events = rpc_client.new_state_subscribe().unwrap();
+
+    rpc_client.set_account(Some("123456".to_owned())).unwrap();
+    rpc_client.connect().unwrap();
+
+    assert_state_event(&state_events, CONNECTING_STATE);
+
+    let mut mock_plugin_client = create_mock_openvpn_plugin_client(openvpn_args_file);
+    let call_result = mock_plugin_client.up();
+
+    assert!(call_result.is_err());
+    assert_no_state_event(&state_events);
+    assert_eq!(rpc_client.get_state().unwrap(), CONNECTING_STATE);
+}
+
+fn assert_state_event(receiver: &mpsc::Receiver<DaemonState>, expected_state: DaemonState) {
     let received_state = receiver
         .recv_timeout(Duration::from_secs(1))
         .expect("Failed to receive new state event from daemon");
 
     assert_eq!(received_state, expected_state);
+}
+
+fn assert_no_state_event(receiver: &mpsc::Receiver<DaemonState>) {
+    assert_eq!(
+        receiver.recv_timeout(Duration::from_secs(1)),
+        Err(mpsc::RecvTimeoutError::Timeout),
+    );
+}
+
+fn create_mock_openvpn_plugin_client<P: AsRef<Path>>(
+    openvpn_args_file_path: P,
+) -> MockOpenVpnPluginRpcClient {
+    let address = get_plugin_address(openvpn_args_file_path);
+
+    MockOpenVpnPluginRpcClient::with_address(address)
+        .expect("Failed to create mock RPC client to connect to OpenVPN plugin event listener")
+}
+
+fn get_plugin_address<P: AsRef<Path>>(openvpn_args_file_path: P) -> String {
+    let args_file_path = openvpn_args_file_path.as_ref();
+
+    wait_for_file_write_finish(&args_file_path, Duration::from_secs(5));
+
+    let args_file = File::open(&args_file_path).expect(&format!(
+        "Failed to open mock OpenVPN command-line file: {}",
+        args_file_path.display(),
+    ));
+
+    let args = BufReader::new(args_file).lines();
+
+    args.skip_while(|element| {
+        element.is_ok() && !element.as_ref().unwrap().contains(OPENVPN_PLUGIN_NAME)
+    }).skip(1)
+        .next()
+        .expect("Missing OpenVPN plugin RPC listener address argument")
+        .expect("Failed to read from mock OpenVPN command line file")
 }

--- a/mullvad-tests/tests/connection.rs
+++ b/mullvad-tests/tests/connection.rs
@@ -8,7 +8,6 @@ use std::fs;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_tests::{wait_for_file_write_finish, DaemonRunner};
 use mullvad_types::states::{DaemonState, SecurityState, TargetState};
 


### PR DESCRIPTION
Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user. **Test code is not user visible.**

This PR was added to the integration tests PR queue before the others because now that the Talpid OpenVPN plugin requires authentication for it to work, the tests in the queued PRs will also have to authenticate themselves. Therefore, this implements the authentication mechanism and also tests part the server part of the IPC authentication.

The alternative would be to somehow disable the authentication, but in terms of effort I believe it would be the same, and this way we can actually test the full path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/227)
<!-- Reviewable:end -->
