### PR TITLE
Call WSAStartup from main thread of daemon on Windows

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -43,6 +43,9 @@ extern crate talpid_types;
 #[macro_use]
 extern crate windows_service;
 
+#[cfg(windows)]
+extern crate winapi;
+
 mod account_history;
 mod cli;
 mod geoip;
@@ -131,6 +134,27 @@ const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";
 
 #[cfg(windows)]
 const TUNNEL_INTERFACE_ALIAS: &str = "Mullvad";
+
+// This function calls WSAStartup, it's intended to be called from the main thread so as to make it
+// outlive all other threads. This has a sideffect of supressing errors about us not calling
+// WSAStartup, as by default the standard library calls it once per the lifetime of the
+// application, whilst it's deinitialized when the calling thread is exited, which usually happens
+// during the shutdown of the daemon.
+#[cfg(windows)]
+fn call_wsastartup() {
+    use std::mem;
+    use winapi::um::winsock2::WSAStartup;
+    unsafe {
+        let mut data = mem::uninitialized();
+        let ret = WSAStartup(
+            0x202, // Version 2.2, as supported since Vista
+            &mut data,
+        );
+        if ret != 0 {
+            error!("WSAStartup returned a non-zero status - {}", ret);
+        }
+    }
+}
 
 /// All events that can happen in the daemon. Sent from various threads and exposed interfaces.
 pub enum DaemonEvent {
@@ -334,6 +358,8 @@ impl Daemon {
     /// Consume the `Daemon` and run the main event loop. Blocks until an error happens or a
     /// shutdown event is received.
     pub fn run(mut self) -> Result<()> {
+        #[cfg(windows)]
+        call_wsastartup();
         if self.settings.get_auto_connect() {
             info!("Automatically connecting since auto-connect is turned on");
             self.set_target_state(TargetState::Secured)?;


### PR DESCRIPTION
I've added some code to call [`WSAStartup`](https://docs.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-wsastartup) from the main thread on Windows, as to not have any log entries about _not calling `WSAStartup`_ during shutdown. This has to be done because Rust's standard library will call the `WSAShutdown` from the same thread that called `WSAStartup`, which won't necessarily be the main thread, or a thread that would outlive other threads. Thus, all other threads which might have open sockets will have errors about the state of `WSAStartup`. Calling `WSAShutdown` is not required during shutdown as the OS will take care of it for us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/292)
<!-- Reviewable:end -->
