### PR TITLE
Move `enable_ipv6` to `TunnelOptions`

### DIFF
--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -410,7 +410,7 @@ export default class AppRenderer {
   async _fetchTunnelOptions() {
     const actions = this._reduxActions;
     const tunnelOptions = await this._daemonRpc.getTunnelOptions();
-    actions.settings.updateEnableIpv6(tunnelOptions.openvpn.enableIpv6);
+    actions.settings.updateEnableIpv6(tunnelOptions.enableIpv6);
   }
 
   async _fetchVersionInfo() {

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -380,7 +380,7 @@ export default class AppRenderer {
 
   async setEnableIpv6(enableIpv6: boolean) {
     const actions = this._reduxActions;
-    await this._daemonRpc.setOpenVpnEnableIpv6(enableIpv6);
+    await this._daemonRpc.setEnableIpv6(enableIpv6);
     actions.settings.updateEnableIpv6(enableIpv6);
   }
 

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -206,14 +206,12 @@ const RelayListSchema = object({
 });
 
 export type TunnelOptions = {
-  openvpn: {
-    enableIpv6: boolean,
-  },
+  enableIpv6: boolean,
 };
 
 const TunnelOptionsSchema = object({
+  enable_ipv6: boolean,
   openvpn: object({
-    enable_ipv6: boolean,
     mssfix: maybe(number),
   }),
 });
@@ -439,9 +437,7 @@ export class DaemonRpc implements DaemonRpcProtocol {
       const validatedObject = validate(TunnelOptionsSchema, response);
 
       return {
-        openvpn: {
-          enableIpv6: validatedObject.openvpn.enable_ipv6,
-        },
+        enableIpv6: validatedObject.enable_ipv6,
       };
     } catch (error) {
       throw new ResponseParseError('Invalid response from get_tunnel_options', error);

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -272,7 +272,7 @@ export interface DaemonRpcProtocol {
   getRelaySettings(): Promise<RelaySettings>;
   setAllowLan(boolean): Promise<void>;
   getAllowLan(): Promise<boolean>;
-  setOpenVpnEnableIpv6(boolean): Promise<void>;
+  setEnableIpv6(boolean): Promise<void>;
   getTunnelOptions(): Promise<TunnelOptions>;
   setAutoConnect(boolean): Promise<void>;
   getAutoConnect(): Promise<boolean>;
@@ -429,8 +429,8 @@ export class DaemonRpc implements DaemonRpcProtocol {
     }
   }
 
-  async setOpenVpnEnableIpv6(enableIpv6: boolean): Promise<void> {
-    await this._transport.send('set_openvpn_enable_ipv6', [enableIpv6]);
+  async setEnableIpv6(enableIpv6: boolean): Promise<void> {
+    await this._transport.send('set_enable_ipv6', [enableIpv6]);
   }
 
   async getTunnelOptions(): Promise<TunnelOptions> {

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -125,11 +125,7 @@ impl Tunnel {
         println!("Common tunnel options");
         println!(
             "\tIPv6:   {}",
-            if options.openvpn.enable_ipv6 {
-                "on"
-            } else {
-                "off"
-            }
+            if options.enable_ipv6 { "on" } else { "off" }
         );
     }
 

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -78,7 +78,7 @@ impl Tunnel {
 
         let mut rpc = new_rpc_client()?;
         rpc.set_enable_ipv6(enabled)?;
-        println!("enable_ipv6 parameter updated");
+        println!("IPv6 {}", if enabled { "on" } else { "off" });
         Ok(())
     }
 

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -43,6 +43,9 @@ impl Command for Tunnel {
                                 .possible_values(&["on", "off"]),
                         ),
                     ).setting(clap::AppSettings::SubcommandRequired),
+            ).subcommand(
+                clap::SubCommand::with_name("get")
+                    .help("Retrieves the current setting for common tunnel options"),
             )
     }
 
@@ -51,6 +54,10 @@ impl Command for Tunnel {
             Self::handle_openvpn_cmd(openvpn_matches)
         } else if let Some(set_matches) = matches.subcommand_matches("set") {
             Self::set_tunnel_option(set_matches)
+        } else if let Some(_) = matches.subcommand_matches("get") {
+            let tunnel_options = Self::get_tunnel_options()?;
+            Self::print_common_tunnel_options(&tunnel_options);
+            Ok(())
         } else {
             unreachable!("No tunnel command given")
         }
@@ -80,7 +87,6 @@ impl Tunnel {
             Self::set_openvpn_option(set_matches)
         } else if let Some(_) = matches.subcommand_matches("get") {
             let tunnel_options = Self::get_tunnel_options()?;
-            Self::print_common_tunnel_options(&tunnel_options);
             Self::print_openvpn_tunnel_options(tunnel_options.openvpn);
             Ok(())
         } else {

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -77,7 +77,7 @@ impl Tunnel {
         let enabled = args.value_of("enable").unwrap() == "on";
 
         let mut rpc = new_rpc_client()?;
-        rpc.set_openvpn_enable_ipv6(enabled)?;
+        rpc.set_enable_ipv6(enabled)?;
         println!("enable_ipv6 parameter updated");
         Ok(())
     }

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -57,8 +57,9 @@ impl Tunnel {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             Self::set_openvpn_option(set_matches)
         } else if let Some(_) = matches.subcommand_matches("get") {
-            let openvpn_options = Self::get_tunnel_options()?.openvpn;
-            Self::print_openvpn_tunnel_options(openvpn_options);
+            let tunnel_options = Self::get_tunnel_options()?;
+            Self::print_common_tunnel_options(&tunnel_options);
+            Self::print_openvpn_tunnel_options(tunnel_options.openvpn);
             Ok(())
         } else {
             unreachable!("Unrecognized subcommand");
@@ -103,6 +104,18 @@ impl Tunnel {
         Ok(rpc.get_tunnel_options()?)
     }
 
+    fn print_common_tunnel_options(options: &TunnelOptions) {
+        println!("Common tunnel options");
+        println!(
+            "\tIPv6:   {}",
+            if options.openvpn.enable_ipv6 {
+                "on"
+            } else {
+                "off"
+            }
+        );
+    }
+
     fn print_openvpn_tunnel_options(options: OpenVpnTunnelOptions) {
         println!("OpenVPN tunnel options");
         println!(
@@ -110,10 +123,6 @@ impl Tunnel {
             options
                 .mssfix
                 .map_or_else(|| "UNSET".to_string(), |v| v.to_string())
-        );
-        println!(
-            "\tIPv6:   {}",
-            if options.enable_ipv6 { "on" } else { "off" }
         );
     }
 }

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -550,7 +550,7 @@ impl Daemon {
     }
 
     fn on_set_enable_ipv6(&mut self, tx: OneshotSender<()>, enable_ipv6: bool) -> Result<()> {
-        let save_result = self.settings.set_openvpn_enable_ipv6(enable_ipv6);
+        let save_result = self.settings.set_enable_ipv6(enable_ipv6);
 
         match save_result.chain_err(|| "Unable to save settings") {
             Ok(settings_changed) => {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -360,9 +360,7 @@ impl Daemon {
             SetAutoConnect(tx, auto_connect) => self.on_set_auto_connect(tx, auto_connect),
             GetAutoConnect(tx) => Ok(self.on_get_auto_connect(tx)),
             SetOpenVpnMssfix(tx, mssfix_arg) => self.on_set_openvpn_mssfix(tx, mssfix_arg),
-            SetOpenVpnEnableIpv6(tx, enable_ipv6) => {
-                self.on_set_openvpn_enable_ipv6(tx, enable_ipv6)
-            }
+            SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6),
             GetTunnelOptions(tx) => self.on_get_tunnel_options(tx),
             GetRelaySettings(tx) => Ok(self.on_get_relay_settings(tx)),
             GetVersionInfo(tx) => Ok(self.on_get_version_info(tx)),
@@ -551,16 +549,12 @@ impl Daemon {
         Ok(())
     }
 
-    fn on_set_openvpn_enable_ipv6(
-        &mut self,
-        tx: OneshotSender<()>,
-        enable_ipv6: bool,
-    ) -> Result<()> {
+    fn on_set_enable_ipv6(&mut self, tx: OneshotSender<()>, enable_ipv6: bool) -> Result<()> {
         let save_result = self.settings.set_openvpn_enable_ipv6(enable_ipv6);
 
         match save_result.chain_err(|| "Unable to save settings") {
             Ok(settings_changed) => {
-                Self::oneshot_send(tx, (), "set_openvpn_enable_ipv6 response");
+                Self::oneshot_send(tx, (), "set_enable_ipv6 response");
 
                 if settings_changed {
                     info!("Initiating tunnel restart because the enable IPv6 setting changed");

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -121,8 +121,8 @@ build_rpc_trait! {
         fn set_openvpn_mssfix(&self, Self::Metadata, Option<u16>) -> BoxFuture<(), Error>;
 
         /// Set if IPv6 is enabled in the tunnel
-        #[rpc(meta, name = "set_openvpn_enable_ipv6")]
-        fn set_openvpn_enable_ipv6(&self, Self::Metadata, bool) -> BoxFuture<(), Error>;
+        #[rpc(meta, name = "set_enable_ipv6")]
+        fn set_enable_ipv6(&self, Self::Metadata, bool) -> BoxFuture<(), Error>;
 
         /// Gets tunnel specific options
         #[rpc(meta, name = "get_tunnel_options")]
@@ -187,7 +187,7 @@ pub enum ManagementCommand {
     /// Set the mssfix argument for OpenVPN
     SetOpenVpnMssfix(OneshotSender<()>, Option<u16>),
     /// Set if IPv6 should be enabled in the tunnel
-    SetOpenVpnEnableIpv6(OneshotSender<()>, bool),
+    SetEnableIpv6(OneshotSender<()>, bool),
     /// Get the tunnel options
     GetTunnelOptions(OneshotSender<TunnelOptions>),
     /// Get information about the currently running and latest app versions
@@ -549,15 +549,11 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
         Box::new(future)
     }
 
-    fn set_openvpn_enable_ipv6(
-        &self,
-        _: Self::Metadata,
-        enable_ipv6: bool,
-    ) -> BoxFuture<(), Error> {
-        trace!("set_openvpn_enable_ipv6");
+    fn set_enable_ipv6(&self, _: Self::Metadata, enable_ipv6: bool) -> BoxFuture<(), Error> {
+        trace!("set_enable_ipv6");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
-            .send_command_to_daemon(ManagementCommand::SetOpenVpnEnableIpv6(tx, enable_ipv6))
+            .send_command_to_daemon(ManagementCommand::SetEnableIpv6(tx, enable_ipv6))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
 
         Box::new(future)

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -181,8 +181,8 @@ impl Settings {
     }
 
     pub fn set_enable_ipv6(&mut self, enable_ipv6: bool) -> Result<bool> {
-        if self.tunnel_options.openvpn.enable_ipv6 != enable_ipv6 {
-            self.tunnel_options.openvpn.enable_ipv6 = enable_ipv6;
+        if self.tunnel_options.enable_ipv6 != enable_ipv6 {
+            self.tunnel_options.enable_ipv6 = enable_ipv6;
             self.save().map(|_| true)
         } else {
             Ok(false)

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -180,7 +180,7 @@ impl Settings {
         }
     }
 
-    pub fn set_openvpn_enable_ipv6(&mut self, enable_ipv6: bool) -> Result<bool> {
+    pub fn set_enable_ipv6(&mut self, enable_ipv6: bool) -> Result<bool> {
         if self.tunnel_options.openvpn.enable_ipv6 != enable_ipv6 {
             self.tunnel_options.openvpn.enable_ipv6 = enable_ipv6;
             self.save().map(|_| true)

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -190,8 +190,8 @@ impl DaemonRpcClient {
         self.call("set_account", &[account])
     }
 
-    pub fn set_openvpn_enable_ipv6(&mut self, enabled: bool) -> Result<()> {
-        self.call("set_openvpn_enable_ipv6", &[enabled])
+    pub fn set_enable_ipv6(&mut self, enabled: bool) -> Result<()> {
+        self.call("set_enable_ipv6", &[enabled])
     }
 
     pub fn set_openvpn_mssfix(&mut self, mssfix: Option<u16>) -> Result<()> {

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -53,6 +53,7 @@ pub struct OpenVpnCommand {
     log: Option<PathBuf>,
     tunnel_options: net::OpenVpnTunnelOptions,
     tunnel_alias: Option<OsString>,
+    enable_ipv6: bool,
 }
 
 impl OpenVpnCommand {
@@ -71,6 +72,7 @@ impl OpenVpnCommand {
             log: None,
             tunnel_options: net::OpenVpnTunnelOptions::default(),
             tunnel_alias: None,
+            enable_ipv6: true,
         }
     }
 
@@ -142,6 +144,12 @@ impl OpenVpnCommand {
         self
     }
 
+    /// Configures if IPv6 should be allowed in the tunnel.
+    pub fn enable_ipv6(&mut self, enable_ipv6: bool) -> &mut Self {
+        self.enable_ipv6 = enable_ipv6;
+        self
+    }
+
     /// Returns all arguments that the subprocess would be spawned with.
     pub fn get_arguments(&self) -> Vec<OsString> {
         let mut args: Vec<OsString> = Self::base_arguments().iter().map(OsString::from).collect();
@@ -184,7 +192,7 @@ impl OpenVpnCommand {
             args.push(OsString::from(mssfix.to_string()));
         }
 
-        if !self.tunnel_options.enable_ipv6 {
+        if !self.enable_ipv6 {
             args.push(OsString::from("--pull-filter"));
             args.push(OsString::from("ignore"));
             args.push(OsString::from("route-ipv6"));

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -128,32 +128,33 @@ impl Error for TransportProtocolParseError {
 
 /// TunnelOptions holds optional settings for tunnels, that are to be applied to any tunnel of the
 /// appropriate type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TunnelOptions {
     /// openvpn holds OpenVPN specific tunnel options.
     pub openvpn: OpenVpnTunnelOptions,
+    /// Enable configuration of IPv6 on the tunnel interface, allowing IPv6 communication to be
+    /// forwarded through the tunnel. By default, this is set to `true`.
+    pub enable_ipv6: bool,
+}
+
+impl Default for TunnelOptions {
+    fn default() -> Self {
+        TunnelOptions {
+            openvpn: OpenVpnTunnelOptions::default(),
+            enable_ipv6: true,
+        }
+    }
 }
 
 
 /// OpenVpnTunnelOptions contains options for an openvpn tunnel that should be applied irrespective
 /// of the relay parameters - i.e. have nothing to do with the particular OpenVPN server, but do
 /// affect the connection.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct OpenVpnTunnelOptions {
     /// Optional argument for openvpn to try and limit TCP packet size,
     /// as discussed [here](https://openvpn.net/archive/openvpn-users/2003-11/msg00154.html)
     pub mssfix: Option<u16>,
-    /// Enable configuration of IPv6 on the tunnel interface, allowing IPv6 communication to be
-    /// forwarded through the tunnel. By default, this is set to `true`.
-    pub enable_ipv6: bool,
-}
-
-impl Default for OpenVpnTunnelOptions {
-    fn default() -> Self {
-        OpenVpnTunnelOptions {
-            mssfix: None,
-            enable_ipv6: true,
-        }
-    }
 }


### PR DESCRIPTION
Currently, there is an `enable_ipv6` parameter in `OpenVpnTunnelOptions`. However, this is a setting that will also be used in other tunnel types. Therefore, this PR moves the option into `TunnelOptions`, so that it becomes common to all tunnel types.

This PR originally started as part of PR #405, but it wasn't as small as I imagined. In order to make the review easier, I split it up so that it can be discussed incrementally.

The only user visible change is to the CLI. The `tunnel` sub-command now has the following sub-commands:

`tunnel get` (prints if IPv6 is enabled)
`tunnel set ipv6 {on,off}`
`tunnel openvpn set mssfix VALUE`
`tunnel openvpn get` (no longer prints if IPv6 is enabled)

One issue is that the settings file is now incompatible with the previous version. It will work correctly, but the `enable_ipv6` option will be reset to `true`. I'm not sure what would be the best way to handle this.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/409)
<!-- Reviewable:end -->
