### PR TITLE
Add editorconfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{rs,sh}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+
+[*.{js,json,css,html}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Set the default behavior
 * text=auto
 
-# Do not break script files on Windows (Cygwin gets upset with CRLF)
+# Do not break script files on Windows, Bash expects LF
 *.sh text eol=lf
+
+# Use LF for Rust because rustfmt works best like that
+*.rs text eol=lf

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,9 +1,7 @@
 # .prettierrc.yml
 # see: https://prettier.io/docs/en/options.html
 printWidth: 100
-tabWidth: 2
 semi: true
-useTabs: false
 singleQuote: true
 trailingComma: all
 bracketSpacing: true


### PR DESCRIPTION
We have lately had some formatting problems in some PRs. Mainly it has been tabs mixed in with spaces for indentation as well as [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) bytes at the start of some files saved in Visual Studio.

I have discussed this with Odd and Emils. Apparently there is no easy way to make VS not do this. And according to what I have heard the "standardized" [EditorConfig](https://editorconfig.org/#overview) should be able to fix this. EditorConfig is also supported by Vim, Visual Studio Code etc, but only with a plugin. You can see the full list of supported editors on their website. But as long as your editor does not break these rules you gain nothing from supporting this configuration file anyway.

So this file does not change any format we have in this repo, it just restates them in a shared config in the hopes of reducing the risk of commiting files with undesired formats.

My goal was not to be as verbose as possible in the config. Rather keeping it minimal. Only stating the configuration we have been having problems with. Feel free to comment on the stuff I added so far and suggest more additions if you feel your editing experience could be improved by another setting.

I'm usually not a fan of having editor configs checked in. But this will help us to get started when moving to new VMs and computers, something we do fairly often when testing on all the platforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/248)
<!-- Reviewable:end -->
