### PR TITLE
Auto-hide scrollbars on macOS only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Auto-hide scrollbars on macOS only, leaving them visible on other platforms.
 
 
 ## [2018.4-beta1] - 2018-10-01

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -43,7 +43,7 @@ export class AdvancedSettings extends Component<Props> {
               <SettingsHeader>
                 <HeaderTitle>Advanced</HeaderTitle>
               </SettingsHeader>
-              <CustomScrollbars style={styles.advanced_settings__scrollview} autoHide={true}>
+              <CustomScrollbars style={styles.advanced_settings__scrollview}>
                 <Cell.Container>
                   <Cell.Label>Enable IPv6</Cell.Label>
                   <Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />

--- a/gui/packages/desktop/src/renderer/components/SelectLocation.js
+++ b/gui/packages/desktop/src/renderer/components/SelectLocation.js
@@ -91,7 +91,7 @@ export default class SelectLocation extends Component<Props, State> {
                 <HeaderTitle>Select location</HeaderTitle>
               </SettingsHeader>
 
-              <CustomScrollbars autoHide={true} ref={this._scrollViewRef}>
+              <CustomScrollbars ref={this._scrollViewRef}>
                 <View style={styles.content}>
                   <SettingsHeader style={styles.subtitle_header}>
                     <HeaderSubTitle>

--- a/gui/packages/desktop/src/renderer/components/Settings.js
+++ b/gui/packages/desktop/src/renderer/components/Settings.js
@@ -45,7 +45,7 @@ export default class Settings extends Component<Props> {
                 <HeaderTitle>Settings</HeaderTitle>
               </SettingsHeader>
 
-              <CustomScrollbars style={styles.settings__scrollview} autoHide={true}>
+              <CustomScrollbars style={styles.settings__scrollview}>
                 <View style={styles.settings__content}>
                   <View>
                     {this._renderTopButtons()}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR makes scrollbar remain visible on all platforms except macOS where it auto hides since which is a default behaviour when using touch pad, but not for mouse. Since we can't really detect if mouse is plugged in easy, then we always auto hide it. :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/483)
<!-- Reviewable:end -->
