### PR TITLE
Handle authentication failure event sent from OpenVPN plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,17 @@ dependencies = [
 [[package]]
 name = "openvpn-plugin"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event#6e2586030d6c8fb0e39d88769677a4085a1dd121"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openvpn-plugin"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1643,7 +1651,7 @@ dependencies = [
  "mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs)",
  "nftnl 0.1.0 (git+https://github.com/mullvad/nftnl-rs)",
  "notify 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
  "os_pipe 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pfctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1690,7 +1698,7 @@ dependencies = [
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
  "talpid-ipc 0.1.0",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2269,6 +2277,7 @@ dependencies = [
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6c24d3508b4fb6da175c10baac54c578b33f09c89ae90c6fe9788b3b4768efdc"
 "checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"
+"checksum openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)" = "<none>"
 "checksum openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f01f94fa077e8648fa20c654f6aef90e1a0feae5455a7b5d80c19eadeb97c7e8"
 "checksum os_pipe 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fe033225d563042c3eeb22ffd1d2ea1aefcc48e7e37151a064c9e0bae64b253f"
 "checksum os_pipe 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9d339267cdef39ee54ef165fdfaa2c7289a7465f0188ebe1c8a63872ca64c7"

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -39,10 +39,12 @@ type State = {
   showCopyIPMessage: boolean,
 };
 
-function getBlockReasonMessage(reason: BlockReason): string {
-  switch (reason) {
-    case 'auth_failed':
-      return 'Authentication failed';
+function getBlockReasonMessage(blockReason: BlockReason): string {
+  switch (blockReason.reason) {
+    case 'auth_failed': {
+      const details = blockReason.details ? `: {blockReason.details}` : '';
+      return `Authentication failed${details}`;
+    }
     case 'ipv6_unavailable':
       return 'Could not configure IPv6, please enable it on your system or disable it in the app';
     case 'set_security_policy_error':
@@ -52,7 +54,7 @@ function getBlockReasonMessage(reason: BlockReason): string {
     case 'no_matching_relay':
       return 'No relay server matches the current settings';
     default:
-      return `Unknown error: ${(reason: empty)}`;
+      return `Unknown error: ${(blockReason.reason: empty)}`;
   }
 }
 

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -41,6 +41,8 @@ type State = {
 
 function getBlockReasonMessage(reason: BlockReason): string {
   switch (reason) {
+    case 'auth_failed':
+      return 'Authentication failed';
     case 'ipv6_unavailable':
       return 'Could not configure IPv6, please enable it on your system or disable it in the app';
     case 'set_security_policy_error':

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -42,11 +42,14 @@ const LocationSchema = object({
 });
 
 export type BlockReason =
-  | 'auth_failed'
-  | 'ipv6_unavailable'
-  | 'set_security_policy_error'
-  | 'start_tunnel_error'
-  | 'no_matching_relay';
+  | {
+      reason:
+        | 'ipv6_unavailable'
+        | 'set_security_policy_error'
+        | 'start_tunnel_error'
+        | 'no_matching_relay',
+    }
+  | { reason: 'auth_failed', details: ?string };
 
 export type TunnelState = 'connecting' | 'connected' | 'disconnecting' | 'disconnected' | 'blocked';
 
@@ -230,17 +233,20 @@ const AccountDataSchema = object({
   expiry: string,
 });
 
-const allBlockReasons: Array<BlockReason> = [
-  'auth_failed',
-  'ipv6_unavailable',
-  'set_security_policy_error',
-  'start_tunnel_error',
-  'no_matching_relay',
-];
 const TunnelStateTransitionSchema = oneOf(
   object({
     state: enumeration('blocked'),
-    details: enumeration(...allBlockReasons),
+    details: oneOf(
+      object({
+        reason: enumeration(
+          'ipv6_unavailable',
+          'set_security_policy_error',
+          'start_tunnel_error',
+          'no_matching_relay',
+        ),
+      }),
+      object({ reason: enumeration('auth_failed'), details: maybe(string) }),
+    ),
   }),
   object({
     state: enumeration('connected', 'connecting', 'disconnected', 'disconnecting'),

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -42,6 +42,7 @@ const LocationSchema = object({
 });
 
 export type BlockReason =
+  | 'auth_failed'
   | 'ipv6_unavailable'
   | 'set_security_policy_error'
   | 'start_tunnel_error'
@@ -230,6 +231,7 @@ const AccountDataSchema = object({
 });
 
 const allBlockReasons: Array<BlockReason> = [
+  'auth_failed',
   'ipv6_unavailable',
   'set_security_policy_error',
   'start_tunnel_error',

--- a/gui/packages/desktop/test/components/Connect.spec.js
+++ b/gui/packages/desktop/test/components/Connect.spec.js
@@ -45,7 +45,7 @@ describe('components/Connect', () => {
       connection: {
         ...defaultProps.connection,
         status: 'blocked',
-        blockReason: 'no_matching_relay',
+        blockReason: { reason: 'no_matching_relay' },
       },
     });
 
@@ -157,7 +157,7 @@ describe('components/Connect', () => {
       connection: {
         ...defaultProps.connection,
         status: 'blocked',
-        blockReason: 'no_matching_relay',
+        blockReason: { reason: 'no_matching_relay' },
       },
     });
     const blockingAccordion = getComponent(component, 'blockingAccordion');

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -25,11 +25,11 @@ impl Command for Status {
         let mut rpc = new_rpc_client()?;
         let state = rpc.get_state()?;
 
-        print_state(state);
+        print_state(&state);
         print_location(&mut rpc)?;
         if matches.subcommand_matches("listen").is_some() {
             for new_state in rpc.new_state_subscribe()? {
-                print_state(new_state);
+                print_state(&new_state);
 
                 if new_state == Connected || new_state == Disconnected {
                     print_location(&mut rpc)?;
@@ -40,7 +40,7 @@ impl Command for Status {
     }
 }
 
-fn print_state(state: TunnelStateTransition) {
+fn print_state(state: &TunnelStateTransition) {
     print!("Tunnel status: ");
     match state {
         Blocked(reason) => println!("Blocked ({})", reason),

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -141,7 +141,7 @@ enum DaemonExecutionState {
 }
 
 impl DaemonExecutionState {
-    pub fn shutdown(&mut self, tunnel_state: TunnelStateTransition) {
+    pub fn shutdown(&mut self, tunnel_state: &TunnelStateTransition) {
         use self::DaemonExecutionState::*;
 
         match self {
@@ -336,9 +336,9 @@ impl Daemon {
             _ => {}
         }
 
-        self.tunnel_state = tunnel_state;
+        self.tunnel_state = tunnel_state.clone();
         self.management_interface_broadcaster
-            .notify_new_state(self.tunnel_state);
+            .notify_new_state(tunnel_state);
     }
 
     fn handle_management_interface_event(&mut self, event: ManagementCommand) {
@@ -376,7 +376,7 @@ impl Daemon {
     }
 
     fn on_get_state(&self, tx: OneshotSender<TunnelStateTransition>) {
-        Self::oneshot_send(tx, self.tunnel_state, "current state");
+        Self::oneshot_send(tx, self.tunnel_state.clone(), "current state");
     }
 
     fn on_get_current_location(&self, tx: OneshotSender<GeoIpLocation>) {
@@ -556,7 +556,7 @@ impl Daemon {
     }
 
     fn handle_trigger_shutdown_event(&mut self) {
-        self.state.shutdown(self.tunnel_state);
+        self.state.shutdown(&self.tunnel_state);
         self.disconnect_tunnel();
     }
 

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -238,7 +238,7 @@ impl DaemonRpcClient {
                 .chain(polled)
                 .for_each(move |state| {
                     if state != current_state {
-                        current_state = state;
+                        current_state = state.clone();
                         if tx.send(state).is_err() {
                             trace!("can't send new state to subscriber");
                             return Err(jsonrpc_client_core::ErrorKind::Shutdown.into());

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -15,7 +15,7 @@ jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ip
 
 libc = "0.2.20"
 log = "0.4"
-openvpn-plugin = { version = "0.3", features = ["serde"] }
+openvpn-plugin = { git = "https://github.com/mullvad/openvpn-plugin-rs", branch = "auth-failed-event", features = ["serde"] }
 os_pipe = "0.7"
 shell-escape = "0.1"
 tokio-core = "0.1"

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -79,6 +79,8 @@ error_chain!{
 /// Possible events from the VPN tunnel and the child process managing it.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum TunnelEvent {
+    /// Sent when the tunnel fails to connect due to an authentication error.
+    AuthFailed,
     /// Sent when the tunnel comes up and is ready for traffic.
     Up(TunnelMetadata),
     /// Sent when the tunnel goes down.
@@ -104,6 +106,7 @@ impl TunnelEvent {
         env: &HashMap<String, String>,
     ) -> Option<TunnelEvent> {
         match *event {
+            OpenVpnPluginEvent::AuthFailed => Some(TunnelEvent::AuthFailed),
             OpenVpnPluginEvent::Up => {
                 let interface = env
                     .get("dev")

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -80,7 +80,7 @@ error_chain!{
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum TunnelEvent {
     /// Sent when the tunnel fails to connect due to an authentication error.
-    AuthFailed,
+    AuthFailed(Option<String>),
     /// Sent when the tunnel comes up and is ready for traffic.
     Up(TunnelMetadata),
     /// Sent when the tunnel goes down.
@@ -106,7 +106,10 @@ impl TunnelEvent {
         env: &HashMap<String, String>,
     ) -> Option<TunnelEvent> {
         match *event {
-            OpenVpnPluginEvent::AuthFailed => Some(TunnelEvent::AuthFailed),
+            OpenVpnPluginEvent::AuthFailed => {
+                let reason = env.get("auth_failed_reason").cloned();
+                Some(TunnelEvent::AuthFailed(reason))
+            }
             OpenVpnPluginEvent::Up => {
                 let interface = env
                     .get("dev")

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -246,13 +246,13 @@ impl ConnectingState {
         use self::EventConsequence::*;
 
         match try_handle_event!(self, self.tunnel_events.poll()) {
-            Ok(TunnelEvent::AuthFailed) => NewState(DisconnectingState::enter(
+            Ok(TunnelEvent::AuthFailed(reason)) => NewState(DisconnectingState::enter(
                 shared_values,
                 (
                     self.close_handle,
                     self.tunnel_close_event,
                     AfterDisconnect::Block(
-                        BlockReason::AuthFailed,
+                        BlockReason::AuthFailed(reason),
                         self.tunnel_parameters.allow_lan,
                     ),
                 ),

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -246,6 +246,17 @@ impl ConnectingState {
         use self::EventConsequence::*;
 
         match try_handle_event!(self, self.tunnel_events.poll()) {
+            Ok(TunnelEvent::AuthFailed) => NewState(DisconnectingState::enter(
+                shared_values,
+                (
+                    self.close_handle,
+                    self.tunnel_close_event,
+                    AfterDisconnect::Block(
+                        BlockReason::AuthFailed,
+                        self.tunnel_parameters.allow_lan,
+                    ),
+                ),
+            )),
             Ok(TunnelEvent::Up(metadata)) => NewState(ConnectedState::enter(
                 shared_values,
                 self.into_connected_state_bootstrap(metadata),

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -18,7 +18,7 @@ tokio-reactor = "0.1"
 tokio = "0.1"
 futures = "0.1"
 
-openvpn-plugin = { version = "0.3", features = ["serde", "log"] }
+openvpn-plugin = { git = "https://github.com/mullvad/openvpn-plugin-rs", branch = "auth-failed-event", features = ["serde", "log"] }
 talpid-ipc = { path = "../talpid-ipc" }
 
 

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -55,8 +55,11 @@ error_chain!{
 
 /// All the OpenVPN events this plugin will register for listening to. Edit this variable to change
 /// events.
-pub static INTERESTING_EVENTS: &'static [OpenVpnPluginEvent] =
-    &[OpenVpnPluginEvent::Up, OpenVpnPluginEvent::RoutePredown];
+pub static INTERESTING_EVENTS: &'static [OpenVpnPluginEvent] = &[
+    OpenVpnPluginEvent::AuthFailed,
+    OpenVpnPluginEvent::Up,
+    OpenVpnPluginEvent::RoutePredown,
+];
 
 openvpn_plugin!(
     ::openvpn_open,

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -29,9 +29,10 @@ impl TunnelStateTransition {
 /// Reason for entering the blocked state.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[serde(tag = "reason", content = "details")]
 pub enum BlockReason {
     /// Authentication with remote server failed.
-    AuthFailed,
+    AuthFailed(Option<String>),
     /// Failed to configure IPv6 because it's disabled in the platform.
     Ipv6Unavailable,
     /// Failed to set security policy.
@@ -45,7 +46,16 @@ pub enum BlockReason {
 impl fmt::Display for BlockReason {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let description = match *self {
-            BlockReason::AuthFailed => "Authentication with remote server failed",
+            BlockReason::AuthFailed(ref reason) => {
+                return write!(
+                    formatter,
+                    "Authentication with remote server failed: {}",
+                    match reason {
+                        Some(ref reason) => reason.as_str(),
+                        None => "No reason provided",
+                    }
+                );
+            }
             BlockReason::Ipv6Unavailable => {
                 "Failed to configure IPv6 because it's disabled in the platform"
             }

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// Event resulting from a transition to a new tunnel state.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "state", content = "details")]
 pub enum TunnelStateTransition {
@@ -27,7 +27,7 @@ impl TunnelStateTransition {
 }
 
 /// Reason for entering the blocked state.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockReason {
     /// Authentication with remote server failed.

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -30,6 +30,8 @@ impl TunnelStateTransition {
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockReason {
+    /// Authentication with remote server failed.
+    AuthFailed,
     /// Failed to configure IPv6 because it's disabled in the platform.
     Ipv6Unavailable,
     /// Failed to set security policy.
@@ -43,6 +45,7 @@ pub enum BlockReason {
 impl fmt::Display for BlockReason {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let description = match *self {
+            BlockReason::AuthFailed => "Authentication with remote server failed",
             BlockReason::Ipv6Unavailable => {
                 "Failed to configure IPv6 because it's disabled in the platform"
             }


### PR DESCRIPTION
This PR adds support for handling authentication failure events from the OpenVPN plugin. These events are generated when the server refuses the connection because the client authentication fails. They may optionally also include a reason message with more details about why the authentication failed.

When such an event is received in the `ConnectingState`, the state machine moves to the `BlockedState`, so that the error and the authentication failure reason is sent to the frontend clients. In the GUI, the error and the reason are shown in an error screen.

The state change event that is sent to the frontend clients changes in this PR because the authentication failure reason string must be included in it. The major consequences are that `TunnelStateTransition` no longer implements `Copy`, and that the (de)serialization of the `BlockReason` has changed to include a `reason` field in all variations and an `details` field in the authentication failure variant.

I haven't yet tested with an actual AUTH_FAILED event sent from an OpenVPN server instance.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not user visible.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/410)
<!-- Reviewable:end -->
