### PR TITLE
Migrate to new settings API

### DIFF
--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -14,10 +14,9 @@ import { createMemoryHistory } from 'history';
 
 import makeRoutes from './routes';
 import ReconnectionBackoff from './lib/reconnection-backoff';
-import { DaemonRpc, ConnectionObserver, SubscriptionListener } from './lib/daemon-rpc';
+import { DaemonRpc, ConnectionObserver } from './lib/daemon-rpc';
 import NotificationController from './lib/notification-controller';
 import setShutdownHandler from './lib/shutdown-handler';
-import { NoAccountError } from './errors';
 
 import configureStore from './redux/store';
 import accountActions from './redux/account/actions';
@@ -26,11 +25,16 @@ import settingsActions from './redux/settings/actions';
 import versionActions from './redux/version/actions';
 import windowActions from './redux/window/actions';
 
+import SettingsProxy from './lib/subscription-proxy/settings-proxy';
+import TunnelStateProxy from './lib/subscription-proxy/tunnel-state-proxy';
+
 import type { WindowShapeParameters } from '../main/window-controller';
 import type {
   AccountToken,
+  Settings,
   TunnelStateTransition,
   RelaySettingsUpdate,
+  RelaySettings,
   TunnelState,
   DaemonRpcProtocol,
   AccountData,
@@ -56,9 +60,13 @@ export default class AppRenderer {
   _accountDataCache = new AccountDataCache((accountToken) => {
     return this._daemonRpc.getAccountData(accountToken);
   });
+  _tunnelStateProxy = new TunnelStateProxy(this._daemonRpc, (tunnelState) => {
+    this._setTunnelState(tunnelState);
+  });
+  _settingsProxy = new SettingsProxy(this._daemonRpc, (settings) => {
+    this._setSettings(settings);
+  });
   _connectedToDaemon = false;
-  _accountToken: ?AccountToken;
-  _tunnelState: ?TunnelStateTransition;
 
   constructor() {
     const store = configureStore(null, this._memoryHistory);
@@ -129,9 +137,6 @@ export default class AppRenderer {
       const accountData = await this._daemonRpc.getAccountData(accountToken);
       await this._daemonRpc.setAccount(accountToken);
 
-      // reset the account token with the one that we just sent to daemon
-      this._accountToken = accountToken;
-
       actions.account.updateAccountExpiry(accountData.expiry);
       actions.account.loginSuccessful();
 
@@ -156,63 +161,11 @@ export default class AppRenderer {
     }
   }
 
-  async _restoreSession() {
-    const actions = this._reduxActions;
-    const history = this._memoryHistory;
-
-    log.debug('Restoring session');
-
-    const accountToken = await this._daemonRpc.getAccount();
-
-    // save the account token received after connecting to daemon
-    this._accountToken = accountToken;
-
-    if (accountToken) {
-      log.debug(`Got account token: ${accountToken}`);
-      actions.account.updateAccountToken(accountToken);
-      actions.account.loginSuccessful();
-
-      // take user to main view if user is still at launch screen `/`
-      if (history.location.pathname === '/') {
-        actions.history.replace('/connect');
-      } else {
-        // TODO: Reinvent the navigation back in history to make sure that user does not end up on
-        // the restricted screen due to changes in daemon's state.
-        for (const entry of history.entries) {
-          if (entry.pathname === '/') {
-            entry.pathname = '/connect';
-          }
-        }
-      }
-    } else {
-      log.debug('No account set, showing login view.');
-
-      // show window when account is not set
-      ipcRenderer.send('show-window');
-
-      // take user to `/login` screen if user is at launch screen `/`
-      if (history.location.pathname === '/') {
-        actions.history.replace('/login');
-      } else {
-        // TODO: Reinvent the navigation back in history to make sure that user does not end up on
-        // the restricted screen due to changes in daemon's state.
-        for (const entry of history.entries) {
-          if (!entry.pathname.startsWith('/settings')) {
-            entry.pathname = '/login';
-          }
-        }
-      }
-    }
-  }
-
   async logout() {
     const actions = this._reduxActions;
 
     try {
       await this._daemonRpc.setAccount(null);
-
-      // reset the account token after log out
-      this._accountToken = null;
 
       await this._fetchAccountHistory();
 
@@ -229,11 +182,10 @@ export default class AppRenderer {
   async connectTunnel() {
     const actions = this._reduxActions;
 
+    const tunnelState = await this._tunnelStateProxy.fetch();
+
     // connect only if tunnel is disconnected or blocked.
-    if (
-      this._tunnelState &&
-      (this._tunnelState.state === 'disconnected' || this._tunnelState.state === 'blocked')
-    ) {
+    if (tunnelState.state === 'disconnected' || tunnelState.state === 'blocked') {
       // switch to connecting state immediately to prevent a lag that may be caused by RPC
       // communication delay
       actions.connection.connecting();
@@ -250,11 +202,8 @@ export default class AppRenderer {
     return this._daemonRpc.updateRelaySettings(relaySettings);
   }
 
-  async fetchRelaySettings() {
+  _setRelaySettings(relaySettings: RelaySettings) {
     const actions = this._reduxActions;
-    const relaySettings = await this._daemonRpc.getRelaySettings();
-
-    log.debug('Got relay settings from daemon', JSON.stringify(relaySettings));
 
     if (relaySettings.normal) {
       const payload = {};
@@ -301,18 +250,16 @@ export default class AppRenderer {
 
   async updateAccountExpiry() {
     const actions = this._reduxActions;
+    const settings = await this._settingsProxy.fetch();
     const accountDataCache = this._accountDataCache;
 
-    try {
-      const accountToken = this._accountToken;
-      if (accountToken) {
-        const accountData = await accountDataCache.fetch(accountToken);
+    if (settings && settings.accountToken) {
+      try {
+        const accountData = await accountDataCache.fetch(settings.accountToken);
         actions.account.updateAccountExpiry(accountData.expiry);
-      } else {
-        throw new NoAccountError();
+      } catch (error) {
+        log.error(`Failed to update account expiry: ${error.message}`);
       }
-    } catch (e) {
-      log.error(`Failed to update account expiry: ${e.message}`);
     }
   }
 
@@ -387,32 +334,6 @@ export default class AppRenderer {
     actions.settings.updateAutoConnect(autoConnect);
   }
 
-  async _fetchAllowLan() {
-    const actions = this._reduxActions;
-    const allowLan = await this._daemonRpc.getAllowLan();
-    actions.settings.updateAllowLan(allowLan);
-  }
-
-  async _fetchAutoConnect() {
-    const actions = this._reduxActions;
-    const autoConnect = await this._daemonRpc.getAutoConnect();
-    actions.settings.updateAutoConnect(autoConnect);
-  }
-
-  async _fetchTunnelState() {
-    const state = await this._daemonRpc.getState();
-
-    log.debug(`Got state: ${JSON.stringify(state)}`);
-
-    this._onChangeTunnelState(state);
-  }
-
-  async _fetchTunnelOptions() {
-    const actions = this._reduxActions;
-    const tunnelOptions = await this._daemonRpc.getTunnelOptions();
-    actions.settings.updateEnableIpv6(tunnelOptions.enableIpv6);
-  }
-
   async _fetchVersionInfo() {
     const actions = this._reduxActions;
     const latestVersionInfo = await this._daemonRpc.getVersionInfo();
@@ -429,32 +350,62 @@ export default class AppRenderer {
     // reset the reconnect backoff when connection established.
     this._reconnectBackoff.reset();
 
-    // attempt to restore the session
     try {
-      await this._restoreSession();
+      await this._runPrimaryApplicationFlow();
     } catch (error) {
-      log.error(`Failed to restore session: ${error.message}`);
+      log.error(`An error was raised when running the primary application flow: ${error.message}`);
+    }
+  }
+
+  async _runPrimaryApplicationFlow() {
+    // fetch initial state and subscribe for changes
+    try {
+      await this._settingsProxy.fetch();
+    } catch (error) {
+      log.error(`Cannot fetch the initial settings: ${error.message}`);
     }
 
-    // make sure to re-subscribe to state notifications when connection is re-established.
     try {
-      await this._subscribeStateListener();
+      await this._tunnelStateProxy.fetch();
     } catch (error) {
-      log.error(`Cannot subscribe for RPC notifications: ${error.message}`);
+      log.error(`Cannot fetch the initial tunnel state: ${error.message}`);
     }
 
-    // fetch initial state
+    // fetch the rest of data
     try {
-      await this._fetchInitialState();
+      await this._fetchRelayLocations();
     } catch (error) {
-      log.error(`Cannot fetch initial state: ${error.message}`);
+      log.error(`Cannot fetch the relay locations: ${error.message}`);
+    }
+
+    try {
+      await this._fetchAccountHistory();
+    } catch (error) {
+      log.error(`Cannot fetch the account history: ${error.message}`);
+    }
+
+    // set the appropriate start view
+    await this._setStartView();
+
+    try {
+      await this._fetchLocation();
+    } catch (error) {
+      log.error(`Cannot fetch the location: ${error.message}`);
+    }
+
+    try {
+      await this._fetchVersionInfo();
+    } catch (error) {
+      log.error(`Cannot fetch the version information: ${error.message}`);
     }
 
     // auto connect the tunnel on startup
     // note: disabled when developing
     if (process.env.NODE_ENV !== 'development') {
+      const settings = await this._settingsProxy.fetch();
+
       // only connect if account is set in the daemon
-      if (this._accountToken) {
+      if (settings.accountToken) {
         try {
           log.debug('Autoconnect the tunnel');
           await this.connectTunnel();
@@ -466,6 +417,51 @@ export default class AppRenderer {
       }
     } else {
       log.debug('Skip autoconnect in development');
+    }
+  }
+
+  async _setStartView() {
+    const actions = this._reduxActions;
+    const history = this._memoryHistory;
+    const settings = await this._settingsProxy.fetch();
+    const accountToken = settings.accountToken;
+
+    if (accountToken) {
+      log.debug(`Account token is set. Showing the tunnel view.`);
+
+      actions.account.updateAccountToken(accountToken);
+      actions.account.loginSuccessful();
+
+      // take user to main view if user is still at launch screen `/`
+      if (history.location.pathname === '/') {
+        actions.history.replace('/connect');
+      } else {
+        // TODO: Reinvent the navigation back in history to make sure that user does not end up on
+        // the restricted screen due to changes in daemon's state.
+        for (const entry of history.entries) {
+          if (entry.pathname === '/') {
+            entry.pathname = '/connect';
+          }
+        }
+      }
+    } else {
+      log.debug('No account set, showing login view.');
+
+      // show window when account is not set
+      ipcRenderer.send('show-window');
+
+      // take user to `/login` screen if user is at launch screen `/`
+      if (history.location.pathname === '/') {
+        actions.history.replace('/login');
+      } else {
+        // TODO: Reinvent the navigation back in history to make sure that user does not end up on
+        // the restricted screen due to changes in daemon's state.
+        for (const entry of history.entries) {
+          if (!entry.pathname.startsWith('/settings')) {
+            entry.pathname = '/login';
+          }
+        }
+      }
     }
   }
 
@@ -499,42 +495,23 @@ export default class AppRenderer {
     this._connectedToDaemon = false;
   }
 
-  _subscribeStateListener(): Promise<void> {
-    const listener = new SubscriptionListener(
-      (newState: TunnelStateTransition) => {
-        log.debug(`Got state update: '${JSON.stringify(newState)}'`);
-
-        this._onChangeTunnelState(newState);
-      },
-      (error: Error) => {
-        log.error(`Failed to deserialize the new state: ${error.message}`);
-      },
-    );
-
-    return this._daemonRpc.subscribeStateListener(listener);
-  }
-
-  _fetchInitialState() {
-    return Promise.all([
-      this._fetchTunnelState(),
-      this.fetchRelaySettings(),
-      this._fetchRelayLocations(),
-      this._fetchAllowLan(),
-      this._fetchAutoConnect(),
-      this._fetchLocation(),
-      this._fetchAccountHistory(),
-      this._fetchTunnelOptions(),
-      this._fetchVersionInfo(),
-    ]);
-  }
-
-  _onChangeTunnelState(tunnelState: TunnelStateTransition) {
-    this._tunnelState = tunnelState;
+  _setTunnelState(tunnelState: TunnelStateTransition) {
+    log.debug(`Tunnel state: ${tunnelState.state}`);
 
     this._updateConnectionStatus(tunnelState);
     this._updateUserLocation(tunnelState.state);
     this._updateTrayIcon(tunnelState.state);
     this._showNotification(tunnelState.state);
+  }
+
+  _setSettings(newSettings: Settings) {
+    const reduxSettings = this._reduxActions.settings;
+
+    reduxSettings.updateAllowLan(newSettings.allowLan);
+    reduxSettings.updateAutoConnect(newSettings.autoConnect);
+    reduxSettings.updateEnableIpv6(newSettings.tunnelOptions.enableIpv6);
+
+    this._setRelaySettings(newSettings.relaySettings);
   }
 
   async _updateUserLocation(tunnelState: TunnelState) {

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -280,17 +280,17 @@ export default class AppRenderer {
       actions.settings.updateRelay({
         normal: payload,
       });
-    } else if (relaySettings.custom_tunnel_endpoint) {
-      const custom_tunnel_endpoint = relaySettings.custom_tunnel_endpoint;
+    } else if (relaySettings.customTunnelEndpoint) {
+      const customTunnelEndpoint = relaySettings.customTunnelEndpoint;
       const {
         host,
         tunnel: {
           openvpn: { port, protocol },
         },
-      } = custom_tunnel_endpoint;
+      } = customTunnelEndpoint;
 
       actions.settings.updateRelay({
-        custom_tunnel_endpoint: {
+        customTunnelEndpoint: {
           host,
           port,
           protocol,

--- a/gui/packages/desktop/src/renderer/components/SelectLocation.js
+++ b/gui/packages/desktop/src/renderer/components/SelectLocation.js
@@ -30,9 +30,9 @@ type State = {
   expanded: Array<string>,
 };
 
-  _selectedCell: ?Cell.CellButton;
-  _scrollView: ?CustomScrollbars;
 export default class SelectLocation extends Component<Props, State> {
+  _selectedCellRef = React.createRef();
+  _scrollViewRef = React.createRef();
 
   state = {
     expanded: [],
@@ -65,8 +65,8 @@ export default class SelectLocation extends Component<Props, State> {
 
   componentDidMount() {
     // restore scroll to selected cell
-    const cell = this._selectedCell;
-    const scrollView = this._scrollView;
+    const cell = this._selectedCellRef.current;
+    const scrollView = this._scrollViewRef.current;
 
     if (scrollView && cell) {
       // eslint-disable-next-line react/no-find-dom-node
@@ -91,7 +91,7 @@ export default class SelectLocation extends Component<Props, State> {
                 <HeaderTitle>Select location</HeaderTitle>
               </SettingsHeader>
 
-              <CustomScrollbars autoHide={true} ref={(ref) => (this._scrollView = ref)}>
+              <CustomScrollbars autoHide={true} ref={this._scrollViewRef}>
                 <View style={styles.content}>
                   <SettingsHeader style={styles.subtitle_header}>
                     <HeaderSubTitle>
@@ -174,11 +174,7 @@ export default class SelectLocation extends Component<Props, State> {
   _renderCountry(relayCountry: RelayLocationRedux) {
     const isSelected = this._isSelected({ country: relayCountry.code });
 
-    const onRef = isSelected
-      ? (element) => {
-          this._selectedCell = element;
-        }
-      : undefined;
+    const cellRef = isSelected ? this._selectedCellRef : undefined;
 
     // either expanded by user or when the city selected within the country
     const isExpanded = this.state.expanded.includes(relayCountry.code);
@@ -207,7 +203,7 @@ export default class SelectLocation extends Component<Props, State> {
           onPress={handleSelect}
           disabled={!relayCountry.hasActiveRelays}
           testName="country"
-          ref={onRef}>
+          ref={cellRef}>
           {this._relayStatusIndicator(relayCountry.hasActiveRelays, isSelected)}
 
           <Cell.Label>{relayCountry.name}</Cell.Label>
@@ -239,11 +235,7 @@ export default class SelectLocation extends Component<Props, State> {
 
     const isSelected = this._isSelected(relayLocation);
 
-    const onRef = isSelected
-      ? (element) => {
-          this._selectedCell = element;
-        }
-      : undefined;
+    const cellRef = isSelected ? this._selectedCellRef : undefined;
 
     // either expanded by user or when the city or a relay from the city is selected
     const isExpanded = this.state.expanded.includes(expandedCode);
@@ -268,7 +260,7 @@ export default class SelectLocation extends Component<Props, State> {
           cellHoverStyle={isSelected ? styles.sub_cell__selected : null}
           style={isSelected ? styles.sub_cell__selected : styles.sub_cell}
           testName="city"
-          ref={onRef}>
+          ref={cellRef}>
           {this._relayStatusIndicator(relayCity.hasActiveRelays, isSelected)}
 
           <Cell.Label>{relayCity.name}</Cell.Label>
@@ -299,11 +291,7 @@ export default class SelectLocation extends Component<Props, State> {
 
     const isSelected = this._isSelected(relayLocation);
 
-    const onRef = isSelected
-      ? (element) => {
-          this._selectedCell = element;
-        }
-      : undefined;
+    const cellRef = isSelected ? this._selectedCellRef : undefined;
 
     const handleSelect = !isSelected
       ? () => {
@@ -318,7 +306,7 @@ export default class SelectLocation extends Component<Props, State> {
         cellHoverStyle={isSelected ? styles.sub_sub_cell__selected : null}
         style={isSelected ? styles.sub_sub_cell__selected : styles.sub_sub_cell}
         testName="relay"
-        ref={onRef}>
+        ref={cellRef}>
         {this._relayStatusIndicator(true, isSelected)}
 
         <Cell.Label>{relay.hostname}</Cell.Label>

--- a/gui/packages/desktop/src/renderer/components/SelectLocation.js
+++ b/gui/packages/desktop/src/renderer/components/SelectLocation.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import { View } from 'reactxp';
+import { View, Component } from 'reactxp';
 import { Accordion } from '@mullvad/components';
 import { Layout, Container } from './Layout';
 import CustomScrollbars from './CustomScrollbars';
@@ -12,15 +12,16 @@ import * as Cell from './Cell';
 import styles from './SelectLocationStyles';
 
 import type {
-  SettingsReduxState,
+  RelaySettingsRedux,
   RelayLocationRedux,
   RelayLocationCityRedux,
   RelayLocationRelayRedux,
 } from '../redux/settings/reducers';
 import type { RelayLocation } from '../lib/daemon-rpc';
 
-export type SelectLocationProps = {
-  settings: SettingsReduxState,
+type Props = {
+  relaySettings: RelaySettingsRedux,
+  relayLocations: Array<RelayLocationRedux>,
   onClose: () => void,
   onSelect: (location: RelayLocation) => void,
 };
@@ -29,19 +30,19 @@ type State = {
   expanded: Array<string>,
 };
 
-export default class SelectLocation extends React.Component<SelectLocationProps, State> {
   _selectedCell: ?Cell.CellButton;
   _scrollView: ?CustomScrollbars;
+export default class SelectLocation extends Component<Props, State> {
 
   state = {
     expanded: [],
   };
 
-  constructor(props: SelectLocationProps, context?: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     // set initially expanded country based on relaySettings
-    const relaySettings = this.props.settings.relaySettings;
+    const relaySettings = this.props.relaySettings;
     if (relaySettings.normal) {
       const { location } = relaySettings.normal;
       if (location === 'any') {
@@ -99,7 +100,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
                     </HeaderSubTitle>
                   </SettingsHeader>
 
-                  {this.props.settings.relayLocations.map((relayCountry) => {
+                  {this.props.relayLocations.map((relayCountry) => {
                     return this._renderCountry(relayCountry);
                   })}
                 </View>
@@ -112,7 +113,7 @@ export default class SelectLocation extends React.Component<SelectLocationProps,
   }
 
   _isSelected(selectedLocation: RelayLocation) {
-    const { relaySettings } = this.props.settings;
+    const relaySettings = this.props.relaySettings;
     if (relaySettings.normal) {
       const otherLocation = relaySettings.normal.location;
 

--- a/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
+++ b/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
@@ -56,7 +56,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
 
       try {
         await props.app.updateRelaySettings(relayUpdate);
-        await props.app.fetchRelaySettings();
       } catch (e) {
         log.error('Failed to update relay settings', e.message);
       }

--- a/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
+++ b/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
@@ -24,8 +24,8 @@ const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) =>
       protocol: protocol === 'any' ? 'Automatic' : protocol,
       port: port === 'any' ? 'Automatic' : port,
     };
-  } else if (relaySettings.custom_tunnel_endpoint) {
-    const { protocol, port } = relaySettings.custom_tunnel_endpoint;
+  } else if (relaySettings.customTunnelEndpoint) {
+    const { protocol, port } = relaySettings.customTunnelEndpoint;
     return { protocol, port };
   } else {
     throw new Error('Unknown type of relay settings.');

--- a/gui/packages/desktop/src/renderer/containers/ConnectPage.js
+++ b/gui/packages/desktop/src/renderer/containers/ConnectPage.js
@@ -48,7 +48,7 @@ function getRelayName(
     }
 
     return 'Unknown';
-  } else if (relaySettings.custom_tunnel_endpoint) {
+  } else if (relaySettings.customTunnelEndpoint) {
     return 'Custom';
   } else {
     throw new Error('Unsupported relay settings.');

--- a/gui/packages/desktop/src/renderer/containers/SelectLocationPage.js
+++ b/gui/packages/desktop/src/renderer/containers/SelectLocationPage.js
@@ -24,7 +24,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
           .build();
 
         await props.app.updateRelaySettings(relayUpdate);
-        await props.app.fetchRelaySettings();
         await props.app.connectTunnel();
 
         history.goBack();

--- a/gui/packages/desktop/src/renderer/containers/SelectLocationPage.js
+++ b/gui/packages/desktop/src/renderer/containers/SelectLocationPage.js
@@ -11,7 +11,8 @@ import type { ReduxState, ReduxDispatch } from '../redux/store';
 import type { SharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: ReduxState) => ({
-  settings: state.settings,
+  relaySettings: state.settings.relaySettings,
+  relayLocations: state.settings.relayLocations,
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) => {
   const history = bindActionCreators({ goBack }, dispatch);

--- a/gui/packages/desktop/src/renderer/containers/SelectLocationPage.js
+++ b/gui/packages/desktop/src/renderer/containers/SelectLocationPage.js
@@ -19,6 +19,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
   return {
     onClose: () => history.goBack(),
     onSelect: async (relayLocation) => {
+      // dismiss the view first
+      history.goBack();
+
       try {
         const relayUpdate = RelaySettingsBuilder.normal()
           .location.fromRaw(relayLocation)
@@ -26,8 +29,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
 
         await props.app.updateRelaySettings(relayUpdate);
         await props.app.connectTunnel();
-
-        history.goBack();
       } catch (e) {
         log.error(`Failed to select server: ${e.message}`);
       }

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -318,16 +318,11 @@ export interface DaemonRpcProtocol {
   disconnect(): void;
   getAccountData(AccountToken): Promise<AccountData>;
   getRelayLocations(): Promise<RelayList>;
-  getAccount(): Promise<?AccountToken>;
   setAccount(accountToken: ?AccountToken): Promise<void>;
   updateRelaySettings(RelaySettingsUpdate): Promise<void>;
-  getRelaySettings(): Promise<RelaySettings>;
   setAllowLan(boolean): Promise<void>;
-  getAllowLan(): Promise<boolean>;
   setEnableIpv6(boolean): Promise<void>;
-  getTunnelOptions(): Promise<TunnelOptions>;
   setAutoConnect(boolean): Promise<void>;
-  getAutoConnect(): Promise<boolean>;
   connectTunnel(): Promise<void>;
   disconnectTunnel(): Promise<void>;
   getLocation(): Promise<Location>;
@@ -413,15 +408,6 @@ export class DaemonRpc implements DaemonRpcProtocol {
     }
   }
 
-  async getAccount(): Promise<?AccountToken> {
-    const response = await this._transport.send('get_account');
-    if (response === null || typeof response === 'string') {
-      return response;
-    } else {
-      throw new ResponseParseError('Invalid response from get_account', null);
-    }
-  }
-
   async setAccount(accountToken: ?AccountToken): Promise<void> {
     await this._transport.send('set_account', accountToken);
   }
@@ -430,65 +416,16 @@ export class DaemonRpc implements DaemonRpcProtocol {
     await this._transport.send('update_relay_settings', [underscoreObjectKeys(relaySettings)]);
   }
 
-  async getRelaySettings(): Promise<RelaySettings> {
-    const response = await this._transport.send('get_relay_settings');
-    try {
-      const validatedObject = camelCaseObjectKeys(validate(RelaySettingsSchema, response));
-
-      /* $FlowFixMe:
-        There is no way to express constraints with string literals, i.e:
-
-        RelaySettingsSchema constraint:
-          oneOf(string, object)
-
-        RelaySettings constraint:
-          'any' | object
-
-        These two are incompatible so we simply enforce the type for now.
-      */
-      return ((validatedObject: any): RelaySettings);
-    } catch (e) {
-      throw new ResponseParseError('Invalid response from get_relay_settings', e);
-    }
-  }
-
   async setAllowLan(allowLan: boolean): Promise<void> {
     await this._transport.send('set_allow_lan', [allowLan]);
-  }
-
-  async getAllowLan(): Promise<boolean> {
-    const response = await this._transport.send('get_allow_lan');
-    if (typeof response === 'boolean') {
-      return response;
-    } else {
-      throw new ResponseParseError('Invalid response from get_allow_lan', null);
-    }
   }
 
   async setEnableIpv6(enableIpv6: boolean): Promise<void> {
     await this._transport.send('set_enable_ipv6', [enableIpv6]);
   }
 
-  async getTunnelOptions(): Promise<TunnelOptions> {
-    const response = await this._transport.send('get_tunnel_options');
-    try {
-      return camelCaseObjectKeys(validate(TunnelOptionsSchema, response));
-    } catch (error) {
-      throw new ResponseParseError('Invalid response from get_tunnel_options', error);
-    }
-  }
-
   async setAutoConnect(autoConnect: boolean): Promise<void> {
     await this._transport.send('set_auto_connect', [autoConnect]);
-  }
-
-  async getAutoConnect(): Promise<boolean> {
-    const response = await this._transport.send('get_auto_connect');
-    if (typeof response === 'boolean') {
-      return response;
-    } else {
-      throw new ResponseParseError('Invalid response from get_auto_connect', null);
-    }
   }
 
   async connectTunnel(): Promise<void> {

--- a/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
+++ b/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
@@ -184,7 +184,7 @@ export default class JsonRpcClient<T> extends EventEmitter {
   }
 
   async subscribe(event: string, listener: (mixed) => void): Promise<*> {
-    log.silly(`Adding a listener to ${event}`);
+    log.silly(`Adding a listener for ${event}`);
 
     try {
       const subscriptionId = await this.send(`${event}_subscribe`);

--- a/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
+++ b/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
@@ -288,10 +288,10 @@ export default class JsonRpcClient<T> extends EventEmitter {
     const listener = this._subscriptions.get(subscriptionId);
 
     if (listener) {
-      log.silly('Got notification', message.payload.method, message.payload.params.result);
+      log.silly(`Got notification for ${message.payload.method}`);
       listener(message.payload.params.result);
     } else {
-      log.warn('Got notification for', message.payload.method, 'but no one is listening for it');
+      log.warn(`Got notification for ${message.payload.method} but no one is listening for it`);
     }
   }
 

--- a/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
+++ b/gui/packages/desktop/src/renderer/lib/jsonrpc-client.js
@@ -206,7 +206,7 @@ export default class JsonRpcClient<T> extends EventEmitter {
     return new Promise((resolve, reject) => {
       const transport = this._transport;
       if (!transport) {
-        reject(new Error('Websocket is not connected.'));
+        reject(new Error('RPC client transport is not connected.'));
         return;
       }
 

--- a/gui/packages/desktop/src/renderer/lib/relay-settings-builder.js
+++ b/gui/packages/desktop/src/renderer/lib/relay-settings-builder.js
@@ -161,7 +161,7 @@ class CustomRelaySettingsBuilder {
 
   build(): RelaySettingsUpdate {
     return {
-      custom_tunnel_endpoint: this._payload,
+      customTunnelEndpoint: this._payload,
     };
   }
 

--- a/gui/packages/desktop/src/renderer/lib/subscription-proxy/base-proxy.js
+++ b/gui/packages/desktop/src/renderer/lib/subscription-proxy/base-proxy.js
@@ -1,0 +1,118 @@
+// @flow
+
+import log from 'electron-log';
+import { ConnectionObserver, SubscriptionListener, ResponseParseError } from '../daemon-rpc';
+import type { DaemonRpcProtocol } from '../daemon-rpc';
+
+export default class BaseSubscriptionProxy<T> {
+  _rpc: DaemonRpcProtocol;
+  _connectionObserver = new ConnectionObserver(
+    () => {},
+    () => {
+      this._didDisconnectFromDaemon();
+    },
+  );
+
+  _isSubscribed = false;
+  _executingPromise: ?Promise<T>;
+
+  _value: ?T;
+  _onUpdate: (T) => void;
+
+  constructor(rpc: DaemonRpcProtocol, onUpdate: (T) => void) {
+    this._rpc = rpc;
+    this._onUpdate = onUpdate;
+
+    rpc.addConnectionObserver(this._connectionObserver);
+  }
+
+  async fetch(): Promise<T> {
+    // return the cached promise if there is an ongoing fetch
+    if (this._executingPromise) {
+      return this._executingPromise;
+    }
+
+    // return the value if it's available
+    if (this._value) {
+      return this._value;
+    }
+
+    // subscribe if needed and fetch the initial state.
+    const fetchPromise = this._subscribeAndFetchValue();
+
+    // cache the fetch promise
+    this._executingPromise = fetchPromise;
+
+    try {
+      const value = await fetchPromise;
+
+      // cache the initial value
+      this._value = value;
+
+      // notify the delegate upon initial fetch
+      this._onUpdate(value);
+
+      return value;
+    } catch (error) {
+      throw error;
+    } finally {
+      // unset the cached fetch promise
+      this._executingPromise = null;
+    }
+  }
+
+  async _subscribeAndFetchValue(): Promise<T> {
+    if (!this._isSubscribed) {
+      await this._subscribeValueListener();
+      this._isSubscribed = true;
+    }
+
+    // request the initial value
+    return await this.constructor.requestValue(this._rpc);
+  }
+
+  static subscribeValueListener(
+    _rpc: DaemonRpcProtocol,
+    _listener: SubscriptionListener<T>,
+  ): Promise<void> {
+    throw new Error(
+      `Override static ${this.constructor.name}.subscribeValueListener() in subclasses`,
+    );
+  }
+
+  static requestValue(_rpc: DaemonRpcProtocol): Promise<T> {
+    throw new Error(`Override static ${this.constructor.name}.requestValue() in subclasses`);
+  }
+
+  _subscribeValueListener(): Promise<void> {
+    const listener = new SubscriptionListener(
+      (value: T) => {
+        this._didReceiveUpdate(value);
+      },
+      (error: Error) => {
+        let reason = '';
+
+        if (error instanceof ResponseParseError) {
+          const validationError = error.validationError;
+          if (validationError) {
+            reason = ` Reason: ${validationError.message}`;
+          }
+        }
+
+        log.error(`Failed to deserialize the payload: ${error.message}.${reason}`);
+      },
+    );
+    return this.constructor.subscribeValueListener(this._rpc, listener);
+  }
+
+  _didReceiveUpdate(updatedValue: T) {
+    this._value = updatedValue;
+    this._onUpdate(updatedValue);
+  }
+
+  _didDisconnectFromDaemon() {
+    this._isSubscribed = false;
+    this._executingPromise = null;
+    this._value = null;
+  }
+}

--- a/gui/packages/desktop/src/renderer/lib/subscription-proxy/settings-proxy.js
+++ b/gui/packages/desktop/src/renderer/lib/subscription-proxy/settings-proxy.js
@@ -1,0 +1,15 @@
+// @flow
+
+import BaseSubscriptionProxy from './base-proxy';
+import { SubscriptionListener } from '../daemon-rpc';
+import type { DaemonRpcProtocol, Settings } from '../daemon-rpc';
+
+export default class SettingsProxy extends BaseSubscriptionProxy<Settings> {
+  static subscribeValueListener(rpc: DaemonRpcProtocol, listener: SubscriptionListener<Settings>) {
+    return rpc.subscribeSettingsListener(listener);
+  }
+
+  static requestValue(rpc: DaemonRpcProtocol): Promise<Settings> {
+    return rpc.getSettings();
+  }
+}

--- a/gui/packages/desktop/src/renderer/lib/subscription-proxy/tunnel-state-proxy.js
+++ b/gui/packages/desktop/src/renderer/lib/subscription-proxy/tunnel-state-proxy.js
@@ -1,0 +1,18 @@
+// @flow
+
+import BaseSubscriptionProxy from './base-proxy';
+import { SubscriptionListener } from '../daemon-rpc';
+import type { DaemonRpcProtocol, TunnelStateTransition } from '../daemon-rpc';
+
+export default class TunnelStateProxy extends BaseSubscriptionProxy<TunnelStateTransition> {
+  static subscribeValueListener(
+    rpc: DaemonRpcProtocol,
+    listener: SubscriptionListener<TunnelStateTransition>,
+  ) {
+    return rpc.subscribeStateListener(listener);
+  }
+
+  static requestValue(rpc: DaemonRpcProtocol): Promise<TunnelStateTransition> {
+    return rpc.getState();
+  }
+}

--- a/gui/packages/desktop/src/renderer/redux/settings/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/reducers.js
@@ -12,7 +12,7 @@ export type RelaySettingsRedux =
       },
     |}
   | {|
-      custom_tunnel_endpoint: {
+      customTunnelEndpoint: {
         host: string,
         port: number,
         protocol: RelayProtocol,

--- a/gui/packages/desktop/test/components/SelectLocation.spec.js
+++ b/gui/packages/desktop/test/components/SelectLocation.spec.js
@@ -5,11 +5,8 @@ import { shallow } from 'enzyme';
 import { CloseBarItem } from '../../src/renderer/components/NavigationBar';
 import SelectLocation from '../../src/renderer/components/SelectLocation';
 
-import type { SettingsReduxState } from '../../src/renderer/redux/settings/reducers';
-import type { SelectLocationProps } from '../../src/renderer/components/SelectLocation';
-
 describe('components/SelectLocation', () => {
-  const state: SettingsReduxState = {
+  const defaultProps = {
     relaySettings: {
       normal: {
         location: 'any',
@@ -58,39 +55,24 @@ describe('components/SelectLocation', () => {
         ],
       },
     ],
-    autoConnect: false,
-    allowLan: false,
-    enableIpv6: true,
-  };
-
-  const makeProps = (
-    state: SettingsReduxState,
-    mergeProps: $Shape<SelectLocationProps>,
-  ): SelectLocationProps => {
-    const defaultProps: SelectLocationProps = {
-      settings: state,
-      onClose: () => {},
-      onSelect: (_server) => {},
-    };
-    return Object.assign({}, defaultProps, mergeProps);
-  };
-
-  const render = (props: SelectLocationProps) => {
-    return shallow(<SelectLocation {...props} />);
   };
 
   it('should call close callback', (done) => {
-    const props = makeProps(state, {
+    const props = {
+      ...defaultProps,
       onClose: () => done(),
-    });
-    const component = render(props)
+      onSelect: () => {},
+    };
+    const component = shallow(<SelectLocation {...props} />)
       .find(CloseBarItem)
       .dive();
     component.simulate('press');
   });
 
   it('should call select callback for country', (done) => {
-    const props = makeProps(state, {
+    const props = {
+      ...defaultProps,
+      onClose: () => {},
       onSelect: (location) => {
         try {
           expect(location).to.deep.equal({
@@ -101,14 +83,17 @@ describe('components/SelectLocation', () => {
           done(e);
         }
       },
-    });
-    const elements = getComponent(render(props), 'country');
+    };
+    const component = shallow(<SelectLocation {...props} />);
+    const elements = getComponent(component, 'country');
     expect(elements).to.have.length(1);
     elements.at(0).simulate('press');
   });
 
   it('should call select callback for city', (done) => {
-    const props = makeProps(state, {
+    const props = {
+      ...defaultProps,
+      onClose: () => {},
       onSelect: (location) => {
         try {
           expect(location).to.deep.equal({
@@ -119,8 +104,9 @@ describe('components/SelectLocation', () => {
           done(e);
         }
       },
-    });
-    const elements = getComponent(render(props), 'city');
+    };
+    const component = shallow(<SelectLocation {...props} />);
+    const elements = getComponent(component, 'city');
     expect(elements).to.have.length(2);
     elements.at(0).simulate('press');
   });

--- a/gui/packages/desktop/test/components/SelectLocation.spec.js
+++ b/gui/packages/desktop/test/components/SelectLocation.spec.js
@@ -34,6 +34,13 @@ describe('components/SelectLocation', () => {
                 includeInCountry: true,
                 weight: 1,
               },
+              {
+                hostname: 'fake2.mullvad.net',
+                ipv4AddrIn: '192.168.0.101',
+                ipv4AddrExit: '192.168.1.101',
+                includeInCountry: true,
+                weight: 1,
+              },
             ],
           },
           {
@@ -107,6 +114,27 @@ describe('components/SelectLocation', () => {
     };
     const component = shallow(<SelectLocation {...props} />);
     const elements = getComponent(component, 'city');
+    expect(elements).to.have.length(2);
+    elements.at(0).simulate('press');
+  });
+
+  it('should call select callback for relay', (done) => {
+    const props = {
+      ...defaultProps,
+      onClose: () => {},
+      onSelect: (location) => {
+        try {
+          expect(location).to.deep.equal({
+            hostname: ['se', 'mma', 'fake1.mullvad.net'],
+          });
+          done();
+        } catch (e) {
+          done(e);
+        }
+      },
+    };
+    const component = shallow(<SelectLocation {...props} />);
+    const elements = getComponent(component, 'relay');
     expect(elements).to.have.length(2);
     elements.at(0).simulate('press');
   });

--- a/gui/packages/desktop/test/relay-settings-builder.spec.js
+++ b/gui/packages/desktop/test/relay-settings-builder.spec.js
@@ -132,7 +132,7 @@ describe('Relay settings builder', () => {
         })
         .build(),
     ).to.deep.equal({
-      custom_tunnel_endpoint: {
+      customTunnelEndpoint: {
         host: 'se2.mullvad.net',
         tunnel: {
           openvpn: {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

## What

Migrate to new `get_settings` API.

### Why

It was painful to stay in sync with daemon due to the amount of data and number of requests needed to obtain it.

Update and fetch was a common strategy to obtain the final setting from the daemon after changing settings, this is not needed anymore.

Also it brings us closer to handling multiple front-ends gracefully.

### How

1. Add facilities to request settings with `get_settings` and subscribe for `settings` notification.
2. Add subscription proxies that hold and maintain the corresponding state.
3. Remove deprecated RPC `get_*` calls which only mirrored a subset of `Settings`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/444)
<!-- Reviewable:end -->
