### PR TITLE
Fix some tunnel state change triggers

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -450,7 +450,7 @@ impl Daemon {
                         self.set_target_state(TargetState::Unsecured)?;
                     } else {
                         info!("Initiating tunnel restart because the account token changed");
-                        self.connect_tunnel()?;
+                        self.reconnect_tunnel()?;
                     }
                 }
             }
@@ -499,7 +499,7 @@ impl Daemon {
 
                 if changed {
                     info!("Initiating tunnel restart because the relay settings changed");
-                    self.connect_tunnel()?;
+                    self.reconnect_tunnel()?;
                 }
             }
             Err(e) => error!("{}", e.display_chain()),
@@ -575,7 +575,7 @@ impl Daemon {
 
                 if settings_changed {
                     info!("Initiating tunnel restart because the enable IPv6 setting changed");
-                    self.connect_tunnel()?;
+                    self.reconnect_tunnel()?;
                 }
             }
             Err(e) => error!("{}", e.display_chain()),
@@ -650,6 +650,13 @@ impl Daemon {
         self.tunnel_command_tx
             .send(TunnelCommand::Disconnect)
             .expect("Tunnel state machine has stopped");
+    }
+
+    fn reconnect_tunnel(&mut self) -> Result<()> {
+        match self.target_state {
+            TargetState::Secured => self.connect_tunnel(),
+            TargetState::Unsecured => Ok(()),
+        }
     }
 
     fn build_tunnel_parameters(&mut self) -> Result<TunnelParameters> {


### PR DESCRIPTION
After the tunnel state refactor, most state handling code has been moved to the new tunnel state machine. However, sending commands to the state machine still require a certain amount of care, in order to avoid triggering tunnel state changes in the wrong situations. Two situations where I missed proper handling was with changing settings and clearing the account token.

Every time some setting changed, the daemon should *reconnect* the tunnel. But *reconnect* in this case means connect if and only if a connection was established or in the process of being established. However, I didn't implement that correctly, since it would *always* attempt to connect the tunnel, not checking the current state to decide to connect or not. This PR fixes this by adding a `reconnect_tunnel` helper function to check the current state and decide if a `TunnelCommand::Connect` should be sent or not to the state machine.

The second situation was discovered accidentally while testing the app. While connected, an attempt to logout in the GUI would cause the daemon to crash. This was because the logout operation cleared the account token, and the daemon would simply try to reconnect the tunnel without an account token. It would then fail to build the `TunnelParameters` to send to the tunnel state machine, and fail. This PR also fixes this by disconnecting the tunnel if the account is cleared, instead of attempting to reconnect.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes to bugs that aren't present in a released version.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/397)
<!-- Reviewable:end -->
