### PR TITLE
Override app paths before single instance check

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -23,11 +23,12 @@ const ApplicationMain = {
   _shouldQuit: false,
 
   run() {
+    this._overrideAppPaths();
+
     if (this._ensureSingleInstance()) {
       return;
     }
 
-    this._overrideAppPaths();
     this._initLogging();
 
     log.info(`Running version ${app.getVersion()}`);


### PR DESCRIPTION
A `lockfile` was still being created in the `Roaming` user directory. To fix this, the app paths are now overridden before the lockfile is created by a check for other running instances.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/345)
<!-- Reviewable:end -->
