### PR TITLE
Add 'BridgeEndpoint' type

### DIFF
--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -1,7 +1,12 @@
 use clap;
 use {new_rpc_client, Command, Result};
 
-use talpid_types::net::{OpenVpnTunnelOptions, TunnelOptions};
+use talpid_types::net::{
+    LocalOpenVpnProxySettings, OpenVpnProxyAuth, OpenVpnProxySettings,
+    OpenVpnProxySettingsValidation, RemoteOpenVpnProxySettings, TunnelOptions,
+};
+
+use std::net::{IpAddr, SocketAddr};
 
 pub struct Tunnel;
 
@@ -14,111 +19,168 @@ impl Command for Tunnel {
         clap::SubCommand::with_name(self.name())
             .about("Manage tunnel specific options")
             .setting(clap::AppSettings::SubcommandRequired)
-            .subcommand(
-                clap::SubCommand::with_name("openvpn")
-                    .about("Manage options for OpenVPN tunnels")
-                    .setting(clap::AppSettings::SubcommandRequired)
-                    .subcommand(
-                        clap::SubCommand::with_name("set")
-                            .subcommand(
-                                clap::SubCommand::with_name("mssfix").arg(
-                                    clap::Arg::with_name("mssfix")
-                                        .help(
-                                            "Sets the optional mssfix parameter. \
-                                             Set an empty string to clear it.",
-                                        )
-                                        .required(true),
-                                ),
-                            )
-                            .setting(clap::AppSettings::SubcommandRequired),
-                    )
-                    .subcommand(
-                        clap::SubCommand::with_name("get")
-                            .help("Retrieves the current settings for OpenVPN tunnels"),
-                    ),
-            )
-            .subcommand(
-                clap::SubCommand::with_name("set")
-                    .subcommand(
-                        clap::SubCommand::with_name("ipv6").arg(
-                            clap::Arg::with_name("enable")
-                                .required(true)
-                                .takes_value(true)
-                                .possible_values(&["on", "off"]),
-                        ),
-                    )
-                    .setting(clap::AppSettings::SubcommandRequired),
-            )
-            .subcommand(
-                clap::SubCommand::with_name("get")
-                    .help("Retrieves the current setting for common tunnel options"),
-            )
+            .subcommand(create_openvpn_subcommand())
+            .subcommand(create_ipv6_subcommand())
     }
 
     fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(openvpn_matches) = matches.subcommand_matches("openvpn") {
             Self::handle_openvpn_cmd(openvpn_matches)
-        } else if let Some(set_matches) = matches.subcommand_matches("set") {
-            Self::set_tunnel_option(set_matches)
-        } else if let Some(_) = matches.subcommand_matches("get") {
-            let tunnel_options = Self::get_tunnel_options()?;
-            Self::print_common_tunnel_options(&tunnel_options);
-            Ok(())
+        } else if let Some(ipv6_matches) = matches.subcommand_matches("ipv6") {
+            Self::handle_ipv6_cmd(ipv6_matches)
         } else {
-            unreachable!("No tunnel command given")
+            unreachable!("unhandled command");
         }
     }
 }
 
+fn create_openvpn_subcommand() -> clap::App<'static, 'static> {
+    clap::SubCommand::with_name("openvpn")
+        .about("Manage options for OpenVPN tunnels")
+        .setting(clap::AppSettings::SubcommandRequired)
+        .subcommand(create_openvpn_mssfix_subcommand())
+        .subcommand(create_openvpn_proxy_subcommand())
+}
+
+fn create_openvpn_mssfix_subcommand() -> clap::App<'static, 'static> {
+    clap::SubCommand::with_name("mssfix")
+        .about("Configure the optional mssfix parameter")
+        .setting(clap::AppSettings::SubcommandRequired)
+        .subcommand(clap::SubCommand::with_name("get"))
+        .subcommand(clap::SubCommand::with_name("unset"))
+        .subcommand(
+            clap::SubCommand::with_name("set").arg(clap::Arg::with_name("mssfix").required(true)),
+        )
+}
+
+fn create_openvpn_proxy_subcommand() -> clap::App<'static, 'static> {
+    clap::SubCommand::with_name("proxy")
+        .about("Configure a SOCKS5 proxy")
+        .setting(clap::AppSettings::SubcommandRequired)
+        .subcommand(clap::SubCommand::with_name("get"))
+        .subcommand(clap::SubCommand::with_name("unset"))
+        .subcommand(
+            clap::SubCommand::with_name("set")
+                .setting(clap::AppSettings::SubcommandRequired)
+                .subcommand(
+                    clap::SubCommand::with_name("local")
+                        .about("Registers a local SOCKS5 proxy")
+                        .arg(
+                            clap::Arg::with_name("local-port")
+                                .help("Specifies the port the local proxy server is listening on")
+                                .required(true)
+                                .index(1),
+                        )
+                        .arg(
+                            clap::Arg::with_name("remote-ip")
+                                .help("Specifies the IP of the proxy server peer")
+                                .required(true)
+                                .index(2),
+                        )
+                        .arg(
+                            clap::Arg::with_name("remote-port")
+                                .help("Specifies the port of the proxy server peer")
+                                .required(true)
+                                .index(3),
+                        ),
+                )
+                .subcommand(
+                    clap::SubCommand::with_name("remote")
+                        .about("Registers a remote SOCKS5 proxy")
+                        .arg(
+                            clap::Arg::with_name("remote-ip")
+                                .help("Specifies the IP of the remote proxy server")
+                                .required(true)
+                                .index(1),
+                        )
+                        .arg(
+                            clap::Arg::with_name("remote-port")
+                                .help("Specifies the port the remote proxy server is listening on")
+                                .required(true)
+                                .index(2),
+                        )
+                        .arg(
+                            clap::Arg::with_name("username")
+                                .help("Specifies the username for remote authentication")
+                                .index(3),
+                        )
+                        .arg(
+                            clap::Arg::with_name("password")
+                                .help("Specifies the password for remote authentication")
+                                .index(4),
+                        ),
+                ),
+        )
+}
+
+fn create_ipv6_subcommand() -> clap::App<'static, 'static> {
+    clap::SubCommand::with_name("ipv6")
+        .setting(clap::AppSettings::SubcommandRequired)
+        .subcommand(clap::SubCommand::with_name("get"))
+        .subcommand(
+            clap::SubCommand::with_name("set").arg(
+                clap::Arg::with_name("enable")
+                    .required(true)
+                    .takes_value(true)
+                    .possible_values(&["on", "off"]),
+            ),
+        )
+}
+
 impl Tunnel {
-    fn set_tunnel_option(matches: &clap::ArgMatches) -> Result<()> {
-        if let Some(ipv6_args) = matches.subcommand_matches("ipv6") {
-            Self::set_enable_ipv6_option(ipv6_args)
-        } else {
-            unreachable!("Invalid option passed to 'tunnel set'");
-        }
-    }
-
-    fn set_enable_ipv6_option(args: &clap::ArgMatches) -> Result<()> {
-        let enabled = args.value_of("enable").unwrap() == "on";
-
-        let mut rpc = new_rpc_client()?;
-        rpc.set_enable_ipv6(enabled)?;
-        println!("IPv6 {}", if enabled { "on" } else { "off" });
-        Ok(())
-    }
-
     fn handle_openvpn_cmd(matches: &clap::ArgMatches) -> Result<()> {
-        if let Some(set_matches) = matches.subcommand_matches("set") {
-            Self::set_openvpn_option(set_matches)
-        } else if let Some(_) = matches.subcommand_matches("get") {
-            let tunnel_options = Self::get_tunnel_options()?;
-            Self::print_openvpn_tunnel_options(tunnel_options.openvpn);
-            Ok(())
+        if let Some(m) = matches.subcommand_matches("mssfix") {
+            Self::handle_openvpn_mssfix_cmd(m)
+        } else if let Some(m) = matches.subcommand_matches("proxy") {
+            Self::handle_openvpn_proxy_cmd(m)
         } else {
-            unreachable!("Unrecognized subcommand");
+            unreachable!("unhandled command");
         }
     }
 
-    fn set_openvpn_option(matches: &clap::ArgMatches) -> Result<()> {
-        if let Some(mssfix_args) = matches.subcommand_matches("mssfix") {
-            Self::set_openvpn_mssfix_option(mssfix_args)
+    fn handle_openvpn_mssfix_cmd(matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(_) = matches.subcommand_matches("get") {
+            Self::process_openvpn_mssfix_get()
+        } else if let Some(_) = matches.subcommand_matches("unset") {
+            Self::process_openvpn_mssfix_unset()
+        } else if let Some(m) = matches.subcommand_matches("set") {
+            Self::process_openvpn_mssfix_set(m)
         } else {
-            unreachable!("Invalid option passed to 'openvpn set'");
+            unreachable!("unhandled command");
         }
     }
 
-    fn set_openvpn_mssfix_option(args: &clap::ArgMatches) -> Result<()> {
-        let mssfix_str = args.value_of("mssfix").unwrap();
-        let mssfix: Option<u16> = if mssfix_str == "" {
-            None
+    fn handle_openvpn_proxy_cmd(matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(_) = matches.subcommand_matches("get") {
+            Self::process_openvpn_proxy_get()
+        } else if let Some(_) = matches.subcommand_matches("unset") {
+            Self::process_openvpn_proxy_unset()
+        } else if let Some(m) = matches.subcommand_matches("set") {
+            Self::process_openvpn_proxy_set(m)
         } else {
-            Some(mssfix_str.parse()?)
-        };
+            unreachable!("unhandled command");
+        }
+    }
 
-        let mut rpc = new_rpc_client()?;
-        rpc.set_openvpn_mssfix(mssfix)?;
-        println!("mssfix parameter updated");
+    fn handle_ipv6_cmd(matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(_) = matches.subcommand_matches("get") {
+            Self::process_ipv6_get()
+        } else if let Some(m) = matches.subcommand_matches("set") {
+            Self::process_ipv6_set(m)
+        } else {
+            unreachable!("unhandled command");
+        }
+    }
+
+    fn process_openvpn_mssfix_get() -> Result<()> {
+        let tunnel_options = Self::get_tunnel_options()?;
+        println!(
+            "mssfix: {}",
+            tunnel_options
+                .openvpn
+                .mssfix
+                .map_or_else(|| "unset".to_string(), |v| v.to_string())
+        );
         Ok(())
     }
 
@@ -127,21 +189,145 @@ impl Tunnel {
         Ok(rpc.get_settings()?.get_tunnel_options().clone())
     }
 
-    fn print_common_tunnel_options(options: &TunnelOptions) {
-        println!("Common tunnel options");
-        println!(
-            "\tIPv6:   {}",
-            if options.enable_ipv6 { "on" } else { "off" }
-        );
+    fn process_openvpn_mssfix_unset() -> Result<()> {
+        let mut rpc = new_rpc_client()?;
+        rpc.set_openvpn_mssfix(None)?;
+        println!("mssfix parameter has been unset");
+        Ok(())
     }
 
-    fn print_openvpn_tunnel_options(options: OpenVpnTunnelOptions) {
-        println!("OpenVPN tunnel options");
+    fn process_openvpn_mssfix_set(matches: &clap::ArgMatches) -> Result<()> {
+        let new_value = value_t!(matches.value_of("mssfix"), u16).unwrap_or_else(|e| e.exit());
+        let mut rpc = new_rpc_client()?;
+        rpc.set_openvpn_mssfix(Some(new_value))?;
+        println!("mssfix parameter has been updated");
+        Ok(())
+    }
+
+    fn process_openvpn_proxy_get() -> Result<()> {
+        let tunnel_options = Self::get_tunnel_options()?;
+        if let Some(proxy) = tunnel_options.openvpn.proxy {
+            if let OpenVpnProxySettings::Local(local_proxy) = proxy {
+                Self::print_local_proxy(&local_proxy)
+            } else if let OpenVpnProxySettings::Remote(remote_proxy) = proxy {
+                Self::print_remote_proxy(&remote_proxy)
+            } else {
+                unreachable!("unhandled proxy type");
+            }
+        } else {
+            println!("proxy: unset");
+            Ok(())
+        }
+    }
+
+    fn print_local_proxy(proxy: &LocalOpenVpnProxySettings) -> Result<()> {
+        println!("proxy: local");
+        println!("  local port: {}", proxy.port);
+        println!("  peer IP: {}", proxy.peer.ip());
+        println!("  peer port: {}", proxy.peer.port());
+        Ok(())
+    }
+
+    fn print_remote_proxy(proxy: &RemoteOpenVpnProxySettings) -> Result<()> {
+        println!("proxy: remote");
+        println!("  server IP: {}", proxy.address.ip());
+        println!("  server port: {}", proxy.address.port());
+
+        if let Some(ref auth) = proxy.auth {
+            println!("  auth username: {}", auth.username);
+            println!("  auth password: {}", auth.password);
+        } else {
+            println!("  auth: none");
+        }
+
+        Ok(())
+    }
+
+    fn process_openvpn_proxy_unset() -> Result<()> {
+        let mut rpc = new_rpc_client()?;
+        rpc.set_openvpn_proxy(None)?;
+        println!("proxy details have been unset");
+        Ok(())
+    }
+
+    fn process_openvpn_proxy_set(matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(args) = matches.subcommand_matches("local") {
+            let local_port =
+                value_t!(args.value_of("local-port"), u16).unwrap_or_else(|e| e.exit());
+            let remote_ip =
+                value_t!(args.value_of("remote-ip"), IpAddr).unwrap_or_else(|e| e.exit());
+            let remote_port =
+                value_t!(args.value_of("remote-port"), u16).unwrap_or_else(|e| e.exit());
+
+            let proxy = LocalOpenVpnProxySettings {
+                port: local_port,
+                peer: SocketAddr::new(remote_ip, remote_port),
+            };
+
+            let packed_proxy = OpenVpnProxySettings::Local(proxy);
+
+            if let Err(error) = OpenVpnProxySettingsValidation::validate(&packed_proxy) {
+                panic!(error);
+            }
+
+            let mut rpc = new_rpc_client()?;
+            rpc.set_openvpn_proxy(Some(packed_proxy))?;
+        } else if let Some(args) = matches.subcommand_matches("remote") {
+            let remote_ip =
+                value_t!(args.value_of("remote-ip"), IpAddr).unwrap_or_else(|e| e.exit());
+            let remote_port =
+                value_t!(args.value_of("remote-port"), u16).unwrap_or_else(|e| e.exit());
+            let username = args.value_of("username");
+            let password = args.value_of("password");
+
+            let auth = match (username, password) {
+                (Some(username), Some(password)) => Some(OpenVpnProxyAuth {
+                    username: username.to_string(),
+                    password: password.to_string(),
+                }),
+                _ => None,
+            };
+
+            let proxy = RemoteOpenVpnProxySettings {
+                address: SocketAddr::new(remote_ip, remote_port),
+                auth: auth,
+            };
+
+            let packed_proxy = OpenVpnProxySettings::Remote(proxy);
+
+            if let Err(error) = OpenVpnProxySettingsValidation::validate(&packed_proxy) {
+                panic!(error);
+            }
+
+            let mut rpc = new_rpc_client()?;
+            rpc.set_openvpn_proxy(Some(packed_proxy))?;
+        } else {
+            unreachable!("unhandled proxy type");
+        }
+
+        println!("proxy details have been updated");
+        Ok(())
+    }
+
+    fn process_ipv6_get() -> Result<()> {
+        let tunnel_options = Self::get_tunnel_options()?;
         println!(
-            "\tmssfix: {}",
-            options
-                .mssfix
-                .map_or_else(|| "UNSET".to_string(), |v| v.to_string())
+            "IPv6: {}",
+            if tunnel_options.enable_ipv6 {
+                "on"
+            } else {
+                "off"
+            }
         );
+        Ok(())
+    }
+
+    fn process_ipv6_set(matches: &clap::ArgMatches) -> Result<()> {
+        let enabled = matches.value_of("enable").unwrap() == "on";
+
+        let mut rpc = new_rpc_client()?;
+        rpc.set_enable_ipv6(enabled)?;
+        println!("IPv6 setting has been updated");
+        Ok(())
     }
 }

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -216,19 +216,18 @@ impl Tunnel {
             }
         } else {
             println!("proxy: unset");
-            Ok(())
         }
+        Ok(())
     }
 
-    fn print_local_proxy(proxy: &LocalOpenVpnProxySettings) -> Result<()> {
+    fn print_local_proxy(proxy: &LocalOpenVpnProxySettings) {
         println!("proxy: local");
         println!("  local port: {}", proxy.port);
         println!("  peer IP: {}", proxy.peer.ip());
         println!("  peer port: {}", proxy.peer.port());
-        Ok(())
     }
 
-    fn print_remote_proxy(proxy: &RemoteOpenVpnProxySettings) -> Result<()> {
+    fn print_remote_proxy(proxy: &RemoteOpenVpnProxySettings) {
         println!("proxy: remote");
         println!("  server IP: {}", proxy.address.ip());
         println!("  server port: {}", proxy.address.port());
@@ -239,8 +238,6 @@ impl Tunnel {
         } else {
             println!("  auth: none");
         }
-
-        Ok(())
     }
 
     fn process_openvpn_proxy_unset() -> Result<()> {

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -24,7 +24,7 @@ impl Command for Tunnel {
                                 clap::SubCommand::with_name("mssfix").arg(
                                     clap::Arg::with_name("mssfix")
                                         .help(
-                                            "Sets the optional  mssfix parameter. \
+                                            "Sets the optional mssfix parameter. \
                                              Set an empty string to clear it.",
                                         )
                                         .required(true),
@@ -34,7 +34,7 @@ impl Command for Tunnel {
                     )
                     .subcommand(
                         clap::SubCommand::with_name("get")
-                            .help("Retrieves the current setting for mssfix"),
+                            .help("Retrieves the current settings for OpenVPN tunnels"),
                     ),
             )
             .subcommand(

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -65,7 +65,7 @@ use talpid_core::{
     tunnel_state_machine::{self, TunnelCommand, TunnelParameters, TunnelParametersGenerator},
 };
 use talpid_types::{
-    net::OpenVpnBridgeSettings,
+    net::OpenVpnProxySettings,
     tunnel::{BlockReason, TunnelStateTransition},
 };
 
@@ -420,7 +420,7 @@ impl Daemon {
             SetAllowLan(tx, allow_lan) => self.on_set_allow_lan(tx, allow_lan),
             SetAutoConnect(tx, auto_connect) => self.on_set_auto_connect(tx, auto_connect),
             SetOpenVpnMssfix(tx, mssfix_arg) => self.on_set_openvpn_mssfix(tx, mssfix_arg),
-            SetOpenVpnBridge(tx, bridge_arg) => self.on_set_openvpn_bridge(tx, bridge_arg),
+            SetOpenVpnProxy(tx, proxy) => self.on_set_openvpn_proxy(tx, proxy),
             SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6),
             GetSettings(tx) => self.on_get_settings(tx),
             GetVersionInfo(tx) => self.on_get_version_info(tx),
@@ -599,15 +599,15 @@ impl Daemon {
         }
     }
 
-    fn on_set_openvpn_bridge(
+    fn on_set_openvpn_proxy(
         &mut self,
         tx: oneshot::Sender<()>,
-        bridge_arg: Option<OpenVpnBridgeSettings>
+        proxy: Option<OpenVpnProxySettings>,
     ) {
-        let save_result = self.settings.set_openvpn_bridge(bridge_arg);
+        let save_result = self.settings.set_openvpn_proxy(proxy);
         match save_result.chain_err(|| "Unable to save settings") {
             Ok(settings_changed) => {
-                Self::oneshot_send(tx, (), "set_openvpn_bridge response");
+                Self::oneshot_send(tx, (), "set_openvpn_proxy response");
                 if settings_changed {
                     self.management_interface_broadcaster
                         .notify_settings(&self.settings);

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -65,7 +65,7 @@ use talpid_core::{
     tunnel_state_machine::{self, TunnelCommand, TunnelParameters, TunnelParametersGenerator},
 };
 use talpid_types::{
-    net::{OpenVpnBridgeSettings, TunnelEndpoint},
+    net::OpenVpnBridgeSettings,
     tunnel::{BlockReason, TunnelStateTransition},
 };
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -177,7 +177,7 @@ pub enum ManagementCommand {
     /// Set the mssfix argument for OpenVPN
     SetOpenVpnMssfix(OneshotSender<()>, Option<u16>),
     /// Set proxy details for OpenVPN
-    SetOpenVpnProxy(OneshotSender<Result<(), mullvad_types::settings::Error>>, Option<OpenVpnProxySettings>),
+    SetOpenVpnProxy(OneshotSender<Result<(), settings::Error>>, Option<OpenVpnProxySettings>),
     /// Set if IPv6 should be enabled in the tunnel
     SetEnableIpv6(OneshotSender<()>, bool),
     /// Get the daemon settings

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -29,7 +29,7 @@ use mullvad_types::settings::Settings;
 use mullvad_types::version::AppVersionInfo;
 
 use serde::{Deserialize, Serialize};
-use talpid_types::net::TunnelOptions;
+use talpid_types::net::{OpenVpnProxySettings, TunnelOptions};
 use talpid_types::tunnel::TunnelStateTransition;
 
 use futures::stream::{self, Stream};
@@ -200,6 +200,10 @@ impl DaemonRpcClient {
 
     pub fn set_openvpn_mssfix(&mut self, mssfix: Option<u16>) -> Result<()> {
         self.call("set_openvpn_mssfix", &[mssfix])
+    }
+
+    pub fn set_openvpn_proxy(&mut self, proxy: Option<OpenVpnProxySettings>) -> Result<()> {
+        self.call("set_openvpn_proxy", &[proxy])
     }
 
     pub fn shutdown(&mut self) -> Result<()> {

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -3,9 +3,7 @@ extern crate serde_json;
 use relay_constraints::{
     Constraint, LocationConstraint, RelayConstraints, RelaySettings, RelaySettingsUpdate,
 };
-use talpid_types::net::{
-    OpenVpnBridgeSettings, TunnelOptions
-};
+use talpid_types::net::{OpenVpnProxySettings, TunnelOptions};
 
 use std::fs::File;
 use std::io;
@@ -184,12 +182,9 @@ impl Settings {
         }
     }
 
-    pub fn set_openvpn_bridge(
-        &mut self,
-        openvpn_bridge: Option<OpenVpnBridgeSettings>
-    ) -> Result<bool> {
-        if self.tunnel_options.openvpn.bridge_settings != openvpn_bridge {
-            self.tunnel_options.openvpn.bridge_settings = openvpn_bridge;
+    pub fn set_openvpn_proxy(&mut self, proxy: Option<OpenVpnProxySettings>) -> Result<bool> {
+        if self.tunnel_options.openvpn.proxy != proxy {
+            self.tunnel_options.openvpn.proxy = proxy;
             self.save().map(|_| true)
         } else {
             Ok(false)

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -3,7 +3,9 @@ extern crate serde_json;
 use relay_constraints::{
     Constraint, LocationConstraint, RelayConstraints, RelaySettings, RelaySettingsUpdate,
 };
-use talpid_types::net::TunnelOptions;
+use talpid_types::net::{
+    OpenVpnBridgeSettings, TunnelOptions
+};
 
 use std::fs::File;
 use std::io;
@@ -176,6 +178,18 @@ impl Settings {
     pub fn set_openvpn_mssfix(&mut self, openvpn_mssfix: Option<u16>) -> Result<bool> {
         if self.tunnel_options.openvpn.mssfix != openvpn_mssfix {
             self.tunnel_options.openvpn.mssfix = openvpn_mssfix;
+            self.save().map(|_| true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn set_openvpn_bridge(
+        &mut self,
+        openvpn_bridge: Option<OpenVpnBridgeSettings>
+    ) -> Result<bool> {
+        if self.tunnel_options.openvpn.bridge_settings != openvpn_bridge {
+            self.tunnel_options.openvpn.bridge_settings = openvpn_bridge;
             self.save().map(|_| true)
         } else {
             Ok(false)

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -133,7 +133,7 @@ impl OpenVpnCommand {
 
     /// Sets extra options
     pub fn tunnel_options(&mut self, tunnel_options: &net::OpenVpnTunnelOptions) -> &mut Self {
-        self.tunnel_options = *tunnel_options;
+        self.tunnel_options = tunnel_options.clone();
         self
     }
 

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -223,18 +223,18 @@ impl<'a> PolicyBatch<'a> {
     fn add_policy_specific_rules(&mut self, policy: &SecurityPolicy) -> Result<()> {
         let allow_lan = match policy {
             SecurityPolicy::Connecting {
-                relay_endpoint,
+                peer_endpoint,
                 allow_lan,
             } => {
-                self.add_allow_endpoint_rules(relay_endpoint)?;
+                self.add_allow_endpoint_rules(peer_endpoint)?;
                 *allow_lan
             }
             SecurityPolicy::Connected {
-                relay_endpoint,
+                peer_endpoint,
                 tunnel,
                 allow_lan,
             } => {
-                self.add_allow_endpoint_rules(relay_endpoint)?;
+                self.add_allow_endpoint_rules(peer_endpoint)?;
                 self.add_dns_rule(tunnel, TransportProtocol::Udp)?;
                 self.add_dns_rule(tunnel, TransportProtocol::Tcp)?;
                 self.add_allow_tunnel_rules(tunnel)?;

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -87,17 +87,17 @@ impl NetworkSecurity {
     ) -> Result<Vec<pfctl::FilterRule>> {
         match policy {
             SecurityPolicy::Connecting {
-                relay_endpoint,
+                peer_endpoint,
                 allow_lan,
             } => {
-                let mut rules = vec![Self::get_allow_relay_rule(relay_endpoint)?];
+                let mut rules = vec![Self::get_allow_relay_rule(peer_endpoint)?];
                 if allow_lan {
                     rules.append(&mut Self::get_allow_lan_rules()?);
                 }
                 Ok(rules)
             }
             SecurityPolicy::Connected {
-                relay_endpoint,
+                peer_endpoint,
                 tunnel,
                 allow_lan,
             } => {
@@ -139,7 +139,7 @@ impl NetworkSecurity {
                     allow_udp_dns_to_relay_rule,
                     block_tcp_dns_rule,
                     block_udp_dns_rule,
-                    Self::get_allow_relay_rule(relay_endpoint)?,
+                    Self::get_allow_relay_rule(peer_endpoint)?,
                     Self::get_allow_tunnel_rule(tunnel.interface.as_str())?,
                 ];
 

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -41,18 +41,18 @@ lazy_static! {
 /// A enum that describes network security strategy
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SecurityPolicy {
-    /// Allow traffic only to relay server
+    /// Allow traffic only to server
     Connecting {
-        /// The relay endpoint that should be allowed.
-        relay_endpoint: Endpoint,
+        /// The peer endpoint that should be allowed.
+        peer_endpoint: Endpoint,
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
     },
 
-    /// Allow traffic only to relay server and over tunnel interface
+    /// Allow traffic only to server and over tunnel interface
     Connected {
-        /// The relay endpoint that should be allowed.
-        relay_endpoint: Endpoint,
+        /// The peer endpoint that should be allowed.
+        peer_endpoint: Endpoint,
         /// Metadata about the tunnel and tunnel interface.
         tunnel: ::tunnel::TunnelMetadata,
         /// Flag setting if communication with LAN networks should be possible.
@@ -70,22 +70,22 @@ impl fmt::Display for SecurityPolicy {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             SecurityPolicy::Connecting {
-                relay_endpoint,
+                peer_endpoint,
                 allow_lan,
             } => write!(
                 f,
                 "Connecting to {}, {} LAN",
-                relay_endpoint,
+                peer_endpoint,
                 if *allow_lan { "Allowing" } else { "Blocking" }
             ),
             SecurityPolicy::Connected {
-                relay_endpoint,
+                peer_endpoint,
                 tunnel,
                 allow_lan,
             } => write!(
                 f,
                 "Connected to {} over \"{}\" (ip: {}, gw: {}), {} LAN",
-                relay_endpoint,
+                peer_endpoint,
                 tunnel.interface,
                 tunnel.ip,
                 tunnel.gateway,

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -86,19 +86,19 @@ impl NetworkSecurityT for NetworkSecurity {
     fn apply_policy(&mut self, policy: SecurityPolicy) -> Result<()> {
         match policy {
             SecurityPolicy::Connecting {
-                relay_endpoint,
+                peer_endpoint,
                 allow_lan,
             } => {
                 let cfg = &WinFwSettings::new(allow_lan);
-                self.set_connecting_state(&relay_endpoint, &cfg)
+                self.set_connecting_state(&peer_endpoint, &cfg)
             }
             SecurityPolicy::Connected {
-                relay_endpoint,
+                peer_endpoint,
                 tunnel,
                 allow_lan,
             } => {
                 let cfg = &WinFwSettings::new(allow_lan);
-                self.set_connected_state(&relay_endpoint, &cfg, &tunnel)
+                self.set_connected_state(&peer_endpoint, &cfg, &tunnel)
             }
             SecurityPolicy::Blocked { allow_lan } => {
                 let cfg = &WinFwSettings::new(allow_lan);

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -10,13 +10,14 @@ use std::fs;
 use std::io::{self, Write};
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
+use std::result::Result as StdResult;
 
 #[cfg(target_os = "linux")]
 use failure::ResultExt as FailureResultExt;
 #[cfg(target_os = "linux")]
 use which;
 
-use talpid_types::net::{Endpoint, TunnelEndpoint, TunnelEndpointData, TunnelOptions};
+use talpid_types::net::{Endpoint, OpenVpnProxySettings, TunnelEndpoint, TunnelEndpointData, TunnelOptions};
 
 /// A module for all OpenVPN related tunnel management.
 pub mod openvpn;
@@ -143,6 +144,8 @@ pub struct TunnelMonitor {
     monitor: OpenVpnMonitor,
     /// Keep the `TempFile` for the user-pass file in the struct, so it's removed on drop.
     _user_pass_file: mktemp::TempFile,
+    /// Keep the 'TempFile' for the proxy user-pass file in the struct, so it's removed on drop.
+    _proxy_auth_file: Option<mktemp::TempFile>,
 }
 
 impl TunnelMonitor {
@@ -164,21 +167,40 @@ impl TunnelMonitor {
         Self::ensure_ipv6_can_be_used_if_enabled(tunnel_options)?;
 
         let user_pass_file =
-            Self::create_user_pass_file(username).chain_err(|| ErrorKind::CredentialsWriteError)?;
+            Self::create_credentials_file(username, "-").chain_err(|| ErrorKind::CredentialsWriteError)?;
+
+        let proxy_auth_file =
+            Self::create_proxy_auth_file(&tunnel_options.openvpn.proxy).chain_err(|| ErrorKind::CredentialsWriteError)?;
+
+        // todo: also send proxy file
         let cmd = Self::create_openvpn_cmd(
             tunnel_endpoint.to_endpoint(),
             tunnel_alias,
             &tunnel_options,
             user_pass_file.as_ref(),
+            match proxy_auth_file {
+                Some(ref file) => Some(file.as_ref()),
+                _ => None},
             log,
             resource_dir,
         )?;
 
         let user_pass_file_path = user_pass_file.to_path_buf();
+
+        let proxy_auth_file_path = match proxy_auth_file {
+            Some(ref file) => Some(file.to_path_buf()),
+            _ => None,
+        };
+
         let on_openvpn_event = move |event, env| {
             if event == OpenVpnPluginEvent::Up {
                 // The user-pass file has been read. Try to delete it early.
                 let _ = fs::remove_file(&user_pass_file_path);
+
+                // The proxy auth file has been read. Try to delete it early.
+                if let Some(ref file_path) = &proxy_auth_file_path {
+                    let _ = fs::remove_file(file_path);
+                }
             }
             match TunnelEvent::from_openvpn_event(&event, &env) {
                 Some(tunnel_event) => on_event(tunnel_event),
@@ -195,6 +217,7 @@ impl TunnelMonitor {
         Ok(TunnelMonitor {
             monitor,
             _user_pass_file: user_pass_file,
+            _proxy_auth_file: proxy_auth_file,
         })
     }
 
@@ -218,6 +241,7 @@ impl TunnelMonitor {
         tunnel_alias: Option<OsString>,
         options: &TunnelOptions,
         user_pass_file: &Path,
+        proxy_auth_file: Option<&Path>,
         log: Option<&Path>,
         resource_dir: &Path,
     ) -> Result<OpenVpnCommand> {
@@ -241,6 +265,10 @@ impl TunnelMonitor {
         if let Some(log) = log {
             cmd.log(log);
         }
+        if let Some(proxy_auth_file) = proxy_auth_file {
+            cmd.proxy_auth(proxy_auth_file);
+        }
+
         Ok(cmd)
     }
 
@@ -273,16 +301,25 @@ impl TunnelMonitor {
         }
     }
 
-    fn create_user_pass_file(username: &str) -> io::Result<mktemp::TempFile> {
+    fn create_credentials_file(username: &str, password: &str) -> io::Result<mktemp::TempFile> {
         let temp_file = mktemp::TempFile::new();
         debug!(
-            "Writing user-pass credentials to {}",
+            "Writing credentials to {}",
             temp_file.as_ref().display()
         );
         let mut file = fs::File::create(&temp_file)?;
         Self::set_user_pass_file_permissions(&file)?;
-        write!(file, "{}\n-\n", username)?;
+        write!(file, "{}\n{}\n", username, password)?;
         Ok(temp_file)
+    }
+
+    fn create_proxy_auth_file(proxy: &Option<OpenVpnProxySettings>) -> StdResult<Option<mktemp::TempFile>, io::Error> {
+        if let Some(OpenVpnProxySettings::Remote(ref remote_proxy)) = proxy {
+            if let Some(ref proxy_auth) = remote_proxy.auth {
+                return Ok(Some(Self::create_credentials_file(&proxy_auth.username, &proxy_auth.password)?));
+            }
+        }
+        Ok(None)
     }
 
     #[cfg(unix)]

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -2,6 +2,7 @@ use error_chain::ChainedError;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Stream};
 
+use talpid_types::net::{Endpoint, OpenVpnProxySettings, TransportProtocol};
 use talpid_types::tunnel::BlockReason;
 
 use super::{
@@ -41,8 +42,27 @@ impl ConnectedState {
     }
 
     fn set_security_policy(&self, shared_values: &mut SharedTunnelStateValues) -> Result<()> {
+        // If a proxy is specified we need to pass it on as the peer endpoint.
+        let peer_endpoint = match self.tunnel_parameters.options.openvpn.proxy {
+            Some(OpenVpnProxySettings::Local(ref local_proxy)) => {
+                Endpoint {
+                    address: local_proxy.peer,
+                    protocol: TransportProtocol::Tcp,
+                }
+            },
+            Some(OpenVpnProxySettings::Remote(ref remote_proxy)) => {
+                Endpoint {
+                    address: remote_proxy.address,
+                    protocol: TransportProtocol::Tcp,
+                }
+            },
+            _ => {
+                self.tunnel_parameters.endpoint.to_endpoint()
+            },
+        };
+
         let policy = SecurityPolicy::Connected {
-            relay_endpoint: self.tunnel_parameters.endpoint.to_endpoint(),
+            peer_endpoint,
             tunnel: self.metadata.clone(),
             allow_lan: shared_values.allow_lan,
         };

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -161,7 +161,7 @@ impl Error for TransportProtocolParseError {
 
 /// TunnelOptions holds optional settings for tunnels, that are to be applied to any tunnel of the
 /// appropriate type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TunnelOptions {
     /// openvpn holds OpenVPN specific tunnel options.
@@ -184,10 +184,26 @@ impl Default for TunnelOptions {
 /// OpenVpnTunnelOptions contains options for an openvpn tunnel that should be applied irrespective
 /// of the relay parameters - i.e. have nothing to do with the particular OpenVPN server, but do
 /// affect the connection.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct OpenVpnTunnelOptions {
     /// Optional argument for openvpn to try and limit TCP packet size,
     /// as discussed [here](https://openvpn.net/archive/openvpn-users/2003-11/msg00154.html)
     pub mssfix: Option<u16>,
+    /// Bridge settings, for when the relay connection should be via a bridge.
+    pub bridge_settings: Option<OpenVpnBridgeSettings>,
+}
+
+
+/// Represents a bridge endpoint. Address, plus extra parameters specific to bridge protocol.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct OpenVpnBridgeSettings {
+    pub bridge: SocketAddr,
+    pub auth: Option<OpenVpnBridgeAuth>
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct OpenVpnBridgeAuth {
+    pub username: String,
+    pub password: String,
 }


### PR DESCRIPTION
Is this an appropriate way of modelling the bridge settings? The design is copied from `TunnelEndpoint`. Another simpler way would be to create a struct that has a `SocketAddr` and optional username and password.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/513)
<!-- Reviewable:end -->
