### PR TITLE
Fix window position rounding

### DIFF
--- a/gui/packages/desktop/src/main/window-controller.js
+++ b/gui/packages/desktop/src/main/window-controller.js
@@ -74,7 +74,10 @@ class AttachedToTrayWindowPositioning implements WindowPositioning {
     x = Math.min(Math.max(x, workArea.x), maxX);
     y = Math.min(Math.max(y, workArea.y), maxY);
 
-    return { x, y };
+    return {
+      x: Math.round(x),
+      y: Math.round(y),
+    };
   }
 
   _getTrayPlacement() {


### PR DESCRIPTION
The code to round the window position coordinates was incorrectly removed when the window positioning code was updated to allow the window to reappear where it was last on Linux. This PR adds that code back to the platforms that aren't Linux, because on Linux there are no divisions to calculate the coordinates, and therefore they'll stay as integers.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fix for an a bug that wasn't released.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
