### PR TITLE
Overhaul build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,57 +2,90 @@
 
 # This script is used to build, and sign a release artifact. See `README.md` for instructions on
 # how to just build a development/testing version.
+#
+# Invoke the script with --dev-build in order to skip checks, cleaning and signing.
 
-set -eu
+################################################################################
+# Platform specific configuration.
+################################################################################
 
-REQUIRED_RUSTC_VERSION="rustc 1.26.0 (a77568041 2018-05-07)"
+case "$(uname -s)" in
+    Linux*)
+        # config
+        ;;
+    Darwin*)
+        export MACOSX_DEPLOYMENT_TARGET="10.7"
+        ;;
+    MINGW*)
+        # config
+        ;;
+esac
+
+################################################################################
+# Verify and configure environment.
+################################################################################
+
 RUSTC_VERSION=`rustc +stable --version`
-if [[ $RUSTC_VERSION != $REQUIRED_RUSTC_VERSION ]]; then
-    echo "You are running the wrong Rust compiler version."
-    echo "You are running $RUSTC_VERSION, but this project requires $REQUIRED_RUSTC_VERSION"
-    echo "for release builds."
-    exit 1
-fi
 
-if [[ "${1:-""}" != "--allow-dirty" ]]; then
+if [[ "${1:-""}" != "--dev-build" ]]; then
+
+    REQUIRED_RUSTC_VERSION="rustc 1.26.2 (594fb253c 2018-06-01)"
+
+    if [[ $RUSTC_VERSION != $REQUIRED_RUSTC_VERSION ]]; then
+        echo "You are running the wrong Rust compiler version."
+        echo "You are running $RUSTC_VERSION, but this project requires $REQUIRED_RUSTC_VERSION"
+        echo "for release builds."
+        exit 1
+    fi
+
     if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
         echo "Dirty working directory!"
         echo "You should only build releases in clean working directories in order to make it"
         echo "easier to reproduce the same build."
-        echo ""
-        echo "Use --allow-dirty to skip this check. Never do this for official releases."
         exit 1
     fi
-fi
 
-if [[ "$(uname -s)" = "Darwin" ]]; then
-    export MACOSX_DEPLOYMENT_TARGET="10.7"
-
-    # if CSC_LINK is set, then we do signing
-    if [[ ! -z ${CSC_LINK-} ]]; then
-        echo "Building with macOS signing activated. Using certificate at $CSC_LINK"
+    if [[ ("$(uname -s)" == "Darwin") || ("$(uname -s)" == "MINGW"*) ]]; then
+        echo "Configuring environment for signing of binaries"
+        if [[ -z ${CSC_LINK-} ]]; then
+            echo "The variable CSC_LINK is not set. It needs to point to a file containing the"
+            echo "private key used for signing of binaries."
+            exit 1
+        fi
         if [[ -z ${CSC_KEY_PASSWORD-} ]]; then
             read -sp "CSC_KEY_PASSWORD = " CSC_KEY_PASSWORD
             echo ""
             export CSC_KEY_PASSWORD
         fi
+        # MacOs: This needs to be set to 'true' to activate signing, even when CSC_LINK is set.
         export CSC_IDENTITY_AUTO_DISCOVERY=true
     else
-        echo "!! CSC_LINK not set. This build will not be signed !!"
         unset CSC_LINK CSC_KEY_PASSWORD
         export CSC_IDENTITY_AUTO_DISCOVERY=false
     fi
+
+    cargo +stable clean
+
+else
+    echo "!! Development build. Not for general distribution !!"
+    unset CSC_LINK CSC_KEY_PASSWORD
+    export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 
-# Remove binaries. To make sure it is rebuilt with the stable toolchain and the latest changes.
-cargo +stable clean
+################################################################################
+# Compile and link all binaries.
+################################################################################
 
 if [[ "$(uname -s)" == "MINGW"* ]]; then
-    ./build_winfw.sh
+    ./build_windows_libraries.sh $1
 fi
 
-echo "Compiling mullvad-daemon in release mode with $RUSTC_VERSION..."
+echo "Building Rust code in release mode using $RUSTC_VERSION..."
 cargo +stable build --release
+
+################################################################################
+# Other work to prepare the release.
+################################################################################
 
 # Only strip binaries on platforms other than Windows.
 if [[ "$(uname -s)" != "MINGW"* ]]; then
@@ -72,6 +105,10 @@ echo "Updating relay list..."
 
 echo "Installing JavaScript dependencies..."
 yarn install
+
+################################################################################
+# Package release.
+################################################################################
 
 echo "Packing final release artifact..."
 case "$(uname -s)" in


### PR DESCRIPTION
Add --dev-build switch.
Add signing of binaries on Windows.

I also intended to update `build_windows_libraries.sh` but this is best done after `winroute` hits master. The planned changes there adds the --dev-build switch and enables parallel builds of C++ projects within a VS solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/231)
<!-- Reviewable:end -->
