### PR TITLE
Set the global allocator to the system default one

### DIFF
--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -22,7 +22,14 @@ mod cmds;
 
 
 use mullvad_ipc_client::{new_standalone_ipc_client, DaemonRpcClient};
+
+use std::alloc::System;
 use std::io;
+
+
+#[global_allocator]
+static GLOBAL: System = System;
+
 
 error_chain! {
     foreign_links {

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -22,6 +22,7 @@ extern crate mullvad_rpc;
 use error_chain::ChainedError;
 use regex::Regex;
 
+use std::alloc::System;
 use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::{HashMap, HashSet};
@@ -29,6 +30,11 @@ use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+
+
+#[global_allocator]
+static GLOBAL: System = System;
+
 
 mod metadata;
 


### PR DESCRIPTION
So. By default Rust uses the jemalloc allocator on Linux and macOS at least. This is supposedly faster. But since it's not included by default in the OS this allocator implementation must be built into the binaries. This costs a few megs. Since we don't really have any performance critical components in that sense, no heavy data processing nor large buffers, my guess is that we would benefit more from slimming off these extra megabytes over having the faster allocator.

I was first thinking about adding this to the changelog. But it does not change anything really noticeable by users, so if we follow that rule it should not be in there I guess.

# File size differences
## Linux
mullvad-daemon: 15 -> 14 MiB
mullvad: 7.5 -> 6.2 MiB
problem-report: 12 -> 9.8 MiB
As you can see, there is some rounding going on. But we saved roughly 4.5 MiB, or about 13%.

## macOS
mullvad-daemon: 9.8 -> 9.6
mullad: 3.9 -> 3.7
problem-report: 6.9 -> 6.7
Or about 0.6 MiB = 3%

## Windows
I have not tested yet. But I think on Windows it already uses the default allocator by default, so this change should not do anything there.

# Performance

Very hard to measure really. As I said, I don't think we have any code heavily relying on allocation really. But from just trying a release build a bit, it feels just like normal :man_shrugging:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/462)
<!-- Reviewable:end -->
