### PR TITLE
Update win signing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ source env.sh
 
 if [[ "${1:-""}" != "--dev-build" ]]; then
 
-    REQUIRED_RUSTC_VERSION="rustc 1.27.1 (5f2b325f6 2018-07-07)"
+    REQUIRED_RUSTC_VERSION="rustc 1.27.2 (58cc626de 2018-07-18)"
 
     if [[ $RUSTC_VERSION != $REQUIRED_RUSTC_VERSION ]]; then
         echo "You are running the wrong Rust compiler version."

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -84,6 +84,7 @@ win:
       to: .
     - from: ./dist-assets/binaries/windows/openvpn.exe
       to: .
+  publisherName: Amagicom AB
 
 linux:
   target:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -85,6 +85,8 @@ win:
     - from: ./dist-assets/binaries/windows/openvpn.exe
       to: .
   publisherName: Amagicom AB
+  signingHashAlgorithms:
+    - sha256
 
 linux:
   target:


### PR DESCRIPTION
Not much to say. See commit messages. The reason we don't need SHA1 signing is because we target Win7+, and these platforms are compatible with SHA256.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/316)
<!-- Reviewable:end -->
