### PR TITLE
Don't auto-connect without account token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix incorrect window position when using external display.
+- Don't auto-connect the daemon on start if no account token is set. This prevents the daemon from
+  blocking all internet if logging out from the app.
 
 #### Linux
 - The app window is now shown in its previous location, instead of at the center of the screen.

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -296,7 +296,7 @@ impl Daemon {
     /// Consume the `Daemon` and run the main event loop. Blocks until an error happens or a
     /// shutdown event is received.
     pub fn run(mut self) -> Result<()> {
-        if self.settings.get_auto_connect() {
+        if self.settings.get_auto_connect() && self.settings.get_account_token().is_some() {
             info!("Automatically connecting since auto-connect is turned on");
             self.set_target_state(TargetState::Secured);
         }


### PR DESCRIPTION
If we don't have any account token set it does not make much sense to try to auto-connect. It will with 100% certainty end up in the blocked state anyway. And why don't we want to block traffic in this case? If there is no account set the user has either never logged into the app or they have logged out, basically meaning they don't want to use it, so we should not activate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/426)
<!-- Reviewable:end -->
