### PR TITLE
Pass --connect-timeout 30 to openvpn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Line wrap the file at 100 chars.                                              Th
 - Auto-hide scrollbars on macOS only, leaving them visible on other platforms.
 - Instead of showing the public IP of the device in the UI, we show the hostname of the VPN server
   the app is connected to. Or nothing if not connected anywhere.
+- Passing `--connect-timeout 30` to `openvpn` to decrease the time the daemon
+  will wait until it tries to reconnect again in the case of a broken TCP connection.
 
 #### Linux
 - Moved CLI binary to `/usr/bin/` as to have the CLI binary in the user's `$PATH` by default.

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -22,6 +22,7 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--dev-type", "tun"],
     &["--ping", "3"],
     &["--ping-exit", "15"],
+    &["--connect-timeout", "30"],
     &["--connect-retry", "0", "0"],
     &["--connect-retry-max", "1"],
     &["--remote-cert-tls", "server"],


### PR DESCRIPTION
As it turns out, during startup on Windows, TCP packets just disappear in a black hole, so OpenVPN will hit it's connection timeout before it will try to reconnect again. With this argument, OpenVPN will timeout faster than the 120 second default, which should improve UX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/506)
<!-- Reviewable:end -->
