### PR TITLE
Always log process exit code

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -850,7 +850,7 @@ impl Drop for Daemon {
 
 
 fn main() {
-    ::std::process::exit(match run() {
+    let exit_code = match run() {
         Ok(_) => 0,
         Err(error) => {
             if let &ErrorKind::LogError(_) = error.kind() {
@@ -860,7 +860,9 @@ fn main() {
             }
             1
         }
-    });
+    };
+    debug!("Process exiting with code {}", exit_code);
+    ::std::process::exit(exit_code);
 }
 
 fn run() -> Result<()> {

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -38,7 +38,7 @@ pub fn handle_service_main(arguments: Vec<OsString>) {
     info!("Service started.");
     match run_service(arguments) {
         Ok(_) => info!("Service stopped."),
-        Err(ref e) => error!("Service stopped with error: {}", e.display_chain()),
+        Err(ref e) => error!("{}", e.display_chain()),
     };
 }
 


### PR DESCRIPTION
I saw this in a problem report:
```
[2018-07-12 02:08:05.918][mullvad_daemon::system_service][ERROR] Service stopped with error: Error: Unable to initialize daemon
Caused by: Firewall error
Caused by: Failed to recover to backed up system state

[2018-07-12 02:11:38.426][mullvad_daemon::management_interface][DEBUG] authenticated: true
```

First of all, the logging could be improved to not have "error: Error:". That is the diff in one of the files.

Secondly it looks like the daemon continues to run after this error? It's supposed to quit if it fails to initialize like this. And I'm honestly not sure if it quits but the logging is strange, or if it somehow manages to carry on. So I add logging just before the main thread exits. So it will be possible to always determine exactly where the process quits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/295)
<!-- Reviewable:end -->
