### PR TITLE
Support older versions of systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix incorrect window position when using external display.
 - Don't auto-connect the daemon on start if no account token is set. This prevents the daemon from
   blocking all internet if logging out from the app.
+- Fix systemd unit file to support older versions of systemd (e.g., in Debian 8).
 
 #### Linux
 - The app window is now shown in its previous location, instead of at the center of the screen.

--- a/dist-assets/linux/mullvad-daemon.service
+++ b/dist-assets/linux/mullvad-daemon.service
@@ -10,7 +10,7 @@ StartLimitIntervalSec=20
 [Service]
 Restart=always
 RestartSec=1
-ExecStart="/opt/Mullvad VPN/resources/mullvad-daemon" -v --disable-stdout-timestamps
+ExecStart=/opt/Mullvad\x20VPN/resources/mullvad-daemon -v --disable-stdout-timestamps
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The mullvad-daemon service unit file required a quotation feature available on certain newer systemd versions. Unfortunately, Debian 8 still includes a version without that feature. This PR therefore changes the unit file to escape the executable path instead of quoting it, so that the feature is not required and older versions of systemd can parse it. This allows the app to run on Debian 8.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
