### PR TITLE
Permit IPv6 LAN communication

### DIFF
--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -156,6 +156,34 @@ const GUID &MullvadGuids::FilterPermitLan_Multicast()
 }
 
 //static
+const GUID &MullvadGuids::FilterPermitLan_Ipv6_fe80_10()
+{
+	static const GUID g =
+	{
+		0x5733b308,
+		0x5856,
+		0x469f,
+		{ 0xa9, 0xf2, 0x24, 0x87, 0x52, 0x61, 0xd1, 0x6 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::FilterPermitLan_Ipv6_Multicast()
+{
+	static const GUID g =
+	{
+		0x7379135f,
+		0x6ce5,
+		0x4107,
+		{ 0x8a, 0x69, 0xf8, 0xea, 0x5a, 0x92, 0xb4, 0x97 }
+	};
+
+	return g;
+}
+
+//static
 const GUID &MullvadGuids::FilterPermitLanService_10_8()
 {
 	static const GUID g =
@@ -192,6 +220,20 @@ const GUID &MullvadGuids::FilterPermitLanService_192_168_16()
 		0x9bf0,
 		0x47f2,
 		{ 0x98, 0x69, 0xd1, 0x5e, 0xf3, 0x5c, 0x3a, 0x8 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::FilterPermitLanService_Ipv6_fe80_10()
+{
+	static const GUID g =
+	{
+		0xd1dff9da,
+		0x1d12,
+		0x4425,
+		{ 0x82, 0x70, 0xdc, 0x7, 0x56, 0xff, 0xb9, 0xf2 }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -20,10 +20,13 @@ public:
 	static const GUID &FilterPermitLan_172_16_12();
 	static const GUID &FilterPermitLan_192_168_16();
 	static const GUID &FilterPermitLan_Multicast();
+	static const GUID &FilterPermitLan_Ipv6_fe80_10();
+	static const GUID &FilterPermitLan_Ipv6_Multicast();
 
 	static const GUID &FilterPermitLanService_10_8();
 	static const GUID &FilterPermitLanService_172_16_12();
 	static const GUID &FilterPermitLanService_192_168_16();
+	static const GUID &FilterPermitLanService_Ipv6_fe80_10();
 
 	static const GUID &FilterPermitLoopback_Outbound_Ipv4();
 	static const GUID &FilterPermitLoopback_Outbound_Ipv6();

--- a/windows/winfw/src/winfw/rules/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/permitlan.cpp
@@ -13,6 +13,11 @@ namespace rules
 
 bool PermitLan::apply(IObjectInstaller &objectInstaller)
 {
+	return applyIpv4(objectInstaller) && applyIpv6(objectInstaller);
+}
+
+bool PermitLan::applyIpv4(IObjectInstaller &objectInstaller) const
+{
 	wfp::FilterBuilder filterBuilder;
 
 	//
@@ -89,7 +94,57 @@ bool PermitLan::apply(IObjectInstaller &objectInstaller)
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 172, 16, 0, 0 }), uint8_t(12)));
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 192, 168, 0, 0 }), uint8_t(16)));
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 224, 0, 0, 0 }), uint8_t(24)));
+
+	// Special multicast for SSDP.
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 239, 255, 255, 250 }), uint8_t(32)));
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+bool PermitLan::applyIpv6(IObjectInstaller &objectInstaller) const
+{
+	wfp::FilterBuilder filterBuilder;
+
+	//
+	// #1 locally-initiated on fe80::/10
+	//
+
+	filterBuilder
+		.key(MullvadGuids::FilterPermitLan_Ipv6_fe80_10())
+		.name(L"Permit locally-initiated traffic on fe80::/10")
+		.description(L"This filter is part of a rule that permits LAN traffic")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerWhitelist())
+		.weight(wfp::FilterBuilder::WeightClass::Max)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+	wfp::IpAddress::Literal6 fe80 { 0xFE80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+
+	conditionBuilder.add_condition(ConditionIp::Local(fe80, uint8_t(10)));
+	conditionBuilder.add_condition(ConditionIp::Remote(fe80, uint8_t(10)));
+
+	if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+	{
+		return false;
+	}
+
+	//
+	// #2 LAN to multicast
+	//
+
+	filterBuilder
+		.key(MullvadGuids::FilterPermitLan_Ipv6_Multicast())
+		.name(L"Permit locally-initiated IPv6 multicast traffic");
+
+	conditionBuilder.reset();
+
+	wfp::IpAddress::Literal6 fe02{ 0xFE02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+
+	conditionBuilder.add_condition(ConditionIp::Local(fe80, uint8_t(10)));
+	conditionBuilder.add_condition(ConditionIp::Remote(fe02, uint8_t(16)));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }

--- a/windows/winfw/src/winfw/rules/permitlan.h
+++ b/windows/winfw/src/winfw/rules/permitlan.h
@@ -13,6 +13,11 @@ public:
 	~PermitLan() = default;
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
+
+private:
+
+	bool applyIpv4(IObjectInstaller &objectInstaller) const;
+	bool applyIpv6(IObjectInstaller &objectInstaller) const;
 };
 
 }

--- a/windows/winfw/src/winfw/rules/permitlanservice.h
+++ b/windows/winfw/src/winfw/rules/permitlanservice.h
@@ -13,6 +13,11 @@ public:
 	~PermitLanService() = default;
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
+
+private:
+
+	bool applyIpv4(IObjectInstaller &objectInstaller) const;
+	bool applyIpv6(IObjectInstaller &objectInstaller) const;
 };
 
 }


### PR DESCRIPTION
Update the rules that permit IPv6 LAN communication and hosting services on an IPv6 LAN.

Tested as far as making sure it doesn't break the app. But someone needs to test it properly, to ensure the advertised new functionality works, before we merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/476)
<!-- Reviewable:end -->
