### PR TITLE
Prefer systemd-resovled over NetworkManager

### DIFF
--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -64,9 +64,9 @@ impl DnsSettings {
     }
 
     fn with_detected_dns_manager() -> Result<Self> {
-        NetworkManager::new()
-            .map(DnsSettings::NetworkManager)
-            .or_else(|_| SystemdResolved::new().map(DnsSettings::SystemdResolved))
+        SystemdResolved::new()
+            .map(DnsSettings::SystemdResolved)
+            .or_else(|_| NetworkManager::new().map(DnsSettings::NetworkManager))
             .or_else(|_| Resolvconf::new().map(DnsSettings::Resolvconf))
             .or_else(|_| StaticResolvConf::new().map(DnsSettings::StaticResolvConf))
             .chain_err(|| ErrorKind::NoDnsSettingsManager)


### PR DESCRIPTION
This PR changes the DNS manager behaviour on Linux to prefer `systemd-resolved` over `NetworkManager`. This ensures that we properly set DNS on Ubuntu 18.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/521)
<!-- Reviewable:end -->
