### PR TITLE
Handle unsupported protocol on interface on Windows

### DIFF
--- a/windows/winroute/src/winroute/InterfacePair.cpp
+++ b/windows/winroute/src/winroute/InterfacePair.cpp
@@ -81,7 +81,7 @@ void InterfacePair::InitializeInterface(PMIB_IPINTERFACE_ROW iface)
 	DWORD status = GetIpInterfaceEntry(iface);
 
 	if (status != NO_ERROR) {
-		if (status == STATUS_NOT_FOUND) {
+		if (status == STATUS_NOT_FOUND || status == ERROR_NOT_FOUND) {
 			iface->Family = AF_UNSPEC;
 		}
 		else {


### PR DESCRIPTION
If IPv6 is disabled, trying to get an IP interface entry for IPv6 fails with an `ERROR_NOT_FOUND` error. Previously, that would lead to an exception that would then become a fatal firewall error in the daemon. Now it is ignored, since there is code to check if at least one protocol is supported.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not user visible.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/351)
<!-- Reviewable:end -->
