### PR TITLE
Fix block reason representation inconsistency

### DIFF
--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -14,8 +14,6 @@ export class BlockedError extends Error {
           return 'Failed to start tunnel connection';
         case 'no_matching_relay':
           return 'No relay server matches the current settings';
-        case 'no_account_token':
-          return 'No account token configured';
         default:
           return `Unknown error: ${(reason: empty)}`;
       }

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -6,7 +6,7 @@ export class BlockedError extends Error {
   constructor(reason: BlockReason) {
     const message = (function() {
       switch (reason) {
-        case 'enable_ipv6_error':
+        case 'ipv6_unavailable':
           return 'Could not configure IPv6, please enable it on your system or disable it in the app';
         case 'set_security_policy_error':
           return 'Failed to apply security policy';

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -228,7 +228,7 @@ const AccountDataSchema = object({
 });
 
 const allBlockReasons: Array<BlockReason> = [
-  'enable_ipv6_error',
+  'ipv6_unavailable',
   'set_security_policy_error',
   'start_tunnel_error',
   'no_matching_relay',

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -42,11 +42,10 @@ const LocationSchema = object({
 });
 
 export type BlockReason =
-  | 'enable_ipv6_error'
+  | 'ipv6_unavailable'
   | 'set_security_policy_error'
   | 'start_tunnel_error'
-  | 'no_matching_relay'
-  | 'no_account_token';
+  | 'no_matching_relay';
 
 export type TunnelState = 'connecting' | 'connected' | 'disconnecting' | 'disconnected' | 'blocked';
 
@@ -232,7 +231,6 @@ const allBlockReasons: Array<BlockReason> = [
   'set_security_policy_error',
   'start_tunnel_error',
   'no_matching_relay',
-  'no_account_token',
 ];
 const TunnelStateTransitionSchema = oneOf(
   object({


### PR DESCRIPTION
The `BlockReason` type was updated in the daemon but not in the GUI, which led to some cases where the blocked state wasn't shown by the GUI. This PR fixes the inconsistency so that both have the same representation.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes bug that's not present in any public release.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/445)
<!-- Reviewable:end -->
