### PR TITLE
Disable IPv6 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
-- Add option to enable or disable IPv6 on the tunnel interface.
+- Add option to enable or disable IPv6 on the tunnel interface. It's disabled by default.
 - Log panics in the daemon to the log file.
 - Warn in the Settings screen if a new version is available.
 - Add a "blocked" state in the app that blocks the entire network and waits for user action when

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -148,7 +148,7 @@ impl Default for TunnelOptions {
     fn default() -> Self {
         TunnelOptions {
             openvpn: OpenVpnTunnelOptions::default(),
-            enable_ipv6: true,
+            enable_ipv6: false,
         }
     }
 }


### PR DESCRIPTION
Richard asked us if we could set `enable_ipv6` to false by default. The vast majority of our users don't know what IPv6 is, nor need it. Having IPv6 on leads to more problems than having it off, so it feels quite natural to have it off by default, to create as smooth experience.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/449)
<!-- Reviewable:end -->
