### PR TITLE
Move the mullvad.exe CLI binary back to resource dir temporarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Line wrap the file at 100 chars.                                              Th
 - Replace WebSockets with Unix domain sockets/Named pipes for IPC. The location
   of the socket can be controlled with `MULLVAD_RPC_SOCKET_PATH`.
 - Update the relay list if it's out of date when the daemon starts.
-- Move the CLI binary (`mullvad` or `mullvad.exe`) up one level, so it's installed directly into
+- Move the CLI binary (`mullvad`) on macOS and Linux up one level, so it's installed directly into
   the app installation directory instead of the `resource` directory.
 
 

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -92,7 +92,6 @@ win:
       to: .
     - from: ../../../dist-assets/binaries/windows/openvpn.exe
       to: .
-  extraFiles:
     - from: ../../../target/release/mullvad.exe
       to: .
 


### PR DESCRIPTION
Since this causes problems with auto-start on Windows we move it back. At least for now. We should also report this bug to electron/electron-builder when we have time.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/443)
<!-- Reviewable:end -->
