### PR TITLE
Put mullvad binary in /usr/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Auto-hide scrollbars on macOS only, leaving them visible on other platforms.
 
+#### Linux
+- Moved CLI binary to `/usr/bin/` as to have the CLI binary in the user's `$PATH` by default.
+
 ### Fixed
 #### Windows
 - Use different method for identifying network interfaces during installation.

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -100,9 +100,6 @@ linux:
     - rpm
   artifactName: MullvadVPN-${version}_${arch}.${ext}
   category: Network
-  extraFiles:
-    - from: ../../../target/release/mullvad
-      to: .
   extraResources:
     - from: ../../../target/release/problem-report
       to: .
@@ -121,7 +118,9 @@ deb:
   fpm: ["--before-install", "../../../dist-assets/linux/before-install.sh",
        "--before-remove", "../../../dist-assets/linux/before-remove.sh",
        "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.service",
-       "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.conf"]
+       "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.conf",
+       "../../../target/release/mullvad=/usr/bin/",
+       ]
   afterInstall: ../../../dist-assets/linux/after-install.sh
   afterRemove: ../../../dist-assets/linux/after-remove.sh
 
@@ -129,7 +128,9 @@ rpm:
   fpm: ["--before-install", "../../../dist-assets/linux/before-install.sh",
        "--before-remove", "../../../dist-assets/linux/before-remove.sh",
        "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.service",
-       "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.conf"]
+       "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.conf",
+       "../../../target/release/mullvad=/usr/bin/",
+       ]
   afterInstall: ../../../dist-assets/linux/after-install.sh
   afterRemove: ../../../dist-assets/linux/after-remove.sh
   depends:


### PR DESCRIPTION
I've made changes to `electron-builder.yml` to add the CLI binary to the installers in `/usr/bin` rather than the resources folder. This moves the binary into `$PATH` by default, and the file is then managed by the respective packaging systems and not our scripts.
I've tested the changes on Fedora and Debian and they work.

I don't know if we can do this nicely for OSX - the `/usr/bin/` there is mounted read only, there are `/local/usr/bin` or something similar but that is not my area of expertise. Maybe we can make this package installable by `brew`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/498)
<!-- Reviewable:end -->
