### PR TITLE
Move log_dir and resource_dir to SharedTunnelStateValues

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -2,7 +2,6 @@ use error_chain::ChainedError;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Stream};
 
-use talpid_types::net::TunnelEndpoint;
 use talpid_types::tunnel::BlockReason;
 
 use super::{
@@ -16,7 +15,6 @@ use tunnel::{CloseHandle, TunnelEvent, TunnelMetadata};
 pub struct ConnectedStateBootstrap {
     pub metadata: TunnelMetadata,
     pub tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
-    pub tunnel_endpoint: TunnelEndpoint,
     pub tunnel_parameters: TunnelParameters,
     pub tunnel_close_event: oneshot::Receiver<()>,
     pub close_handle: CloseHandle,
@@ -26,7 +24,6 @@ pub struct ConnectedStateBootstrap {
 pub struct ConnectedState {
     metadata: TunnelMetadata,
     tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
-    tunnel_endpoint: TunnelEndpoint,
     tunnel_parameters: TunnelParameters,
     tunnel_close_event: oneshot::Receiver<()>,
     close_handle: CloseHandle,
@@ -37,7 +34,6 @@ impl ConnectedState {
         ConnectedState {
             metadata: bootstrap.metadata,
             tunnel_events: bootstrap.tunnel_events,
-            tunnel_endpoint: bootstrap.tunnel_endpoint,
             tunnel_parameters: bootstrap.tunnel_parameters,
             tunnel_close_event: bootstrap.tunnel_close_event,
             close_handle: bootstrap.close_handle,
@@ -46,7 +42,7 @@ impl ConnectedState {
 
     fn set_security_policy(&self, shared_values: &mut SharedTunnelStateValues) -> Result<()> {
         let policy = SecurityPolicy::Connected {
-            relay_endpoint: self.tunnel_endpoint.to_endpoint(),
+            relay_endpoint: self.tunnel_parameters.endpoint.to_endpoint(),
             tunnel: self.metadata.clone(),
             allow_lan: self.tunnel_parameters.allow_lan,
         };

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -46,26 +46,12 @@ error_chain! {
 /// The tunnel has been started, but it is not established/functional.
 pub struct ConnectingState {
     tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
-    tunnel_endpoint: TunnelEndpoint,
     tunnel_parameters: TunnelParameters,
     tunnel_close_event: oneshot::Receiver<()>,
     close_handle: CloseHandle,
 }
 
 impl ConnectingState {
-    fn new(parameters: TunnelParameters) -> Result<Self> {
-        let tunnel_endpoint = parameters.endpoint;
-        let (tunnel_events, tunnel_close_event, close_handle) = Self::start_tunnel(&parameters)?;
-
-        Ok(ConnectingState {
-            tunnel_events,
-            tunnel_endpoint,
-            tunnel_parameters: parameters,
-            tunnel_close_event,
-            close_handle,
-        })
-    }
-
     fn set_security_policy(
         shared_values: &mut SharedTunnelStateValues,
         endpoint: TunnelEndpoint,
@@ -83,13 +69,16 @@ impl ConnectingState {
 
     fn start_tunnel(
         parameters: &TunnelParameters,
+        log_dir: &Option<PathBuf>,
+        resource_dir: &Path,
     ) -> Result<(
         mpsc::UnboundedReceiver<TunnelEvent>,
         oneshot::Receiver<()>,
         CloseHandle,
     )> {
         let (event_tx, event_rx) = mpsc::unbounded();
-        let monitor = Self::spawn_tunnel_monitor(&parameters, event_tx.wait())?;
+        let monitor =
+            Self::spawn_tunnel_monitor(&parameters, log_dir, resource_dir, event_tx.wait())?;
         let close_handle = monitor.close_handle();
         let tunnel_close_event = Self::spawn_tunnel_monitor_wait_thread(monitor);
 
@@ -98,6 +87,8 @@ impl ConnectingState {
 
     fn spawn_tunnel_monitor(
         parameters: &TunnelParameters,
+        log_dir: &Option<PathBuf>,
+        resource_dir: &Path,
         events: Wait<mpsc::UnboundedSender<TunnelEvent>>,
     ) -> Result<TunnelMonitor> {
         let event_tx = Mutex::new(events);
@@ -111,7 +102,7 @@ impl ConnectingState {
                 warn!("Tunnel state machine stopped before tunnel event was received");
             }
         };
-        let log_file = Self::prepare_tunnel_log_file(&parameters)?;
+        let log_file = Self::prepare_tunnel_log_file(&parameters, log_dir)?;
 
         Ok(TunnelMonitor::new(
             parameters.endpoint,
@@ -119,13 +110,16 @@ impl ConnectingState {
             TUNNEL_INTERFACE_ALIAS.to_owned().map(OsString::from),
             &parameters.username,
             log_file.as_ref().map(PathBuf::as_path),
-            &parameters.resource_dir,
+            resource_dir,
             on_tunnel_event,
         )?)
     }
 
-    fn prepare_tunnel_log_file(parameters: &TunnelParameters) -> Result<Option<PathBuf>> {
-        if let Some(ref log_dir) = parameters.log_dir {
+    fn prepare_tunnel_log_file(
+        parameters: &TunnelParameters,
+        log_dir: &Option<PathBuf>,
+    ) -> Result<Option<PathBuf>> {
+        if let Some(ref log_dir) = log_dir {
             let filename = match parameters.endpoint.tunnel {
                 TunnelEndpointData::OpenVpn(_) => OPENVPN_LOG_FILENAME,
                 TunnelEndpointData::Wireguard(_) => WIREGUARD_LOG_FILENAME,
@@ -170,7 +164,6 @@ impl ConnectingState {
         ConnectedStateBootstrap {
             metadata,
             tunnel_events: self.tunnel_events,
-            tunnel_endpoint: self.tunnel_endpoint,
             tunnel_parameters: self.tunnel_parameters,
             tunnel_close_event: self.tunnel_close_event,
             close_handle: self.close_handle,
@@ -187,7 +180,11 @@ impl ConnectingState {
         match try_handle_event!(self, commands.poll()) {
             Ok(TunnelCommand::AllowLan(allow_lan)) => {
                 self.tunnel_parameters.allow_lan = allow_lan;
-                match Self::set_security_policy(shared_values, self.tunnel_endpoint, allow_lan) {
+                match Self::set_security_policy(
+                    shared_values,
+                    self.tunnel_parameters.endpoint,
+                    allow_lan,
+                ) {
                     Ok(()) => SameState(self),
                     Err(error) => {
                         error!("{}", error.display_chain());
@@ -309,11 +306,23 @@ impl TunnelState for ConnectingState {
             return BlockedState::enter(shared_values, (BlockReason::StartTunnelError, allow_lan));
         }
 
-        match Self::new(parameters) {
-            Ok(connecting_state) => (
-                TunnelStateWrapper::from(connecting_state),
-                TunnelStateTransition::Connecting,
-            ),
+        match Self::start_tunnel(
+            &parameters,
+            &shared_values.log_dir,
+            &shared_values.resource_dir,
+        ) {
+            Ok((tunnel_events, tunnel_close_event, close_handle)) => {
+                let connecting_state = ConnectingState {
+                    tunnel_events,
+                    tunnel_parameters: parameters,
+                    tunnel_close_event,
+                    close_handle,
+                };
+                (
+                    TunnelStateWrapper::from(connecting_state),
+                    TunnelStateTransition::Connecting,
+                )
+            }
             Err(error) => {
                 let block_reason = match *error.kind() {
                     ErrorKind::TunnelMonitorError(tunnel::ErrorKind::EnableIpv6Error) => {


### PR DESCRIPTION
We stored the `log_dir` and `resource_dir` in the `Daemon` and then we sent them over inside the `TunnelParameters` for every new connect command. But these directories never change once the daemon is up and running. And I don't see us changing this in the near future. So they could just as well be sent to the tunnel state machine on initialization and kept there in the shared state instead.

Main goal here was to simplify `TunnelParameters`, reducing its complexity before introducing something the state machine can keep to pull out new endpoints from.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/493)
<!-- Reviewable:end -->
