### PR TITLE
Fail less when restoring windows dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Line wrap the file at 100 chars.                                              Th
 - Make the pkg installer kill any running GUI process after installation is done. Prevents
   accidentally running an old GUI with a newer daemon.
 
+#### Windows
+- Failing to restore DNS settings on daemon start does not make the daemon exit with an error, just
+  log the error and continue.
+
 ### Changed
 - The "Buy more credit" button is changed to open a dedicated account login page instead of one
   having a create account form first.


### PR DESCRIPTION
I found a Windows user log where the daemon exited directly on start. And this was because they could not restore the backed up DNS state. This restore function does not have any error sink callback, so I don't know what the exact error on the C++ side was. But anyway, since failing to restore it also does not delete the backup file, they probably get stuck in this problem forever(?)

So this PR suggests we instead just capture and log any restore error and then move on. Or is this just hiding the problem under the carpet? I'm thinking that if the user has `auto-connect` and expect to be protected at all times then this change will at least allow them to become secured on boot, compared to now when the daemon just exits and don't secure the network at all.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/435)
<!-- Reviewable:end -->
