### PR TITLE
Attempt to apply target state if in blocked state

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -593,7 +593,7 @@ impl Daemon {
     /// progress towards that state.
     /// Returns an error if trying to set secured state, but no account token is present.
     fn set_target_state(&mut self, new_state: TargetState) -> ::std::result::Result<(), ()> {
-        if new_state != self.target_state {
+        if new_state != self.target_state || self.tunnel_state.is_blocked() {
             debug!("Target state {:?} => {:?}", self.target_state, new_state);
             self.target_state = new_state;
             match self.target_state {

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -17,6 +17,15 @@ pub enum TunnelStateTransition {
     Blocked(BlockReason),
 }
 
+impl TunnelStateTransition {
+    pub fn is_blocked(&self) -> bool {
+        match self {
+            TunnelStateTransition::Blocked(_) => true,
+            _ => false,
+        }
+    }
+}
+
 /// Reason for entering the blocked state.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
Previously, if the daemon was in a blocked state whilst trying to connect, there would be no way to make the daemon to connect again without getting out of the blocked state. This small change makes it so that target states will be applied if the current and the target states don't match or if the tunnel is currently in a blocked state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/436)
<!-- Reviewable:end -->
