### PR TITLE
Move CLI binary back to resource dir on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+#### macOS
+- Move the CLI binary (`mullvad`) back into the `Resources/` directory. A bug caused the app to not
+  be signed if it was placed in the app root directory.
 
 
 ## [2018.3-beta1] - 2018-09-13

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -40,6 +40,8 @@ mac:
   extendInfo:
     LSUIElement: true
   extraResources:
+    - from: ../../../target/release/mullvad
+      to: .
     - from: ../../../target/release/problem-report
       to: .
     - from: ../../../target/release/mullvad-daemon
@@ -50,9 +52,6 @@ mac:
       to: .
     - from: ../../../dist-assets/uninstall_macos.sh
       to: ./uninstall.sh
-  extraFiles:
-    - from: ../../../target/release/mullvad
-      to: .
 
 pkg:
   allowAnywhere: false
@@ -78,6 +77,8 @@ win:
     - sha256
   signDlls: true
   extraResources:
+    - from: ../../../target/release/mullvad.exe
+      to: .
     - from: ../../../target/release/problem-report.exe
       to: .
     - from: ../../../target/release/mullvad-daemon.exe
@@ -92,8 +93,6 @@ win:
       to: .
     - from: ../../../dist-assets/binaries/windows/openvpn.exe
       to: .
-    - from: ../../../target/release/mullvad.exe
-      to: .
 
 linux:
   target:
@@ -101,6 +100,9 @@ linux:
     - rpm
   artifactName: MullvadVPN-${version}_${arch}.${ext}
   category: Network
+  extraFiles:
+    - from: ../../../target/release/mullvad
+      to: .
   extraResources:
     - from: ../../../target/release/problem-report
       to: .
@@ -113,9 +115,6 @@ linux:
     - from: ../../../dist-assets/linux/mullvad-daemon.conf
       to: .
     - from: ../../../dist-assets/linux/mullvad-daemon.service
-      to: .
-  extraFiles:
-    - from: ../../../target/release/mullvad
       to: .
 
 deb:


### PR DESCRIPTION
Apparently having `extraFiles` causes the `codesign` tool to fail. Probably a bug in electron-builder. But we have to move the CLI back for now to be able to continue.

Moving the structure around a bit in general, so the CLI binary comes first in the list of files to include on all platforms.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/454)
<!-- Reviewable:end -->
