### PR TITLE
Don't log entire uniqueness check error chain by default

### DIFF
--- a/mullvad-daemon/src/rpc_uniqueness_check.rs
+++ b/mullvad-daemon/src/rpc_uniqueness_check.rs
@@ -15,10 +15,10 @@ pub fn is_another_instance_running() -> bool {
         Err(error) => {
             let msg =
                 "Failed to locate/connect to another daemon instance, assuming there isn't one";
-            if log_enabled!(Level::Debug) {
-                debug!("{}\n{}", msg, error.display_chain());
+            if log_enabled!(Level::Trace) {
+                trace!("{}\n{}", msg, error.display_chain());
             } else {
-                info!("{}", msg);
+                debug!("{}", msg);
             }
             false
         }


### PR DESCRIPTION
This error chain is driving me nuts. It's in every problem report, right at the top, and has multiple lines just screaming "Hey, I'm a critical error" basically. When in reality this should happen during the happy path. We don't care much about the details why it can't be found. So moving it to trace to get rid of it from normal user logs.