### PR TITLE
Simplify is_another_instance_running

### DIFF
--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -8,7 +8,7 @@ use super::Arguments;
 error_chain! {
     errors {
         AuthDenied {
-            description("Authentication failed with Talpid Core IPC server")
+            description("Failed to authenticate with Talpid IPC server")
         }
         IpcSendingError {
             description("Failed while sending an event over the IPC channel")


### PR DESCRIPTION
Since `DaemonRpcClient::new` does an auth call internally we should not need the `client.get_state()` in order to actually communicate with the other instance.

As such, the old error message was also wrong. Because that error did not just happen when failing to load the RPC credentials, it failed for any error during RPC client setup, which is basically one of
* Load credentials
* Connect websocket
* Call auth.

Lastly, what made me start looking into this: Only logs the error chain if we are in debug mode. It's confusing and too noisy seeing `Error: Blabla` and a cause chain as a normal operation output on every start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/294)
<!-- Reviewable:end -->
