### PR TITLE
Rename 'ApplyPolicyNetBlocked' into 'ApplyPolicyBlocked' and extend w…

### DIFF
--- a/windows/winfw/src/extras/cli/commands/winfw/policy.cpp
+++ b/windows/winfw/src/extras/cli/commands/winfw/policy.cpp
@@ -55,8 +55,8 @@ Policy::Policy(MessageSink messageSink)
 
 	m_dispatcher.addSubcommand
 	(
-		L"netblocked",
-		std::bind(&Policy::processNetBlocked, this)
+		L"blocked",
+		std::bind(&Policy::processBlocked, this, std::placeholders::_1)
 	);
 
 	m_dispatcher.addSubcommand
@@ -149,9 +149,15 @@ void Policy::processConnected(const KeyValuePairs &arguments)
 		: L"Failed to apply policy."));
 }
 
-void Policy::processNetBlocked()
+void Policy::processBlocked(const KeyValuePairs &arguments)
 {
-	auto success = WinFw_ApplyPolicyNetBlocked();
+	auto settings = detail::CreateSettings
+	(
+		GetArgumentValue(arguments, L"dhcp"),
+		GetArgumentValue(arguments, L"lan")
+	);
+
+	auto success = WinFw_ApplyPolicyBlocked(settings);
 
 	m_messageSink((success
 		? L"Successfully applied policy."

--- a/windows/winfw/src/extras/cli/commands/winfw/policy.h
+++ b/windows/winfw/src/extras/cli/commands/winfw/policy.h
@@ -28,7 +28,7 @@ private:
 
 	void processConnecting(const KeyValuePairs &arguments);
 	void processConnected(const KeyValuePairs &arguments);
-	void processNetBlocked();
+	void processBlocked(const KeyValuePairs &arguments);
 	void processReset();
 };
 

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -118,11 +118,12 @@ bool FwContext::applyPolicyConnected(const WinFwSettings &settings, const WinFwR
 	return applyRuleset(ruleset);
 }
 
-bool FwContext::applyPolicyNetBlocked()
+bool FwContext::applyPolicyBlocked(const WinFwSettings &settings)
 {
 	Ruleset ruleset;
 
 	AppendNetBlockedRules(ruleset);
+	AppendSettingsRules(ruleset, settings);
 
 	return applyRuleset(ruleset);
 }

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -15,7 +15,7 @@ public:
 
 	bool applyPolicyConnecting(const WinFwSettings &settings, const WinFwRelay &relay);
 	bool applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *primaryDns);
-	bool applyPolicyNetBlocked();
+	bool applyPolicyBlocked(const WinFwSettings &settings);
 
 	bool reset();
 

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -147,7 +147,8 @@ WinFw_ApplyPolicyConnected(
 WINFW_LINKAGE
 bool
 WINFW_API
-WinFw_ApplyPolicyNetBlocked(
+WinFw_ApplyPolicyBlocked(
+	const WinFwSettings &settings
 )
 {
 	if (nullptr == g_fwContext)
@@ -157,7 +158,7 @@ WinFw_ApplyPolicyNetBlocked(
 
 	try
 	{
-		return g_fwContext->applyPolicyNetBlocked();
+		return g_fwContext->applyPolicyBlocked(settings);
 	}
 	catch (std::exception &err)
 	{

--- a/windows/winfw/src/winfw/winfw.def
+++ b/windows/winfw/src/winfw/winfw.def
@@ -5,5 +5,5 @@ WinFw_Initialize
 WinFw_Deinitialize
 WinFw_ApplyPolicyConnecting
 WinFw_ApplyPolicyConnected
-WinFw_ApplyPolicyNetBlocked
+WinFw_ApplyPolicyBlocked
 WinFw_Reset

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -127,15 +127,17 @@ WinFw_ApplyPolicyConnected(
 );
 
 //
-// ApplyPolicyNetBlocked:
+// ApplyPolicyBlocked:
 //
-// Apply restrictions in the firewall that block all traffic.
+// Apply restrictions in the firewall that block all traffic, except:
+// - What is specified by settings
 //
 extern "C"
 WINFW_LINKAGE
 bool
 WINFW_API
-WinFw_ApplyPolicyNetBlocked(
+WinFw_ApplyPolicyBlocked(
+	const WinFwSettings &settings
 );
 
 //


### PR DESCRIPTION
…ith args

Loopback is always permitted to avoid a local meltdown.

Arguments to `ApplyPolicyBlocked` conditionally permit LAN and DHCP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/408)
<!-- Reviewable:end -->
