### PR TITLE
Handle rpc calls concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,18 +622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-core"
-version = "8.0.2"
-source = "git+https://github.com/paritytech/jsonrpc#98e892b07949b030461cd8781b2c7b635370327f"
-dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jsonrpc-ipc-server"
 version = "8.0.1"
 source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent#1e76ca656bdd80ebad6eb33f29a4869407fb119b"
@@ -657,31 +645,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-macros"
-version = "8.0.1"
-source = "git+https://github.com/paritytech/jsonrpc#98e892b07949b030461cd8781b2c7b635370327f"
-dependencies = [
- "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-pubsub 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jsonrpc-pubsub"
 version = "8.0.1"
 source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent#1e76ca656bdd80ebad6eb33f29a4869407fb119b"
 dependencies = [
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jsonrpc-pubsub"
-version = "8.0.1"
-source = "git+https://github.com/paritytech/jsonrpc#98e892b07949b030461cd8781b2c7b635370327f"
-dependencies = [
- "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -993,8 +961,7 @@ dependencies = [
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1062,7 +1029,7 @@ dependencies = [
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
  "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1701,12 +1668,12 @@ dependencies = [
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
- "jsonrpc-macros 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
+ "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1722,7 +1689,8 @@ dependencies = [
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "windres 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2278,12 +2246,9 @@ source = "git+https://github.com/mullvad/rust-openssl#4dbd237fe1f6454d8a0042ccf4
 "checksum jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)" = "<none>"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
-"checksum jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
 "checksum jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
 "checksum jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
-"checksum jsonrpc-macros 8.0.1 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
 "checksum jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
-"checksum jsonrpc-pubsub 8.0.1 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
 "checksum jsonrpc-server-utils 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "513e981828a4953ea7ddbb64c24d15d4983ecf6900dc1cd36f257d61c27138d5"
 "checksum jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "jsonrpc-client-core"
 version = "0.5.0"
-source = "git+https://github.com/mullvad/jsonrpc-client-rs#32c0d940f6e0ff0ee11690d746bfbfecd9345ed7"
+source = "git+https://github.com/mullvad/jsonrpc-client-rs#e9dbdc807ccda4a9254ad39152dcaa7f2cef4888"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -586,12 +586,12 @@ dependencies = [
 [[package]]
 name = "jsonrpc-client-ipc"
 version = "0.5.0"
-source = "git+https://github.com/mullvad/jsonrpc-client-rs#32c0d940f6e0ff0ee11690d746bfbfecd9345ed7"
+source = "git+https://github.com/mullvad/jsonrpc-client-rs#e9dbdc807ccda4a9254ad39152dcaa7f2cef4888"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "jsonrpc-server-utils 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-tokio-ipc 0.1.5 (git+https://github.com/NikVolf/parity-tokio-ipc?rev=stable)",
+ "parity-tokio-ipc 0.1.5 (git+https://github.com/NikVolf/parity-tokio-ipc?rev=master)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -612,6 +612,18 @@ dependencies = [
 [[package]]
 name = "jsonrpc-core"
 version = "8.0.2"
+source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent#1e76ca656bdd80ebad6eb33f29a4869407fb119b"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-core"
+version = "8.0.2"
 source = "git+https://github.com/paritytech/jsonrpc#98e892b07949b030461cd8781b2c7b635370327f"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -624,14 +636,24 @@ dependencies = [
 [[package]]
 name = "jsonrpc-ipc-server"
 version = "8.0.1"
-source = "git+https://github.com/paritytech/jsonrpc#98e892b07949b030461cd8781b2c7b635370327f"
+source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent#1e76ca656bdd80ebad6eb33f29a4869407fb119b"
 dependencies = [
- "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-server-utils 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-tokio-ipc 0.1.5 (git+https://github.com/nikvolf/parity-tokio-ipc?branch=stable)",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-macros"
+version = "8.0.1"
+source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent#1e76ca656bdd80ebad6eb33f29a4869407fb119b"
+dependencies = [
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -642,6 +664,16 @@ dependencies = [
  "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
  "jsonrpc-pubsub 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-pubsub"
+version = "8.0.1"
+source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent#1e76ca656bdd80ebad6eb33f29a4869407fb119b"
+dependencies = [
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -670,11 +702,11 @@ dependencies = [
 [[package]]
 name = "jsonrpc-server-utils"
 version = "8.0.1"
-source = "git+https://github.com/paritytech/jsonrpc#98e892b07949b030461cd8781b2c7b635370327f"
+source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent#1e76ca656bdd80ebad6eb33f29a4869407fb119b"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -919,10 +951,10 @@ dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-ipc-server 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-macros 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-pubsub 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -962,6 +994,7 @@ dependencies = [
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1211,7 +1244,7 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-named-pipes 0.1.0 (git+https://github.com/nikvolf/tokio-named-pipes?branch=stable)",
+ "tokio-named-pipes 0.2.0 (git+https://github.com/nikvolf/tokio-named-pipes?branch=stable)",
  "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1219,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "parity-tokio-ipc"
 version = "0.1.5"
-source = "git+https://github.com/NikVolf/parity-tokio-ipc?rev=stable#b4a6cdf7d9b1e51c5d744d7f47d391a69a943232"
+source = "git+https://github.com/NikVolf/parity-tokio-ipc?rev=master#306ea3e6ff8b8c1bb0308183af3eefd761cff9a3"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1227,10 +1260,9 @@ dependencies = [
  "mio-named-pipes 0.1.6 (git+https://github.com/alexcrichton/mio-named-pipes)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-named-pipes 0.1.0 (git+https://github.com/nikvolf/tokio-named-pipes?branch=stable)",
- "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-named-pipes 0.2.0 (git+https://github.com/nikvolf/tokio-named-pipes?branch=stable)",
+ "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1633,8 +1665,8 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-macros 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1667,10 +1699,10 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
- "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-ipc-server 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
+ "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
- "jsonrpc-pubsub 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
+ "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1834,14 +1866,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-named-pipes"
-version = "0.1.0"
-source = "git+https://github.com/nikvolf/tokio-named-pipes?branch=stable#9a9372618552d2c25c2ee4511e5e0fb4eef318e3"
+version = "0.2.0"
+source = "git+https://github.com/nikvolf/tokio-named-pipes?branch=stable#0afa6247222a7aa6e8b370e949a0f4007f0018b6"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (git+https://github.com/alexcrichton/mio-named-pipes)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1964,6 +1996,22 @@ dependencies = [
  "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-uds"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2229,12 +2277,15 @@ source = "git+https://github.com/mullvad/rust-openssl#4dbd237fe1f6454d8a0042ccf4
 "checksum jsonrpc-client-http 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e642eb74423b9dfcb4512fda167148746b76f788a823cd712fadf409f31d302"
 "checksum jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)" = "<none>"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
+"checksum jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
 "checksum jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
-"checksum jsonrpc-ipc-server 8.0.1 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
+"checksum jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
+"checksum jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
 "checksum jsonrpc-macros 8.0.1 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
+"checksum jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
 "checksum jsonrpc-pubsub 8.0.1 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
 "checksum jsonrpc-server-utils 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "513e981828a4953ea7ddbb64c24d15d4983ecf6900dc1cd36f257d61c27138d5"
-"checksum jsonrpc-server-utils 8.0.1 (git+https://github.com/paritytech/jsonrpc)" = "<none>"
+"checksum jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
@@ -2275,7 +2326,7 @@ source = "git+https://github.com/mullvad/rust-openssl#4dbd237fe1f6454d8a0042ccf4
 "checksum os_pipe 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fe033225d563042c3eeb22ffd1d2ea1aefcc48e7e37151a064c9e0bae64b253f"
 "checksum os_pipe 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9d339267cdef39ee54ef165fdfaa2c7289a7465f0188ebe1c8a63872ca64c7"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parity-tokio-ipc 0.1.5 (git+https://github.com/NikVolf/parity-tokio-ipc?rev=stable)" = "<none>"
+"checksum parity-tokio-ipc 0.1.5 (git+https://github.com/NikVolf/parity-tokio-ipc?rev=master)" = "<none>"
 "checksum parity-tokio-ipc 0.1.5 (git+https://github.com/nikvolf/parity-tokio-ipc?branch=stable)" = "<none>"
 "checksum parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69376b761943787ebd5cc85a5bc95958651a22609c5c1c2b65de21786baec72b"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
@@ -2339,7 +2390,7 @@ source = "git+https://github.com/mullvad/rust-openssl#4dbd237fe1f6454d8a0042ccf4
 "checksum tokio-executor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "424f0c87ecd66b863045d84e384cb7ce0ae384d8b065b9f0363d29c0d1b30b2f"
 "checksum tokio-fs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5cbe4ca6e71cb0b62a66e4e6f53a8c06a6eefe46cc5f665ad6f274c9906f135"
 "checksum tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9635ee806f26d302b8baa1e145689a280d8f5aa8d0552e7344808da54cc21"
-"checksum tokio-named-pipes 0.1.0 (git+https://github.com/nikvolf/tokio-named-pipes?branch=stable)" = "<none>"
+"checksum tokio-named-pipes 0.2.0 (git+https://github.com/nikvolf/tokio-named-pipes?branch=stable)" = "<none>"
 "checksum tokio-openssl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4646ae1fd623393de3d796ea53af75acd02938dd5579544fbd6d236d041978a6"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-reactor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8703a5762ff6913510dc64272c714c4389ffd8c4b3cf602879b8bd14ff06b604"
@@ -2350,6 +2401,7 @@ source = "git+https://github.com/mullvad/rust-openssl#4dbd237fe1f6454d8a0042ccf4
 "checksum tokio-timer 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1c76b4e97a4f61030edff8bd272364e4f731b9f54c7307eb4eb733c3926eb96a"
 "checksum tokio-udp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43eb534af6e8f37d43ab1b612660df14755c42bd003c5f8d2475ee78cc4600c0"
 "checksum tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
+"checksum tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "424c1ed15a0132251813ccea50640b224c809d6ceafb88154c1a8775873a0e89"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -15,10 +15,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 log-panics = "2.0.0"
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
-jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
-jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
-jsonrpc-ipc-server = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
+jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
 uuid = { version = "0.6", features = ["v4"] }
 lazy_static = "1.0"
 rand = "0.5"

--- a/mullvad-ipc-client/Cargo.toml
+++ b/mullvad-ipc-client/Cargo.toml
@@ -14,6 +14,7 @@ talpid-types = { path = "../talpid-types" }
 mullvad-paths = { path = "../mullvad-paths" }
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }
 jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }
+tokio-reactor = "0.1"
 tokio-core = "0.1"
 tokio-timer = "0.1"
 futures = "0.1"

--- a/mullvad-ipc-client/Cargo.toml
+++ b/mullvad-ipc-client/Cargo.toml
@@ -14,8 +14,7 @@ talpid-types = { path = "../talpid-types" }
 mullvad-paths = { path = "../mullvad-paths" }
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }
 jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }
-tokio-reactor = "0.1"
-tokio-core = "0.1"
+tokio = "0.1"
 tokio-timer = "0.1"
 futures = "0.1"
 log = "0.4"

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -14,6 +14,7 @@ extern crate serde;
 extern crate talpid_ipc;
 extern crate talpid_types;
 extern crate tokio_core;
+extern crate tokio_reactor;
 extern crate tokio_timer;
 
 use std::path::Path;
@@ -35,7 +36,6 @@ use futures::sync::oneshot;
 use jsonrpc_client_core::{Client, ClientHandle, Future};
 pub use jsonrpc_client_core::{Error as RpcError, ErrorKind as RpcErrorKind};
 use jsonrpc_client_ipc::IpcTransport;
-use tokio_core::reactor;
 
 error_chain! {
     errors {
@@ -71,7 +71,7 @@ error_chain! {
 static NO_ARGS: [u8; 0] = [];
 
 pub fn new_standalone_transport<
-    F: Send + 'static + FnOnce(String, reactor::Handle) -> Result<T>,
+    F: Send + 'static + FnOnce(String, tokio_reactor::Handle) -> Result<T>,
     T: jsonrpc_client_core::Transport,
 >(
     rpc_path: String,
@@ -85,7 +85,7 @@ pub fn new_standalone_transport<
         Ok((mut core, client, client_handle)) => {
             tx.send(Ok(client_handle))
                 .expect("Failed to send client handle");
-            if let Err(e) = core.run(client) {
+            if let Err(e) = client.wait() {
                 error!("JSON-RPC client failed: {}", e.description());
             }
         }
@@ -105,13 +105,13 @@ pub fn new_standalone_ipc_client(path: &impl AsRef<Path>) -> Result<DaemonRpcCli
 }
 
 fn spawn_transport<
-    F: Send + FnOnce(String, reactor::Handle) -> Result<T>,
+    F: Send + FnOnce(String, tokio_reactor::Handle) -> Result<T>,
     T: jsonrpc_client_core::Transport,
 >(
     address: String,
     transport_func: F,
-) -> Result<(reactor::Core, Client<T>, ClientHandle)> {
-    let core = reactor::Core::new().chain_err(|| ErrorKind::TokioError)?;
+) -> Result<(tokio_reactor::Reactor, Client<T>, ClientHandle)> {
+    let core = tokio_reactor::Reactor::new().chain_err(|| ErrorKind::TokioError)?;
     let (client, client_handle) = transport_func(address, core.handle())?.into_client();
     Ok((core, client, client_handle))
 }
@@ -215,6 +215,20 @@ impl DaemonRpcClient {
             .call_method(method, args)
             .wait()
             .chain_err(|| ErrorKind::RpcCallError(method.to_owned()))
+    }
+
+    pub fn call_async<T, A> (&mut self, method: &'static str, args: A) -> Box<Future<Item=(), Error=()>>
+    where
+    T:for<'de> Deserialize<'de> + Send + 'static + std::fmt::Debug,
+    A:  Serialize + Send + 'static,
+    {
+        let meth = method.to_string();
+        Box::new(self.rpc_client
+            .call_method(method, &args)
+            .then(move |result: std::result::Result<T, _>| {
+                println!("received {} - {:?}",meth, result );
+                futures::future::ok(())
+            }))
     }
 
     pub fn new_state_subscribe(&mut self) -> Result<mpsc::Receiver<TunnelStateTransition>> {

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -13,8 +13,7 @@ extern crate mullvad_types;
 extern crate serde;
 extern crate talpid_ipc;
 extern crate talpid_types;
-extern crate tokio_core;
-extern crate tokio_reactor;
+extern crate tokio;
 extern crate tokio_timer;
 
 use std::path::Path;
@@ -71,7 +70,7 @@ error_chain! {
 static NO_ARGS: [u8; 0] = [];
 
 pub fn new_standalone_transport<
-    F: Send + 'static + FnOnce(String, tokio_reactor::Handle) -> Result<T>,
+    F: Send + 'static + FnOnce(String) -> Result<T>,
     T: jsonrpc_client_core::Transport,
 >(
     rpc_path: String,
@@ -82,9 +81,10 @@ pub fn new_standalone_transport<
         Err(e) => tx
             .send(Err(e))
             .expect("Failed to send error back to caller"),
-        Ok((mut core, client, client_handle)) => {
+        Ok((client, client_handle)) => {
             tx.send(Ok(client_handle))
                 .expect("Failed to send client handle");
+
             if let Err(e) = client.wait() {
                 error!("JSON-RPC client failed: {}", e.description());
             }
@@ -99,21 +99,17 @@ pub fn new_standalone_transport<
 pub fn new_standalone_ipc_client(path: &impl AsRef<Path>) -> Result<DaemonRpcClient> {
     let path = path.as_ref().to_string_lossy().to_string();
 
-    new_standalone_transport(path, |path, handle| {
-        IpcTransport::new(&path, &handle).chain_err(|| ErrorKind::TransportError)
+    new_standalone_transport(path, |path| {
+        IpcTransport::new(&path, &tokio::reactor::Handle::current()).chain_err(|| ErrorKind::TransportError)
     })
 }
 
-fn spawn_transport<
-    F: Send + FnOnce(String, tokio_reactor::Handle) -> Result<T>,
-    T: jsonrpc_client_core::Transport,
->(
+fn spawn_transport<F: Send + FnOnce(String) -> Result<T>, T: jsonrpc_client_core::Transport>(
     address: String,
     transport_func: F,
-) -> Result<(tokio_reactor::Reactor, Client<T>, ClientHandle)> {
-    let core = tokio_reactor::Reactor::new().chain_err(|| ErrorKind::TokioError)?;
-    let (client, client_handle) = transport_func(address, core.handle())?.into_client();
-    Ok((core, client, client_handle))
+) -> Result<(Client<T>, ClientHandle)> {
+    let (client, client_handle) = transport_func(address)?.into_client();
+    Ok((client, client_handle))
 }
 
 pub struct DaemonRpcClient {
@@ -217,18 +213,22 @@ impl DaemonRpcClient {
             .chain_err(|| ErrorKind::RpcCallError(method.to_owned()))
     }
 
-    pub fn call_async<T, A> (&mut self, method: &'static str, args: A) -> Box<Future<Item=(), Error=()>>
+    pub fn call_async<T, A>(
+        &mut self,
+        method: &'static str,
+        args: A,
+    ) -> Box<Future<Item = (), Error = ()>>
     where
-    T:for<'de> Deserialize<'de> + Send + 'static + std::fmt::Debug,
-    A:  Serialize + Send + 'static,
+        T: for<'de> Deserialize<'de> + Send + 'static + std::fmt::Debug,
+        A: Serialize + Send + 'static,
     {
         let meth = method.to_string();
-        Box::new(self.rpc_client
-            .call_method(method, &args)
-            .then(move |result: std::result::Result<T, _>| {
-                println!("received {} - {:?}",meth, result );
+        Box::new(self.rpc_client.call_method(method, &args).then(
+            move |result: std::result::Result<T, _>| {
+                println!("received {} - {:?}", meth, result);
                 futures::future::ok(())
-            }))
+            },
+        ))
     }
 
     pub fn new_state_subscribe(&mut self) -> Result<mpsc::Receiver<TunnelStateTransition>> {

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -19,7 +19,7 @@ talpid-types = { path = "../talpid-types" }
 tempfile = "3.0"
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }
 jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs", branch = "master" }
-tokio-core = "0.1"
+tokio = "0.1"
 futures = "0.1.23"
 
 [target.'cfg(unix)'.dependencies]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -10,8 +10,9 @@ atty = "0.2"
 duct = "0.11"
 error-chain = "0.12"
 futures = "0.1"
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
-jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
+jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+
 libc = "0.2.20"
 log = "0.4"
 openvpn-plugin = { version = "0.3", features = ["serde"] }

--- a/talpid-ipc/Cargo.toml
+++ b/talpid-ipc/Cargo.toml
@@ -10,9 +10,10 @@ error-chain = "0.12"
 serde = "1.0"
 serde_json = "1.0"
 log = "0.4"
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
-jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
-jsonrpc-ipc-server = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
+jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
+
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs" }
 jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs" }
 

--- a/talpid-ipc/Cargo.toml
+++ b/talpid-ipc/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs" }
 [dev-dependencies]
 assert_matches = "1.0"
 env_logger = "0.5"
-jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc", branch = "master" }
+jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent" }
 uuid = { version = "0.6", features = ["v4"] }
 futures = "0.1.23"
-tokio-core = "0.1"
+tokio = "0.1"

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -14,7 +14,8 @@ log = "0.4"
 env_logger = "0.5"
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs" }
 jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs" }
-tokio-core = "0.1"
+tokio-reactor = "0.1"
+tokio = "0.1"
 futures = "0.1"
 
 openvpn-plugin = { version = "0.3", features = ["serde", "log"] }

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -18,7 +18,8 @@ extern crate futures;
 extern crate jsonrpc_client_ipc;
 #[macro_use]
 extern crate openvpn_plugin;
-extern crate tokio_core;
+extern crate tokio;
+extern crate tokio_reactor;
 
 use error_chain::ChainedError;
 use openvpn_plugin::types::{EventResult, OpenVpnPluginEvent};

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -3,10 +3,14 @@ use std::collections::HashMap;
 
 extern crate futures;
 
+use futures::executor::spawn;
 use jsonrpc_client_core::{Future, Result as ClientResult, Transport};
 use jsonrpc_client_ipc::IpcTransport;
-use tokio_core::reactor::Core;
 
+use tokio::reactor::Handle;
+use tokio::runtime::Runtime;
+
+use std::thread;
 use super::Arguments;
 
 error_chain! {
@@ -27,29 +31,36 @@ error_chain! {
 pub struct EventProcessor {
     ipc_client: EventProxy,
     client_stop: ::std::sync::mpsc::Receiver<ClientResult<()>>,
-    core: Core,
 }
 
 impl EventProcessor {
     pub fn new(arguments: Arguments) -> Result<EventProcessor> {
         trace!("Creating EventProcessor");
-        let core = Core::new().chain_err(|| "Unable to initialize Tokio Core")?;
-        let handle = core.handle();
-        let (client, client_handle) = IpcTransport::new(&arguments.ipc_socket_path, &handle)
-            .chain_err(|| "Unable to create IPC transport")?
-            .into_client();
 
-        let (tx, client_stop) = ::std::sync::mpsc::channel();
 
-        let client_future = client.then(move |result| tx.send(result)).map_err(|_| ());
-        handle.spawn(client_future);
 
+        let (start_tx, start_rx) = futures::sync::oneshot::channel();
+        thread::spawn(move|| {
+            let mut rt = Runtime::new().expect("failed to spawn runtime");
+
+            let (client, client_handle) =
+                IpcTransport::new(&arguments.ipc_socket_path, &rt.handle())
+                    .expect("Unable to create IPC transport")
+                    .into_client();
+
+            let (tx, client_stop) = ::std::sync::mpsc::channel();
+            let client_future = client.then(move |result| tx.send(result)).map_err(|_| ());
+            start_tx.send((client_stop, client_handle)).expect("failed to send client handles");
+
+            rt.block_on(client_future);
+        });
+
+        let (client_stop, client_handle) = start_rx.wait().chain_err(|| ErrorKind::Shutdown)?;
         let ipc_client = EventProxy::new(client_handle);
 
         Ok(EventProcessor {
             ipc_client,
             client_stop,
-            core,
         })
     }
 
@@ -63,7 +74,7 @@ impl EventProcessor {
             .ipc_client
             .openvpn_event(event, env)
             .map_err(|e| Error::with_chain(e, ErrorKind::IpcSendingError));
-        self.core.run(call_future)?;
+        call_future.wait()?;
         self.check_client_status()
     }
 


### PR DESCRIPTION
This PR just changes the version of `jsonrpc-*` server crates we depend on, with the side effect of forcing us to depend on a newer version of `parity-tokio-ipc`, which forces us to use newer versions of Tokio.
The underlying issue that this fixes is that we no longer use a version of `jsonrpc-ipc-server` that can't handle requests and responses concurrently. This is fixed by hastily added changes on our branch of `jsonrpc` - https://github.com/paritytech/jsonrpc/compare/master...mullvad:make-ipc-server-concurrent?expand=1