### PR TITLE
Stop notification flood when reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Replace repeated `Disconnecting` followed by `Connecting` notifications with a single
+  `Reconnecting` notification.
+
 #### Linux
 - Add support for DNS configuration using resolvconf.
 

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -511,7 +511,7 @@ export default class AppRenderer {
     this._updateConnectionStatus(tunnelState);
     this._updateUserLocation(tunnelState.state);
     this._updateTrayIcon(tunnelState.state);
-    this._showNotification(tunnelState.state);
+    this._notificationController.notify(tunnelState);
   }
 
   _setSettings(newSettings: Settings) {
@@ -573,29 +573,6 @@ export default class AppRenderer {
     const type = iconTypes[tunnelState] || 'unsecured';
 
     ipcRenderer.send('change-tray-icon', type);
-  }
-
-  _showNotification(tunnelState: TunnelState) {
-    switch (tunnelState) {
-      case 'connecting':
-        this._notificationController.show('Connecting');
-        break;
-      case 'connected':
-        this._notificationController.show('Secured');
-        break;
-      case 'disconnected':
-        this._notificationController.show('Unsecured');
-        break;
-      case 'blocked':
-        this._notificationController.show('Blocked all connections');
-        break;
-      case 'disconnecting':
-        // no-op
-        break;
-      default:
-        log.error(`Unexpected TunnelState: ${(tunnelState: empty)}`);
-        return;
-    }
   }
 }
 

--- a/gui/packages/desktop/src/renderer/lib/notification-controller.js
+++ b/gui/packages/desktop/src/renderer/lib/notification-controller.js
@@ -1,11 +1,36 @@
 // @flow
 
 import { remote } from 'electron';
+import log from 'electron-log';
+
+import type { TunnelState } from './daemon-rpc';
 
 export default class NotificationController {
   _activeNotification: ?Notification;
 
-  show(message: string) {
+  notify(tunnelState: TunnelState) {
+    switch (tunnelState) {
+      case 'connecting':
+        this._show('Connecting');
+        break;
+      case 'connected':
+        this._show('Secured');
+        break;
+      case 'disconnected':
+        this._show('Unsecured');
+        break;
+      case 'blocked':
+        this._show('Blocked all connections');
+        break;
+      case 'disconnecting':
+        // no-op
+        break;
+      default:
+        log.error(`Unexpected TunnelStateTransition: ${(tunnelState: empty)}`);
+    }
+  }
+
+  _show(message: string) {
     const lastNotification = this._activeNotification;
     const sameAsLastNotification = lastNotification && lastNotification.body === message;
 


### PR DESCRIPTION
Some situations cause the daemon to try to reconnect multiple times in a row. These attempts would lead to multiple `Disconnecting` followed by `Connecting` notifications appearing. This PR changes how the notifications are shown so that a single `Reconnecting` notification is shown once while the reconnection attempts continue.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/460)
<!-- Reviewable:end -->
