### PR TITLE
Simplify CLI `relay list` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - The "Buy more credit" button is changed to open a dedicated account login page instead of one
   having a create account form first.
+- The CLI command to list relays is now shorter, `mullvad relay list` instead of
+  `mullvad relay list locations`.
 
 
 ## [2018.2] - 2018-08-13

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -82,12 +82,7 @@ impl Command for Relay {
                     ),
             ).subcommand(clap::SubCommand::with_name("get"))
             .subcommand(
-                clap::SubCommand::with_name("list")
-                    .setting(clap::AppSettings::SubcommandRequired)
-                    .subcommand(
-                        clap::SubCommand::with_name("locations")
-                            .about("List available countries and cities"),
-                    ),
+                clap::SubCommand::with_name("list").about("List available countries and cities"),
             )
     }
 


### PR DESCRIPTION
The `relay list` command only had one `locations` sub-command. This PR merges them so that the same action can expressed with a shorter command line.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/362)
<!-- Reviewable:end -->
