### PR TITLE
Periodically update the GUI with the relay list from the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Don't temporarily show the unsecured state in the GUI when the app is reconnecting or blocking.
+- Periodically update list of relays in the GUI.
 
 
 ## [2018.3] - 2018-09-17


### PR DESCRIPTION
The relay list is updated by the daemon daily, but previously the GUI would only load the relay list when it connects to the daemon. Therefore, when running normally, the GUI would keep using an old relay list. This PR changes the GUI to periodically request for a new relay list from the daemon.

A `RelayListCache` helper class was created, that allows turning on and off the periodic updates. Currently the update interval is set at once an hour.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/463)
<!-- Reviewable:end -->
