### PR TITLE
Do not take user to "connecting screen" when in settings

### DIFF
--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -469,6 +469,7 @@ export default class AppRenderer {
 
   async _onCloseConnection(error: ?Error) {
     const actions = this._reduxActions;
+    const history = this._memoryHistory;
 
     // save to redux that the app disconnected from daemon
     actions.daemon.disconnected();
@@ -489,8 +490,10 @@ export default class AppRenderer {
         recover();
       });
 
-      // take user back to the launch screen `/`.
-      actions.history.replace('/');
+      // take user back to the launch screen `/` except when user is in settings.
+      if (!history.location.pathname.startsWith('/settings')) {
+        actions.history.replace('/');
+      }
     }
   }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Previously, on each failed attempt to reconnect to daemon, the app would take user to "connecting screen" rendering it impossible to send a problem report :/ Perhaps it was not spotted before because normally we would wait for RPC file but in case of unix socket IPC we make a direct attempt to connect to fixed socket, so the app keeps looking and trying to reconnect and taking user to the "Connecting to Daemon" screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/403)
<!-- Reviewable:end -->
