### PR TITLE
Select individual servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
   configuration, which prevents leaking traffic until the user specifically requests to disconnect.
 - Add support for Ubuntu 14.04 and other distributions that use the Upstart init system.
 - Make scrollbar thumb draggable.
+- Ability to expand cities with multiple servers and configure the app to use a specific server.
 
 #### Windows
 - Extend uninstaller to also remove logs, cache and optionally settings.

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -346,6 +346,7 @@ export default class AppRenderer {
         latitude: city.latitude,
         longitude: city.longitude,
         hasActiveRelays: city.has_active_relays,
+        relays: city.relays,
       })),
     }));
 

--- a/gui/packages/desktop/src/renderer/components/SelectLocationStyles.js
+++ b/gui/packages/desktop/src/renderer/components/SelectLocationStyles.js
@@ -60,6 +60,13 @@ export default {
     paddingLeft: 20,
     paddingRight: 0,
   }),
+  cell_selected: Styles.createViewStyle({
+    paddingTop: 0,
+    paddingBottom: 0,
+    paddingLeft: 20,
+    paddingRight: 0,
+    backgroundColor: colors.green,
+  }),
   sub_cell: Styles.createViewStyle({
     paddingTop: 0,
     paddingBottom: 0,
@@ -74,11 +81,18 @@ export default {
     paddingLeft: 40,
     backgroundColor: colors.green,
   }),
-  cell_selected: Styles.createViewStyle({
+  sub_sub_cell: Styles.createViewStyle({
     paddingTop: 0,
     paddingBottom: 0,
-    paddingLeft: 20,
     paddingRight: 0,
+    paddingLeft: 60,
+    backgroundColor: colors.blue20,
+  }),
+  sub_sub_cell__selected: Styles.createViewStyle({
+    paddingTop: 0,
+    paddingBottom: 0,
+    paddingRight: 0,
+    paddingLeft: 60,
     backgroundColor: colors.green,
   }),
   expand_chevron_hover: Styles.createViewStyle({

--- a/gui/packages/desktop/src/renderer/containers/ConnectPage.js
+++ b/gui/packages/desktop/src/renderer/containers/ConnectPage.js
@@ -36,6 +36,15 @@ function getRelayName(
           return city.name;
         }
       }
+    } else if (location.hostname) {
+      const [countryCode, cityCode, hostname] = location.hostname;
+      const country = relayLocations.find(({ code }) => code === countryCode);
+      if (country) {
+        const city = country.cities.find(({ code }) => code === cityCode);
+        if (city) {
+          return `${city.name} (${hostname})`;
+        }
+      }
     }
 
     return 'Unknown';

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -185,6 +185,15 @@ export type RelayListCity = {
   latitude: number,
   longitude: number,
   has_active_relays: boolean,
+  relays: Array<RelayListHostname>,
+};
+
+export type RelayListHostname = {
+  hostname: string,
+  ipv4_addr_in: string,
+  ipv4_addr_exit: string,
+  include_in_country: boolean,
+  weight: number,
 };
 
 const RelayListSchema = object({

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -70,7 +70,10 @@ export type TunnelState =
   | BlockedState;
 
 export type RelayProtocol = 'tcp' | 'udp';
-export type RelayLocation = {| city: [string, string] |} | {| country: string |};
+export type RelayLocation =
+  | {| hostname: [string, string, string] |}
+  | {| city: [string, string] |}
+  | {| country: string |};
 
 type OpenVpnConstraints = {
   port: 'any' | { only: number },
@@ -138,6 +141,9 @@ const RelaySettingsSchema = oneOf(
     normal: object({
       location: constraint(
         oneOf(
+          object({
+            hostname: arrayOf(string),
+          }),
           object({
             city: arrayOf(string),
           }),

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -199,6 +199,15 @@ const RelayListSchema = object({
           latitude: number,
           longitude: number,
           has_active_relays: boolean,
+          relays: arrayOf(
+            object({
+              hostname: string,
+              ipv4_addr_in: string,
+              ipv4_addr_exit: string,
+              include_in_country: boolean,
+              weight: number,
+            }),
+          ),
         }),
       ),
     }),

--- a/gui/packages/desktop/src/renderer/lib/relay-settings-builder.js
+++ b/gui/packages/desktop/src/renderer/lib/relay-settings-builder.js
@@ -49,6 +49,10 @@ class NormalRelaySettingsBuilder {
         this._payload.location = { only: { city: [country, city] } };
         return this;
       },
+      hostname: (country: string, city: string, hostname: string) => {
+        this._payload.location = { only: { hostname: [country, city, hostname] } };
+        return this;
+      },
       any: () => {
         this._payload.location = 'any';
         return this;
@@ -56,6 +60,11 @@ class NormalRelaySettingsBuilder {
       fromRaw: function(location: 'any' | RelayLocation) {
         if (location === 'any') {
           return this.any();
+        }
+
+        if (location.hostname) {
+          const [country, city, hostname] = location.hostname;
+          return this.hostname(country, city, hostname);
         }
 
         if (location.city) {

--- a/gui/packages/desktop/src/renderer/redux/settings/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/reducers.js
@@ -19,12 +19,21 @@ export type RelaySettingsRedux =
       },
     |};
 
+export type RelayLocationRelayRedux = {
+  hostname: string,
+  ipv4AddrIn: string,
+  ipv4AddrExit: string,
+  includeInCountry: boolean,
+  weight: number,
+};
+
 export type RelayLocationCityRedux = {
   name: string,
   code: string,
   latitude: number,
   longitude: number,
   hasActiveRelays: boolean,
+  relays: Array<RelayLocationRelayRedux>,
 };
 
 export type RelayLocationRedux = {

--- a/gui/packages/desktop/test/components/SelectLocation.spec.js
+++ b/gui/packages/desktop/test/components/SelectLocation.spec.js
@@ -29,6 +29,15 @@ describe('components/SelectLocation', () => {
             latitude: 0,
             longitude: 0,
             hasActiveRelays: true,
+            relays: [
+              {
+                hostname: 'fake1.mullvad.net',
+                ipv4AddrIn: '192.168.0.100',
+                ipv4AddrExit: '192.168.1.100',
+                includeInCountry: true,
+                weight: 1,
+              },
+            ],
           },
           {
             name: 'Stockholm',
@@ -36,6 +45,15 @@ describe('components/SelectLocation', () => {
             latitude: 0,
             longitude: 0,
             hasActiveRelays: true,
+            relays: [
+              {
+                hostname: 'fake2.mullvad.net',
+                ipv4AddrIn: '192.168.0.101',
+                ipv4AddrExit: '192.168.1.101',
+                includeInCountry: true,
+                weight: 1,
+              },
+            ],
           },
         ],
       },

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -261,6 +261,14 @@ impl RelaySelector {
                     loc.country_code == *country && loc.city_code == *city
                 })
             }
+            Constraint::Only(LocationConstraint::Hostname(ref country, ref city, ref hostname)) => {
+                relay
+                    .location
+                    .as_ref()
+                    .map_or(relay.hostname == *hostname, |loc| {
+                        loc.country_code == *country && loc.city_code == *city
+                    })
+            }
         };
         if !matches_location {
             return None;

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -70,8 +70,9 @@ impl ParsedRelays {
                 let city_code = city.code.clone();
                 let latitude = city.latitude;
                 let longitude = city.longitude;
-                relays.extend(city.relays.drain(..).map(|mut relay| {
-                    relay.location = Some(Location {
+                for relay in &mut city.relays {
+                    let mut relay_with_location = relay.clone();
+                    relay_with_location.location = Some(Location {
                         country: country_name.clone(),
                         country_code: country_code.clone(),
                         city: city_name.clone(),
@@ -79,8 +80,9 @@ impl ParsedRelays {
                         latitude,
                         longitude,
                     });
-                    relay
-                }));
+                    relays.push(relay_with_location);
+                    relay.tunnels.clear();
+                }
             }
         }
         ParsedRelays {

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 
 pub type CountryCode = String;
 pub type CityCode = String;
+pub type Hostname = String;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Location {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -1,4 +1,4 @@
-use location::{CityCode, CountryCode};
+use location::{CityCode, CountryCode, Hostname};
 use CustomTunnelEndpoint;
 
 use std::fmt;
@@ -96,6 +96,8 @@ pub enum LocationConstraint {
     Country(CountryCode),
     /// A city is composed of a country code and a city code.
     City(CountryCode, CityCode),
+    /// An single hostname in a given city.
+    Hostname(CountryCode, CityCode, Hostname),
 }
 
 

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -44,6 +44,7 @@ pub struct Relay {
     pub ipv4_addr_exit: Ipv4Addr,
     pub include_in_country: bool,
     pub weight: u64,
+    #[serde(skip_serializing_if = "RelayTunnels::is_empty", default)]
     pub tunnels: RelayTunnels,
     #[serde(skip)]
     pub location: Option<Location>,
@@ -54,4 +55,15 @@ pub struct Relay {
 pub struct RelayTunnels {
     pub openvpn: Vec<OpenVpnEndpointData>,
     pub wireguard: Vec<WireguardEndpointData>,
+}
+
+impl RelayTunnels {
+    pub fn is_empty(&self) -> bool {
+        self.openvpn.is_empty() && self.wireguard.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.openvpn.clear();
+        self.wireguard.clear();
+    }
 }


### PR DESCRIPTION
A very requested feature is to be able to not only select a city and have the app randomize server selection within that city. But to be able to select a specific server and have the app only connect to that one.

This PR adds that functionality. Now the `get_relay_locations` call exposes all relays under each city. And the `LocationConstraint`s can now have an optional hostname string attached to it. If a hostname is given then the relay selection algorithm will only pick among servers with that exact hostname. So in theory there can be multiple relays with the same hostname and the app will randomize between them. But in practice all hostnames are unique, so it will mean the app will stick with one single relay server.

If that single server is removed from the relay list because it's decommissioned or otherwise offline that will result in the same behavior as selecting a non-existent country or city. The relay selector will fail to select a relay and the app will revert back to the unsecured state. This is of course not desired since it might make users leak traffic if their selected server is suddenly taken offline. We can remedy this when we have the blocked state in a while.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/378)
<!-- Reviewable:end -->
