### PR TITLE
Update version automatically on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ flow-typed
 dist-assets/relays.json
 windows/**/bin/
 **/.vs/
+*.bak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "mullvad-cli"
-version = "0.1.0"
+version = "2018.1.0"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "mullvad-daemon"
-version = "0.1.0"
+version = "2018.1.0"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ regular installation of Visual Studio 2017 Community edition works as well).
 
 - The host has to have `msbuild.exe` available in `%PATH%`.
 
-- The host has to have `bash` installed. The one coming with [Git for Windows] works.
+- The host has to have `bash` installed as well as a few base unix utilities, including `sed` and
+  `tail`. The environment coming with [Git for Windows] works fine.
 
 [Git for Windows]: https://git-scm.com/download/win
 

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mullvad-cli"
-version = "0.1.0"
+version = "2018.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
 description = "Run Talpid easily from the command line"
 license = "GPL-3.0"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mullvad-daemon"
-version = "0.1.0"
+version = "2018.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
 description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
 license = "GPL-3.0"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
 description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
 license = "GPL-3.0"
-build = "build.rs"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -1,6 +1,5 @@
 use std::env;
-use std::fs::File;
-use std::io::Write;
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -8,25 +7,9 @@ use std::process::Command;
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    File::create(out_dir.join("git-commit-desc.txt"))
-        .unwrap()
-        .write_all(commit_description().as_bytes())
-        .unwrap();
-    File::create(out_dir.join("git-commit-date.txt"))
-        .unwrap()
-        .write_all(commit_date().as_bytes())
-        .unwrap();
-}
-
-fn commit_description() -> String {
-    let output = Command::new("git")
-        .args(&["describe", "--dirty"])
-        .output()
-        .expect("Unable to get git commit description");
-    ::std::str::from_utf8(&output.stdout)
-        .unwrap()
-        .trim()
-        .to_owned()
+    let product_version = env!("CARGO_PKG_VERSION").replacen(".0", "", 1);
+    fs::write(out_dir.join("product-version.txt"), product_version).unwrap();
+    fs::write(out_dir.join("git-commit-date.txt"), commit_date()).unwrap();
 }
 
 fn commit_date() -> String {

--- a/mullvad-daemon/src/bin/problem-report.rs
+++ b/mullvad-daemon/src/bin/problem-report.rs
@@ -82,7 +82,7 @@ quick_main!(run);
 
 fn run() -> Result<()> {
     let app = clap::App::new("problem-report")
-        .version(crate_version!())
+        .version(daemon_version())
         .author(crate_authors!())
         .about("Mullvad VPN problem report tool. Collects logs and sends them to Mullvad support.")
         .setting(clap::AppSettings::SubcommandRequired)
@@ -441,15 +441,18 @@ fn read_file_lossy(path: &Path, max_bytes: usize) -> io::Result<String> {
 
 fn collect_metadata() -> HashMap<String, String> {
     let mut metadata = HashMap::new();
-    metadata.insert(String::from("mullvad-daemon-version"), daemon_version());
+    metadata.insert(
+        String::from("mullvad-daemon-version"),
+        daemon_version().to_owned(),
+    );
     metadata.insert(String::from("os"), os_version());
     metadata
 }
 
-fn daemon_version() -> String {
-    format!(
-        "{} {}",
-        include_str!(concat!(env!("OUT_DIR"), "/git-commit-desc.txt")),
+fn daemon_version() -> &'static str {
+    concat!(
+        include_str!(concat!(env!("OUT_DIR"), "/product-version.txt")),
+        " ",
         include_str!(concat!(env!("OUT_DIR"), "/git-commit-date.txt"))
     )
 }

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -37,7 +37,7 @@ pub fn get_config() -> Config {
 
 fn create_app() -> App<'static, 'static> {
     let app = App::new(crate_name!())
-        .version(version::current())
+        .version(version::CURRENT)
         .author(crate_authors!())
         .about(crate_description!())
         .arg(

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -490,7 +490,7 @@ impl Daemon {
         &mut self,
         tx: OneshotSender<BoxFuture<AppVersionInfo, mullvad_rpc::Error>>,
     ) {
-        let current_version = version::current().to_owned();
+        let current_version = version::CURRENT.to_owned();
         let fut = self
             .version_proxy
             .latest_app_version()
@@ -506,7 +506,7 @@ impl Daemon {
     }
 
     fn on_get_current_version(&mut self, tx: OneshotSender<AppVersion>) {
-        let current_version = version::current().to_owned();
+        let current_version = version::CURRENT.to_owned();
         Self::oneshot_send(tx, current_version, "get_current_version response");
     }
 
@@ -915,8 +915,8 @@ fn log_version() {
     info!(
         "Starting {} - {} {}",
         env!("CARGO_PKG_NAME"),
-        version::current(),
-        version::commit_date(),
+        version::CURRENT,
+        version::COMMIT_DATE,
     )
 }
 

--- a/mullvad-daemon/src/version.rs
+++ b/mullvad-daemon/src/version.rs
@@ -1,9 +1,5 @@
-/// Returns a string that identifies the current version of the application
-pub fn current() -> &'static str {
-    include_str!(concat!(env!("OUT_DIR"), "/git-commit-desc.txt"))
-}
+/// A string that identifies the current version of the application
+pub const CURRENT: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 
-/// Current description returns the current build date
-pub fn commit_date() -> &'static str {
-    include_str!(concat!(env!("OUT_DIR"), "/git-commit-date.txt"))
-}
+/// Contains the date of the git commit this was built from
+pub const COMMIT_DATE: &str = include_str!(concat!(env!("OUT_DIR"), "/git-commit-date.txt"));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mullvad-vpn",
-  "version": "2018.1.0-beta10",
+  "version": "2018.1.0",
   "description": "Mullvad VPN client",
   "main": "init.js",
   "author": {

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -29,12 +29,19 @@ if [[ $(grep $VERSION CHANGELOG.md) == "" ]]; then
     exit 1
 fi
 
-echo "Updating version in package.json..."
+echo "Updating version in metadata files..."
 SEMVER_VERSION=`echo $VERSION | sed -re 's/($|-.*)/.0\1/g'`
-sed -i -re "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" package.json
+sed -i -re "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" \
+    package.json
+sed -i -re "s/^version = \"[^\"]+\"\$/version = \"$SEMVER_VERSION\"/g" \
+    mullvad-daemon/Cargo.toml \
+    mullvad-cli/Cargo.toml
 
-echo "Commiting package.json change to git..."
-git commit -S package.json -m "Updating version in package.json"
+echo "Commiting metadata changes to git..."
+git commit -S -m "Updating version in package.json" \
+    package.json \
+    mullvad-daemon/Cargo.toml \
+    mullvad-cli/Cargo.toml
 
 echo "Tagging current git commit with release tag $VERSION..."
 git tag -s $VERSION -m $VERSION


### PR DESCRIPTION
Adding everyone since someone might have a say about the version format.

Basically it works like this:
1. Take version from `package.json` and strip the `.0` that is just there to make it semver.
1. If it's not a release version we append `-dev-<commit hash>` to the version.
1. We build the daemon with the newly formatted version string with the help of the `MULLVAD_PRODUCT_VERSION` environment variable.
1. We make the full format string into a semver compatible version again and inject it into `package.json`
1. We package the electron app.
1. We restore `package.json` so we don't get the dirty version in there.

Building from master after this fix will yield a version looking something like `2018.1-dev-f2618bc0` in the daemon, but `2018.1.0-dev-f2618bc0` in the GUI/installer. Since we can't get rid of the `.0` there. After releasing `2018.2-beta1` a dev build will look like `2018.2-beta1-dev-f2618bc0`.. You get the point. `<last-release>[-dev-<commit>]`

This way won't in any way add a `dirty` tag to the version. I felt that was more work than it was worth. Do we want to know if it was build from a dirty working directory? We still check this for release builds and fail to build on dirty working directories for release builds though!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/240)
<!-- Reviewable:end -->
