### PR TITLE
Fix invalid style key for windows platform

### DIFF
--- a/app/components/NavigationBar.js
+++ b/app/components/NavigationBar.js
@@ -15,8 +15,8 @@ const styles = {
     darwin: Styles.createViewStyle({
       marginTop: 24,
     }),
-    windows: Styles.createViewStyle({
-      marginTop: 24,
+    win32: Styles.createViewStyle({
+      marginTop: 12,
     }),
     linux: Styles.createViewStyle({
       marginTop: 12,


### PR DESCRIPTION
Checklist for a PR:

* [X] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.

This PR fixes incorrect style key used for windows, it should be `win32` instead of `windows`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/328)
<!-- Reviewable:end -->
