### PR TITLE
Add clearer fallback message when authentication fails

### DIFF
--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -42,8 +42,10 @@ type State = {
 function getBlockReasonMessage(blockReason: BlockReason): string {
   switch (blockReason.reason) {
     case 'auth_failed': {
-      const details = blockReason.details ? `: ${blockReason.details}` : '';
-      return `Authentication failed${details}`;
+      const details =
+        blockReason.details ||
+        'Check that the account is valid, has time left and not too many connections';
+      return `Authentication failed: ${details}`;
     }
     case 'ipv6_unavailable':
       return 'Could not configure IPv6, please enable it on your system or disable it in the app';


### PR DESCRIPTION
Improve the fallback message for authentication failed, so it informs users how they should proceed, what to check for.

Also add `: ` to the format string. the `$details` does not feel like the place to store the formatting?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/457)
<!-- Reviewable:end -->
