### PR TITLE
Improve macos install uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add firewall rules allowing traffic to the SSDP/WS-discover multicast IP, 239.255.255.250, if
   local area network sharing is activated. This allows discovery of devices using these protocols.
 
+#### macOS
+- Add uninstall script that can uninstall and remove all the files installed by the app.
+
 #### Windows
 - Extend uninstaller to also remove logs, cache and optionally settings.
 - Add installation log (%PROGRAMDATA%\Mullvad VPN\install.log).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### macOS
 - Fix edge cases when window's arrow appeared misaligned and pointed to the wrong menubar item.
+- Make the pkg installer kill any running GUI process after installation is done. Prevents
+  accidentally running an old GUI with a newer daemon.
 
 ### Changed
 - The "Buy more credit" button is changed to open a dedicated account login page instead of one

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -42,6 +42,8 @@ DAEMON_PLIST=$(cat <<-EOM
 EOM
 )
 
+pkill -x "Mullvad VPN" || echo "Unable to kill GUI, not running?"
+sleep 1
 launchctl unload -w $DAEMON_PLIST_PATH
 echo "$DAEMON_PLIST" > $DAEMON_PLIST_PATH
 launchctl load -w $DAEMON_PLIST_PATH

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -ue
+
+read -p "Are you sure you want to stop and uninstall Mullvad VPN? (y/n) "
+if [[ "$REPLY" =~ [Yy]$ ]]; then
+    echo "Uninstalling Mullvad VPN ..."
+else
+    echo "Aborting uninstall"
+    exit 0
+fi
+
+echo "Stopping GUI process ..."
+sudo pkill -x "Mullvad VPN" || echo "No GUI process found"
+
+echo "Stopping and unloading mullvad-daemon system daemon ..."
+DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"
+sudo launchctl unload -w "$DAEMON_PLIST_PATH"
+sudo rm -f "$DAEMON_PLIST_PATH"
+
+echo "Removing app from /Applications ..."
+sudo rm -rf /Applications/Mullvad\ VPN.app
+
+read -p "Do you want to delete the log and cache files the app has created? (y/n) "
+if [[ "$REPLY" =~ [Yy]$ ]]; then
+    sudo rm -rf /var/log/mullvad-vpn /var/root/Library/Caches/mullvad-vpn
+    for user in /Users/*; do
+        user_log_dir="$user/Library/Logs/Mullvad VPN"
+        if [[ -d "$user_log_dir" ]]; then
+            echo "Deleting GUI logs at $user_log_dir"
+            sudo rm -rf "$user_log_dir"
+        fi
+    done
+fi
+
+read -p "Do you want to delete the Mullvad VPN settings? (y/n) "
+if [[ "$REPLY" =~ [Yy]$ ]]; then
+    sudo rm -rf /etc/mullvad-vpn
+fi
+

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -50,6 +50,8 @@ mac:
       to: .
     - from: ../../../dist-assets/binaries/macos/openvpn
       to: .
+    - from: ../../../dist-assets/uninstall_macos.sh
+      to: ./uninstall.sh
 
 pkg:
   allowAnywhere: false


### PR DESCRIPTION
Richard asked me for a simple way to uninstall the app on macOS. This is not fully straight forward since the app, except for the files in `/Applications/` also creates a system daemon plist file as well as log, cache and settings directories.

I wrote a quick script that will kill any running instance of the program, unload the daemon and then remove all the files. The user is prompted if they want to keep logs, cache or settings.

Even if this uninstaller might not be super discoverable it can be found by semi-pros and support can instruct others how to use it, and we can write it in the guide about the app.

This PR also makes the macOS install process a bit smoother by making sure to kill any running GUI process. This is to ensure that after install the user is not left with a new daemon and an old GUI running. They would likely be incompatible anyway and cause all kinds of problems.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/425)
<!-- Reviewable:end -->
