### PR TITLE
Show window at its last known position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Line wrap the file at 100 chars.                                              Th
 - Log panics in the daemon to the log file.
 - Warn in the Settings screen if a new version is available.
 
+### Fixed
+#### Linux
+- The app window is now shown in its previous location, instead of at the center of the screen.
+
 ### Changed
 - The "Buy more credit" button is changed to open a dedicated account login page instead of one
   having a create account form first.

--- a/gui/packages/desktop/src/main/window-controller.js
+++ b/gui/packages/desktop/src/main/window-controller.js
@@ -3,85 +3,37 @@
 import { screen } from 'electron';
 import type { BrowserWindow, Tray, Display } from 'electron';
 
-export default class WindowController {
-  _window: BrowserWindow;
+type Position = { x: number, y: number };
+
+interface WindowPositioning {
+  getPosition(window: BrowserWindow): Position;
+}
+
+class StandaloneWindowPositioning implements WindowPositioning {
+  getPosition(window: BrowserWindow): Position {
+    const windowBounds = window.getBounds();
+
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const workArea = primaryDisplay.workArea;
+    const maxX = workArea.x + workArea.width - windowBounds.width;
+    const maxY = workArea.y + workArea.height - windowBounds.height;
+
+    const x = Math.min(Math.max(windowBounds.x, workArea.x), maxX);
+    const y = Math.min(Math.max(windowBounds.y, workArea.y), maxY);
+
+    return { x, y };
+  }
+}
+
+class AttachedToTrayWindowPositioning implements WindowPositioning {
   _tray: Tray;
-  _isWindowReady = false;
 
-  get window(): BrowserWindow {
-    return this._window;
-  }
-
-  constructor(window: BrowserWindow, tray: Tray) {
-    this._window = window;
+  constructor(tray: Tray) {
     this._tray = tray;
-
-    this._installDisplayMetricsHandler();
-    this._installWindowReadyHandlers();
   }
 
-  show(whenReady: boolean = true) {
-    if (whenReady) {
-      this._executeWhenWindowIsReady(() => this._showImmediately());
-    } else {
-      this._showImmediately();
-    }
-  }
-
-  hide() {
-    this._window.hide();
-  }
-
-  toggle() {
-    if (this._window.isVisible()) {
-      this.hide();
-    } else {
-      this.show();
-    }
-  }
-
-  _showImmediately() {
-    const window = this._window;
-
-    this._updatePosition();
-
-    window.show();
-    window.focus();
-  }
-
-  _updatePosition() {
-    const { x, y } = this._getWindowPosition();
-    this._window.setPosition(x, y, false);
-  }
-
-  _getTrayPlacement() {
-    switch (process.platform) {
-      case 'darwin':
-        // macOS has menubar always placed at the top
-        return 'top';
-
-      case 'win32': {
-        // taskbar occupies some part of the screen excluded from work area
-        const primaryDisplay = screen.getPrimaryDisplay();
-        const displaySize = primaryDisplay.size;
-        const workArea = primaryDisplay.workArea;
-
-        if (workArea.width < displaySize.width) {
-          return workArea.x > 0 ? 'left' : 'right';
-        } else if (workArea.height < displaySize.height) {
-          return workArea.y > 0 ? 'top' : 'bottom';
-        } else {
-          return 'none';
-        }
-      }
-
-      default:
-        return 'none';
-    }
-  }
-
-  _getWindowPosition(): { x: number, y: number } {
-    const windowBounds = this._window.getBounds();
+  getPosition(window: BrowserWindow): Position {
+    const windowBounds = window.getBounds();
     const trayBounds = this._tray.getBounds();
 
     const primaryDisplay = screen.getPrimaryDisplay();
@@ -122,10 +74,90 @@ export default class WindowController {
     x = Math.min(Math.max(x, workArea.x), maxX);
     y = Math.min(Math.max(y, workArea.y), maxY);
 
-    return {
-      x: Math.round(x),
-      y: Math.round(y),
-    };
+    return { x, y };
+  }
+
+  _getTrayPlacement() {
+    switch (process.platform) {
+      case 'darwin':
+        // macOS has menubar always placed at the top
+        return 'top';
+
+      case 'win32': {
+        // taskbar occupies some part of the screen excluded from work area
+        const primaryDisplay = screen.getPrimaryDisplay();
+        const displaySize = primaryDisplay.size;
+        const workArea = primaryDisplay.workArea;
+
+        if (workArea.width < displaySize.width) {
+          return workArea.x > 0 ? 'left' : 'right';
+        } else if (workArea.height < displaySize.height) {
+          return workArea.y > 0 ? 'top' : 'bottom';
+        } else {
+          return 'none';
+        }
+      }
+
+      default:
+        return 'none';
+    }
+  }
+}
+
+export default class WindowController {
+  _window: BrowserWindow;
+  _windowPositioning: WindowPositioning;
+  _isWindowReady = false;
+
+  get window(): BrowserWindow {
+    return this._window;
+  }
+
+  constructor(window: BrowserWindow, tray: Tray) {
+    this._window = window;
+
+    if (process.platform === 'linux') {
+      this._windowPositioning = new StandaloneWindowPositioning();
+    } else {
+      this._windowPositioning = new AttachedToTrayWindowPositioning(tray);
+    }
+
+    this._installDisplayMetricsHandler();
+    this._installWindowReadyHandlers();
+  }
+
+  show(whenReady: boolean = true) {
+    if (whenReady) {
+      this._executeWhenWindowIsReady(() => this._showImmediately());
+    } else {
+      this._showImmediately();
+    }
+  }
+
+  hide() {
+    this._window.hide();
+  }
+
+  toggle() {
+    if (this._window.isVisible()) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+
+  _showImmediately() {
+    const window = this._window;
+
+    this._updatePosition();
+
+    window.show();
+    window.focus();
+  }
+
+  _updatePosition() {
+    const { x, y } = this._windowPositioning.getPosition(this._window);
+    this._window.setPosition(x, y, false);
   }
 
   // Installs display event handlers to update the window position on any changes in the display or workarea dimensions.


### PR DESCRIPTION
On Linux, the window was previously always shown in the center of the screen. Since the user can drag the window to a location of her or his own preference, it's useful to show the screen at the previous location of the window. This PR changes the `window-controller` to keep track of the last known window position, and if a fixed location for the window isn't required for the platform, the last position is used to show the window.

The current implementation has a behavior that I'm not sure if I should consider it a bug or a feature. If the Window is outside or partly outside of the work area bounds, when it is shown again it is "moved" so that it is fully inside the work area. It can be considered a bug because it's not at its previous location, but it could also be a feature because if the work area changes or if the user loses track of the window it is successfully restored. Should be simple to fix if necessary.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/376)
<!-- Reviewable:end -->
