### PR TITLE
Replace custom ClipboardData with DataTransfer type

### DIFF
--- a/app/components/AccountInput.js
+++ b/app/components/AccountInput.js
@@ -4,17 +4,9 @@ import { TextInput } from 'reactxp';
 import { formatAccount } from '../lib/formatters';
 import { colors } from '../config';
 
-// @TODO: move it into types.js
-
 // ESLint issue: https://github.com/babel/babel-eslint/issues/445
-// eslint-disable-next-line no-unused-vars
-declare class ClipboardData {
-  setData(type: string, data: string): void;
-  getData(type: string): string;
-}
-
 declare class ClipboardEvent extends Event {
-  clipboardData: ClipboardData;
+  clipboardData: DataTransfer;
 }
 
 export type AccountInputProps = {


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

Newer flow support `DataTransfer` so there is no point in having a custom `ClipboardData`. Unfortunately `ClipboardEvent` is not yet defined in Flow 0.66, I have heard it is in Flow 0.74 but we can't update to it yet due to compatibility issues in `validated` package. 

This PR solves half of the problem :) Less code is better!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/326)
<!-- Reviewable:end -->
