### PR TITLE
Restore missing Problem Report page style

### DIFF
--- a/app/components/Support.js
+++ b/app/components/Support.js
@@ -286,9 +286,9 @@ export default class Support extends Component<SupportProps, SupportState> {
             <Text style={styles.support__status_security__secure}>Secure Connection</Text>
             <Text style={styles.support__send_status}>Sent</Text>
 
-            <Text style={styles.support__subtitle}>Thanks! We will look into this.</Text>
+            <Text style={styles.support__sent_message}>Thanks! We will look into this.</Text>
             {this.state.email.trim().length > 0 ? (
-              <Text style={styles.support__subtitle}>
+              <Text style={styles.support__sent_message}>
                 If needed we will contact you on {'\u00A0'}
                 <Text style={styles.support__sent_email}>{this.state.email}</Text>
               </Text>

--- a/app/components/SupportStyles.js
+++ b/app/components/SupportStyles.js
@@ -88,6 +88,15 @@ export default Object.assign(
       backgroundColor: colors.white,
       flex: 1,
     },
+    support__sent_message: {
+      fontFamily: 'Open Sans',
+      fontSize: 13,
+      fontWeight: '600',
+      overflow: 'visible',
+      color: colors.white60,
+      lineHeight: 20,
+      letterSpacing: -0.2,
+    },
     support__sent_email: {
       fontWeight: '900',
       color: colors.white,


### PR DESCRIPTION
Fixes a regression in the Problem Report page. It caused some text that's displayed after a problem report is sent to have an incorrect appearance. The regression was caused because the text shared its style definition with some text that was replaced with a custom component. The style is now restored but given a more specific name.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not applicable since this fixes a regression that was not released.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/341)
<!-- Reviewable:end -->
