### PR TITLE
Calculate arrow position relative to tray icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,18 @@ Line wrap the file at 100 chars.                                              Th
 - Add option to enable or disable IPv6 on the tunnel interface.
 - Log panics in the daemon to the log file.
 - Warn in the Settings screen if a new version is available.
+
 #### Windows
 - Extend uninstaller to also remove logs, cache and optionally settings.
 
 ### Fixed
+- Fix incorrect window position when using external display.
+
 #### Linux
 - The app window is now shown in its previous location, instead of at the center of the screen.
+
+#### macOS
+- Fix edge cases when window's arrow appeared misaligned and pointed to the wrong menubar item.
 
 ### Changed
 - The "Buy more credit" button is changed to open a dedicated account login page instead of one
@@ -42,9 +48,6 @@ Line wrap the file at 100 chars.                                              Th
 - Replace WebSockets with Unix domain sockets/Named pipes for IPC. The location
   of the socket can be controlled with `MULLVAD_RPC_SOCKET_PATH`.
 - Update the relay list if it's out of date when the daemon starts.
-
-### Fixed
-- Fix incorrect window position when using external display.
 
 
 ## [2018.2] - 2018-08-13

--- a/gui/packages/desktop/src/renderer/components/PlatformWindow.js
+++ b/gui/packages/desktop/src/renderer/components/PlatformWindow.js
@@ -3,16 +3,32 @@
 import * as React from 'react';
 import { Component, View, Styles } from 'reactxp';
 
-const styles = {
-  darwin: Styles.createViewStyle({
-    WebkitMask: `
-      url(../assets/images/app-triangle.svg) 50% 0% no-repeat,
-      url(../assets/images/app-header-backdrop.svg) no-repeat`,
-  }),
+type Props = {
+  arrowPosition?: number,
 };
 
-export default class PlatformWindow extends Component {
+export default class PlatformWindow extends Component<Props> {
   render() {
-    return <View style={styles[process.platform]}>{this.props.children}</View>;
+    let style = undefined;
+
+    if (process.platform === 'darwin') {
+      const arrowPosition = this.props.arrowPosition;
+      let arrowPositionCss = '50%';
+
+      if (typeof arrowPosition === 'number') {
+        const arrowWidth = 30;
+        const adjustedArrowPosition = arrowPosition - arrowWidth * 0.5;
+        arrowPositionCss = `${adjustedArrowPosition}px`;
+      }
+
+      const webkitMask = [
+        `url(../assets/images/app-triangle.svg) ${arrowPositionCss} 0% no-repeat`,
+        `url(../assets/images/app-header-backdrop.svg) no-repeat`,
+      ];
+
+      style = Styles.createViewStyle({ WebkitMask: webkitMask.join(',') }, false);
+    }
+
+    return <View style={style}>{this.props.children}</View>;
   }
 }

--- a/gui/packages/desktop/src/renderer/containers/PlatformWindowContainer.js
+++ b/gui/packages/desktop/src/renderer/containers/PlatformWindowContainer.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { connect } from 'react-redux';
+import PlatformWindow from '../components/PlatformWindow';
+
+import type { ReduxState, ReduxDispatch } from '../redux/store';
+import type { SharedRouteProps } from '../routes';
+
+const mapStateToProps = (state: ReduxState) => ({
+  arrowPosition: state.window.arrowPosition,
+});
+
+const mapDispatchToProps = (_dispatch: ReduxDispatch, _props: SharedRouteProps) => ({});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PlatformWindow);

--- a/gui/packages/desktop/src/renderer/redux/store.js
+++ b/gui/packages/desktop/src/renderer/redux/store.js
@@ -3,18 +3,20 @@
 import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
 import { routerMiddleware, connectRouter, push, replace } from 'connected-react-router';
 
-import account from './account/reducers';
+import accountReducer from './account/reducers';
 import accountActions from './account/actions';
-import connection from './connection/reducers';
+import connectionReducer from './connection/reducers';
 import connectionActions from './connection/actions';
-import settings from './settings/reducers';
+import settingsReducer from './settings/reducers';
 import settingsActions from './settings/actions';
-import support from './support/reducers';
+import supportReducer from './support/reducers';
 import supportActions from './support/actions';
-import version from './version/reducers';
+import versionReducer from './version/reducers';
 import versionActions from './version/actions';
-import daemon from './daemon/reducers';
+import daemonReducer from './daemon/reducers';
 import daemonActions from './daemon/actions';
+import windowReducer from './window/reducers';
+import windowActions from './window/actions';
 
 import type { Store, StoreEnhancer } from 'redux';
 import type { History } from 'history';
@@ -24,6 +26,7 @@ import type { SettingsReduxState } from './settings/reducers';
 import type { SupportReduxState } from './support/reducers';
 import type { VersionReduxState } from './version/reducers';
 import type { DaemonReduxState } from './daemon/reducers';
+import type { WindowReduxState } from './window/reducers';
 
 import type { AccountAction } from './account/actions';
 import type { ConnectionAction } from './connection/actions';
@@ -31,6 +34,7 @@ import type { SettingsAction } from './settings/actions';
 import type { SupportAction } from './support/actions';
 import type { VersionAction } from './version/actions';
 import type { DaemonAction } from './daemon/actions';
+import type { WindowAction } from './window/actions';
 
 export type ReduxState = {
   account: AccountReduxState,
@@ -39,6 +43,7 @@ export type ReduxState = {
   support: SupportReduxState,
   version: VersionReduxState,
   daemon: DaemonReduxState,
+  window: WindowReduxState,
 };
 
 export type ReduxAction =
@@ -47,7 +52,8 @@ export type ReduxAction =
   | SettingsAction
   | SupportAction
   | VersionAction
-  | DaemonAction;
+  | DaemonAction
+  | WindowAction;
 export type ReduxStore = Store<ReduxState, ReduxAction, ReduxDispatch>;
 export type ReduxGetState = () => ReduxState;
 export type ReduxDispatch = (action: ReduxAction) => any;
@@ -65,17 +71,19 @@ export default function configureStore(
     ...supportActions,
     ...versionActions,
     ...daemonActions,
+    ...windowActions,
     pushRoute: (route) => push(route),
     replaceRoute: (route) => replace(route),
   };
 
   const reducers = {
-    account,
-    connection,
-    settings,
-    support,
-    version,
-    daemon,
+    account: accountReducer,
+    connection: connectionReducer,
+    settings: settingsReducer,
+    support: supportReducer,
+    version: versionReducer,
+    daemon: daemonReducer,
+    window: windowReducer,
   };
 
   const middlewares = [router];

--- a/gui/packages/desktop/src/renderer/redux/window/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/window/actions.js
@@ -1,0 +1,17 @@
+// @flow
+
+export type UpdateWindowArrowPositionAction = {
+  type: 'UPDATE_WINDOW_ARROW_POSITION',
+  arrowPosition: number,
+};
+
+export type WindowAction = UpdateWindowArrowPositionAction;
+
+function updateWindowArrowPosition(arrowPosition: number): UpdateWindowArrowPositionAction {
+  return {
+    type: 'UPDATE_WINDOW_ARROW_POSITION',
+    arrowPosition,
+  };
+}
+
+export default { updateWindowArrowPosition };

--- a/gui/packages/desktop/src/renderer/redux/window/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/window/reducers.js
@@ -1,0 +1,22 @@
+// @flow
+
+import type { ReduxAction } from '../store';
+
+export type WindowReduxState = {
+  arrowPosition?: number,
+};
+
+const initialState: WindowReduxState = {};
+
+export default function(
+  state: WindowReduxState = initialState,
+  action: ReduxAction,
+): WindowReduxState {
+  switch (action.type) {
+    case 'UPDATE_WINDOW_ARROW_POSITION':
+      return { ...state, arrowPosition: action.arrowPosition };
+
+    default:
+      return state;
+  }
+}

--- a/gui/packages/desktop/src/renderer/routes.js
+++ b/gui/packages/desktop/src/renderer/routes.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Switch, Route, Redirect } from 'react-router';
 import TransitionContainer from './components/TransitionContainer';
-import PlatformWindow from './components/PlatformWindow';
+import PlatformWindowContainer from './containers/PlatformWindowContainer';
 import LaunchPage from './containers/LaunchPage';
 import LoginPage from './containers/LoginPage';
 import ConnectPage from './containers/ConnectPage';
@@ -120,7 +120,7 @@ export default function makeRoutes(
         previousRoute = toRoute;
 
         return (
-          <PlatformWindow>
+          <PlatformWindowContainer>
             <TransitionContainer {...transitionProps}>
               <Switch key={location.key} location={location}>
                 <LaunchRoute exact path="/" component={LaunchPage} />
@@ -134,7 +134,7 @@ export default function makeRoutes(
                 <PrivateRoute exact path="/select-location" component={SelectLocationPage} />
               </Switch>
             </TransitionContainer>
-          </PlatformWindow>
+          </PlatformWindowContainer>
         );
       }}
     />


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [Х] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [Х] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR fixes edge cases when window's arrow appeared misaligned and pointed to the wrong menubar item. 

### Why

The arrow that points to the corresponding tray icon used to be fixed in the middle of window and the window itself is centered around the tray icon.

However, dragging the tray icon (cmd+mouse) to the very edge of the screen may cause situations when the window can no longer be centered around the tray icon, since it would otherwise appear partially outside of screen boundaries. So the window is forced into the screen boundaries in order to remain fully visible. 

In such scenario we have to adjust the position of arrow in order to correctly point to the tray icon.

### How

This PR adds an IPC call from main to renderer process that passes the frames of tray item and window itself in order to update the position of arrow.

### Known issues

For some reason Electron does not re-render the window shadow and I couldn't find the way to force it. https://github.com/electron/electron/issues/14304

![screenshot 2018-08-29 16 11 04](https://user-images.githubusercontent.com/704044/44789804-3c562700-aba6-11e8-9805-9afcb68e0b15.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/390)
<!-- Reviewable:end -->