### PR TITLE
Autogenerate more state machine code

### DIFF
--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -151,8 +151,7 @@ impl TunnelStateMachine {
             NetworkSecurity::new(cache_dir).chain_err(|| ErrorKind::NetworkSecurityError)?;
         let mut shared_values = SharedTunnelStateValues { security };
 
-        let initial_state = TunnelStateWrapper::new(&mut shared_values, ());
-
+        let (initial_state, _) = DisconnectedState::enter(&mut shared_values, ());
         Ok(TunnelStateMachine {
             current_state: Some(initial_state),
             commands,
@@ -309,15 +308,6 @@ state_wrapper! {
 }
 
 impl TunnelStateWrapper {
-    fn new(
-        shared_values: &mut SharedTunnelStateValues,
-        bootstrap: <DisconnectedState as TunnelState>::Bootstrap,
-    ) -> TunnelStateWrapper {
-        let (new_state, _transition) = DisconnectedState::enter(shared_values, bootstrap);
-
-        new_state
-    }
-
     fn handle_event(
         self,
         commands: &mut mpsc::UnboundedReceiver<TunnelCommand>,


### PR DESCRIPTION
When starting to play with the reconnect counter etc I found these potential improvements. Tell me what you think of it.

First commit is just added a bit of logging and reduce number of wildcard enum imports where I personally believe they don't add any clarity.

The rest of the commits tries to remove some boilerplate and room for errors on the state machine code. More specifically it generates the `TunnelStateWrapper` automatically.

I removed the `Debug` implementation, since no one was using it anyway (compiled fine without it) so obviously it wasn't used. If we need it we can easily add so the macro generates it for us.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/486)
<!-- Reviewable:end -->
