### PR TITLE
Reset current_relay when disconnected

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -342,6 +342,7 @@ impl Daemon {
 
         if tunnel_state == Disconnected {
             self.state.disconnected();
+            self.current_relay = None;
         }
 
         self.tunnel_state = tunnel_state;


### PR DESCRIPTION
There was a bug here. `self.current_relay` was never reset to `None` on disconnect, so after the first connect it would always have the value of the last connected to relay. This caused problems with the location fetching, since that uses the current relay if there is one.

I also don't think we should not set `self.current_relay` in `build_tunnel_parameters`. That sounds like an odd side effect. I think we should work more towards a state transition system where the tunnel state machine emits more information. For example can the transition state enum variant contain the currently connecing/connected relay for those states. As such we can remove `Daemon::current_relay` and instead base this information off of `Daemon::tunnel_state`. But this fix will do for now.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/392)
<!-- Reviewable:end -->
