### PR TITLE
Openvpn log first in report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Changed
 - App now uses statically linked OpenSSL on all platforms.
+- Add OpenVPN logs at the top of the problem report instead of middle, to aid support work.
+- Lower per log size limit in the problem report to 128 kiB.
 
 ### Fixed
 - Disable account input when logging in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 - Hide the app icon from taskbar.
 - Autohide the main window on focus loss.
 
+
 ## [2018.2-beta1] - 2018-07-02
 ### Added
 - Refresh account expiration when account view becomes visible.

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Maximum number of bytes to read from each log file
-const LOG_MAX_READ_BYTES: usize = 512 * 1024;
+const LOG_MAX_READ_BYTES: usize = 128 * 1024;
 const EXTRA_BYTES: usize = 32 * 1024;
 /// Fit five logs plus some system information in the report.
 const REPORT_MAX_SIZE: usize = (5 * LOG_MAX_READ_BYTES) + EXTRA_BYTES;

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -64,7 +64,7 @@ error_chain!{
             description("Error listing the files in the mullvad-daemon log directory")
             display(
                 "Error listing the files in the mullvad-daemon log directory: {}",
-                path.to_string_lossy()
+                path.display()
             )
         }
         WriteReportError(path: PathBuf) {
@@ -177,9 +177,24 @@ fn collect_report(
     let mut problem_report = ProblemReport::new(redact_custom_strings);
 
     match logs_from_log_directory() {
-        Ok(logs) => problem_report.try_add_logs(logs),
+        Ok(logs) => {
+            let mut other_logs = Vec::new();
+            for log in logs {
+                match log {
+                    Ok(path) => if is_tunnel_log(&path) {
+                        problem_report.add_log(&path);
+                    } else {
+                        other_logs.push(path);
+                    },
+                    Err(error) => problem_report.add_error("Unable to get log path", error),
+                }
+            }
+            for other_log in other_logs {
+                problem_report.add_log(&other_log);
+            }
+        }
         Err(error) => problem_report.add_error("Failed to list logs in log directory", error),
-    }
+    };
 
     problem_report.add_logs(extra_logs);
 
@@ -211,6 +226,13 @@ fn logs_from_log_directory() -> Result<impl Iterator<Item = Result<PathBuf>>> {
                 ))),
             })
         })
+}
+
+fn is_tunnel_log(path: &Path) -> bool {
+    match path.file_name() {
+        Some(file_name) => file_name.to_string_lossy().contains("openvpn"),
+        None => false,
+    }
 }
 
 fn send_problem_report(user_email: &str, user_message: &str, report_path: &Path) -> Result<()> {
@@ -273,23 +295,6 @@ impl ProblemReport {
     {
         for path in paths {
             self.add_log(path.as_ref());
-        }
-    }
-
-    /// Tries to attach some file logs to this report.
-    ///
-    /// This method receives a result with an iterator of results of file paths. If any of the
-    /// results are errors, they are collected and displayed in the final report.
-    pub fn try_add_logs<I, P>(&mut self, paths: I)
-    where
-        I: IntoIterator<Item = Result<P>>,
-        P: AsRef<Path>,
-    {
-        for path_result in paths {
-            match path_result {
-                Ok(path) => self.add_log(path.as_ref()),
-                Err(error) => self.add_error("Error getting next log file", error),
-            }
         }
     }
 


### PR DESCRIPTION
Support has specified that ~90% of all support cases are solved by reading the OpenVPN log. Sadly the order of the logs is: daemon - openvpn - frontend. And since both daemon and frontend are huge it's a bit work to scroll to the openvpn logs. As such now I rearrange so the OpenVPN logs are always first. This should reduce work for support.

Also lowering max log size again. Apparently 512 kiB has way too much old data according to support. Too large emails just make them slow to open and handle.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/274)
<!-- Reviewable:end -->
