### PR TITLE
Download relay list every 2 hours instead of 24

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -27,7 +27,7 @@ const DATE_TIME_FORMAT_STR: &str = "[%Y-%m-%d %H:%M:%S%.3f]";
 const RELAYS_FILENAME: &str = "relays.json";
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 const UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60);
-const MAX_CACHE_AGE: Duration = Duration::from_secs(60 * 60 * 24);
+const MAX_CACHE_AGE: Duration = Duration::from_secs(60 * 60 * 2);
 
 error_chain! {
     errors {


### PR DESCRIPTION
Downloading the relay list once per day makes it become a bit too outdated at times. We want better long term solutions that can make it almost instant. But until then just lowering the poll interval should help a lot and not cost too much traffic.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/482)
<!-- Reviewable:end -->
