### PR TITLE
Increase ping-exit to 20 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Line wrap the file at 100 chars.                                              Th
   the app is connected to. Or nothing if not connected anywhere.
 - Passing `--connect-timeout 30` to `openvpn` to decrease the time the daemon
   will wait until it tries to reconnect again in the case of a broken TCP connection.
+- Increase timeout parameter to OpenVPN from 15 to 20 seconds. Should make active VPN tunnels drop
+  less frequent when on unstable networks.
 
 #### Linux
 - Moved CLI binary to `/usr/bin/` as to have the CLI binary in the user's `$PATH` by default.

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -20,8 +20,8 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--dev", "tun"],
     #[cfg(windows)]
     &["--dev-type", "tun"],
-    &["--ping", "3"],
-    &["--ping-exit", "15"],
+    &["--ping", "4"],
+    &["--ping-exit", "20"],
     &["--connect-timeout", "30"],
     &["--connect-retry", "0", "0"],
     &["--connect-retry-max", "1"],


### PR DESCRIPTION
Some users report that their tunnels break more frequently than with the old client. We suspect it's because the `ping-exit` value is set lower, so during temporary connectivity problems this app will be more likely to timeout the tunnel. This change should hopefully partially mitigate that, being able to handle temporary network issues for 20 seconds instead of 15.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/507)
<!-- Reviewable:end -->
