### PR TITLE
Fix yarn workspaces on Windows

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -1,7 +1,7 @@
 !include stdutils.nsh
 !include winver.nsh
 
-!addplugindir "${PROJECT_DIR}\windows\nsis-plugins\bin\Win32-Release"
+!addplugindir "${BUILD_RESOURCES_DIR}\..\windows\nsis-plugins\bin\Win32-Release"
 
 #
 # NOTES
@@ -55,12 +55,12 @@
 !macro ExtractDriver
 
 	SetOutPath "$TEMP\driver"
-	File "${PROJECT_DIR}\dist-assets\binaries\windows\driver\*"
+	File "${BUILD_RESOURCES_DIR}\binaries\windows\driver\*"
 
 	${If} ${IsWin7}
-		File "${PROJECT_DIR}\dist-assets\binaries\windows\driver\ndis5\*"
+		File "${BUILD_RESOURCES_DIR}\binaries\windows\driver\ndis5\*"
 	${Else}
-		File "${PROJECT_DIR}\dist-assets\binaries\windows\driver\ndis6\*"
+		File "${BUILD_RESOURCES_DIR}\binaries\windows\driver\ndis6\*"
 	${EndIf}
 	
 !macroend

--- a/gui/packages/desktop/package.json
+++ b/gui/packages/desktop/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@mullvad/components": "0.1.0",
     "babel-runtime": "^6.26.0",
-    "chai-as-promised": "^7.1.1",
     "connected-react-router": "^4.3.0",
     "d3-geo-projection": "^2.3.2",
     "electron-log": "^2.2.8",
@@ -47,6 +46,7 @@
     "babel-preset-react": "^6.24.1",
     "browser-sync": "^2.23.6",
     "chai": "^4.1.0",
+    "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "cross-env": "^5.1.3",
     "electron": "^2.0.2",

--- a/gui/packages/desktop/package.json
+++ b/gui/packages/desktop/package.json
@@ -50,7 +50,7 @@
     "chai-spies": "^1.0.0",
     "cross-env": "^5.1.3",
     "electron": "^2.0.2",
-    "electron-builder": "^20.27.1",
+    "electron-builder": "^20.28",
     "electron-devtools-installer": "^2.2.1",
     "electron-mocha": "^6.0.4",
     "enzyme": "^3.2.0",

--- a/gui/packages/mobile/postinstall.js
+++ b/gui/packages/mobile/postinstall.js
@@ -22,7 +22,11 @@ try {
 
 try {
   console.log('Adding a symlink to react-native');
-  fs.symlinkSync(sourcePath, symlinkPath);
+
+  // Symlinks require elevated permissions on Windows. Use junction instead.
+  const type = process.platform === 'win32' ? 'junction' : undefined;
+
+  fs.symlinkSync(sourcePath, symlinkPath, type);
   console.log('Done');
 } catch (error) {
   console.error('Cannot symlink react-native: ' + error.message);

--- a/gui/packages/yarn-fixes/package.json
+++ b/gui/packages/yarn-fixes/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "yarn-fixes",
+  "version": "0.1.0",
+  "scripts": {
+    "preinstall": "node ./patch-yarn.js"
+  }
+}

--- a/gui/packages/yarn-fixes/patch-yarn.js
+++ b/gui/packages/yarn-fixes/patch-yarn.js
@@ -1,0 +1,31 @@
+// Yarn 1.9.4 has a path lookup bug on Windows, when it looks for the binaries referenced in
+// scripts under '\gui\node_modules\node_modules' instead of '\gui\node_modules'.
+// This patch adds a junction between those two to keep that house of cards from falling apart.
+// GitHub issue: https://github.com/yarnpkg/yarn/issues/4564
+
+const path = require('path');
+const fs = require('fs');
+
+if (process.platform !== 'win32') {
+  return;
+}
+
+const sourcePath = path.resolve(path.join(__dirname, '../../node_modules'));
+const symlinkPath = path.join(__dirname, '../../node_modules/node_modules');
+
+try {
+  console.log('Removing a symlink to node_modules/node_modules');
+  fs.unlinkSync(symlinkPath);
+} catch (error) {
+  if (error.code !== 'ENOENT') {
+    throw error;
+  }
+}
+
+try {
+  console.log('Applying yarn workspaces patch for node_modules/node_modules');
+  fs.symlinkSync(sourcePath, symlinkPath, 'junction');
+  console.log('Done');
+} catch (error) {
+  console.error('Cannot symlink node_modules/node_modules: ' + error.message);
+}

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -772,35 +772,35 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-builder-bin@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.1.1.tgz#02c6adfbfa3c09404a23ff7874d2cab5a8fcb9ca"
+app-builder-bin@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.1.2.tgz#528ce8e543aa595210c9595f91bdf5638cecd79b"
 
-app-builder-lib@20.27.1, app-builder-lib@~20.27.0:
-  version "20.27.1"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.27.1.tgz#02d5da95cc68256ec3812999e9686d7f6dfdfcc1"
+app-builder-lib@20.28.2, app-builder-lib@~20.28.0:
+  version "20.28.2"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.28.2.tgz#5e126190acc17f53d9b2f3e3f5a99f07c35263f3"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "2.1.1"
+    app-builder-bin "2.1.2"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"
-    builder-util "6.0.0"
+    builder-util "6.1.2"
     builder-util-runtime "4.4.1"
     chromium-pickle-js "^0.2.0"
     debug "^3.1.0"
     ejs "^2.6.1"
     electron-osx-sign "0.4.10"
-    electron-publish "20.27.0"
+    electron-publish "20.28.0"
     fs-extra-p "^4.6.1"
     hosted-git-info "^2.7.1"
-    is-ci "^1.1.0"
+    is-ci "^1.2.0"
     isbinaryfile "^3.0.3"
     js-yaml "^3.12.0"
     lazy-val "^1.0.3"
     minimatch "^3.0.4"
     normalize-package-data "^2.4.0"
     plist "^3.0.1"
-    read-config-file "3.1.0"
+    read-config-file "3.1.2"
     sanitize-filename "^1.6.1"
     semver "^5.5.0"
     temp-file "^3.1.3"
@@ -1962,22 +1962,22 @@ builder-util-runtime@4.4.1, builder-util-runtime@^4.4.1:
     fs-extra-p "^4.6.1"
     sax "^1.2.4"
 
-builder-util@6.0.0, builder-util@~6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-6.0.0.tgz#5f4941c096778758d8c186ef95eaa0e8b536cab8"
+builder-util@6.1.2, builder-util@~6.1.0:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-6.1.2.tgz#c96db6b33f9f60603c0ccd298dd25bba1eb3596a"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "2.1.1"
+    app-builder-bin "2.1.2"
     bluebird-lst "^1.0.5"
     builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     debug "^3.1.0"
     fs-extra-p "^4.6.1"
-    is-ci "^1.1.0"
+    is-ci "^1.2.0"
     js-yaml "^3.12.0"
     lazy-val "^1.0.3"
     semver "^5.5.0"
-    source-map-support "^0.5.6"
+    source-map-support "^0.5.8"
     stat-mode "^0.2.2"
     temp-file "^3.1.3"
 
@@ -2167,6 +2167,10 @@ chromium-pickle-js@^0.2.0:
 ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
+
+ci-info@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.4.0.tgz#4841d53cad49f11b827b648ebde27a6e189b412f"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -2654,13 +2658,13 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
-dmg-builder@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-5.2.0.tgz#93d0c327fdd536794d8b7cf4fb16d1748ed8d9cf"
+dmg-builder@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-5.3.0.tgz#1b902c2438fe5ed8202987caa20efffdac057fcd"
   dependencies:
-    app-builder-lib "~20.27.0"
+    app-builder-lib "~20.28.0"
     bluebird-lst "^1.0.5"
-    builder-util "~6.0.0"
+    builder-util "~6.1.0"
     fs-extra-p "^4.6.1"
     iconv-lite "^0.4.23"
     js-yaml "^3.12.0"
@@ -2773,20 +2777,20 @@ ejs@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
-electron-builder@^20.27.1:
-  version "20.27.1"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.27.1.tgz#f3405280b5c5c5b2c7c0e8c6ac4c0d6b63375573"
+electron-builder@^20.28:
+  version "20.28.2"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.28.2.tgz#5ca19a117e9ee9c966ab4231958fe7463e598e62"
   dependencies:
-    app-builder-lib "20.27.1"
+    app-builder-lib "20.28.2"
     bluebird-lst "^1.0.5"
-    builder-util "6.0.0"
+    builder-util "6.1.2"
     builder-util-runtime "4.4.1"
     chalk "^2.4.1"
-    dmg-builder "5.2.0"
+    dmg-builder "5.3.0"
     fs-extra-p "^4.6.1"
-    is-ci "^1.1.0"
+    is-ci "^1.2.0"
     lazy-val "^1.0.3"
-    read-config-file "3.1.0"
+    read-config-file "3.1.2"
     sanitize-filename "^1.6.1"
     update-notifier "^2.5.0"
     yargs "^12.0.1"
@@ -2839,12 +2843,12 @@ electron-osx-sign@0.4.10:
     minimist "^1.2.0"
     plist "^2.1.0"
 
-electron-publish@20.27.0:
-  version "20.27.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.27.0.tgz#0f44befa800b94458c78a8f63a4bc9109c5b5b10"
+electron-publish@20.28.0:
+  version "20.28.0"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.28.0.tgz#226ba6ac5729e6b2f46d4b347281f17f8aa7f4a4"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "~6.0.0"
+    builder-util "~6.1.0"
     builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     fs-extra-p "^4.6.1"
@@ -4123,11 +4127,17 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
-is-ci@^1.0.10, is-ci@^1.1.0:
+is-ci@^1.0.10:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   dependencies:
     ci-info "^1.0.0"
+
+is-ci@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.0.tgz#3f4a08d6303a09882cef3f0fb97439c5f5ce2d53"
+  dependencies:
+    ci-info "^1.3.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -6202,9 +6212,9 @@ reactxp@^1.3.3:
     subscribableevent "^1.0.0"
     synctasks "^0.3.3"
 
-read-config-file@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.1.0.tgz#d433283c76f32204d6995542e4a04723db9e8308"
+read-config-file@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.1.2.tgz#9b299cb7a2bcec1511a4c22e71620df0a2e3b896"
   dependencies:
     ajv "^6.5.2"
     ajv-keywords "^3.2.0"
@@ -6910,9 +6920,9 @@ source-map-support@^0.4.15, source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+source-map-support@^0.5.8:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

## WHY

For some reason Yarn on Windows looks for binaries, referenced in `scripts` section of `package.json`, in `gui/node_modules/node_modules` directory instead of `gui/node_modules`. (Issue: https://github.com/yarnpkg/yarn/issues/4564)

## HOW

This PR adds a package with no source code that performs a preinstall script that creates a junction between `gui/node_modules/node_modules` and `gui/node_modules`.

Other things I've tried before coming up with this solution:

1. Adding the same script to preinstall step in root `package.json` - it didn't work because yarn removed the junction at some point later.

2. Using BAT file and package.json bounded to `os: win32`. Didn't work either because yarn refuses to proceed with installation on other OS. Corresponding issue: https://github.com/yarnpkg/yarn/issues/6288

Please try this patch on your windows machine, after pulling the PR's branch, please run:

```
cd gui
yarn install --force
```

If something still goes wrong, please run:

```
yarn install --force --verbose > yarn.log
```

And submit `yarn.log` to me in private chat on Slack. Thanks.

## ALSO

This PR fixes the similar issue related to wiring react-native on Windows. Unfortunately creating a symlink on Windows requires elevated permissions, but junctions are available for low privilege users and work just fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/369)
<!-- Reviewable:end -->
