### PR TITLE
Add setting to enable or disable IPv6 on the tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add option to enable or disable IPv6 on the tunnel interface.
+
 ### Changed
 - The "Buy more credit" button is changed to open a dedicated account login page instead of one
   having a create account form first.

--- a/app/app.js
+++ b/app/app.js
@@ -369,6 +369,12 @@ export default class AppRenderer {
     actions.settings.updateAllowLan(allowLan);
   }
 
+  async setEnableIpv6(enableIpv6: boolean) {
+    const actions = this._reduxActions;
+    await this._daemonRpc.setOpenVpnEnableIpv6(enableIpv6);
+    actions.settings.updateEnableIpv6(enableIpv6);
+  }
+
   async setAutoConnect(autoConnect: boolean) {
     const actions = this._reduxActions;
     await this._daemonRpc.setAutoConnect(autoConnect);
@@ -391,6 +397,12 @@ export default class AppRenderer {
     const securityState = await this._daemonRpc.getState();
     const connectionState = this._securityStateToConnectionState(securityState);
     this._updateConnectionState(connectionState);
+  }
+
+  async _fetchTunnelOptions() {
+    const actions = this._reduxActions;
+    const tunnelOptions = await this._daemonRpc.getTunnelOptions();
+    actions.settings.updateEnableIpv6(tunnelOptions.openvpn.enableIpv6);
   }
 
   async _connectToDaemon(): Promise<void> {
@@ -523,6 +535,7 @@ export default class AppRenderer {
       this._fetchAutoConnect(),
       this._fetchLocation(),
       this._fetchAccountHistory(),
+      this._fetchTunnelOptions(),
     ]);
   }
 

--- a/app/components/AdvancedSettings.js
+++ b/app/components/AdvancedSettings.js
@@ -6,12 +6,15 @@ import { Layout, Container } from './Layout';
 import NavigationBar, { BackBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 import CustomScrollbars from './CustomScrollbars';
+import Switch from './Switch';
 import styles from './AdvancedSettingsStyles';
 import Img from './Img';
 
 type AdvancedSettingsProps = {
+  enableIpv6: boolean,
   protocol: string,
   port: string | number,
+  setEnableIpv6: (boolean) => void,
   onUpdate: (protocol: string, port: string | number) => void,
   onClose: () => void,
 };
@@ -40,6 +43,20 @@ export class AdvancedSettings extends Component<AdvancedSettingsProps> {
                 <HeaderTitle>Advanced</HeaderTitle>
               </SettingsHeader>
               <CustomScrollbars style={styles.advanced_settings__scrollview} autoHide={true}>
+                <View style={styles.advanced_settings__ipv6}>
+                  <View style={styles.advanced_settings__cell_label_container}>
+                    <Text style={styles.advanced_settings__cell_label}>Enable IPv6</Text>
+                  </View>
+                  <View style={styles.advanced_settings__ipv6_accessory}>
+                    <Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
+                  </View>
+                </View>
+                <View style={styles.advanced_settings__cell_footer}>
+                  <Text style={styles.advanced_settings__cell_footer_label}>
+                    {'Enable IPv6 communication through the tunnel.'}
+                  </Text>
+                </View>
+
                 <View style={styles.advanced_settings__content}>
                   <Selector
                     title={'Network protocols'}

--- a/app/components/AdvancedSettingsStyles.js
+++ b/app/components/AdvancedSettingsStyles.js
@@ -24,6 +24,14 @@ export default {
     flexBasis: 'auto',
     overflow: 'visible',
   }),
+  advanced_settings__ipv6: Styles.createViewStyle({
+    backgroundColor: colors.blue,
+    flexDirection: 'row',
+    alignItems: 'center',
+  }),
+  advanced_settings__ipv6_accessory: Styles.createViewStyle({
+    marginRight: 12,
+  }),
   advanced_settings__cell: Styles.createViewStyle({
     cursor: 'default',
     backgroundColor: colors.green,

--- a/app/containers/AdvancedSettingsPage.js
+++ b/app/containers/AdvancedSettingsPage.js
@@ -8,10 +8,16 @@ import RelaySettingsBuilder from '../lib/relay-settings-builder';
 import { log } from '../lib/platform';
 
 import type { ReduxState, ReduxDispatch } from '../redux/store';
+import type { RelaySettingsRedux } from '../redux/settings/reducers';
 import type { SharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: ReduxState) => {
-  const relaySettings = state.settings.relaySettings;
+  const protocolAndPort = mapRelaySettingsToProtocolAndPort(state.settings.relaySettings);
+
+  return { enableIpv6: state.settings.enableIpv6, ...protocolAndPort };
+};
+
+const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) => {
   if (relaySettings.normal) {
     const { protocol, port } = relaySettings.normal;
     return {
@@ -53,6 +59,14 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
         await props.app.fetchRelaySettings();
       } catch (e) {
         log.error('Failed to update relay settings', e.message);
+      }
+    },
+
+    setEnableIpv6: async (enableIpv6) => {
+      try {
+        await props.app.setEnableIpv6(enableIpv6);
+      } catch (e) {
+        log.error('Failed to update enable IPv6', e.message);
       }
     },
   };

--- a/app/lib/daemon-rpc.js
+++ b/app/lib/daemon-rpc.js
@@ -49,16 +49,16 @@ export type BackendState = {
 export type RelayProtocol = 'tcp' | 'udp';
 export type RelayLocation = {| city: [string, string] |} | {| country: string |};
 
-type OpenVpnParameters = {
+type OpenVpnConstraints = {
   port: 'any' | { only: number },
   protocol: 'any' | { only: RelayProtocol },
 };
 
-type TunnelOptions<TOpenVpnParameters> = {
-  openvpn: TOpenVpnParameters,
+type TunnelConstraints<TOpenVpnConstraints> = {
+  openvpn: TOpenVpnConstraints,
 };
 
-type RelaySettingsNormal<TTunnelOptions> = {
+type RelaySettingsNormal<TTunnelConstraints> = {
   location:
     | 'any'
     | {
@@ -67,7 +67,7 @@ type RelaySettingsNormal<TTunnelOptions> = {
   tunnel:
     | 'any'
     | {
-        only: TTunnelOptions,
+        only: TTunnelConstraints,
       },
 };
 
@@ -83,7 +83,7 @@ export type RelaySettingsCustom = {
 };
 export type RelaySettings =
   | {|
-      normal: RelaySettingsNormal<TunnelOptions<OpenVpnParameters>>,
+      normal: RelaySettingsNormal<TunnelConstraints<OpenVpnConstraints>>,
     |}
   | {|
       custom_tunnel_endpoint: RelaySettingsCustom,
@@ -91,7 +91,7 @@ export type RelaySettings =
 
 // types describing the partial update of RelaySettings
 export type RelaySettingsNormalUpdate = $Shape<
-  RelaySettingsNormal<TunnelOptions<$Shape<OpenVpnParameters>>>,
+  RelaySettingsNormal<TunnelConstraints<$Shape<OpenVpnConstraints>>>,
 >;
 export type RelaySettingsUpdate =
   | {|

--- a/app/redux/settings/actions.js
+++ b/app/redux/settings/actions.js
@@ -22,11 +22,17 @@ export type UpdateAllowLanAction = {
   allowLan: boolean,
 };
 
+export type UpdateEnableIpv6Action = {
+  type: 'UPDATE_ENABLE_IPV6',
+  enableIpv6: boolean,
+};
+
 export type SettingsAction =
   | UpdateRelayAction
   | UpdateRelayLocationsAction
   | UpdateAutoConnectAction
-  | UpdateAllowLanAction;
+  | UpdateAllowLanAction
+  | UpdateEnableIpv6Action;
 
 function updateRelay(relay: RelaySettingsRedux): UpdateRelayAction {
   return {
@@ -58,4 +64,17 @@ function updateAllowLan(allowLan: boolean): UpdateAllowLanAction {
   };
 }
 
-export default { updateRelay, updateRelayLocations, updateAutoConnect, updateAllowLan };
+function updateEnableIpv6(enableIpv6: boolean): UpdateEnableIpv6Action {
+  return {
+    type: 'UPDATE_ENABLE_IPV6',
+    enableIpv6,
+  };
+}
+
+export default {
+  updateRelay,
+  updateRelayLocations,
+  updateAutoConnect,
+  updateAllowLan,
+  updateEnableIpv6,
+};

--- a/app/redux/settings/reducers.js
+++ b/app/redux/settings/reducers.js
@@ -39,6 +39,7 @@ export type SettingsReduxState = {
   relayLocations: Array<RelayLocationRedux>,
   autoConnect: boolean,
   allowLan: boolean,
+  enableIpv6: boolean,
 };
 
 const initialState: SettingsReduxState = {
@@ -52,6 +53,7 @@ const initialState: SettingsReduxState = {
   relayLocations: [],
   autoConnect: false,
   allowLan: false,
+  enableIpv6: true,
 };
 
 export default function(
@@ -81,6 +83,12 @@ export default function(
       return {
         ...state,
         autoConnect: action.autoConnect,
+      };
+
+    case 'UPDATE_ENABLE_IPV6':
+      return {
+        ...state,
+        enableIpv6: action.enableIpv6,
       };
 
     default:

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -389,6 +389,9 @@ impl Daemon {
             SetAutoConnect(tx, auto_connect) => self.on_set_auto_connect(tx, auto_connect),
             GetAutoConnect(tx) => Ok(self.on_get_auto_connect(tx)),
             SetOpenVpnMssfix(tx, mssfix_arg) => self.on_set_openvpn_mssfix(tx, mssfix_arg),
+            SetOpenVpnEnableIpv6(tx, enable_ipv6) => {
+                self.on_set_openvpn_enable_ipv6(tx, enable_ipv6)
+            }
             GetTunnelOptions(tx) => self.on_get_tunnel_options(tx),
             GetRelaySettings(tx) => Ok(self.on_get_relay_settings(tx)),
             GetVersionInfo(tx) => Ok(self.on_get_version_info(tx)),
@@ -572,6 +575,19 @@ impl Daemon {
         let save_result = self.settings.set_openvpn_mssfix(mssfix_arg);
         match save_result.chain_err(|| "Unable to save settings") {
             Ok(_) => Self::oneshot_send(tx, (), "set_openvpn_mssfix response"),
+            Err(e) => error!("{}", e.display_chain()),
+        };
+        Ok(())
+    }
+
+    fn on_set_openvpn_enable_ipv6(
+        &mut self,
+        tx: OneshotSender<()>,
+        enable_ipv6: bool,
+    ) -> Result<()> {
+        let save_result = self.settings.set_openvpn_enable_ipv6(enable_ipv6);
+        match save_result.chain_err(|| "Unable to save settings") {
+            Ok(_) => Self::oneshot_send(tx, (), "set_openvpn_enable_ipv6 response"),
             Err(e) => error!("{}", e.display_chain()),
         };
         Ok(())

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -180,6 +180,15 @@ impl Settings {
         }
     }
 
+    pub fn set_openvpn_enable_ipv6(&mut self, enable_ipv6: bool) -> Result<bool> {
+        if self.tunnel_options.openvpn.enable_ipv6 != enable_ipv6 {
+            self.tunnel_options.openvpn.enable_ipv6 = enable_ipv6;
+            self.save().map(|_| true)
+        } else {
+            Ok(false)
+        }
+    }
+
     pub fn get_tunnel_options(&self) -> &TunnelOptions {
         &self.tunnel_options
     }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -203,6 +203,10 @@ impl DaemonRpcClient {
         self.call("set_account", &[account])
     }
 
+    pub fn set_openvpn_enable_ipv6(&mut self, enabled: bool) -> Result<()> {
+        self.call("set_openvpn_enable_ipv6", &[enabled])
+    }
+
     pub fn set_openvpn_mssfix(&mut self, mssfix: Option<u16>) -> Result<()> {
         self.call("set_openvpn_mssfix", &[mssfix])
     }

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -184,6 +184,16 @@ impl OpenVpnCommand {
             args.push(OsString::from(mssfix.to_string()));
         }
 
+        if !self.tunnel_options.enable_ipv6 {
+            args.push(OsString::from("--pull-filter"));
+            args.push(OsString::from("ignore"));
+            args.push(OsString::from("route-ipv6"));
+
+            args.push(OsString::from("--pull-filter"));
+            args.push(OsString::from("ignore"));
+            args.push(OsString::from("ifconfig-ipv6"));
+        }
+
         if let Some(ref tunnel_device) = self.tunnel_alias {
             args.push(OsString::from("--dev-node"));
             args.push(tunnel_device.clone());

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -138,9 +138,22 @@ pub struct TunnelOptions {
 /// OpenVpnTunnelOptions contains options for an openvpn tunnel that should be applied irrespective
 /// of the relay parameters - i.e. have nothing to do with the particular OpenVPN server, but do
 /// affect the connection.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(default)]
 pub struct OpenVpnTunnelOptions {
     /// Optional argument for openvpn to try and limit TCP packet size,
     /// as discussed [here](https://openvpn.net/archive/openvpn-users/2003-11/msg00154.html)
     pub mssfix: Option<u16>,
+    /// Enable configuration of IPv6 on the tunnel interface, allowing IPv6 communication to be
+    /// forwarded through the tunnel. By default, this is set to `true`.
+    pub enable_ipv6: bool,
+}
+
+impl Default for OpenVpnTunnelOptions {
+    fn default() -> Self {
+        OpenVpnTunnelOptions {
+            mssfix: None,
+            enable_ipv6: true,
+        }
+    }
 }

--- a/test/components/SelectLocation.spec.js
+++ b/test/components/SelectLocation.spec.js
@@ -42,6 +42,7 @@ describe('components/SelectLocation', () => {
     ],
     autoConnect: false,
     allowLan: false,
+    enableIpv6: true,
   };
 
   const makeProps = (


### PR DESCRIPTION
If the operating system doesn't support IPv6 or if it is disabled then opening the tunnel with OpenVPN would fail. This PR adds an option to the daemon that allows the user to disable IPv6 support, so that when the tunnel is started it may ignore the IPv6 specific options. This option can be set through the CLI or the GUI. On the GUI, a toggle was added to the "Advanced Settings" screen for changing the option.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/354)
<!-- Reviewable:end -->
