### PR TITLE
Override executable name on Linux

### DIFF
--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -23,6 +23,10 @@ directories:
   buildResources: ../../../dist-assets/
   output: ../../../dist/
 
+# override package.json
+extraMetadata:
+  name: mullvad-vpn
+
 files:
   - package.json
   - init.js


### PR DESCRIPTION
GitHub issue: https://github.com/electron-userland/electron-builder/issues/1895

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

## What

This PR overrides the name of executable produced on Linux.

## Why

Because electron-builder defaults the executable name on Linux to the `name` field from `package.json`, as opposed to using `productName` as per documentation. This results into app being called `desktop` which is undesired.

## How

Via electron-builder.yml configuration.

## Testing

I would appreciate if you could test it on Linux. I'll do the same on Windows/macOS to verify we don't have regressions in how executables are called there after migration to workspaces.

Please git checkout and build this branch to verify that executable name is correct.

```
git fetch
git checkout fix-executable-name-on-linux
./build.sh --dev-build
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/371)
<!-- Reviewable:end -->
