### PR TITLE
Revert the tunnel auto-connect on startup

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -419,6 +419,17 @@ export default class AppRenderer {
     } catch (error) {
       log.error(`Cannot fetch initial state: ${error.message}`);
     }
+
+    // auto connect the tunnel on startup
+    // note: disabled when developing
+    if (process.env.NODE_ENV !== 'development') {
+      try {
+        log.debug('Auto-connecting the tunnel...');
+        await this.connectTunnel();
+      } catch (error) {
+        log.error(`Failed to auto-connect the tunnel: ${error.message}`);
+      }
+    }
   }
 
   async _onCloseConnection(error: ?Error) {


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

This PR brings back the tunnel auto-connect on the app startup but disables it for development mode since it's fairly common to not want to connect the tunnel on each hot reload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/307)
<!-- Reviewable:end -->
