### PR TITLE
Revert to tokio timer 0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "windows-service 0.1.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=55c5dfb372e6b3f5607a3159c5388d27b6b84ff6)",
@@ -1770,6 +1770,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-timer"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2201,6 +2210,7 @@ source = "git+https://github.com/mullvad/rust-openssl#4dbd237fe1f6454d8a0042ccf4
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b4c329b47f071eb8a746040465fa751bd95e4716e98daef6a9b4e434c17d565"
 "checksum tokio-threadpool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "24ab84f574027b0e875378f31575cf175360891919e93a3490f07e76e00e4efb"
+"checksum tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
 "checksum tokio-timer 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1c76b4e97a4f61030edff8bd272364e4f731b9f54c7307eb4eb733c3926eb96a"
 "checksum tokio-udp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43eb534af6e8f37d43ab1b612660df14755c42bd003c5f8d2475ee78cc4600c0"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -23,7 +23,7 @@ uuid = { version = "0.6", features = ["v4"] }
 lazy_static = "1.0"
 rand = "0.5"
 tokio-core = "0.1"
-tokio-timer = "0.2"
+tokio-timer = "0.1"
 regex = "1.0"
 
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -386,7 +386,7 @@ impl RelayListUpdater {
                     .chain_err(|| "Failed to update list of relays")
                 {
                     Ok(()) => info!("Updated list of relays"),
-                    Err(error) => error!("{}", error),
+                    Err(error) => error!("{}", error.display_chain()),
                 }
             }
         }

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -20,7 +20,6 @@ use std::sync::{mpsc, Arc, Mutex, MutexGuard};
 use std::time::{self, Duration, SystemTime};
 use std::{io, thread};
 
-use rand::distributions::{IndependentSample, Range};
 use rand::{self, Rng, ThreadRng};
 use tokio_timer::{TimeoutError, Timer};
 
@@ -308,7 +307,7 @@ impl RelaySelector {
             None
         } else {
             // Pick a random number in the range 0 - total_weight. This choses the relay.
-            let mut i: u64 = Range::new(0, total_weight + 1).ind_sample(&mut self.rng);
+            let mut i: u64 = self.rng.gen_range(0, total_weight + 1);
             Some(
                 relays
                     .iter()


### PR DESCRIPTION
Previously the relay list downloader would fail with incorrect timeout errors. This was because when the the `tokio-timer` dependency was upgraded to 0.2, the semantics of how to use the timers changed. It is now expected that the normal use case will also use the new `tokio` crate. Since this is not our case, we have two short-term options: reverting to `tokio-timer` 0.1 or using a workaround.

This PR reverts to the version of `tokio-timer` that was previously used.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not included in change log because this fixes a bug that was introduced after the latest release.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/372)
<!-- Reviewable:end -->
