### PR TITLE
Log initialization errors to log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 - Automatic rotation of the daemon log. The existing log is renamed to `daemon.old.log` on daemon
   startup.
 - Add `status listen` subcommand in the CLI to continuously monitor the tunnel state.
+- Log errors present in initialization sequence to the log file.
 
 #### macOS
 - Add colors to terminal output.


### PR DESCRIPTION
Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

Previously all errors returned by the `run()` function were printed only to the standard error by the `quick_main!()` macro. Now we have a custom `main()` function that attempts to always log the error instead, so that it can get persisted to the log file.

Because log setup can fail, resulting in an error that would not be logged, the `main` function handles that case with a special `LogError` error kind by printing the error directly to the standard error.

The `LogError` error kind replaces the `NoLog` error kind that apparently was unused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/259)
<!-- Reviewable:end -->
