### PR TITLE
Don't allow the user to change install dir on Windows

### DIFF
--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -63,7 +63,7 @@ nsis:
   oneClick: false
   perMachine: true
   allowElevation: true
-  allowToChangeInstallationDirectory: true
+  allowToChangeInstallationDirectory: false
   include: ../../../dist-assets/windows/installer.nsh
   installerSidebar: ../../../dist-assets/windows/installersidebar.bmp
 


### PR DESCRIPTION
Limit the Windows installer so users can't select install location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/453)
<!-- Reviewable:end -->
