### PR TITLE
Move firewall logging and make nicer

### DIFF
--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -18,7 +18,7 @@ use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
 
-use super::{NetworkSecurity, SecurityPolicy};
+use super::{NetworkSecurityT, SecurityPolicy};
 
 mod dns;
 use self::dns::DnsSettings;
@@ -71,17 +71,17 @@ enum End {
     Dst,
 }
 
-/// The Linux implementation for the `NetworkSecurity` trait.
-pub struct LinuxNetworkSecurity {
+/// The Linux implementation for the firewall and DNS.
+pub struct NetworkSecurity {
     dns_settings: DnsSettings,
     table_name: CString,
 }
 
-impl NetworkSecurity for LinuxNetworkSecurity {
+impl NetworkSecurityT for NetworkSecurity {
     type Error = Error;
 
     fn new(_cache_dir: impl AsRef<Path>) -> Result<Self> {
-        Ok(LinuxNetworkSecurity {
+        Ok(NetworkSecurity {
             dns_settings: DnsSettings::new()?,
             table_name: TABLE_NAME.clone(),
         })
@@ -117,7 +117,7 @@ impl NetworkSecurity for LinuxNetworkSecurity {
     }
 }
 
-impl LinuxNetworkSecurity {
+impl NetworkSecurity {
     fn send_and_process(&self, batch: &FinalizedBatch) -> Result<()> {
         let socket =
             mnl::Socket::new(mnl::Bus::Netfilter).chain_err(|| ErrorKind::NetlinkOpenError)?;

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -1,7 +1,7 @@
 extern crate pfctl;
 extern crate tokio_core;
 
-use super::{NetworkSecurity, SecurityPolicy};
+use super::{NetworkSecurityT, SecurityPolicy};
 
 use ipnetwork::IpNetwork;
 
@@ -26,17 +26,17 @@ error_chain! {
 const ANCHOR_NAME: &'static str = "mullvad";
 
 /// The macOS firewall and DNS implementation.
-pub struct MacosNetworkSecurity {
+pub struct NetworkSecurity {
     pf: pfctl::PfCtl,
     pf_was_enabled: Option<bool>,
     dns_monitor: DnsMonitor,
 }
 
-impl NetworkSecurity for MacosNetworkSecurity {
+impl NetworkSecurityT for NetworkSecurity {
     type Error = Error;
 
     fn new(_cache_dir: impl AsRef<Path>) -> Result<Self> {
-        Ok(MacosNetworkSecurity {
+        Ok(NetworkSecurity {
             pf: pfctl::PfCtl::new()?,
             pf_was_enabled: None,
             dns_monitor: DnsMonitor::new()?,
@@ -61,7 +61,7 @@ impl NetworkSecurity for MacosNetworkSecurity {
     }
 }
 
-impl MacosNetworkSecurity {
+impl NetworkSecurity {
     fn set_rules(&mut self, policy: SecurityPolicy) -> Result<()> {
         let mut new_filter_rules = vec![];
 

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -5,6 +5,22 @@ use std::net::Ipv4Addr;
 use std::path::Path;
 use talpid_types::net::Endpoint;
 
+
+#[cfg(target_os = "macos")]
+#[path = "macos/mod.rs"]
+mod imp;
+
+#[cfg(target_os = "linux")]
+#[path = "linux/mod.rs"]
+mod imp;
+
+#[cfg(windows)]
+#[path = "windows/mod.rs"]
+mod imp;
+
+pub use self::imp::{Error, ErrorKind};
+
+
 #[cfg(unix)]
 lazy_static! {
     static ref PRIVATE_NETS: [Ipv4Network; 3] = [
@@ -44,8 +60,38 @@ pub enum SecurityPolicy {
     },
 }
 
-/// Abstract firewall interaction trait
-pub trait NetworkSecurity: Sized {
+/// Manages network security of the computer/device. Can apply and enforce security policies
+/// by manipulating the OS firewall and DNS settings.
+pub struct NetworkSecurity {
+    inner: imp::NetworkSecurity,
+}
+
+impl NetworkSecurity {
+    /// Returns a new `NetworkSecurity`, ready to apply policies.
+    pub fn new(cache_dir: impl AsRef<Path>) -> Result<Self, Error> {
+        Ok(NetworkSecurity {
+            inner: imp::NetworkSecurity::new(cache_dir)?,
+        })
+    }
+
+    /// Applies and starts enforcing the given `SecurityPolicy` Makes sure it is being kept in place
+    /// until this method is called again with another policy, or until `reset_policy` is called.
+    pub fn apply_policy(&mut self, policy: SecurityPolicy) -> Result<(), Error> {
+        debug!("Setting security policy: {:?}", policy);
+        self.inner.apply_policy(policy)
+    }
+
+    /// Resets/removes any currently enforced `SecurityPolicy`. Returns the system to the same state
+    /// it had before any policy was applied through this `NetworkSecurity` instance.
+    pub fn reset_policy(&mut self) -> Result<(), Error> {
+        debug!("Resetting security policy");
+        self.inner.reset_policy()
+    }
+}
+
+
+/// Abstract firewall interaction trait. Used by the OS specific implementations.
+trait NetworkSecurityT: Sized {
     /// The error type thrown by the implementer of this trait
     type Error: ::std::error::Error;
 
@@ -59,19 +105,3 @@ pub trait NetworkSecurity: Sized {
     /// modifying the system.
     fn reset_policy(&mut self) -> ::std::result::Result<(), Self::Error>;
 }
-
-
-#[cfg(target_os = "macos")]
-mod macos;
-#[cfg(target_os = "macos")]
-pub use self::macos::{Error, ErrorKind, MacosNetworkSecurity as NetworkSecurityImpl, Result};
-
-#[cfg(target_os = "linux")]
-mod linux;
-#[cfg(target_os = "linux")]
-pub use self::linux::{Error, ErrorKind, LinuxNetworkSecurity as NetworkSecurityImpl, Result};
-
-#[cfg(windows)]
-mod windows;
-#[cfg(windows)]
-pub use self::windows::{Error, ErrorKind, Result, WindowsNetworkSecurity as NetworkSecurityImpl};

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -8,7 +8,7 @@ use super::{
     ConnectingState, DisconnectedState, EventConsequence, ResultExt, SharedTunnelStateValues,
     TunnelCommand, TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
-use security::{NetworkSecurity, SecurityPolicy};
+use security::SecurityPolicy;
 
 /// No tunnel is running and all network connections are blocked.
 pub struct BlockedState;
@@ -16,7 +16,6 @@ pub struct BlockedState;
 impl BlockedState {
     fn set_security_policy(shared_values: &mut SharedTunnelStateValues, allow_lan: bool) {
         let policy = SecurityPolicy::Blocked { allow_lan };
-        debug!("Setting security policy: {:?}", policy);
         if let Err(error) = shared_values
             .security
             .apply_policy(policy)

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -10,7 +10,7 @@ use super::{
     SharedTunnelStateValues, TunnelCommand, TunnelParameters, TunnelState, TunnelStateTransition,
     TunnelStateWrapper,
 };
-use security::{NetworkSecurity, SecurityPolicy};
+use security::SecurityPolicy;
 use tunnel::{CloseHandle, TunnelEvent, TunnelMetadata};
 
 pub struct ConnectedStateBootstrap {
@@ -50,8 +50,6 @@ impl ConnectedState {
             tunnel: self.metadata.clone(),
             allow_lan: self.tunnel_parameters.allow_lan,
         };
-
-        debug!("Setting security policy: {:?}", policy);
         shared_values
             .security
             .apply_policy(policy)

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -18,7 +18,7 @@ use super::{
     TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
 use logging;
-use security::{NetworkSecurity, SecurityPolicy};
+use security::SecurityPolicy;
 use tunnel::{CloseHandle, TunnelEvent, TunnelMetadata, TunnelMonitor};
 
 const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
@@ -63,8 +63,6 @@ impl ConnectingState {
             relay_endpoint: endpoint.to_endpoint(),
             allow_lan,
         };
-
-        debug!("Setting security policy: {:?}", policy);
         shared_values
             .security
             .apply_policy(policy)

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -6,14 +6,12 @@ use super::{
     BlockedState, ConnectingState, Error, EventConsequence, SharedTunnelStateValues, TunnelCommand,
     TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
-use security::NetworkSecurity;
 
 /// No tunnel is running.
 pub struct DisconnectedState;
 
 impl DisconnectedState {
     fn reset_security_policy(shared_values: &mut SharedTunnelStateValues) {
-        debug!("Resetting security policy");
         if let Err(error) = shared_values.security.reset_policy() {
             let chained_error = Error::with_chain(error, "Failed to reset security policy");
             error!("{}", chained_error.display_chain());

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -26,7 +26,7 @@ use self::connecting_state::ConnectingState;
 use self::disconnected_state::DisconnectedState;
 use self::disconnecting_state::{AfterDisconnect, DisconnectingState};
 use super::mpsc::IntoSender;
-use super::security::{NetworkSecurity, NetworkSecurityImpl};
+use super::security::NetworkSecurity;
 
 error_chain! {
     errors {
@@ -149,7 +149,7 @@ impl TunnelStateMachine {
         commands: mpsc::UnboundedReceiver<TunnelCommand>,
     ) -> Result<Self> {
         let security =
-            NetworkSecurityImpl::new(cache_dir).chain_err(|| ErrorKind::NetworkSecurityError)?;
+            NetworkSecurity::new(cache_dir).chain_err(|| ErrorKind::NetworkSecurityError)?;
         let mut shared_values = SharedTunnelStateValues { security };
 
         let initial_state = TunnelStateWrapper::new(&mut shared_values, ());
@@ -214,7 +214,7 @@ impl<T: TunnelState> From<EventConsequence<T>> for TunnelStateMachineAction {
 
 /// Values that are common to all tunnel states.
 struct SharedTunnelStateValues {
-    security: NetworkSecurityImpl,
+    security: NetworkSecurity,
 }
 
 /// Asynchronous result of an attempt to progress a state.

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -80,6 +80,12 @@ impl Endpoint {
     }
 }
 
+impl fmt::Display for Endpoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}:{}", self.address, self.protocol)
+    }
+}
+
 /// Representation of a transport protocol, either UDP or TCP.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
I noticed that for basically every place where we called `apply_policy(some_policy)` we first debug logged the policy. This felt like a lot of duplication and prone to missing an invocation or two. On top of that, I think major state changing events should be logged beautifully to the `info` level rather than just `debug`.

As such I created a unified wrapper for all the network security implementations and made that one log for us. This has the benefit that we have one single, not conditionally compiled, type that we expose from the `security` module. This design is very common in the standard library as well. Look for example at `std::sync::Mutex` (https://doc.rust-lang.org/src/std/sync/mutex.rs.html#121-130) which is basically just a wrapper type for the OS specific mutex implementation.

Now every user must not also import the trait into context to use the methods, because the methods on the exposed type are implemented directly on the type, and the trait is not even visible outside the `security` module.

I also implemented the `Display` attribute for the `SecurityPolicy` type, so we could log it without debug logging and be nicer to read. With this implementation the logging entries look something like this:

```
[talpid_core::security][INFO] Applying security policy: Connecting to 182.211.124.133:1196:UDP, Allowing LAN
[talpid_core::security][INFO] Applying security policy: Connected to 182.211.124.133:1196:UDP over "tun0" (ip: 10.11.0.8, gw: 10.11.0.1), Allowing LAN
[talpid_core::security][INFO] Resetting security policy
[talpid_core::security][INFO] Applying security policy: Blocked, Allowing LAN
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/415)
<!-- Reviewable:end -->
