### PR TITLE
Fix relay list downloading in buildscript

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -144,11 +144,12 @@ process.stdin.on('end', function () {
 JSONRPC_CODE
 set -e
 
-curl -X POST \
+JSONRPC_RESPONSE="$(curl -X POST \
+    --fail \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc": "2.0", "id": "0", "method": "relay_list"}' \
-     https://api.mullvad.net/rpc/  | \
-node -e "$JSONRPC_CODE" >  dist-assets/relays.json
+     https://api.mullvad.net/rpc/)"
+echo $JSONRPC_RESPONSE | node -e "$JSONRPC_CODE" >  dist-assets/relays.json
 
 echo "Installing JavaScript dependencies..."
 cd gui


### PR DESCRIPTION
This small PR tries to ensure that if we fail to download the relay list, the script fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/420)
<!-- Reviewable:end -->
