### PR TITLE
Spawn thread with timer so `Deadline` future works correctly

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -15,13 +15,15 @@ use talpid_types::net::{TransportProtocol, TunnelEndpoint, TunnelEndpointData};
 
 use std::fs::File;
 use std::net::IpAddr;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex, MutexGuard};
 use std::time::{self, Duration, Instant, SystemTime};
 use std::{io, thread};
 
 use rand::{self, Rng, ThreadRng};
-use tokio_timer::{Deadline, DeadlineError};
+use tokio_timer::{timer, DeadlineError, Timer};
 
 const RELAYS_FILENAME: &str = "relays.json";
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
@@ -348,6 +350,7 @@ struct RelayListUpdater {
     cache_path: PathBuf,
     parsed_relays: Arc<Mutex<ParsedRelays>>,
     close_handle: mpsc::Receiver<()>,
+    timer: TimerHandle,
 }
 
 impl RelayListUpdater {
@@ -356,11 +359,32 @@ impl RelayListUpdater {
         cache_path: PathBuf,
         parsed_relays: Arc<Mutex<ParsedRelays>>,
     ) -> RelayListUpdaterHandle {
+        let timer = Self::start_timer();
         let (tx, rx) = mpsc::channel();
 
-        thread::spawn(move || Self::new(rpc_handle, cache_path, parsed_relays, rx).run());
+        thread::spawn(move || Self::new(rpc_handle, cache_path, parsed_relays, rx, timer).run());
 
         tx
+    }
+
+    fn start_timer() -> TimerHandle {
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let mut timer = Timer::default();
+            let alive = Arc::new(AtomicBool::new(true));
+
+            let _ = tx.send(TimerHandle {
+                handle: timer.handle(),
+                alive: alive.clone(),
+            });
+
+            while alive.load(Ordering::Relaxed) {
+                timer.turn(None).expect("Timer failed to run iteration");
+            }
+        });
+
+        rx.recv().expect("Failed to create timer")
     }
 
     fn new(
@@ -368,6 +392,7 @@ impl RelayListUpdater {
         cache_path: PathBuf,
         parsed_relays: Arc<Mutex<ParsedRelays>>,
         close_handle: mpsc::Receiver<()>,
+        timer: TimerHandle,
     ) -> Self {
         let rpc_client = RelayListProxy::new(rpc_handle);
 
@@ -376,6 +401,7 @@ impl RelayListUpdater {
             cache_path,
             parsed_relays,
             close_handle,
+            timer,
         }
     }
 
@@ -442,7 +468,10 @@ impl RelayListUpdater {
             .rpc_client
             .relay_list()
             .map_err(|e| Error::with_chain(e, ErrorKind::DownloadError));
-        let relay_list = Deadline::new(download_future, timeout_instant).wait()?;
+        let relay_list = self
+            .timer
+            .deadline(download_future, timeout_instant)
+            .wait()?;
 
         Ok(relay_list)
     }
@@ -459,5 +488,24 @@ impl RelayListUpdater {
         self.parsed_relays
             .lock()
             .expect("A thread crashed while it held a lock to the list of relays")
+    }
+}
+
+struct TimerHandle {
+    handle: timer::Handle,
+    alive: Arc<AtomicBool>,
+}
+
+impl Deref for TimerHandle {
+    type Target = timer::Handle;
+
+    fn deref(&self) -> &Self::Target {
+        &self.handle
+    }
+}
+
+impl Drop for TimerHandle {
+    fn drop(&mut self) {
+        self.alive.store(false, Ordering::Relaxed);
     }
 }

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -415,7 +415,7 @@ impl RelayListUpdater {
                     .chain_err(|| "Failed to update list of relays")
                 {
                     Ok(()) => info!("Updated list of relays"),
-                    Err(error) => error!("{}", error),
+                    Err(error) => error!("{}", error.display_chain()),
                 }
             }
         }


### PR DESCRIPTION
Previously the relay list downloader would fail with incorrect timeout errors. This was because when the the `tokio-timer` dependency was upgraded to 0.2, the semantics of how to use the timers changed. It is now expected that the normal use case will also use `tokio` 0.2. Since this is not our case, we have two short-term options: reverting to `tokio-timer` 0.1 or using a workaround.

This PR attempts a work-around. I'm assuming that in the long term it is desired to use the new `tokio` crate, but as discussed such upgrade will require a lot of changes, which can't be done now because of higher priorities.

The workaround is to create a `Timer` instance manually, and run it in a separate thread. This would be automatically taken care of by `tokio` with multiple `Timer` instances, one per executor thread. Our use case is pretty simple, so having one thread should be good enough. The implementation is slightly more complex because a `TimerHandle` type is created to keep track of when the timer thread should stop execution.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Wasn't included in changelog because this fixes a bug that is only present in unreleased versions.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/370)
<!-- Reviewable:end -->
