### PR TITLE
Ignore errors when forwarding tunnel events

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -1,13 +1,11 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use error_chain::ChainedError;
-use futures::sink::Wait;
 use futures::sync::{mpsc, oneshot};
-use futures::{Async, Future, Sink, Stream};
+use futures::{Async, Future, Stream};
 
 use talpid_types::net::{TunnelEndpoint, TunnelEndpointData};
 use talpid_types::tunnel::BlockReason;
@@ -72,8 +70,7 @@ impl ConnectingState {
         resource_dir: &Path,
     ) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::unbounded();
-        let monitor =
-            Self::spawn_tunnel_monitor(&parameters, log_dir, resource_dir, event_tx.wait())?;
+        let monitor = Self::spawn_tunnel_monitor(&parameters, log_dir, resource_dir, event_tx)?;
         let close_handle = monitor.close_handle();
         let tunnel_close_event = Self::spawn_tunnel_monitor_wait_thread(monitor);
 
@@ -89,14 +86,10 @@ impl ConnectingState {
         parameters: &TunnelParameters,
         log_dir: &Option<PathBuf>,
         resource_dir: &Path,
-        events: Wait<mpsc::UnboundedSender<TunnelEvent>>,
+        events: mpsc::UnboundedSender<TunnelEvent>,
     ) -> Result<TunnelMonitor> {
-        let event_tx = Mutex::new(events);
         let on_tunnel_event = move |event| {
-            let send_result = event_tx
-                .lock()
-                .expect("A thread panicked while sending a tunnel event")
-                .send(event);
+            let send_result = events.unbounded_send(event);
 
             if send_result.is_err() {
                 warn!("Tunnel state machine stopped before tunnel event was received");

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -89,11 +89,7 @@ impl ConnectingState {
         events: mpsc::UnboundedSender<TunnelEvent>,
     ) -> Result<TunnelMonitor> {
         let on_tunnel_event = move |event| {
-            let send_result = events.unbounded_send(event);
-
-            if send_result.is_err() {
-                warn!("Tunnel state machine stopped before tunnel event was received");
-            }
+            let _ = events.unbounded_send(event);
         };
         let log_file = Self::prepare_tunnel_log_file(&parameters, log_dir)?;
 


### PR DESCRIPTION
Previously the daemon would log a warning saying Tunnel state machine stopped before tunnel event was received when disconnecting. This was because when the daemon leaves the connected state, the receiving end of the tunnel event channel is dropped, so no further events can be sent. However, before the OpenVPN process is finished, it does send a final Down event, which when attempted to forward through the tunnel event channel would fail. The error handling code was assuming that the receiver would only be dropped if the tunnel state machine crashed.

This PR fixes the issue by ignoring any errors, since if the tunnel state machine does in fact unexpectedly stop, there should be enough logging elsewhere to help find the reason.

This PR also refactors the event forwarding closure so that the `Mutex` and the `Wait` sink wrapper aren't necessary anymore.

Since this is a minor change, I didn't add an entry to the change log. However, it is user visible, even if it is probably rarely or never seen by the user. Should I add a change log entry?

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/515)
<!-- Reviewable:end -->
