### PR TITLE
Add everyone to the authors field of binaries

### DIFF
--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "mullvad-cli"
 version = "2018.3.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = [
+    "Mullvad VPN <admin@mullvad.net>",
+    "Andrej Mihajlov <and@mullvad.net>",
+    "Emīls Piņķis <emils@mullvad.net>",
+    "Erik Larkö <erik@mullvad.net>",
+    "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>",
+    "Linus Färnstrand <linus@mullvad.net>",
+]
 description = "Manage the Mullvad VPN daemon via a convenient CLI"
 license = "GPL-3.0"
 

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "mullvad-daemon"
 version = "2018.3.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = [
+    "Mullvad VPN <admin@mullvad.net>",
+    "Andrej Mihajlov <and@mullvad.net>",
+    "Emīls Piņķis <emils@mullvad.net>",
+    "Erik Larkö <erik@mullvad.net>",
+    "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>",
+    "Linus Färnstrand <linus@mullvad.net>",
+]
 description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
 license = "GPL-3.0"
 

--- a/mullvad-ipc-client/Cargo.toml
+++ b/mullvad-ipc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-ipc-client"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>"]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "RPC client for Mullvad daemon"
 license = "GPL-3.0"
 

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "mullvad-paths"
 version = "0.1.0"
-authors = [
-    "Mullvad VPN <admin@mullvad.net>",
-    "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>",
-    "Linus Färnstrand <linus@mullvad.net>"
-]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Mullvad VPN application paths and directories"
 license = "GPL-3.0"
 

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "mullvad-problem-report"
 version = "2018.3.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = [
+    "Mullvad VPN <admin@mullvad.net>",
+    "Andrej Mihajlov <and@mullvad.net>",
+    "Emīls Piņķis <emils@mullvad.net>",
+    "Erik Larkö <erik@mullvad.net>",
+    "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>",
+    "Linus Färnstrand <linus@mullvad.net>",
+]
 description = "Collect Mullvad VPN logs into a report and send it to support"
 license = "GPL-3.0"
 

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-rpc"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Mullvad VPN RPC clients. Providing an interface to query our infrastructure for information."
 license = "GPL-3.0"
 

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-tests"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>"]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Mullvad test specific modules and binaries"
 license = "GPL-3.0"
 

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-types"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Common base data structures for Mullvad VPN client"
 license = "GPL-3.0"
 

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "talpid-core"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Privacy preserving and secure VPN client library"
 license = "GPL-3.0"
 

--- a/talpid-ipc/Cargo.toml
+++ b/talpid-ipc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "talpid-ipc"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "IPC client and server for talpid"
 license = "GPL-3.0"
 

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "talpid-openvpn-plugin"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = [
+    "Mullvad VPN <admin@mullvad.net>",
+    "Andrej Mihajlov <and@mullvad.net>",
+    "Emīls Piņķis <emils@mullvad.net>",
+    "Erik Larkö <erik@mullvad.net>",
+    "Janito Vaqueiro Ferreira Filho <janito@mullvad.net>",
+    "Linus Färnstrand <linus@mullvad.net>",
+]
 description = "OpenVPN shared library plugin for relaying OpenVPN events to talpid_core"
 license = "GPL-3.0"
 

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "talpid-types"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>", "Erik Larkö <erik@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Common base structures for talpid"
 license = "GPL-3.0"
 


### PR DESCRIPTION
Our authors fields in crate metadata have been a bit random. Or basically we start with "Mullvad VPN" and whoever first created that crate. Then maybe some more people are added there. But many people have touched many crates where they are not added as authors.

So my thought was to add everyone to every crate in this repository. Because the repository represents one unified product. However, having to maintain the long list of authors in the library crates will be more work, and very little benefit. Thus I removed all individual persons from the library author fields. But added everyone to the binaries. For the binaries that use the `clap` CLI library all authors are listed on `--help` so this is a reason to list the entire team in binaries.

Added everyone as reviewers since it's your names. I want you to check spelling, and also I don't want to add or remove people's names from files without their consent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/475)
<!-- Reviewable:end -->
