### PR TITLE
Netsh timeout

### DIFF
--- a/windows/windns/src/windns/netconfighelpers.cpp
+++ b/windows/windns/src/windns/netconfighelpers.cpp
@@ -42,7 +42,7 @@ void SetDnsServers(uint32_t interfaceIndex, const std::vector<std::wstring> &ser
 	}
 }
 
-void RevertDnsServers(const InterfaceConfig &config)
+void RevertDnsServers(const InterfaceConfig &config, uint32_t timeout)
 {
 	XTRACE("Reverting DNS configuration for interface with index=", config.interfaceIndex());
 
@@ -50,15 +50,15 @@ void RevertDnsServers(const InterfaceConfig &config)
 
 	if (config.dhcp() || nullptr == servers || 0 == servers->size())
 	{
-		NetSh::SetIpv4Dhcp(config.interfaceIndex());
+		NetSh::SetIpv4Dhcp(config.interfaceIndex(), timeout);
 		return;
 	}
 
-	NetSh::SetIpv4PrimaryDns(config.interfaceIndex(), (*servers)[0]);
+	NetSh::SetIpv4PrimaryDns(config.interfaceIndex(), (*servers)[0], timeout);
 
 	if (servers->size() > 1)
 	{
-		NetSh::SetIpv4SecondaryDns(config.interfaceIndex(), (*servers)[1]);
+		NetSh::SetIpv4SecondaryDns(config.interfaceIndex(), (*servers)[1], timeout);
 	}
 }
 

--- a/windows/windns/src/windns/netconfighelpers.h
+++ b/windows/windns/src/windns/netconfighelpers.h
@@ -19,6 +19,6 @@ uint32_t GetInterfaceIndex(CComPtr<IWbemClassObject> instance);
 
 void SetDnsServers(uint32_t interfaceIndex, const std::vector<std::wstring> &servers);
 
-void RevertDnsServers(const InterfaceConfig &config);
+void RevertDnsServers(const InterfaceConfig &config, uint32_t timeout = 0);
 
 }

--- a/windows/windns/src/windns/netsh.h
+++ b/windows/windns/src/windns/netsh.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "clientsinkinfo.h"
 #include <string>
 #include <cstdint>
 #include <stdexcept>
@@ -8,18 +9,20 @@ class NetSh
 {
 public:
 
-	static void SetIpv4PrimaryDns(uint32_t interfaceIndex, std::wstring server);
+	static void RegisterErrorSink(const ErrorSinkInfo &errorSink);
+
+	static void SetIpv4PrimaryDns(uint32_t interfaceIndex, std::wstring server, uint32_t timeout = 0);
 	
 	//
 	// Caveat: This sets the primary DNS server if there isn't already one.
 	//
-	static void SetIpv4SecondaryDns(uint32_t interfaceIndex, std::wstring server);
+	static void SetIpv4SecondaryDns(uint32_t interfaceIndex, std::wstring server, uint32_t timeout = 0);
 
-	static void SetIpv4Dhcp(uint32_t interfaceIndex);
+	static void SetIpv4Dhcp(uint32_t interfaceIndex, uint32_t timeout = 0);
 
-	static void SetIpv6PrimaryDns(uint32_t interfaceIndex, std::wstring server);
-	static void SetIpv6SecondaryDns(uint32_t interfaceIndex, std::wstring server);
-	static void SetIpv6Dhcp(uint32_t interfaceIndex);
+	static void SetIpv6PrimaryDns(uint32_t interfaceIndex, std::wstring server, uint32_t timeout = 0);
+	static void SetIpv6SecondaryDns(uint32_t interfaceIndex, std::wstring server, uint32_t timeout = 0);
+	static void SetIpv6Dhcp(uint32_t interfaceIndex, uint32_t timeout = 0);
 
 private:
 


### PR DESCRIPTION
This commit introduces a higher timeout when running `netsh` during recovery. Also logs if the execution of `netsh` consumes more time than `timeout / 2`.

There are several things I particularly dislike about this implementation. But I'm in the middle of a major `windns` overhaul and I'd rather fix it properly in the new code, than spend time on it now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/469)
<!-- Reviewable:end -->
