### PR TITLE
Update relay list when the daemon starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
   `mullvad relay list locations`.
 - Replace WebSockets with Unix domain sockets/Named pipes for IPC. The location
   of the socket can be controlled with `MULLVAD_RPC_SOCKET_PATH`.
+- Update the relay list if it's out of date when the daemon starts.
 
 ### Fixed
 - Fix incorrect window position when using external display.

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -243,6 +243,9 @@ impl Daemon {
         let management_interface_broadcaster =
             Self::start_management_interface(tx.clone(), cache_dir.clone())?;
 
+        // Attempt to download a fresh relay list
+        relay_selector.update();
+
         Ok(Daemon {
             tunnel_command_tx: Sink::wait(tunnel_command_tx),
             tunnel_state: TunnelStateTransition::Disconnected,

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -122,7 +122,7 @@ impl ParsedRelays {
 pub struct RelaySelector {
     parsed_relays: Arc<Mutex<ParsedRelays>>,
     rng: ThreadRng,
-    _updater: RelayListUpdaterHandle,
+    updater: RelayListUpdaterHandle,
 }
 
 impl RelaySelector {
@@ -148,8 +148,15 @@ impl RelaySelector {
         RelaySelector {
             parsed_relays,
             rng: rand::thread_rng(),
-            _updater: updater,
+            updater,
         }
+    }
+
+    /// Download the newest relay list.
+    pub fn update(&self) {
+        self.updater
+            .send(())
+            .expect("Relay list updated thread has stopped unexpectedly");
     }
 
     /// Returns all countries and cities. The cities in the object returned does not have any


### PR DESCRIPTION
Previously, the first check to see if the relay list is outdated or not would happen an hour after the daemon has started. This is a minor inconvenience if the daemon hasn't been executed for a while, because it might attempt to use servers that aren't available. This PR changes this so that when the daemon starts it performs the check to see if the relay list should be updated, and fetch a new relay list if necessary.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/388)
<!-- Reviewable:end -->
