### PR TITLE
Reformat with rustfmt 0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
         - cargo test --verbose
         # Install and run rustfmt on nightly only until rustfmt.toml settings are stabilized.
         - rustup component add rustfmt-preview
-        - rustfmt --version
+        - cargo fmt --version || true
         - cargo fmt -- --check --unstable-features
 
     - language: rust

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -23,12 +23,10 @@ impl Command for Account {
                             .help("The Mullvad account token to configure the client with")
                             .required(true),
                     ),
-            )
-            .subcommand(
+            ).subcommand(
                 clap::SubCommand::with_name("get")
                     .about("Display information about the currently configured account"),
-            )
-            .subcommand(
+            ).subcommand(
                 clap::SubCommand::with_name("unset")
                     .about("Removes the account number from the settings"),
             )

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -22,8 +22,7 @@ impl Command for AutoConnect {
                             .required(true)
                             .possible_values(&["on", "off"]),
                     ),
-            )
-            .subcommand(
+            ).subcommand(
                 clap::SubCommand::with_name("get")
                     .about("Display the current auto-connect setting"),
             )

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -22,8 +22,7 @@ impl Command for Lan {
                             .required(true)
                             .possible_values(&["allow", "block"]),
                     ),
-            )
-            .subcommand(
+            ).subcommand(
                 clap::SubCommand::with_name("get")
                     .about("Display the current local network sharing setting"),
             )

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -34,50 +34,42 @@ impl Command for Relay {
                                     .required(true)
                                     .index(1)
                                     .possible_values(&["openvpn", "wireguard"]),
-                            )
-                            .arg(
+                            ).arg(
                                 clap::Arg::with_name("host")
                                     .help("Hostname or IP")
                                     .required(true)
                                     .index(2),
-                            )
-                            .arg(
+                            ).arg(
                                 clap::Arg::with_name("port")
                                     .help("Remote network port")
                                     .required(true)
                                     .index(3),
-                            )
-                            .arg(
+                            ).arg(
                                 clap::Arg::with_name("protocol")
                                     .help("Transport protocol. For Wireguard this is ignored.")
                                     .index(4)
                                     .default_value("udp")
                                     .possible_values(&["udp", "tcp"]),
                             ),
-                    )
-                    .subcommand(
+                    ).subcommand(
                         clap::SubCommand::with_name("location")
                             .about(
                                 "Set country or city to select relays from. Use the 'list' \
                                  command to show available alternatives.",
-                            )
-                            .arg(
+                            ).arg(
                                 clap::Arg::with_name("country")
                                     .help(
                                         "The two letter country code, or 'any' for no preference.",
-                                    )
-                                    .required(true)
+                                    ).required(true)
                                     .index(1)
                                     .validator(country_code_validator),
-                            )
-                            .arg(
+                            ).arg(
                                 clap::Arg::with_name("city")
                                     .help("The three letter city code")
                                     .index(2)
                                     .validator(city_code_validator),
                             ),
-                    )
-                    .subcommand(
+                    ).subcommand(
                         clap::SubCommand::with_name("tunnel")
                             .about("Set tunnel constraints")
                             .arg(clap::Arg::with_name("port").required(true).index(1))
@@ -88,8 +80,7 @@ impl Command for Relay {
                                     .possible_values(&["any", "udp", "tcp"]),
                             ),
                     ),
-            )
-            .subcommand(clap::SubCommand::with_name("get"))
+            ).subcommand(clap::SubCommand::with_name("get"))
             .subcommand(
                 clap::SubCommand::with_name("list")
                     .setting(clap::AppSettings::SubcommandRequired)

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -27,13 +27,10 @@ impl Command for Tunnel {
                                         .help(
                                             "Sets the optional  mssfix parameter. \
                                              Set an empty string to clear it.",
-                                        )
-                                        .required(true),
+                                        ).required(true),
                                 ),
-                            )
-                            .setting(clap::AppSettings::SubcommandRequired),
-                    )
-                    .subcommand(
+                            ).setting(clap::AppSettings::SubcommandRequired),
+                    ).subcommand(
                         clap::SubCommand::with_name("get")
                             .help("Retrieves the current setting for mssfix"),
                     ),

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -484,8 +484,7 @@ impl Daemon {
             .join(
                 self.version_proxy
                     .is_app_version_supported(&current_version),
-            )
-            .map(|(latest_versions, is_supported)| AppVersionInfo {
+            ).map(|(latest_versions, is_supported)| AppVersionInfo {
                 current_is_supported: is_supported,
                 latest: latest_versions,
             });

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -315,8 +315,7 @@ impl RelaySelector {
                     .find(|relay| {
                         i = i.saturating_sub(relay.weight);
                         i == 0
-                    })
-                    .unwrap(),
+                    }).unwrap(),
             )
         }
     }

--- a/mullvad-daemon/src/rpc_address_file.rs
+++ b/mullvad-daemon/src/rpc_address_file.rs
@@ -35,7 +35,8 @@ pub fn write(rpc_address: &str, shared_secret: &str) -> Result<()> {
     // Avoids opening an existing file owned by another user and writing sensitive data to it.
     remove()?;
 
-    let file_path = mullvad_paths::get_rpc_address_path().chain_err(|| ErrorKind::UnknownFilePath)?;
+    let file_path =
+        mullvad_paths::get_rpc_address_path().chain_err(|| ErrorKind::UnknownFilePath)?;
 
     if let Some(parent_dir) = file_path.parent() {
         fs::create_dir_all(parent_dir)
@@ -52,7 +53,8 @@ pub fn write(rpc_address: &str, shared_secret: &str) -> Result<()> {
 
 /// Removes the RPC file, if it exists.
 pub fn remove() -> Result<()> {
-    let file_path = mullvad_paths::get_rpc_address_path().chain_err(|| ErrorKind::UnknownFilePath)?;
+    let file_path =
+        mullvad_paths::get_rpc_address_path().chain_err(|| ErrorKind::UnknownFilePath)?;
 
     if let Err(error) = fs::remove_file(&file_path) {
         if error.kind() == io::ErrorKind::NotFound {

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -117,8 +117,8 @@ impl DaemonRpcClient {
         P: AsRef<Path>,
     {
         let file_path = file_path.as_ref();
-        let rpc_file =
-            File::open(file_path).chain_err(|| ErrorKind::ReadRpcFileError(file_path.to_owned()))?;
+        let rpc_file = File::open(file_path)
+            .chain_err(|| ErrorKind::ReadRpcFileError(file_path.to_owned()))?;
 
         let reader = BufReader::new(rpc_file);
         let mut lines = reader.lines();

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -100,16 +100,14 @@ fn run() -> Result<()> {
                         .value_name("PATH")
                         .takes_value(true)
                         .required(true),
-                )
-                .arg(
+                ).arg(
                     clap::Arg::with_name("extra_logs")
                         .help("Paths to additional log files to be included.")
                         .multiple(true)
                         .value_name("EXTRA LOGS")
                         .takes_value(true)
                         .required(false),
-                )
-                .arg(
+                ).arg(
                     clap::Arg::with_name("redact")
                         .help("List of words and expressions to remove from the report")
                         .long("redact")
@@ -117,8 +115,7 @@ fn run() -> Result<()> {
                         .multiple(true)
                         .takes_value(true),
                 ),
-        )
-        .subcommand(
+        ).subcommand(
             clap::SubCommand::with_name("send")
                 .about("Send collected problem report")
                 .arg(
@@ -128,16 +125,14 @@ fn run() -> Result<()> {
                         .help("The path to previously collected report file.")
                         .takes_value(true)
                         .required(true),
-                )
-                .arg(
+                ).arg(
                     clap::Arg::with_name("email")
                         .long("email")
                         .short("e")
                         .help("Reporter's email")
                         .takes_value(true)
                         .required(false),
-                )
-                .arg(
+                ).arg(
                     clap::Arg::with_name("message")
                         .long("message")
                         .short("m")

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -55,8 +55,7 @@ fn create_request_processing_future<CC: hyper::client::Connect>(
                 } else {
                     future::err(ErrorKind::HttpError(response.status()).into())
                 }
-            })
-            .and_then(|response: hyper::Response| response.body().concat2().from_err())
+            }).and_then(|response: hyper::Response| response.body().concat2().from_err())
             .map(|response_chunk| response_chunk.to_vec())
             .then(move |response_result| {
                 if let Err(_) = response_tx.send(response_result) {

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -41,6 +41,5 @@ fn resolve_to_ip(host: &str) -> Result<IpAddr> {
         .or_else(|| {
             info!("No IPv4 for host {}", host);
             ipv6.pop()
-        })
-        .ok_or_else(|| ErrorKind::InvalidHost(host.to_owned()).into())
+        }).ok_or_else(|| ErrorKind::InvalidHost(host.to_owned()).into())
 }

--- a/talpid-core/src/firewall/linux/mod.rs
+++ b/talpid-core/src/firewall/linux/mod.rs
@@ -373,7 +373,8 @@ fn check_iface(rule: &mut Rule, direction: Direction, iface: &str) -> Result<()>
 }
 
 fn iface_index(name: &str) -> Result<libc::c_uint> {
-    let c_name = CString::new(name).chain_err(|| ErrorKind::InvalidInterfaceName(name.to_owned()))?;
+    let c_name =
+        CString::new(name).chain_err(|| ErrorKind::InvalidInterfaceName(name.to_owned()))?;
     let index = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
     if index == 0 {
         let error = io::Error::last_os_error();

--- a/talpid-core/src/firewall/macos/dns.rs
+++ b/talpid-core/src/firewall/macos/dns.rs
@@ -281,8 +281,7 @@ fn read_dns(store: &SCDynamicStore, path: CFString) -> Option<Vec<DnsServer>> {
             dictionary
                 .find2(&CFString::from_static_string("ServerAddresses"))
                 .map(|array_ptr| unsafe { CFType::wrap_under_get_rule(array_ptr) })
-        })
-        .and_then(|addresses| {
+        }).and_then(|addresses| {
             if let Some(array) = addresses.downcast::<CFArray<CFType>>() {
                 parse_cf_array_to_strings(array)
             } else {

--- a/talpid-core/src/firewall/macos/mod.rs
+++ b/talpid-core/src/firewall/macos/mod.rs
@@ -57,8 +57,8 @@ impl Firewall for PacketFilter {
             self.restore_state(),
             self.restore_dns(),
         ].into_iter()
-            .collect::<Result<Vec<_>>>()
-            .map(|_| ())
+        .collect::<Result<Vec<_>>>()
+        .map(|_| ())
     }
 }
 
@@ -200,8 +200,7 @@ impl PacketFilter {
             let allow_multicast = rule_builder
                 .to(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V4(
                     *super::MULTICAST_NET,
-                ))))
-                .build()?;
+                )))).build()?;
             rules.push(allow_net);
             rules.push(allow_multicast);
         }

--- a/talpid-ipc/src/client.rs
+++ b/talpid-ipc/src/client.rs
@@ -257,11 +257,12 @@ impl Handler {
     ) -> Result<(SubscriptionId, JsonValue)> {
         match notification.remove("params") {
             Some(JsonValue::Object(mut parameters)) => {
-                let raw_id = parameters
-                    .remove("subscription")
-                    .ok_or_else(|| ErrorKind::InvalidSubscriptionEvent("Missing subscription ID"))?;
-                let id = SubscriptionId::parse_value(&raw_id)
-                    .ok_or_else(|| ErrorKind::InvalidSubscriptionEvent("Invalid subscription ID"))?;
+                let raw_id = parameters.remove("subscription").ok_or_else(|| {
+                    ErrorKind::InvalidSubscriptionEvent("Missing subscription ID")
+                })?;
+                let id = SubscriptionId::parse_value(&raw_id).ok_or_else(|| {
+                    ErrorKind::InvalidSubscriptionEvent("Invalid subscription ID")
+                })?;
                 let event = parameters
                     .remove("result")
                     .ok_or_else(|| ErrorKind::InvalidSubscriptionEvent("Missing event data"))?;
@@ -385,8 +386,7 @@ impl WsIpcClient {
                 id,
                 handler: Box::new(handler),
                 unsubscribe_method,
-            })
-            .chain_err(|| ErrorKind::ConnectionHandlerStopped)
+            }).chain_err(|| ErrorKind::ConnectionHandlerStopped)
     }
 
     pub fn call<S, T, O>(&mut self, method: S, params: &T) -> Result<O>
@@ -408,9 +408,12 @@ impl WsIpcClient {
             .send(command)
             .chain_err(|| ErrorKind::ConnectionHandlerStopped)?;
 
-        let json_result = response_rx.recv().chain_err(|| ErrorKind::MissingResponse)?;
+        let json_result = response_rx
+            .recv()
+            .chain_err(|| ErrorKind::MissingResponse)?;
 
-        Ok(serde_json::from_value(json_result?).chain_err(|| ErrorKind::DeserializeResponseError)?)
+        Ok(serde_json::from_value(json_result?)
+            .chain_err(|| ErrorKind::DeserializeResponseError)?)
     }
 }
 

--- a/talpid-ipc/src/lib.rs
+++ b/talpid-ipc/src/lib.rs
@@ -67,8 +67,7 @@ impl IpcServer {
             .map(|server| IpcServer {
                 address: format!("ws://{}", server.addr()),
                 server: server,
-            })
-            .chain_err(|| ErrorKind::IpcServerError)
+            }).chain_err(|| ErrorKind::IpcServerError)
     }
 
     /// Returns the localhost address this `IpcServer` is listening on.

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -25,8 +25,8 @@ pub struct EventProcessor {
 impl EventProcessor {
     pub fn new(arguments: &Arguments) -> Result<EventProcessor> {
         trace!("Creating EventProcessor");
-        let mut ipc_client =
-            WsIpcClient::connect(&arguments.server_id).chain_err(|| "Unable to create IPC client")?;
+        let mut ipc_client = WsIpcClient::connect(&arguments.server_id)
+            .chain_err(|| "Unable to create IPC client")?;
 
         trace!("Authenticating EventProcessor");
         match ipc_client.call("authenticate", &[&arguments.credentials]) {


### PR DESCRIPTION
Rustfmt 0.9.0 is out via rustup. Reformatting using it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/333)
<!-- Reviewable:end -->
