### PR TITLE
Flush file writes when saving config and backup files

### DIFF
--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -94,11 +94,15 @@ impl AccountHistory {
     /// Serializes the account history and saves it to the file it was loaded from.
     fn save(&self) -> Result<()> {
         debug!("Writing account history to {}", self.cache_path.display());
-        let file = File::create(&self.cache_path)
+        let mut file = File::create(&self.cache_path)
             .map(io::BufWriter::new)
             .chain_err(|| ErrorKind::WriteError(self.cache_path.clone()))?;
 
-        serde_json::to_writer_pretty(file, self)
+        serde_json::to_writer_pretty(&mut file, self)
+            .chain_err(|| ErrorKind::WriteError(self.cache_path.clone()))?;
+
+        file.get_mut()
+            .sync_all()
             .chain_err(|| ErrorKind::WriteError(self.cache_path.clone()))
     }
 }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -81,9 +81,11 @@ impl Settings {
         let path = Self::get_settings_path()?;
 
         debug!("Writing settings to {}", path.display());
-        let file = File::create(&path).chain_err(|| ErrorKind::WriteError(path.clone()))?;
+        let mut file = File::create(&path).chain_err(|| ErrorKind::WriteError(path.clone()))?;
 
-        serde_json::to_writer_pretty(file, self).chain_err(|| ErrorKind::WriteError(path))
+        serde_json::to_writer_pretty(&mut file, self)
+            .chain_err(|| ErrorKind::WriteError(path.clone()))?;
+        file.sync_all().chain_err(|| ErrorKind::WriteError(path))
     }
 
     fn get_settings_path() -> Result<PathBuf> {

--- a/talpid-core/src/firewall/windows/system_state.rs
+++ b/talpid-core/src/firewall/windows/system_state.rs
@@ -24,7 +24,9 @@ impl SystemStateWriter {
     /// Writes a binary blob representing the system state to the backup location before any
     /// security policies are applied.
     pub fn write_backup(&self, data: &[u8]) -> io::Result<()> {
-        fs::write(&self.backup_path, &data)
+        let mut backup_file = File::create(&self.backup_path)?;
+        backup_file.write_all(data)?;
+        backup_file.sync_all()
     }
 
     pub fn read_backup(&self) -> io::Result<Option<Vec<u8>>> {


### PR DESCRIPTION
I've added `File::flush` calls after every write we do where we want to ensure that the data we write actually exists on disk. 
This fixes an issue where if I forcefully restart my Windows VM, the daemon would fail to start up upon reboot, due to the fact that all relevant files would be empty. Might be an edge case, but I think if we call `Settings::save()`, we'd prefer a slightly stronger guarantee that our settings will be persisted to disk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/230)
<!-- Reviewable:end -->
