### PR TITLE
Add resolved nm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
             key_url: "https://pgp.key-server.io/download/0xE03043828C3FF4BB"
          packages:
           - binutils
+          - libdbus-1-dev
       cache: cargo
       before_script: *rust_before_script
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Auto-hide scrollbars on macOS only, leaving them visible on other platforms.
 
+#### Linux
+- Add support for DNS configuration using systemd-resolved and resolvconf.
+
 ### Fixed
 #### Windows
 - Use different method for identifying network interfaces during installation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,18 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Monitor and enforce IPv6 DNS settings on network interfaces (previously IPv4-only).
 
+#### Linux
+- Add support for DNS configuration using systemd-resolved and NetworkManager.
+
+
 ### Changed
 - Auto-hide scrollbars on macOS only, leaving them visible on other platforms.
-
-#### Linux
-- Add support for DNS configuration using systemd-resolved and resolvconf.
 
 ### Fixed
 #### Windows
 - Use different method for identifying network interfaces during installation.
 - Properly restore DNS settings on network interfaces. Fixes issue #352.
+
 
 ## [2018.4-beta1] - 2018-10-01
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +707,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1625,6 +1642,7 @@ version = "0.1.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbus 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "duct 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2187,6 +2205,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2af0e75710d6181e234c8ecc79f14a97907850a541b13b0be1dd10992f2e4620"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e"
+"checksum dbus 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e34c238dfb3f5881d46ad301403cd8f8ecf946e2a4e89bdd1166728b68b5008"
 "checksum derive_builder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c998e6ab02a828dd9735c18f154e14100e674ed08cb4e1938f0e4177543f439"
 "checksum derive_builder_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "735e24ee9e5fa8e16b86da5007856e97d592e11867e45d76e0c0d0a164a0b757"
 "checksum dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37a76dd8b997af7107d0bb69d43903cf37153a18266f8b3fdb9911f28efb5444"
@@ -2238,6 +2257,7 @@ dependencies = [
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8720f9274907052cb50313f91201597868da9d625f8dd125f2aca5bddb7e83a1"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum linked_hash_set 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7c91c4c7bbeb4f2f7c4e5be11e6a05bd6830bc37249c47ce1ad86ad453ff9c"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For Debian/Ubuntu based distributions, you need to install the following. For ot
 you need the equivalent packages:
 ```bash
 # For building the daemon
-sudo apt install gcc
+sudo apt install gcc libdbus-1-dev
 # For running the frontend app
 sudo apt install libappindicator1 gconf2
 ```

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ sections.
   choose a specific method:
     * `"static-file"`: change the `/etc/resolv.conf` file directly
     * `"resolvconf"`: use the `resolvconf` program
+    * `"systemd"`: use systemd's `resolved` service through DBus
 
 
 ## Building and running the Electron GUI app

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ sections.
     * `"static-file"`: change the `/etc/resolv.conf` file directly
     * `"resolvconf"`: use the `resolvconf` program
     * `"systemd"`: use systemd's `resolved` service through DBus
+    * `"network-manager"`: use `NetworkManager` service through DBus
 
 
 ## Building and running the Electron GUI app

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -137,3 +137,4 @@ rpm:
       - libappindicator
       - libnotify
       - libnsl
+      - dbus-libs

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -29,6 +29,7 @@ ipnetwork = "0.13"
 lazy_static = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+dbus = "0.6"
 failure = "0.1"
 notify = "4.0"
 resolv-conf = "0.6.1"

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -1,6 +1,7 @@
 mod resolvconf;
 mod static_resolv_conf;
 mod systemd_resolved;
+mod network_manager;
 
 use std::env;
 use std::net::IpAddr;

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -43,6 +43,7 @@ impl DnsSettings {
     fn with_detected_dns_manager() -> Result<Self> {
         SystemdResolved::new()
             .map(DnsSettings::SystemdResolved)
+            .or_else(|_| Resolvconf::new().map(DnsSettings::Resolvconf))
             .or_else(|_| StaticResolvConf::new().map(DnsSettings::StaticResolvConf))
             .chain_err(|| ErrorKind::NoDnsSettingsManager)
     }

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -1,11 +1,12 @@
+mod network_manager;
 mod resolvconf;
 mod static_resolv_conf;
 mod systemd_resolved;
-mod network_manager;
 
 use std::env;
 use std::net::IpAddr;
 
+use self::network_manager::NetworkManager;
 use self::resolvconf::Resolvconf;
 use self::static_resolv_conf::StaticResolvConf;
 use self::systemd_resolved::SystemdResolved;
@@ -21,6 +22,7 @@ error_chain! {
         Resolvconf(resolvconf::Error, resolvconf::ErrorKind);
         StaticResolvConf(static_resolv_conf::Error, static_resolv_conf::ErrorKind);
         SystemdResolved(systemd_resolved::Error, systemd_resolved::ErrorKind);
+        NetworkManager(network_manager::Error, network_manager::ErrorKind);
     }
 }
 
@@ -28,6 +30,7 @@ pub enum DnsSettings {
     Resolvconf(Resolvconf),
     StaticResolvConf(StaticResolvConf),
     SystemdResolved(SystemdResolved),
+    NetworkManager(NetworkManager),
 }
 
 impl DnsSettings {
@@ -38,13 +41,15 @@ impl DnsSettings {
             Some("static-file") => DnsSettings::StaticResolvConf(StaticResolvConf::new()?),
             Some("resolvconf") => DnsSettings::Resolvconf(Resolvconf::new()?),
             Some("systemd") => DnsSettings::SystemdResolved(SystemdResolved::new()?),
+            Some("network-manager") => DnsSettings::NetworkManager(NetworkManager::new()?),
             Some(_) | None => Self::with_detected_dns_manager()?,
         })
     }
 
     fn with_detected_dns_manager() -> Result<Self> {
-        SystemdResolved::new()
-            .map(DnsSettings::SystemdResolved)
+        NetworkManager::new()
+            .map(DnsSettings::NetworkManager)
+            .or_else(|_| SystemdResolved::new().map(DnsSettings::SystemdResolved))
             .or_else(|_| Resolvconf::new().map(DnsSettings::Resolvconf))
             .or_else(|_| StaticResolvConf::new().map(DnsSettings::StaticResolvConf))
             .chain_err(|| ErrorKind::NoDnsSettingsManager)
@@ -57,8 +62,9 @@ impl DnsSettings {
             Resolvconf(ref mut resolvconf) => resolvconf.set_dns(interface, servers)?,
             StaticResolvConf(ref mut static_resolv_conf) => static_resolv_conf.set_dns(servers)?,
             SystemdResolved(ref mut systemd_resolved) => {
-                systemd_resolved.set_dns(interface, servers)?
+                systemd_resolved.set_dns(interface, &servers)?
             }
+            NetworkManager(ref mut network_manager) => network_manager.set_dns(&servers)?,
         }
 
         Ok(())
@@ -71,6 +77,7 @@ impl DnsSettings {
             Resolvconf(ref mut resolvconf) => resolvconf.reset()?,
             StaticResolvConf(ref mut static_resolv_conf) => static_resolv_conf.reset()?,
             SystemdResolved(ref mut systemd_resolved) => systemd_resolved.reset()?,
+            NetworkManager(ref mut network_manager) => network_manager.reset()?,
         }
 
         Ok(())

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -36,6 +36,7 @@ impl DnsSettings {
         Ok(match dns_module.as_ref().and_then(|value| value.to_str()) {
             Some("static-file") => DnsSettings::StaticResolvConf(StaticResolvConf::new()?),
             Some("resolvconf") => DnsSettings::Resolvconf(Resolvconf::new()?),
+            Some("systemd") => DnsSettings::SystemdResolved(SystemdResolved::new()?),
             Some(_) | None => Self::with_detected_dns_manager()?,
         })
     }

--- a/talpid-core/src/security/linux/dns/network_manager.rs
+++ b/talpid-core/src/security/linux/dns/network_manager.rs
@@ -1,0 +1,110 @@
+extern crate dbus;
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use self::dbus::arg::{RefArg, Variant};
+use self::dbus::stdintf::*;
+use self::dbus::BusType;
+
+error_chain! {
+    errors {
+        NoNetworkManager {
+            description("NetworkManager not detected")
+        }
+    }
+
+    foreign_links {
+        DbusError(dbus::Error);
+    }
+}
+
+const NM_BUS: &str = "org.freedesktop.NetworkManager";
+const NM_TOP_OBJECT: &str = "org.freedesktop.NetworkManager";
+const NM_OBJECT_PATH: &str = "/org/freedesktop/NetworkManager";
+const RPC_TIMEOUT_MS: i32 = 1000;
+const GLOBAL_DNS_CONF_KEY: &str = "GlobalDnsConfiguration";
+
+pub struct NetworkManager {
+    dbus_connection: dbus::Connection,
+}
+
+
+impl NetworkManager {
+    pub fn new() -> Result<Self> {
+        let dbus_connection = dbus::Connection::get_private(BusType::System)?;
+        let manager = NetworkManager { dbus_connection };
+        manager.ensure_network_manager_exists()?;
+        Ok(manager)
+    }
+
+    fn ensure_network_manager_exists(&self) -> Result<()> {
+        let _: Box<RefArg> = self
+            .as_manager()
+            .get(&NM_TOP_OBJECT, GLOBAL_DNS_CONF_KEY)
+            .chain_err(|| ErrorKind::NoNetworkManager)?;
+        Ok(())
+    }
+
+    fn as_manager<'a>(&'a self) -> dbus::ConnPath<'a, &'a dbus::Connection> {
+        self.dbus_connection
+            .with_path(NM_BUS, NM_OBJECT_PATH, RPC_TIMEOUT_MS)
+    }
+
+    pub fn set_dns(&mut self, servers: &[IpAddr]) -> Result<()> {
+        self.set_global_dns(create_global_settings(servers))
+    }
+
+    fn set_global_dns(&mut self, config: GlobalDnsConfig) -> Result<()> {
+        self.as_manager()
+            .set(NM_TOP_OBJECT, GLOBAL_DNS_CONF_KEY, config)
+            .map_err(|e| e.into())
+    }
+
+    pub fn reset(&mut self) -> Result<()> {
+        self.set_global_dns(create_empty_global_settings())
+    }
+}
+
+type GlobalDnsConfig = HashMap<&'static str, Variant<Box<RefArg>>>;
+
+// The NetworkManager GlobalDnsConfiguration schema looks something like this
+// {
+//  "searches": ["example.com", "search-domain.com"],
+//  "options": "this field is currently unused",
+//  "domains": {
+//   "*": {
+//     "servers": [ "1.1.1.1" ]
+//   }
+//   "example.com": {
+//     "servers": [ "8.8.8.8", "8.8.4.4" ]
+//   }
+//  }
+// }
+fn create_global_settings(server_list: &[IpAddr]) -> GlobalDnsConfig {
+    let mut global_settings = HashMap::new();
+    let mut domain_settings = HashMap::new();
+    let mut specific_domain_config = HashMap::new();
+
+    let dns_server_list = as_variant(
+        server_list
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+    );
+    specific_domain_config.insert("servers".to_owned(), dns_server_list);
+    domain_settings.insert("*".to_owned(), as_variant(specific_domain_config));
+    global_settings.insert("domains", as_variant(domain_settings));
+    global_settings.insert("searches", as_variant(vec![] as Vec<String>));
+    global_settings.insert("options", as_variant(vec![] as Vec<String>));
+
+    global_settings
+}
+
+fn create_empty_global_settings() -> GlobalDnsConfig {
+    HashMap::new()
+}
+
+fn as_variant<T: RefArg + 'static>(t: T) -> Variant<Box<RefArg>> {
+    Variant(Box::new(t) as Box<RefArg>)
+}

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -1,0 +1,234 @@
+extern crate dbus;
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use error_chain::ChainedError;
+use libc::{AF_INET, AF_INET6};
+
+use self::dbus::arg::RefArg;
+use self::dbus::stdintf::*;
+use self::dbus::{BusType, Interface, Member, MessageItem, MessageItemArray, Signature};
+
+use super::super::iface_index;
+
+error_chain! {
+    errors {
+        NoSystemdResolved {
+            description("Systemd resolved not detected")
+        }
+        InvalidInterfaceName {
+            description("Invalid network interface name")
+        }
+        DbusRpcError {
+            description("Failed to perform RPC call on DBus")
+        }
+        GetLinkError {
+            description("Failed to find link interface in resolved manager")
+        }
+        SetDnsError {
+            description("Failed to configure DNS servers")
+        }
+        RevertDnsError {
+            description("Failed to revert DNS configuration")
+        }
+        DBusError {
+            description("Failed to initialize a connection to dbus")
+        }
+    }
+
+}
+
+const RESOLVED_BUS: &str = "org.freedesktop.resolve1";
+const RPC_TIMEOUT_MS: i32 = 1000;
+
+lazy_static! {
+    static ref LINK_INTERFACE: Interface<'static> =
+        Interface::from_slice("org.freedesktop.resolve1.Link".as_bytes()).unwrap();
+    static ref MANAGER_INTERFACE: Interface<'static> =
+        Interface::from_slice("org.freedesktop.resolve1.Manager".as_bytes()).unwrap();
+    static ref GET_LINK_METHOD: Member<'static> = Member::from_slice("GetLink".as_bytes()).unwrap();
+    static ref SET_DNS_METHOD: Member<'static> = Member::from_slice("SetDNS".as_bytes()).unwrap();
+    static ref REVERT_METHOD: Member<'static> = Member::from_slice("Revert".as_bytes()).unwrap();
+}
+
+pub struct SystemdResolved {
+    dbus_connection: dbus::Connection,
+    interface_links: HashMap<String, dbus::Path<'static>>,
+}
+
+impl SystemdResolved {
+    pub fn new() -> Result<Self> {
+        let dbus_connection =
+            dbus::Connection::get_private(BusType::System).chain_err(|| ErrorKind::DBusError)?;
+        let systemd_resolved = SystemdResolved {
+            dbus_connection,
+            interface_links: HashMap::new(),
+        };
+
+        systemd_resolved.ensure_resolved_exists()?;
+
+        Ok(systemd_resolved)
+    }
+
+    fn ensure_resolved_exists(&self) -> Result<()> {
+        let _: Box<RefArg> = self
+            .as_manager_object()
+            .get(&MANAGER_INTERFACE, "DNS")
+            .chain_err(|| ErrorKind::NoSystemdResolved)?;
+
+        Ok(())
+    }
+
+    fn as_manager_object<'a>(&'a self) -> dbus::ConnPath<'a, &'a dbus::Connection> {
+        self.dbus_connection
+            .with_path(RESOLVED_BUS, "/org/freedesktop/resolve1", RPC_TIMEOUT_MS)
+    }
+
+    fn as_link_object<'a>(
+        &'a self,
+        link_object_path: dbus::Path<'a>,
+    ) -> dbus::ConnPath<'a, &'a dbus::Connection> {
+        self.dbus_connection
+            .with_path(RESOLVED_BUS, link_object_path, RPC_TIMEOUT_MS)
+    }
+
+    pub fn set_dns(&mut self, interface_name: &str, servers: &[IpAddr]) -> Result<()> {
+        let new_entry = if let Some(link_object_path) = self.interface_links.get(interface_name) {
+            self.set_link_dns(&link_object_path, servers)?;
+
+            None
+        } else {
+            let link_object_path = self.fetch_link(interface_name)?;
+
+            self.set_link_dns(&link_object_path, servers)?;
+
+            Some((interface_name.to_owned(), link_object_path))
+        };
+
+        if let Some((interface_name, link_object_path)) = new_entry {
+            self.interface_links
+                .insert(interface_name, link_object_path);
+        }
+
+        Ok(())
+    }
+
+    fn fetch_link(&self, interface_name: &str) -> Result<dbus::Path<'static>> {
+        let interface_index =
+            iface_index(interface_name).chain_err(|| ErrorKind::InvalidInterfaceName)?;
+
+        let mut reply = self
+            .as_manager_object()
+            .method_call_with_args(&MANAGER_INTERFACE, &GET_LINK_METHOD, |message| {
+                message.append_items(&[MessageItem::Int32(interface_index as i32)]);
+            })
+            .chain_err(|| ErrorKind::DbusRpcError)?;
+
+        let result = reply.as_result().chain_err(|| ErrorKind::GetLinkError)?;
+
+        result.read1().chain_err(|| ErrorKind::GetLinkError)
+    }
+
+    fn set_link_dns<'a, 'b: 'a>(
+        &'a self,
+        link_object_path: &'b dbus::Path<'static>,
+        servers: &[IpAddr],
+    ) -> Result<()> {
+
+        let server_addresses = build_addresses_argument(servers);
+
+        let mut reply = self
+            .as_link_object(link_object_path.clone())
+            .method_call_with_args(&LINK_INTERFACE, &SET_DNS_METHOD, |message| {
+                message.append_items(&[server_addresses]);
+            })
+            .chain_err(|| ErrorKind::DbusRpcError)?;
+
+        reply
+            .as_result()
+            .map(|_| ())
+            .chain_err(|| ErrorKind::SetDnsError)
+    }
+
+    pub fn reset(&mut self) -> Result<()> {
+        let mut result = Ok(());
+        let interface_links: Vec<_> = self.interface_links.drain().collect();
+
+        for (interface_name, link_object_path) in interface_links {
+            if let Err(error) = self.revert_link(link_object_path, &interface_name) {
+                let chained_error = error.chain_err(|| {
+                    format!(
+                        "Failed to revert DNS settings of interface: {}",
+                        interface_name
+                    )
+                });
+                error!("{}", chained_error.display_chain());
+                result = Err(Error::from(ErrorKind::RevertDnsError));
+            }
+        }
+
+        result
+    }
+
+    fn revert_link(
+        &mut self,
+        link_object_path: dbus::Path<'static>,
+        interface_name: &str,
+    ) -> Result<()> {
+        let link = self.as_link_object(link_object_path);
+
+        match link.method_call_with_args(&LINK_INTERFACE, &REVERT_METHOD, |_| {}) {
+            Ok(mut reply) => reply
+                .as_result()
+                .map(|_| ())
+                .chain_err(|| ErrorKind::RevertDnsError),
+            Err(error) => {
+                if error.name() == Some("org.freedesktop.DBus.Error.UnknownObject") {
+                    info!(
+                        "Not reseting DNS of interface {} because it no longer exists",
+                        interface_name
+                    );
+                    Ok(())
+                } else {
+                    Err(error).chain_err(|| ErrorKind::DbusRpcError)
+                }
+            }
+        }
+    }
+}
+
+fn build_addresses_argument(addresses: &[IpAddr]) -> MessageItem {
+    let addresses = addresses
+        .iter()
+        .map(ip_address_to_message_item)
+        .collect();
+
+    MessageItem::Array(
+        MessageItemArray::new(addresses, Signature::make::<Vec<(i32, Vec<u8>)>>())
+            .expect("Invalid construction of DBus array of IP addresses argument"),
+    )
+}
+
+fn ip_address_to_message_item(address: &IpAddr) -> MessageItem {
+    let (protocol, octets) = match address {
+        IpAddr::V4(ipv4_address) => (AF_INET, bytes_to_message_item_array(&ipv4_address.octets())),
+        IpAddr::V6(ipv6_address) => (
+            AF_INET6,
+            bytes_to_message_item_array(&ipv6_address.octets()),
+        ),
+    };
+
+    MessageItem::Struct(vec![
+        MessageItem::Int32(protocol),
+        MessageItem::Array(octets),
+    ])
+}
+
+fn bytes_to_message_item_array(bytes: &[u8]) -> MessageItemArray {
+    MessageItemArray::new(
+        bytes.into_iter().cloned().map(MessageItem::Byte).collect(),
+        Signature::make::<Vec<u8>>(),
+    )
+    .expect("Invalid construction of DBus array of bytes argument")
+}

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -135,7 +135,6 @@ impl SystemdResolved {
         link_object_path: &'b dbus::Path<'static>,
         servers: &[IpAddr],
     ) -> Result<()> {
-
         let server_addresses = build_addresses_argument(servers);
 
         let mut reply = self
@@ -199,10 +198,7 @@ impl SystemdResolved {
 }
 
 fn build_addresses_argument(addresses: &[IpAddr]) -> MessageItem {
-    let addresses = addresses
-        .iter()
-        .map(ip_address_to_message_item)
-        .collect();
+    let addresses = addresses.iter().map(ip_address_to_message_item).collect();
 
     MessageItem::Array(
         MessageItemArray::new(addresses, Signature::make::<Vec<(i32, Vec<u8>)>>())


### PR DESCRIPTION
I've piggy-backed off of @jvff previous efforts a bit and added back `resolved` support and also added `NetworkManager` support for managing DNS on Linux. Hopefully, this will resolve certain issues we have with DNS - this does fix issues with DNS settings being cleared if the networks were changed between suspension and wakeup.

I've tested the NetworkManager code on Ubuntu 14.04 since it dosen't use SystemD, and it successfully links `libdbus` during runtime. It uses a version of NetworkManager that is too old, but the daemon gracefully handles that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/489)
<!-- Reviewable:end -->
