### PR TITLE
Move mullvad CLI binary to directly under install dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Line wrap the file at 100 chars.                                              Th
 - Replace WebSockets with Unix domain sockets/Named pipes for IPC. The location
   of the socket can be controlled with `MULLVAD_RPC_SOCKET_PATH`.
 - Update the relay list if it's out of date when the daemon starts.
+- Move the CLI binary (`mullvad` or `mullvad.exe`) up one level, so it's installed directly into
+  the app installation directory instead of the `resource` directory.
 
 
 ## [2018.2] - 2018-08-13

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -40,8 +40,6 @@ mac:
   extendInfo:
     LSUIElement: true
   extraResources:
-    - from: ../../../target/release/mullvad
-      to: .
     - from: ../../../target/release/problem-report
       to: .
     - from: ../../../target/release/mullvad-daemon
@@ -52,6 +50,9 @@ mac:
       to: .
     - from: ../../../dist-assets/uninstall_macos.sh
       to: ./uninstall.sh
+  extraFiles:
+    - from: ../../../target/release/mullvad
+      to: .
 
 pkg:
   allowAnywhere: false
@@ -72,10 +73,11 @@ win:
       arch:
         - x64
   artifactName: MullvadVPN-${version}.${ext}
+  publisherName: Amagicom AB
+  signingHashAlgorithms:
+    - sha256
   signDlls: true
   extraResources:
-    - from: ../../../target/release/mullvad.exe
-      to: .
     - from: ../../../target/release/problem-report.exe
       to: .
     - from: ../../../target/release/mullvad-daemon.exe
@@ -90,9 +92,9 @@ win:
       to: .
     - from: ../../../dist-assets/binaries/windows/openvpn.exe
       to: .
-  publisherName: Amagicom AB
-  signingHashAlgorithms:
-    - sha256
+  extraFiles:
+    - from: ../../../target/release/mullvad.exe
+      to: .
 
 linux:
   target:
@@ -101,8 +103,6 @@ linux:
   artifactName: MullvadVPN-${version}_${arch}.${ext}
   category: Network
   extraResources:
-    - from: ../../../target/release/mullvad
-      to: .
     - from: ../../../target/release/problem-report
       to: .
     - from: ../../../target/release/mullvad-daemon
@@ -114,6 +114,9 @@ linux:
     - from: ../../../dist-assets/linux/mullvad-daemon.conf
       to: .
     - from: ../../../dist-assets/linux/mullvad-daemon.service
+      to: .
+  extraFiles:
+    - from: ../../../target/release/mullvad
       to: .
 
 deb:


### PR DESCRIPTION
We have talked about this a bit before. Moving the CLI binary to be listed under `extraFiles` instead of `extraResources`. This makes it show up directly in the installation directory instead of under `resources/`. Should make it easier to find and use for those who wish to use the CLI.

I have tested this on all three platforms, works fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/422)
<!-- Reviewable:end -->
