### PR TITLE
Daemon tunnel state machine

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -59,11 +59,13 @@ mod tunnel_state_machine;
 mod version;
 
 use error_chain::ChainedError;
-use futures::Future;
+use futures::sync::mpsc::UnboundedSender;
+use futures::{Future, Sink};
 use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
 
 use management_interface::{BoxFuture, ManagementCommand, ManagementInterfaceServer};
 use mullvad_rpc::{AccountsProxy, AppVersionProxy, HttpHandle};
+use tunnel_state_machine::{TunnelCommand, TunnelParameters, TunnelStateTransition};
 
 use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
@@ -72,17 +74,14 @@ use mullvad_types::relay_list::{Relay, RelayList};
 use mullvad_types::states::{DaemonState, SecurityState, TargetState};
 use mullvad_types::version::{AppVersion, AppVersionInfo};
 
-use std::io;
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::sync::{mpsc, Arc, Mutex};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::sync::mpsc;
+use std::time::Duration;
+use std::{mem, thread};
 
-use talpid_core::firewall::{Firewall, FirewallProxy, SecurityPolicy};
 use talpid_core::mpsc::IntoSender;
-use talpid_core::tunnel::{self, TunnelEvent, TunnelMetadata, TunnelMonitor};
-use talpid_types::net::{TunnelEndpoint, TunnelEndpointData, TunnelOptions};
+use talpid_types::net::TunnelOptions;
 
 
 error_chain!{
@@ -97,21 +96,9 @@ error_chain!{
         DaemonIsAlreadyRunning {
             description("Another instance of the daemon is already running")
         }
-        /// The client is in the wrong state for the requested operation. Optimally the code should
-        /// be written in such a way so such states can't exist.
-        InvalidState {
-            description("Client is in an invalid state for the requested operation")
-        }
-        TunnelError(msg: &'static str) {
-            description("Error in the tunnel monitor")
-            display("Tunnel monitor error: {}", msg)
-        }
         ManagementInterfaceError(msg: &'static str) {
             description("Error in the management interface")
             display("Management interface error: {}", msg)
-        }
-        FirewallError {
-            description("Firewall error")
         }
         InvalidSettings(msg: &'static str) {
             description("Invalid settings")
@@ -121,27 +108,20 @@ error_chain!{
             description("Found no valid relays to connect to")
         }
     }
+
+    links {
+        TunnelError(tunnel_state_machine::Error, tunnel_state_machine::ErrorKind);
+    }
 }
 
-static MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
-
 const DAEMON_LOG_FILENAME: &str = "daemon.log";
-const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
-const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";
 
-#[cfg(windows)]
-const TUNNEL_INTERFACE_ALIAS: &str = "Mullvad";
+type SyncUnboundedSender<T> = ::futures::sink::Wait<UnboundedSender<T>>;
 
 /// All events that can happen in the daemon. Sent from various threads and exposed interfaces.
 pub enum DaemonEvent {
-    /// An event coming from the tunnel software to indicate a change in state.
-    TunnelEvent(TunnelEvent),
-    /// Triggered by the thread waiting for the tunnel process. Means the tunnel process
-    /// exited.
-    TunnelExited(tunnel::Result<()>),
-    /// Triggered by the thread waiting for a tunnel close operation to complete. Contains the
-    /// result of trying to kill the tunnel.
-    TunnelKillResult(io::Result<()>),
+    /// Tunnel has changed state.
+    TunnelStateTransition(TunnelStateTransition),
     /// An event coming from the JSONRPC-2.0 management interface.
     ManagementInterfaceEvent(ManagementCommand),
     /// Triggered if the server hosting the JSONRPC-2.0 management interface dies unexpectedly.
@@ -150,9 +130,9 @@ pub enum DaemonEvent {
     TriggerShutdown,
 }
 
-impl From<TunnelEvent> for DaemonEvent {
-    fn from(tunnel_event: TunnelEvent) -> Self {
-        DaemonEvent::TunnelEvent(tunnel_event)
+impl From<TunnelStateTransition> for DaemonEvent {
+    fn from(tunnel_state_transition: TunnelStateTransition) -> Self {
+        DaemonEvent::TunnelStateTransition(tunnel_state_transition)
     }
 }
 
@@ -162,39 +142,57 @@ impl From<ManagementCommand> for DaemonEvent {
     }
 }
 
-/// Represents the internal state of the actual tunnel.
-// TODO(linus): Put the tunnel::CloseHandle into this state, so it can't exist when not running.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum TunnelState {
-    /// No tunnel is running.
-    NotRunning,
-    /// The tunnel has been started, but it is not established/functional.
-    Connecting,
-    /// The tunnel is up and working.
-    Connected,
-    /// This state is active from when we manually trigger a tunnel kill until the tunnel wait
-    /// operation (TunnelExit) returned.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum DaemonExecutionState {
+    Running,
     Exiting,
+    Finished,
 }
 
-impl TunnelState {
-    pub fn as_security_state(&self) -> SecurityState {
-        use TunnelState::*;
-        match *self {
-            NotRunning | Connecting => SecurityState::Unsecured,
-            Connected | Exiting => SecurityState::Secured,
+impl DaemonExecutionState {
+    pub fn shutdown(&mut self, tunnel_state: TunnelStateTransition) {
+        use self::DaemonExecutionState::*;
+
+        match self {
+            Running => {
+                match tunnel_state {
+                    TunnelStateTransition::Disconnected => mem::replace(self, Finished),
+                    _ => mem::replace(self, Exiting),
+                };
+            }
+            Exiting | Finished => {}
+        };
+    }
+
+    pub fn disconnected(&mut self) {
+        use self::DaemonExecutionState::*;
+
+        match self {
+            Exiting => {
+                mem::replace(self, Finished);
+            }
+            Running | Finished => {}
+        };
+    }
+
+    pub fn is_running(&mut self) -> bool {
+        use self::DaemonExecutionState::*;
+
+        match self {
+            Running => true,
+            Exiting | Finished => false,
         }
     }
 }
 
 
 struct Daemon {
-    state: TunnelState,
-    // The tunnel_close_handle must only exist in the Connecting and Connected states!
-    tunnel_close_handle: Option<tunnel::CloseHandle>,
+    tunnel_command_tx: SyncUnboundedSender<TunnelCommand>,
+    tunnel_state: TunnelStateTransition,
+    security_state: SecurityState,
     last_broadcasted_state: DaemonState,
     target_state: TargetState,
-    shutdown: bool,
+    state: DaemonExecutionState,
     rx: mpsc::Receiver<DaemonEvent>,
     tx: mpsc::Sender<DaemonEvent>,
     management_interface_broadcaster: management_interface::EventBroadcaster,
@@ -204,10 +202,7 @@ struct Daemon {
     https_handle: mullvad_rpc::rest::RequestSender,
     tokio_remote: tokio_core::reactor::Remote,
     relay_selector: relays::RelaySelector,
-    firewall: FirewallProxy,
     current_relay: Option<Relay>,
-    tunnel_endpoint: Option<TunnelEndpoint>,
-    tunnel_metadata: Option<TunnelMetadata>,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
 }
@@ -241,19 +236,23 @@ impl Daemon {
             relays::RelaySelector::new(rpc_handle.clone(), &resource_dir, &cache_dir);
 
         let (tx, rx) = mpsc::channel();
+        let tunnel_command_tx =
+            tunnel_state_machine::spawn(cache_dir.clone(), IntoSender::from(tx.clone()))?;
+
+        let target_state = TargetState::Unsecured;
         let management_interface_broadcaster =
             Self::start_management_interface(tx.clone(), cache_dir.clone())?;
-        let state = TunnelState::NotRunning;
-        let target_state = TargetState::Unsecured;
+
         Ok(Daemon {
-            state,
-            tunnel_close_handle: None,
+            tunnel_command_tx: Sink::wait(tunnel_command_tx),
+            tunnel_state: TunnelStateTransition::Disconnected,
+            security_state: SecurityState::Unsecured,
             target_state,
             last_broadcasted_state: DaemonState {
-                state: state.as_security_state(),
+                state: SecurityState::Unsecured,
                 target_state,
             },
-            shutdown: false,
+            state: DaemonExecutionState::Running,
             rx,
             tx,
             management_interface_broadcaster,
@@ -263,10 +262,7 @@ impl Daemon {
             https_handle,
             tokio_remote,
             relay_selector,
-            firewall: FirewallProxy::new(&cache_dir).chain_err(|| ErrorKind::FirewallError)?,
             current_relay: None,
-            tunnel_endpoint: None,
-            tunnel_metadata: None,
             log_dir,
             resource_dir,
         })
@@ -324,7 +320,7 @@ impl Daemon {
         }
         while let Ok(event) = self.rx.recv() {
             self.handle_event(event)?;
-            if self.shutdown && self.state == TunnelState::NotRunning {
+            if self.state == DaemonExecutionState::Finished {
                 break;
             }
         }
@@ -334,45 +330,34 @@ impl Daemon {
     fn handle_event(&mut self, event: DaemonEvent) -> Result<()> {
         use DaemonEvent::*;
         match event {
-            TunnelEvent(event) => self.handle_tunnel_event(event),
-            TunnelExited(result) => self.handle_tunnel_exited(result),
-            TunnelKillResult(result) => self.handle_tunnel_kill_result(result),
+            TunnelStateTransition(transition) => self.handle_tunnel_state_transition(transition),
             ManagementInterfaceEvent(event) => self.handle_management_interface_event(event),
             ManagementInterfaceExited(result) => self.handle_management_interface_exited(result),
             TriggerShutdown => self.handle_trigger_shutdown_event(),
         }
     }
 
-    fn handle_tunnel_event(&mut self, tunnel_event: TunnelEvent) -> Result<()> {
-        debug!("Tunnel event: {:?}", tunnel_event);
-        if self.state == TunnelState::Connecting {
-            if let TunnelEvent::Up(metadata) = tunnel_event {
-                self.tunnel_metadata = Some(metadata);
-                self.set_security_policy()?;
-                self.set_state(TunnelState::Connected)
-            } else {
-                Ok(())
-            }
-        } else if self.state == TunnelState::Connected && tunnel_event == TunnelEvent::Down {
-            self.kill_tunnel()
-        } else {
-            Ok(())
-        }
-    }
+    fn handle_tunnel_state_transition(
+        &mut self,
+        tunnel_state: TunnelStateTransition,
+    ) -> Result<()> {
+        use self::TunnelStateTransition::*;
 
-    fn handle_tunnel_exited(&mut self, result: tunnel::Result<()>) -> Result<()> {
-        if let Err(e) = result.chain_err(|| "Tunnel exited in an unexpected way") {
-            error!("{}", e.display_chain());
-        }
-        self.current_relay = None;
-        self.tunnel_endpoint = None;
-        self.tunnel_metadata = None;
-        self.tunnel_close_handle = None;
-        self.set_state(TunnelState::NotRunning)
-    }
+        debug!("New tunnel state: {:?}", tunnel_state);
 
-    fn handle_tunnel_kill_result(&mut self, result: io::Result<()>) -> Result<()> {
-        result.chain_err(|| "Error while trying to close tunnel")
+        if tunnel_state == Disconnected {
+            self.state.disconnected();
+        }
+
+        self.tunnel_state = tunnel_state;
+        self.security_state = match tunnel_state {
+            Disconnected | Connecting => SecurityState::Unsecured,
+            Connected | Disconnecting => SecurityState::Secured,
+        };
+
+        self.broadcast_state();
+
+        Ok(())
     }
 
     fn handle_management_interface_event(&mut self, event: ManagementCommand) -> Result<()> {
@@ -403,7 +388,7 @@ impl Daemon {
     }
 
     fn on_set_target_state(&mut self, new_target_state: TargetState) -> Result<()> {
-        if !self.shutdown {
+        if self.state.is_running() {
             self.set_target_state(new_target_state)
         } else {
             warn!("Ignoring target state change request due to shutdown");
@@ -466,11 +451,9 @@ impl Daemon {
         match save_result.chain_err(|| "Unable to save settings") {
             Ok(account_changed) => {
                 Self::oneshot_send(tx, (), "set_account response");
-                let tunnel_needs_restart =
-                    self.state == TunnelState::Connecting || self.state == TunnelState::Connected;
-                if account_changed && tunnel_needs_restart {
+                if account_changed {
                     info!("Initiating tunnel restart because the account token changed");
-                    self.kill_tunnel()?;
+                    self.connect_tunnel()?;
                 }
             }
             Err(e) => error!("{}", e.display_chain()),
@@ -516,12 +499,9 @@ impl Daemon {
             Ok(changed) => {
                 Self::oneshot_send(tx, (), "update_relay_settings response");
 
-                let tunnel_needs_restart =
-                    self.state == TunnelState::Connecting || self.state == TunnelState::Connected;
-
-                if changed && tunnel_needs_restart {
+                if changed {
                     info!("Initiating tunnel restart because the relay settings changed");
-                    self.kill_tunnel()?;
+                    self.connect_tunnel()?;
                 }
             }
             Err(e) => error!("{}", e.display_chain()),
@@ -538,8 +518,10 @@ impl Daemon {
         let save_result = self.settings.set_allow_lan(allow_lan);
         match save_result.chain_err(|| "Unable to save settings") {
             Ok(settings_changed) => {
-                if settings_changed && self.target_state == TargetState::Secured {
-                    self.set_security_policy()?;
+                if settings_changed {
+                    self.tunnel_command_tx
+                        .send(TunnelCommand::AllowLan(allow_lan))
+                        .expect("Tunnel state machine has stopped");
                 }
                 Self::oneshot_send(tx, (), "set_allow_lan response");
             }
@@ -593,12 +575,9 @@ impl Daemon {
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set_openvpn_enable_ipv6 response");
 
-                let tunnel_needs_restart =
-                    self.state == TunnelState::Connecting || self.state == TunnelState::Connected;
-
-                if settings_changed && tunnel_needs_restart {
+                if settings_changed {
                     info!("Initiating tunnel restart because the enable IPv6 setting changed");
-                    self.kill_tunnel()?;
+                    self.connect_tunnel()?;
                 }
             }
             Err(e) => error!("{}", e.display_chain()),
@@ -628,29 +607,15 @@ impl Daemon {
     }
 
     fn handle_trigger_shutdown_event(&mut self) -> Result<()> {
-        self.shutdown = true;
-        self.set_target_state(TargetState::Unsecured)
-    }
+        self.state.shutdown(self.tunnel_state);
+        self.disconnect_tunnel();
 
-    /// Update the state of the client. If it changed, notify the subscribers and trigger
-    /// appropriate actions.
-    fn set_state(&mut self, new_state: TunnelState) -> Result<()> {
-        if new_state != self.state {
-            debug!("State {:?} => {:?}", self.state, new_state);
-            self.state = new_state;
-            self.broadcast_state();
-            self.verify_state_consistency()?;
-            self.apply_target_state()
-        } else {
-            // Calling set_state with the same state we already have is an error. Should try to
-            // mitigate this possibility completely with a better state machine later.
-            Err(ErrorKind::InvalidState.into())
-        }
+        Ok(())
     }
 
     fn broadcast_state(&mut self) {
         let new_daemon_state = DaemonState {
-            state: self.state.as_security_state(),
+            state: self.security_state,
             target_state: self.target_state,
         };
         if self.last_broadcasted_state != new_daemon_state {
@@ -658,21 +623,6 @@ impl Daemon {
             self.management_interface_broadcaster
                 .notify_new_state(new_daemon_state);
         }
-    }
-
-    // Check that the current state is valid and consistent.
-    fn verify_state_consistency(&self) -> Result<()> {
-        use TunnelState::*;
-        ensure!(
-            match self.state {
-                NotRunning => self.tunnel_close_handle.is_none(),
-                Connecting => self.tunnel_close_handle.is_some(),
-                Connected => self.tunnel_close_handle.is_some(),
-                Exiting => self.tunnel_close_handle.is_none(),
-            },
-            ErrorKind::InvalidState
-        );
-        Ok(())
     }
 
     /// Set the target state of the client. If it changed trigger the operations needed to
@@ -689,171 +639,72 @@ impl Daemon {
     }
 
     fn apply_target_state(&mut self) -> Result<()> {
-        match (self.target_state, self.state) {
-            (TargetState::Secured, TunnelState::NotRunning) => {
+        match self.target_state {
+            TargetState::Secured => {
                 debug!("Triggering tunnel start");
-                if let Err(e) = self.start_tunnel().chain_err(|| "Failed to start tunnel") {
+                if let Err(e) = self.connect_tunnel().chain_err(|| "Failed to start tunnel") {
                     error!("{}", e.display_chain());
                     self.current_relay = None;
-                    self.tunnel_endpoint = None;
                     self.management_interface_broadcaster.notify_error(&e);
                     self.set_target_state(TargetState::Unsecured)?;
                 }
-                Ok(())
             }
-            (TargetState::Unsecured, TunnelState::NotRunning) => self.reset_security_policy(),
-            (TargetState::Unsecured, TunnelState::Connecting)
-            | (TargetState::Unsecured, TunnelState::Connected) => self.kill_tunnel(),
-            (..) => Ok(()),
+            TargetState::Unsecured => self.disconnect_tunnel(),
         }
+
+        Ok(())
     }
 
-    fn start_tunnel(&mut self) -> Result<()> {
-        ensure!(
-            self.target_state == TargetState::Secured && self.state == TunnelState::NotRunning,
-            ErrorKind::InvalidState
-        );
+    fn connect_tunnel(&mut self) -> Result<()> {
+        let parameters = self.build_tunnel_parameters()?;
 
-        match self.settings.get_relay_settings() {
-            RelaySettings::CustomTunnelEndpoint(custom_relay) => {
-                let tunnel_endpoint = custom_relay
-                    .to_tunnel_endpoint()
-                    .chain_err(|| ErrorKind::NoRelay)?;
-                self.tunnel_endpoint = Some(tunnel_endpoint);
-            }
+        self.tunnel_command_tx
+            .send(TunnelCommand::Connect(parameters))
+            .expect("Tunnel state machine has stopped");
+
+        Ok(())
+    }
+
+    fn disconnect_tunnel(&mut self) {
+        self.tunnel_command_tx
+            .send(TunnelCommand::Disconnect)
+            .expect("Tunnel state machine has stopped");
+    }
+
+    fn build_tunnel_parameters(&mut self) -> Result<TunnelParameters> {
+        let endpoint = match self.settings.get_relay_settings() {
+            RelaySettings::CustomTunnelEndpoint(custom_relay) => custom_relay
+                .to_tunnel_endpoint()
+                .chain_err(|| ErrorKind::NoRelay)?,
             RelaySettings::Normal(constraints) => {
                 let (relay, tunnel_endpoint) = self
                     .relay_selector
                     .get_tunnel_endpoint(&constraints)
                     .chain_err(|| ErrorKind::NoRelay)?;
-                self.tunnel_endpoint = Some(tunnel_endpoint);
                 self.current_relay = Some(relay);
+                tunnel_endpoint
             }
-        }
+        };
 
         let account_token = self
             .settings
             .get_account_token()
             .ok_or(ErrorKind::InvalidSettings("No account token"))?;
 
-        self.set_security_policy()?;
-
-        let tunnel_monitor =
-            self.spawn_tunnel_monitor(self.tunnel_endpoint.unwrap(), &account_token)?;
-        self.tunnel_close_handle = Some(tunnel_monitor.close_handle());
-        self.spawn_tunnel_monitor_wait_thread(tunnel_monitor);
-
-        self.set_state(TunnelState::Connecting)?;
-        Ok(())
-    }
-
-    fn spawn_tunnel_monitor(
-        &self,
-        tunnel_endpoint: TunnelEndpoint,
-        account_token: &str,
-    ) -> Result<TunnelMonitor> {
-        // Must wrap the channel in a Mutex because TunnelMonitor forces the closure to be Sync
-        let event_tx = Arc::new(Mutex::new(self.tx.clone()));
-        let on_tunnel_event = move |event| {
-            let _ = event_tx
-                .lock()
-                .unwrap()
-                .send(DaemonEvent::TunnelEvent(event));
-        };
-
-        let tunnel_log = if let Some(ref log_dir) = self.log_dir {
-            let filename = match tunnel_endpoint.tunnel {
-                TunnelEndpointData::OpenVpn(_) => OPENVPN_LOG_FILENAME,
-                TunnelEndpointData::Wireguard(_) => WIREGUARD_LOG_FILENAME,
-            };
-            let tunnel_log = log_dir.join(filename);
-            logging::rotate_log(&tunnel_log).chain_err(|| "Unable to rotate tunnel log")?;
-            Some(tunnel_log)
-        } else {
-            None
-        };
-
-        let tunnel_options = self.settings.get_tunnel_options();
-        let tunnel_alias = {
-            #[cfg(windows)]
-            {
-                Some(TUNNEL_INTERFACE_ALIAS.into())
-            }
-            #[cfg(not(windows))]
-            {
-                None
-            }
-        };
-        TunnelMonitor::new(
-            tunnel_endpoint,
-            &tunnel_options,
-            tunnel_alias,
+        Ok(TunnelParameters {
+            endpoint,
+            options: self.settings.get_tunnel_options().clone(),
+            log_dir: self.log_dir.clone(),
+            resource_dir: self.resource_dir.clone(),
             account_token,
-            tunnel_log.as_ref().map(PathBuf::as_path),
-            &self.resource_dir,
-            on_tunnel_event,
-        ).chain_err(|| ErrorKind::TunnelError("Unable to start tunnel monitor"))
-    }
-
-    fn spawn_tunnel_monitor_wait_thread(&self, tunnel_monitor: TunnelMonitor) {
-        let error_tx = self.tx.clone();
-        thread::spawn(move || {
-            let start = Instant::now();
-            let result = tunnel_monitor.wait();
-            if let Some(sleep_dur) = MIN_TUNNEL_ALIVE_TIME.checked_sub(start.elapsed()) {
-                thread::sleep(sleep_dur);
-            }
-            let _ = error_tx.send(DaemonEvent::TunnelExited(result));
-            trace!("Tunnel monitor thread exit");
-        });
-    }
-
-    fn kill_tunnel(&mut self) -> Result<()> {
-        ensure!(
-            self.state == TunnelState::Connecting || self.state == TunnelState::Connected,
-            ErrorKind::InvalidState
-        );
-        let close_handle = self.tunnel_close_handle.take().unwrap();
-        self.set_state(TunnelState::Exiting)?;
-        let result_tx = self.tx.clone();
-        thread::spawn(move || {
-            let result = close_handle.close();
-            let _ = result_tx.send(DaemonEvent::TunnelKillResult(result));
-            trace!("Tunnel kill thread exit");
-        });
-        Ok(())
+            allow_lan: self.settings.get_allow_lan(),
+        })
     }
 
     pub fn shutdown_handle(&self) -> DaemonShutdownHandle {
         DaemonShutdownHandle {
             tx: self.tx.clone(),
         }
-    }
-
-    fn set_security_policy(&mut self) -> Result<()> {
-        let policy = match (self.tunnel_endpoint, self.tunnel_metadata.as_ref()) {
-            (Some(relay), None) => SecurityPolicy::Connecting {
-                relay_endpoint: relay.to_endpoint(),
-                allow_lan: self.settings.get_allow_lan(),
-            },
-            (Some(relay), Some(tunnel_metadata)) => SecurityPolicy::Connected {
-                relay_endpoint: relay.to_endpoint(),
-                tunnel: tunnel_metadata.clone(),
-                allow_lan: self.settings.get_allow_lan(),
-            },
-            _ => bail!(ErrorKind::InvalidState),
-        };
-        debug!("Set security policy: {:?}", policy);
-        self.firewall
-            .apply_policy(policy)
-            .chain_err(|| ErrorKind::FirewallError)
-    }
-
-    fn reset_security_policy(&mut self) -> Result<()> {
-        debug!("Reset security policy");
-        self.firewall
-            .reset_policy()
-            .chain_err(|| ErrorKind::FirewallError)
     }
 }
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -55,6 +55,7 @@ mod rpc_uniqueness_check;
 mod settings;
 mod shutdown;
 mod system_service;
+mod tunnel_state_machine;
 mod version;
 
 use error_chain::ChainedError;

--- a/mullvad-daemon/src/tunnel_state_machine/connected_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/connected_state.rs
@@ -1,0 +1,72 @@
+use futures::sync::mpsc;
+use futures::Stream;
+
+use talpid_core::tunnel::TunnelEvent;
+
+use super::{
+    AfterDisconnect, CloseHandle, DisconnectingState, EventConsequence, StateEntryResult,
+    TunnelCommand, TunnelState, TunnelStateWrapper,
+};
+
+pub struct ConnectedStateBootstrap {
+    pub tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
+    pub close_handle: CloseHandle,
+}
+
+/// The tunnel is up and working.
+pub struct ConnectedState {
+    close_handle: CloseHandle,
+    tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
+}
+
+impl ConnectedState {
+    fn from(bootstrap: ConnectedStateBootstrap) -> Self {
+        ConnectedState {
+            close_handle: bootstrap.close_handle,
+            tunnel_events: bootstrap.tunnel_events,
+        }
+    }
+
+    fn handle_commands(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self> {
+        use self::EventConsequence::*;
+
+        match try_handle_event!(self, commands.poll()) {
+            Ok(TunnelCommand::Connect(_)) => SameState(self),
+            Ok(TunnelCommand::Disconnect) | Err(_) => NewState(DisconnectingState::enter((
+                self.close_handle.close(),
+                AfterDisconnect::Nothing,
+            ))),
+        }
+    }
+
+    fn handle_tunnel_events(mut self) -> EventConsequence<Self> {
+        use self::EventConsequence::*;
+
+        match try_handle_event!(self, self.tunnel_events.poll()) {
+            Ok(TunnelEvent::Down) | Err(_) => NewState(DisconnectingState::enter((
+                self.close_handle.close(),
+                AfterDisconnect::Nothing,
+            ))),
+            Ok(_) => SameState(self),
+        }
+    }
+}
+
+impl TunnelState for ConnectedState {
+    type Bootstrap = ConnectedStateBootstrap;
+
+    fn enter(bootstrap: Self::Bootstrap) -> StateEntryResult {
+        Ok(TunnelStateWrapper::from(ConnectedState::from(bootstrap)))
+    }
+
+    fn handle_event(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self> {
+        self.handle_commands(commands)
+            .or_else(Self::handle_tunnel_events)
+    }
+}

--- a/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
@@ -1,0 +1,172 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use futures::sink::Wait;
+use futures::sync::mpsc;
+use futures::{Sink, Stream};
+
+use talpid_core::tunnel::{TunnelEvent, TunnelMonitor};
+use talpid_types::net::TunnelEndpointData;
+
+use super::{
+    AfterDisconnect, CloseHandle, ConnectedState, ConnectedStateBootstrap, DisconnectedState,
+    DisconnectingState, EventConsequence, Result, ResultExt, StateEntryResult, TunnelCommand,
+    TunnelParameters, TunnelState, TunnelStateWrapper, OPENVPN_LOG_FILENAME,
+    WIREGUARD_LOG_FILENAME,
+};
+use logging;
+
+const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
+
+#[cfg(windows)]
+const TUNNEL_INTERFACE_ALIAS: Option<&str> = Some("Mullvad");
+#[cfg(not(windows))]
+const TUNNEL_INTERFACE_ALIAS: Option<&str> = None;
+
+/// The tunnel has been started, but it is not established/functional.
+pub struct ConnectingState {
+    close_handle: CloseHandle,
+    tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
+}
+
+impl ConnectingState {
+    fn new(parameters: TunnelParameters) -> Result<Self> {
+        let (event_tx, event_rx) = mpsc::unbounded();
+        let monitor = Self::spawn_tunnel_monitor(parameters, event_tx.wait())?;
+        let close_handle = CloseHandle::new(&monitor);
+
+        Self::spawn_tunnel_monitor_wait_thread(monitor);
+
+        Ok(ConnectingState {
+            close_handle,
+            tunnel_events: event_rx,
+        })
+    }
+
+    fn spawn_tunnel_monitor(
+        parameters: TunnelParameters,
+        events: Wait<mpsc::UnboundedSender<TunnelEvent>>,
+    ) -> Result<TunnelMonitor> {
+        let event_tx = Mutex::new(events);
+        let on_tunnel_event = move |event| {
+            let send_result = event_tx
+                .lock()
+                .expect("A thread panicked while sending a tunnel event")
+                .send(event);
+
+            if send_result.is_err() {
+                warn!("Tunnel state machine stopped before tunnel event was received");
+            }
+        };
+        let log_file = Self::prepare_tunnel_log_file(&parameters)?;
+
+        TunnelMonitor::new(
+            parameters.endpoint,
+            &parameters.options,
+            TUNNEL_INTERFACE_ALIAS.to_owned().map(OsString::from),
+            &parameters.account_token,
+            log_file.as_ref().map(PathBuf::as_path),
+            &parameters.resource_dir,
+            on_tunnel_event,
+        ).chain_err(|| "Unable to start tunnel monitor")
+    }
+
+    fn prepare_tunnel_log_file(parameters: &TunnelParameters) -> Result<Option<PathBuf>> {
+        if let Some(ref log_dir) = parameters.log_dir {
+            let filename = match parameters.endpoint.tunnel {
+                TunnelEndpointData::OpenVpn(_) => OPENVPN_LOG_FILENAME,
+                TunnelEndpointData::Wireguard(_) => WIREGUARD_LOG_FILENAME,
+            };
+            let tunnel_log = log_dir.join(filename);
+            logging::rotate_log(&tunnel_log).chain_err(|| "Unable to rotate tunnel log")?;
+            Ok(Some(tunnel_log))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn spawn_tunnel_monitor_wait_thread(tunnel_monitor: TunnelMonitor) {
+        thread::spawn(move || {
+            let start = Instant::now();
+
+            match tunnel_monitor.wait() {
+                Ok(_) => debug!("Tunnel has finished without errors"),
+                Err(error) => {
+                    let chained_error = error.chain_err(|| "Tunnel has stopped unexpectedly");
+                    warn!("{}", chained_error);
+                }
+            }
+
+            if let Some(remaining_time) = MIN_TUNNEL_ALIVE_TIME.checked_sub(start.elapsed()) {
+                thread::sleep(remaining_time);
+            }
+
+            trace!("Tunnel monitor thread exit");
+        });
+    }
+
+    fn into_connected_state_bootstrap(self) -> ConnectedStateBootstrap {
+        ConnectedStateBootstrap {
+            tunnel_events: self.tunnel_events,
+            close_handle: self.close_handle,
+        }
+    }
+
+    fn handle_commands(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self> {
+        use self::EventConsequence::*;
+
+        match try_handle_event!(self, commands.poll()) {
+            Ok(TunnelCommand::Connect(_)) => SameState(self),
+            Ok(TunnelCommand::Disconnect) | Err(_) => NewState(DisconnectingState::enter((
+                self.close_handle.close(),
+                AfterDisconnect::Nothing,
+            ))),
+        }
+    }
+
+    fn handle_tunnel_events(mut self) -> EventConsequence<Self> {
+        use self::EventConsequence::*;
+
+        match try_handle_event!(self, self.tunnel_events.poll()) {
+            Ok(TunnelEvent::Up(_)) => {
+                NewState(ConnectedState::enter(self.into_connected_state_bootstrap()))
+            }
+            Ok(_) => SameState(self),
+            Err(_) => NewState(DisconnectingState::enter((
+                self.close_handle.close(),
+                AfterDisconnect::Nothing,
+            ))),
+        }
+    }
+}
+
+impl TunnelState for ConnectingState {
+    type Bootstrap = TunnelParameters;
+
+    fn enter(parameters: Self::Bootstrap) -> StateEntryResult {
+        Self::new(parameters)
+            .map(TunnelStateWrapper::from)
+            .chain_err(|| "Failed to start tunnel")
+            .map_err(|error| {
+                (
+                    error,
+                    DisconnectedState::enter(())
+                        .expect("Failed to transition to fallback disconnected state"),
+                )
+            })
+    }
+
+    fn handle_event(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self> {
+        self.handle_commands(commands)
+            .or_else(Self::handle_tunnel_events)
+    }
+}

--- a/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
@@ -174,7 +174,7 @@ impl ConnectingState {
             Err(_) => NewState(DisconnectingState::enter((
                 self.close_handle,
                 self.tunnel_close_event,
-                AfterDisconnect::Nothing,
+                AfterDisconnect::Reconnect(self.tunnel_parameters),
             ))),
         }
     }

--- a/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
@@ -16,11 +16,13 @@ use super::{
     AfterDisconnect, ConnectedState, ConnectedStateBootstrap, DisconnectedState,
     DisconnectingState, EventConsequence, Result, ResultExt, SharedTunnelStateValues,
     StateEntryResult, TunnelCommand, TunnelParameters, TunnelState, TunnelStateWrapper,
-    OPENVPN_LOG_FILENAME, WIREGUARD_LOG_FILENAME,
 };
 use logging;
 
 const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
+
+const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
+const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";
 
 #[cfg(windows)]
 const TUNNEL_INTERFACE_ALIAS: Option<&str> = Some("Mullvad");

--- a/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
@@ -1,18 +1,33 @@
+use error_chain::ChainedError;
 use futures::sync::mpsc;
 use futures::Stream;
 
+use talpid_core::firewall::Firewall;
+
 use super::{
-    ConnectingState, EventConsequence, SharedTunnelStateValues, StateEntryResult, TunnelCommand,
-    TunnelState, TunnelStateWrapper,
+    ConnectingState, Error, EventConsequence, SharedTunnelStateValues, StateEntryResult,
+    TunnelCommand, TunnelState, TunnelStateWrapper,
 };
 
 /// No tunnel is running.
 pub struct DisconnectedState;
 
+impl DisconnectedState {
+    fn reset_security_policy(shared_values: &mut SharedTunnelStateValues) {
+        debug!("Reset security policy");
+        if let Err(error) = shared_values.firewall.reset_policy() {
+            let chained_error = Error::with_chain(error, "Failed to reset security policy");
+            error!("{}", chained_error.display_chain());
+        }
+    }
+}
+
 impl TunnelState for DisconnectedState {
     type Bootstrap = ();
 
-    fn enter(_: &mut SharedTunnelStateValues, _: Self::Bootstrap) -> StateEntryResult {
+    fn enter(shared_values: &mut SharedTunnelStateValues, _: Self::Bootstrap) -> StateEntryResult {
+        Self::reset_security_policy(shared_values);
+
         Ok(TunnelStateWrapper::from(DisconnectedState))
     }
 
@@ -27,7 +42,7 @@ impl TunnelState for DisconnectedState {
             Ok(TunnelCommand::Connect(parameters)) => {
                 NewState(ConnectingState::enter(shared_values, parameters))
             }
-            Ok(TunnelCommand::Disconnect) | Err(_) => SameState(self),
+            _ => SameState(self),
         }
     }
 }

--- a/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
@@ -1,0 +1,30 @@
+use futures::sync::mpsc;
+use futures::Stream;
+
+use super::{
+    ConnectingState, EventConsequence, StateEntryResult, TunnelCommand, TunnelState,
+    TunnelStateWrapper,
+};
+
+/// No tunnel is running.
+pub struct DisconnectedState;
+
+impl TunnelState for DisconnectedState {
+    type Bootstrap = ();
+
+    fn enter(_: Self::Bootstrap) -> StateEntryResult {
+        Ok(TunnelStateWrapper::from(DisconnectedState))
+    }
+
+    fn handle_event(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self> {
+        use self::EventConsequence::*;
+
+        match try_handle_event!(self, commands.poll()) {
+            Ok(TunnelCommand::Connect(parameters)) => NewState(ConnectingState::enter(parameters)),
+            Ok(TunnelCommand::Disconnect) | Err(_) => SameState(self),
+        }
+    }
+}

--- a/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
@@ -2,8 +2,8 @@ use futures::sync::mpsc;
 use futures::Stream;
 
 use super::{
-    ConnectingState, EventConsequence, StateEntryResult, TunnelCommand, TunnelState,
-    TunnelStateWrapper,
+    ConnectingState, EventConsequence, SharedTunnelStateValues, StateEntryResult, TunnelCommand,
+    TunnelState, TunnelStateWrapper,
 };
 
 /// No tunnel is running.
@@ -12,18 +12,21 @@ pub struct DisconnectedState;
 impl TunnelState for DisconnectedState {
     type Bootstrap = ();
 
-    fn enter(_: Self::Bootstrap) -> StateEntryResult {
+    fn enter(_: &mut SharedTunnelStateValues, _: Self::Bootstrap) -> StateEntryResult {
         Ok(TunnelStateWrapper::from(DisconnectedState))
     }
 
     fn handle_event(
         self,
         commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+        shared_values: &mut SharedTunnelStateValues,
     ) -> EventConsequence<Self> {
         use self::EventConsequence::*;
 
         match try_handle_event!(self, commands.poll()) {
-            Ok(TunnelCommand::Connect(parameters)) => NewState(ConnectingState::enter(parameters)),
+            Ok(TunnelCommand::Connect(parameters)) => {
+                NewState(ConnectingState::enter(shared_values, parameters))
+            }
             Ok(TunnelCommand::Disconnect) | Err(_) => SameState(self),
         }
     }

--- a/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
@@ -42,7 +42,8 @@ impl TunnelState for DisconnectedState {
             Ok(TunnelCommand::Connect(parameters)) => {
                 NewState(ConnectingState::enter(shared_values, parameters))
             }
-            _ => SameState(self),
+            Ok(_) => SameState(self),
+            Err(_) => Finished,
         }
     }
 }

--- a/mullvad-daemon/src/tunnel_state_machine/disconnecting_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/disconnecting_state.rs
@@ -1,0 +1,75 @@
+use std::io;
+
+use futures::sync::{mpsc, oneshot};
+use futures::{Async, Future, Stream};
+
+use super::{
+    ConnectingState, DisconnectedState, EventConsequence, StateEntryResult, TunnelCommand,
+    TunnelParameters, TunnelState, TunnelStateWrapper,
+};
+
+/// This state is active from when we manually trigger a tunnel kill until the tunnel wait
+/// operation (TunnelExit) returned.
+pub struct DisconnectingState {
+    exited: oneshot::Receiver<io::Result<()>>,
+    after_disconnect: AfterDisconnect,
+}
+
+impl DisconnectingState {
+    fn handle_commands(
+        mut self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self> {
+        use self::AfterDisconnect::*;
+
+        self.after_disconnect = match try_handle_event!(self, commands.poll()) {
+            Ok(TunnelCommand::Connect(parameters)) => Reconnect(parameters),
+            Ok(TunnelCommand::Disconnect) | Err(_) => Nothing,
+        };
+
+        EventConsequence::SameState(self)
+    }
+
+    fn handle_exit_event(mut self) -> EventConsequence<Self> {
+        use self::EventConsequence::*;
+
+        match self.exited.poll() {
+            Ok(Async::NotReady) => NoEvents(self),
+            Ok(Async::Ready(_)) | Err(_) => NewState(self.after_disconnect()),
+        }
+    }
+
+    fn after_disconnect(self) -> StateEntryResult {
+        match self.after_disconnect {
+            AfterDisconnect::Nothing => DisconnectedState::enter(()),
+            AfterDisconnect::Reconnect(tunnel_parameters) => {
+                ConnectingState::enter(tunnel_parameters)
+            }
+        }
+    }
+}
+
+impl TunnelState for DisconnectingState {
+    type Bootstrap = (oneshot::Receiver<io::Result<()>>, AfterDisconnect);
+
+    fn enter((exited, after_disconnect): Self::Bootstrap) -> StateEntryResult {
+        Ok(TunnelStateWrapper::from(DisconnectingState {
+            exited,
+            after_disconnect,
+        }))
+    }
+
+    fn handle_event(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self> {
+        self.handle_commands(commands)
+            .or_else(Self::handle_exit_event)
+    }
+}
+
+/// Which state should be transitioned to after disconnection is complete.
+pub enum AfterDisconnect {
+    Nothing,
+    Reconnect(TunnelParameters),
+}

--- a/mullvad-daemon/src/tunnel_state_machine/macros.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/macros.rs
@@ -1,0 +1,21 @@
+/// Try to receive an event from a `Stream`'s asynchronous poll expression.
+///
+/// This macro is similar to the `try_ready!` macro provided in `futures`. If there is an event
+/// ready, it will be returned wrapped in a `Result`. If there are no events ready to be received,
+/// the outer function will return with a transition that indicates that no events were received,
+/// which is analogous to `Async::NotReady`.
+///
+/// When the asynchronous event indicates that the stream has finished or that it has failed, an
+/// error type is returned so that either close scenario can be handled in a similar way.
+macro_rules! try_handle_event {
+    ($same_state:expr, $event:expr) => {
+        match $event {
+            Ok(::futures::Async::Ready(Some(event))) => Ok(event),
+            Ok(::futures::Async::Ready(None)) => Err(None),
+            Ok(::futures::Async::NotReady) => {
+                return ::tunnel_state_machine::EventConsequence::NoEvents($same_state);
+            }
+            Err(error) => Err(Some(error)),
+        }
+    };
+}

--- a/mullvad-daemon/src/tunnel_state_machine/mod.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/mod.rs
@@ -1,0 +1,304 @@
+#[macro_use]
+mod macros;
+
+mod connected_state;
+mod connecting_state;
+mod disconnected_state;
+mod disconnecting_state;
+
+use std::fmt::{Debug, Formatter, Result as FmtResult};
+use std::io;
+use std::path::PathBuf;
+use std::thread;
+
+use error_chain::ChainedError;
+use futures::sync::{mpsc, oneshot};
+use futures::{Async, Future, Poll};
+use tokio_core::reactor::Core;
+
+use mullvad_types::account::AccountToken;
+use talpid_core::tunnel::{self, TunnelMonitor};
+use talpid_types::net::{TunnelEndpoint, TunnelOptions};
+
+use self::connected_state::{ConnectedState, ConnectedStateBootstrap};
+use self::connecting_state::ConnectingState;
+use self::disconnected_state::DisconnectedState;
+use self::disconnecting_state::{AfterDisconnect, DisconnectingState};
+use super::{OPENVPN_LOG_FILENAME, WIREGUARD_LOG_FILENAME};
+
+error_chain!{}
+
+/// Spawn the tunnel state machine thread, returning a channel for sending tunnel commands.
+pub fn spawn() -> mpsc::UnboundedSender<TunnelCommand> {
+    let (command_tx, command_rx) = mpsc::unbounded();
+
+    thread::spawn(move || {
+        if let Err(error) = event_loop(command_rx) {
+            error!("{}", error.display_chain());
+        }
+    });
+
+    command_tx
+}
+
+fn event_loop(commands: mpsc::UnboundedReceiver<TunnelCommand>) -> Result<()> {
+    let mut reactor =
+        Core::new().chain_err(|| "Failed to initialize tunnel state machine event loop")?;
+
+    let state_machine = TunnelStateMachine::new(commands);
+
+    reactor
+        .run(state_machine)
+        .chain_err(|| "Tunnel state machine finished with an error")
+}
+
+/// Representation of external commands for the tunnel state machine.
+pub enum TunnelCommand {
+    /// Open tunnel connection.
+    Connect(TunnelParameters),
+    /// Close tunnel connection.
+    Disconnect,
+}
+
+/// Information necessary to open a tunnel.
+pub struct TunnelParameters {
+    pub endpoint: TunnelEndpoint,
+    pub options: TunnelOptions,
+    pub log_dir: Option<PathBuf>,
+    pub resource_dir: PathBuf,
+    pub account_token: AccountToken,
+}
+
+/// Asynchronous handling of the tunnel state machine.
+///
+/// This type implements `Future`, and attempts to advance the state machine based on the events
+/// received on the commands stream and possibly on events that specific states are also listening
+/// to.
+struct TunnelStateMachine {
+    current_state: Option<TunnelStateWrapper>,
+    commands: mpsc::UnboundedReceiver<TunnelCommand>,
+}
+
+impl TunnelStateMachine {
+    fn new(commands: mpsc::UnboundedReceiver<TunnelCommand>) -> Self {
+        let initial_state =
+            TunnelStateWrapper::enter(()).expect("Failed to create initial tunnel state");
+
+        TunnelStateMachine {
+            current_state: Some(initial_state),
+            commands,
+        }
+    }
+}
+
+impl Future for TunnelStateMachine {
+    type Item = ();
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let mut state = self
+            .current_state
+            .take()
+            .expect("State machine lost track of its state!");
+        let mut event_was_received = true;
+
+        while event_was_received {
+            let transition = state.handle_event(&mut self.commands);
+
+            event_was_received = transition.is_because_of_an_event();
+            state = transition.into_wrapped_tunnel_state();
+        }
+
+        self.current_state = Some(state);
+
+        Ok(Async::NotReady)
+    }
+}
+
+/// Asynchronous result of an attempt to progress a state.
+enum EventConsequence<T: TunnelState> {
+    /// Transition to a new state.
+    NewState(StateEntryResult),
+    /// An event was received, but it was ignored by the state so no transition is performed.
+    SameState(T),
+    /// No events were received, the event loop should block until one becomes available.
+    NoEvents(T),
+}
+
+impl<T> EventConsequence<T>
+where
+    T: TunnelState,
+{
+    /// Checks if this transition happened after an event was received.
+    pub fn is_because_of_an_event(&self) -> bool {
+        use self::EventConsequence::*;
+
+        match self {
+            NewState(_) | SameState(_) => true,
+            NoEvents(_) => false,
+        }
+    }
+
+    /// Helper method to chain handling multiple different event types.
+    ///
+    /// The `handle_event` is only called if no events were handled so far.
+    pub fn or_else<F>(self, handle_event: F) -> Self
+    where
+        F: FnOnce(T) -> Self,
+    {
+        use self::EventConsequence::*;
+
+        match self {
+            NoEvents(state) => handle_event(state),
+            consequence => consequence,
+        }
+    }
+
+    /// Extracts the destination state as a `TunnelStateWrapper`.
+    ///
+    /// If the destination state isn't the original target state, an error is logged.
+    pub fn into_wrapped_tunnel_state(self) -> TunnelStateWrapper {
+        use self::EventConsequence::*;
+
+        match self {
+            NewState(Ok(wrapped_tunnel_state)) => wrapped_tunnel_state,
+            NewState(Err((error, wrapped_tunnel_state))) => {
+                error!("{}", error.chain_err(|| "Tunnel state transition failed"));
+                wrapped_tunnel_state
+            }
+            SameState(tunnel_state) | NoEvents(tunnel_state) => tunnel_state.into(),
+        }
+    }
+}
+
+/// Result of entering a `T: TunnelState`.
+///
+/// It is either the state itself when successful, or an error paired with a fallback state.
+type StateEntryResult = ::std::result::Result<TunnelStateWrapper, (Error, TunnelStateWrapper)>;
+
+/// Trait that contains the method all states should implement to handle an event and advance the
+/// state machine.
+trait TunnelState: Into<TunnelStateWrapper> + Sized {
+    /// Type representing extra information required for entering the state.
+    type Bootstrap;
+
+    /// Constructor function.
+    ///
+    /// This is the state entry point. It attempts to enter the state, and may fail by entering an
+    /// error or fallback state instead.
+    fn enter(bootstrap: Self::Bootstrap) -> StateEntryResult;
+
+    /// Main state function.
+    ///
+    /// This is state exit point. It consumes itself and returns the next state to advance to when
+    /// it has completed, or itself if it wants to ignore a received event or if no events were
+    /// ready to be received. See [`EventConsequence`] for more details.
+    ///
+    /// An implementation can handle events from many sources, but it should also handle command
+    /// events received through the provided `commands` stream.
+    ///
+    /// [`EventConsequence`]: enum.EventConsequence.html
+    fn handle_event(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<Self>;
+}
+
+/// Valid states of the tunnel.
+///
+/// All implementations must implement `TunnelState` so that they can handle events and
+/// commands in order to advance the state machine.
+enum TunnelStateWrapper {
+    Disconnected(DisconnectedState),
+    Connecting(ConnectingState),
+    Connected(ConnectedState),
+    Disconnecting(DisconnectingState),
+}
+
+macro_rules! impl_from_for_tunnel_state {
+    ($state_variant:ident($state_type:ident)) => {
+        impl From<$state_type> for TunnelStateWrapper {
+            fn from(state: $state_type) -> Self {
+                TunnelStateWrapper::$state_variant(state)
+            }
+        }
+    };
+}
+
+impl_from_for_tunnel_state!(Disconnected(DisconnectedState));
+impl_from_for_tunnel_state!(Connecting(ConnectingState));
+impl_from_for_tunnel_state!(Connected(ConnectedState));
+impl_from_for_tunnel_state!(Disconnecting(DisconnectingState));
+
+impl TunnelState for TunnelStateWrapper {
+    type Bootstrap = <DisconnectedState as TunnelState>::Bootstrap;
+
+    fn enter(bootstrap: Self::Bootstrap) -> StateEntryResult {
+        DisconnectedState::enter(bootstrap)
+    }
+
+    fn handle_event(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+    ) -> EventConsequence<TunnelStateWrapper> {
+        use self::EventConsequence::*;
+
+        macro_rules! handle_event {
+            ( $($state:ident),* $(,)* ) => {
+                match self {
+                    $(
+                        TunnelStateWrapper::$state(state) => match state.handle_event(commands) {
+                            NewState(tunnel_state) => NewState(tunnel_state),
+                            SameState(state) => SameState(TunnelStateWrapper::$state(state)),
+                            NoEvents(state) => NoEvents(TunnelStateWrapper::$state(state)),
+                        },
+                    )*
+                }
+            }
+        }
+
+        handle_event! {
+            Disconnected,
+            Connecting,
+            Connected,
+            Disconnecting,
+        }
+    }
+}
+
+impl Debug for TunnelStateWrapper {
+    fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
+        use self::TunnelStateWrapper::*;
+
+        match *self {
+            Disconnected(_) => write!(formatter, "TunnelStateWrapper::Disconnected(_)"),
+            Connecting(_) => write!(formatter, "TunnelStateWrapper::Connecting(_)"),
+            Connected(_) => write!(formatter, "TunnelStateWrapper::Connected(_)"),
+            Disconnecting(_) => write!(formatter, "TunnelStateWrapper::Disconnecting(_)"),
+        }
+    }
+}
+
+/// Internal handle to request tunnel to be closed.
+pub struct CloseHandle {
+    tunnel_close_handle: tunnel::CloseHandle,
+}
+
+impl CloseHandle {
+    fn new(tunnel_monitor: &TunnelMonitor) -> Self {
+        CloseHandle {
+            tunnel_close_handle: tunnel_monitor.close_handle(),
+        }
+    }
+
+    fn close(self) -> oneshot::Receiver<io::Result<()>> {
+        let (close_tx, close_rx) = oneshot::channel();
+
+        thread::spawn(move || {
+            let _ = close_tx.send(self.tunnel_close_handle.close());
+            trace!("Tunnel kill thread exit");
+        });
+
+        close_rx
+    }
+}

--- a/mullvad-daemon/src/tunnel_state_machine/mod.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/mod.rs
@@ -25,7 +25,6 @@ use self::connected_state::{ConnectedState, ConnectedStateBootstrap};
 use self::connecting_state::ConnectingState;
 use self::disconnected_state::DisconnectedState;
 use self::disconnecting_state::{AfterDisconnect, DisconnectingState};
-use super::{OPENVPN_LOG_FILENAME, WIREGUARD_LOG_FILENAME};
 
 error_chain! {
     errors {

--- a/mullvad-daemon/src/tunnel_state_machine/mod.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/mod.rs
@@ -76,6 +76,7 @@ pub enum TunnelCommand {
 }
 
 /// Information necessary to open a tunnel.
+#[derive(Debug, PartialEq)]
 pub struct TunnelParameters {
     pub endpoint: TunnelEndpoint,
     pub options: TunnelOptions,

--- a/mullvad-daemon/src/tunnel_state_machine/mod.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/mod.rs
@@ -216,6 +216,7 @@ impl From<EventConsequence<TunnelStateWrapper>> for TunnelStateMachineAction {
             }
             SameState(state) => Repeat(state),
             NoEvents(state) => Notify(Some(state), Ok(Async::NotReady)),
+            Finished => Notify(None, Ok(Async::Ready(None))),
         }
     }
 }
@@ -233,6 +234,8 @@ enum EventConsequence<T: TunnelState> {
     SameState(T),
     /// No events were received, the event loop should block until one becomes available.
     NoEvents(T),
+    /// The state machine has finished its execution.
+    Finished,
 }
 
 impl<T> EventConsequence<T>
@@ -356,6 +359,7 @@ impl TunnelState for TunnelStateWrapper {
                                 NewState(tunnel_state) => NewState(tunnel_state),
                                 SameState(state) => SameState(TunnelStateWrapper::$state(state)),
                                 NoEvents(state) => NoEvents(TunnelStateWrapper::$state(state)),
+                                Finished => Finished,
                             }
                         }
                     )*

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -280,7 +280,7 @@ impl TunnelMonitor {
         CloseHandle(self.monitor.close_handle())
     }
 
-    /// Consumes the monitor and block until the tunnel exits or there is an error.
+    /// Consumes the monitor and blocks until the tunnel exits or there is an error.
     pub fn wait(self) -> Result<()> {
         self.monitor
             .wait()


### PR DESCRIPTION
This is the initial PR for refactoring the daemon to separate the tunnel handling code into a state machine. The idea is to have the compiler detect if there are mishandled transitions and prevent transitions to invalid states.

This uses `futures` and already includes the firewall handling code in the state machine. What's missing is handling relay selection in the tunnel state machine, which is done in a separate PR.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user. **Internal refactor is not user visible.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/277)
<!-- Reviewable:end -->
