### PR TITLE
Remove unused patched openssl crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,11 +2157,6 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
-[[patch.unused]]
-name = "openssl-sys"
-version = "0.9.34"
-source = "git+https://github.com/mullvad/rust-openssl#4dbd237fe1f6454d8a0042ccf4ad157904d6eec1"
-
 [metadata]
 "checksum aho-corasick 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c1c6d463cbe7ed28720b5b489e7c083eeb8f90d08be2a0d6bb9e1ffea9ce1afa"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ members = [
     "talpid-core",
     "talpid-ipc",
 ]
-
-[patch.crates-io]
-openssl-sys = { git = "https://github.com/mullvad/rust-openssl" }


### PR DESCRIPTION
Tried removing this, as we talked about. Turned out we didn't even use the crate any more, so not "patching" it can't possibly hurt? :D

I guess we stopped using this when switching to IPC?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/447)
<!-- Reviewable:end -->
