### PR TITLE
Allow configuration of OpenVPN mssfix option in GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Allow configuration of OpenVPN mssfix option with GUI (under Advanced Settings).
+
 #### Windows
 - Monitor and enforce IPv6 DNS settings on network interfaces (previously IPv4-only).
 

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -348,6 +348,12 @@ export default class AppRenderer {
     actions.settings.updateEnableIpv6(enableIpv6);
   }
 
+  async setOpenVpnMssfix(mssfix: ?number) {
+    const actions = this._reduxActions;
+    actions.settings.updateOpenVpnMssfix(mssfix);
+    await this._daemonRpc.setOpenVpnMssfix(mssfix);
+  }
+
   async setAutoConnect(autoConnect: boolean) {
     const actions = this._reduxActions;
     await this._daemonRpc.setAutoConnect(autoConnect);

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -538,6 +538,7 @@ export default class AppRenderer {
     reduxSettings.updateAllowLan(newSettings.allowLan);
     reduxSettings.updateAutoConnect(newSettings.autoConnect);
     reduxSettings.updateEnableIpv6(newSettings.tunnelOptions.enableIpv6);
+    reduxSettings.updateOpenVpnMssfix(newSettings.tunnelOptions.openvpn.mssfix);
 
     this._setRelaySettings(newSettings.relaySettings);
   }

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -19,6 +19,7 @@ import Img from './Img';
 type Props = {
   enableIpv6: boolean,
   protocol: string,
+  mssfix: ?number,
   port: string | number,
   setEnableIpv6: (boolean) => void,
   onUpdate: (protocol: string, port: string | number) => void,
@@ -76,7 +77,12 @@ export class AdvancedSettings extends Component<Props> {
 
                 <Cell.Container>
                   <Cell.Label>Mssfix</Cell.Label>
-                  <Cell.Input keyboardType={'numeric'} maxLength={5} placeholder={'None'} />
+                  <Cell.Input
+                    keyboardType={'numeric'}
+                    maxLength={5}
+                    placeholder={'None'}
+                    value={this.props.mssfix}
+                  />
                 </Cell.Container>
                 <Cell.Footer>Change OpenVPN MSS value</Cell.Footer>
               </View>

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -168,10 +168,12 @@ export class AdvancedSettings extends Component<Props, State> {
   };
 
   _onMssfixBlur = () => {
-    this.props.setOpenVpnMssfix(this.state.editedMssfix);
-    this.setState((state, _props) => {
-      return { focusOnMssfix: false, persistedMssfix: state.editedMssfix };
-    });
+    this.setState({ focusOnMssfix: false });
+
+    if (this._mssfixIsValid()) {
+      this.props.setOpenVpnMssfix(this.state.editedMssfix);
+      this.setState((state, _props) => ({ persistedMssfix: state.editedMssfix }));
+    }
   };
 
   _mssfixIsValid(): boolean {

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -16,6 +16,9 @@ import Switch from './Switch';
 import styles from './AdvancedSettingsStyles';
 import Img from './Img';
 
+const MIN_MSSFIX_VALUE = 1000;
+const MAX_MSSFIX_VALUE = 1500;
+
 type Props = {
   enableIpv6: boolean,
   protocol: string,
@@ -64,6 +67,13 @@ export class AdvancedSettings extends Component<Props, State> {
       portSelector = this._createPortSelector();
     }
 
+    let mssfixStyle;
+    if (this._mssfixIsValid()) {
+      mssfixStyle = styles.advanced_settings__mssfix_valid_value;
+    } else {
+      mssfixStyle = styles.advanced_settings__mssfix_invalid_value;
+    }
+
     return (
       <Layout>
         <Container>
@@ -109,6 +119,7 @@ export class AdvancedSettings extends Component<Props, State> {
                     maxLength={5}
                     placeholder={'None'}
                     value={this.state.editedMssfix}
+                    style={mssfixStyle}
                     onChangeText={this._onMssfixChange}
                     onFocus={this._onMssfixFocus}
                     onBlur={this._onMssfixBlur}
@@ -162,6 +173,12 @@ export class AdvancedSettings extends Component<Props, State> {
       return { focusOnMssfix: false, persistedMssfix: state.editedMssfix };
     });
   };
+
+  _mssfixIsValid(): boolean {
+    const mssfix = this.state.editedMssfix;
+
+    return mssfix >= MIN_MSSFIX_VALUE && mssfix <= MAX_MSSFIX_VALUE;
+  }
 }
 
 type SelectorProps<T> = {

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -22,11 +22,24 @@ type Props = {
   mssfix: ?number,
   port: string | number,
   setEnableIpv6: (boolean) => void,
+  setOpenVpnMssfix: (?number) => void,
   onUpdate: (protocol: string, port: string | number) => void,
   onClose: () => void,
 };
 
-export class AdvancedSettings extends Component<Props> {
+type State = {
+  mssfix: ?number,
+};
+
+export class AdvancedSettings extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      mssfix: props.mssfix,
+    };
+  }
+
   render() {
     let portSelector = null;
     let protocol = this.props.protocol.toUpperCase();
@@ -81,7 +94,9 @@ export class AdvancedSettings extends Component<Props> {
                     keyboardType={'numeric'}
                     maxLength={5}
                     placeholder={'None'}
-                    value={this.props.mssfix}
+                    value={this.state.mssfix}
+                    onChangeText={this._onMssfixChange}
+                    onBlur={this._persistMssfix}
                   />
                 </Cell.Container>
                 <Cell.Footer>Change OpenVPN MSS value</Cell.Footer>
@@ -111,6 +126,20 @@ export class AdvancedSettings extends Component<Props> {
       />
     );
   }
+
+  _onMssfixChange = (mssfixString: string) => {
+    const mssfix = mssfixString.replace(/[^0-9]/g, '');
+
+    if (mssfix === '') {
+      this.setState({ mssfix: null });
+    } else {
+      this.setState({ mssfix: parseInt(mssfix, 10) });
+    }
+  };
+
+  _persistMssfix = () => {
+    this.props.setOpenVpnMssfix(this.state.mssfix);
+  };
 }
 
 type SelectorProps<T> = {

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -28,7 +28,9 @@ type Props = {
 };
 
 type State = {
-  mssfix: ?number,
+  persistedMssfix: ?number,
+  editedMssfix: ?number,
+  focusOnMssfix: boolean,
 };
 
 export class AdvancedSettings extends Component<Props, State> {
@@ -36,8 +38,20 @@ export class AdvancedSettings extends Component<Props, State> {
     super(props);
 
     this.state = {
-      mssfix: props.mssfix,
+      persistedMssfix: props.mssfix,
+      editedMssfix: props.mssfix,
+      focusOnMssfix: false,
     };
+  }
+
+  componentDidUpdate(_oldProps: Props, _oldState: State) {
+    if (this.props.mssfix !== this.state.persistedMssfix) {
+      this.setState((state, props) => ({
+        ...state,
+        persistedMssfix: props.mssfix,
+        editedMssfix: state.focusOnMssfix ? state.editedMssfix : props.mssfix,
+      }));
+    }
   }
 
   render() {
@@ -94,9 +108,10 @@ export class AdvancedSettings extends Component<Props, State> {
                     keyboardType={'numeric'}
                     maxLength={5}
                     placeholder={'None'}
-                    value={this.state.mssfix}
+                    value={this.state.editedMssfix}
                     onChangeText={this._onMssfixChange}
-                    onBlur={this._persistMssfix}
+                    onFocus={this._onMssfixFocus}
+                    onBlur={this._onMssfixBlur}
                   />
                 </Cell.Container>
                 <Cell.Footer>Change OpenVPN MSS value</Cell.Footer>
@@ -131,14 +146,21 @@ export class AdvancedSettings extends Component<Props, State> {
     const mssfix = mssfixString.replace(/[^0-9]/g, '');
 
     if (mssfix === '') {
-      this.setState({ mssfix: null });
+      this.setState({ editedMssfix: null });
     } else {
-      this.setState({ mssfix: parseInt(mssfix, 10) });
+      this.setState({ editedMssfix: parseInt(mssfix, 10) });
     }
   };
 
-  _persistMssfix = () => {
-    this.props.setOpenVpnMssfix(this.state.mssfix);
+  _onMssfixFocus = () => {
+    this.setState({ focusOnMssfix: true });
+  };
+
+  _onMssfixBlur = () => {
+    this.props.setOpenVpnMssfix(this.state.editedMssfix);
+    this.setState((state, _props) => {
+      return { focusOnMssfix: false, persistedMssfix: state.editedMssfix };
+    });
   };
 }
 

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -73,6 +73,12 @@ export class AdvancedSettings extends Component<Props> {
                     {portSelector}
                   </View>
                 </NavigationScrollbars>
+
+                <Cell.Container>
+                  <Cell.Label>Mssfix</Cell.Label>
+                  <Cell.Input keyboardType={'numeric'} maxLength={5} placeholder={'None'} />
+                </Cell.Container>
+                <Cell.Footer>Change OpenVPN MSS value</Cell.Footer>
               </View>
             </NavigationContainer>
           </View>

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettingsStyles.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettingsStyles.js
@@ -85,4 +85,10 @@ export default {
     color: colors.white,
     flex: 0,
   }),
+  advanced_settings__mssfix_valid_value: Styles.createTextStyle({
+    color: colors.blue,
+  }),
+  advanced_settings__mssfix_invalid_value: Styles.createTextStyle({
+    color: colors.red,
+  }),
 };

--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { Button, Text, Component, Styles, Types, View } from 'reactxp';
+import { Button, Component, Styles, Text, TextInput, Types, View } from 'reactxp';
 import PlainImg from './Img';
 import { colors } from '../../config';
 
@@ -58,6 +58,29 @@ const styles = {
       lineHeight: 26,
       letterSpacing: -0.2,
       color: colors.white,
+    }),
+  },
+
+  input: {
+    view: Styles.createViewStyle({
+      flexGrow: 1,
+      paddingLeft: 12,
+      paddingRight: 12,
+      paddingTop: 8,
+      paddingBottom: 8,
+      marginRight: 3,
+      borderWidth: 2,
+      borderRadius: 8,
+      borderColor: 'transparent',
+    }),
+    text: Styles.createTextStyle({
+      color: colors.blue,
+      backgroundColor: 'rgba(255, 255, 255, 0.5)',
+      fontFamily: 'DINPro',
+      fontSize: 20,
+      fontWeight: '900',
+      lineHeight: 26,
+      textAlign: 'center',
     }),
   },
 
@@ -146,6 +169,19 @@ export function Label({
         </View>
       )}
     </CellHoverContext.Consumer>
+  );
+}
+
+export function Input({ style, ...otherProps }: Types.TextInputProps) {
+  return (
+    <TextInput
+      maxLength={10}
+      placeholderTextColor={colors.blue40}
+      autoCorrect={false}
+      autoFocus={false}
+      style={[styles.input.text, styles.input.view, style]}
+      {...otherProps}
+    />
   );
 }
 

--- a/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
+++ b/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
@@ -72,6 +72,14 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
         log.error('Failed to update enable IPv6', e.message);
       }
     },
+
+    setOpenVpnMssfix: async (mssfix) => {
+      try {
+        await props.app.setOpenVpnMssfix(mssfix);
+      } catch (e) {
+        log.error('Failed to update mssfix value', e.message);
+      }
+    },
   };
 };
 

--- a/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
+++ b/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
@@ -14,7 +14,11 @@ import type { SharedRouteProps } from '../routes';
 const mapStateToProps = (state: ReduxState) => {
   const protocolAndPort = mapRelaySettingsToProtocolAndPort(state.settings.relaySettings);
 
-  return { enableIpv6: state.settings.enableIpv6, ...protocolAndPort };
+  return {
+    enableIpv6: state.settings.enableIpv6,
+    mssfix: state.settings.openVpn.mssfix,
+    ...protocolAndPort,
+  };
 };
 
 const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) => {

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -336,6 +336,7 @@ export interface DaemonRpcProtocol {
   updateRelaySettings(RelaySettingsUpdate): Promise<void>;
   setAllowLan(boolean): Promise<void>;
   setEnableIpv6(boolean): Promise<void>;
+  setOpenVpnMssfix(?number): Promise<void>;
   setAutoConnect(boolean): Promise<void>;
   connectTunnel(): Promise<void>;
   disconnectTunnel(): Promise<void>;
@@ -436,6 +437,10 @@ export class DaemonRpc implements DaemonRpcProtocol {
 
   async setEnableIpv6(enableIpv6: boolean): Promise<void> {
     await this._transport.send('set_enable_ipv6', [enableIpv6]);
+  }
+
+  async setOpenVpnMssfix(mssfix: ?number): Promise<void> {
+    await this._transport.send('set_openvpn_mssfix', [mssfix]);
   }
 
   async setAutoConnect(autoConnect: boolean): Promise<void> {

--- a/gui/packages/desktop/src/renderer/redux/settings/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/actions.js
@@ -27,12 +27,18 @@ export type UpdateEnableIpv6Action = {
   enableIpv6: boolean,
 };
 
+export type UpdateOpenVpnMssfixAction = {
+  type: 'UPDATE_OPENVPN_MSSFIX',
+  mssfix: ?number,
+};
+
 export type SettingsAction =
   | UpdateRelayAction
   | UpdateRelayLocationsAction
   | UpdateAutoConnectAction
   | UpdateAllowLanAction
-  | UpdateEnableIpv6Action;
+  | UpdateEnableIpv6Action
+  | UpdateOpenVpnMssfixAction;
 
 function updateRelay(relay: RelaySettingsRedux): UpdateRelayAction {
   return {
@@ -71,10 +77,18 @@ function updateEnableIpv6(enableIpv6: boolean): UpdateEnableIpv6Action {
   };
 }
 
+function updateOpenVpnMssfix(mssfix: ?number): UpdateOpenVpnMssfixAction {
+  return {
+    type: 'UPDATE_OPENVPN_MSSFIX',
+    mssfix,
+  };
+}
+
 export default {
   updateRelay,
   updateRelayLocations,
   updateAutoConnect,
   updateAllowLan,
   updateEnableIpv6,
+  updateOpenVpnMssfix,
 };

--- a/gui/packages/desktop/src/renderer/redux/settings/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/reducers.js
@@ -49,6 +49,9 @@ export type SettingsReduxState = {
   autoConnect: boolean,
   allowLan: boolean,
   enableIpv6: boolean,
+  openVpn: {
+    mssfix: ?number,
+  },
 };
 
 const initialState: SettingsReduxState = {
@@ -63,6 +66,9 @@ const initialState: SettingsReduxState = {
   autoConnect: false,
   allowLan: false,
   enableIpv6: true,
+  openVpn: {
+    mssfix: null,
+  },
 };
 
 export default function(
@@ -98,6 +104,15 @@ export default function(
       return {
         ...state,
         enableIpv6: action.enableIpv6,
+      };
+
+    case 'UPDATE_OPENVPN_MSSFIX':
+      return {
+        ...state,
+        openVpn: {
+          ...state.openVpn,
+          mssfix: action.mssfix,
+        },
       };
 
     default:


### PR DESCRIPTION
The OpenVPN mssfix option can be used sometimes in order to solve some issues, with the possible cost of a lower performance. The option could previously only be set by the CLI, but this PR adds the ability to see and configure it using the GUI.

In the GUI, the value is limited to be in the range of 1000-1500. The input field itself is limited to 5 digits (one extra to help typing). The value is updated in the daemon when the input field loses focus. If a value outside the range is typed, it is not stored, and is discarded when the user leaves the view. To give a hint on the valid range, the value is colored red when outside the valid range.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/488)
<!-- Reviewable:end -->
