### PR TITLE
Increase the pending stop timeout from 3 to 10 seconds

### DIFF
--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -98,7 +98,7 @@ fn start_event_monitor(
             match event {
                 ServiceControl::Stop | ServiceControl::Preshutdown => {
                     persistent_service_status
-                        .set_pending_stop(Duration::from_secs(3))
+                        .set_pending_stop(Duration::from_secs(10))
                         .unwrap();
 
                     shutdown_handle.shutdown();


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

This PR bumps the pending stop timeout from 3 to 10 seconds to cover the cases when openvpn may take a long time to quit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/252)
<!-- Reviewable:end -->
