### PR TITLE
Add issue template and improve PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+Thank you for wanting to help us improve the Mullvad VPN app by reporting
+issues.
+
+**Before reporting an issue**, please note that this is **not** the correct
+place for:
+* General Mullvad support - contact support@mullvad.net for that
+
+* Bugs and issues regarding the old Mullvad client.
+
+  With the old Mullvad client we mean the one written in python and
+  with version numbers such as 65, 66, 67 and similar.
+  This source code repository is only for the new Mullvad VPN app with version
+  numbers looking like `<year>.<number>`, such as 2018.1 and so on.
+
+
+Please proceed and report an issue if you have found a bug or a problem with
+the new *Mullvad VPN app*, the one being developed in this repository.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
-Checklist for a PR:
+Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.
 
-* [ ] Describe the change in **`CHANGELOG.md`**. Only applicable if the change has any impact for a user.
+Git checklist:
+
+* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
+* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)


### PR DESCRIPTION
Assigning everyone since it's partly a change in process. Or not really a change in process, but how we communicate it.

I added an issue template to try to mitigate people asking for general Mullvad support and reporting bugs in the old python client.

I also improved the PR template to remind people to put changelog entries in the `[Unreleased]` section and to check that they follow style. Basically a reminder to check that the things you want reviewed are sane before requesting someone else to spend time on reading it. The goal it to try to reduce number of iterations in PRs due to minor details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/338)
<!-- Reviewable:end -->
