### PR TITLE
Don't flash unsecured state when reconnecting or blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Add support for DNS configuration using resolvconf.
 
+### Fixed
+- Don't temporarily show the unsecured state in the GUI when the app is reconnecting or blocking.
+
 
 ## [2018.3] - 2018-09-17
 ### Changed

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -547,7 +547,7 @@ export default class AppRenderer {
         break;
 
       case 'disconnecting':
-        actions.connection.disconnecting();
+        actions.connection.disconnecting(stateTransition.details);
         break;
 
       case 'disconnected':

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -195,7 +195,7 @@ export default class Connect extends Component<Props, State> {
         center: [longitude, latitude],
         // do not show the marker when connecting
         showMarker: state !== 'connecting',
-        markerStyle: state === 'connected' || state === 'blocked' ? 'secure' : 'unsecure',
+        markerStyle: this._getMarkerStyle(),
         // zoom in when connected
         zoomLevel: state === 'connected' ? 'low' : 'medium',
         // a magic offset to align marker with spinner
@@ -211,6 +211,31 @@ export default class Connect extends Component<Props, State> {
         // remove the offset since the marker is hidden
         offset: [0, 0],
       };
+    }
+  }
+
+  _getMarkerStyle() {
+    const { status } = this.props.connection;
+
+    switch (status.state) {
+      case 'connecting':
+      case 'connected':
+      case 'blocked':
+        return 'secure';
+      case 'disconnected':
+        return 'unsecure';
+      case 'disconnecting':
+        switch (status.details) {
+          case 'block':
+          case 'reconnect':
+            return 'secure';
+          case 'nothing':
+            return 'unsecure';
+          default:
+            throw new Error(`Invalid action after disconnection: $(status.details: empty)}`);
+        }
+      default:
+        throw new Error(`Invalid connection status: ${(status.state: empty)}`);
     }
   }
 

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -390,17 +390,26 @@ export default class Connect extends Component<Props, State> {
   // Private
 
   headerBarStyle(): HeaderBarStyle {
-    const { state } = this.props.connection.status;
-    switch (state) {
-      case 'disconnecting':
+    const { status } = this.props.connection;
+    switch (status.state) {
       case 'disconnected':
         return 'error';
       case 'connecting':
       case 'connected':
       case 'blocked':
         return 'success';
+      case 'disconnecting':
+        switch (status.details) {
+          case 'block':
+          case 'reconnect':
+            return 'success';
+          case 'nothing':
+            return 'error';
+          default:
+            throw new Error(`Invalid action after disconnection: ${(status.details: empty)}`);
+        }
       default:
-        throw new Error(`Invalid TunnelState: ${(state: empty)}`);
+        throw new Error(`Invalid TunnelState: ${(status.state: empty)}`);
     }
   }
 

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -51,10 +51,13 @@ export type BlockReason =
     }
   | { reason: 'auth_failed', details: ?string };
 
+export type AfterDisconnect = 'nothing' | 'block' | 'reconnect';
+
 export type TunnelState = 'connecting' | 'connected' | 'disconnecting' | 'disconnected' | 'blocked';
 
 export type TunnelStateTransition =
-  | { state: 'disconnecting' | 'disconnected' | 'connecting' | 'connected' }
+  | { state: 'disconnected' | 'connecting' | 'connected' }
+  | { state: 'disconnecting', details: AfterDisconnect }
   | { state: 'blocked', details: BlockReason };
 
 export type RelayProtocol = 'tcp' | 'udp';
@@ -235,6 +238,10 @@ const AccountDataSchema = object({
 
 const TunnelStateTransitionSchema = oneOf(
   object({
+    state: enumeration('disconnecting'),
+    details: enumeration('nothing', 'block', 'reconnect'),
+  }),
+  object({
     state: enumeration('blocked'),
     details: oneOf(
       object({
@@ -249,7 +256,7 @@ const TunnelStateTransitionSchema = oneOf(
     ),
   }),
   object({
-    state: enumeration('connected', 'connecting', 'disconnected', 'disconnecting'),
+    state: enumeration('connected', 'connecting', 'disconnected'),
   }),
 );
 

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { BlockReason, Ip } from '../../lib/daemon-rpc';
+import type { AfterDisconnect, BlockReason, Ip } from '../../lib/daemon-rpc';
 
 type ConnectingAction = {
   type: 'CONNECTING',
@@ -16,6 +16,7 @@ type DisconnectedAction = {
 
 type DisconnectingAction = {
   type: 'DISCONNECTING',
+  afterDisconnect: AfterDisconnect,
 };
 
 type BlockedAction = {
@@ -71,9 +72,10 @@ function disconnected(): DisconnectedAction {
   };
 }
 
-function disconnecting(): DisconnectingAction {
+function disconnecting(afterDisconnect: AfterDisconnect): DisconnectingAction {
   return {
     type: 'DISCONNECTING',
+    afterDisconnect,
   };
 }
 

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -41,7 +41,7 @@ export default function(
       return { ...state, status: { state: 'disconnected' } };
 
     case 'DISCONNECTING':
-      return { ...state, status: { state: 'disconnecting', details: 'nothing' } };
+      return { ...state, status: { state: 'disconnecting', details: action.afterDisconnect } };
 
     case 'BLOCKED':
       return { ...state, status: { state: 'blocked', details: action.reason } };

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -1,28 +1,26 @@
 // @flow
 
 import type { ReduxAction } from '../store';
-import type { BlockReason, TunnelState, Ip } from '../../lib/daemon-rpc';
+import type { TunnelStateTransition, Ip } from '../../lib/daemon-rpc';
 
 export type ConnectionReduxState = {
-  status: TunnelState,
+  status: TunnelStateTransition,
   isOnline: boolean,
   ip: ?Ip,
   latitude: ?number,
   longitude: ?number,
   country: ?string,
   city: ?string,
-  blockReason: ?BlockReason,
 };
 
 const initialState: ConnectionReduxState = {
-  status: 'disconnected',
+  status: { state: 'disconnected' },
   isOnline: true,
   ip: null,
   latitude: null,
   longitude: null,
   country: null,
   city: null,
-  blockReason: null,
 };
 
 export default function(
@@ -34,19 +32,19 @@ export default function(
       return { ...state, ...action.newLocation };
 
     case 'CONNECTING':
-      return { ...state, ...{ status: 'connecting', blockReason: null } };
+      return { ...state, status: { state: 'connecting' } };
 
     case 'CONNECTED':
-      return { ...state, ...{ status: 'connected', blockReason: null } };
+      return { ...state, status: { state: 'connected' } };
 
     case 'DISCONNECTED':
-      return { ...state, ...{ status: 'disconnected', blockReason: null } };
+      return { ...state, status: { state: 'disconnected' } };
 
     case 'DISCONNECTING':
-      return { ...state, ...{ status: 'disconnecting', blockReason: null } };
+      return { ...state, status: { state: 'disconnecting', details: 'nothing' } };
 
     case 'BLOCKED':
-      return { ...state, ...{ status: 'blocked', blockReason: action.reason } };
+      return { ...state, status: { state: 'blocked', details: action.reason } };
 
     case 'ONLINE':
       return { ...state, ...{ isOnline: true } };

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -47,10 +47,10 @@ export default function(
       return { ...state, status: { state: 'blocked', details: action.reason } };
 
     case 'ONLINE':
-      return { ...state, ...{ isOnline: true } };
+      return { ...state, isOnline: true };
 
     case 'OFFLINE':
-      return { ...state, ...{ isOnline: false } };
+      return { ...state, isOnline: false };
 
     default:
       return state;

--- a/gui/packages/desktop/test/components/Connect.spec.js
+++ b/gui/packages/desktop/test/components/Connect.spec.js
@@ -12,7 +12,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'disconnected',
+        status: { state: 'disconnected' },
       },
     });
 
@@ -28,7 +28,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'connected',
+        status: { state: 'connected' },
       },
     });
 
@@ -44,8 +44,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'blocked',
-        blockReason: { reason: 'no_matching_relay' },
+        status: { state: 'blocked', details: { reason: 'no_matching_relay' } },
       },
     });
 
@@ -61,7 +60,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'connecting',
+        status: { state: 'connecting' },
         country: 'Norway',
         city: 'Oslo',
         ip: '4.3.2.1',
@@ -79,7 +78,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'connected',
+        status: { state: 'connected' },
         country: 'Norway',
         city: 'Oslo',
         ip: '4.3.2.1',
@@ -97,7 +96,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'disconnected',
+        status: { state: 'disconnected' },
         country: 'Norway',
         city: 'Oslo',
         ip: '4.3.2.1',
@@ -116,7 +115,7 @@ describe('components/Connect', () => {
       onConnect: () => done(),
       connection: {
         ...defaultProps.connection,
-        status: 'disconnected',
+        status: { state: 'disconnected' },
       },
     });
     const connectButton = getComponent(component, 'secureConnection');
@@ -125,11 +124,11 @@ describe('components/Connect', () => {
   });
 
   it('hides the blocking internet message when connected, disconnecting or disconnected', () => {
-    for (const status of ['connected', 'disconnecting', 'disconnected']) {
+    for (const state of ['connected', 'disconnecting', 'disconnected']) {
       const component = renderWithProps({
         connection: {
           ...defaultProps.connection,
-          status,
+          status: { state },
         },
       });
       const blockingAccordion = getComponent(component, 'blockingAccordion');
@@ -142,7 +141,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'connecting',
+        status: { state: 'connecting' },
         country: 'Norway',
         city: 'Oslo',
       },
@@ -156,8 +155,7 @@ describe('components/Connect', () => {
     const component = renderWithProps({
       connection: {
         ...defaultProps.connection,
-        status: 'blocked',
-        blockReason: { reason: 'no_matching_relay' },
+        status: { state: 'blocked', details: { reason: 'no_matching_relay' } },
       },
     });
     const blockingAccordion = getComponent(component, 'blockingAccordion');
@@ -175,14 +173,13 @@ const defaultProps: ConnectProps = {
   accountExpiry: '',
   selectedRelayName: '',
   connection: {
-    status: 'disconnected',
+    status: { state: 'disconnected' },
     isOnline: true,
     ip: null,
     latitude: null,
     longitude: null,
     country: null,
     city: null,
-    blockReason: null,
   },
   updateAccountExpiry: () => Promise.resolve(),
 };

--- a/gui/packages/desktop/test/components/Connect.spec.js
+++ b/gui/packages/desktop/test/components/Connect.spec.js
@@ -123,12 +123,26 @@ describe('components/Connect', () => {
     connectButton.prop('onPress')();
   });
 
-  it('hides the blocking internet message when connected, disconnecting or disconnected', () => {
-    for (const state of ['connected', 'disconnecting', 'disconnected']) {
+  it('hides the blocking internet message when connected or disconnected', () => {
+    for (const state of ['connected', 'disconnected']) {
       const component = renderWithProps({
         connection: {
           ...defaultProps.connection,
           status: { state },
+        },
+      });
+      const blockingAccordion = getComponent(component, 'blockingAccordion');
+
+      expect(blockingAccordion.prop('height')).to.equal(0);
+    }
+  });
+
+  it('hides the blocking internet message when disconnecting', () => {
+    for (const afterDisconnect of ['nothing', 'block', 'reconnect']) {
+      const component = renderWithProps({
+        connection: {
+          ...defaultProps.connection,
+          status: { state: 'disconnecting', details: afterDisconnect },
         },
       });
       const blockingAccordion = getComponent(component, 'blockingAccordion');

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -47,7 +47,7 @@ fn print_state(state: &TunnelStateTransition) {
         Connected => println!("Connected"),
         Connecting => println!("Connecting..."),
         Disconnected => println!("Disconnected"),
-        Disconnecting => println!("Disconnecting..."),
+        Disconnecting(_) => println!("Disconnecting..."),
     }
 }
 

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -12,9 +12,18 @@ pub enum TunnelStateTransition {
     /// Tunnel is connected.
     Connected,
     /// Disconnecting tunnel.
-    Disconnecting,
+    Disconnecting(ActionAfterDisconnect),
     /// Tunnel is disconnected but secured by blocking all connections.
     Blocked(BlockReason),
+}
+
+/// Action that will be taken after disconnection is complete.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionAfterDisconnect {
+    Nothing,
+    Block,
+    Reconnect,
 }
 
 impl TunnelStateTransition {


### PR DESCRIPTION
The GUI would previously treat the `disconnecting` state as an `unsecured` state. While that was technically incorrect, it did have the advantage of very fast visual feedback to the user, since otherwise the `unsecured` state would only appear when the `disconnected` state is reached many milliseconds later.

However, since reconnection or blocking inevitably passes through the `disconnecting` state, the `unsecured` state would appear for a few milliseconds incorrectly. This PR fixes this by distinguishing the different actions that will be taken after disconnection is complete and only showing prematurely the `unsecured` state if the state that will be reached afterwards is `disconnected`.

Showing the state is assumed to be relative to the color of the header and the style of the map marker.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/455)
<!-- Reviewable:end -->
