### PR TITLE
Refer to auto-connect as "computer start" rather than login

### DIFF
--- a/app/components/Preferences.js
+++ b/app/components/Preferences.js
@@ -61,7 +61,7 @@ export default class Preferences extends Component<PreferencesProps, State> {
                 </View>
                 <View style={styles.preferences__cell_footer}>
                   <Text style={styles.preferences__cell_footer_label}>
-                    {'Automatically connect the VPN at login to the system.'}
+                    {'Automatically connect the VPN when the computer starts.'}
                   </Text>
                 </View>
 


### PR DESCRIPTION
I think the two messages were nearly identical. Very hard to understand the difference from just reading the descriptions.

And also the one for `auto-connect` is not really correct. No one has to log in for it to connect. It connects early on in the boot process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/305)
<!-- Reviewable:end -->
