### PR TITLE
Allow selecting relay in sole city of a country

### DIFF
--- a/gui/packages/desktop/src/renderer/components/SelectLocation.js
+++ b/gui/packages/desktop/src/renderer/components/SelectLocation.js
@@ -182,6 +182,10 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
     // either expanded by user or when the city selected within the country
     const isExpanded = this.state.expanded.includes(relayCountry.code);
 
+    const hasChildren =
+      relayCountry.cities.length > 1 ||
+      (relayCountry.cities.length == 1 && relayCountry.cities[0].relays.length > 1);
+
     const handleSelect =
       relayCountry.hasActiveRelays && !isSelected
         ? () => {
@@ -207,7 +211,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
 
           <Cell.Label>{relayCountry.name}</Cell.Label>
 
-          {relayCountry.cities.length > 1 ? (
+          {hasChildren ? (
             <Cell.Img
               style={styles.collapse_button}
               hoverStyle={styles.expand_chevron_hover}
@@ -219,7 +223,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
           ) : null}
         </Cell.CellButton>
 
-        {relayCountry.cities.length > 1 && (
+        {hasChildren && (
           <Accordion height={isExpanded ? 'auto' : 0}>
             {relayCountry.cities.map((relayCity) => this._renderCity(relayCountry.code, relayCity))}
           </Accordion>


### PR DESCRIPTION
Previously, when the code to allow selecting a relay in a city was
implemented, the code to expand a country missed a case where a country
could have a single city that had multiple relays. In that case, the
country wouldn't be expandable and the user wouldn't be able to select a
specific relay from that city. This fixes that issue by also allowing a
country to expand if it has only one city that has more than one relay.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug in a feature that hasn't been released yet.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/419)
<!-- Reviewable:end -->
