### PR TITLE
Make build.sh soruce env.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ set -eu
 SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 RUSTC_VERSION=`rustc +stable --version`
 PRODUCT_VERSION=$(node -p "require('./package.json').version" | sed -Ee 's/\.0//g')
+source env.sh
 
 if [[ "${1:-""}" != "--dev-build" ]]; then
 

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 # Sourcing this file should set up the environment to build the app
 
-SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 case "$(uname -s)" in
   Linux*)


### PR DESCRIPTION
I've fixed _not sourcing_ the env file in `build.sh` and I've verified that the paths will be correct even if executed in `git-bash`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/273)
<!-- Reviewable:end -->
