### PR TITLE
Fix Tray icon behavior on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Disable account input when logging in.
 
+#### Windows
+- Hide the app icon from taskbar.
+- Autohide the main window on focus loss.
 
 ## [2018.2-beta1] - 2018-07-02
 ### Added

--- a/app/main.js
+++ b/app/main.js
@@ -307,6 +307,7 @@ const ApplicationMain = {
         return new BrowserWindow({
           ...options,
           transparent: true,
+          skipTaskbar: true,
         });
 
       default:

--- a/app/main.js
+++ b/app/main.js
@@ -391,12 +391,12 @@ const ApplicationMain = {
   _isMenubarApp() {
     const platform = process.platform;
 
-    return platform === 'windows' || platform === 'darwin';
+    return platform === 'win32' || platform === 'darwin';
   },
 
   _installMenubarAppEventHandlers(windowController: WindowController) {
     switch (process.platform) {
-      case 'windows':
+      case 'win32':
         windowController.window.on('blur', () => windowController.hide());
         break;
 

--- a/app/main.js
+++ b/app/main.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { execFile } from 'child_process';
 import mkdirp from 'mkdirp';
 import uuid from 'uuid';
-import { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage } from 'electron';
+import { app, screen, BrowserWindow, ipcMain, Tray, Menu, nativeImage } from 'electron';
 import TrayIconController from './tray-icon-controller';
 import WindowController from './window-controller';
 import { RpcAddressFile } from './lib/rpc-address-file';
@@ -101,8 +101,6 @@ const ApplicationMain = {
     const windowController = new WindowController(window, tray);
     const trayIconController = new TrayIconController(tray, 'unsecured');
 
-    tray.on('click', () => windowController.toggle());
-
     this._registerIpcListeners();
     this._setAppMenu();
     this._addContextMenu(window);
@@ -117,10 +115,19 @@ const ApplicationMain = {
       window.openDevTools({ mode: 'detach' });
     }
 
-    if (this._isMenubarApp()) {
-      this._installMenubarAppEventHandlers(windowController);
-    } else {
-      windowController.show();
+    switch (process.platform) {
+      case 'win32':
+        this._installWindowsMenubarAppWindowHandlers(tray, windowController);
+        break;
+      case 'darwin':
+        this._installMacOsMenubarAppWindowHandlers(tray, windowController);
+        break;
+      default:
+        tray.on('click', () => {
+          windowController.toggle();
+        });
+        windowController.show();
+        break;
     }
 
     window.loadFile('build/index.html');
@@ -388,30 +395,28 @@ const ApplicationMain = {
     return tray;
   },
 
-  _isMenubarApp() {
-    const platform = process.platform;
+  _installWindowsMenubarAppWindowHandlers(tray: Tray, windowController: WindowController) {
+    tray.on('click', () => windowController.toggle());
+    tray.on('right-click', () => windowController.hide());
 
-    return platform === 'win32' || platform === 'darwin';
-  },
-
-  _installMenubarAppEventHandlers(windowController: WindowController) {
-    switch (process.platform) {
-      case 'win32':
-        windowController.window.on('blur', () => windowController.hide());
-        break;
-
-      case 'darwin':
-        this._installMacOsMenubarAppWindowHandlers(windowController);
-        break;
-
-      default:
-        break;
-    }
+    windowController.window.on('blur', () => {
+      // Detect if blur happened when user had a cursor above the tray icon.
+      const trayBounds = tray.getBounds();
+      const cursorPos = screen.getCursorScreenPoint();
+      const isCursorInside =
+        cursorPos.x >= trayBounds.x &&
+        cursorPos.y >= trayBounds.y &&
+        cursorPos.x <= trayBounds.x + trayBounds.width &&
+        cursorPos.y <= trayBounds.y + trayBounds.height;
+      if (!isCursorInside) {
+        windowController.hide();
+      }
+    });
   },
 
   // setup NSEvent monitor to fix inconsistent window.blur on macOS
   // see https://github.com/electron/electron/issues/8689
-  _installMacOsMenubarAppWindowHandlers(windowController: WindowController) {
+  _installMacOsMenubarAppWindowHandlers(tray: Tray, windowController: WindowController) {
     // $FlowFixMe: this module is only available on macOS
     const { NSEventMonitor, NSEventMask } = require('nseventmonitor');
     const macEventMonitor = new NSEventMonitor();
@@ -420,6 +425,7 @@ const ApplicationMain = {
 
     window.on('show', () => macEventMonitor.start(eventMask, () => windowController.hide()));
     window.on('hide', () => macEventMonitor.stop());
+    tray.on('click', () => windowController.toggle());
   },
 };
 

--- a/app/window-controller.js
+++ b/app/window-controller.js
@@ -1,6 +1,6 @@
 // @flow
 
-import electron, { screen } from 'electron';
+import { screen } from 'electron';
 import type { BrowserWindow, Tray, Display } from 'electron';
 
 export default class WindowController {
@@ -62,7 +62,7 @@ export default class WindowController {
 
       case 'win32': {
         // taskbar occupies some part of the screen excluded from work area
-        const primaryDisplay = electron.screen.getPrimaryDisplay();
+        const primaryDisplay = screen.getPrimaryDisplay();
         const displaySize = primaryDisplay.size;
         const workArea = primaryDisplay.workArea;
 
@@ -84,7 +84,7 @@ export default class WindowController {
     const windowBounds = this._window.getBounds();
     const trayBounds = this._tray.getBounds();
 
-    const primaryDisplay = electron.screen.getPrimaryDisplay();
+    const primaryDisplay = screen.getPrimaryDisplay();
     const workArea = primaryDisplay.workArea;
     const placement = this._getTrayPlacement();
     const maxX = workArea.x + workArea.width - windowBounds.width;

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "flow-typed": "^2.4.0",
     "mock-socket": "^7.1.0",
     "npm-run-all": "^4.0.1",
-    "prettier": "1.13.3",
+    "prettier": "1.13.7",
     "rimraf": "^2.5.4"
   },
   "scripts": {
@@ -73,8 +73,8 @@
     "develop": "cross-env BABEL_ENV=electron npm run private:compile -- --source-maps true && run-p -r private:watch private:serve",
     "test": "cross-env BABEL_ENV=electron electron-mocha --renderer -R spec --require babel-core/register --require-main test/setup/main.js --preload test/setup/renderer.js test/*.spec.js test/**/*.spec.js",
     "lint": "eslint --no-ignore scripts app test *.js",
-    "format": "prettier --write 'app/**/*.js' 'test/**/*.js'",
-    "check-format": "prettier --list-different 'app/**/*.js' 'test/**/*.js'",
+    "format": "cross-env prettier --write 'app/**/*.js' 'test/**/*.js'",
+    "check-format": "cross-env prettier --list-different 'app/**/*.js' 'test/**/*.js'",
     "flow": "flow",
     "pack:mac": "cross-env BABEL_ENV=electron run-s private:clean private:compile private:build:mac && rm -r ./dist/mac",
     "pack:win": "cross-env BABEL_ENV=electron run-s private:clean private:compile private:build:win",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5978,9 +5978,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.3.tgz#e74c09a7df6519d472ca6febaa37cf7addb48a20"
+prettier@1.13.7:
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
 pretty-bytes@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

1. This PR fixes the tray icon behavior. Since we can't resolve the race between `window.blur` and `tray.click` in a reasonable way, I had to use the mouse position to predict the user intent. Additional right-click handler on tray icon is used to cover edge case when right clicking on the tray icon would trigger the `window.blur` but not `tray.click` leaving the window hanging visible.

2. Updates `prettier` and fixed it to run with `cross-env` since apparently on Windows we need to use double quotes to pass the file glob patterns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/269)
<!-- Reviewable:end -->
