### PR TITLE
Automatically reconnect tunnel on mssfix change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.
+- Fix so changing the OpenVPN mssfix setting triggers setting up a new tunnel with the new setting.
 
 
 ## [2018.4-beta3] - 2018-10-12

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -589,6 +589,8 @@ impl Daemon {
                 if settings_changed {
                     self.management_interface_broadcaster
                         .notify_settings(&self.settings);
+                    info!("Initiating tunnel restart because the OpenVPN mssfix setting changed");
+                    self.reconnect_tunnel();
                 }
             }
             Err(e) => error!("{}", e.display_chain()),


### PR DESCRIPTION
I realized that changing this setting never triggered a new tunnel. We probably want that. So it behaves just like the other settings when they change.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/523)
<!-- Reviewable:end -->
