### PR TITLE
Create `Cell.Img` type

### DIFF
--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Button, Text, Component, Styles, Types } from 'reactxp';
-import Img from './Img';
+import PlainImg from './Img';
 import { colors } from '../../config';
 
 const styles = {
@@ -49,6 +49,7 @@ const styles = {
 
 export class SubText extends Text {}
 export class Label extends Text {}
+export class Img extends PlainImg {}
 
 type CellButtonProps = {
   children?: React.Node,

--- a/gui/packages/desktop/src/renderer/components/SelectLocation.js
+++ b/gui/packages/desktop/src/renderer/components/SelectLocation.js
@@ -10,7 +10,6 @@ import NavigationBar, { CloseBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle, HeaderSubTitle } from './SettingsHeader';
 import * as Cell from './Cell';
 import styles from './SelectLocationStyles';
-import Img from './Img';
 
 import type {
   SettingsReduxState,
@@ -146,7 +145,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
     const statusClass = active ? styles.relay_status__active : styles.relay_status__inactive;
 
     return isSelected ? (
-      <Img style={styles.tick_icon} source="icon-tick" height={24} width={24} />
+      <Cell.Img style={styles.tick_icon} source="icon-tick" height={24} width={24} />
     ) : (
       <View style={[styles.relay_status, statusClass]} />
     );
@@ -190,7 +189,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
           <Cell.Label>{relayCountry.name}</Cell.Label>
 
           {relayCountry.cities.length > 1 ? (
-            <Img
+            <Cell.Img
               style={styles.collapse_button}
               hoverStyle={styles.expand_chevron_hover}
               onPress={handleCollapse}

--- a/gui/packages/desktop/src/renderer/components/Settings.js
+++ b/gui/packages/desktop/src/renderer/components/Settings.js
@@ -10,7 +10,6 @@ import NavigationBar, { CloseBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 import CustomScrollbars from './CustomScrollbars';
 import styles from './SettingsStyles';
-import Img from './Img';
 import WindowStateObserver from '../lib/window-state-observer';
 
 import type { LoginState } from '../redux/account/reducers';
@@ -104,7 +103,7 @@ export default class Settings extends Component<Props> {
                 style={styles.settings__account_paid_until_label__error}>
                 {'OUT OF TIME'}
               </Cell.SubText>
-              <Img height={12} width={7} source="icon-chevron" />
+              <Cell.Img height={12} width={7} source="icon-chevron" />
             </Cell.CellButton>
           ) : (
             <Cell.CellButton
@@ -114,19 +113,19 @@ export default class Settings extends Component<Props> {
               <Cell.SubText testName="settings__account_paid_until_subtext">
                 {formattedExpiry}
               </Cell.SubText>
-              <Img height={12} width={7} source="icon-chevron" />
+              <Cell.Img height={12} width={7} source="icon-chevron" />
             </Cell.CellButton>
           )}
         </View>
 
         <Cell.CellButton onPress={this.props.onViewPreferences} testName="settings__preferences">
           <Cell.Label>Preferences</Cell.Label>
-          <Img height={12} width={7} source="icon-chevron" />
+          <Cell.Img height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
 
         <Cell.CellButton onPress={this.props.onViewAdvancedSettings} testName="settings__advanced">
           <Cell.Label>Advanced</Cell.Label>
-          <Img height={12} width={7} source="icon-chevron" />
+          <Cell.Img height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
         <View style={styles.settings__cell_spacer} />
       </View>
@@ -141,7 +140,7 @@ export default class Settings extends Component<Props> {
           testName="settings__version">
           <Cell.Label>App version</Cell.Label>
           <Cell.SubText>{this._formattedVersion()}</Cell.SubText>
-          <Img height={16} width={16} source="icon-extLink" />
+          <Cell.Img height={16} width={16} source="icon-extLink" />
         </Cell.CellButton>
         <View style={styles.settings__cell_spacer} />
       </View>
@@ -164,19 +163,19 @@ export default class Settings extends Component<Props> {
           onPress={this.props.onExternalLink.bind(this, 'faq')}
           testName="settings__external_link">
           <Cell.Label>FAQs</Cell.Label>
-          <Img height={16} width={16} source="icon-extLink" />
+          <Cell.Img height={16} width={16} source="icon-extLink" />
         </Cell.CellButton>
 
         <Cell.CellButton
           onPress={this.props.onExternalLink.bind(this, 'guides')}
           testName="settings__external_link">
           <Cell.Label>Guides</Cell.Label>
-          <Img height={16} width={16} source="icon-extLink" />
+          <Cell.Img height={16} width={16} source="icon-extLink" />
         </Cell.CellButton>
 
         <Cell.CellButton onPress={this.props.onViewSupport} testName="settings__view_support">
           <Cell.Label>Report a problem</Cell.Label>
-          <Img height={12} width={7} source="icon-chevron" />
+          <Cell.Img height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
       </View>
     );


### PR DESCRIPTION
This PR creates a `Cell.Img` type based on the `Img` type. The reason for having two types is that `CellButton` changes the `tintColor` props of every child `Img` type. This prevents this property from being set manually by a `View` that uses a `CellButton` with an `Img` in it. Having it so that `CellButton` only touches `Cell.Img` types makes it easier to use `Cell.Img` types to conform to the `Cell` styles and to use a generic `Img` type when customization is required.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/363)
<!-- Reviewable:end -->
