### PR TITLE
Reconnect to different relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,15 +23,17 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Fall back and try to connect over TCP port 443 if protocol is set to automatic and two attempts
+  with UDP fail in a row. If that also fails, alternate between UDP and TCP with random ports.
+
 ### Fixed
 - Place Mssfix setting inside scrollable area
+- Pick new random relay for each reconnect attempt instead of just retrying with the same one.
 
 #### Linux
 - The app will have it's window resized correctly when display scaling settings are changed. This
  should also fix bad window behaviour on startup.
-
-### Fixed
-#### Linux
 - Fixed systemd-resolved DNS management.
 
 

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -205,7 +205,7 @@ impl Relay {
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
         let constraints = rpc.get_settings()?.get_relay_settings();
-        println!("Current constraints: {:#?}", constraints);
+        println!("Current constraints: {}", constraints);
 
         Ok(())
     }

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -1,5 +1,7 @@
-use std::net::{IpAddr, ToSocketAddrs};
-
+use std::{
+    fmt,
+    net::{IpAddr, ToSocketAddrs},
+};
 use talpid_types::net::{TunnelEndpoint, TunnelEndpointData};
 
 error_chain!{
@@ -23,6 +25,12 @@ impl CustomTunnelEndpoint {
             address: resolve_to_ip(&self.host)?,
             tunnel: self.tunnel,
         })
+    }
+}
+
+impl fmt::Display for CustomTunnelEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} over {}", self.host, self.tunnel)
     }
 }
 

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -57,6 +57,17 @@ pub enum RelaySettings {
     Normal(RelayConstraints),
 }
 
+impl fmt::Display for RelaySettings {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            RelaySettings::CustomTunnelEndpoint(endpoint) => {
+                write!(f, "custom endpoint {}", endpoint)
+            }
+            RelaySettings::Normal(constraints) => constraints.fmt(f),
+        }
+    }
+}
+
 impl Default for RelaySettings {
     fn default() -> Self {
         RelaySettings::Normal(RelayConstraints::default())
@@ -95,6 +106,20 @@ impl RelayConstraints {
     }
 }
 
+impl fmt::Display for RelayConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self.tunnel {
+            Constraint::Any => write!(f, "any relay")?,
+            Constraint::Only(ref tunnel_constraint) => tunnel_constraint.fmt(f)?,
+        }
+        write!(f, " in ")?;
+        match self.location {
+            Constraint::Any => write!(f, "any location"),
+            Constraint::Only(ref location_constraint) => location_constraint.fmt(f),
+        }
+    }
+}
+
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -107,6 +132,18 @@ pub enum LocationConstraint {
     Hostname(CountryCode, CityCode, Hostname),
 }
 
+impl fmt::Display for LocationConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            LocationConstraint::Country(country) => write!(f, "country {}", country),
+            LocationConstraint::City(country, city) => write!(f, "city {}, {}", city, country),
+            LocationConstraint::Hostname(country, city, hostname) => {
+                write!(f, "city {}, {}, hostname {}", city, country, hostname)
+            }
+        }
+    }
+}
+
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub enum TunnelConstraints {
@@ -114,6 +151,21 @@ pub enum TunnelConstraints {
     OpenVpn(OpenVpnConstraints),
     #[serde(rename = "wireguard")]
     Wireguard(WireguardConstraints),
+}
+
+impl fmt::Display for TunnelConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            TunnelConstraints::OpenVpn(openvpn_constraints) => {
+                write!(f, "OpenVPN over ")?;
+                openvpn_constraints.fmt(f)
+            }
+            TunnelConstraints::Wireguard(wireguard_constraints) => {
+                write!(f, "Wireguard over ")?;
+                wireguard_constraints.fmt(f)
+            }
+        }
+    }
 }
 
 impl Match<OpenVpnEndpointData> for TunnelConstraints {
@@ -140,6 +192,20 @@ pub struct OpenVpnConstraints {
     pub protocol: Constraint<TransportProtocol>,
 }
 
+impl fmt::Display for OpenVpnConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self.port {
+            Constraint::Any => write!(f, "any port")?,
+            Constraint::Only(port) => write!(f, "port {}", port)?,
+        }
+        write!(f, " over ")?;
+        match self.protocol {
+            Constraint::Any => write!(f, "any protocol"),
+            Constraint::Only(protocol) => write!(f, "{}", protocol),
+        }
+    }
+}
+
 impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
     fn matches(&self, endpoint: &OpenVpnEndpointData) -> bool {
         self.port.matches(&endpoint.port) && self.protocol.matches(&endpoint.protocol)
@@ -149,6 +215,15 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct WireguardConstraints {
     pub port: Constraint<u16>,
+}
+
+impl fmt::Display for WireguardConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self.port {
+            Constraint::Any => write!(f, "any port"),
+            Constraint::Only(port) => write!(f, "port {}", port),
+        }
+    }
 }
 
 impl Match<WireguardEndpointData> for WireguardConstraints {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -24,6 +24,13 @@ impl<T: fmt::Debug + Clone + Eq + PartialEq> Constraint<T> {
             Constraint::Only(value) => value,
         }
     }
+
+    pub fn or(self, other: Constraint<T>) -> Constraint<T> {
+        match self {
+            Constraint::Any => other,
+            Constraint::Only(value) => Constraint::Only(value),
+        }
+    }
 }
 
 impl<T: fmt::Debug + Clone + Eq + PartialEq> Default for Constraint<T> {

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -136,7 +136,7 @@ impl Settings {
         let new_settings = self.relay_settings.merge(update);
         if self.relay_settings != new_settings {
             debug!(
-                "changing relay settings from {:?} to {:?}",
+                "changing relay settings from {} to {}",
                 self.relay_settings, new_settings
             );
 

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -55,9 +55,7 @@ impl TunnelState for BlockedState {
                 Self::set_security_policy(shared_values);
                 SameState(self)
             }
-            Ok(TunnelCommand::Connect(parameters)) => {
-                NewState(ConnectingState::enter(shared_values, parameters))
-            }
+            Ok(TunnelCommand::Connect) => NewState(ConnectingState::enter(shared_values, 0)),
             Ok(TunnelCommand::Disconnect) | Err(_) => {
                 NewState(DisconnectedState::enter(shared_values, ()))
             }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -79,20 +79,14 @@ impl ConnectedState {
                     }
                 }
             }
-            Ok(TunnelCommand::Connect(parameters)) => {
-                if parameters != self.tunnel_parameters {
-                    NewState(DisconnectingState::enter(
-                        shared_values,
-                        (
-                            self.close_handle,
-                            self.tunnel_close_event,
-                            AfterDisconnect::Reconnect(parameters),
-                        ),
-                    ))
-                } else {
-                    SameState(self)
-                }
-            }
+            Ok(TunnelCommand::Connect) => NewState(DisconnectingState::enter(
+                shared_values,
+                (
+                    self.close_handle,
+                    self.tunnel_close_event,
+                    AfterDisconnect::Reconnect(0),
+                ),
+            )),
             Ok(TunnelCommand::Disconnect) | Err(_) => NewState(DisconnectingState::enter(
                 shared_values,
                 (
@@ -124,7 +118,7 @@ impl ConnectedState {
                 (
                     self.close_handle,
                     self.tunnel_close_event,
-                    AfterDisconnect::Reconnect(self.tunnel_parameters),
+                    AfterDisconnect::Reconnect(0),
                 ),
             )),
             Ok(_) => SameState(self),
@@ -144,10 +138,7 @@ impl ConnectedState {
         }
 
         info!("Tunnel closed. Reconnecting.");
-        NewState(ConnectingState::enter(
-            shared_values,
-            self.tunnel_parameters,
-        ))
+        NewState(ConnectingState::enter(shared_values, 0))
     }
 }
 

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -46,9 +46,7 @@ impl TunnelState for DisconnectedState {
                 shared_values.allow_lan = allow_lan;
                 SameState(self)
             }
-            Ok(TunnelCommand::Connect(parameters)) => {
-                NewState(ConnectingState::enter(shared_values, parameters))
-            }
+            Ok(TunnelCommand::Connect) => NewState(ConnectingState::enter(shared_values, 0)),
             Ok(TunnelCommand::Block(reason)) => {
                 NewState(BlockedState::enter(shared_values, reason))
             }

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -128,7 +128,7 @@ pub enum TunnelCommand {
     /// Enable or disable LAN access in the firewall.
     AllowLan(bool),
     /// Open tunnel connection.
-    Connect(TunnelParameters),
+    Connect,
     /// Close tunnel connection.
     Disconnect,
     /// Disconnect any open tunnel and block all network access

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -44,6 +44,7 @@ error_chain! {
 /// Spawn the tunnel state machine thread, returning a channel for sending tunnel commands.
 pub fn spawn<P, T>(
     allow_lan: bool,
+    tunnel_parameters_generator: impl TunnelParametersGenerator,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
     cache_dir: P,
@@ -59,6 +60,7 @@ where
     thread::spawn(move || {
         match create_event_loop(
             allow_lan,
+            tunnel_parameters_generator,
             log_dir,
             resource_dir,
             cache_dir,
@@ -92,6 +94,7 @@ where
 
 fn create_event_loop<T>(
     allow_lan: bool,
+    tunnel_parameters_generator: impl TunnelParametersGenerator,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
     cache_dir: impl AsRef<Path>,
@@ -102,8 +105,14 @@ where
     T: From<TunnelStateTransition> + Send + 'static,
 {
     let reactor = Core::new().chain_err(|| ErrorKind::ReactorError)?;
-    let state_machine =
-        TunnelStateMachine::new(allow_lan, log_dir, resource_dir, cache_dir, commands)?;
+    let state_machine = TunnelStateMachine::new(
+        allow_lan,
+        tunnel_parameters_generator,
+        log_dir,
+        resource_dir,
+        cache_dir,
+        commands,
+    )?;
 
     let future = state_machine.for_each(move |state_change_event| {
         state_change_listener
@@ -152,6 +161,7 @@ struct TunnelStateMachine {
 impl TunnelStateMachine {
     fn new(
         allow_lan: bool,
+        tunnel_parameters_generator: impl TunnelParametersGenerator,
         log_dir: Option<PathBuf>,
         resource_dir: PathBuf,
         cache_dir: impl AsRef<Path>,
@@ -162,6 +172,7 @@ impl TunnelStateMachine {
         let mut shared_values = SharedTunnelStateValues {
             security,
             allow_lan,
+            tunnel_parameters_generator: Box::new(tunnel_parameters_generator),
             log_dir,
             resource_dir,
         };
@@ -225,12 +236,21 @@ impl<T: TunnelState> From<EventConsequence<T>> for TunnelStateMachineAction {
     }
 }
 
+/// Trait for any type that can provide a stream of `TunnelParameters` to the `TunnelStateMachine`.
+pub trait TunnelParametersGenerator: Send + 'static {
+    /// Given the number of consecutive failed retry attempts, it should yield a `TunnelParameters`
+    /// to establish a tunnel with.
+    /// If this returns `None` then the state machine goes into the `Blocked` state.
+    fn generate(&mut self, retry_attempt: u32) -> Option<TunnelParameters>;
+}
 
 /// Values that are common to all tunnel states.
 struct SharedTunnelStateValues {
     security: NetworkSecurity,
     /// Should LAN access be allowed outside the tunnel.
     allow_lan: bool,
+    /// The generator of new `TunnelParameter`s
+    tunnel_parameters_generator: Box<dyn TunnelParametersGenerator>,
     /// Directory to store tunnel log file.
     log_dir: Option<PathBuf>,
     /// Resource directory path.

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -33,6 +33,21 @@ pub enum TunnelEndpointData {
     Wireguard(WireguardEndpointData),
 }
 
+impl fmt::Display for TunnelEndpointData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            TunnelEndpointData::OpenVpn(openvpn_data) => {
+                write!(f, "OpenVPN ")?;
+                openvpn_data.fmt(f)
+            }
+            TunnelEndpointData::Wireguard(wireguard_data) => {
+                write!(f, "Wireguard ")?;
+                wireguard_data.fmt(f)
+            }
+        }
+    }
+}
+
 impl TunnelEndpointData {
     pub fn port(self) -> u16 {
         match self {
@@ -55,9 +70,21 @@ pub struct OpenVpnEndpointData {
     pub protocol: TransportProtocol,
 }
 
+impl fmt::Display for OpenVpnEndpointData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{} port {}", self.protocol, self.port)
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct WireguardEndpointData {
     pub port: u16,
+}
+
+impl fmt::Display for WireguardEndpointData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "port {}", self.port)
+    }
 }
 
 


### PR DESCRIPTION
Main thing implemented here is the fallback to TCP if connecting to UDP fails and the protocol is set to automatic. While implementing this I realized that when we are in a reconnect loop, each new connection attempt uses the exact same relay parameteters, we never try a new relay. This is a serious bug. Since if only one server is down, anyone who get randomized for that relay will end up in an infinite loop trying to connect to just that one over and over again until they manually trigger a reconnect (and thereby randomly picks a new relay)

While doing this I could not avoid implementing `Display` for a number of types, so I could better print them. Both in the daemon log, but also in the output from the CLI.

The fallback strategy has been discussed with Richard. UDP two times, then TCP port 443 and then just try random ports alternating between protocols.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/517)
<!-- Reviewable:end -->
