### PR TITLE
Reduce the blocking internet banner transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Line wrap the file at 100 chars.                                              Th
   will wait until it tries to reconnect again in the case of a broken TCP connection.
 - Increase timeout parameter to OpenVPN from 15 to 20 seconds. Should make active VPN tunnels drop
   less frequent when on unstable networks.
+- Reduce the transparency of "blocking internet" banner to increase the text readability.
 
 #### Linux
 - Moved CLI binary to `/usr/bin/` as to have the CLI binary in the user's `$PATH` by default.

--- a/gui/packages/desktop/src/renderer/components/BlockingInternetBanner.js
+++ b/gui/packages/desktop/src/renderer/components/BlockingInternetBanner.js
@@ -7,7 +7,7 @@ import { colors } from '../../config';
 const styles = {
   container: Styles.createViewStyle({
     flexDirection: 'row',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    backgroundColor: 'rgba(25, 38, 56, 0.95)',
     paddingTop: 8,
     paddingLeft: 20,
     paddingRight: 20,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR adjusts the colour and transparency of the blocking internet banner to increase text legibility.

Before/After:

<img width="1043" alt="screenshot 2018-10-08 at 14 51 20" src="https://user-images.githubusercontent.com/704044/46609947-ab119300-cb09-11e8-92e1-dfe58cd49efb.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/508)
<!-- Reviewable:end -->
