### PR TITLE
Hide notifications when window is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Line wrap the file at 100 chars.                                              Th
   session.
 - Account token can be copied to the clipboard by clicking on it in the account settings screen.
 - Automatically scroll to selected country/city in locations view.
-- Show system notifications when connection state changes.
+- Show system notifications when connection state changes and the window is not visible.
 - Add launch view displayed when connecting to system service.
 
 ### Changed

--- a/app/notification-controller.js
+++ b/app/notification-controller.js
@@ -7,6 +7,12 @@ export default class NotificationController {
 
   show(message: string) {
     const lastNotification = this._activeNotification;
+    const sameAsLastNotification = lastNotification && lastNotification.body === message;
+
+    if (sameAsLastNotification) {
+      return;
+    }
+
     const newNotification = new Notification(remote.app.getName(), { body: message, silent: true });
 
     this._activeNotification = newNotification;

--- a/app/notification-controller.js
+++ b/app/notification-controller.js
@@ -9,7 +9,7 @@ export default class NotificationController {
     const lastNotification = this._activeNotification;
     const sameAsLastNotification = lastNotification && lastNotification.body === message;
 
-    if (sameAsLastNotification) {
+    if (sameAsLastNotification || remote.getCurrentWindow().isVisible()) {
       return;
     }
 


### PR DESCRIPTION
Notifications were previously always shown. This lead to the situation where when the window was visible the notification would appear over it, hiding part of the window. Another situation was that sometimes the same notification would be shown more than once, which was undesired.

This PR fixes both situations by only showing notifications if they differ from the previous notification and if the window is currently hidden.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/353)
<!-- Reviewable:end -->
