### PR TITLE
Silence the tokio_io and "want" crates

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -32,9 +32,11 @@ const SILENCED_CRATES: &[&str] = &[
     // jsonrpc_core does some logging under the "rpc" target as well.
     "rpc",
     "tokio_core",
+    "tokio_io",
     "tokio_proto",
     "tokio_reactor",
     "jsonrpc_ws_server",
+    "want",
     "ws",
     "mio",
     "hyper",


### PR DESCRIPTION
Silencing some crates that I think are new since we last touched the list of crates to silence from too much logging. When running on trace level these two transitive dependencies generate a lot of noise I think we are better without.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/400)
<!-- Reviewable:end -->
