### PR TITLE
Autoconnect on daemon start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 - Bundle the root CA signing the API and only trust that single one, limiting
   trust to a single root CA
 - Add a unique UUID to problem reports. Makes it easier for Mullvad support staff to find reports.
+- Add "auto-connect" setting in daemon, and make it configurable from CLI. Determines if the daemon
+  should secure the network and start establishing a tunnel directly when it starts on boot.
 
 ### Changed
 - App now uses statically linked OpenSSL on all platforms.

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -1,0 +1,58 @@
+use clap;
+use {Command, Result};
+
+use mullvad_ipc_client::DaemonRpcClient;
+
+pub struct AutoConnect;
+
+impl Command for AutoConnect {
+    fn name(&self) -> &'static str {
+        "auto-connect"
+    }
+
+    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
+        clap::SubCommand::with_name(self.name())
+            .about("Control the daemon auto-connect setting")
+            .setting(clap::AppSettings::SubcommandRequired)
+            .subcommand(
+                clap::SubCommand::with_name("set")
+                    .about("Change auto-connect setting")
+                    .arg(
+                        clap::Arg::with_name("policy")
+                            .required(true)
+                            .possible_values(&["on", "off"]),
+                    ),
+            )
+            .subcommand(
+                clap::SubCommand::with_name("get")
+                    .about("Display the current auto-connect setting"),
+            )
+    }
+
+    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(set_matches) = matches.subcommand_matches("set") {
+            let auto_connect = value_t_or_exit!(set_matches.value_of("policy"), String);
+            self.set(auto_connect == "on")
+        } else if let Some(_matches) = matches.subcommand_matches("get") {
+            self.get()
+        } else {
+            unreachable!("No auto-connect command given");
+        }
+    }
+}
+
+impl AutoConnect {
+    fn set(&self, auto_connect: bool) -> Result<()> {
+        let mut rpc = DaemonRpcClient::new()?;
+        rpc.set_auto_connect(auto_connect)?;
+        println!("Changed auto-connect sharing setting");
+        Ok(())
+    }
+
+    fn get(&self) -> Result<()> {
+        let mut rpc = DaemonRpcClient::new()?;
+        let auto_connect = rpc.get_auto_connect()?;
+        println!("Autoconnect: {}", if auto_connect { "on" } else { "off" });
+        Ok(())
+    }
+}

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -4,6 +4,9 @@ use Command;
 mod account;
 pub use self::account::Account;
 
+mod auto_connect;
+pub use self::auto_connect::AutoConnect;
+
 mod status;
 pub use self::status::Status;
 
@@ -29,6 +32,7 @@ pub use self::version::Version;
 pub fn get_commands() -> HashMap<&'static str, Box<Command>> {
     let commands: Vec<Box<Command>> = vec![
         Box::new(Account),
+        Box::new(AutoConnect),
         Box::new(Status),
         Box::new(Connect),
         Box::new(Disconnect),

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -334,6 +334,10 @@ impl Daemon {
     /// Consume the `Daemon` and run the main event loop. Blocks until an error happens or a
     /// shutdown event is received.
     pub fn run(mut self) -> Result<()> {
+        if self.settings.get_autoconnect() {
+            info!("Automatically connecting since autoconnect is turned on");
+            self.set_target_state(TargetState::Secured)?;
+        }
         while let Ok(event) = self.rx.recv() {
             self.handle_event(event)?;
             if self.shutdown && self.state == TunnelState::NotRunning {

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -35,8 +35,10 @@ static SETTINGS_FILE: &str = "settings.json";
 pub struct Settings {
     account_token: Option<String>,
     relay_settings: RelaySettings,
-    /// If the app should allow communication with private (LAN) networks.
+    /// If the daemon should allow communication with private (LAN) networks.
     allow_lan: bool,
+    /// If the daemon should connect the VPN tunnel directly on start or not.
+    auto_connect: bool,
     /// Options that should be applied to tunnels of a specific type regardless of where the relays
     /// might be located.
     tunnel_options: TunnelOptions,
@@ -51,6 +53,7 @@ impl Default for Settings {
                 tunnel: Constraint::Any,
             }),
             allow_lan: false,
+            auto_connect: false,
             tunnel_options: TunnelOptions::default(),
         }
     }
@@ -149,6 +152,19 @@ impl Settings {
     pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<bool> {
         if allow_lan != self.allow_lan {
             self.allow_lan = allow_lan;
+            self.save().map(|_| true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn get_auto_connect(&self) -> bool {
+        self.auto_connect
+    }
+
+    pub fn set_auto_connect(&mut self, auto_connect: bool) -> Result<bool> {
+        if auto_connect != self.auto_connect {
+            self.auto_connect = auto_connect;
             self.save().map(|_| true)
         } else {
             Ok(false)

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -155,8 +155,20 @@ impl DaemonRpcClient {
         self.call("get_account_data", &[account])
     }
 
+    pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<()> {
+        self.call("set_allow_lan", &[allow_lan])
+    }
+
     pub fn get_allow_lan(&mut self) -> Result<bool> {
         self.call("get_allow_lan", &NO_ARGS)
+    }
+
+    pub fn set_auto_connect(&mut self, auto_connect: bool) -> Result<()> {
+        self.call("set_auto_connect", &[auto_connect])
+    }
+
+    pub fn get_auto_connect(&mut self) -> Result<bool> {
+        self.call("get_auto_connect", &NO_ARGS)
     }
 
     pub fn get_current_location(&mut self) -> Result<GeoIpLocation> {
@@ -189,10 +201,6 @@ impl DaemonRpcClient {
 
     pub fn set_account(&mut self, account: Option<AccountToken>) -> Result<()> {
         self.call("set_account", &[account])
-    }
-
-    pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<()> {
-        self.call("set_allow_lan", &[allow_lan])
     }
 
     pub fn set_openvpn_mssfix(&mut self, mssfix: Option<u16>) -> Result<()> {


### PR DESCRIPTION
The most requested feature mentioned in the feedback on the beta is to be able to autostart the app. After some discussion with the stakeholder we decided to try to get this into the `2018.2` release. If everything else for this release is done this should not be a blocker, but we should try to get it in.

This can be split up into multiple features. One is to make the daemon autoconnect on start, before any frontend even connects to it. Later we also want to make it possible to add the GUI to autostart on user login.

This PR solves half the first part. Makes it possible to have the daemon autoconnect on start, and exposes that setting in the CLI. We then have to expose this setting in the GUI. But keeping that as a separate feature.

What should we officially call this feature. At the moment I call it "autoconnect". Maybe more correct is to spell it "auto-connect"? Another option is to replace connect with secure: "auto-secure". It depends a bit on what terminology we want to use and what the main use-case is.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/276)
<!-- Reviewable:end -->
