### PR TITLE
Handle window close on Linux

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -32,6 +32,7 @@ const ApplicationMain = {
 
     log.info(`Running version ${app.getVersion()}`);
 
+    app.on('activate', () => this._onActivate());
     app.on('ready', () => this._onReady());
     app.on('window-all-closed', () => app.quit());
     app.on('before-quit', () => this._onBeforeQuit());
@@ -118,6 +119,13 @@ const ApplicationMain = {
         // Windows: %LOCALAPPDATA%\{appname}\logs
         // Linux: ~/.config/{appname}/logs
         return path.join(app.getPath('userData'), 'logs');
+    }
+  },
+
+  _onActivate() {
+    const windowController = this._windowController;
+    if (windowController) {
+      windowController.show();
     }
   },
 

--- a/app/main.js
+++ b/app/main.js
@@ -131,6 +131,14 @@ const ApplicationMain = {
 
   _onBeforeQuit() {
     this._shouldQuit = true;
+
+    if (process.env.NODE_ENV === 'development') {
+      const windowController = this._windowController;
+      if (windowController) {
+        windowController.window.closeDevTools();
+      }
+    }
+
     return true;
   },
 
@@ -152,8 +160,6 @@ const ApplicationMain = {
 
     if (process.env.NODE_ENV === 'development') {
       await this._installDevTools();
-
-      window.on('close', () => window.closeDevTools());
       window.openDevTools({ mode: 'detach' });
     }
 

--- a/app/main.js
+++ b/app/main.js
@@ -150,10 +150,7 @@ const ApplicationMain = {
         this._installMacOsMenubarAppWindowHandlers(tray, windowController);
         break;
       default:
-        tray.on('click', () => {
-          windowController.toggle();
-        });
-        windowController.show();
+        this._installGenericMenubarAppWindowHandlers(tray, windowController);
         break;
     }
 
@@ -456,6 +453,13 @@ const ApplicationMain = {
     window.on('show', () => macEventMonitor.start(eventMask, () => windowController.hide()));
     window.on('hide', () => macEventMonitor.stop());
     tray.on('click', () => windowController.toggle());
+  },
+
+  _installGenericMenubarAppWindowHandlers(tray: Tray, windowController: WindowController) {
+    tray.on('click', () => {
+      windowController.toggle();
+    });
+    windowController.show();
   },
 };
 


### PR DESCRIPTION
Currently the app doesn't have a way to minimize the main window on Linux without using the tray icon. As a way around that, this PR changes the window close behavior to hide the window but not quit the app. This way, the app is only truly closed through the `Quit` button in the Settings page.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Linux version not released yet.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/342)
<!-- Reviewable:end -->
