### PR TITLE
Redact IPv6 addresses that start or end with colons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Don't temporarily show the unsecured state in the GUI when the app is reconnecting or blocking.
 - Periodically update list of relays in the GUI.
+- Redact IPv6 address that start or end with double colons in problem reports.
 
 
 ## [2018.3] - 2018-09-17

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -490,9 +490,7 @@ mod tests {
 
     #[test]
     fn does_not_redact_localhost_ipv4() {
-        let report = ProblemReport::new(vec![]);
-        let res = report.redact("127.0.0.1");
-        assert_eq!("127.0.0.1", res);
+        assert_does_not_redact("127.0.0.1");
     }
 
     #[test]
@@ -512,9 +510,7 @@ mod tests {
 
     #[test]
     fn doesnt_redact_not_ipv6() {
-        let report = ProblemReport::new(vec![]);
-        let actual = report.redact("[talpid_core::security]");
-        assert_eq!("[talpid_core::security]", actual);
+        assert_does_not_redact("[talpid_core::security]");
     }
 
     fn assert_redacts_ipv6(input: &str) {
@@ -525,8 +521,12 @@ mod tests {
 
     #[test]
     fn test_does_not_redact_time() {
+        assert_does_not_redact("09:47:59");
+    }
+
+    fn assert_does_not_redact(input: &str) {
         let report = ProblemReport::new(vec![]);
-        let res = report.redact("09:47:59");
-        assert_eq!("09:47:59", res);
+        let res = report.redact(input);
+        assert_eq!(input, res);
     }
 }

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -524,13 +524,6 @@ mod tests {
     }
 
     #[test]
-    fn test_does_not_redact_localhost_ipv6() {
-        let report = ProblemReport::new(vec![]);
-        let res = report.redact("::1");
-        assert_eq!("::1", res);
-    }
-
-    #[test]
     fn test_does_not_redact_time() {
         let report = ProblemReport::new(vec![]);
         let res = report.redact("09:47:59");


### PR DESCRIPTION
The `problem-report` binary wouldn't fully redact IPv6 addresses that either start or end with double colons (`::`). This PR changes the regular expressions to redact IPv6 address to fix this.

One issue encountered along the way was that the `\b` boundary specifier in the regular expression wouldn't consider `:` as part of a word, so it wouldn't consider a match as a redaction candidate if the match started or ended with a colon. The solution I found was to create a custom boundary specification, and since I can't match without consuming the input, I had to use capture groups to place them back in the output string.

Another edge case that complicated things a little was the localhost IPv6 address `::1`. For the regular expression to match addresses that start with colons, I had to manually tweak the hextet representation for when we have `::{hextet}` so that `1` is ignored.

I tried to split the regular expression into (hopefully) comprehensible chunks, but some regex-fu will still be required :/

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/464)
<!-- Reviewable:end -->
