### PR TITLE
Update to the latest electron-builder and enable DLL signing

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -66,6 +66,7 @@ win:
       arch:
         - x64
   artifactName: MullvadVPN-${version}.${ext}
+  signDlls: true
   extraResources:
     - from: ./target/release/mullvad.exe
       to: .

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "chai-spies": "^1.0.0",
     "cross-env": "^5.1.3",
     "electron": "^2.0.2",
-    "electron-builder": "^20.19.1",
+    "electron-builder": "^20.20.4",
     "electron-devtools-installer": "^2.2.1",
     "electron-mocha": "^6.0.4",
     "enzyme": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,9 +194,9 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.1.tgz#88ebc1263c7133937d108b80c5572e64e1d9322d"
+ajv@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -266,9 +266,9 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
-app-builder-bin@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.10.3.tgz#ab4d7b1a3bf4005dea16bf0b184077b3136f8ae9"
+app-builder-bin@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.11.1.tgz#33741167f2873cf76805c9557b62caac8ede017b"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -1496,12 +1496,12 @@ builder-util-runtime@4.4.0, builder-util-runtime@^4.4.0:
     fs-extra-p "^4.6.1"
     sax "^1.2.4"
 
-builder-util@5.13.2, builder-util@^5.13.1, builder-util@^5.13.2:
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.13.2.tgz#58b43b5b2c4acdeb9d4994b47152acdb111683ea"
+builder-util@5.16.0, builder-util@^5.14.0, builder-util@~5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.16.0.tgz#8b9aabe15a1a5c4ffa8ebc511049248918f717df"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "1.10.3"
+    app-builder-bin "1.11.1"
     bluebird-lst "^1.0.5"
     builder-util-runtime "^4.4.0"
     chalk "^2.4.1"
@@ -2421,13 +2421,13 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
-dmg-builder@4.11.6:
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-4.11.6.tgz#ea686a487376b9288ffb306e0db6b6c8a9b7ed86"
+dmg-builder@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-4.14.0.tgz#6d19922a82cee78cc13557ab0cbc16047864002a"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^5.13.2"
-    electron-builder-lib "~20.19.1"
+    builder-util "~5.16.0"
+    electron-builder-lib "~20.20.4"
     fs-extra-p "^4.6.1"
     iconv-lite "^0.4.23"
     js-yaml "^3.12.0"
@@ -2591,24 +2591,24 @@ ejs@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
-electron-builder-lib@20.19.1, electron-builder-lib@~20.19.1:
-  version "20.19.1"
-  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.19.1.tgz#5d385130eeff74c192e4ad81b3295264a7899471"
+electron-builder-lib@20.20.4, electron-builder-lib@~20.20.4:
+  version "20.20.4"
+  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.20.4.tgz#fd129ae85c5514f16f4f392218141ebe3dc8411d"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "1.10.3"
+    app-builder-bin "1.11.1"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"
-    builder-util "5.13.2"
+    builder-util "5.16.0"
     builder-util-runtime "4.4.0"
     chromium-pickle-js "^0.2.0"
     debug "^3.1.0"
     ejs "^2.6.1"
     electron-osx-sign "0.4.10"
-    electron-publish "20.19.0"
+    electron-publish "20.22.0"
     env-paths "^1.0.0"
     fs-extra-p "^4.6.1"
-    hosted-git-info "^2.6.1"
+    hosted-git-info "^2.7.1"
     is-ci "^1.1.0"
     isbinaryfile "^3.0.2"
     js-yaml "^3.12.0"
@@ -2616,27 +2616,26 @@ electron-builder-lib@20.19.1, electron-builder-lib@~20.19.1:
     minimatch "^3.0.4"
     normalize-package-data "^2.4.0"
     plist "^3.0.1"
-    read-config-file "3.0.2"
+    read-config-file "3.1.0"
     sanitize-filename "^1.6.1"
     semver "^5.5.0"
-    stream-json "^1.1.0"
     sumchecker "^2.0.2"
     temp-file "^3.1.3"
 
-electron-builder@^20.19.1:
-  version "20.19.1"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.19.1.tgz#a35288abfaade8aa7d57267e277474de6ca4b8c3"
+electron-builder@^20.20.4:
+  version "20.20.4"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.20.4.tgz#09d879c6551df801444a153dc7b159a304e1d55d"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "5.13.2"
+    builder-util "5.16.0"
     builder-util-runtime "4.4.0"
     chalk "^2.4.1"
-    dmg-builder "4.11.6"
-    electron-builder-lib "20.19.1"
+    dmg-builder "4.14.0"
+    electron-builder-lib "20.20.4"
     fs-extra-p "^4.6.1"
     is-ci "^1.1.0"
     lazy-val "^1.0.3"
-    read-config-file "3.0.2"
+    read-config-file "3.1.0"
     sanitize-filename "^1.6.1"
     update-notifier "^2.5.0"
     yargs "^12.0.1"
@@ -2689,12 +2688,12 @@ electron-osx-sign@0.4.10:
     minimist "^1.2.0"
     plist "^2.1.0"
 
-electron-publish@20.19.0:
-  version "20.19.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.19.0.tgz#5d272ba4d4a8b54da8770505da4bcbf460662394"
+electron-publish@20.22.0:
+  version "20.22.0"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.22.0.tgz#352f04fc4821176e0c40a16d64b1c94026e2441f"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^5.13.1"
+    builder-util "^5.14.0"
     builder-util-runtime "^4.4.0"
     chalk "^2.4.1"
     fs-extra-p "^4.6.1"
@@ -3987,9 +3986,9 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-hosted-git-info@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.1.tgz#6e4cee78b01bb849dcf93527708c69fdbee410df"
+hosted-git-info@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
 html-wiring@^1.0.0:
   version "1.2.0"
@@ -6377,11 +6376,11 @@ read-chunk@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-1.0.1.tgz#5f68cab307e663f19993527d9b589cace4661194"
 
-read-config-file@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.0.2.tgz#3866666a8772d350cfbfe9a4b26187df34883c56"
+read-config-file@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.1.0.tgz#d433283c76f32204d6995542e4a04723db9e8308"
   dependencies:
-    ajv "^6.5.1"
+    ajv "^6.5.2"
     ajv-keywords "^3.2.0"
     bluebird-lst "^1.0.5"
     dotenv "^6.0.0"
@@ -7234,10 +7233,6 @@ stream-buffers@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
 
-stream-chain@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.0.3.tgz#9155237a719c8bb2de883c2d1af66d1546f910c9"
-
 stream-combiner2@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
@@ -7256,12 +7251,6 @@ stream-counter@~0.2.0:
   resolved "https://registry.yarnpkg.com/stream-counter/-/stream-counter-0.2.0.tgz#ded266556319c8b0e222812b9cf3b26fa7d947de"
   dependencies:
     readable-stream "~1.1.8"
-
-stream-json@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.1.0.tgz#0a91e84e3cfb017f2446d9023025694982c99e89"
-  dependencies:
-    stream-chain "^2.0.3"
 
 stream-shift@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

The newer version of electron-builder disabled DLL signing by default, so this PR turns on the flag that should enable DLL signing for us.

See:
- https://github.com/electron-userland/electron-builder/issues/3101#issuecomment-404212384
- https://www.electron.build/configuration/win/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/288)
<!-- Reviewable:end -->
