### PR TITLE
Resize window if display metrics are changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Place Mssfix setting inside scrollable area
 
+#### Linux
+- The app will have it's window resized correctly when display scaling settings are changed. This
+ should also fix bad window behaviour on startup.
+
 
 ## [2018.4-beta2] - 2018-10-08
 ### Added


### PR DESCRIPTION
I don't quite understand why,but on Linux the browser window won't resize itself after the scaling settings are changed, unlike every other platform. To remedy this, the `WindowController` class will forcibly set the window size every time the window receives a `display-metrics-changed` event. I'm OK with making a less drastic change if doing this every time the metrics are changed is too heavy-handed in your opinion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/511)
<!-- Reviewable:end -->
