### PR TITLE
Add plist option to allow app to use integrated GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - The app window is now shown in its previous location, instead of at the center of the screen.
 
+#### macOS
+- Allow the app to use the integrated GPU for rendering. This saves battery and keeps the computer
+  cooler.
+
 ### Changed
 - The "Buy more credit" button is changed to open a dedicated account login page instead of one
   having a create account form first.

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -39,6 +39,7 @@ mac:
   category: public.app-category.tools
   extendInfo:
     LSUIElement: true
+    NSSupportsAutomaticGraphicsSwitching: true
   extraResources:
     - from: ../../../target/release/mullvad
       to: .


### PR DESCRIPTION
A user was telling us their GPU spins up as soon as they run our app. And correctly, by default in macOS any app that has an OpenGL canvas defaults to be rendered on the powerful discrete GPU. This is a waste of power and battery. With the plist option I add here it should allow the app to be rendered on the internal GPU. 

I have not tested this out as I don't have access to a mac today. Could you please compare the generated `Info.plist` before and after and verify that the app still works? If you are able to detect that it actually uses the internal GPU that would of course be even better.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/395)
<!-- Reviewable:end -->
