### PR TITLE
Simpler state machine

### DIFF
--- a/mullvad-daemon/src/tunnel_state_machine/connected_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/connected_state.rs
@@ -49,7 +49,7 @@ impl ConnectedState {
             allow_lan: self.tunnel_parameters.allow_lan,
         };
 
-        debug!("Set security policy: {:?}", policy);
+        debug!("Setting security policy: {:?}", policy);
         shared_values
             .firewall
             .apply_policy(policy)

--- a/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/connecting_state.rs
@@ -67,7 +67,7 @@ impl ConnectingState {
             allow_lan,
         };
 
-        debug!("Set security policy: {:?}", policy);
+        debug!("Setting security policy: {:?}", policy);
         shared_values
             .firewall
             .apply_policy(policy)

--- a/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
+++ b/mullvad-daemon/src/tunnel_state_machine/disconnected_state.rs
@@ -14,7 +14,7 @@ pub struct DisconnectedState;
 
 impl DisconnectedState {
     fn reset_security_policy(shared_values: &mut SharedTunnelStateValues) {
-        debug!("Reset security policy");
+        debug!("Resetting security policy");
         if let Err(error) = shared_values.firewall.reset_policy() {
             let chained_error = Error::with_chain(error, "Failed to reset security policy");
             error!("{}", chained_error.display_chain());


### PR DESCRIPTION
In the current implementation both the states and the state wrapper implements `TunnelState` making two levels of the abstraction implement it. The wrapper is not really a state, at least not how I look at it. And it also created some confusion whether a given state variable was an actual state or the wrapper in some locations. So I played around with making the wrapper not implement `TunnelState`. This turned out nice IMO. The benefit here is that `TunnelStateWrapper::handle_event` can now return a `TunnelStateMachineAction` directly. Both some of the macros as well as the `poll` implementation became noticeably simpler as well.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/377)
<!-- Reviewable:end -->
