### PR TITLE
Fix bug that ignored hostname in location constraint filter

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -262,12 +262,11 @@ impl RelaySelector {
                 })
             }
             Constraint::Only(LocationConstraint::Hostname(ref country, ref city, ref hostname)) => {
-                relay
-                    .location
-                    .as_ref()
-                    .map_or(relay.hostname == *hostname, |loc| {
-                        loc.country_code == *country && loc.city_code == *city
-                    })
+                relay.location.as_ref().map_or(false, |loc| {
+                    loc.country_code == *country
+                        && loc.city_code == *city
+                        && relay.hostname == *hostname
+                })
             }
         };
         if !matches_location {


### PR DESCRIPTION
I messed up the logic for checking the hostname when we filtered out matching relays in the `LocationConstraint::Hostname` case. So all hosts within the given city was still being included in the selection process. This should fix that.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/417)
<!-- Reviewable:end -->
