### PR TITLE
Dirty hack to fix the issue with RPC timeout

### DIFF
--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -511,18 +511,16 @@ export default class AppRenderer {
     });
   }
 
-  _fetchInitialState() {
-    return Promise.all([
-      this._fetchTunnelState(),
-      this.fetchRelaySettings(),
-      this._fetchRelayLocations(),
-      this._fetchAllowLan(),
-      this._fetchAutoConnect(),
-      this._fetchLocation(),
-      this._fetchAccountHistory(),
-      this._fetchTunnelOptions(),
-      this._fetchVersionInfo(),
-    ]);
+  async _fetchInitialState() {
+    await this._fetchTunnelState();
+    await this.fetchRelaySettings();
+    await this._fetchRelayLocations();
+    await this._fetchAllowLan();
+    await this._fetchAutoConnect();
+    await this._fetchLocation();
+    await this._fetchAccountHistory();
+    await this._fetchTunnelOptions();
+    await this._fetchVersionInfo();
   }
 
   _updateTrayIcon(connectionState: ConnectionState) {

--- a/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
+++ b/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
@@ -126,7 +126,7 @@ export class TransportError extends Error {
   }
 }
 
-const DEFAULT_TIMEOUT_MILLIS = 5000;
+const DEFAULT_TIMEOUT_MILLIS = 15000;
 
 export default class JsonRpcClient<T> extends EventEmitter {
   _unansweredRequests: Map<string, UnansweredRequest> = new Map();


### PR DESCRIPTION
and set the request timeout to 10s

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This is a dirty hack to battle the RPC timeout issues due the fact that any RPC calls that trigger network calls in the daemon block all other RPC calls until finished. We used to run a lot of calls simultaneously because that wasn't the case with Websocket RPC we had before. 

It was also faster than running requests one by one. This PR may degrade the overall performance but hopefully should prevent the app from breaking apart due to IPC timeouts. Please test it thoroughly.

There are only two requests that may cause the timeout:

1. `get_account_data` which is throttled in the GUI already. There should be only one request running at a time.

2. `get_current_location` - one of the recent PRs limits the calls to this RPC method to `disconnected` and `connecting` states only, which should reduce the risk of running into timeout issue. Also, the initial fetch includes this call to pick up the location, however with the 15 second timeout we should be able to sustain one `get_account_data` call and one `get_current_location` or even more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/432)
<!-- Reviewable:end -->
