### PR TITLE
Unpatch yarn on postinstall

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "node unpatch-yarn.js",
     "flow": "flow",
     "lint": "eslint \"packages/**/*.js\"",
     "format": "yarn run private:format --write",

--- a/gui/unpatch-yarn.js
+++ b/gui/unpatch-yarn.js
@@ -1,0 +1,24 @@
+// This is a companion script that reverts the effect of preinstall script in 
+// `\gui\packages\yarn-fixes`.
+//
+// The symlink to `\gui\node_modules\node_modules` that fixes the bug, described in 
+// https://github.com/yarnpkg/yarn/issues/4564, must be removed after node modules installation, 
+// because circular symlinks cause scripts like electron-builder to crash.
+
+const path = require('path');
+const fs = require('fs');
+
+if (process.platform !== 'win32') {
+  return;
+}
+
+const symlinkPath = path.join(__dirname, 'node_modules/node_modules');
+
+try {
+  console.log('Removing a symlink to node_modules/node_modules');
+  fs.unlinkSync(symlinkPath);
+} catch (error) {
+  if (error.code !== 'ENOENT') {
+    throw error;
+  }
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Leaving `node_modules/node_modules` symlnik that points to `node_modules/` breaks electron-builder. This PR adds a `postinstall` script to the root workspace that reverts the effect of `preinstall` script from `yarn-fixes/package.json`.

Unfortunately it's impossible to add a `postinstall` anywhere else because we need the symlink for the duration of the entire workspace installation and `postinstall` for each package is triggered too early.

It's also sad that moving `preinstall` script from `yarn-fixes` package to root workspace does not work, because yarn cleans up the `node_modules` folder right after `preinstall` event for the workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/381)
<!-- Reviewable:end -->
