### PR TITLE
Add disconnecting state

### DIFF
--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -103,21 +103,6 @@ export default class AppRenderer {
     webFrame.setVisualZoomLevelLimits(1, 1);
   }
 
-  dispose() {
-    const openConnectionObserver = this._openConnectionObserver;
-    const closeConnectionObserver = this._closeConnectionObserver;
-
-    if (openConnectionObserver) {
-      openConnectionObserver.unsubscribe();
-      this._openConnectionObserver = null;
-    }
-
-    if (closeConnectionObserver) {
-      closeConnectionObserver.unsubscribe();
-      this._closeConnectionObserver = null;
-    }
-  }
-
   renderView() {
     return (
       <Provider store={this._reduxStore}>

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -48,6 +48,7 @@ export default class AppRenderer {
   _reduxActions: *;
   _accountDataState = new AccountDataState();
   _connectedToDaemon = false;
+  _tunnelState: ?TunnelState;
 
   constructor() {
     const store = configureStore(null, this._memoryHistory);
@@ -229,18 +230,22 @@ export default class AppRenderer {
   async connectTunnel() {
     const actions = this._reduxActions;
 
-    try {
-      const currentState = await this._daemonRpc.getState();
-      if (currentState === 'connected' || currentState === 'connecting') {
-        log.debug('Refusing to connect as connection is already secured');
-        actions.connection.connected();
-      } else {
-        actions.connection.connecting();
-        await this._daemonRpc.connectTunnel();
-      }
-    } catch (error) {
-      actions.connection.disconnected();
-      throw error;
+    // avoid connecting when there is no account set in daemon.
+    const accountToken = await this._daemonRpc.getAccount();
+    if (!accountToken) {
+      throw new NoAccountError();
+    }
+
+    // connect only if tunnel is disconnected or blocked.
+    if (
+      this._tunnelState &&
+      (this._tunnelState.state === 'disconnected' || this._tunnelState.state === 'blocked')
+    ) {
+      // switch to connecting state immediately to prevent a lag that may be caused by RPC
+      // communication delay
+      actions.connection.connecting();
+
+      await this._daemonRpc.connectTunnel();
     }
   }
 
@@ -415,8 +420,11 @@ export default class AppRenderer {
   }
 
   async _fetchTunnelState() {
-    const tunnelState = await this._daemonRpc.getState();
-    this._updateConnectionState(tunnelState);
+    const state = await this._daemonRpc.getState();
+
+    log.debug(`Got state: ${JSON.stringify(state)}`);
+
+    this._onChangeTunnelState(state);
   }
 
   async _fetchTunnelOptions() {
@@ -511,14 +519,13 @@ export default class AppRenderer {
   async _subscribeStateListener() {
     await this._daemonRpc.subscribeStateListener((newState, error) => {
       if (error) {
-        log.error(`Received an error when processing the incoming state change: ${error.message}`);
+        log.error(`Failed to deserialize the new state: ${error.message}`);
       }
 
       if (newState) {
-        log.debug(`Got new state from daemon '${JSON.stringify(newState)}'`);
+        log.debug(`Got state update: '${JSON.stringify(newState)}'`);
 
-        this._updateConnectionState(newState);
-        this._refreshStateOnChange();
+        this._onChangeTunnelState(newState);
       }
     });
   }
@@ -537,44 +544,28 @@ export default class AppRenderer {
     ]);
   }
 
-  _updateTrayIcon(connectionState: ConnectionState) {
-    const iconTypes: { [ConnectionState]: TrayIconType } = {
-      connected: 'secured',
-      connecting: 'securing',
-      blocked: 'securing',
-    };
-    const type = iconTypes[connectionState] || 'unsecured';
+  _onChangeTunnelState(tunnelState: TunnelState) {
+    this._tunnelState = tunnelState;
 
-    ipcRenderer.send('change-tray-icon', type);
+    this._updateConnectionStatus(tunnelState);
+    this._updateConnectionLocation(tunnelState.state);
+    this._updateTrayIcon(tunnelState.state);
+    this._showNotification(tunnelState.state);
   }
 
-  async _refreshStateOnChange() {
-    try {
-      await this._fetchLocation();
-    } catch (error) {
-      log.error(`Failed to fetch the location: ${error.message}`);
+  async _updateConnectionLocation(connectionState: ConnectionState) {
+    if (connectionState === 'connecting' || connectionState === 'disconnected') {
+      try {
+        await this._fetchLocation();
+      } catch (error) {
+        log.error(`Failed to update the location: ${error.message}`);
+      }
     }
   }
 
-  _tunnelStateToConnectionState(tunnelState: TunnelState): ConnectionState {
-    switch (tunnelState.state) {
-      case 'disconnected':
-      // Fall through
-      case 'disconnecting':
-        return 'disconnected';
-      case 'connected':
-        return 'connected';
-      case 'connecting':
-        return 'connecting';
-      case 'blocked':
-        return 'blocked';
-      default:
-        throw new Error('Unknown tunnel state: ' + (tunnelState: empty));
-    }
-  }
-
-  _updateConnectionState(tunnelState: TunnelState) {
+  _updateConnectionStatus(tunnelState: TunnelState) {
     const actions = this._reduxActions;
+
     switch (tunnelState.state) {
       case 'connecting':
         actions.connection.connecting();
@@ -583,7 +574,8 @@ export default class AppRenderer {
         actions.connection.connected();
         break;
       case 'disconnecting':
-      // Fall through
+        actions.connection.disconnecting();
+        break;
       case 'disconnected':
         actions.connection.disconnected();
         break;
@@ -593,10 +585,17 @@ export default class AppRenderer {
       default:
         log.error(`Unexpected TunnelState: ${(tunnelState: empty)}`);
     }
+  }
 
-    const connectionState = this._tunnelStateToConnectionState(tunnelState);
-    this._updateTrayIcon(connectionState);
-    this._showNotification(connectionState);
+  _updateTrayIcon(connectionState: ConnectionState) {
+    const iconTypes: { [ConnectionState]: TrayIconType } = {
+      connected: 'secured',
+      connecting: 'securing',
+      blocked: 'securing',
+    };
+    const type = iconTypes[connectionState] || 'unsecured';
+
+    ipcRenderer.send('change-tray-icon', type);
   }
 
   _showNotification(connectionState: ConnectionState) {
@@ -612,6 +611,9 @@ export default class AppRenderer {
         break;
       case 'blocked':
         this._notificationController.show('Blocked all connections');
+        break;
+      case 'disconnecting':
+        // no-op
         break;
       default:
         log.error(`Unexpected ConnectionState: ${(connectionState: empty)}`);

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -335,7 +335,7 @@ export default class Connect extends Component<Props, State> {
       case 'blocked':
         return 'success';
       default:
-        throw new Error(`Invalid ConnectionState: ${(status: empty)}`);
+        throw new Error(`Invalid TunnelState: ${(status: empty)}`);
     }
   }
 

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -154,7 +154,7 @@ export default class Connect extends Component<Props, State> {
   }
 
   renderMap() {
-    let [isConnecting, isConnected, isDisconnected] = [false, false, false];
+    let [isConnecting, isConnected, isDisconnected, isDisconnecting] = [false, false, false, false];
     switch (this.props.connection.status) {
       case 'connecting':
         isConnecting = true;
@@ -164,6 +164,9 @@ export default class Connect extends Component<Props, State> {
         break;
       case 'disconnected':
         isDisconnected = true;
+        break;
+      case 'disconnecting':
+        isDisconnecting = true;
         break;
     }
 
@@ -193,8 +196,8 @@ export default class Connect extends Component<Props, State> {
               **********************************
             */}
 
-            {/* location when connecting or disconnected */}
-            {isConnecting || isDisconnected ? (
+            {/* location when connecting, disconnecting or disconnected */}
+            {isConnecting || isDisconnecting || isDisconnected ? (
               <Text style={styles.status_location} testName="location">
                 {this.props.connection.country}
               </Text>
@@ -216,7 +219,7 @@ export default class Connect extends Component<Props, State> {
             */}
 
             <Text style={this.ipAddressStyle()} onPress={this.onIPAddressClick.bind(this)}>
-              {isConnected || isDisconnected ? (
+              {isConnected || isDisconnecting || isDisconnected ? (
                 <Text testName="ipAddress">
                   {this.state.showCopyIPMessage
                     ? 'IP copied to clipboard!'
@@ -232,8 +235,8 @@ export default class Connect extends Component<Props, State> {
             **********************************
           */}
 
-          {/* footer when disconnected */}
-          {isDisconnected ? (
+          {/* footer when disconnecting or disconnected */}
+          {isDisconnecting || isDisconnected ? (
             <View style={styles.footer}>
               <AppButton.TransparentButton
                 style={styles.switch_location_button}
@@ -324,6 +327,7 @@ export default class Connect extends Component<Props, State> {
   headerBarStyle(): HeaderBarStyle {
     const { status } = this.props.connection;
     switch (status) {
+      case 'disconnecting':
       case 'disconnected':
         return 'error';
       case 'connecting':

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -14,6 +14,10 @@ type DisconnectedAction = {
   type: 'DISCONNECTED',
 };
 
+type DisconnectingAction = {
+  type: 'DISCONNECTING',
+};
+
 type BlockedAction = {
   type: 'BLOCKED',
   reason: string,
@@ -44,6 +48,7 @@ export type ConnectionAction =
   | ConnectingAction
   | ConnectedAction
   | DisconnectedAction
+  | DisconnectingAction
   | BlockedAction
   | OnlineAction
   | OfflineAction;
@@ -63,6 +68,12 @@ function connected(): ConnectedAction {
 function disconnected(): DisconnectedAction {
   return {
     type: 'DISCONNECTED',
+  };
+}
+
+function disconnecting(): DisconnectingAction {
+  return {
+    type: 'DISCONNECTING',
   };
 }
 
@@ -97,6 +108,7 @@ export default {
   connecting,
   connected,
   disconnected,
+  disconnecting,
   blocked,
   online,
   offline,

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -3,7 +3,12 @@
 import type { ReduxAction } from '../store';
 import type { Ip } from '../../lib/daemon-rpc';
 
-export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'blocked';
+export type ConnectionState =
+  | 'disconnected'
+  | 'disconnecting'
+  | 'connecting'
+  | 'connected'
+  | 'blocked';
 export type ConnectionReduxState = {
   status: ConnectionState,
   isOnline: boolean,
@@ -42,6 +47,9 @@ export default function(
 
     case 'DISCONNECTED':
       return { ...state, ...{ status: 'disconnected', blockReason: null } };
+
+    case 'DISCONNECTING':
+      return { ...state, ...{ status: 'disconnecting', blockReason: null } };
 
     case 'BLOCKED':
       return { ...state, ...{ status: 'blocked', blockReason: action.reason } };

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -1,16 +1,10 @@
 // @flow
 
 import type { ReduxAction } from '../store';
-import type { Ip } from '../../lib/daemon-rpc';
+import type { TunnelState, Ip } from '../../lib/daemon-rpc';
 
-export type ConnectionState =
-  | 'disconnected'
-  | 'disconnecting'
-  | 'connecting'
-  | 'connected'
-  | 'blocked';
 export type ConnectionReduxState = {
-  status: ConnectionState,
+  status: TunnelState,
   isOnline: boolean,
   ip: ?Ip,
   latitude: ?number,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. This PR adds `disconnecting` state which is not really handled anyhow for now but allows using `ConnectionState` and `TunnelState.state` interchangeably.

2. Store `tunnelState` in `AppRenderer` so we can use it when we need to verify if we can do some things or not. See the revamped `connectTunnel`.

3. Fixed the bug in connectTunnel which would switch the app into "Connected" state when the daemons state was "connecting"...

4. Request location only when "connecting" or "disconnecting". Why? Because we transition the map only when connecting to server or when disconnecting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/424)
<!-- Reviewable:end -->
