### PR TITLE
Remove comp-lzo OpenVPN setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Moved CLI binary to `/usr/bin/` as to have the CLI binary in the user's `$PATH` by default.
 
+### Removed
+- Remove `--comp-lzo` argument to OpenVPN. Disables any possibility of establishing a VPN tunnel
+  with compression.
+
 ### Fixed
 #### Windows
 - Use different method for identifying network interfaces during installation.

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -24,7 +24,6 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--ping-exit", "15"],
     &["--connect-retry", "0", "0"],
     &["--connect-retry-max", "1"],
-    &["--comp-lzo"],
     &["--remote-cert-tls", "server"],
     &["--rcvbuf", "1048576"],
     &["--sndbuf", "1048576"],


### PR DESCRIPTION
Removes the `--comp-lzo` flag to OpenVPN. Our relay servers already disables compression, but this  removes any possibility of the app establishing a VPN tunnel with compression in it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/505)
<!-- Reviewable:end -->
