### PR TITLE
Place Mssfix setting inside scrollable area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Fixed
+- Place Mssfix setting inside scrollable area
 
 
 ## [2018.4-beta2] - 2018-10-08

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -110,22 +110,22 @@ export class AdvancedSettings extends Component<Props, State> {
 
                     {portSelector}
                   </View>
-                </NavigationScrollbars>
 
-                <Cell.Container>
-                  <Cell.Label>Mssfix</Cell.Label>
-                  <Cell.Input
-                    keyboardType={'numeric'}
-                    maxLength={5}
-                    placeholder={'None'}
-                    value={this.state.editedMssfix}
-                    style={mssfixStyle}
-                    onChangeText={this._onMssfixChange}
-                    onFocus={this._onMssfixFocus}
-                    onBlur={this._onMssfixBlur}
-                  />
-                </Cell.Container>
-                <Cell.Footer>Change OpenVPN MSS value</Cell.Footer>
+                  <Cell.Container>
+                    <Cell.Label>Mssfix</Cell.Label>
+                    <Cell.Input
+                      keyboardType={'numeric'}
+                      maxLength={5}
+                      placeholder={'None'}
+                      value={this.state.editedMssfix}
+                      style={mssfixStyle}
+                      onChangeText={this._onMssfixChange}
+                      onFocus={this._onMssfixFocus}
+                      onBlur={this._onMssfixBlur}
+                    />
+                  </Cell.Container>
+                  <Cell.Footer>Change OpenVPN MSS value</Cell.Footer>
+                </NavigationScrollbars>
               </View>
             </NavigationContainer>
           </View>


### PR DESCRIPTION
The mssfix setting in the GUI is placed where it doesn't scroll with the other settings. This PR moves it so that it scrolls with the other settings.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/510)
<!-- Reviewable:end -->
