### PR TITLE
Settings update subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,8 +1039,10 @@ dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mullvad-paths 0.1.0",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-types 0.1.0",
 ]
 

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -59,8 +59,8 @@ impl Account {
 
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        let account_token = rpc.get_account()?;
-        if let Some(account_token) = account_token {
+        let settings = rpc.get_settings()?;
+        if let Some(account_token) = settings.get_account_token() {
             println!("Mullvad account: {}", account_token);
             let expiry = rpc.get_account_data(account_token)?;
             println!("Expires at     : {}", expiry.expiry);

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -49,7 +49,7 @@ impl AutoConnect {
 
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        let auto_connect = rpc.get_auto_connect()?;
+        let auto_connect = rpc.get_settings()?.get_auto_connect();
         println!("Autoconnect: {}", if auto_connect { "on" } else { "off" });
         Ok(())
     }

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -48,7 +48,7 @@ impl Lan {
 
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        let allow_lan = rpc.get_allow_lan()?;
+        let allow_lan = rpc.get_settings()?.get_allow_lan();
         println!(
             "Local network sharing setting: {}",
             if allow_lan { "allow" } else { "block" }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -191,7 +191,7 @@ impl Relay {
 
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        let constraints = rpc.get_relay_settings()?;
+        let constraints = rpc.get_settings()?.get_relay_settings();
         println!("Current constraints: {:#?}", constraints);
 
         Ok(())

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -118,7 +118,7 @@ impl Tunnel {
 
     fn get_tunnel_options() -> Result<TunnelOptions> {
         let mut rpc = new_rpc_client()?;
-        Ok(rpc.get_tunnel_options()?)
+        Ok(rpc.get_settings()?.get_tunnel_options().clone())
     }
 
     fn print_common_tunnel_options(options: &TunnelOptions) {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -364,6 +364,7 @@ impl Daemon {
             SetOpenVpnMssfix(tx, mssfix_arg) => self.on_set_openvpn_mssfix(tx, mssfix_arg),
             SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6),
             GetTunnelOptions(tx) => self.on_get_tunnel_options(tx),
+            GetSettings(tx) => Ok(self.on_get_settings(tx)),
             GetRelaySettings(tx) => Ok(self.on_get_relay_settings(tx)),
             GetVersionInfo(tx) => Ok(self.on_get_version_info(tx)),
             GetCurrentVersion(tx) => Ok(self.on_get_current_version(tx)),
@@ -595,6 +596,10 @@ impl Daemon {
         let tunnel_options = self.settings.get_tunnel_options().clone();
         Self::oneshot_send(tx, tunnel_options, "get_tunnel_options response");
         Ok(())
+    }
+
+    fn on_get_settings(&self, tx: OneshotSender<settings::Settings>) {
+        Self::oneshot_send(tx, self.settings.clone(), "get_settings response");
     }
 
     fn oneshot_send<T>(tx: OneshotSender<T>, t: T, msg: &'static str) {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -51,7 +51,6 @@ mod logging;
 mod management_interface;
 mod relays;
 mod rpc_uniqueness_check;
-mod settings;
 mod shutdown;
 mod system_service;
 mod version;
@@ -68,6 +67,7 @@ use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
 use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
 use mullvad_types::relay_list::{Relay, RelayList};
+use mullvad_types::settings::Settings;
 use mullvad_types::states::TargetState;
 use mullvad_types::version::{AppVersion, AppVersionInfo};
 
@@ -185,7 +185,7 @@ struct Daemon {
     rx: mpsc::Receiver<DaemonEvent>,
     tx: mpsc::Sender<DaemonEvent>,
     management_interface_broadcaster: management_interface::EventBroadcaster,
-    settings: settings::Settings,
+    settings: Settings,
     accounts_proxy: AccountsProxy<HttpHandle>,
     version_proxy: AppVersionProxy<HttpHandle>,
     https_handle: mullvad_rpc::rest::RequestSender,
@@ -243,7 +243,7 @@ impl Daemon {
             rx,
             tx,
             management_interface_broadcaster,
-            settings: settings::Settings::load().chain_err(|| "Unable to read settings")?,
+            settings: Settings::load().chain_err(|| "Unable to read settings")?,
             accounts_proxy: AccountsProxy::new(rpc_handle.clone()),
             version_proxy: AppVersionProxy::new(rpc_handle),
             https_handle,
@@ -570,7 +570,7 @@ impl Daemon {
         Self::oneshot_send(tx, tunnel_options, "get_tunnel_options response");
     }
 
-    fn on_get_settings(&self, tx: OneshotSender<settings::Settings>) {
+    fn on_get_settings(&self, tx: OneshotSender<Settings>) {
         Self::oneshot_send(tx, self.settings.clone(), "get_settings response");
     }
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -12,11 +12,11 @@ use mullvad_types::location::GeoIpLocation;
 use mullvad_paths;
 use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
 use mullvad_types::relay_list::RelayList;
+use mullvad_types::settings::Settings;
 use mullvad_types::states::TargetState;
 use mullvad_types::version;
 
 use serde;
-use settings::Settings;
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -25,7 +25,9 @@ use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
 use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
 use mullvad_types::relay_list::RelayList;
+use mullvad_types::settings::Settings;
 use mullvad_types::version::AppVersionInfo;
+
 use serde::{Deserialize, Serialize};
 use talpid_types::net::TunnelOptions;
 use talpid_types::tunnel::TunnelStateTransition;
@@ -180,6 +182,10 @@ impl DaemonRpcClient {
 
     pub fn get_tunnel_options(&mut self) -> Result<TunnelOptions> {
         self.call("get_tunnel_options", &NO_ARGS)
+    }
+
+    pub fn get_settings(&mut self) -> Result<Settings> {
+        self.call("get_settings", &NO_ARGS)
     }
 
     pub fn get_version_info(&mut self) -> Result<AppVersionInfo> {

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -9,7 +9,9 @@ license = "GPL-3.0"
 chrono = { version = "0.4", features = ["serde"] }
 serde_derive = "1.0"
 serde = "1.0"
+serde_json = "1.0"
 error-chain = "0.12"
 log = "0.4"
 
 talpid-types = { path = "../talpid-types" }
+mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -11,6 +11,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
+extern crate mullvad_paths;
 extern crate talpid_types;
 
 #[macro_use]
@@ -23,6 +24,7 @@ pub mod account;
 pub mod location;
 pub mod relay_constraints;
 pub mod relay_list;
+pub mod settings;
 pub mod states;
 pub mod version;
 

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -1,6 +1,6 @@
 extern crate serde_json;
 
-use mullvad_types::relay_constraints::{
+use relay_constraints::{
     Constraint, LocationConstraint, RelayConstraints, RelaySettings, RelaySettingsUpdate,
 };
 use talpid_types::net::TunnelOptions;
@@ -30,6 +30,8 @@ error_chain! {
 
 static SETTINGS_FILE: &str = "settings.json";
 
+
+/// Mullvad daemon settings.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Settings {


### PR DESCRIPTION
As we discussed on Slack: Introduce a `get_settings` call together with a way to subscribe for settings updates from the daemon. I also ported over the CLI to only use `get_settings` for fetching settings values.

This PR still keeps all the calls for individual settings, but as soon as the GUI has switched over we can remove them, I have a commit ready that does that. So we should be able to merge this PR without breaking anything, and then we can move over the GUI when we have time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/428)
<!-- Reviewable:end -->
