### PR TITLE
Improve blocked state UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add option to enable or disable IPv6 on the tunnel interface. It's disabled by default.
 - Log panics in the daemon to the log file.
 - Warn in the Settings screen if a new version is available.
-- Add a "blocked" state in the app that blocks the entire network and waits for user action when
-  something has gone wrong.
+- Add a "blocked" state in the app that blocks the entire network and shows a message about what
+  went wrong. Then it waits for user action.
 - Add support for Ubuntu 14.04 and other distributions that use the Upstart init system.
 - Make scrollbar thumb draggable.
 - Ability to expand cities with multiple servers and configure the app to use a specific server.

--- a/gui/packages/desktop/src/renderer/components/BlockingInternetBanner.js
+++ b/gui/packages/desktop/src/renderer/components/BlockingInternetBanner.js
@@ -1,0 +1,70 @@
+// @flow
+
+import * as React from 'react';
+import { View, Text, Component, Styles } from 'reactxp';
+import { colors } from '../../config';
+
+const styles = {
+  container: Styles.createViewStyle({
+    flexDirection: 'row',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    backdropFilter: 'blur(4px)',
+    paddingTop: 8,
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 8,
+  }),
+  icon: Styles.createViewStyle({
+    width: 10,
+    height: 10,
+    flex: 0,
+    borderRadius: 5,
+    marginTop: 4,
+    marginRight: 8,
+    backgroundColor: colors.red,
+  }),
+  textContainer: Styles.createViewStyle({
+    flex: 1,
+  }),
+  title: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 12,
+    fontWeight: '800',
+    lineHeight: 17,
+    color: colors.white60,
+  }),
+  subtitle: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 12,
+    fontWeight: '800',
+    lineHeight: 17,
+    color: colors.white40,
+  }),
+};
+
+export class BannerTitle extends Component {
+  render() {
+    return <Text style={styles.title}>{this.props.children}</Text>;
+  }
+}
+
+export class BannerSubtitle extends Component {
+  render() {
+    return React.Children.count(this.props.children) > 0 ? (
+      <Text style={styles.subtitle}>{this.props.children}</Text>
+    ) : null;
+  }
+}
+
+export default class BlockingInternetBanner extends Component<{
+  children: Array<React.Element<typeof BannerTitle> | React.Element<typeof BannerSubtitle>>,
+}> {
+  render() {
+    return (
+      <View style={styles.container}>
+        <View style={styles.icon} />
+        <View style={styles.textContainer}>{this.props.children}</View>
+      </View>
+    );
+  }
+}

--- a/gui/packages/desktop/src/renderer/components/ConnectStyles.js
+++ b/gui/packages/desktop/src/renderer/components/ConnectStyles.js
@@ -29,20 +29,6 @@ export default {
     paddingLeft: 24,
     paddingRight: 24,
   }),
-  blocking_container: Styles.createViewStyle({
-    width: '100%',
-    position: 'absolute',
-  }),
-  blocking_icon: Styles.createViewStyle({
-    width: 10,
-    height: 10,
-    flex: 0,
-    display: 'flex',
-    borderRadius: 5,
-    marginTop: 4,
-    marginRight: 8,
-    backgroundColor: colors.red,
-  }),
   status: Styles.createViewStyle({
     paddingTop: 0,
     paddingLeft: 24,
@@ -61,20 +47,9 @@ export default {
   switch_location_button: Styles.createViewStyle({
     marginBottom: 16,
   }),
-
-  blocking_message: Styles.createTextStyle({
-    display: 'flex',
-    flexDirection: 'row',
-    fontFamily: 'Open Sans',
-    fontSize: 12,
-    fontWeight: '800',
-    lineHeight: 17,
-    paddingTop: 8,
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 8,
-    color: colors.white60,
-    backgroundColor: colors.blue,
+  blocking_container: Styles.createViewStyle({
+    width: '100%',
+    position: 'absolute',
   }),
   server_label: Styles.createTextStyle({
     fontFamily: 'DINPro',

--- a/gui/packages/desktop/src/renderer/errors.js
+++ b/gui/packages/desktop/src/renderer/errors.js
@@ -1,28 +1,5 @@
 // @flow
 
-import type { BlockReason } from './lib/daemon-rpc';
-
-export class BlockedError extends Error {
-  constructor(reason: BlockReason) {
-    const message = (function() {
-      switch (reason) {
-        case 'ipv6_unavailable':
-          return 'Could not configure IPv6, please enable it on your system or disable it in the app';
-        case 'set_security_policy_error':
-          return 'Failed to apply security policy';
-        case 'start_tunnel_error':
-          return 'Failed to start tunnel connection';
-        case 'no_matching_relay':
-          return 'No relay server matches the current settings';
-        default:
-          return `Unknown error: ${(reason: empty)}`;
-      }
-    })();
-
-    super(message);
-  }
-}
-
 export class NoCreditError extends Error {
   constructor() {
     super("Account doesn't have enough credit available for connection");
@@ -44,12 +21,6 @@ export class NoDaemonError extends Error {
 export class InvalidAccountError extends Error {
   constructor() {
     super('Invalid account number');
-  }
-}
-
-export class NoAccountError extends Error {
-  constructor() {
-    super('No account was set');
   }
 }
 

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Ip } from '../../lib/daemon-rpc';
+import type { BlockReason, Ip } from '../../lib/daemon-rpc';
 
 type ConnectingAction = {
   type: 'CONNECTING',
@@ -20,7 +20,7 @@ type DisconnectingAction = {
 
 type BlockedAction = {
   type: 'BLOCKED',
-  reason: string,
+  reason: BlockReason,
 };
 
 type NewLocationAction = {
@@ -77,7 +77,7 @@ function disconnecting(): DisconnectingAction {
   };
 }
 
-function blocked(reason: string): BlockedAction {
+function blocked(reason: BlockReason): BlockedAction {
   return {
     type: 'BLOCKED',
     reason,

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { ReduxAction } from '../store';
-import type { TunnelState, Ip } from '../../lib/daemon-rpc';
+import type { BlockReason, TunnelState, Ip } from '../../lib/daemon-rpc';
 
 export type ConnectionReduxState = {
   status: TunnelState,
@@ -11,7 +11,7 @@ export type ConnectionReduxState = {
   longitude: ?number,
   country: ?string,
   city: ?string,
-  blockReason: ?string,
+  blockReason: ?BlockReason,
 };
 
 const initialState: ConnectionReduxState = {

--- a/gui/packages/desktop/test/components/Connect.spec.js
+++ b/gui/packages/desktop/test/components/Connect.spec.js
@@ -40,6 +40,23 @@ describe('components/Connect', () => {
     expect(disconnectButton.html()).to.contain('Disconnect');
   });
 
+  it('shows blocked hints when blocked', () => {
+    const component = renderWithProps({
+      connection: {
+        ...defaultProps.connection,
+        status: 'blocked',
+        blockReason: 'no_matching_relay',
+      },
+    });
+
+    const header = getComponent(component, 'header');
+    const securityMessage = getComponent(component, 'networkSecurityMessage');
+    const cancelButton = getComponent(component, 'cancel');
+    expect(header.prop('barStyle')).to.equal('success');
+    expect(securityMessage.html()).to.contain('BLOCKED ');
+    expect(cancelButton.html()).to.contain('Cancel');
+  });
+
   it('shows the connection location when connecting', () => {
     const component = renderWithProps({
       connection: {
@@ -47,6 +64,7 @@ describe('components/Connect', () => {
         status: 'connecting',
         country: 'Norway',
         city: 'Oslo',
+        ip: '4.3.2.1',
       },
     });
     const countryAndCity = getComponent(component, 'location');
@@ -105,6 +123,47 @@ describe('components/Connect', () => {
 
     connectButton.prop('onPress')();
   });
+
+  it('hides the blocking internet message when connected, disconnecting or disconnected', () => {
+    for (const status of ['connected', 'disconnecting', 'disconnected']) {
+      const component = renderWithProps({
+        connection: {
+          ...defaultProps.connection,
+          status,
+        },
+      });
+      const blockingAccordion = getComponent(component, 'blockingAccordion');
+
+      expect(blockingAccordion.prop('height')).to.equal(0);
+    }
+  });
+
+  it('shows the blocking internet message when connecting', () => {
+    const component = renderWithProps({
+      connection: {
+        ...defaultProps.connection,
+        status: 'connecting',
+        country: 'Norway',
+        city: 'Oslo',
+      },
+    });
+    const blockingAccordion = getComponent(component, 'blockingAccordion');
+
+    expect(blockingAccordion.prop('height')).to.equal('auto');
+  });
+
+  it('shows the blocking internet message when blocked', () => {
+    const component = renderWithProps({
+      connection: {
+        ...defaultProps.connection,
+        status: 'blocked',
+        blockReason: 'no_matching_relay',
+      },
+    });
+    const blockingAccordion = getComponent(component, 'blockingAccordion');
+    expect(blockingAccordion.prop('height')).to.equal('auto');
+    expect(blockingAccordion.dive().html()).to.contain('No relay server');
+  });
 });
 
 const defaultProps: ConnectProps = {
@@ -123,6 +182,7 @@ const defaultProps: ConnectProps = {
     longitude: null,
     country: null,
     city: null,
+    blockReason: null,
   },
   updateAccountExpiry: () => Promise.resolve(),
 };


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR adds a banner message explaining the reason why daemon entered a blocked state. It also enables the end users to leave the state by hitting "cancel" or even switching the location. The GUI sends `disconnect` to daemon when user hits "cancel".

![screenshot 2018-09-13 14 05 03](https://user-images.githubusercontent.com/704044/45488051-d69e9900-b768-11e8-9ebd-296f4886fd65.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/450)
<!-- Reviewable:end -->
