### PR TITLE
Replace `DaemonState` with `TunnelStateTransition`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,10 +1024,10 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-ipc-client 0.1.0",
  "mullvad-paths 0.1.0",
- "mullvad-types 0.1.0",
  "notify 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
+ "talpid-types 0.1.0",
  "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -78,10 +78,9 @@ use std::time::Duration;
 use std::{mem, thread};
 
 use talpid_core::mpsc::IntoSender;
-use talpid_core::tunnel_state_machine::{
-    self, TunnelCommand, TunnelParameters, TunnelStateTransition,
-};
+use talpid_core::tunnel_state_machine::{self, TunnelCommand, TunnelParameters};
 use talpid_types::net::TunnelOptions;
+use talpid_types::tunnel::TunnelStateTransition;
 
 
 error_chain!{

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -68,7 +68,7 @@ use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
 use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
 use mullvad_types::relay_list::{Relay, RelayList};
-use mullvad_types::states::{DaemonState, SecurityState, TargetState};
+use mullvad_types::states::TargetState;
 use mullvad_types::version::{AppVersion, AppVersionInfo};
 
 use std::net::IpAddr;
@@ -188,8 +188,6 @@ impl DaemonExecutionState {
 struct Daemon {
     tunnel_command_tx: SyncUnboundedSender<TunnelCommand>,
     tunnel_state: TunnelStateTransition,
-    security_state: SecurityState,
-    last_broadcasted_state: DaemonState,
     target_state: TargetState,
     state: DaemonExecutionState,
     rx: mpsc::Receiver<DaemonEvent>,
@@ -248,12 +246,7 @@ impl Daemon {
         Ok(Daemon {
             tunnel_command_tx: Sink::wait(tunnel_command_tx),
             tunnel_state: TunnelStateTransition::Disconnected,
-            security_state: SecurityState::Unsecured,
             target_state,
-            last_broadcasted_state: DaemonState {
-                state: SecurityState::Unsecured,
-                target_state,
-            },
             state: DaemonExecutionState::Running,
             rx,
             tx,
@@ -348,12 +341,9 @@ impl Daemon {
         }
 
         self.tunnel_state = tunnel_state;
-        self.security_state = match tunnel_state {
-            Disconnected | Connecting => SecurityState::Unsecured,
-            Connected | Disconnecting => SecurityState::Secured,
-        };
 
-        self.broadcast_state();
+        self.management_interface_broadcaster
+            .notify_new_state(self.tunnel_state);
 
         Ok(())
     }
@@ -394,8 +384,8 @@ impl Daemon {
         }
     }
 
-    fn on_get_state(&self, tx: OneshotSender<DaemonState>) {
-        Self::oneshot_send(tx, self.last_broadcasted_state, "current state");
+    fn on_get_state(&self, tx: OneshotSender<TunnelStateTransition>) {
+        Self::oneshot_send(tx, self.tunnel_state, "current state");
     }
 
     fn on_get_current_location(&self, tx: OneshotSender<GeoIpLocation>) {
@@ -607,25 +597,12 @@ impl Daemon {
         Ok(())
     }
 
-    fn broadcast_state(&mut self) {
-        let new_daemon_state = DaemonState {
-            state: self.security_state,
-            target_state: self.target_state,
-        };
-        if self.last_broadcasted_state != new_daemon_state {
-            self.last_broadcasted_state = new_daemon_state;
-            self.management_interface_broadcaster
-                .notify_new_state(new_daemon_state);
-        }
-    }
-
     /// Set the target state of the client. If it changed trigger the operations needed to
     /// progress towards that state.
     fn set_target_state(&mut self, new_state: TargetState) -> Result<()> {
         if new_state != self.target_state {
             debug!("Target state {:?} => {:?}", self.target_state, new_state);
             self.target_state = new_state;
-            self.broadcast_state();
             self.apply_target_state()
         } else {
             Ok(())

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -25,10 +25,10 @@ use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
 use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
 use mullvad_types::relay_list::RelayList;
-use mullvad_types::states::DaemonState;
 use mullvad_types::version::AppVersionInfo;
 use serde::{Deserialize, Serialize};
 use talpid_types::net::TunnelOptions;
+use talpid_types::tunnel::TunnelStateTransition;
 
 use futures::stream::{self, Stream};
 use futures::sync::oneshot;
@@ -177,7 +177,7 @@ impl DaemonRpcClient {
         self.call("get_relay_settings", &NO_ARGS)
     }
 
-    pub fn get_state(&mut self) -> Result<DaemonState> {
+    pub fn get_state(&mut self) -> Result<TunnelStateTransition> {
         self.call("get_state", &NO_ARGS)
     }
 
@@ -220,7 +220,7 @@ impl DaemonRpcClient {
             .chain_err(|| ErrorKind::RpcCallError(method.to_owned()))
     }
 
-    pub fn new_state_subscribe(&mut self) -> Result<mpsc::Receiver<DaemonState>> {
+    pub fn new_state_subscribe(&mut self) -> Result<mpsc::Receiver<TunnelStateTransition>> {
         let client = self.rpc_client.clone();
         let mut current_state = self.get_state()?;
         let first_message = stream::once(Ok(current_state.clone()));

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -12,10 +12,10 @@ integration-tests = []
 duct = "0.11"
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-paths = { path = "../mullvad-paths" }
-mullvad-types = { path = "../mullvad-types" }
 notify = "4.0"
 openvpn-plugin = { version = "0.3", features = ["serde"] }
 talpid-ipc = { path = "../talpid-ipc" }
+talpid-types = { path = "../talpid-types" }
 tempfile = "3.0"
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }
 jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }

--- a/mullvad-tests/tests/startup.rs
+++ b/mullvad-tests/tests/startup.rs
@@ -2,21 +2,18 @@
 
 extern crate mullvad_paths;
 extern crate mullvad_tests;
-extern crate mullvad_types;
+extern crate talpid_types;
+
+use talpid_types::tunnel::TunnelStateTransition;
 
 use mullvad_tests::DaemonRunner;
-use mullvad_types::states::{DaemonState, SecurityState, TargetState};
 
 #[test]
-fn starts_in_not_connected_state() {
+fn starts_in_disconnected_state() {
     let mut daemon = DaemonRunner::spawn();
     let mut rpc_client = daemon.rpc_client().expect("Failed to create RPC client");
 
     let state = rpc_client.get_state().expect("Failed to read daemon state");
-    let not_connected_state = DaemonState {
-        state: SecurityState::Unsecured,
-        target_state: TargetState::Unsecured,
-    };
 
-    assert_eq!(state, not_connected_state);
+    assert_eq!(state, TunnelStateTransition::Disconnected);
 }

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -1,22 +1,3 @@
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct DaemonState {
-    pub state: SecurityState,
-    pub target_state: TargetState,
-}
-
-/// Security state of the computer.
-/// TODO(linus): There is a difference between lockdown(firewall) and tunnel functionality. The
-/// firewall can be set to prevent any leaks but the tunnel is not connected. Then we are secured,
-/// but disconnected. The frontend should probably reflect these states in some way. I think it
-/// be reasonable to have three states, since unsecured but tunnel is up is probably an invalid
-/// state.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SecurityState {
-    Unsecured,
-    Secured,
-}
-
 /// Represents the state the client strives towards.
 /// When in `Secured`, the client should keep the computer from leaking and try to
 /// establish a VPN tunnel if it is not up.

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -17,6 +17,7 @@ use futures::{Async, Future, Poll, Stream};
 use tokio_core::reactor::Core;
 
 use talpid_types::net::{TunnelEndpoint, TunnelOptions};
+use talpid_types::tunnel::TunnelStateTransition;
 
 use self::connected_state::{ConnectedState, ConnectedStateBootstrap};
 use self::connecting_state::ConnectingState;
@@ -124,19 +125,6 @@ pub struct TunnelParameters {
     pub username: String,
     /// Should LAN access be allowed outside the tunnel.
     pub allow_lan: bool,
-}
-
-/// Event resulting from a transition to a new tunnel state.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum TunnelStateTransition {
-    /// No connection is established and network is unsecured.
-    Disconnected,
-    /// Network is secured but tunnel is still connecting.
-    Connecting,
-    /// Tunnel is connected.
-    Connected,
-    /// Disconnecting tunnel.
-    Disconnecting,
 }
 
 /// Asynchronous handling of the tunnel state machine.

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -10,3 +10,4 @@
 extern crate serde_derive;
 
 pub mod net;
+pub mod tunnel;

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,0 +1,12 @@
+/// Event resulting from a transition to a new tunnel state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TunnelStateTransition {
+    /// No connection is established and network is unsecured.
+    Disconnected,
+    /// Network is secured but tunnel is still connecting.
+    Connecting,
+    /// Tunnel is connected.
+    Connected,
+    /// Disconnecting tunnel.
+    Disconnecting,
+}

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,5 +1,6 @@
 /// Event resulting from a transition to a new tunnel state.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum TunnelStateTransition {
     /// No connection is established and network is unsecured.
     Disconnected,


### PR DESCRIPTION
This PR changes the tunnel state representation that's used for IPC. It was previously a pair of `target` and `current` states, which each could assume the values `unsecured` or `secured`. Now, it is a direct representation of the `TunnelStateTransition` type emitted by the `TunnelStateMachine`. This means it is currently sent as a string that can be either `connected`, `connecting`, `disconnected` or `disconnecting`.

Not only does this simplify the daemon side code when sending the state representation, it also simplifies the GUI code because it now has a closer mapping to how the state information is used internally. The only mapping done in the GUI code is to join the `disconnected` and `disconnecting` states into a single `disconnected` state.

This is also a step towards the blocked state implementation, because the transition to the blocked state will emit a `TunnelStateTransition::Blocked` event.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor; not user visible.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/393)
<!-- Reviewable:end -->
