### PR TITLE
Make trying to connect without account token not block, just disconnect

### DIFF
--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -1,8 +1,8 @@
 use clap;
+use error_chain::ChainedError;
 use new_rpc_client;
 use Command;
 use Result;
-
 
 pub struct Connect;
 
@@ -18,7 +18,9 @@ impl Command for Connect {
 
     fn run(&self, _matches: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        rpc.connect()?;
+        if let Err(e) = rpc.connect() {
+            eprintln!("{}", e.display_chain());
+        }
         Ok(())
     }
 }

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -29,8 +29,6 @@ pub enum BlockReason {
     StartTunnelError,
     /// No relay server matching the current filter parameters.
     NoMatchingRelay,
-    /// No account token configured.
-    NoAccountToken,
 }
 
 impl fmt::Display for BlockReason {
@@ -42,7 +40,6 @@ impl fmt::Display for BlockReason {
             BlockReason::SetSecurityPolicyError => "Failed to set security policy",
             BlockReason::StartTunnelError => "Failed to start connection to remote server",
             BlockReason::NoMatchingRelay => "No relay server matches the current settings",
-            BlockReason::NoAccountToken => "No account token configured",
         };
 
         write!(formatter, "{}", description)


### PR DESCRIPTION
Changing behavior so that trying to connect when no account token is set leads to going back to disconnected state instead of blocking. Unsetting the account number has to be done by a user, and can't happen by itself, so it should not lead to unexpected traffic leaks.

We already disable auto-connect when no account token is present. And we also automatically disconnect when a frontend unsets the account token. So it feels like all other aspects of the app already equate no account token == disconnected state. As such, this change feels more consistent with those other parts.

I did not change anything in the GUI yet. Since I know you are messing around there quite a lot at the moment I did not want to create any potential merge conflicts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/431)
<!-- Reviewable:end -->
