### PR TITLE
Reconnect to daemon in GUI no matter what

### DIFF
--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -305,7 +305,6 @@ export interface DaemonRpcProtocol {
   subscribeStateListener((state: ?TunnelState, error: ?Error) => void): Promise<void>;
   addOpenConnectionObserver(() => void): ConnectionObserver;
   addCloseConnectionObserver((error: ?Error) => void): ConnectionObserver;
-  authenticate(sharedSecret: string): Promise<void>;
   getAccountHistory(): Promise<Array<AccountToken>>;
   removeAccountFromHistory(accountToken: AccountToken): Promise<void>;
   getCurrentVersion(): Promise<string>;
@@ -334,10 +333,6 @@ const NETWORK_CALL_TIMEOUT = 10000;
 
 export class DaemonRpc implements DaemonRpcProtocol {
   _transport = new JsonRpcClient(new SocketTransport());
-
-  async authenticate(sharedSecret: string): Promise<void> {
-    await this._transport.send('auth', sharedSecret);
-  }
 
   connect(connectionParams: { path: string }) {
     this._transport.connect(connectionParams);


### PR DESCRIPTION
I've made sure that when using the IPC transport for JSON-RPC, we will always reconnect to the daemon. I've also made sure that the socket transport doesn't call `onClose` more than once after `connect` has been called, otherwise the app will try to connect as many times as `onClose` is called. This should make the error handling around the socket transport less insane.

I've also pruned some last bits of the auth code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/412)
<!-- Reviewable:end -->
