### PR TITLE
Show app version as soon as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix incorrect window position when using external display.
 - Don't auto-connect the daemon on start if no account token is set. This prevents the daemon from
   blocking all internet if logging out from the app.
+- Reduce latency to show app version in Settings screen.
 
 #### Linux
 - The app window is now shown in its previous location, instead of at the center of the screen.

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -415,11 +415,16 @@ export default class AppRenderer {
 
   async _fetchVersionInfo() {
     const actions = this._reduxActions;
-    const latestVersionInfo = await this._daemonRpc.getVersionInfo();
+
     const versionFromDaemon = await this._daemonRpc.getCurrentVersion();
     const versionFromGui = remote.app.getVersion().replace('.0', '');
 
     actions.version.updateVersion(versionFromDaemon, versionFromDaemon === versionFromGui);
+
+    // fetching the version info has a higher latency because the daemon communicates with the API
+    // server
+    const latestVersionInfo = await this._daemonRpc.getVersionInfo();
+
     actions.version.updateLatest(latestVersionInfo);
   }
 

--- a/gui/packages/desktop/src/renderer/redux/version/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/version/reducers.js
@@ -4,22 +4,22 @@ import type { ReduxAction } from '../store';
 
 export type VersionReduxState = {
   current: string,
-  latest: string,
-  latestStable: string,
+  latest: ?string,
+  latestStable: ?string,
   upToDate: boolean,
   consistent: boolean,
 };
 
 const initialState: VersionReduxState = {
   current: '',
-  latest: '',
-  latestStable: '',
-  upToDate: false,
+  latest: null,
+  latestStable: null,
+  upToDate: true,
   consistent: true,
 };
 
-const checkIfLatest = (current: string, latest: string, latestStable: string): boolean => {
-  return current === latest || current === latestStable;
+const checkIfLatest = (current: string, latest: ?string, latestStable: ?string): boolean => {
+  return latest === null || latestStable === null || current === latest || current === latestStable;
 };
 
 export default function(


### PR DESCRIPTION
Because fetching the latest version info from the API server takes a noticeable amount of time, the app version would take a while to appear in the settings screen. On the GUI side, there already was two IPC calls, one to fetch the app version and the second to fetch the latest version information from the API server. This PR makes sure to update the app version in the GUI as soon as the first IPC call returns. From then until the second IPC call returns, no message is shown under the assumption that the user has the latest version already.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
