### PR TITLE
Win installer ident tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Auto-hide scrollbars on macOS only, leaving them visible on other platforms.
 
+### Fixed
+#### Windows
+- Use different method for identifying network interfaces during installation.
 
 ## [2018.4-beta1] - 2018-10-01
 ### Added

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -44,7 +44,7 @@ public:
 private:
 
 	static std::set<VirtualNic> ParseVirtualNics(const std::wstring &textBlock);
-	static std::wstring GetNicAlias(const std::wstring &name);
+	static std::wstring GetNicAlias(const std::wstring &node, const std::wstring &name);
 
 	std::set<VirtualNic> m_baseline;
 	std::set<VirtualNic> m_currentState;


### PR DESCRIPTION
This fix addresses an issue some customers have had with identifying the TAP network interfaces during installation. WMI inconsistently normalizes the `name` property on network interfaces in its dataset, and destroy its uniqueness.

This change instead uses another property to identify network interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/490)
<!-- Reviewable:end -->
