### PR TITLE
Remove redux-thunk

### DIFF
--- a/gui/packages/desktop/package.json
+++ b/gui/packages/desktop/package.json
@@ -30,7 +30,6 @@
     "react-simple-maps": "^0.10.1",
     "reactxp": "^1.3.3",
     "redux": "^4.0.0",
-    "redux-thunk": "^2.3.0",
     "uuid": "^3.0.1",
     "validated": "^1.3.0"
   },

--- a/gui/packages/desktop/src/renderer/components/Account.js
+++ b/gui/packages/desktop/src/renderer/components/Account.js
@@ -2,7 +2,7 @@
 
 import moment from 'moment';
 import * as React from 'react';
-import { Component, Text, View } from 'reactxp';
+import { Component, Clipboard, Text, View } from 'reactxp';
 import * as AppButton from './AppButton';
 import { Layout, Container } from './Layout';
 import NavigationBar, { BackBarItem } from './NavigationBar';
@@ -20,7 +20,6 @@ type Props = {
   updateAccountExpiry: () => Promise<void>,
   onLogout: () => void,
   onClose: () => void,
-  onCopyAccountToken: () => void,
   onBuyMore: () => void,
 };
 
@@ -67,7 +66,7 @@ export default class Account extends Component<Props, State> {
       3000,
     );
     this.setState({ showAccountTokenCopiedMessage: true });
-    this.props.onCopyAccountToken();
+    Clipboard.setText(this.props.accountToken);
   }
 
   render() {

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -2,15 +2,15 @@
 
 import moment from 'moment';
 import * as React from 'react';
+import { Component, Clipboard, Text, View, Types } from 'reactxp';
+import { Accordion } from '@mullvad/components';
 import { Layout, Container, Header } from './Layout';
 import { SettingsBarButton, Brand } from './HeaderBar';
-import { Component, Text, View, Types } from 'reactxp';
 import * as AppButton from './AppButton';
 import Img from './Img';
-import { Accordion } from '@mullvad/components';
+import Map from './Map';
 import styles from './ConnectStyles';
 import { NoCreditError, NoInternetError } from '../errors';
-import Map from './Map';
 import WindowStateObserver from '../lib/window-state-observer';
 
 import type { HeaderBarStyle } from './HeaderBar';
@@ -23,7 +23,6 @@ type Props = {
   onSettings: () => void,
   onSelectLocation: () => void,
   onConnect: () => void,
-  onCopyIP: () => void,
   onDisconnect: () => void,
   onExternalLink: (type: string) => void,
   updateAccountExpiry: () => Promise<void>,
@@ -330,7 +329,11 @@ export default class Connect extends Component<Props, State> {
     }
     this._copyTimer = setTimeout(() => this.setState({ showCopyIPMessage: false }), 3000);
     this.setState({ showCopyIPMessage: true });
-    this.props.onCopyIP();
+
+    const { ip } = this.props.connection;
+    if (ip) {
+      Clipboard.setText(ip);
+    }
   }
 
   // Private

--- a/gui/packages/desktop/src/renderer/containers/AccountPage.js
+++ b/gui/packages/desktop/src/renderer/containers/AccountPage.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { goBack } from 'connected-react-router';
 import Account from '../components/Account';
-import accountActions from '../redux/account/actions';
 import { links } from '../../config';
 
 import type { ReduxState, ReduxDispatch } from '../redux/store';
@@ -17,11 +16,9 @@ const mapStateToProps = (state: ReduxState) => ({
   expiryLocale: remote.app.getLocale(),
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) => {
-  const { copyAccountToken } = bindActionCreators(accountActions, dispatch);
   const history = bindActionCreators({ goBack }, dispatch);
   return {
     updateAccountExpiry: () => props.app.updateAccountExpiry(),
-    onCopyAccountToken: () => copyAccountToken(),
     onLogout: () => {
       props.app.logout();
     },

--- a/gui/packages/desktop/src/renderer/containers/ConnectPage.js
+++ b/gui/packages/desktop/src/renderer/containers/ConnectPage.js
@@ -1,4 +1,5 @@
 // @flow
+
 import { shell } from 'electron';
 import log from 'electron-log';
 import { connect } from 'react-redux';
@@ -6,7 +7,6 @@ import { bindActionCreators } from 'redux';
 import { push } from 'connected-react-router';
 import { links } from '../../config';
 import Connect from '../components/Connect';
-import connectActions from '../redux/connection/actions';
 
 import type { ReduxState, ReduxDispatch } from '../redux/store';
 import type { SharedRouteProps } from '../routes';
@@ -55,7 +55,6 @@ const mapStateToProps = (state: ReduxState) => {
 };
 
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) => {
-  const { copyIPAddress } = bindActionCreators(connectActions, dispatch);
   const history = bindActionCreators({ push }, dispatch);
 
   return {
@@ -71,9 +70,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
       } catch (error) {
         log.error(`Failed to connect the tunnel: ${error.message}`);
       }
-    },
-    onCopyIP: () => {
-      copyIPAddress();
     },
     onDisconnect: () => {
       try {

--- a/gui/packages/desktop/src/renderer/redux/account/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/account/actions.js
@@ -1,8 +1,6 @@
 // @flow
 
-import { Clipboard } from 'reactxp';
 import type { AccountToken } from '../../lib/daemon-rpc';
-import type { ReduxThunk } from '../store';
 
 type StartLoginAction = {
   type: 'START_LOGIN',
@@ -104,15 +102,6 @@ function updateAccountExpiry(expiry: string): UpdateAccountExpiryAction {
   };
 }
 
-function copyAccountToken(): ReduxThunk {
-  return (_, getState) => {
-    const accountToken = getState().account.accountToken;
-    if (accountToken) {
-      Clipboard.setText(accountToken);
-    }
-  };
-}
-
 export default {
   startLogin,
   loginSuccessful,
@@ -122,5 +111,4 @@ export default {
   updateAccountToken,
   updateAccountHistory,
   updateAccountExpiry,
-  copyAccountToken,
 };

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { Clipboard } from 'reactxp';
-import type { ReduxThunk } from '../store';
 import type { Ip } from '../../lib/daemon-rpc';
 
 type ConnectingAction = {
@@ -81,15 +79,6 @@ function offline(): OfflineAction {
   };
 }
 
-function copyIPAddress(): ReduxThunk {
-  return (_, getState) => {
-    const ip = getState().connection.ip;
-    if (ip) {
-      Clipboard.setText(ip);
-    }
-  };
-}
-
 export default {
   newLocation,
   connecting,
@@ -97,5 +86,4 @@ export default {
   disconnected,
   online,
   offline,
-  copyIPAddress,
 };

--- a/gui/packages/desktop/src/renderer/redux/store.js
+++ b/gui/packages/desktop/src/renderer/redux/store.js
@@ -2,7 +2,6 @@
 
 import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
 import { routerMiddleware, connectRouter, push, replace } from 'connected-react-router';
-import thunk from 'redux-thunk';
 
 import account from './account/reducers';
 import accountActions from './account/actions';
@@ -45,8 +44,7 @@ export type ReduxAction =
   | DaemonAction;
 export type ReduxStore = Store<ReduxState, ReduxAction, ReduxDispatch>;
 export type ReduxGetState = () => ReduxState;
-export type ReduxDispatch = (action: ReduxAction | ReduxThunk) => any;
-export type ReduxThunk = (dispatch: ReduxDispatch, getState: ReduxGetState) => any;
+export type ReduxDispatch = (action: ReduxAction) => any;
 
 export default function configureStore(
   initialState: ?ReduxState,
@@ -72,7 +70,7 @@ export default function configureStore(
     daemon,
   };
 
-  const middlewares = [thunk, router];
+  const middlewares = [router];
 
   const composeEnhancers = (() => {
     const reduxCompose = window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;

--- a/gui/packages/desktop/test/components/Account.spec.js
+++ b/gui/packages/desktop/test/components/Account.spec.js
@@ -14,7 +14,6 @@ describe('components/Account', () => {
       accountExpiry: new Date('2038-01-01').toISOString(),
       expiryLocale: 'en-US',
       updateAccountExpiry: () => Promise.resolve(),
-      onCopyAccountToken: () => {},
       onClose: () => {},
       onLogout: () => {},
       onBuyMore: () => {},

--- a/gui/packages/desktop/test/components/Connect.spec.js
+++ b/gui/packages/desktop/test/components/Connect.spec.js
@@ -111,7 +111,6 @@ const defaultProps: ConnectProps = {
   onSettings: () => {},
   onSelectLocation: () => {},
   onConnect: () => {},
-  onCopyIP: () => {},
   onDisconnect: () => {},
   onExternalLink: () => {},
   accountExpiry: '',

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -6307,10 +6307,6 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux-thunk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
-
 redux@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR removes `redux-thunk` from project for multiple reasons:

1. We only used it twice and for things that we don't need redux at all :) ReactXP provides a cross platform access to Clipboard so we can just do everything from Components.

2. Recent update to `react-redux` broke `redux-thunk` anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/365)
<!-- Reviewable:end -->
