### PR TITLE
Add UUID in id field of problem reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Bundle the root CA signing the API and only trust that single one, limiting
   trust to a single root CA
+- Add a unique UUID to problem reports. Makes it easier for Mullvad support staff to find reports.
 
 ### Changed
 - App now uses statically linked OpenSSL on all platforms.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "mullvad-paths 0.1.0",
  "mullvad-rpc 0.1.0",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.25"
 error-chain = "0.12"
 lazy_static = "1.0"
 regex = "1.0"
+uuid = { version = "0.6", features = ["v4"] }
 
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-rpc = { path = "../mullvad-rpc" }

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -13,6 +13,7 @@ extern crate error_chain;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
+extern crate uuid;
 
 extern crate mullvad_paths;
 extern crate mullvad_rpc;
@@ -449,11 +450,12 @@ fn read_file_lossy(path: &Path, max_bytes: usize) -> io::Result<String> {
 
 fn collect_metadata() -> HashMap<String, String> {
     let mut metadata = HashMap::new();
+    metadata.insert("id".to_owned(), uuid::Uuid::new_v4().to_string());
     metadata.insert(
-        String::from("mullvad-product-version"),
+        "mullvad-product-version".to_owned(),
         product_version().to_owned(),
     );
-    metadata.insert(String::from("os"), os_version());
+    metadata.insert("os".to_owned(), os_version());
     metadata
 }
 


### PR DESCRIPTION
Asked for feature. To have each report contain a unique id.

Checklist for a PR:

* [ ] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/278)
<!-- Reviewable:end -->
