### PR TITLE
Redirect to /account/login when clicking add credit button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- The "Buy more credit" button is changed to open a dedicated account login page instead of one
+  having a create account form first.
 
 
 ## [2018.2-beta3] - 2018-08-09

--- a/app/config.json
+++ b/app/config.json
@@ -1,7 +1,7 @@
 {
   "links": {
     "createAccount": "https://mullvad.net/account/create/",
-    "purchase": "https://mullvad.net/account/",
+    "purchase": "https://mullvad.net/account/login/",
     "faq": "https://mullvad.net/faq/",
     "guides": "https://mullvad.net/guides/",
     "download": "https://mullvad.net/download/",


### PR DESCRIPTION
When users click the "Buy more credit" they were taken to https://mullvad.net/account/login/. This works fine for users who are logged in to our website already. But since we have a very short cookie expiry time the vast majority of users are not logged in to our site when clicking this button. In that case they are redirected to https://mullvad.net/account/login/create/ which will show a login form, but before that it will show a create account form. This is confusing, being logged in to the app and clicking to buy more credit just to be greeted with a page telling them to create an account. Instead this page will only have a login form, making it more clear.

For users who are already logged in they will be automatically redirected to https://mullvad.net/account/ and get where they should anyway.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/356)
<!-- Reviewable:end -->
