### PR TITLE
Check for IPv6 support on TAP adapter on Windows

### DIFF
--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -35,6 +35,8 @@ extern crate uuid;
 #[cfg(target_os = "linux")]
 extern crate which;
 #[cfg(windows)]
+extern crate widestring;
+#[cfg(windows)]
 extern crate winreg;
 
 extern crate openvpn_plugin;
@@ -44,6 +46,9 @@ extern crate talpid_types;
 #[cfg(target_os = "linux")]
 #[macro_use]
 extern crate nftnl;
+
+#[cfg(windows)]
+mod winnet;
 
 /// Working with processes.
 pub mod process;

--- a/talpid-core/src/security/windows/dns.rs
+++ b/talpid-core/src/security/windows/dns.rs
@@ -1,16 +1,14 @@
-extern crate widestring;
-
-use super::ffi;
-use super::system_state::SystemStateWriter;
-
-use self::widestring::WideCString;
-use libc;
 use std::net::IpAddr;
 use std::path::Path;
 use std::ptr;
 use std::slice;
 
 use error_chain::ChainedError;
+use libc;
+use widestring::WideCString;
+
+use super::system_state::SystemStateWriter;
+use winnet;
 
 const DNS_STATE_FILENAME: &'static str = "dns-state-backup";
 
@@ -49,7 +47,7 @@ pub struct WinDns {
 
 impl WinDns {
     pub fn new<P: AsRef<Path>>(cache_dir: P) -> Result<Self> {
-        unsafe { WinDns_Initialize(Some(ffi::error_sink), ptr::null_mut()).into_result()? };
+        unsafe { WinDns_Initialize(Some(winnet::error_sink), ptr::null_mut()).into_result()? };
 
         let backup_writer = SystemStateWriter::new(
             cache_dir
@@ -191,7 +189,7 @@ extern "system" {
 
     #[link_name(WinDns_Initialize)]
     pub fn WinDns_Initialize(
-        sink: Option<ffi::ErrorSink>,
+        sink: Option<winnet::ErrorSink>,
         sink_context: *mut libc::c_void,
     ) -> InitializationResult;
 

--- a/talpid-core/src/security/windows/ffi.rs
+++ b/talpid-core/src/security/windows/ffi.rs
@@ -1,16 +1,3 @@
-use libc::{c_char, c_void};
-
-pub type ErrorSink = extern "system" fn(msg: *const c_char, ctx: *mut c_void);
-
-pub extern "system" fn error_sink(msg: *const c_char, _ctx: *mut c_void) {
-    use std::ffi::CStr;
-    if msg.is_null() {
-        error!("Log message from FFI boundary is NULL");
-    } else {
-        error!("{}", unsafe { CStr::from_ptr(msg).to_string_lossy() });
-    }
-}
-
 #[macro_export]
 macro_rules! ffi_error {
     ($result:ident, $error:expr) => {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -332,8 +332,16 @@ fn is_ipv6_enabled_in_os() -> bool {
             .map(|ipv6_disabled_bits: u32| {
                 (ipv6_disabled_bits & IPV6_DISABLED_ON_TUNNELS_MASK) == 0
             }).unwrap_or(true);
+        let enabled_on_tap = ::winnet::get_tap_interface_ipv6_status().unwrap_or(false);
 
-        globally_enabled && ::winnet::get_tap_interface_ipv6_status().unwrap_or(false)
+        if !globally_enabled {
+            debug!("IPv6 disabled in tunnel interfaces");
+        }
+        if !enabled_on_tap {
+            debug!("IPv6 disabled in TAP adapter");
+        }
+
+        globally_enabled && enabled_on_tap
     }
     #[cfg(target_os = "linux")]
     {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -324,11 +324,13 @@ fn is_ipv6_enabled_in_os() -> bool {
 
         const IPV6_DISABLED: u8 = 0xFF;
 
-        RegKey::predef(HKEY_LOCAL_MACHINE)
+        let globally_enabled = RegKey::predef(HKEY_LOCAL_MACHINE)
             .open_subkey(r#"SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters"#)
             .and_then(|ipv6_config| ipv6_config.get_value("DisabledComponents"))
             .map(|ipv6_disabled_bits: u32| (ipv6_disabled_bits & 0xFF) == IPV6_DISABLED as u32)
-            .unwrap_or(false)
+            .unwrap_or(false);
+
+        globally_enabled && ::winnet::get_tap_interface_ipv6_status().unwrap_or(false)
     }
     #[cfg(target_os = "linux")]
     {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -322,13 +322,16 @@ fn is_ipv6_enabled_in_os() -> bool {
         use winreg::enums::*;
         use winreg::RegKey;
 
-        const IPV6_DISABLED: u8 = 0xFF;
+        const IPV6_DISABLED_ON_TUNNELS_MASK: u32 = 0x01;
 
+        // Check registry if IPv6 is disabled on tunnel interfaces, as documented in
+        // https://support.microsoft.com/en-us/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users
         let globally_enabled = RegKey::predef(HKEY_LOCAL_MACHINE)
             .open_subkey(r#"SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters"#)
             .and_then(|ipv6_config| ipv6_config.get_value("DisabledComponents"))
-            .map(|ipv6_disabled_bits: u32| (ipv6_disabled_bits & 0xFF) == IPV6_DISABLED as u32)
-            .unwrap_or(false);
+            .map(|ipv6_disabled_bits: u32| {
+                (ipv6_disabled_bits & IPV6_DISABLED_ON_TUNNELS_MASK) == 0
+            }).unwrap_or(true);
 
         globally_enabled && ::winnet::get_tap_interface_ipv6_status().unwrap_or(false)
     }

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -1,7 +1,7 @@
-use super::ffi;
-use super::widestring::WideCString;
-use libc;
 use std::ptr;
+
+use libc::{c_char, c_void, wchar_t};
+use widestring::WideCString;
 
 error_chain!{
     errors{
@@ -15,6 +15,17 @@ error_chain!{
     }
 }
 
+pub type ErrorSink = extern "system" fn(msg: *const c_char, ctx: *mut c_void);
+
+pub extern "system" fn error_sink(msg: *const c_char, _ctx: *mut c_void) {
+    use std::ffi::CStr;
+    if msg.is_null() {
+        error!("Log message from FFI boundary is NULL");
+    } else {
+        error!("{}", unsafe { CStr::from_ptr(msg).to_string_lossy() });
+    }
+}
+
 /// Returns true if metrics were changed, false otherwise
 pub fn ensure_top_metric_for_interface(interface_alias: &str) -> Result<bool> {
     let interface_alias_ws =
@@ -22,7 +33,7 @@ pub fn ensure_top_metric_for_interface(interface_alias: &str) -> Result<bool> {
     unsafe {
         WinRoute_EnsureTopMetric(
             interface_alias_ws.as_wide_c_str().as_ptr(),
-            Some(ffi::error_sink),
+            Some(error_sink),
             ptr::null_mut(),
         ).into()
     }
@@ -56,8 +67,8 @@ impl Into<Result<bool>> for MetricResult {
 extern "system" {
     #[link_name(WinRoute_EnsureTopMetric)]
     fn WinRoute_EnsureTopMetric(
-        tunnel_interface_alias: *const libc::wchar_t,
-        sink: Option<ffi::ErrorSink>,
-        sink_context: *mut libc::c_void,
+        tunnel_interface_alias: *const wchar_t,
+        sink: Option<ErrorSink>,
+        sink_context: *mut c_void,
     ) -> MetricResult;
 }

--- a/windows/winroute/extras.sln
+++ b/windows/winroute/extras.sln
@@ -1,0 +1,57 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "loader", "src\extras\loader\loader.vcxproj", "{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF} = {B52E2D10-A94A-4605-914A-2DCEF6A757EF}
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4} = {89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "winroute", "src\winroute\winroute.vcxproj", "{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF} = {B52E2D10-A94A-4605-914A-2DCEF6A757EF}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcommon", "..\windows-libraries\src\libcommon\libcommon.vcxproj", "{B52E2D10-A94A-4605-914A-2DCEF6A757EF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Debug|x64.ActiveCfg = Debug|x64
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Debug|x64.Build.0 = Debug|x64
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Debug|x86.ActiveCfg = Debug|Win32
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Debug|x86.Build.0 = Debug|Win32
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Release|x64.ActiveCfg = Release|x64
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Release|x64.Build.0 = Release|x64
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Release|x86.ActiveCfg = Release|Win32
+		{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}.Release|x86.Build.0 = Release|Win32
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Debug|x64.ActiveCfg = Debug|x64
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Debug|x64.Build.0 = Debug|x64
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Debug|x86.ActiveCfg = Debug|Win32
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Debug|x86.Build.0 = Debug|Win32
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Release|x64.ActiveCfg = Release|x64
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Release|x64.Build.0 = Release|x64
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Release|x86.ActiveCfg = Release|Win32
+		{89C5CDE8-04DB-4D9C-A8D8-7F786DAFB6D4}.Release|x86.Build.0 = Release|Win32
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Debug|x64.ActiveCfg = Debug|x64
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Debug|x64.Build.0 = Debug|x64
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Debug|x86.ActiveCfg = Debug|Win32
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Debug|x86.Build.0 = Debug|Win32
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Release|x64.ActiveCfg = Release|x64
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Release|x64.Build.0 = Release|x64
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Release|x86.ActiveCfg = Release|Win32
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B11B65B3-3DA6-495C-B0F5-5ACBB2F1743D}
+	EndGlobalSection
+EndGlobal

--- a/windows/winroute/src/extras/loader/loader.cpp
+++ b/windows/winroute/src/extras/loader/loader.cpp
@@ -1,0 +1,10 @@
+#include "stdafx.h"
+#include "../../winroute/winroute.h"
+
+int main()
+{
+	const auto status = GetTapInterfaceIpv6Status(nullptr, nullptr);
+
+    return 0;
+}
+

--- a/windows/winroute/src/extras/loader/loader.vcxproj
+++ b/windows/winroute/src/extras/loader/loader.vcxproj
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="loader.cpp" />
+    <ClCompile Include="stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{227C50F4-D9F6-4D9A-84A0-33CE84432D0D}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>loader</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(SolutionDir)bin\temp\$(Platform)-$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(SolutionDir)bin\temp\$(Platform)-$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(SolutionDir)bin\temp\$(Platform)-$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(SolutionDir)bin\temp\$(Platform)-$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>winroute.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>winroute.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>winroute.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>winroute.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/windows/winroute/src/extras/loader/loader.vcxproj.filters
+++ b/windows/winroute/src/extras/loader/loader.vcxproj.filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="loader.cpp" />
+    <ClCompile Include="stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+</Project>

--- a/windows/winroute/src/extras/loader/stdafx.cpp
+++ b/windows/winroute/src/extras/loader/stdafx.cpp
@@ -1,0 +1,8 @@
+// stdafx.cpp : source file that includes just the standard includes
+// loader.pch will be the pre-compiled header
+// stdafx.obj will contain the pre-compiled type information
+
+#include "stdafx.h"
+
+// TODO: reference any additional headers you need in STDAFX.H
+// and not in this file

--- a/windows/winroute/src/extras/loader/stdafx.h
+++ b/windows/winroute/src/extras/loader/stdafx.h
@@ -1,0 +1,15 @@
+// stdafx.h : include file for standard system include files,
+// or project specific include files that are used frequently, but
+// are changed infrequently
+//
+
+#pragma once
+
+#include "targetver.h"
+
+#include <stdio.h>
+#include <tchar.h>
+
+
+
+// TODO: reference additional headers your program requires here

--- a/windows/winroute/src/extras/loader/targetver.h
+++ b/windows/winroute/src/extras/loader/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/windows/winroute/src/winroute/InterfacePair.h
+++ b/windows/winroute/src/winroute/InterfacePair.h
@@ -14,8 +14,8 @@ public:
 
 
 private:
-	MIB_IPINTERFACE_ROW IPv4Iface;
-	MIB_IPINTERFACE_ROW IPv6Iface;
+	MIB_IPINTERFACE_ROW IPv4Iface = { 0 };
+	MIB_IPINTERFACE_ROW IPv6Iface = { 0 };
 
 	void InitializeInterface(PMIB_IPINTERFACE_ROW iface);
 	bool HasIPv4();

--- a/windows/winroute/src/winroute/NetworkInterfaces.h
+++ b/windows/winroute/src/winroute/NetworkInterfaces.h
@@ -16,6 +16,9 @@ private:
 	bool HasHighestMetric(PMIB_IPINTERFACE_ROW targetIface);
 
 public:
+	NetworkInterfaces(const NetworkInterfaces &) = delete;
+	NetworkInterfaces &operator=(const NetworkInterfaces &) = delete;
+
 	void EnsureIfaceMetricIsHighest(NET_LUID interfaceLuid);
 	NetworkInterfaces();
 	bool SetTopMetricForInterfacesByAlias(const wchar_t *deviceAlias);

--- a/windows/winroute/src/winroute/NetworkInterfaces.h
+++ b/windows/winroute/src/winroute/NetworkInterfaces.h
@@ -6,6 +6,7 @@
 #include <iphlpapi.h>
 #include <netioapi.h>
 #include <cstdint>
+#include <string>
 
 class NetworkInterfaces
 {
@@ -20,6 +21,9 @@ public:
 	bool SetTopMetricForInterfacesByAlias(const wchar_t *deviceAlias);
 	bool SetTopMetricForInterfacesWithLuid(NET_LUID targetIface);
 	~NetworkInterfaces();
+
+	static NET_LUID GetInterfaceLuid(const std::wstring &interfaceAlias);
+	const MIB_IPINTERFACE_ROW *GetInterface(NET_LUID interfaceLuid, ADDRESS_FAMILY interfaceFamily);
 };
 
 const static uint32_t MAX_METRIC = 1;

--- a/windows/winroute/src/winroute/winroute.def
+++ b/windows/winroute/src/winroute/winroute.def
@@ -1,3 +1,4 @@
 LIBRARY winroute
 EXPORTS
 	WinRoute_EnsureTopMetric
+	GetTapInterfaceIpv6Status

--- a/windows/winroute/src/winroute/winroute.h
+++ b/windows/winroute/src/winroute/winroute.h
@@ -28,3 +28,23 @@ WinRoute_EnsureTopMetric(
 	WinRouteErrorSink errorSink,
 	void* errorSinkContext
 );
+
+enum class TAP_IPV6_STATUS : uint32_t
+{
+	ENABLED = 0,
+	DISABLED = 1,
+	FAILURE = 2,
+};
+
+//
+// This has nothing to do with routing.
+// We should probably rename this module and use it to gather one-off network functions.
+//
+extern "C"
+WINROUTE_LINKAGE
+TAP_IPV6_STATUS
+WINROUTE_API
+GetTapInterfaceIpv6Status(
+	WinRouteErrorSink errorSink,
+	void* errorSinkContext
+);


### PR DESCRIPTION
This PR complements the IPv6 check by also checking if the TAP adapter on Windows has IPv6 enabled. If it's not enabled and the app is configured to enable IPv6 in the tunnel, then the app moves to the blocked state and an error is reported.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not user visible.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/423)
<!-- Reviewable:end -->
