### PR TITLE
Windns improve error handling

### DIFF
--- a/windows/windns/src/windns/confineoperation.cpp
+++ b/windows/windns/src/windns/confineoperation.cpp
@@ -50,6 +50,24 @@ bool ConfineOperation
 	}
 }
 
+bool ConfineOperation
+(
+	const char *literalOperation,
+	ILogSink *logSink,
+	std::function<void()> operation
+)
+{
+	auto ForwardError = [logSink](const char *error, const char **details, uint32_t numDetails)
+	{
+		if (nullptr != logSink)
+		{
+			logSink->error(error, details, numDetails);
+		}
+	};
+
+	return ConfineOperation(literalOperation, ForwardError, operation);
+}
+
 std::vector<uint8_t> CreateRawStringArray(const std::vector<std::string> &arr)
 {
 	//

--- a/windows/windns/src/windns/confineoperation.h
+++ b/windows/windns/src/windns/confineoperation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ilogsink.h"
 #include <functional>
 #include <vector>
 #include <string>
@@ -9,6 +10,13 @@ bool ConfineOperation
 (
 	const char *literalOperation,
 	std::function<void(const char *, const char **, uint32_t)> errorCallback,
+	std::function<void()> operation
+);
+
+bool ConfineOperation
+(
+	const char *literalOperation,
+	ILogSink *logSink,
 	std::function<void()> operation
 );
 

--- a/windows/windns/src/windns/dnsagent.cpp
+++ b/windows/windns/src/windns/dnsagent.cpp
@@ -363,13 +363,29 @@ void DnsAgent::setNameServers(const std::wstring &interfaceGuid, const std::vect
 {
 	XTRACE(L"Overriding name servers for interface ", interfaceGuid);
 
+	uint32_t interfaceIndex = 0;
+
+	try
+	{
+		interfaceIndex = NetSh::ConvertInterfaceGuidToIndex(interfaceGuid);
+	}
+	catch (...)
+	{
+		//
+		// The interface cannot be linked to a virtual or physical adapter.
+		//
+
+		XTRACE(L"Ignoring floating interface ", interfaceGuid);
+		return;
+	}
+
 	if (Protocol::IPv4 == m_protocol)
 	{
-		NetSh::Instance().SetIpv4StaticDns(NetSh::ConvertInterfaceGuidToIndex(interfaceGuid), enforcedServers);
+		NetSh::Instance().SetIpv4StaticDns(interfaceIndex, enforcedServers);
 	}
 	else
 	{
-		NetSh::Instance().SetIpv6StaticDns(NetSh::ConvertInterfaceGuidToIndex(interfaceGuid), enforcedServers);
+		NetSh::Instance().SetIpv6StaticDns(interfaceIndex, enforcedServers);
 	}
 }
 

--- a/windows/windns/src/windns/dnsagent.h
+++ b/windows/windns/src/windns/dnsagent.h
@@ -73,7 +73,6 @@ private:
 	ProcessingResult processInterfaceEvent(const HANDLE *interfaceEvents, size_t startIndex);
 
 	std::vector<std::wstring> discoverInterfaces();
-	std::vector<InterfaceSnap> createSnaps(const std::vector<std::wstring> &interfaces);
 
 	void setNameServers(const std::wstring &interfaceGuid, const std::vector<std::wstring> &enforcedServers);
 

--- a/windows/windns/src/windns/interfacesnap.cpp
+++ b/windows/windns/src/windns/interfacesnap.cpp
@@ -81,7 +81,7 @@ InterfaceSnap::InterfaceSnap(Protocol protocol, const std::wstring &interfaceGui
 	// DHCP name servers are the servers most recently supplied by DHCP.
 	// An adapter can be configured for DHCP and static name servers at the same time.
 	// Static name servers always have precedence.
-	m_dhcpNameServers = GetNameServers(m_interfaceGuid, m_protocol, NameServerType::Dhcp);
+	//m_dhcpNameServers = GetNameServers(m_interfaceGuid, m_protocol, NameServerType::Dhcp);
 }
 
 InterfaceSnap::InterfaceSnap(common::serialization::Deserializer &deserializer)
@@ -99,7 +99,6 @@ InterfaceSnap::InterfaceSnap(common::serialization::Deserializer &deserializer)
 	d >> m_interfaceGuid;
 	d >> (uint8_t &)m_configuredForDhcp;
 	d >> m_staticNameServers;
-	d >> m_dhcpNameServers;
 }
 
 void InterfaceSnap::serialize(common::serialization::Serializer &serializer) const
@@ -110,7 +109,6 @@ void InterfaceSnap::serialize(common::serialization::Serializer &serializer) con
 	s << m_interfaceGuid;
 	s << (uint8_t &)m_configuredForDhcp;
 	s << m_staticNameServers;
-	s << m_dhcpNameServers;
 }
 
 bool InterfaceSnap::needsOverriding(const std::vector<std::wstring> &enforcedServers) const

--- a/windows/windns/src/windns/interfacesnap.h
+++ b/windows/windns/src/windns/interfacesnap.h
@@ -29,7 +29,5 @@ private:
 	std::wstring m_interfaceGuid;
 
 	bool m_configuredForDhcp;
-
 	std::vector<std::wstring> m_staticNameServers;
-	std::vector<std::wstring> m_dhcpNameServers;
 };

--- a/windows/windns/src/windns/recoverylogic.cpp
+++ b/windows/windns/src/windns/recoverylogic.cpp
@@ -34,15 +34,32 @@ void RecoveryLogic::RestoreInterfaces(const RecoveryFormatter::Unpacked &data,
 				return;
 			}
 
-			XTRACE("Resetting name server configuration for interface ", snap.interfaceGuid());
+			XTRACE(L"Resetting name server configuration for interface ", snap.interfaceGuid());
+
+			uint32_t interfaceIndex = 0;
+
+			try
+			{
+				interfaceIndex = NetSh::ConvertInterfaceGuidToIndex(snap.interfaceGuid());
+			}
+			catch (...)
+			{
+				//
+				// The interface cannot be linked to a virtual or physical adapter.
+				// It's either floating or has been removed.
+				//
+
+				XTRACE(L"Ignoring floating/invalid interface ", snap.interfaceGuid());
+				return;
+			}
 
 			if (snap.nameServers().empty())
 			{
-				NetSh::Instance().SetIpv4DhcpDns(NetSh::ConvertInterfaceGuidToIndex(snap.interfaceGuid()), timeout);
+				NetSh::Instance().SetIpv4DhcpDns(interfaceIndex, timeout);
 			}
 			else
 			{
-				NetSh::Instance().SetIpv4StaticDns(NetSh::ConvertInterfaceGuidToIndex(snap.interfaceGuid()), snap.nameServers(), timeout);
+				NetSh::Instance().SetIpv4StaticDns(interfaceIndex, snap.nameServers(), timeout);
 			}
 		});
 
@@ -65,15 +82,32 @@ void RecoveryLogic::RestoreInterfaces(const RecoveryFormatter::Unpacked &data,
 				return;
 			}
 
-			XTRACE("Resetting name server configuration for interface ", snap.interfaceGuid());
+			XTRACE(L"Resetting name server configuration for interface ", snap.interfaceGuid());
+
+			uint32_t interfaceIndex = 0;
+
+			try
+			{
+				interfaceIndex = NetSh::ConvertInterfaceGuidToIndex(snap.interfaceGuid());
+			}
+			catch (...)
+			{
+				//
+				// The interface cannot be linked to a virtual or physical adapter.
+				// It's either floating or has been removed.
+				//
+
+				XTRACE(L"Ignoring floating/invalid interface ", snap.interfaceGuid());
+				return;
+			}
 
 			if (snap.nameServers().empty())
 			{
-				NetSh::Instance().SetIpv6DhcpDns(NetSh::ConvertInterfaceGuidToIndex(snap.interfaceGuid()), timeout);
+				NetSh::Instance().SetIpv6DhcpDns(interfaceIndex, timeout);
 			}
 			else
 			{
-				NetSh::Instance().SetIpv6StaticDns(NetSh::ConvertInterfaceGuidToIndex(snap.interfaceGuid()), snap.nameServers(), timeout);
+				NetSh::Instance().SetIpv6StaticDns(interfaceIndex, snap.nameServers(), timeout);
 			}
 		});
 

--- a/windows/windns/src/windns/recoverylogic.cpp
+++ b/windows/windns/src/windns/recoverylogic.cpp
@@ -14,16 +14,11 @@ void RecoveryLogic::RestoreInterfaces(const RecoveryFormatter::Unpacked &data,
 		throw std::runtime_error("Invalid logger sink");
 	}
 
-	auto forwardError = [logSink](const char *msg, const char **details, uint32_t numDetails)
-	{
-		logSink->error(msg, details, numDetails);
-	};
-
 	bool success = true;
 
 	for (const auto &snap : data.v4Snaps)
 	{
-		const auto status = ConfineOperation("Reset interface DNS settings", forwardError, [&snap, &timeout]()
+		const auto status = ConfineOperation("Reset interface DNS settings", logSink, [&snap, &timeout]()
 		{
 			if (snap.internalInterface())
 			{
@@ -71,7 +66,7 @@ void RecoveryLogic::RestoreInterfaces(const RecoveryFormatter::Unpacked &data,
 
 	for (const auto &snap : data.v6Snaps)
 	{
-		const auto status = ConfineOperation("Reset interface DNS settings", forwardError, [&snap, &timeout]()
+		const auto status = ConfineOperation("Reset interface DNS settings", logSink, [&snap, &timeout]()
 		{
 			if (snap.internalInterface())
 			{

--- a/windows/windns/src/windns/windnscontext.cpp
+++ b/windows/windns/src/windns/windnscontext.cpp
@@ -18,12 +18,7 @@ WinDnsContext::WinDnsContext(ILogSink *logSink)
 
 WinDnsContext::~WinDnsContext()
 {
-	auto forwardError = [this](const char *msg, const char **details, uint32_t numDetails)
-	{
-		m_logSink->error(msg, details, numDetails);
-	};
-
-	ConfineOperation("Reset DNS settings", forwardError, [this]()
+	ConfineOperation("Reset DNS settings", m_logSink, [this]()
 	{
 		this->reset();
 	});


### PR DESCRIPTION
Two major changes that affect the behavior of `windns`:

- Ignore "floating" interfaces. If the interface GUID cannot be linked to a physical or virtual adapter we skip it without raising an error. It will however be logged as an error because it's non-trivial to determine if the link resolution is intermittently failing for a legitimate interface. I had never encountered a similar interface in my testing, but apparently they are quite common. 

- Make DNS enforcement a best-effort operation. I.e. if an certain interface cannot be overridden we don't fail and abort, but just keep going. This affects initial overriding of settings, processing of interface update events, and processing of changes to the set of servers we intend to use when overriding settings.

The processing of interface update events is more accurate as well. If an interface is changed such that it can be considered an "internal interface", we now properly recognize this and update our tracking information.

Also, the code no longer tracks which DNS servers have been pushed by DHCP. The current code has no use for this data, and querying for it is relatively expensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/504)
<!-- Reviewable:end -->
