### PR TITLE
Set mssfix max to 1450. Adjust gui placeholder text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ Line wrap the file at 100 chars.                                              Th
   might have security issues.
 
 ### Fixed
-- Place Mssfix setting inside scrollable area
+- Place Mssfix setting inside scrollable area.
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.
+- Fix so mssfix can be unset. Previously emptying the textbox did nothing.
 
 #### Linux
 - The app will have it's window resized correctly when display scaling settings are changed. This

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -17,7 +17,7 @@ import styles from './AdvancedSettingsStyles';
 import Img from './Img';
 
 const MIN_MSSFIX_VALUE = 1000;
-const MAX_MSSFIX_VALUE = 1500;
+const MAX_MSSFIX_VALUE = 1450;
 
 type Props = {
   enableIpv6: boolean,
@@ -116,7 +116,7 @@ export class AdvancedSettings extends Component<Props, State> {
                     <Cell.Input
                       keyboardType={'numeric'}
                       maxLength={5}
-                      placeholder={'None'}
+                      placeholder={'Default'}
                       value={this.state.editedMssfix}
                       style={mssfixStyle}
                       onChangeText={this._onMssfixChange}
@@ -124,7 +124,9 @@ export class AdvancedSettings extends Component<Props, State> {
                       onBlur={this._onMssfixBlur}
                     />
                   </Cell.Container>
-                  <Cell.Footer>Change OpenVPN MSS value</Cell.Footer>
+                  <Cell.Footer>
+                    Set OpenVPN MSS value. Valid range: {MIN_MSSFIX_VALUE} - {MAX_MSSFIX_VALUE}.
+                  </Cell.Footer>
                 </NavigationScrollbars>
               </View>
             </NavigationContainer>

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -181,7 +181,7 @@ export class AdvancedSettings extends Component<Props, State> {
   _mssfixIsValid(): boolean {
     const mssfix = this.state.editedMssfix;
 
-    return mssfix >= MIN_MSSFIX_VALUE && mssfix <= MAX_MSSFIX_VALUE;
+    return mssfix === null || (mssfix >= MIN_MSSFIX_VALUE && mssfix <= MAX_MSSFIX_VALUE);
   }
 }
 


### PR DESCRIPTION
Richard notified me that the default mssfix value is 1450 and that we should probably change so we don't allow increasing from what the default is. So I adjusted `MAX_MSSFIX_VALUE` accordingly.

We also had users reporting that they did not understand what to enter into the textbox. Some tried entering "--mssfix 1300" etc. So I updated the placeholder text to show the valid range, hopefully that should be more informing?

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/520)
<!-- Reviewable:end -->
