### PR TITLE
Continue logging in when Mullvad API is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Add support for DNS configuration using resolvconf.
 
+### Changed
+- Logging in no longer requires a connection with the Mullvad API server.
+
 ### Fixed
 - Don't temporarily show the unsecured state in the GUI when the app is reconnecting or blocking.
 


### PR DESCRIPTION
Logging in to the app performs a HTTP request to a Mullvad server that provides the expiration date of the account. If the account doesn't exist, the error is handled accordingly. However, if there's a connection issue to access the server, the user can't log in. This PR changes this so that logging in continues if an unknown error occurs. If the account is invalid or unauthorized for some reason, the connection will fail afterwards.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/458)
<!-- Reviewable:end -->
