### PR TITLE
Shorten text around version warning to fit on one line

### DIFF
--- a/gui/packages/desktop/src/renderer/components/Cell.js
+++ b/gui/packages/desktop/src/renderer/components/Cell.js
@@ -74,8 +74,9 @@ const styles = {
     fontFamily: 'Open Sans',
     fontSize: 13,
     fontWeight: '800',
-    flex: 0,
+    flex: -1,
     textAlign: 'right',
+    marginLeft: 8,
   }),
 };
 

--- a/gui/packages/desktop/src/renderer/components/Settings.js
+++ b/gui/packages/desktop/src/renderer/components/Settings.js
@@ -126,7 +126,7 @@ export default class Settings extends Component<Props> {
     if (!this.props.consistentVersion || !this.props.upToDateVersion) {
       const message = !this.props.consistentVersion
         ? 'Inconsistent internal version information, please restart the app.'
-        : 'This is not the latest version, download the update to remain safe.';
+        : 'Update available, download to remain safe.';
 
       icon = (
         <Img source="icon-alert" tintColor={colors.red} style={styles.settings__version_warning} />


### PR DESCRIPTION
In order to easier fit the quit button in view I make the text shown around the upgrade message shorter to fit on one line. This still communicates what the red exclamation point means. Given that we'll soon have more verbose explanations for outdated versions on the main screen this should be enough IMO.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/491)
<!-- Reviewable:end -->
