### PR TITLE
Make `DnsMonitor` implement `Send` in macOS

### DIFF
--- a/talpid-core/src/firewall/macos/dns.rs
+++ b/talpid-core/src/firewall/macos/dns.rs
@@ -37,7 +37,7 @@ struct State {
 }
 
 pub struct DnsMonitor {
-    store: SCDynamicStore,
+    store: Arc<SCDynamicStore>,
 
     /// The current DNS injection state. If this is `None` it means we are not injecting any DNS.
     /// When it's `Some(state)` we are actively making sure `state.desired_dns` is configured
@@ -54,7 +54,7 @@ impl DnsMonitor {
         let state = Arc::new(Mutex::new(None));
         Self::spawn(state.clone())?;
         Ok(DnsMonitor {
-            store: SCDynamicStoreBuilder::new("mullvad-dns").build(),
+            store: Arc::new(SCDynamicStoreBuilder::new("mullvad-dns").build()),
             state,
         })
     }


### PR DESCRIPTION
This is a naive attempt at fixing the tunnel state machine on macOS. The code doesn't compile on macOS because during initialization of the tunnel state machine, the firewall is sent between threads but `Send` isn't implemented for `DnsMonitor`.

Checklist for a PR:

* [x] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user. **Internal change, not user visible.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/279)
<!-- Reviewable:end -->
