### PR TITLE
Refactor GUI to use more of `Cell` components

### DIFF
--- a/gui/packages/desktop/src/renderer/components/Account.js
+++ b/gui/packages/desktop/src/renderer/components/Account.js
@@ -23,14 +23,6 @@ type Props = {
 };
 
 export default class Account extends Component<Props> {
-  _copyTimer: ?TimeoutID;
-
-  componentWillUnmount() {
-    if (this._copyTimer) {
-      clearTimeout(this._copyTimer);
-    }
-  }
-
   render() {
     return (
       <Layout>

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { Button, Component, Text, View } from 'reactxp';
+import * as Cell from './Cell';
 import { Layout, Container } from './Layout';
 import NavigationBar, { BackBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
@@ -43,19 +44,11 @@ export class AdvancedSettings extends Component<Props> {
                 <HeaderTitle>Advanced</HeaderTitle>
               </SettingsHeader>
               <CustomScrollbars style={styles.advanced_settings__scrollview} autoHide={true}>
-                <View style={styles.advanced_settings__ipv6}>
-                  <View style={styles.advanced_settings__cell_label_container}>
-                    <Text style={styles.advanced_settings__cell_label}>Enable IPv6</Text>
-                  </View>
-                  <View style={styles.advanced_settings__ipv6_accessory}>
-                    <Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
-                  </View>
-                </View>
-                <View style={styles.advanced_settings__cell_footer}>
-                  <Text style={styles.advanced_settings__cell_footer_label}>
-                    {'Enable IPv6 communication through the tunnel.'}
-                  </Text>
-                </View>
+                <Cell.Container>
+                  <Cell.Label>Enable IPv6</Cell.Label>
+                  <Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
+                </Cell.Container>
+                <Cell.Footer>Enable IPv6 communication through the tunnel.</Cell.Footer>
 
                 <View style={styles.advanced_settings__content}>
                   <Selector

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -10,7 +10,7 @@ import Switch from './Switch';
 import styles from './AdvancedSettingsStyles';
 import Img from './Img';
 
-type AdvancedSettingsProps = {
+type Props = {
   enableIpv6: boolean,
   protocol: string,
   port: string | number,
@@ -19,7 +19,7 @@ type AdvancedSettingsProps = {
   onClose: () => void,
 };
 
-export class AdvancedSettings extends Component<AdvancedSettingsProps> {
+export class AdvancedSettings extends Component<Props> {
   render() {
     let portSelector = null;
     let protocol = this.props.protocol.toUpperCase();

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettingsStyles.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettingsStyles.js
@@ -24,14 +24,6 @@ export default {
     flexBasis: 'auto',
     overflow: 'visible',
   }),
-  advanced_settings__ipv6: Styles.createViewStyle({
-    backgroundColor: colors.blue,
-    flexDirection: 'row',
-    alignItems: 'center',
-  }),
-  advanced_settings__ipv6_accessory: Styles.createViewStyle({
-    marginRight: 12,
-  }),
   advanced_settings__cell: Styles.createViewStyle({
     cursor: 'default',
     backgroundColor: colors.green,
@@ -70,19 +62,6 @@ export default {
     flexDirection: 'row',
     justifyContent: 'flex-start',
   }),
-  advanced_settings__cell_footer: Styles.createViewStyle({
-    paddingTop: 8,
-    paddingRight: 24,
-    paddingBottom: 24,
-    paddingLeft: 24,
-  }),
-  advanced_settings__cell_label_container: Styles.createViewStyle({
-    paddingTop: 14,
-    paddingRight: 12,
-    paddingBottom: 14,
-    paddingLeft: 24,
-    flexGrow: 1,
-  }),
 
   advanced_settings__section_title: Styles.createTextStyle({
     backgroundColor: colors.blue,
@@ -105,13 +84,5 @@ export default {
     letterSpacing: -0.2,
     color: colors.white,
     flex: 0,
-  }),
-  advanced_settings__cell_footer_label: Styles.createTextStyle({
-    fontFamily: 'Open Sans',
-    fontSize: 13,
-    fontWeight: '600',
-    lineHeight: 20,
-    letterSpacing: -0.2,
-    color: colors.white80,
   }),
 };

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -166,11 +166,20 @@ export function Container({ children }: ContainerProps) {
   return <View style={styles.cellContainer}>{children}</View>;
 }
 
-export function Label({ children }: ContainerProps) {
+export type LabelProps = {
+  children: React.Node,
+  cellHoverStyle?: Types.ViewStyle,
+};
+
+export function Label({ children, cellHoverStyle }: LabelProps) {
   return (
-    <View style={styles.label.container}>
-      <Text style={styles.label.text}>{children}</Text>
-    </View>
+    <CellHoverContext.Consumer>
+      {(hovered) => (
+        <View style={[styles.label.container, hovered && cellHoverStyle]}>
+          <Text style={styles.label.text}>{children}</Text>
+        </View>
+      )}
+    </CellHoverContext.Consumer>
   );
 }
 

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -8,6 +8,8 @@ import { colors } from '../../config';
 const styles = {
   cellButton: Styles.createViewStyle({
     backgroundColor: colors.blue,
+    paddingTop: 0,
+    paddingBottom: 0,
     paddingLeft: 16,
     paddingRight: 16,
     marginBottom: 1,

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -6,7 +6,7 @@ import PlainImg from './Img';
 import { colors } from '../../config';
 
 const styles = {
-  cell: Styles.createViewStyle({
+  cellButton: Styles.createViewStyle({
     backgroundColor: colors.blue,
     paddingLeft: 16,
     paddingRight: 16,
@@ -115,7 +115,7 @@ export class CellButton extends Component<CellButtonProps, State> {
     const { children, style, cellHoverStyle, ...otherProps } = this.props;
     return (
       <Button
-        style={[styles.cell, style, this.backgroundStyle(cellHoverStyle)]}
+        style={[styles.cellButton, style, this.backgroundStyle(cellHoverStyle)]}
         onHoverStart={this.onHoverStart}
         onHoverEnd={this.onHoverEnd}
         {...otherProps}>

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { Button, Text, Component, Styles, Types } from 'reactxp';
+import { Button, Text, Component, Styles, Types, View } from 'reactxp';
 import PlainImg from './Img';
 import { colors } from '../../config';
 
@@ -19,6 +19,14 @@ const styles = {
     alignContent: 'center',
     cursor: 'default',
   }),
+  cellContainer: Styles.createViewStyle({
+    backgroundColor: colors.blue,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 24,
+    paddingRight: 12,
+  }),
+
   cellHover: Styles.createViewStyle({
     backgroundColor: colors.blue80,
   }),
@@ -115,4 +123,10 @@ export class CellButton extends Component<CellButtonProps, State> {
       </Button>
     );
   }
+}
+
+type ContainerProps = { children: React.Node };
+
+export function Container({ children }: ContainerProps) {
+  return <View style={styles.cellContainer}>{children}</View>;
 }

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -27,6 +27,23 @@ const styles = {
     paddingRight: 12,
   }),
 
+  footer: {
+    container: Styles.createViewStyle({
+      paddingTop: 8,
+      paddingRight: 24,
+      paddingBottom: 24,
+      paddingLeft: 24,
+    }),
+    text: Styles.createTextStyle({
+      fontFamily: 'Open Sans',
+      fontSize: 13,
+      fontWeight: '600',
+      lineHeight: 20,
+      letterSpacing: -0.2,
+      color: colors.white80,
+    }),
+  },
+
   cellHover: Styles.createViewStyle({
     backgroundColor: colors.blue80,
   }),
@@ -129,4 +146,12 @@ type ContainerProps = { children: React.Node };
 
 export function Container({ children }: ContainerProps) {
   return <View style={styles.cellContainer}>{children}</View>;
+}
+
+export function Footer({ children }: ContainerProps) {
+  return (
+    <View style={styles.footer.container}>
+      <Text style={styles.footer.text}>{children}</Text>
+    </View>
+  );
 }

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -86,8 +86,6 @@ const styles = {
   }),
 };
 
-export class Img extends PlainImg {}
-
 type CellButtonProps = {
   children?: React.Node,
   disabled?: boolean,

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -8,8 +8,6 @@ import { colors } from '../../config';
 const styles = {
   cell: Styles.createViewStyle({
     backgroundColor: colors.blue,
-    paddingTop: 14,
-    paddingBottom: 14,
     paddingLeft: 16,
     paddingRight: 16,
     marginBottom: 1,
@@ -44,6 +42,22 @@ const styles = {
     }),
   },
 
+  label: {
+    container: Styles.createViewStyle({
+      marginTop: 14,
+      marginBottom: 14,
+      flexGrow: 1,
+    }),
+    text: Styles.createTextStyle({
+      fontFamily: 'DINPro',
+      fontSize: 20,
+      fontWeight: '900',
+      lineHeight: 26,
+      letterSpacing: -0.2,
+      color: colors.white,
+    }),
+  },
+
   cellHover: Styles.createViewStyle({
     backgroundColor: colors.blue80,
   }),
@@ -73,7 +87,6 @@ const styles = {
 };
 
 export class SubText extends Text {}
-export class Label extends Text {}
 export class Img extends PlainImg {}
 
 type CellButtonProps = {
@@ -150,6 +163,14 @@ type ContainerProps = { children: React.Node };
 
 export function Container({ children }: ContainerProps) {
   return <View style={styles.cellContainer}>{children}</View>;
+}
+
+export function Label({ children }: ContainerProps) {
+  return (
+    <View style={styles.label.container}>
+      <Text style={styles.label.text}>{children}</Text>
+    </View>
+  );
 }
 
 export function Footer({ children }: ContainerProps) {

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -52,7 +52,7 @@ const styles = {
     marginLeft: 8,
   }),
 
-  label: Styles.createTextStyle({
+  labelText: Styles.createTextStyle({
     color: colors.white,
     alignSelf: 'center',
     fontFamily: 'DINPro',
@@ -111,7 +111,11 @@ export class CellButton extends Component<CellButtonProps, State> {
 
             if (node.type === Label) {
               updatedProps = {
-                style: [styles.label, node.props.style, this.textStyle(node.props.cellHoverStyle)],
+                style: [
+                  styles.labelText,
+                  node.props.style,
+                  this.textStyle(node.props.cellHoverStyle),
+                ],
               };
             }
 
@@ -134,7 +138,7 @@ export class CellButton extends Component<CellButtonProps, State> {
 
             return React.cloneElement(node, updatedProps);
           } else if (node) {
-            return <Label style={[styles.label, this.textStyle()]}>{children}</Label>;
+            return <Label style={[styles.labelText, this.textStyle()]}>{children}</Label>;
           }
         })}
       </Button>

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -131,11 +131,14 @@ export function Label({
   textStyle,
   cellHoverContainerStyle,
   cellHoverTextStyle,
+  ...otherProps
 }: LabelProps) {
   return (
     <CellHoverContext.Consumer>
       {(hovered) => (
-        <View style={[styles.label.container, containerStyle, hovered && cellHoverContainerStyle]}>
+        <View
+          style={[styles.label.container, containerStyle, hovered && cellHoverContainerStyle]}
+          {...otherProps}>
           <Text style={[styles.label.text, textStyle, hovered && cellHoverTextStyle]}>
             {children}
           </Text>

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -21,7 +21,7 @@ const styles = {
     backgroundColor: colors.blue,
     flexDirection: 'row',
     alignItems: 'center',
-    paddingLeft: 24,
+    paddingLeft: 16,
     paddingRight: 12,
   }),
 
@@ -44,6 +44,7 @@ const styles = {
 
   label: {
     container: Styles.createViewStyle({
+      marginLeft: 8,
       marginTop: 14,
       marginBottom: 14,
       flexGrow: 1,

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -66,16 +66,6 @@ const styles = {
     marginLeft: 8,
   }),
 
-  labelText: Styles.createTextStyle({
-    color: colors.white,
-    alignSelf: 'center',
-    fontFamily: 'DINPro',
-    fontSize: 20,
-    fontWeight: '900',
-    lineHeight: 26,
-    flex: 1,
-    marginLeft: 8,
-  }),
   subtext: Styles.createTextStyle({
     color: colors.white60,
     fontFamily: 'Open Sans',
@@ -100,59 +90,19 @@ const CellHoverContext = React.createContext(false);
 export class CellButton extends Component<CellButtonProps, State> {
   state = { hovered: false };
 
-  textStyle = (cellHoverStyle?: Types.ViewStyle) => (this.state.hovered ? cellHoverStyle : null);
-  iconStyle = (cellHoverStyle?: Types.ViewStyle) => (this.state.hovered ? cellHoverStyle : null);
-  subtextStyle = (cellHoverStyle?: Types.ViewStyle) => (this.state.hovered ? cellHoverStyle : null);
-  backgroundStyle = (cellHoverStyle?: Types.ViewStyle) =>
-    this.state.hovered ? cellHoverStyle || styles.cellHover : null;
-
   onHoverStart = () => (!this.props.disabled ? this.setState({ hovered: true }) : null);
   onHoverEnd = () => (!this.props.disabled ? this.setState({ hovered: false }) : null);
 
   render() {
     const { children, style, cellHoverStyle, ...otherProps } = this.props;
+    const hoverStyle = cellHoverStyle || styles.cellHover;
     return (
       <Button
-        style={[styles.cellButton, style, this.backgroundStyle(cellHoverStyle)]}
+        style={[styles.cellButton, style, this.state.hovered && hoverStyle]}
         onHoverStart={this.onHoverStart}
         onHoverEnd={this.onHoverEnd}
         {...otherProps}>
-        {React.Children.map(children, (node) => {
-          if (React.isValidElement(node)) {
-            let updatedProps = {};
-
-            if (node.type === Label) {
-              updatedProps = {
-                style: [
-                  styles.labelText,
-                  node.props.style,
-                  this.textStyle(node.props.cellHoverStyle),
-                ],
-              };
-            }
-
-            if (node.type === Img) {
-              updatedProps = {
-                tintColor: 'currentColor',
-                style: [styles.icon, node.props.style, this.iconStyle(node.props.cellHoverStyle)],
-              };
-            }
-
-            if (node.type === SubText) {
-              updatedProps = {
-                style: [
-                  styles.subtext,
-                  node.props.style,
-                  this.subtextStyle(node.props.cellHoverStyle),
-                ],
-              };
-            }
-
-            return React.cloneElement(node, updatedProps);
-          } else if (node) {
-            return <Label style={[styles.labelText, this.textStyle()]}>{children}</Label>;
-          }
-        })}
+        <CellHoverContext.Provider value={this.state.hovered}>{children}</CellHoverContext.Provider>
       </Button>
     );
   }

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -185,14 +185,19 @@ export function Label({ children, cellHoverStyle }: LabelProps) {
 
 export type SubTextProps = {
   children: React.Node,
+  cellHoverStyle?: Types.ViewStyle,
   style?: Types.ViewStyle,
 };
 
-export function SubText({ children, style, ...otherProps }: SubTextProps) {
+export function SubText({ children, style, cellHoverStyle, ...otherProps }: SubTextProps) {
   return (
-    <Text style={[styles.subtext, style]} {...otherProps}>
-      {children}
-    </Text>
+    <CellHoverContext.Consumer>
+      {(hovered) => (
+        <Text style={[styles.subtext, style, hovered && cellHoverStyle]} {...otherProps}>
+          {children}
+        </Text>
+      )}
+    </CellHoverContext.Consumer>
   );
 }
 

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -196,6 +196,25 @@ export function SubText({ children, style, ...otherProps }: SubTextProps) {
   );
 }
 
+export type IconProps = {
+  cellHoverStyle?: Types.ViewStyle,
+  style?: Types.ViewStyle,
+};
+
+export function Icon({ style, cellHoverStyle, ...otherProps }: IconProps) {
+  return (
+    <CellHoverContext.Consumer>
+      {(hovered) => (
+        <PlainImg
+          tintColor={'currentColor'}
+          style={[styles.icon, style, hovered && cellHoverStyle]}
+          {...otherProps}
+        />
+      )}
+    </CellHoverContext.Consumer>
+  );
+}
+
 export function Footer({ children }: ContainerProps) {
   return (
     <View style={styles.footer.container}>

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -86,7 +86,6 @@ const styles = {
   }),
 };
 
-export class SubText extends Text {}
 export class Img extends PlainImg {}
 
 type CellButtonProps = {
@@ -170,6 +169,19 @@ export function Label({ children }: ContainerProps) {
     <View style={styles.label.container}>
       <Text style={styles.label.text}>{children}</Text>
     </View>
+  );
+}
+
+export type SubTextProps = {
+  children: React.Node,
+  style?: Types.ViewStyle,
+};
+
+export function SubText({ children, style, ...otherProps }: SubTextProps) {
+  return (
+    <Text style={[styles.subtext, style]} {...otherProps}>
+      {children}
+    </Text>
   );
 }
 

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -97,6 +97,8 @@ type CellButtonProps = {
 
 type State = { hovered: boolean };
 
+const CellHoverContext = React.createContext(false);
+
 export class CellButton extends Component<CellButtonProps, State> {
   state = { hovered: false };
 

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -119,15 +119,26 @@ export function Container({ children }: ContainerProps) {
 
 export type LabelProps = {
   children: React.Node,
-  cellHoverStyle?: Types.ViewStyle,
+  containerStyle?: Types.ViewStyle,
+  textStyle?: Types.TextStyle,
+  cellHoverContainerStyle?: Types.ViewStyle,
+  cellHoverTextStyle?: Types.TextStyle,
 };
 
-export function Label({ children, cellHoverStyle }: LabelProps) {
+export function Label({
+  children,
+  containerStyle,
+  textStyle,
+  cellHoverContainerStyle,
+  cellHoverTextStyle,
+}: LabelProps) {
   return (
     <CellHoverContext.Consumer>
       {(hovered) => (
-        <View style={[styles.label.container, hovered && cellHoverStyle]}>
-          <Text style={styles.label.text}>{children}</Text>
+        <View style={[styles.label.container, containerStyle, hovered && cellHoverContainerStyle]}>
+          <Text style={[styles.label.text, textStyle, hovered && cellHoverTextStyle]}>
+            {children}
+          </Text>
         </View>
       )}
     </CellHoverContext.Consumer>

--- a/gui/packages/desktop/src/renderer/components/Login.js
+++ b/gui/packages/desktop/src/renderer/components/Login.js
@@ -447,12 +447,13 @@ class AccountDropdownItem extends React.Component<AccountDropdownItemProps> {
         <Cell.CellButton
           style={styles.account_dropdown__item}
           cellHoverStyle={styles.account_dropdown__item_hover}>
-          <Text
-            style={styles.account_dropdown__label}
-            cellHoverStyle={styles.account_dropdown__label_hover}
+          <Cell.Label
+            textStyle={styles.account_dropdown__label}
+            containerStyle={styles.account_dropdown__label_container}
+            cellHoverTextStyle={styles.account_dropdown__label_hover}
             onPress={() => this.props.onSelect(this.props.value)}>
             {this.props.label}
-          </Text>
+          </Cell.Label>
           <Img
             style={styles.account_dropdown__remove}
             cellHoverStyle={styles.account_dropdown__remove_cell_hover}

--- a/gui/packages/desktop/src/renderer/components/Login.js
+++ b/gui/packages/desktop/src/renderer/components/Login.js
@@ -447,12 +447,12 @@ class AccountDropdownItem extends React.Component<AccountDropdownItemProps> {
         <Cell.CellButton
           style={styles.account_dropdown__item}
           cellHoverStyle={styles.account_dropdown__item_hover}>
-          <Cell.Label
+          <Text
             style={styles.account_dropdown__label}
             cellHoverStyle={styles.account_dropdown__label_hover}
             onPress={() => this.props.onSelect(this.props.value)}>
             {this.props.label}
-          </Cell.Label>
+          </Text>
           <Img
             style={styles.account_dropdown__remove}
             cellHoverStyle={styles.account_dropdown__remove_cell_hover}

--- a/gui/packages/desktop/src/renderer/components/Login.js
+++ b/gui/packages/desktop/src/renderer/components/Login.js
@@ -457,6 +457,7 @@ class AccountDropdownItem extends React.Component<AccountDropdownItemProps> {
           <Img
             style={styles.account_dropdown__remove}
             hoverStyle={styles.account_dropdown__remove_hover}
+            tintColor={'currentColor'}
             source="icon-close-sml"
             height={16}
             width={16}

--- a/gui/packages/desktop/src/renderer/components/Login.js
+++ b/gui/packages/desktop/src/renderer/components/Login.js
@@ -456,7 +456,6 @@ class AccountDropdownItem extends React.Component<AccountDropdownItemProps> {
           </Cell.Label>
           <Img
             style={styles.account_dropdown__remove}
-            cellHoverStyle={styles.account_dropdown__remove_cell_hover}
             hoverStyle={styles.account_dropdown__remove_hover}
             source="icon-close-sml"
             height={16}

--- a/gui/packages/desktop/src/renderer/components/LoginStyles.js
+++ b/gui/packages/desktop/src/renderer/components/LoginStyles.js
@@ -104,9 +104,6 @@ export default {
     paddingLeft: 12,
     marginLeft: 0,
   }),
-  account_dropdown__remove_cell_hover: Styles.createViewStyle({
-    color: colors.blue60,
-  }),
   account_dropdown__remove_hover: Styles.createViewStyle({
     color: colors.blue,
   }),

--- a/gui/packages/desktop/src/renderer/components/LoginStyles.js
+++ b/gui/packages/desktop/src/renderer/components/LoginStyles.js
@@ -113,6 +113,11 @@ export default {
   account_dropdown__label_hover: Styles.createViewStyle({
     color: colors.blue,
   }),
+  account_dropdown__label_container: Styles.createViewStyle({
+    marginLeft: 12,
+    marginTop: 11,
+    marginBottom: 11,
+  }),
 
   login_footer__prompt: Styles.createTextStyle({
     color: colors.white80,
@@ -157,19 +162,10 @@ export default {
     flex: 1,
   }),
   account_dropdown__label: Styles.createTextStyle({
-    flex: 1,
-    fontFamily: 'DINPro',
-    fontSize: 20,
-    fontWeight: '900',
-    lineHeight: 26,
     color: colors.blue80,
     borderWidth: 0,
     textAlign: 'left',
     marginLeft: 0,
-    paddingTop: 10,
-    paddingRight: 0,
-    paddingLeft: 12,
-    paddingBottom: 12,
     cursor: 'default',
   }),
 };

--- a/gui/packages/desktop/src/renderer/components/Preferences.js
+++ b/gui/packages/desktop/src/renderer/components/Preferences.js
@@ -1,7 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { Component, Text, View } from 'reactxp';
+import { Component, View } from 'reactxp';
+import * as Cell from './Cell';
 import { Layout, Container } from './Layout';
 import NavigationBar, { BackBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
@@ -47,49 +48,27 @@ export default class Preferences extends Component<PreferencesProps, State> {
               </SettingsHeader>
 
               <View style={styles.preferences__content}>
-                <View style={styles.preferences__cell}>
-                  <View style={styles.preferences__cell_label_container}>
-                    <Text style={styles.preferences__cell_label}>Auto-connect</Text>
-                  </View>
-                  <View style={styles.preferences__cell_accessory}>
-                    <Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
-                  </View>
-                </View>
-                <View style={styles.preferences__cell_footer}>
-                  <Text style={styles.preferences__cell_footer_label}>
-                    {'Automatically connect the VPN when the computer starts.'}
-                  </Text>
-                </View>
+                <Cell.Container>
+                  <Cell.Label style={styles.preferences__cell_label}>Auto-connect</Cell.Label>
+                  <Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
+                </Cell.Container>
+                <Cell.Footer>Automatically connect the VPN when the computer starts.</Cell.Footer>
 
-                <View style={styles.preferences__cell}>
-                  <View style={styles.preferences__cell_label_container}>
-                    <Text style={styles.preferences__cell_label}>Auto-start</Text>
-                  </View>
-                  <View style={styles.preferences__cell_accessory}>
-                    <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
-                  </View>
-                </View>
-                <View style={styles.preferences__cell_footer}>
-                  <Text style={styles.preferences__cell_footer_label}>
-                    {'Automatically open Mullvad VPN at login to the system.'}
-                  </Text>
-                </View>
+                <Cell.Container>
+                  <Cell.Label style={styles.preferences__cell_label}>Auto-start</Cell.Label>
+                  <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
+                </Cell.Container>
+                <Cell.Footer>Automatically open Mullvad VPN at login to the system.</Cell.Footer>
 
-                <View style={styles.preferences__cell}>
-                  <View style={styles.preferences__cell_label_container}>
-                    <Text style={styles.preferences__cell_label}>Local network sharing</Text>
-                  </View>
-                  <View style={styles.preferences__cell_accessory}>
-                    <Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
-                  </View>
-                </View>
-                <View style={styles.preferences__cell_footer}>
-                  <Text style={styles.preferences__cell_footer_label}>
-                    {
-                      'Allows access to other devices on the same network for sharing, printing etc.'
-                    }
-                  </Text>
-                </View>
+                <Cell.Container>
+                  <Cell.Label style={styles.preferences__cell_label}>
+                    Local network sharing
+                  </Cell.Label>
+                  <Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
+                </Cell.Container>
+                <Cell.Footer>
+                  Allows access to other devices on the same network for sharing, printing etc.
+                </Cell.Footer>
               </View>
             </View>
           </View>

--- a/gui/packages/desktop/src/renderer/components/Preferences.js
+++ b/gui/packages/desktop/src/renderer/components/Preferences.js
@@ -49,21 +49,19 @@ export default class Preferences extends Component<PreferencesProps, State> {
 
               <View style={styles.preferences__content}>
                 <Cell.Container>
-                  <Cell.Label style={styles.preferences__cell_label}>Auto-connect</Cell.Label>
+                  <Cell.Label>Auto-connect</Cell.Label>
                   <Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
                 </Cell.Container>
                 <Cell.Footer>Automatically connect the VPN when the computer starts.</Cell.Footer>
 
                 <Cell.Container>
-                  <Cell.Label style={styles.preferences__cell_label}>Auto-start</Cell.Label>
+                  <Cell.Label>Auto-start</Cell.Label>
                   <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
                 </Cell.Container>
                 <Cell.Footer>Automatically open Mullvad VPN at login to the system.</Cell.Footer>
 
                 <Cell.Container>
-                  <Cell.Label style={styles.preferences__cell_label}>
-                    Local network sharing
-                  </Cell.Label>
+                  <Cell.Label>Local network sharing</Cell.Label>
                   <Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
                 </Cell.Container>
                 <Cell.Footer>

--- a/gui/packages/desktop/src/renderer/components/PreferencesStyles.js
+++ b/gui/packages/desktop/src/renderer/components/PreferencesStyles.js
@@ -19,16 +19,4 @@ export default {
     flexShrink: 1,
     flexBasis: 'auto',
   }),
-
-  preferences__cell_label: Styles.createTextStyle({
-    fontFamily: 'DINPro',
-    fontSize: 20,
-    fontWeight: '900',
-    lineHeight: 26,
-    letterSpacing: -0.2,
-    color: colors.white,
-    paddingTop: 14,
-    paddingBottom: 14,
-    flexGrow: 1,
-  }),
 };

--- a/gui/packages/desktop/src/renderer/components/PreferencesStyles.js
+++ b/gui/packages/desktop/src/renderer/components/PreferencesStyles.js
@@ -19,27 +19,6 @@ export default {
     flexShrink: 1,
     flexBasis: 'auto',
   }),
-  preferences__cell: Styles.createViewStyle({
-    backgroundColor: colors.blue,
-    flexDirection: 'row',
-    alignItems: 'center',
-  }),
-  preferences__cell_accessory: Styles.createViewStyle({
-    marginRight: 12,
-  }),
-  preferences__cell_footer: Styles.createViewStyle({
-    paddingTop: 8,
-    paddingRight: 24,
-    paddingBottom: 24,
-    paddingLeft: 24,
-  }),
-  preferences__cell_label_container: Styles.createViewStyle({
-    paddingTop: 14,
-    paddingRight: 12,
-    paddingBottom: 14,
-    paddingLeft: 24,
-    flexGrow: 1,
-  }),
 
   preferences__cell_label: Styles.createTextStyle({
     fontFamily: 'DINPro',
@@ -48,13 +27,8 @@ export default {
     lineHeight: 26,
     letterSpacing: -0.2,
     color: colors.white,
-  }),
-  preferences__cell_footer_label: Styles.createTextStyle({
-    fontFamily: 'Open Sans',
-    fontSize: 13,
-    fontWeight: '600',
-    lineHeight: 20,
-    letterSpacing: -0.2,
-    color: colors.white80,
+    paddingTop: 14,
+    paddingBottom: 14,
+    flexGrow: 1,
   }),
 };

--- a/gui/packages/desktop/src/renderer/components/SelectLocation.js
+++ b/gui/packages/desktop/src/renderer/components/SelectLocation.js
@@ -165,7 +165,7 @@ export default class SelectLocation extends Component<Props, State> {
     const statusClass = active ? styles.relay_status__active : styles.relay_status__inactive;
 
     return isSelected ? (
-      <Cell.Img style={styles.tick_icon} source="icon-tick" height={24} width={24} />
+      <Cell.Icon style={styles.tick_icon} source="icon-tick" height={24} width={24} />
     ) : (
       <View style={[styles.relay_status, statusClass]} />
     );
@@ -209,7 +209,7 @@ export default class SelectLocation extends Component<Props, State> {
           <Cell.Label>{relayCountry.name}</Cell.Label>
 
           {hasChildren ? (
-            <Cell.Img
+            <Cell.Icon
               style={styles.collapse_button}
               hoverStyle={styles.expand_chevron_hover}
               onPress={handleCollapse}
@@ -266,7 +266,7 @@ export default class SelectLocation extends Component<Props, State> {
           <Cell.Label>{relayCity.name}</Cell.Label>
 
           {relayCity.relays.length > 1 ? (
-            <Cell.Img
+            <Cell.Icon
               style={styles.collapse_button}
               hoverStyle={styles.expand_chevron_hover}
               onPress={handleCollapse}

--- a/gui/packages/desktop/src/renderer/components/Settings.js
+++ b/gui/packages/desktop/src/renderer/components/Settings.js
@@ -91,7 +91,7 @@ export default class Settings extends Component<Props> {
                 style={styles.settings__account_paid_until_label__error}>
                 {'OUT OF TIME'}
               </Cell.SubText>
-              <Cell.Img height={12} width={7} source="icon-chevron" />
+              <Cell.Icon height={12} width={7} source="icon-chevron" />
             </Cell.CellButton>
           ) : (
             <Cell.CellButton
@@ -101,19 +101,19 @@ export default class Settings extends Component<Props> {
               <Cell.SubText testName="settings__account_paid_until_subtext">
                 {formattedExpiry}
               </Cell.SubText>
-              <Cell.Img height={12} width={7} source="icon-chevron" />
+              <Cell.Icon height={12} width={7} source="icon-chevron" />
             </Cell.CellButton>
           )}
         </View>
 
         <Cell.CellButton onPress={this.props.onViewPreferences} testName="settings__preferences">
           <Cell.Label>Preferences</Cell.Label>
-          <Cell.Img height={12} width={7} source="icon-chevron" />
+          <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
 
         <Cell.CellButton onPress={this.props.onViewAdvancedSettings} testName="settings__advanced">
           <Cell.Label>Advanced</Cell.Label>
-          <Cell.Img height={12} width={7} source="icon-chevron" />
+          <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
         <View style={styles.settings__cell_spacer} />
       </View>
@@ -148,7 +148,7 @@ export default class Settings extends Component<Props> {
           {icon}
           <Cell.Label>App version</Cell.Label>
           <Cell.SubText>{this.props.appVersion}</Cell.SubText>
-          <Cell.Img height={16} width={16} source="icon-extLink" />
+          <Cell.Icon height={16} width={16} source="icon-extLink" />
         </Cell.CellButton>
         {footer}
       </View>
@@ -162,19 +162,19 @@ export default class Settings extends Component<Props> {
           onPress={this.props.onExternalLink.bind(this, 'faq')}
           testName="settings__external_link">
           <Cell.Label>FAQs</Cell.Label>
-          <Cell.Img height={16} width={16} source="icon-extLink" />
+          <Cell.Icon height={16} width={16} source="icon-extLink" />
         </Cell.CellButton>
 
         <Cell.CellButton
           onPress={this.props.onExternalLink.bind(this, 'guides')}
           testName="settings__external_link">
           <Cell.Label>Guides</Cell.Label>
-          <Cell.Img height={16} width={16} source="icon-extLink" />
+          <Cell.Icon height={16} width={16} source="icon-extLink" />
         </Cell.CellButton>
 
         <Cell.CellButton onPress={this.props.onViewSupport} testName="settings__view_support">
           <Cell.Label>Report a problem</Cell.Label>
-          <Cell.Img height={12} width={7} source="icon-chevron" />
+          <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
       </View>
     );


### PR DESCRIPTION
This is a small PR that changes the `Preferences` and the `AdvancedSettings` pages to use more of the components in the `Cell` module. The main objective is to have simpler code and abstract away the handling of styles and appearance of common elements. The downside of this PR is that the `Login` view had to switch from using a `Cell.Label` to use a normal `Text` view, because its appearance is customized.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, not user visible.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/478)
<!-- Reviewable:end -->
