### PR TITLE
Revert serve.js since it didn't quite work on Windows

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,3 +1,4 @@
+import electron from 'electron';
 import { spawn } from 'child_process';
 import browserSync from 'browser-sync';
 import browserSyncConnectUtils from 'browser-sync/dist/connect-utils';
@@ -30,7 +31,7 @@ bsync.init({
 }, (err, bs) => {
   if (err) return console.error(err);
 
-  const child = spawn('electron', ['.'], {
+  const child = spawn(electron, ['.'], {
     env: {
       ...{
         NODE_ENV: 'development',


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

I previously reported that it was a bug but actually stringifying electron returns the path to Electron binary and calling `electron` as is didn't work on Windows for some reason, so going back that shady way of running electron :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/253)
<!-- Reviewable:end -->
