### PR TITLE
Ignore `systemd-resolved` when it's running in consumer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
 - The app will have it's window resized correctly when display scaling settings are changed. This
  should also fix bad window behaviour on startup.
 - Fixed systemd-resolved DNS management.
+- Skip systemd-resolved as the DNS manager if it's running in consumer mode.
 
 
 ## [2018.4-beta2] - 2018-10-08

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -37,7 +37,7 @@ impl fmt::Display for DnsSettings {
         let name = match self {
             DnsSettings::Resolvconf(..) => "resolvconf",
             DnsSettings::StaticResolvConf(..) => "/etc/resolv.conf",
-            DnsSettings::SystemdResolved(..) => "systemd-resolve",
+            DnsSettings::SystemdResolved(..) => "systemd-resolved",
             DnsSettings::NetworkManager(..) => "network manager",
         };
         f.write_str(name)

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -1,3 +1,5 @@
+extern crate resolv_conf;
+
 mod network_manager;
 mod resolvconf;
 mod static_resolv_conf;
@@ -9,6 +11,8 @@ use self::network_manager::NetworkManager;
 use self::resolvconf::Resolvconf;
 use self::static_resolv_conf::StaticResolvConf;
 use self::systemd_resolved::SystemdResolved;
+
+const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 
 error_chain! {
     errors {

--- a/talpid-core/src/security/linux/dns/static_resolv_conf.rs
+++ b/talpid-core/src/security/linux/dns/static_resolv_conf.rs
@@ -1,5 +1,4 @@
 extern crate notify;
-extern crate resolv_conf;
 
 use std::net::IpAddr;
 use std::ops::DerefMut;
@@ -9,9 +8,9 @@ use std::{fs, io, thread};
 use error_chain::ChainedError;
 
 use self::notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use self::resolv_conf::{Config, ScopedIp};
+use super::resolv_conf::{Config, ScopedIp};
+use super::RESOLV_CONF_PATH;
 
-const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 const RESOLV_CONF_BACKUP_PATH: &str = "/etc/resolv.conf.mullvadbackup";
 
 error_chain! {

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -1,6 +1,8 @@
 extern crate dbus;
 
-use std::net::IpAddr;
+use std::fs;
+use std::net::{IpAddr, Ipv4Addr};
+use std::path::Path;
 
 use error_chain::ChainedError;
 use libc::{AF_INET, AF_INET6};
@@ -10,6 +12,7 @@ use self::dbus::stdintf::*;
 use self::dbus::{BusType, Interface, Member, MessageItem, MessageItemArray, Signature};
 
 use super::super::iface_index;
+use super::{resolv_conf, RESOLV_CONF_PATH};
 
 error_chain! {
     errors {
@@ -38,6 +41,7 @@ error_chain! {
 
 }
 
+const DYNAMIC_RESOLV_CONF_PATH: &str = "/run/systemd/resolve/resolv.conf";
 const RESOLVED_BUS: &str = "org.freedesktop.resolve1";
 const RPC_TIMEOUT_MS: i32 = 1000;
 
@@ -65,6 +69,7 @@ impl SystemdResolved {
             interface_link: None,
         };
 
+        SystemdResolved::ensure_resolved_is_active()?;
         systemd_resolved.ensure_resolved_exists()?;
 
         Ok(systemd_resolved)
@@ -77,6 +82,21 @@ impl SystemdResolved {
             .chain_err(|| ErrorKind::NoSystemdResolved)?;
 
         Ok(())
+    }
+
+    fn ensure_resolved_is_active() -> Result<()> {
+        ensure!(
+            Self::resolv_conf_is_resolved_symlink(),
+            ErrorKind::NoSystemdResolved
+        );
+
+        Ok(())
+    }
+
+    fn resolv_conf_is_resolved_symlink() -> bool {
+        fs::read_link(RESOLV_CONF_PATH)
+            .map(|resolv_conf_target| resolv_conf_target == Path::new(DYNAMIC_RESOLV_CONF_PATH))
+            .unwrap_or_else(|_| false)
     }
 
     fn as_manager_object<'a>(&'a self) -> dbus::ConnPath<'a, &'a dbus::Connection> {


### PR DESCRIPTION
In some Linux systems, `systemd-resolved` is running but isn't actively managing the system's DNS servers. In this state, the `resolved` daemon only provides resolution services. Therefore, it doesn't act as a provider of DNS servers to the system, but a consumer of DNS servers from the `/etc/resolv.conf` file.

When the `systemd-resolved` daemon is running in such mode, the Mullvad daemon can't rely on it to manage DNS. Therefore, this PR implements the same checks described in the `systemd-resolved` [manual](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html#/etc/resolv.conf) to detect if it's running in consumer mode. If so, auto detection of the DNS manager will skip the `SystemdResolved` DNS manager implementation.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/519)
<!-- Reviewable:end -->
