### PR TITLE
Another sweep over our paths and trying to finalize their names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,14 @@ Line wrap the file at 100 chars.                                              Th
 - Format the expiry date and time using the system locale.
 - Account tokens are now required to have at least ten digits.
 
+### macOS
+- Rename directores for settings, logs and cache from `mullvad-daemon` to `mullvad-vpn`.
+
 #### Windows
-- Use local user directory to store settings and electron cache, instead of the roaming user
-  directory.
+- Use local user directory to store system service settings and GUI electron cache, instead of the
+  roaming user directory.
+- Where the system service would use `%LOCALAPPDATA%\Mullvad\Mullvad VPN\` it now just uses
+  `%LOCALAPPDATA%\Mullvad VPN\`
 
 ### Fixed
 - Ignore empty strings as redaction requests in the problem report tool, to avoid adding redacted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,17 +20,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "app_dirs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,7 +859,7 @@ dependencies = [
 name = "mullvad-paths"
 version = "0.1.0"
 dependencies = [
- "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1032,15 +1021,6 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ole32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1353,15 +1333,6 @@ dependencies = [
 name = "shell-escape"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "shell32-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "simple-signal"
@@ -1972,16 +1943,10 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
-[[package]]
-name = "xdg"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-"checksum app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "664470abf00fae0f31c0eb6e1ca12d82961b2a2541ef898bc9dd51a9254d218b"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
@@ -2080,7 +2045,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
-"checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum openssl 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ed18a0f40ec4e9a8a81f8865033d823b7195d16a0a5721e10963ee1b0c2980ca"
 "checksum openssl-sys 0.9.34 (git+https://github.com/mullvad/rust-openssl)" = "<none>"
 "checksum openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f01f94fa077e8648fa20c654f6aef90e1a0feae5455a7b5d80c19eadeb97c7e8"
@@ -2119,7 +2083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum shared_child 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcd5e483b3475af9bc2a35311c2f3bbf0bd98fde91410ab15a0d4ba3c3127b4e"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
-"checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
 "checksum simple-signal 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53f7da44adcc42667d57483bd93f81295f27d66897804b757573b61b6f13288b"
 "checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
@@ -2185,4 +2148,3 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum windres 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c437ac5da816407bfb202da316d55f36be0cf9db14146a1ff4e4744a3d7dc565"
 "checksum ws 0.7.5 (git+https://github.com/tomusdrw/ws-rs)" = "<none>"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"

--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ The settings directory can be changed by setting the `MULLVAD_SETTINGS_DIR` envi
 
 | Platform | Path |
 |----------|------|
-| Linux | `/etc/mullvad-daemon/settings.json` |
-| macOS | `/etc/mullvad-daemon/settings.json` |
-| Windows | `%LOCALAPPDATA%\Mullvad\Mullvad VPN\settings.json`
+| Linux | `/etc/mullvad-vpn/` |
+| macOS | `/etc/mullvad-vpn/` |
+| Windows | `%LOCALAPPDATA%\Mullvad VPN\`
 
 #### Logs
 
@@ -288,8 +288,8 @@ The log directory can be changed by setting the `MULLVAD_LOG_DIR` environment va
 
 | Platform | Path |
 |----------|------|
-| Linux | `/var/log/mullvad-daemon/` + systemd |
-| macOS | `/var/log/mullvad-daemon/` |
+| Linux | `/var/log/mullvad-vpn/` + systemd |
+| macOS | `/var/log/mullvad-vpn/` |
 | Windows | `C:\ProgramData\Mullvad VPN\` |
 
 #### Cache
@@ -298,9 +298,9 @@ The cache directory can be changed by setting the `MULLVAD_CACHE_DIR` environmen
 
 | Platform | Path |
 |----------|------|
-| Linux | `/var/cache/mullvad-daemon/` |
-| macOS | `/var/root/Library/Caches/mullvad-daemon/` |
-| Windows | `%LOCALAPPDATA%\Mullvad\Mullvad VPN\` |
+| Linux | `/var/cache/mullvad-vpn/` |
+| macOS | `/var/root/Library/Caches/mullvad-vpn/` |
+| Windows | `%LOCALAPPDATA%\Mullvad VPN\` |
 
 #### RPC address file
 

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -2,7 +2,7 @@
 
 set -eu
 
-LOG_DIR=/var/log/mullvad-daemon
+LOG_DIR=/var/log/mullvad-vpn
 
 mkdir -p $LOG_DIR
 exec 2>&1 > $LOG_DIR/postinstall.log

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -2,7 +2,7 @@
 
 set -eux
 
-LOG_DIR=/var/log/mullvad-daemon
+LOG_DIR=/var/log/mullvad-vpn
 
 mkdir -p $LOG_DIR
 exec 2>&1 > $LOG_DIR/preinstall.log
@@ -21,28 +21,56 @@ fi
 
 # Migrate settings from <=2018.1 paths
 OLD_SETTINGS_DIR="$HOME/Library/Application Support/mullvad-daemon"
-NEW_SETTINGS_DIR="/etc/mullvad-daemon"
+NEW_SETTINGS_DIR="/etc/mullvad-vpn"
 if [ -d "$OLD_SETTINGS_DIR" ]; then
     echo "Found old setting dir $OLD_SETTINGS_DIR. Moving to $NEW_SETTINGS_DIR"
     mkdir -p "$NEW_SETTINGS_DIR"
     mv "$OLD_SETTINGS_DIR/settings.json" "$NEW_SETTINGS_DIR/settings.json" || \
         echo "Unable to migrate settings, not present in old dir?"
-    rm -r "$OLD_SETTINGS_DIR"
+    rm -rf "$OLD_SETTINGS_DIR"
+fi
+
+# Migrate settings from <=2018.2-betaX paths
+OLD_SETTINGS_DIR="/etc/mullvad-daemon"
+NEW_SETTINGS_DIR="/etc/mullvad-vpn"
+if [ -d "$OLD_SETTINGS_DIR" ]; then
+    echo "Found old setting dir $OLD_SETTINGS_DIR. Moving to $NEW_SETTINGS_DIR"
+    mkdir -p "$NEW_SETTINGS_DIR"
+    mv "$OLD_SETTINGS_DIR/settings.json" "$NEW_SETTINGS_DIR/settings.json" || \
+        echo "Unable to migrate settings, not present in old dir?"
+    rm -rf "$OLD_SETTINGS_DIR"
 fi
 
 # Delete logs from <=2018.1 paths
 OLD_LOG_DIR="$HOME/Library/Logs/MullvadVPN"
 if [ -d "$OLD_LOG_DIR" ]; then
     echo "Found old log dir $OLD_LOG_DIR. Deleting"
-    rm -r "$OLD_LOG_DIR"
+    rm -rf "$OLD_LOG_DIR"
+fi
+
+# Delete logs from <=2018.2-betaX paths
+OLD_LOG_DIR="/var/log/mullvad-daemon"
+if [ -d "$OLD_LOG_DIR" ]; then
+    echo "Found old log dir $OLD_LOG_DIR. Deleting"
+    rm -rf "$OLD_LOG_DIR"
 fi
 
 # Migrate cache files from <=2018.1 paths
 OLD_CACHE_DIR="$HOME/Library/Caches/mullvad-daemon"
-NEW_CACHE_DIR="/var/root/Library/Caches/mullvad-daemon"
+NEW_CACHE_DIR="/var/root/Library/Caches/mullvad-vpn"
 if [ -d "$OLD_CACHE_DIR" ]; then
     echo "Found old cache dir at $OLD_CACHE_DIR, moving to $NEW_CACHE_DIR"
     mkdir -p "$NEW_CACHE_DIR"
     mv "$OLD_CACHE_DIR"/* "$NEW_CACHE_DIR/" || echo "Unable to migrate cache. No cache files?"
-    rm -r "$OLD_CACHE_DIR"
+    rm -rf "$OLD_CACHE_DIR"
+fi
+
+# Migrate cache files from <=2018.2-betaX paths
+OLD_CACHE_DIR="/var/root/Library/Caches/mullvad-daemon"
+NEW_CACHE_DIR="/var/root/Library/Caches/mullvad-vpn"
+if [ -d "$OLD_CACHE_DIR" ]; then
+    echo "Found old cache dir at $OLD_CACHE_DIR, moving to $NEW_CACHE_DIR"
+    mkdir -p "$NEW_CACHE_DIR"
+    mv "$OLD_CACHE_DIR"/* "$NEW_CACHE_DIR/" || echo "Unable to migrate cache. No cache files?"
+    rm -rf "$OLD_CACHE_DIR"
 fi

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -14,4 +14,4 @@ error-chain = "0.12"
 log = "0.4"
 
 [target.'cfg(any(windows, target_os = "macos"))'.dependencies]
-app_dirs = "1.2"
+dirs = "1.0"

--- a/mullvad-paths/src/logs.rs
+++ b/mullvad-paths/src/logs.rs
@@ -1,31 +1,29 @@
-use {ErrorKind, Result, ResultExt};
+use Result;
 
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 
 /// Creates and returns the logging directory pointed to by `MULLVAD_LOG_DIR`, or the default
 /// one if that variable is unset.
 pub fn log_dir() -> Result<PathBuf> {
-    let dir = get_log_dir()?;
-    fs::create_dir_all(&dir).chain_err(|| ErrorKind::CreateDirFailed(dir.clone()))?;
-    Ok(dir)
+    ::create_and_return(get_log_dir)
 }
 
 /// Get the logging directory, but don't try to create it.
 pub fn get_log_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_LOG_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_log_dir(),
+        None => get_default_log_dir().map(|dir| dir.join(::PRODUCT_NAME)),
     }
 }
 
-#[cfg(unix)]
 fn get_default_log_dir() -> Result<PathBuf> {
-    Ok(PathBuf::from("/var/log/mullvad-daemon"))
-}
-
-#[cfg(windows)]
-fn get_default_log_dir() -> Result<PathBuf> {
-    ::get_program_data_dir()
+    #[cfg(unix)]
+    {
+        Ok(PathBuf::from("/var/log"))
+    }
+    #[cfg(windows)]
+    {
+        ::get_allusersprofile_dir()
+    }
 }

--- a/mullvad-paths/src/rpc_address.rs
+++ b/mullvad-paths/src/rpc_address.rs
@@ -12,12 +12,13 @@ pub fn get_rpc_address_path() -> Result<PathBuf> {
     }
 }
 
-#[cfg(unix)]
 fn get_default_rpc_address_dir() -> Result<PathBuf> {
-    Ok(PathBuf::from("/tmp"))
-}
-
-#[cfg(windows)]
-fn get_default_rpc_address_dir() -> Result<PathBuf> {
-    ::get_program_data_dir()
+    #[cfg(unix)]
+    {
+        Ok(PathBuf::from("/tmp"))
+    }
+    #[cfg(windows)]
+    {
+        ::get_allusersprofile_dir().map(|dir| dir.join(::PRODUCT_NAME))
+    }
 }

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -1,33 +1,28 @@
-use {ErrorKind, Result, ResultExt};
+use Result;
 
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 
 /// Creates and returns the settings directory pointed to by `MULLVAD_SETTINGS_DIR`, or the default
 /// one if that variable is unset.
 pub fn settings_dir() -> Result<PathBuf> {
-    let dir = get_settings_dir()?;
-    fs::create_dir_all(&dir).chain_err(|| ErrorKind::CreateDirFailed(dir.clone()))?;
-    Ok(dir)
+    ::create_and_return(get_settings_dir)
 }
 
 fn get_settings_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_SETTINGS_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_settings_dir(),
+        None => get_default_settings_dir().map(|dir| dir.join(::PRODUCT_NAME)),
     }
 }
 
-#[cfg(unix)]
 fn get_default_settings_dir() -> Result<PathBuf> {
-    Ok(PathBuf::from("/etc/mullvad-daemon"))
-}
-
-#[cfg(windows)]
-fn get_default_settings_dir() -> Result<PathBuf> {
-    Ok(::app_dirs::get_app_root(
-        ::app_dirs::AppDataType::UserData,
-        &::metadata::APP_INFO,
-    )?)
+    #[cfg(unix)]
+    {
+        Ok(PathBuf::from("/etc"))
+    }
+    #[cfg(windows)]
+    {
+        ::dirs::data_local_dir().ok_or_else(|| ::ErrorKind::FindDirError.into())
+    }
 }


### PR DESCRIPTION
So the paths where we store files came up for discussion again during #332. There were arguments about that we should save files under folders named after the product rather than the component. And there were arguments about our two layers of `Mullvad\Mullvad VPN` directories being just repetitive.

So this is my *proposal* for new folder names. Everyone is assigned as reviewers since I want us to all agree on this. We must settle on paths before `2018.2` is released stable, because the more platforms we support the harder it will be to maintain any kind of migration code. And for macOS we already need migration code because the paths have already changed a lot since `2018.1` so we need to take that burden anyway.

This PR basically:
* Renames all folders named `mullvad-daemon` to `mullvad-vpn`
* Shortens all instances of `Mullvad\Mullvad VPN` into just one layer `Mullvad VPN`

Left to do after we have reached consensus on paths:
* [x] Update the changelog
* [x] Update migration code in install scripts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/339)
<!-- Reviewable:end -->
