### PR TITLE
Fix resolved by always resolving interface names to real IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Line wrap the file at 100 chars.                                              Th
 - The app will have it's window resized correctly when display scaling settings are changed. This
  should also fix bad window behaviour on startup.
 
+### Fixed
+#### Linux
+- Fixed systemd-resolved DNS management.
+
 
 ## [2018.4-beta2] - 2018-10-08
 ### Added

--- a/gui/packages/desktop/src/main/window-controller.js
+++ b/gui/packages/desktop/src/main/window-controller.js
@@ -213,8 +213,7 @@ export default class WindowController {
     // On linux, the window won't be properly rescaled back to it's original
     // size if the DPI scaling factor is changed.
     // https://github.com/electron/electron/issues/11050
-    if (process.platform === 'linux' && changedMetrics.includes('scaleFactor'))
-      {
+    if (process.platform === 'linux' && changedMetrics.includes('scaleFactor')) {
       this._forceResizeWindow();
     }
   };


### PR DESCRIPTION
I've slightly refined the code I sent you yesterday. The code still would log a human readable interface name if resetting fails for whatever reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/512)
<!-- Reviewable:end -->
