### PR TITLE
Don't rely on exit ip in relay_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Add support for DNS configuration using systemd-resolved and NetworkManager.
 
-
 ### Changed
 - Auto-hide scrollbars on macOS only, leaving them visible on other platforms.
+- Instead of showing the public IP of the device in the UI, we show the hostname of the VPN server
+  the app is connected to. Or nothing if not connected anywhere.
 
 #### Linux
 - Moved CLI binary to `/usr/bin/` as to have the CLI binary in the user's `$PATH` by default.

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -333,21 +333,9 @@ export default class AppRenderer {
   }
 
   async _fetchLocation() {
-    const actions = this._reduxActions;
-    const location = await this._daemonRpc.getLocation();
-
-    log.info('Got location from daemon');
-
-    const locationUpdate = {
-      country: location.country,
-      city: location.city,
-      latitude: location.latitude,
-      longitude: location.longitude,
-      mullvadExitIp: location.mullvad_exit_ip,
-      hostname: location.hostname,
-    };
-
-    actions.connection.newLocation(locationUpdate);
+    this._reduxActions
+      .connection
+      .newLocation(await this._daemonRpc.getLocation());
   }
 
   async setAllowLan(allowLan: boolean) {

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -339,12 +339,12 @@ export default class AppRenderer {
     log.info('Got location from daemon');
 
     const locationUpdate = {
-      ip: location.ip,
       country: location.country,
       city: location.city,
       latitude: location.latitude,
       longitude: location.longitude,
       mullvadExitIp: location.mullvad_exit_ip,
+      hostname: location.hostname,
     };
 
     actions.connection.newLocation(locationUpdate);

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -333,9 +333,7 @@ export default class AppRenderer {
   }
 
   async _fetchLocation() {
-    this._reduxActions
-      .connection
-      .newLocation(await this._daemonRpc.getLocation());
+    this._reduxActions.connection.newLocation(await this._daemonRpc.getLocation());
   }
 
   async setAllowLan(allowLan: boolean) {

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -372,6 +372,7 @@ export function TunnelControl(props: TunnelControlProps) {
             <Secured displayStyle={SecuredDisplayStyle.securing} />
             <Location>
               <City />
+              <Country />
             </Location>
             <Hostname />
           </Body>

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -3,7 +3,7 @@
 import moment from 'moment';
 import * as React from 'react';
 import { Component, Text, View, Types } from 'reactxp';
-import { Accordion, ClipboardLabel, SecuredLabel, SecuredDisplayStyle } from '@mullvad/components';
+import { Accordion, SecuredLabel, SecuredDisplayStyle } from '@mullvad/components';
 import { Layout, Container, Header } from './Layout';
 import { SettingsBarButton, Brand } from './HeaderBar';
 import BlockingInternetBanner, { BannerTitle, BannerSubtitle } from './BlockingInternetBanner';

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -176,7 +176,7 @@ export default class Connect extends Component<Props> {
             selectedRelayName={this.props.selectedRelayName}
             city={this.props.connection.city}
             country={this.props.connection.country}
-            ip={this.props.connection.ip}
+            hostname={this.props.connection.hostname}
             onConnect={this.props.onConnect}
             onDisconnect={this.props.onDisconnect}
             onSelectLocation={this.props.onSelectLocation}
@@ -318,13 +318,7 @@ export function TunnelControl(props: TunnelControlProps) {
   const Location = ({ children }) => <View style={styles.status_location}>{children}</View>;
   const City = () => <Text style={styles.status_location_text}>{props.city}</Text>;
   const Country = () => <Text style={styles.status_location_text}>{props.country}</Text>;
-  const Ip = () => (
-    <ClipboardLabel
-      style={styles.status_ipaddress}
-      value={props.ip || ''}
-      message={'IP copied to clipboard!'}
-    />
-  );
+  const Hostname = () => <Text style={styles.status_hostname}>{props.hostname || ''}</Text>;
 
   const SwitchLocation = () => {
     return (
@@ -379,6 +373,7 @@ export function TunnelControl(props: TunnelControlProps) {
             <Location>
               <City />
             </Location>
+            <Hostname />
           </Body>
           <Footer>
             <SwitchLocation />
@@ -395,7 +390,7 @@ export function TunnelControl(props: TunnelControlProps) {
               <City />
               <Country />
             </Location>
-            <Ip />
+            <Hostname />
           </Body>
           <Footer>
             <SwitchLocation />
@@ -425,7 +420,6 @@ export function TunnelControl(props: TunnelControlProps) {
             <Location>
               <Country />
             </Location>
-            <Ip />
           </Body>
           <Footer>
             <SelectedLocation />
@@ -442,7 +436,6 @@ export function TunnelControl(props: TunnelControlProps) {
             <Location>
               <Country />
             </Location>
-            <Ip />
           </Body>
           <Footer>
             <SelectedLocation />

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -307,7 +307,7 @@ type TunnelControlProps = {
   selectedRelayName: string,
   city: ?string,
   country: ?string,
-  ip: ?string,
+  hostname: ?string,
   onConnect: () => void,
   onDisconnect: () => void,
   onSelectLocation: () => void,

--- a/gui/packages/desktop/src/renderer/components/ConnectStyles.js
+++ b/gui/packages/desktop/src/renderer/components/ConnectStyles.js
@@ -76,11 +76,12 @@ export default {
     lineHeight: 22,
     marginBottom: 4,
   }),
-  status_ipaddress: Styles.createTextStyle({
+  status_hostname: Styles.createTextStyle({
     fontFamily: 'Open Sans',
     fontSize: 16,
     fontWeight: '800',
     color: colors.white,
+    paddingBottom: 2,
   }),
   status_location: Styles.createTextStyle({
     flexDirection: 'column',

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -25,12 +25,12 @@ export type AccountData = { expiry: string };
 export type AccountToken = string;
 export type Ip = string;
 export type Location = {
-  ip: Ip,
   country: string,
   city: ?string,
   latitude: number,
   longitude: number,
   mullvad_exit_ip: boolean,
+  hostname: ?string,
 };
 const LocationSchema = object({
   country: string,

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -33,12 +33,12 @@ export type Location = {
   mullvad_exit_ip: boolean,
 };
 const LocationSchema = object({
-  ip: string,
   country: string,
   city: maybe(string),
   latitude: number,
   longitude: number,
   mullvad_exit_ip: boolean,
+  hostname: maybe(string),
 });
 
 export type BlockReason =
@@ -207,7 +207,6 @@ const RelayListSchema = object({
             object({
               hostname: string,
               ipv4_addr_in: string,
-              ipv4_addr_exit: string,
               include_in_country: boolean,
               weight: number,
             }),

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -453,7 +453,7 @@ export class DaemonRpc implements DaemonRpcProtocol {
   async getLocation(): Promise<Location> {
     const response = await this._transport.send('get_current_location', [], NETWORK_CALL_TIMEOUT);
     try {
-      return validate(LocationSchema, response);
+      return camelCaseObjectKeys(validate(LocationSchema, response));
     } catch (error) {
       throw new ResponseParseError('Invalid response from get_current_location', error);
     }
@@ -462,7 +462,7 @@ export class DaemonRpc implements DaemonRpcProtocol {
   async getState(): Promise<TunnelStateTransition> {
     const response = await this._transport.send('get_state');
     try {
-      return validate(TunnelStateTransitionSchema, response);
+      return camelCaseObjectKeys(validate(TunnelStateTransitionSchema, response));
     } catch (error) {
       throw new ResponseParseError('Invalid response from get_state', error);
     }

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -27,12 +27,12 @@ type BlockedAction = {
 type NewLocationAction = {
   type: 'NEW_LOCATION',
   newLocation: {
-    ip: Ip,
     country: string,
     city: ?string,
     latitude: number,
     longitude: number,
     mullvadExitIp: boolean,
+    hostname: ?string,
   },
 };
 

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { AfterDisconnect, BlockReason, Ip } from '../../lib/daemon-rpc';
+import type { AfterDisconnect, BlockReason } from '../../lib/daemon-rpc';
 
 type ConnectingAction = {
   type: 'CONNECTING',

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -58,11 +58,13 @@ fn print_location(rpc: &mut DaemonRpcClient) -> Result<()> {
     } else {
         format!("{}", location.country)
     };
+    if let Some(hostname) = location.hostname {
+        println!("Relay: {}", hostname);
+    }
     println!("Location: {}", city_and_country);
     println!(
         "Position: {:.5}°N, {:.5}°W",
         location.latitude, location.longitude
     );
-    println!("IP: {}", location.ip);
     Ok(())
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -61,7 +61,7 @@ use mullvad_types::{
     version::{AppVersion, AppVersionInfo},
 };
 
-use std::{mem, net::IpAddr, path::PathBuf, sync::mpsc, thread, time::Duration};
+use std::{mem, path::PathBuf, sync::mpsc, thread, time::Duration};
 
 use talpid_core::{
     mpsc::IntoSender,
@@ -411,13 +411,14 @@ impl Daemon {
     fn on_get_current_location(&self, tx: OneshotSender<GeoIpLocation>) {
         if let Some(ref relay) = self.current_relay {
             let location = relay.location.as_ref().cloned().unwrap();
+            let hostname = relay.hostname.clone();
             let geo_ip_location = GeoIpLocation {
-                ip: IpAddr::V4(relay.ipv4_addr_exit),
                 country: location.country,
                 city: Some(location.city),
                 latitude: location.latitude,
                 longitude: location.longitude,
                 mullvad_exit_ip: true,
+                hostname: Some(hostname),
             };
             Self::oneshot_send(tx, geo_ip_location, "current location");
         } else {

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -16,10 +16,10 @@ pub struct Location {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GeoIpLocation {
-    pub ip: IpAddr,
     pub country: String,
     pub city: Option<String>,
     pub latitude: f64,
     pub longitude: f64,
     pub mullvad_exit_ip: bool,
+    pub hostname: Option<String>,
 }

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -1,5 +1,3 @@
-use std::net::IpAddr;
-
 pub type CountryCode = String;
 pub type CityCode = String;
 pub type Hostname = String;
@@ -21,5 +19,6 @@ pub struct GeoIpLocation {
     pub latitude: f64,
     pub longitude: f64,
     pub mullvad_exit_ip: bool,
+    #[serde(default)]
     pub hostname: Option<String>,
 }

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -38,7 +38,6 @@ pub struct RelayListCity {
 pub struct Relay {
     pub hostname: String,
     pub ipv4_addr_in: Ipv4Addr,
-    pub ipv4_addr_exit: Ipv4Addr,
     pub include_in_country: bool,
     pub weight: u64,
     #[serde(skip_serializing_if = "RelayTunnels::is_empty", default)]


### PR DESCRIPTION
We need to remove the `ipv4_addr_exit` from the `relay_list` API call. So we need to make the app not depend on that field asap. This first step removes that field so we can correctly parse API responses where it's absent.

This leads to us not having the IP as local metadata for relays we connect to. We could get it via am.i.mullvad and we probably want to do that at some point. But we have also talked about showing the relay hostname instead of the IP. So to make the fix a bit quicker, and likely move towards what we want, I here replace the IP in the UI with the hostname for the `connecting` and `connected` states. For the other states we simply show nothing for now.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/497)
<!-- Reviewable:end -->
