### PR TITLE
Keep the user input in problem report form until submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Disable account input when logging in.
+- Keep the user input in problem report form while the app runs, or until the report is successfully
+  submitted.
 
 #### Windows
 - Hide the app icon from taskbar.

--- a/app/containers/SupportPage.js
+++ b/app/containers/SupportPage.js
@@ -8,26 +8,25 @@ import { collectProblemReport, sendProblemReport } from '../lib/problem-report';
 
 import type { ReduxState, ReduxDispatch } from '../redux/store';
 import type { SharedRouteProps } from '../routes';
+import supportActions from '../redux/support/actions';
 
 const mapStateToProps = (state: ReduxState) => ({
-  account: state.account,
+  defaultEmail: state.support.email,
+  defaultMessage: state.support.message,
+  accountHistory: state.account.accountHistory,
 });
 
 const mapDispatchToProps = (dispatch: ReduxDispatch, _props: SharedRouteProps) => {
+  const { saveReportForm, clearReportForm } = bindActionCreators(supportActions, dispatch);
   const { push: pushHistory } = bindActionCreators({ push }, dispatch);
 
   return {
     onClose: () => pushHistory('/settings'),
-
-    onCollectLog: (toRedact) => {
-      return collectProblemReport(toRedact);
-    },
-
-    onViewLog: (path) => openItem(path),
-
-    onSend: (email, message, savedReport) => {
-      return sendProblemReport(email, message, savedReport);
-    },
+    viewLog: (path) => openItem(path),
+    saveReportForm,
+    clearReportForm,
+    collectProblemReport,
+    sendProblemReport,
   };
 };
 

--- a/app/redux/store.js
+++ b/app/redux/store.js
@@ -9,24 +9,29 @@ import connection from './connection/reducers';
 import connectionActions from './connection/actions';
 import settings from './settings/reducers';
 import settingsActions from './settings/actions';
+import support from './support/reducers';
+import supportActions from './support/actions';
 
 import type { Store } from 'redux';
 import type { History } from 'history';
 import type { AccountReduxState } from './account/reducers';
 import type { ConnectionReduxState } from './connection/reducers';
 import type { SettingsReduxState } from './settings/reducers';
+import type { SupportReduxState } from './support/reducers';
 
-import type { ConnectionAction } from './connection/actions';
 import type { AccountAction } from './account/actions';
+import type { ConnectionAction } from './connection/actions';
 import type { SettingsAction } from './settings/actions';
+import type { SupportAction } from './support/actions';
 
 export type ReduxState = {
   account: AccountReduxState,
   connection: ConnectionReduxState,
   settings: SettingsReduxState,
+  support: SupportReduxState,
 };
 
-export type ReduxAction = AccountAction | SettingsAction | ConnectionAction;
+export type ReduxAction = AccountAction | ConnectionAction | SettingsAction | SupportAction;
 export type ReduxStore = Store<ReduxState, ReduxAction, ReduxDispatch>;
 export type ReduxGetState = () => ReduxState;
 export type ReduxDispatch = (action: ReduxAction | ReduxThunk) => any;
@@ -42,6 +47,7 @@ export default function configureStore(
     ...accountActions,
     ...connectionActions,
     ...settingsActions,
+    ...supportActions,
     pushRoute: (route) => push(route),
     replaceRoute: (route) => replace(route),
   };
@@ -50,6 +56,7 @@ export default function configureStore(
     account,
     connection,
     settings,
+    support,
     router: routerReducer,
   };
 

--- a/app/redux/support/actions.js
+++ b/app/redux/support/actions.js
@@ -1,0 +1,32 @@
+// @flow
+
+export type SupportReportForm = {
+  email: string,
+  message: string,
+};
+
+export type KeepReportFormAction = {
+  type: 'SAVE_REPORT_FORM',
+  form: SupportReportForm,
+};
+
+export type ClearReportFormAction = {
+  type: 'CLEAR_REPORT_FORM',
+};
+
+export type SupportAction = KeepReportFormAction | ClearReportFormAction;
+
+function saveReportForm(form: SupportReportForm): KeepReportFormAction {
+  return {
+    type: 'SAVE_REPORT_FORM',
+    form,
+  };
+}
+
+function clearReportForm(): ClearReportFormAction {
+  return {
+    type: 'CLEAR_REPORT_FORM',
+  };
+}
+
+export default { saveReportForm, clearReportForm };

--- a/app/redux/support/reducers.js
+++ b/app/redux/support/reducers.js
@@ -1,0 +1,37 @@
+// @flow
+
+import type { ReduxAction } from '../store';
+
+export type SupportReduxState = {
+  email: string,
+  message: string,
+};
+
+const initialState: SupportReduxState = {
+  email: '',
+  message: '',
+};
+
+export default function(
+  state: SupportReduxState = initialState,
+  action: ReduxAction,
+): SupportReduxState {
+  switch (action.type) {
+    case 'SAVE_REPORT_FORM':
+      return {
+        ...state,
+        email: action.form.email,
+        message: action.form.message,
+      };
+
+    case 'CLEAR_REPORT_FORM':
+      return {
+        ...state,
+        email: '',
+        message: '',
+      };
+
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

This PR persists the user input into Redux for the duration of the application runtime, or until the problem report is successfully submitted. Also, this PR refines Support tests that previously used `setTimeout` to catch up with the async nature of React's `setState`, the new technique is to return a `Promise` from the props that run asynchronously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/272)
<!-- Reviewable:end -->
