### PR TITLE
Add blocked state to tunnel state machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add option to enable or disable IPv6 on the tunnel interface.
 - Log panics in the daemon to the log file.
 - Warn in the Settings screen if a new version is available.
+- Enter a "blocked" state in case of connection error, which prevents leaking connections until the
+  user specifically requests to disconnect.
 
 #### Windows
 - Extend uninstaller to also remove logs, cache and optionally settings.

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -547,6 +547,8 @@ export default class AppRenderer {
   _tunnelStateToConnectionState(tunnelState: TunnelState): ConnectionState {
     if (tunnelState === 'disconnected' || tunnelState === 'disconnecting') {
       return 'disconnected';
+    } else if (tunnelState === 'blocked') {
+      return 'connecting';
     } else if (tunnelState === 'connected' || tunnelState === 'connecting') {
       return tunnelState;
     }

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -504,7 +504,11 @@ export default class AppRenderer {
       if (newState) {
         const connectionState = this._tunnelStateToConnectionState(newState);
 
-        log.debug(`Got new state from daemon '${newState}', translated to '${connectionState}'`);
+        log.debug(
+          `Got new state from daemon '${JSON.stringify(
+            newState,
+          )}', translated to '${connectionState}'`,
+        );
 
         this._updateConnectionState(connectionState);
         this._refreshStateOnChange();
@@ -546,7 +550,7 @@ export default class AppRenderer {
   }
 
   _tunnelStateToConnectionState(tunnelState: TunnelState): ConnectionState {
-    switch (tunnelState) {
+    switch (tunnelState.state) {
       case 'disconnected':
       // Fall through
       case 'disconnecting':

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -10,7 +10,7 @@ import * as AppButton from './AppButton';
 import Img from './Img';
 import Map from './Map';
 import styles from './ConnectStyles';
-import { NoCreditError, NoInternetError } from '../errors';
+import { BlockedError, NoCreditError, NoInternetError } from '../errors';
 import WindowStateObserver from '../lib/window-state-observer';
 
 import type { HeaderBarStyle } from './HeaderBar';
@@ -101,6 +101,11 @@ export default class Connect extends Component<Props, State> {
     if (error instanceof NoInternetError) {
       title = 'Offline';
       message = 'Your internet connection will be secured when you get back online';
+    }
+
+    if (error instanceof BlockedError) {
+      title = 'Blocked';
+      message = error.message;
     }
 
     return (
@@ -345,6 +350,7 @@ export default class Connect extends Component<Props, State> {
         return 'error';
       case 'connecting':
       case 'connected':
+      case 'blocked':
         return 'success';
       default:
         throw new Error(`Invalid ConnectionState: ${(status: empty)}`);
@@ -390,6 +396,11 @@ export default class Connect extends Component<Props, State> {
     const expiry = this.props.accountExpiry;
     if (expiry && moment(expiry).isSameOrBefore(moment())) {
       return new NoCreditError();
+    }
+
+    // Tunnel is blocked due to an error?
+    if (this.props.connection.status === 'blocked') {
+      return new BlockedError();
     }
 
     return null;

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -400,7 +400,7 @@ export default class Connect extends Component<Props, State> {
 
     // Tunnel is blocked due to an error?
     if (this.props.connection.status === 'blocked') {
-      return new BlockedError();
+      return new BlockedError(this.props.connection.blockReason);
     }
 
     return null;

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -1,8 +1,10 @@
 // @flow
 
+import type { BlockReason } from './lib/daemon-rpc';
+
 export class BlockedError extends Error {
-  constructor() {
-    super('Network connections blocked due to an internal error');
+  constructor(reason: BlockReason) {
+    super(reason);
   }
 }
 

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -1,5 +1,11 @@
 // @flow
 
+export class BlockedError extends Error {
+  constructor() {
+    super('Network connections blocked due to an internal error');
+  }
+}
+
 export class NoCreditError extends Error {
   constructor() {
     super("Account doesn't have enough credit available for connection");

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -5,6 +5,9 @@ import type { BlockReason } from './lib/daemon-rpc';
 export class BlockedError extends Error {
   constructor(reason: BlockReason) {
     switch (reason) {
+      case 'set_security_policy_error':
+        super('Failed to apply security policy');
+        break;
       case 'start_tunnel_error':
         super('Failed to start tunnel connection');
         break;

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -4,7 +4,13 @@ import type { BlockReason } from './lib/daemon-rpc';
 
 export class BlockedError extends Error {
   constructor(reason: BlockReason) {
-    super(reason);
+    switch (reason) {
+      case 'start_tunnel_error':
+        super('Failed to start tunnel connection');
+        break;
+      default:
+        super(`Unknown error: ${(reason: empty)}`);
+    }
   }
 }
 

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -41,7 +41,7 @@ const LocationSchema = object({
   mullvad_exit_ip: boolean,
 });
 
-export type BlockReason = string;
+export type BlockReason = 'start_tunnel_error';
 export type DisconnectedState = {
   state: 'disconnected',
 };
@@ -218,9 +218,10 @@ const AccountDataSchema = object({
   expiry: string,
 });
 
+const allBlockReasons: Array<BlockReason> = ['start_tunnel_error'];
 const BlockedStateSchema = object({
   state: enumeration('blocked'),
-  details: string,
+  details: enumeration(...allBlockReasons),
 });
 const ConnectedStateSchema = object({ state: enumeration('connected') });
 const ConnectingStateSchema = object({ state: enumeration('connecting') });

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -41,7 +41,7 @@ const LocationSchema = object({
   mullvad_exit_ip: boolean,
 });
 
-export type BlockReason = 'start_tunnel_error';
+export type BlockReason = 'set_security_policy_error' | 'start_tunnel_error';
 export type DisconnectedState = {
   state: 'disconnected',
 };
@@ -218,7 +218,7 @@ const AccountDataSchema = object({
   expiry: string,
 });
 
-const allBlockReasons: Array<BlockReason> = ['start_tunnel_error'];
+const allBlockReasons: Array<BlockReason> = ['set_security_policy_error', 'start_tunnel_error'];
 const BlockedStateSchema = object({
   state: enumeration('blocked'),
   details: enumeration(...allBlockReasons),

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -41,7 +41,29 @@ const LocationSchema = object({
   mullvad_exit_ip: boolean,
 });
 
-export type TunnelState = 'disconnected' | 'connecting' | 'connected' | 'disconnecting' | 'blocked';
+export type BlockReason = string;
+export type DisconnectedState = {
+  state: 'disconnected',
+};
+export type ConnectingState = {
+  state: 'connecting',
+};
+export type ConnectedState = {
+  state: 'connected',
+};
+export type DisconnectingState = {
+  state: 'disconnecting',
+};
+export type BlockedState = {
+  state: 'blocked',
+  details: BlockReason,
+};
+export type TunnelState =
+  | DisconnectedState
+  | ConnectingState
+  | ConnectedState
+  | DisconnectingState
+  | BlockedState;
 
 export type RelayProtocol = 'tcp' | 'udp';
 export type RelayLocation = {| city: [string, string] |} | {| country: string |};
@@ -196,14 +218,22 @@ const AccountDataSchema = object({
   expiry: string,
 });
 
-const allTunnelStates: Array<TunnelState> = [
-  'disconnected',
-  'connecting',
-  'connected',
-  'disconnecting',
-  'blocked',
-];
-const TunnelStateSchema = enumeration(...allTunnelStates);
+const BlockedStateSchema = object({
+  state: enumeration('blocked'),
+  details: string,
+});
+const ConnectedStateSchema = object({ state: enumeration('connected') });
+const ConnectingStateSchema = object({ state: enumeration('connecting') });
+const DisconnectedStateSchema = object({ state: enumeration('disconnected') });
+const DisconnectingStateSchema = object({ state: enumeration('disconnecting') });
+
+const TunnelStateSchema = oneOf(
+  BlockedStateSchema,
+  ConnectedStateSchema,
+  ConnectingStateSchema,
+  DisconnectedStateSchema,
+  DisconnectingStateSchema,
+);
 
 export type AppVersionInfo = {
   currentIsSupported: boolean,

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -41,7 +41,7 @@ const LocationSchema = object({
   mullvad_exit_ip: boolean,
 });
 
-export type TunnelState = 'disconnected' | 'connecting' | 'connected' | 'disconnecting';
+export type TunnelState = 'disconnected' | 'connecting' | 'connected' | 'disconnecting' | 'blocked';
 
 export type RelayProtocol = 'tcp' | 'udp';
 export type RelayLocation = {| city: [string, string] |} | {| country: string |};
@@ -201,6 +201,7 @@ const allTunnelStates: Array<TunnelState> = [
   'connecting',
   'connected',
   'disconnecting',
+  'blocked',
 ];
 const TunnelStateSchema = enumeration(...allTunnelStates);
 

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -16,6 +16,7 @@ type DisconnectedAction = {
 
 type BlockedAction = {
   type: 'BLOCKED',
+  reason: string,
 };
 
 type NewLocationAction = {
@@ -65,9 +66,10 @@ function disconnected(): DisconnectedAction {
   };
 }
 
-function blocked(): BlockedAction {
+function blocked(reason: string): BlockedAction {
   return {
     type: 'BLOCKED',
+    reason,
   };
 }
 

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -14,6 +14,10 @@ type DisconnectedAction = {
   type: 'DISCONNECTED',
 };
 
+type BlockedAction = {
+  type: 'BLOCKED',
+};
+
 type NewLocationAction = {
   type: 'NEW_LOCATION',
   newLocation: {
@@ -39,6 +43,7 @@ export type ConnectionAction =
   | ConnectingAction
   | ConnectedAction
   | DisconnectedAction
+  | BlockedAction
   | OnlineAction
   | OfflineAction;
 
@@ -57,6 +62,12 @@ function connected(): ConnectedAction {
 function disconnected(): DisconnectedAction {
   return {
     type: 'DISCONNECTED',
+  };
+}
+
+function blocked(): BlockedAction {
+  return {
+    type: 'BLOCKED',
   };
 }
 
@@ -84,6 +95,7 @@ export default {
   connecting,
   connected,
   disconnected,
+  blocked,
   online,
   offline,
 };

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -3,7 +3,7 @@
 import type { ReduxAction } from '../store';
 import type { Ip } from '../../lib/daemon-rpc';
 
-export type ConnectionState = 'disconnected' | 'connecting' | 'connected';
+export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'blocked';
 export type ConnectionReduxState = {
   status: ConnectionState,
   isOnline: boolean,
@@ -40,6 +40,9 @@ export default function(
 
     case 'DISCONNECTED':
       return { ...state, ...{ status: 'disconnected' } };
+
+    case 'BLOCKED':
+      return { ...state, ...{ status: 'blocked' } };
 
     case 'ONLINE':
       return { ...state, ...{ isOnline: true } };

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -12,6 +12,7 @@ export type ConnectionReduxState = {
   longitude: ?number,
   country: ?string,
   city: ?string,
+  blockReason: ?string,
 };
 
 const initialState: ConnectionReduxState = {
@@ -22,6 +23,7 @@ const initialState: ConnectionReduxState = {
   longitude: null,
   country: null,
   city: null,
+  blockReason: null,
 };
 
 export default function(
@@ -33,16 +35,16 @@ export default function(
       return { ...state, ...action.newLocation };
 
     case 'CONNECTING':
-      return { ...state, ...{ status: 'connecting' } };
+      return { ...state, ...{ status: 'connecting', blockReason: null } };
 
     case 'CONNECTED':
-      return { ...state, ...{ status: 'connected' } };
+      return { ...state, ...{ status: 'connected', blockReason: null } };
 
     case 'DISCONNECTED':
-      return { ...state, ...{ status: 'disconnected' } };
+      return { ...state, ...{ status: 'disconnected', blockReason: null } };
 
     case 'BLOCKED':
-      return { ...state, ...{ status: 'blocked' } };
+      return { ...state, ...{ status: 'blocked', blockReason: action.reason } };
 
     case 'ONLINE':
       return { ...state, ...{ isOnline: true } };

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -43,6 +43,7 @@ impl Command for Status {
 fn print_state(state: TunnelStateTransition) {
     print!("Tunnel status: ");
     match state {
+        Blocked => println!("Blocked"),
         Connected => println!("Connected"),
         Connecting => println!("Connecting..."),
         Disconnected => println!("Disconnected"),

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -43,7 +43,7 @@ impl Command for Status {
 fn print_state(state: TunnelStateTransition) {
     print!("Tunnel status: ");
     match state {
-        Blocked => println!("Blocked"),
+        Blocked(reason) => println!("Blocked ({})", reason),
         Connected => println!("Connected"),
         Connecting => println!("Connecting..."),
         Disconnected => println!("Disconnected"),

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -335,9 +335,13 @@ impl Daemon {
 
         debug!("New tunnel state: {:?}", tunnel_state);
 
-        if tunnel_state == Disconnected {
-            self.state.disconnected();
-            self.current_relay = None;
+        match tunnel_state {
+            Disconnected => {
+                self.state.disconnected();
+                self.current_relay = None;
+            }
+            Blocked(ref reason) => info!("Blocking all network connections, reason: {}", reason),
+            _ => {}
         }
 
         self.tunnel_state = tunnel_state;

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -1,0 +1,42 @@
+use futures::sync::mpsc;
+use futures::Stream;
+
+use super::{
+    ConnectingState, DisconnectedState, EventConsequence, SharedTunnelStateValues, TunnelCommand,
+    TunnelState, TunnelStateTransition, TunnelStateWrapper,
+};
+
+/// No tunnel is running and all network connections are blocked.
+pub struct BlockedState;
+
+impl TunnelState for BlockedState {
+    type Bootstrap = ();
+
+    fn enter(
+        _: &mut SharedTunnelStateValues,
+        _: Self::Bootstrap,
+    ) -> (TunnelStateWrapper, TunnelStateTransition) {
+        (
+            TunnelStateWrapper::from(BlockedState),
+            TunnelStateTransition::Blocked,
+        )
+    }
+
+    fn handle_event(
+        self,
+        commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,
+        shared_values: &mut SharedTunnelStateValues,
+    ) -> EventConsequence<Self> {
+        use self::EventConsequence::*;
+
+        match try_handle_event!(self, commands.poll()) {
+            Ok(TunnelCommand::Connect(parameters)) => {
+                NewState(ConnectingState::enter(shared_values, parameters))
+            }
+            Ok(TunnelCommand::Disconnect) | Err(_) => {
+                NewState(DisconnectedState::enter(shared_values, ()))
+            }
+            _ => SameState(self),
+        }
+    }
+}

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -1,6 +1,8 @@
 use futures::sync::mpsc;
 use futures::Stream;
 
+use talpid_types::tunnel::BlockReason;
+
 use super::{
     ConnectingState, DisconnectedState, EventConsequence, SharedTunnelStateValues, TunnelCommand,
     TunnelState, TunnelStateTransition, TunnelStateWrapper,
@@ -10,15 +12,15 @@ use super::{
 pub struct BlockedState;
 
 impl TunnelState for BlockedState {
-    type Bootstrap = ();
+    type Bootstrap = BlockReason;
 
     fn enter(
         _: &mut SharedTunnelStateValues,
-        _: Self::Bootstrap,
+        block_reason: Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
         (
             TunnelStateWrapper::from(BlockedState),
-            TunnelStateTransition::Blocked,
+            TunnelStateTransition::Blocked(block_reason),
         )
     }
 

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -1,3 +1,4 @@
+use error_chain::ChainedError;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Stream};
 
@@ -92,7 +93,8 @@ impl ConnectedState {
                 match self.set_security_policy(shared_values) {
                     Ok(()) => SameState(self),
                     Err(error) => {
-                        error!("{}", error.chain_err(|| "Failed to update security policy"));
+                        error!("{}", error.display_chain());
+
                         NewState(DisconnectingState::enter(
                             shared_values,
                             (
@@ -161,7 +163,8 @@ impl TunnelState for ConnectedState {
                 TunnelStateTransition::Connected,
             ),
             Err(error) => {
-                error!("{}", error.chain_err(|| "Failed to set security policy"));
+                error!("{}", error.display_chain());
+
                 DisconnectingState::enter(
                     shared_values,
                     (

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -3,6 +3,7 @@ use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Stream};
 
 use talpid_types::net::TunnelEndpoint;
+use talpid_types::tunnel::BlockReason;
 
 use super::{
     AfterDisconnect, ConnectingState, DisconnectingState, EventConsequence, Result, ResultExt,
@@ -100,7 +101,7 @@ impl ConnectedState {
                             (
                                 self.close_handle,
                                 self.tunnel_close_event,
-                                AfterDisconnect::Nothing,
+                                AfterDisconnect::Block(BlockReason::SetSecurityPolicyError),
                             ),
                         ))
                     }
@@ -170,7 +171,7 @@ impl TunnelState for ConnectedState {
                     (
                         connected_state.close_handle,
                         connected_state.tunnel_close_event,
-                        AfterDisconnect::Nothing,
+                        AfterDisconnect::Block(BlockReason::SetSecurityPolicyError),
                     ),
                 )
             }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -13,7 +13,7 @@ use talpid_types::net::{TunnelEndpoint, TunnelEndpointData};
 use super::{
     AfterDisconnect, ConnectedState, ConnectedStateBootstrap, DisconnectedState,
     DisconnectingState, EventConsequence, Result, ResultExt, SharedTunnelStateValues,
-    TunnelCommand, TunnelParameters, TunnelState, TunnelStateWrapper,
+    TunnelCommand, TunnelParameters, TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
 use logging;
 use security::{NetworkSecurity, SecurityPolicy};
@@ -269,9 +269,12 @@ impl TunnelState for ConnectingState {
     fn enter(
         shared_values: &mut SharedTunnelStateValues,
         parameters: Self::Bootstrap,
-    ) -> TunnelStateWrapper {
+    ) -> (TunnelStateWrapper, TunnelStateTransition) {
         match Self::new(shared_values, parameters) {
-            Ok(connecting_state) => TunnelStateWrapper::from(connecting_state),
+            Ok(connecting_state) => (
+                TunnelStateWrapper::from(connecting_state),
+                TunnelStateTransition::Connecting,
+            ),
             Err(error) => {
                 error!("{}", error.chain_err(|| "Failed to start tunnel"));
                 DisconnectedState::enter(shared_values, ())

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -3,8 +3,8 @@ use futures::sync::mpsc;
 use futures::Stream;
 
 use super::{
-    ConnectingState, Error, EventConsequence, SharedTunnelStateValues, StateEntryResult,
-    TunnelCommand, TunnelState, TunnelStateWrapper,
+    ConnectingState, Error, EventConsequence, SharedTunnelStateValues, TunnelCommand, TunnelState,
+    TunnelStateWrapper,
 };
 use security::NetworkSecurity;
 
@@ -24,10 +24,13 @@ impl DisconnectedState {
 impl TunnelState for DisconnectedState {
     type Bootstrap = ();
 
-    fn enter(shared_values: &mut SharedTunnelStateValues, _: Self::Bootstrap) -> StateEntryResult {
+    fn enter(
+        shared_values: &mut SharedTunnelStateValues,
+        _: Self::Bootstrap,
+    ) -> TunnelStateWrapper {
         Self::reset_security_policy(shared_values);
 
-        Ok(TunnelStateWrapper::from(DisconnectedState))
+        TunnelStateWrapper::from(DisconnectedState)
     }
 
     fn handle_event(

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -4,7 +4,7 @@ use futures::Stream;
 
 use super::{
     ConnectingState, Error, EventConsequence, SharedTunnelStateValues, TunnelCommand, TunnelState,
-    TunnelStateWrapper,
+    TunnelStateTransition, TunnelStateWrapper,
 };
 use security::NetworkSecurity;
 
@@ -27,10 +27,13 @@ impl TunnelState for DisconnectedState {
     fn enter(
         shared_values: &mut SharedTunnelStateValues,
         _: Self::Bootstrap,
-    ) -> TunnelStateWrapper {
+    ) -> (TunnelStateWrapper, TunnelStateTransition) {
         Self::reset_security_policy(shared_values);
 
-        TunnelStateWrapper::from(DisconnectedState)
+        (
+            TunnelStateWrapper::from(DisconnectedState),
+            TunnelStateTransition::Disconnected,
+        )
     }
 
     fn handle_event(

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -6,7 +6,7 @@ use futures::{Async, Future, Stream};
 
 use super::{
     ConnectingState, DisconnectedState, EventConsequence, ResultExt, SharedTunnelStateValues,
-    StateEntryResult, TunnelCommand, TunnelParameters, TunnelState, TunnelStateWrapper,
+    TunnelCommand, TunnelParameters, TunnelState, TunnelStateWrapper,
 };
 use tunnel::CloseHandle;
 
@@ -57,7 +57,7 @@ impl DisconnectingState {
         }
     }
 
-    fn after_disconnect(self, shared_values: &mut SharedTunnelStateValues) -> StateEntryResult {
+    fn after_disconnect(self, shared_values: &mut SharedTunnelStateValues) -> TunnelStateWrapper {
         match self.after_disconnect {
             AfterDisconnect::Nothing => DisconnectedState::enter(shared_values, ()),
             AfterDisconnect::Reconnect(tunnel_parameters) => {
@@ -73,7 +73,7 @@ impl TunnelState for DisconnectingState {
     fn enter(
         _: &mut SharedTunnelStateValues,
         (close_handle, exited, after_disconnect): Self::Bootstrap,
-    ) -> StateEntryResult {
+    ) -> TunnelStateWrapper {
         thread::spawn(move || {
             let close_result = close_handle
                 .close()
@@ -84,10 +84,10 @@ impl TunnelState for DisconnectingState {
             }
         });
 
-        Ok(TunnelStateWrapper::from(DisconnectingState {
+        TunnelStateWrapper::from(DisconnectingState {
             exited,
             after_disconnect,
-        }))
+        })
     }
 
     fn handle_event(

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod macros;
 
+mod blocked_state;
 mod connected_state;
 mod connecting_state;
 mod disconnected_state;
@@ -19,6 +20,7 @@ use tokio_core::reactor::Core;
 use talpid_types::net::{TunnelEndpoint, TunnelOptions};
 use talpid_types::tunnel::TunnelStateTransition;
 
+use self::blocked_state::BlockedState;
 use self::connected_state::{ConnectedState, ConnectedStateBootstrap};
 use self::connecting_state::ConnectingState;
 use self::disconnected_state::DisconnectedState;
@@ -286,6 +288,7 @@ enum TunnelStateWrapper {
     Connecting(ConnectingState),
     Connected(ConnectedState),
     Disconnecting(DisconnectingState),
+    Blocked(BlockedState),
 }
 
 impl TunnelStateWrapper {
@@ -321,6 +324,7 @@ impl TunnelStateWrapper {
             Connecting,
             Connected,
             Disconnecting,
+            Blocked,
         }
     }
 }
@@ -339,6 +343,7 @@ impl_from_for_tunnel_state!(Disconnected(DisconnectedState));
 impl_from_for_tunnel_state!(Connecting(ConnectingState));
 impl_from_for_tunnel_state!(Connected(ConnectedState));
 impl_from_for_tunnel_state!(Disconnecting(DisconnectingState));
+impl_from_for_tunnel_state!(Blocked(BlockedState));
 
 impl Debug for TunnelStateWrapper {
     fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
@@ -349,6 +354,7 @@ impl Debug for TunnelStateWrapper {
             Connecting(_) => write!(formatter, "TunnelStateWrapper::Connecting(_)"),
             Connected(_) => write!(formatter, "TunnelStateWrapper::Connected(_)"),
             Disconnecting(_) => write!(formatter, "TunnelStateWrapper::Disconnecting(_)"),
+            Blocked(_) => write!(formatter, "TunnelStateWrapper::Blocked(_)"),
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -148,8 +148,7 @@ impl TunnelStateMachine {
             NetworkSecurityImpl::new(cache_dir).chain_err(|| ErrorKind::NetworkSecurityError)?;
         let mut shared_values = SharedTunnelStateValues { security };
 
-        let initial_state = TunnelStateWrapper::new(&mut shared_values, ())
-            .expect("Failed to create initial tunnel state");
+        let initial_state = TunnelStateWrapper::new(&mut shared_values, ());
 
         Ok(TunnelStateMachine {
             current_state: Some(initial_state),
@@ -199,7 +198,7 @@ impl<T: TunnelState> From<EventConsequence<T>> for TunnelStateMachineAction {
         use self::TunnelStateMachineAction::*;
 
         match event_consequence {
-            NewState(Ok(state_wrapper)) | NewState(Err((_, state_wrapper))) => {
+            NewState(state_wrapper) => {
                 let transition = state_wrapper.info();
                 Notify(Some(state_wrapper), Ok(Async::Ready(Some(transition))))
             }
@@ -218,7 +217,7 @@ struct SharedTunnelStateValues {
 /// Asynchronous result of an attempt to progress a state.
 enum EventConsequence<T: TunnelState> {
     /// Transition to a new state.
-    NewState(StateEntryResult),
+    NewState(TunnelStateWrapper),
     /// An event was received, but it was ignored by the state so no transition is performed.
     SameState(T),
     /// No events were received, the event loop should block until one becomes available.
@@ -247,11 +246,6 @@ where
     }
 }
 
-/// Result of entering a `T: TunnelState`.
-///
-/// It is either the state itself when successful, or an error paired with a fallback state.
-type StateEntryResult = ::std::result::Result<TunnelStateWrapper, (Error, TunnelStateWrapper)>;
-
 /// Trait that contains the method all states should implement to handle an event and advance the
 /// state machine.
 trait TunnelState: Into<TunnelStateWrapper> + Sized {
@@ -265,7 +259,7 @@ trait TunnelState: Into<TunnelStateWrapper> + Sized {
     fn enter(
         shared_values: &mut SharedTunnelStateValues,
         bootstrap: Self::Bootstrap,
-    ) -> StateEntryResult;
+    ) -> TunnelStateWrapper;
 
     /// Main state function.
     ///
@@ -299,7 +293,7 @@ impl TunnelStateWrapper {
     fn new(
         shared_values: &mut SharedTunnelStateValues,
         bootstrap: <DisconnectedState as TunnelState>::Bootstrap,
-    ) -> StateEntryResult {
+    ) -> TunnelStateWrapper {
         DisconnectedState::enter(shared_values, bootstrap)
     }
 

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -20,10 +20,17 @@ pub enum TunnelStateTransition {
 /// Reason for entering the blocked state.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum BlockReason {}
+pub enum BlockReason {
+    /// Failed to start connection to remote server
+    StartTunnelError,
+}
 
 impl fmt::Display for BlockReason {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        Ok(())
+        let description = match *self {
+            BlockReason::StartTunnelError => "Failed to start connection to remote server",
+        };
+
+        write!(formatter, "{}", description)
     }
 }

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -21,6 +21,8 @@ pub enum TunnelStateTransition {
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockReason {
+    /// Failed to set security policy
+    SetSecurityPolicyError,
     /// Failed to start connection to remote server
     StartTunnelError,
 }
@@ -28,6 +30,7 @@ pub enum BlockReason {
 impl fmt::Display for BlockReason {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let description = match *self {
+            BlockReason::SetSecurityPolicyError => "Failed to set security policy",
             BlockReason::StartTunnelError => "Failed to start connection to remote server",
         };
 

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,6 +1,6 @@
 /// Event resulting from a transition to a new tunnel state.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum TunnelStateTransition {
     /// No connection is established and network is unsecured.
     Disconnected,

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -10,4 +10,6 @@ pub enum TunnelStateTransition {
     Connected,
     /// Disconnecting tunnel.
     Disconnecting,
+    /// Tunnel is disconnected but secured by blocking all connections.
+    Blocked,
 }

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,6 +1,9 @@
+use std::fmt;
+
 /// Event resulting from a transition to a new tunnel state.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[serde(tag = "state", content = "details")]
 pub enum TunnelStateTransition {
     /// No connection is established and network is unsecured.
     Disconnected,
@@ -11,5 +14,16 @@ pub enum TunnelStateTransition {
     /// Disconnecting tunnel.
     Disconnecting,
     /// Tunnel is disconnected but secured by blocking all connections.
-    Blocked,
+    Blocked(BlockReason),
+}
+
+/// Reason for entering the blocked state.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockReason {}
+
+impl fmt::Display for BlockReason {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
 }


### PR DESCRIPTION
In case of an error, the tunnel state machine progresses to the `disconnected` state, which is an `unsecured` state. It's preferred to only move to an `unsecured` state when the user specifically allows it. Therefore, a new `blocked` state was added to the state machine. When on that state, it will block the firewall so that it blocks all connections, preventing any connection from leaking out.

This PR adds the `blocked` state, which is currently only reached if starting the tunnel fails when entering the `connecting` state, or if setting the security policy fails (in either the `connecting` state or the `connected` state).

Transitioning to the `blocked` state also allows including a `BlockCause` parameter, which is an output from the state machine to the daemon. This allows reporting errors from inside the state machine, which should eventually reach either the log or the GUI.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/380)
<!-- Reviewable:end -->
