### PR TITLE
Allow SSDP/WS-discovery multicast IP, for chromecasts etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for Ubuntu 14.04 and other distributions that use the Upstart init system.
 - Make scrollbar thumb draggable.
 - Ability to expand cities with multiple servers and configure the app to use a specific server.
+- Add firewall rules allowing traffic to the SSDP/WS-discover multicast IP, 239.255.255.250, if
+  local area network sharing is activated. This allows discovery of devices using these protocols.
 
 #### Windows
 - Extend uninstaller to also remove logs, cache and optionally settings.

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -309,7 +309,6 @@ impl<'a> PolicyBatch<'a> {
                 let mut rule = Rule::new(chain)?;
                 check_net(&mut rule, End::Src, IpNetwork::V4(*net))?;
                 check_net(&mut rule, End::Dst, IpNetwork::V4(*net))?;
-
                 add_verdict(&mut rule, Verdict::Accept)?;
 
                 self.batch.add(&rule, nftnl::MsgType::Add)?;
@@ -320,12 +319,18 @@ impl<'a> PolicyBatch<'a> {
             let mut rule = Rule::new(&self.out_chain)?;
             check_net(&mut rule, End::Src, IpNetwork::V4(*net))?;
             check_net(&mut rule, End::Dst, IpNetwork::V4(*super::MULTICAST_NET))?;
+            add_verdict(&mut rule, Verdict::Accept)?;
 
+            self.batch.add(&rule, nftnl::MsgType::Add)?;
+
+            // LAN -> SSDP + WS-Discovery protocols
+            let mut rule = Rule::new(&self.out_chain)?;
+            check_net(&mut rule, End::Src, IpNetwork::V4(*net))?;
+            check_ip(&mut rule, End::Dst, *super::SSDP_IP)?;
             add_verdict(&mut rule, Verdict::Accept)?;
 
             self.batch.add(&rule, nftnl::MsgType::Add)?;
         }
-
         Ok(())
     }
 }

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -207,8 +207,10 @@ impl NetworkSecurity {
                 .to(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V4(
                     *super::MULTICAST_NET,
                 )))).build()?;
+            let allow_ssdp = rule_builder.to(pfctl::Ip::from(*super::SSDP_IP)).build()?;
             rules.push(allow_net);
             rules.push(allow_multicast);
+            rules.push(allow_ssdp);
         }
         Ok(rules)
     }

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -2,7 +2,7 @@
 use ipnetwork::Ipv4Network;
 use std::fmt;
 #[cfg(unix)]
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
 use talpid_types::net::Endpoint;
 
@@ -31,6 +31,7 @@ lazy_static! {
     ];
     static ref MULTICAST_NET: Ipv4Network =
         Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap();
+    static ref SSDP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(239, 255, 255, 250));
 }
 
 /// A enum that describes network security strategy

--- a/windows/winfw/src/winfw/rules/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/permitlan.cpp
@@ -89,6 +89,7 @@ bool PermitLan::apply(IObjectInstaller &objectInstaller)
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 172, 16, 0, 0 }), uint8_t(12)));
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 192, 168, 0, 0 }), uint8_t(16)));
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 224, 0, 0, 0 }), uint8_t(24)));
+	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 239, 255, 255, 250 }), uint8_t(32)));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }


### PR DESCRIPTION
If users have enabled local area network sharing they probably want to be able to reach their chromecasts, sonos speakers, network printers and other devices using the SSDP or WS-discovery protocols. This PR adds a firewall rule (if LAN sharing is active) that allows packets **out** from the computer if the source IP is a private network and the destination IP is the special multicast IP these protocols use: 239.255.255.250

https://en.wikipedia.org/wiki/Simple_Service_Discovery_Protocol
https://en.wikipedia.org/wiki/WS-Discovery

This still requires some testing and security scrutiny before we can be fully sure this will work and is safe. But getting the PR published makes it easier to progress from here.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/413)
<!-- Reviewable:end -->
