### PR TITLE
Fix scroll flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove the `shutdown` command from the CLI.
 
 ### Fixed
+- Fix scroll flickering.
 - Fix bug in account input field that advanced the cursor to the end regardless its prior position.
 - Redact all 16 digit numbers from problem report logs. Extra safety against accidentally sending
   account numbers.

--- a/app/components/AdvancedSettingsStyles.js
+++ b/app/components/AdvancedSettingsStyles.js
@@ -44,6 +44,7 @@ export default {
       flexGrow: 1,
       flexShrink: 0,
       flexBasis: 'auto',
+      overflow: 'visible',
     },
     advanced_settings__cell: {
       backgroundColor: '#44AD4D',

--- a/app/components/SelectLocation.js
+++ b/app/components/SelectLocation.js
@@ -76,7 +76,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
               </View>
 
               <CustomScrollbars autoHide={true} ref={(ref) => (this._scrollView = ref)}>
-                <View>
+                <View style={styles.content}>
                   <Text style={styles.subtitle}>
                     While connected, your real location is masked with a private and secure location
                     in the selected region

--- a/app/components/SelectLocationStyles.js
+++ b/app/components/SelectLocationStyles.js
@@ -27,6 +27,9 @@ export default {
       flex: 0,
       opacity: 0.6,
     },
+    content: {
+      overflow: 'visible',
+    },
     relay_status: {
       width: 16,
       height: 16,

--- a/app/components/SettingsStyles.js
+++ b/app/components/SettingsStyles.js
@@ -24,6 +24,7 @@ export default Object.assign(
       flexDirection: 'column',
       flex: 1,
       justifyContent: 'space-between',
+      overflow: 'visible',
     },
     settings__scrollview: {
       flexGrow: 1,


### PR DESCRIPTION
`overflow: auto` + `overflow: hidden` do not seem to work together properly.

Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

This PR fixes a scroll flickering that can be easily reproduced in location picker by scrolling fast in different directions. Visually it looks like the clipping area of scrolled content does not update at the same pace as the scroll view itself, so that the clip box has to catch up with the scroll view.

Setting `overflow: visible` for scrolled content make this bug go away.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/243)
<!-- Reviewable:end -->
