### PR TITLE
Make CI source env.{sh,ps1}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 sudo: false
-env:
-  global:
-    - MACOSX_DEPLOYMENT_TARGET="10.7"
-    - LIBMNL_LIB_DIR="$TRAVIS_BUILD_DIR/dist-assets/binaries/linux"
-    - LIBNFTNL_LIB_DIR="$TRAVIS_BUILD_DIR/dist-assets/binaries/linux"
 
 git:
   submodules: false
@@ -47,10 +42,8 @@ matrix:
       rust: stable
       os: osx
       cache: cargo
-      env:
-      - OPENSSL_LIB_DIR="$TRAVIS_BUILD_DIR/dist-assets/binaries/macos"
-      - OPENSSL_INCLUDE_DIR="$TRAVIS_BUILD_DIR/dist-assets/binaries/macos/include"
-      before_script:
+      before_script: &rust_before_script
+        - source env.sh
         - env
       script: &rust_script
         - cargo build --verbose
@@ -68,11 +61,7 @@ matrix:
          packages:
           - binutils
       cache: cargo
-      env: &rust_linux_env
-      - OPENSSL_LIB_DIR="$TRAVIS_BUILD_DIR/dist-assets/binaries/linux"
-      - OPENSSL_INCLUDE_DIR="$TRAVIS_BUILD_DIR/dist-assets/binaries/linux/include"
-      before_script: &rust_before_script
-        - env
+      before_script: *rust_before_script
       script:
         - cargo build --verbose
         - cargo test --verbose
@@ -86,7 +75,6 @@ matrix:
       os: linux
       addons: *rust_linux_addons
       cache: cargo
-      env: *rust_linux_env
       before_script: *rust_before_script
       script: *rust_script
 
@@ -95,7 +83,6 @@ matrix:
       os: linux
       addons: *rust_linux_addons
       cache: cargo
-      env: *rust_linux_env
       before_script: *rust_before_script
       script: *rust_script
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,8 +37,6 @@ install:
       } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
         $Env:PATH += ';C:\msys64\mingw32\bin'
       }
-  - ps: $Env:OPENSSL_LIB_DIR = $Env:APPVEYOR_BUILD_FOLDER + "\dist-assets\binaries\windows"
-  - ps: $Env:OPENSSL_INCLUDE_DIR = $Env:APPVEYOR_BUILD_FOLDER + "\dist-assets\binaries\windows\include"
 
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
@@ -52,6 +50,7 @@ install:
 
 # This is the "test phase", tweak it as you see fit
 test_script:
+  - ps: . .\env.ps1
   - bash -x build_windows_modules.sh
   - cargo build
   - cargo test


### PR DESCRIPTION
I found an old task saying we should use `env.{sh,ps1}` in our CI scripts, to avoid duplicating a lot of variables. I vaguely remembered something being fixed so this could be easily done. Since it was basically a fix taking a few minutes to implement I tried it out, and it seems to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/386)
<!-- Reviewable:end -->
