### PR TITLE
Block if IPv6 is enabled on app but disabled in system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add option to enable or disable IPv6 on the tunnel interface.
 - Log panics in the daemon to the log file.
 - Warn in the Settings screen if a new version is available.
-- Enter a "blocked" state in case of connection error, relay server unavailability or invalid
-  configuration, which prevents leaking traffic until the user specifically requests to disconnect.
+- Add a "blocked" state in the app that blocks the entire network and waits for user action when
+  something has gone wrong.
 - Add support for Ubuntu 14.04 and other distributions that use the Upstart init system.
 - Make scrollbar thumb draggable.
 - Ability to expand cities with multiple servers and configure the app to use a specific server.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -4,25 +4,24 @@ import type { BlockReason } from './lib/daemon-rpc';
 
 export class BlockedError extends Error {
   constructor(reason: BlockReason) {
-    switch (reason) {
-      case 'enable_ipv6_error':
-        super('Could not configure IPv6, please enable it on your system or disable it in the app');
-        break;
-      case 'set_security_policy_error':
-        super('Failed to apply security policy');
-        break;
-      case 'start_tunnel_error':
-        super('Failed to start tunnel connection');
-        break;
-      case 'no_matching_relay':
-        super('No relay server matches the current settings');
-        break;
-      case 'no_account_token':
-        super('No account token configured');
-        break;
-      default:
-        super(`Unknown error: ${(reason: empty)}`);
-    }
+    const message = (function() {
+      switch (reason) {
+        case 'enable_ipv6_error':
+          return 'Could not configure IPv6, please enable it on your system or disable it in the app';
+        case 'set_security_policy_error':
+          return 'Failed to apply security policy';
+        case 'start_tunnel_error':
+          return 'Failed to start tunnel connection';
+        case 'no_matching_relay':
+          return 'No relay server matches the current settings';
+        case 'no_account_token':
+          return 'No account token configured';
+        default:
+          return `Unknown error: ${(reason: empty)}`;
+      }
+    })();
+
+    super(message);
   }
 }
 

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -5,6 +5,9 @@ import type { BlockReason } from './lib/daemon-rpc';
 export class BlockedError extends Error {
   constructor(reason: BlockReason) {
     switch (reason) {
+      case 'enable_ipv6_error':
+        super('Could not configure IPv6, please enable it on your system or disable it in the app');
+        break;
       case 'set_security_policy_error':
         super('Failed to apply security policy');
         break;

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -42,6 +42,7 @@ const LocationSchema = object({
 });
 
 export type BlockReason =
+  | 'enable_ipv6_error'
   | 'set_security_policy_error'
   | 'start_tunnel_error'
   | 'no_matching_relay'
@@ -245,6 +246,7 @@ const AccountDataSchema = object({
 });
 
 const allBlockReasons: Array<BlockReason> = [
+  'enable_ipv6_error',
   'set_security_policy_error',
   'start_tunnel_error',
   'no_matching_relay',

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -43,6 +43,7 @@ tokio-core = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "0.3"
+winreg = "0.5"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -34,6 +34,8 @@ extern crate tokio_core;
 extern crate uuid;
 #[cfg(target_os = "linux")]
 extern crate which;
+#[cfg(windows)]
+extern crate winreg;
 
 extern crate openvpn_plugin;
 extern crate talpid_ipc;

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -332,7 +332,9 @@ fn is_ipv6_enabled_in_os() -> bool {
     }
     #[cfg(target_os = "linux")]
     {
-        true
+        fs::read_to_string("/proc/sys/net/ipv6/conf/all/disable_ipv6")
+            .map(|disable_ipv6| disable_ipv6.trim() == "0")
+            .unwrap_or(false)
     }
     #[cfg(target_os = "macos")]
     {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -150,10 +150,8 @@ impl TunnelMonitor {
     where
         L: Fn(TunnelEvent) + Send + Sync + 'static,
     {
-        match tunnel_endpoint.tunnel {
-            TunnelEndpointData::OpenVpn(_) => (),
-            TunnelEndpointData::Wireguard(_) => bail!(ErrorKind::UnsupportedTunnelProtocol),
-        }
+        Self::ensure_endpoint_is_openvpn(&tunnel_endpoint)?;
+
         let user_pass_file =
             Self::create_user_pass_file(username).chain_err(|| ErrorKind::CredentialsWriteError)?;
         let cmd = Self::create_openvpn_cmd(
@@ -186,6 +184,13 @@ impl TunnelMonitor {
             monitor,
             _user_pass_file: user_pass_file,
         })
+    }
+
+    fn ensure_endpoint_is_openvpn(endpoint: &TunnelEndpoint) -> Result<()> {
+        match endpoint.tunnel {
+            TunnelEndpointData::OpenVpn(_) => Ok(()),
+            TunnelEndpointData::Wireguard(_) => bail!(ErrorKind::UnsupportedTunnelProtocol),
+        }
     }
 
     fn create_openvpn_cmd(

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -317,5 +317,25 @@ impl CloseHandle {
 }
 
 fn is_ipv6_enabled_in_os() -> bool {
-    true
+    #[cfg(windows)]
+    {
+        use winreg::enums::*;
+        use winreg::RegKey;
+
+        const IPV6_DISABLED: u8 = 0xFF;
+
+        RegKey::predef(HKEY_LOCAL_MACHINE)
+            .open_subkey(r#"SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters"#)
+            .and_then(|ipv6_config| ipv6_config.get_value("DisabledComponents"))
+            .map(|ipv6_disabled_bits: u32| (ipv6_disabled_bits & 0xFF) == IPV6_DISABLED as u32)
+            .unwrap_or(false)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        true
+    }
+    #[cfg(target_os = "macos")]
+    {
+        true
+    }
 }

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -21,6 +21,8 @@ pub enum TunnelStateTransition {
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockReason {
+    /// Failed to configure IPv6 because it's disabled in the platform.
+    Ipv6Unavailable,
     /// Failed to set security policy.
     SetSecurityPolicyError,
     /// Failed to start connection to remote server.
@@ -34,6 +36,9 @@ pub enum BlockReason {
 impl fmt::Display for BlockReason {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let description = match *self {
+            BlockReason::Ipv6Unavailable => {
+                "Failed to configure IPv6 because it's disabled in the platform"
+            }
             BlockReason::SetSecurityPolicyError => "Failed to set security policy",
             BlockReason::StartTunnelError => "Failed to start connection to remote server",
             BlockReason::NoMatchingRelay => "No relay server matches the current settings",


### PR DESCRIPTION
Recently, the app GUI gained a toggle switch to enable or disable IPv6 in the tunnel. This allows a user that has IPv6 disabled in his operating system to disable IPv6 in the app, so that opening the tunnel doesn't fail because it can't configure IPv6. However, if IPv6 is enabled in the app but not in the operating system, the user would only know why the connection failed by looking at the log file and understanding the error message. This PR addresses this by handling the failure by moving to the new blocked state, which then leads to an error message being shown to the user.

IPv6 is currently checked on Linux and Windows, and another PR should add the check for macOS in the future.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/405)
<!-- Reviewable:end -->
