### PR TITLE
typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The host has to have the following installed:
 For Debian based distributions, you need to install the following. For other distributions you need
 the equivalent packages:
 ```bash
-sudo apt install gcc libssl-dev libappindactor1
+sudo apt install gcc libssl-dev libappindicator1
 ```
 
 ### All platforms


### PR DESCRIPTION
`libappindactor1` isn't a valid package, but libappindicator1 is. Maybe a typo?

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/359)
<!-- Reviewable:end -->
