### PR TITLE
Remove the call to disconnectTunnel() on logout

### DIFF
--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -200,11 +200,9 @@ export default class AppRenderer {
     const actions = this._reduxActions;
 
     try {
-      await Promise.all([
-        this.disconnectTunnel(),
-        this._daemonRpc.setAccount(null),
-        this._fetchAccountHistory(),
-      ]);
+      await this._daemonRpc.setAccount(null);
+      await this._fetchAccountHistory();
+
       actions.account.loggedOut();
       actions.history.replace('/login');
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

In conversation with @faern, he mentioned that `setAccount(null)` automatically disconnects the tunnel, so I removed the call to `disconnectTunnel()` on `logout` and serialized the remaining of calls:

- Reset account token
- Fetch account history

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/404)
<!-- Reviewable:end -->
