### PR TITLE
Adjust rpc timeouts

### DIFF
--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -329,6 +329,9 @@ export type ConnectionObserver = {
   unsubscribe: () => void,
 };
 
+// Timeout used for RPC calls that do networking
+const NETWORK_CALL_TIMEOUT = 10000;
+
 export class DaemonRpc implements DaemonRpcProtocol {
   _transport = new JsonRpcClient(new SocketTransport());
 
@@ -363,11 +366,9 @@ export class DaemonRpc implements DaemonRpcProtocol {
   }
 
   async getAccountData(accountToken: AccountToken): Promise<AccountData> {
-    // send the IPC with 30s timeout since the backend will wait
-    // for a HTTP request before replying
     let response;
     try {
-      response = await this._transport.send('get_account_data', accountToken, 30000);
+      response = await this._transport.send('get_account_data', accountToken, NETWORK_CALL_TIMEOUT);
     } catch (error) {
       if (error instanceof JsonRpcRemoteError) {
         switch (error.code) {
@@ -490,10 +491,7 @@ export class DaemonRpc implements DaemonRpcProtocol {
   }
 
   async getLocation(): Promise<Location> {
-    // send the IPC with 30s timeout since the backend will wait
-    // for a HTTP request before replying
-
-    const response = await this._transport.send('get_current_location', [], 30000);
+    const response = await this._transport.send('get_current_location', [], NETWORK_CALL_TIMEOUT);
     try {
       return validate(LocationSchema, response);
     } catch (error) {

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -542,7 +542,7 @@ export class DaemonRpc implements DaemonRpcProtocol {
   }
 
   async getVersionInfo(): Promise<AppVersionInfo> {
-    const response = await this._transport.send('get_version_info');
+    const response = await this._transport.send('get_version_info', [], NETWORK_CALL_TIMEOUT);
     try {
       const versionInfo = validate(AppVersionInfoSchema, response);
       return {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

As discussed on Slack today, it turned out that we forgot to override the default timeouts for `get_current_version` and `get_version_info` RPC calls which do networking.

This PR adds a constant `NETWORK_CALL_TIMEOUT` for the previously hardcoded 30s timeout already used for `get_current_location` and `get_account_data` RPC calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/418)
<!-- Reviewable:end -->