### PR TITLE
Blocked state block network

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -604,8 +604,9 @@ impl Daemon {
     }
 
     fn connect_tunnel(&mut self) {
+        let allow_lan = self.settings.get_allow_lan();
         let command = match self.settings.get_account_token() {
-            None => TunnelCommand::Block(BlockReason::NoAccountToken),
+            None => TunnelCommand::Block(BlockReason::NoAccountToken, allow_lan),
             Some(account_token) => match self.settings.get_relay_settings() {
                 RelaySettings::CustomTunnelEndpoint(custom_relay) => custom_relay
                     .to_tunnel_endpoint()
@@ -622,7 +623,7 @@ impl Daemon {
             .map(|parameters| TunnelCommand::Connect(parameters))
             .unwrap_or_else(|error| {
                 error!("{}", error.display_chain());
-                TunnelCommand::Block(BlockReason::NoMatchingRelay)
+                TunnelCommand::Block(BlockReason::NoMatchingRelay, allow_lan)
             }),
         };
         self.send_tunnel_command(command);

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -147,6 +147,13 @@ impl MacosNetworkSecurity {
                 }
                 Ok(rules)
             }
+            SecurityPolicy::Blocked { allow_lan } => {
+                let mut rules = Vec::new();
+                if allow_lan {
+                    rules.append(&mut Self::get_allow_lan_rules()?);
+                }
+                Ok(rules)
+            }
         }
     }
 

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -36,6 +36,12 @@ pub enum SecurityPolicy {
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
     },
+
+    /// Block all network traffic in and out from the computer.
+    Blocked {
+        /// Flag setting if communication with LAN networks should be possible.
+        allow_lan: bool,
+    },
 }
 
 /// Abstract firewall interaction trait

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -277,9 +277,7 @@ mod winfw {
         ) -> ApplyConnectedResult;
 
         #[link_name(WinFw_ApplyPolicyBlocked)]
-        pub fn WinFw_ApplyPolicyBlocked(
-            settings: &WinFwSettings,
-        ) -> ApplyBlockedResult;
+        pub fn WinFw_ApplyPolicyBlocked(settings: &WinFwSettings) -> ApplyBlockedResult;
 
         #[link_name(WinFw_Reset)]
         pub fn WinFw_Reset() -> ResettingPolicyResult;

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -19,30 +19,35 @@ mod system_state;
 
 use self::dns::WinDns;
 
-error_chain!{
-    errors{
+error_chain! {
+    errors {
         /// Failure to initialize windows firewall module
-        Initialization{
+        Initialization {
             description("Failed to initialise windows firewall module")
         }
 
         /// Failure to deinitialize windows firewall module
-        Deinitialization{
+        Deinitialization {
             description("Failed to deinitialize windows firewall module")
         }
 
-        /// Failure to apply a firewall _connected_ policy
-        ApplyingConnectedPolicy{
+        /// Failure to apply a firewall _connecting_ policy
+        ApplyingConnectingPolicy {
             description("Failed to apply firewall policy for when the daemon is connecting to a tunnel")
         }
 
-        /// Failure to apply a firewall _connecting_ policy
-        ApplyingConnectingPolicy{
+        /// Failure to apply a firewall _connected_ policy
+        ApplyingConnectedPolicy {
             description("Failed to apply firewall policy for when the daemon is connected to a tunnel")
         }
 
+        /// Failure to apply firewall _blocked_ policy
+        ApplyingBlockedPolicy {
+            description("Failed to apply blocked security policy")
+        }
+
         /// Failure to reset firewall policies
-        ResettingPolicy{
+        ResettingPolicy {
             description("Failed to reset firewall policies")
         }
     }
@@ -92,6 +97,10 @@ impl NetworkSecurity for WindowsNetworkSecurity {
             } => {
                 let cfg = &WinFwSettings::new(allow_lan);
                 self.set_connected_state(&relay_endpoint, &cfg, &tunnel)
+            }
+            SecurityPolicy::Blocked { allow_lan } => {
+                let cfg = &WinFwSettings::new(allow_lan);
+                self.set_blocked_state(&cfg)
             }
         }
     }
@@ -177,6 +186,11 @@ impl WindowsNetworkSecurity {
             ).into_result()
         }
     }
+
+    fn set_blocked_state(&mut self, winfw_settings: &WinFwSettings) -> Result<()> {
+        trace!("Applying 'blocked' firewall policy");
+        unsafe { WinFw_ApplyPolicyBlocked(winfw_settings).into_result() }
+    }
 }
 
 
@@ -227,13 +241,14 @@ mod winfw {
     ffi_error!(InitializationResult, ErrorKind::Initialization.into());
     ffi_error!(DeinitializationResult, ErrorKind::Deinitialization.into());
     ffi_error!(
-        ApplyConnectedResult,
-        ErrorKind::ApplyingConnectedPolicy.into()
-    );
-    ffi_error!(
         ApplyConnectingResult,
         ErrorKind::ApplyingConnectingPolicy.into()
     );
+    ffi_error!(
+        ApplyConnectedResult,
+        ErrorKind::ApplyingConnectedPolicy.into()
+    );
+    ffi_error!(ApplyBlockedResult, ErrorKind::ApplyingBlockedPolicy.into());
     ffi_error!(ResettingPolicyResult, ErrorKind::ResettingPolicy.into());
 
     extern "system" {
@@ -260,6 +275,11 @@ mod winfw {
             tunnelIfaceAlias: *const libc::wchar_t,
             primaryDns: *const libc::wchar_t,
         ) -> ApplyConnectedResult;
+
+        #[link_name(WinFw_ApplyPolicyBlocked)]
+        pub fn WinFw_ApplyPolicyBlocked(
+            settings: &WinFwSettings,
+        ) -> ApplyBlockedResult;
 
         #[link_name(WinFw_Reset)]
         pub fn WinFw_Reset() -> ResettingPolicyResult;

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -1,23 +1,40 @@
+use error_chain::ChainedError;
 use futures::sync::mpsc;
 use futures::Stream;
 
 use talpid_types::tunnel::BlockReason;
 
 use super::{
-    ConnectingState, DisconnectedState, EventConsequence, SharedTunnelStateValues, TunnelCommand,
-    TunnelState, TunnelStateTransition, TunnelStateWrapper,
+    ConnectingState, DisconnectedState, EventConsequence, ResultExt, SharedTunnelStateValues,
+    TunnelCommand, TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
+use security::{NetworkSecurity, SecurityPolicy};
 
 /// No tunnel is running and all network connections are blocked.
 pub struct BlockedState;
 
+impl BlockedState {
+    fn set_security_policy(shared_values: &mut SharedTunnelStateValues, allow_lan: bool) {
+        let policy = SecurityPolicy::Blocked { allow_lan };
+        debug!("Setting security policy: {:?}", policy);
+        if let Err(error) = shared_values
+            .security
+            .apply_policy(policy)
+            .chain_err(|| "Failed to apply security policy for blocked state")
+        {
+            error!("{}", error.display_chain());
+        }
+    }
+}
+
 impl TunnelState for BlockedState {
-    type Bootstrap = BlockReason;
+    type Bootstrap = (BlockReason, bool);
 
     fn enter(
-        _: &mut SharedTunnelStateValues,
-        block_reason: Self::Bootstrap,
+        shared_values: &mut SharedTunnelStateValues,
+        (block_reason, allow_lan): Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
+        Self::set_security_policy(shared_values, allow_lan);
         (
             TunnelStateWrapper::from(BlockedState),
             TunnelStateTransition::Blocked(block_reason),
@@ -32,16 +49,19 @@ impl TunnelState for BlockedState {
         use self::EventConsequence::*;
 
         match try_handle_event!(self, commands.poll()) {
+            Ok(TunnelCommand::AllowLan(allow_lan)) => {
+                Self::set_security_policy(shared_values, allow_lan);
+                SameState(self)
+            }
             Ok(TunnelCommand::Connect(parameters)) => {
                 NewState(ConnectingState::enter(shared_values, parameters))
             }
             Ok(TunnelCommand::Disconnect) | Err(_) => {
                 NewState(DisconnectedState::enter(shared_values, ()))
             }
-            Ok(TunnelCommand::Block(reason)) => {
-                NewState(BlockedState::enter(shared_values, reason))
+            Ok(TunnelCommand::Block(reason, allow_lan)) => {
+                NewState(BlockedState::enter(shared_values, (reason, allow_lan)))
             }
-            _ => SameState(self),
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -79,7 +79,10 @@ impl ConnectedState {
                             (
                                 self.close_handle,
                                 self.tunnel_close_event,
-                                AfterDisconnect::Block(BlockReason::SetSecurityPolicyError),
+                                AfterDisconnect::Block(
+                                    BlockReason::SetSecurityPolicyError,
+                                    allow_lan,
+                                ),
                             ),
                         ))
                     }
@@ -107,12 +110,12 @@ impl ConnectedState {
                     AfterDisconnect::Nothing,
                 ),
             )),
-            Ok(TunnelCommand::Block(reason)) => NewState(DisconnectingState::enter(
+            Ok(TunnelCommand::Block(reason, allow_lan)) => NewState(DisconnectingState::enter(
                 shared_values,
                 (
                     self.close_handle,
                     self.tunnel_close_event,
-                    AfterDisconnect::Block(reason),
+                    AfterDisconnect::Block(reason, allow_lan),
                 ),
             )),
         }
@@ -179,7 +182,10 @@ impl TunnelState for ConnectedState {
                     (
                         connected_state.close_handle,
                         connected_state.tunnel_close_event,
-                        AfterDisconnect::Block(BlockReason::SetSecurityPolicyError),
+                        AfterDisconnect::Block(
+                            BlockReason::SetSecurityPolicyError,
+                            connected_state.tunnel_parameters.allow_lan,
+                        ),
                     ),
                 )
             }

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -47,8 +47,8 @@ impl TunnelState for DisconnectedState {
             Ok(TunnelCommand::Connect(parameters)) => {
                 NewState(ConnectingState::enter(shared_values, parameters))
             }
-            Ok(TunnelCommand::Block(reason)) => {
-                NewState(BlockedState::enter(shared_values, reason))
+            Ok(TunnelCommand::Block(reason, allow_lan)) => {
+                NewState(BlockedState::enter(shared_values, (reason, allow_lan)))
             }
             Ok(_) => SameState(self),
             Err(_) => Finished,

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -111,7 +111,7 @@ pub enum TunnelCommand {
     /// Close tunnel connection.
     Disconnect,
     /// Disconnect any open tunnel and block all network access
-    Block(BlockReason),
+    Block(BlockReason, bool),
 }
 
 /// Information necessary to open a tunnel.


### PR DESCRIPTION
Up until this PR the new blocked state didn't actually do anything other than waiting for being told to exit itself again. This PR adds so that entering the blocked state activates a new blocked security policy.

Sadly the number of `allow_lan` we have to pass around kind of exploded. Maybe we can fix that in some way, but I did not try that in this PR.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/411)
<!-- Reviewable:end -->
