### PR TITLE
Add CVE identifiers from audit to changes that fixes them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Line wrap the file at 100 chars.                                              Th
 - Redact IPv6 address that start or end with double colons in problem reports.
 - Improve tray icon response time by disabling the double click handling.
 
+### Security
+- Prevent Electron from executing/navigating to files being drag-and-dropped onto the app GUI. This
+  fixes [MUL-01-001](./audits/2018-09-24-assured-cure53.md#miscellaneous-issues)
+
 
 ## [2018.3] - 2018-09-17
 ### Changed
@@ -53,7 +57,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Lock the installation directory to `C:\Program Files\Mullvad VPN`. This prevents potential local
   privilege escalation by ensuring all binaries executed by the `SYSTEM` user, as part of the
-  Mullvad system service, are stored where unprivileged users can't modify them.
+  Mullvad system service, are stored where unprivileged users can't modify them. This fixes
+  [MUL-01-004](./audits/2018-09-24-assured-cure53.md#identified-vulnerabilities).
 
 
 ## [2018.3-beta1] - 2018-09-13


### PR DESCRIPTION
To make the audit more visible, and be more transparent in general. I here add the identifiers assigned to the issues found in the last audit to the changelog entries where they were being fixed.

We should usually not edit changelog entries for already released versions. But this just adds the link where in the audit this is being talked about.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/481)
<!-- Reviewable:end -->
