### PR TITLE
Simplify semver->product version conversion

### DIFF
--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -411,10 +411,7 @@ export default class AppRenderer {
     const actions = this._reduxActions;
     const latestVersionInfo = await this._daemonRpc.getVersionInfo();
     const versionFromDaemon = await this._daemonRpc.getCurrentVersion();
-    const versionFromGui = remote.app
-      .getVersion()
-      .replace('.0-', '-') // remove the .0 in yyyy.x.0-zzz
-      .replace(/\.0$/, ''); // remove the .0 in yyyy.x.0
+    const versionFromGui = remote.app.getVersion().replace('.0', '');
 
     actions.version.updateVersion(versionFromDaemon, versionFromDaemon === versionFromGui);
     actions.version.updateLatest(latestVersionInfo);


### PR DESCRIPTION
I think this semver->product version conversion code was more complex than it had to be. In `build.sh` we simply use `sed -Ee 's/\.0//g'` to go from semver to product version format, and it has so far worked fine there. The thing is that our semver formatted version is always guaranteed to have exactly one `.0` in it, and the product version is just the same string with this `.0` removed.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/373)
<!-- Reviewable:end -->
