### PR TITLE
Show extra connection details in GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Line wrap the file at 100 chars.                                              Th
   with UDP fail in a row. If that also fails, alternate between UDP and TCP with random ports.
 - Add new system and in-app notifications to inform the user when the app becomes outdated,
   unsupported or may have security issues.
+- Allow the user to view the relay in/out IP address in the GUI.
 
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.

--- a/gui/packages/components/src/ConnectionInfo.tsx
+++ b/gui/packages/components/src/ConnectionInfo.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { Component, Styles, Text, View } from 'reactxp';
+import { default as Accordion } from './Accordion';
+
+const styles = {
+  toggle: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 14,
+    fontWeight: '800',
+    color: 'rgb(255, 255, 255, 0.4)',
+    paddingBottom: 2,
+  }),
+  content: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 16,
+    fontWeight: '800',
+    color: 'rgb(255, 255, 255)',
+    paddingBottom: 2,
+  }),
+};
+
+interface IInAddress {
+  ip: string;
+  port: number;
+  protocol: string;
+}
+
+interface IOutAddress {
+  ipv4: string | null;
+  ipv6: string | null;
+}
+
+interface IProps {
+  inAddress: IInAddress;
+  outAddress: IOutAddress;
+  startExpanded: boolean;
+  onToggle: (expanded: boolean) => void;
+}
+
+interface IState {
+  expanded: boolean;
+}
+
+export default class ConnectionInfo extends Component<IProps, IState> {
+  public static defaultProps = {
+    inAddress: {
+      ip: null,
+      port: null,
+      protocol: null,
+    },
+    outAddress: null,
+    startExpanded: false,
+    onToggle: (_: boolean) => {},
+  };
+
+  constructor(props: IProps) {
+    super(props);
+
+    this.state = {
+      expanded: props.startExpanded,
+    };
+  }
+
+  public render() {
+    return (
+      <View>
+        <Accordion height={this.state.expanded ? 'auto' : 0}>
+          <Text style={styles.content}>{this.inAddress()}</Text>
+          <Text style={styles.content}>{this.outAddress()}</Text>
+        </Accordion>
+        <Text style={styles.toggle} onPress={() => this.toggle()}>
+          {this.state.expanded ? 'LESS' : 'MORE'}
+        </Text>
+      </View>
+    );
+  }
+
+  private toggle() {
+    this.setState((state, props) => {
+      const expanded = !state.expanded;
+
+      props.onToggle(expanded);
+
+      return { expanded };
+    });
+  }
+
+  private inAddress() {
+    const { ip, port, protocol } = this.props.inAddress;
+
+    return (
+      'IN: ' + (ip || '<unknown>') + (port ? `:${port}` : '') + (protocol ? ` - ${protocol}` : '')
+    );
+  }
+
+  private outAddress() {
+    const { ipv4, ipv6 } = this.props.outAddress;
+
+    if (ipv4 || ipv6) {
+      return `OUT: ${ipv4}` + (ipv6 ? ` / ${ipv6}` : '');
+    } else {
+      return '';
+    }
+  }
+}

--- a/gui/packages/components/src/index.ts
+++ b/gui/packages/components/src/index.ts
@@ -1,3 +1,4 @@
 export { default as Accordion } from './Accordion';
 export { default as ClipboardLabel } from './ClipboardLabel';
+export { default as ConnectionInfo } from './ConnectionInfo';
 export { default as SecuredLabel, SecuredDisplayStyle } from './SecuredLabel';

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -229,7 +229,7 @@ export default class AppRenderer {
     if (tunnelState.state === 'disconnected' || tunnelState.state === 'blocked') {
       // switch to connecting state immediately to prevent a lag that may be caused by RPC
       // communication delay
-      actions.connection.connecting();
+      actions.connection.connecting(null);
 
       await this._daemonRpc.connectTunnel();
     }
@@ -616,11 +616,11 @@ export default class AppRenderer {
 
     switch (stateTransition.state) {
       case 'connecting':
-        actions.connection.connecting();
+        actions.connection.connecting(stateTransition.details);
         break;
 
       case 'connected':
-        actions.connection.connected();
+        actions.connection.connected(stateTransition.details);
         break;
 
       case 'disconnecting':

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -596,7 +596,7 @@ export default class AppRenderer {
   }
 
   async _updateUserLocation(tunnelState: TunnelState) {
-    if (tunnelState === 'connecting' || tunnelState === 'disconnected') {
+    if (['connected', 'connecting', 'disconnected'].includes(tunnelState)) {
       try {
         await this._fetchLocation();
       } catch (error) {

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -478,12 +478,6 @@ export default class AppRenderer {
     await this._setStartView();
 
     try {
-      await this._fetchLocation();
-    } catch (error) {
-      log.error(`Cannot fetch the location: ${error.message}`);
-    }
-
-    try {
       await this._fetchLatestVersionInfo();
     } catch (error) {
       log.error(`Cannot fetch the latest version information: ${error.message}`);

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -171,7 +171,7 @@ export default class Connect extends Component<Props> {
             relayIp={relayIp}
             relayPort={relayPort}
             relayProtocol={relayProtocol}
-            outIpv4={null}
+            outIpv4={this.props.connection.ip}
             outIpv6={null}
             onConnect={this.props.onConnect}
             onDisconnect={this.props.onDisconnect}

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -226,138 +226,154 @@ type TunnelControlProps = {
   style: Types.ViewStyleRuleSet,
 };
 
-export function TunnelControl(props: TunnelControlProps) {
-  const Location = ({ children }) => <View style={styles.status_location}>{children}</View>;
-  const City = () => <Text style={styles.status_location_text}>{props.city}</Text>;
-  const Country = () => <Text style={styles.status_location_text}>{props.country}</Text>;
-  const Hostname = () => <Text style={styles.status_hostname}>{props.hostname || ''}</Text>;
+class TunnelControl extends Component<TunnelControlProps> {
+  render() {
+    const Location = ({ children }) => <View style={styles.status_location}>{children}</View>;
+    const City = () => <Text style={styles.status_location_text}>{this.props.city}</Text>;
+    const Country = () => <Text style={styles.status_location_text}>{this.props.country}</Text>;
+    const Hostname = () => <Text style={styles.status_hostname}>{this.props.hostname || ''}</Text>;
 
-  const SwitchLocation = () => {
-    return (
+    const SwitchLocation = () => {
+      return (
+        <AppButton.TransparentButton
+          style={styles.switch_location_button}
+          onPress={this.props.onSelectLocation}>
+          <AppButton.Label>{'Switch location'}</AppButton.Label>
+        </AppButton.TransparentButton>
+      );
+    };
+
+    const SelectedLocation = () => (
       <AppButton.TransparentButton
         style={styles.switch_location_button}
-        onPress={props.onSelectLocation}>
-        <AppButton.Label>{'Switch location'}</AppButton.Label>
+        onPress={this.props.onSelectLocation}>
+        <AppButton.Label>{this.props.selectedRelayName}</AppButton.Label>
+        <Img height={12} width={7} source="icon-chevron" />
       </AppButton.TransparentButton>
     );
-  };
 
-  const SelectedLocation = () => (
-    <AppButton.TransparentButton
-      style={styles.switch_location_button}
-      onPress={props.onSelectLocation}>
-      <AppButton.Label>{props.selectedRelayName}</AppButton.Label>
-      <Img height={12} width={7} source="icon-chevron" />
-    </AppButton.TransparentButton>
-  );
+    const Connect = () => (
+      <AppButton.GreenButton onPress={this.props.onConnect}>
+        {'Secure my connection'}
+      </AppButton.GreenButton>
+    );
 
-  const Connect = () => (
-    <AppButton.GreenButton onPress={props.onConnect}>
-      {'Secure my connection'}
-    </AppButton.GreenButton>
-  );
+    const Disconnect = () => (
+      <AppButton.RedTransparentButton onPress={this.props.onDisconnect}>
+        {'Disconnect'}
+      </AppButton.RedTransparentButton>
+    );
 
-  const Disconnect = () => (
-    <AppButton.RedTransparentButton onPress={props.onDisconnect}>
-      {'Disconnect'}
-    </AppButton.RedTransparentButton>
-  );
+    const Cancel = () => (
+      <AppButton.RedTransparentButton onPress={this.props.onDisconnect}>
+        {'Cancel'}
+      </AppButton.RedTransparentButton>
+    );
 
-  const Cancel = () => (
-    <AppButton.RedTransparentButton onPress={props.onDisconnect}>
-      {'Cancel'}
-    </AppButton.RedTransparentButton>
-  );
+    const Secured = ({ displayStyle }) => (
+      <SecuredLabel style={styles.status_security} displayStyle={displayStyle} />
+    );
+    const Footer = ({ children }) => <View style={styles.footer}>{children}</View>;
 
-  const Secured = ({ displayStyle }) => (
-    <SecuredLabel style={styles.status_security} displayStyle={displayStyle} />
-  );
-  const Wrapper = ({ children }) => <View style={props.style}>{children}</View>;
-  const Body = ({ children }) => <View style={styles.body}>{children}</View>;
-  const Footer = ({ children }) => <View style={styles.footer}>{children}</View>;
+    switch (this.props.tunnelState) {
+      case 'connecting':
+        return (
+          <Wrapper>
+            <Body>
+              <Secured displayStyle={SecuredDisplayStyle.securing} />
+              <Location>
+                <City />
+                <Country />
+              </Location>
+              <Hostname />
+            </Body>
+            <Footer>
+              <SwitchLocation />
+              <Cancel />
+            </Footer>
+          </Wrapper>
+        );
+      case 'connected':
+        return (
+          <Wrapper>
+            <Body>
+              <Secured displayStyle={SecuredDisplayStyle.secured} />
+              <Location>
+                <City />
+                <Country />
+              </Location>
+              <Hostname />
+            </Body>
+            <Footer>
+              <SwitchLocation />
+              <Disconnect />
+            </Footer>
+          </Wrapper>
+        );
 
-  switch (props.tunnelState) {
-    case 'connecting':
-      return (
-        <Wrapper>
-          <Body>
-            <Secured displayStyle={SecuredDisplayStyle.securing} />
-            <Location>
-              <City />
-              <Country />
-            </Location>
-            <Hostname />
-          </Body>
-          <Footer>
-            <SwitchLocation />
-            <Cancel />
-          </Footer>
-        </Wrapper>
-      );
-    case 'connected':
-      return (
-        <Wrapper>
-          <Body>
-            <Secured displayStyle={SecuredDisplayStyle.secured} />
-            <Location>
-              <City />
-              <Country />
-            </Location>
-            <Hostname />
-          </Body>
-          <Footer>
-            <SwitchLocation />
-            <Disconnect />
-          </Footer>
-        </Wrapper>
-      );
+      case 'blocked':
+        return (
+          <Wrapper>
+            <Body>
+              <Secured displayStyle={SecuredDisplayStyle.blocked} />
+            </Body>
+            <Footer>
+              <SwitchLocation />
+              <Cancel />
+            </Footer>
+          </Wrapper>
+        );
 
-    case 'blocked':
-      return (
-        <Wrapper>
-          <Body>
-            <Secured displayStyle={SecuredDisplayStyle.blocked} />
-          </Body>
-          <Footer>
-            <SwitchLocation />
-            <Cancel />
-          </Footer>
-        </Wrapper>
-      );
+      case 'disconnecting':
+        return (
+          <Wrapper>
+            <Body>
+              <Secured displayStyle={SecuredDisplayStyle.secured} />
+              <Location>
+                <Country />
+              </Location>
+            </Body>
+            <Footer>
+              <SelectedLocation />
+              <Connect />
+            </Footer>
+          </Wrapper>
+        );
 
-    case 'disconnecting':
-      return (
-        <Wrapper>
-          <Body>
-            <Secured displayStyle={SecuredDisplayStyle.secured} />
-            <Location>
-              <Country />
-            </Location>
-          </Body>
-          <Footer>
-            <SelectedLocation />
-            <Connect />
-          </Footer>
-        </Wrapper>
-      );
+      case 'disconnected':
+        return (
+          <Wrapper>
+            <Body>
+              <Secured displayStyle={SecuredDisplayStyle.unsecured} />
+              <Location>
+                <Country />
+              </Location>
+            </Body>
+            <Footer>
+              <SelectedLocation />
+              <Connect />
+            </Footer>
+          </Wrapper>
+        );
 
-    case 'disconnected':
-      return (
-        <Wrapper>
-          <Body>
-            <Secured displayStyle={SecuredDisplayStyle.unsecured} />
-            <Location>
-              <Country />
-            </Location>
-          </Body>
-          <Footer>
-            <SelectedLocation />
-            <Connect />
-          </Footer>
-        </Wrapper>
-      );
+      default:
+        throw new Error(`Unknown TunnelState: ${(this.props.tunnelState: empty)}`);
+    }
+  }
+}
 
-    default:
-      throw new Error(`Unknown TunnelState: ${(props.tunnelState: empty)}`);
+type ContainerProps = {
+  children?: Types.ReactNode,
+};
+
+class Wrapper extends Component<ContainerProps> {
+  render() {
+    return <View style={styles.tunnel_control}>{this.props.children}</View>;
+  }
+}
+
+class Body extends Component<ContainerProps> {
+  render() {
+    return <View style={styles.body}>{this.props.children}</View>;
   }
 }

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -136,6 +136,19 @@ export default class Connect extends Component<Props> {
   }
 
   renderMap() {
+    const tunnelState = this.props.connection.status.state;
+    const details = this.props.connection.status.details;
+
+    let relayIp = null;
+    let relayPort = null;
+    let relayProtocol = null;
+
+    if ((tunnelState === 'connecting' || tunnelState === 'connected') && details) {
+      relayIp = details.address;
+      relayPort = details.tunnel.openvpn.port;
+      relayProtocol = details.tunnel.openvpn.protocol;
+    }
+
     return (
       <View style={styles.connect}>
         <View style={styles.map}>
@@ -143,7 +156,7 @@ export default class Connect extends Component<Props> {
         </View>
         <View style={styles.container}>
           {/* show spinner when connecting */}
-          {this.props.connection.status.state === 'connecting' ? (
+          {tunnelState === 'connecting' ? (
             <View style={styles.status_icon}>
               <Img source="icon-spinner" height={60} width={60} alt="" />
             </View>
@@ -155,9 +168,9 @@ export default class Connect extends Component<Props> {
             city={this.props.connection.city}
             country={this.props.connection.country}
             hostname={this.props.connection.hostname}
-            relayIp={null}
-            relayPort={null}
-            relayProtocol={null}
+            relayIp={relayIp}
+            relayPort={relayPort}
+            relayProtocol={relayProtocol}
             outIpv4={null}
             outIpv6={null}
             onConnect={this.props.onConnect}

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -3,7 +3,7 @@
 import moment from 'moment';
 import * as React from 'react';
 import { Component, Text, View, Types } from 'reactxp';
-import { SecuredLabel, SecuredDisplayStyle } from '@mullvad/components';
+import { ConnectionInfo, SecuredLabel, SecuredDisplayStyle } from '@mullvad/components';
 import { Layout, Container, Header } from './Layout';
 import { SettingsBarButton, Brand } from './HeaderBar';
 import NotificationArea from './NotificationArea';
@@ -150,12 +150,16 @@ export default class Connect extends Component<Props> {
           ) : null}
 
           <TunnelControl
-            style={styles.tunnel_control}
             tunnelState={this.props.connection.status.state}
             selectedRelayName={this.props.selectedRelayName}
             city={this.props.connection.city}
             country={this.props.connection.country}
             hostname={this.props.connection.hostname}
+            relayIp={null}
+            relayPort={null}
+            relayProtocol={null}
+            outIpv4={null}
+            outIpv6={null}
             onConnect={this.props.onConnect}
             onDisconnect={this.props.onDisconnect}
             onSelectLocation={this.props.onSelectLocation}
@@ -220,13 +224,25 @@ type TunnelControlProps = {
   city: ?string,
   country: ?string,
   hostname: ?string,
+  relayIp: ?string,
+  relayPort: ?number,
+  relayProtocol: ?string,
+  outIpv4: ?string,
+  outIpv6: ?string,
   onConnect: () => void,
   onDisconnect: () => void,
   onSelectLocation: () => void,
-  style: Types.ViewStyleRuleSet,
 };
 
-class TunnelControl extends Component<TunnelControlProps> {
+type TunnelControlState = {
+  showConnectionInfo: boolean,
+};
+
+class TunnelControl extends Component<TunnelControlProps, TunnelControlState> {
+  state = {
+    showConnectionInfo: false,
+  };
+
   render() {
     const Location = ({ children }) => <View style={styles.status_location}>{children}</View>;
     const City = () => <Text style={styles.status_location_text}>{this.props.city}</Text>;
@@ -275,6 +291,22 @@ class TunnelControl extends Component<TunnelControlProps> {
     );
     const Footer = ({ children }) => <View style={styles.footer}>{children}</View>;
 
+    const connectionInfoProps = {
+      inAddress: {
+        ip: this.props.relayIp,
+        port: this.props.relayPort,
+        protocol: this.props.relayProtocol,
+      },
+      outAddress: {
+        ipv4: this.props.outIpv4,
+        ipv6: this.props.outIpv6,
+      },
+      startExpanded: this.state.showConnectionInfo,
+      onToggle: (expanded) => {
+        this.setState({ showConnectionInfo: expanded });
+      },
+    };
+
     switch (this.props.tunnelState) {
       case 'connecting':
         return (
@@ -286,6 +318,7 @@ class TunnelControl extends Component<TunnelControlProps> {
                 <Country />
               </Location>
               <Hostname />
+              <ConnectionInfo {...connectionInfoProps} />
             </Body>
             <Footer>
               <SwitchLocation />
@@ -303,6 +336,7 @@ class TunnelControl extends Component<TunnelControlProps> {
                 <Country />
               </Location>
               <Hostname />
+              <ConnectionInfo {...connectionInfoProps} />
             </Body>
             <Footer>
               <SwitchLocation />

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -25,6 +25,7 @@ export type AccountData = { expiry: string };
 export type AccountToken = string;
 export type Ip = string;
 export type Location = {
+  ip: ?string,
   country: string,
   city: ?string,
   latitude: number,
@@ -33,6 +34,7 @@ export type Location = {
   hostname: ?string,
 };
 const LocationSchema = object({
+  ip: maybe(string),
   country: string,
   city: maybe(string),
   latitude: number,

--- a/gui/packages/desktop/src/renderer/redux/connection/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/actions.js
@@ -1,13 +1,15 @@
 // @flow
 
-import type { AfterDisconnect, BlockReason } from '../../lib/daemon-rpc';
+import type { AfterDisconnect, BlockReason, TunnelEndpoint } from '../../lib/daemon-rpc';
 
 type ConnectingAction = {
   type: 'CONNECTING',
+  tunnelEndpoint: ?TunnelEndpoint,
 };
 
 type ConnectedAction = {
   type: 'CONNECTED',
+  tunnelEndpoint: TunnelEndpoint,
 };
 
 type DisconnectedAction = {
@@ -54,15 +56,17 @@ export type ConnectionAction =
   | OnlineAction
   | OfflineAction;
 
-function connecting(): ConnectingAction {
+function connecting(tunnelEndpoint: ?TunnelEndpoint): ConnectingAction {
   return {
     type: 'CONNECTING',
+    tunnelEndpoint,
   };
 }
 
-function connected(): ConnectedAction {
+function connected(tunnelEndpoint: TunnelEndpoint): ConnectedAction {
   return {
     type: 'CONNECTED',
+    tunnelEndpoint,
   };
 }
 

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -32,10 +32,10 @@ export default function(
       return { ...state, ...action.newLocation };
 
     case 'CONNECTING':
-      return { ...state, status: { state: 'connecting' } };
+      return { ...state, status: { state: 'connecting', details: action.tunnelEndpoint } };
 
     case 'CONNECTED':
-      return { ...state, status: { state: 'connected' } };
+      return { ...state, status: { state: 'connected', details: action.tunnelEndpoint } };
 
     case 'DISCONNECTED':
       return { ...state, status: { state: 'disconnected' } };

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -31,8 +31,9 @@ impl Command for Status {
             for new_state in rpc.new_state_subscribe()? {
                 print_state(&new_state);
 
-                if new_state == Connected || new_state == Disconnected {
-                    print_location(&mut rpc)?;
+                match new_state {
+                    Connected(_) | Disconnected => print_location(&mut rpc)?,
+                    _ => {}
                 }
             }
         }
@@ -44,8 +45,8 @@ fn print_state(state: &TunnelStateTransition) {
     print!("Tunnel status: ");
     match state {
         Blocked(reason) => println!("Blocked ({})", reason),
-        Connected => println!("Connected"),
-        Connecting => println!("Connecting..."),
+        Connected(_) => println!("Connected"),
+        Connecting(_) => println!("Connecting..."),
         Disconnected => println!("Disconnected"),
         Disconnecting(_) => println!("Disconnecting..."),
     }

--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -21,13 +21,13 @@ error_chain! {
 
 pub fn send_location_request(
     request_sender: mullvad_rpc::rest::RequestSender,
-) -> Box<Future<Item = GeoIpLocation, Error = Error>> {
+) -> impl Future<Item = GeoIpLocation, Error = Error> {
     let (response_tx, response_rx) = futures::sync::oneshot::channel();
     let request = mullvad_rpc::rest::create_get_request(URI.parse().unwrap());
-    let future = futures::Sink::send(request_sender.clone(), (request, response_tx))
+
+    futures::Sink::send(request_sender, (request, response_tx))
         .map_err(|e| Error::with_chain(e, ErrorKind::NoResponse))
         .and_then(|_| response_rx.map_err(|e| Error::with_chain(e, ErrorKind::NoResponse)))
         .and_then(|response_result| response_result.map_err(Error::from))
-        .and_then(|response| serde_json::from_slice(&response).map_err(Error::from));
-    Box::new(future)
+        .and_then(|response| serde_json::from_slice(&response).map_err(Error::from))
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -455,7 +455,7 @@ impl Daemon {
                         })
                 });
             }
-            Connecting | Connected | Disconnecting(..) => {
+            Connecting(_) | Connected(_) | Disconnecting(..) => {
                 if let Some(ref relay) = self.last_generated_relay {
                     let location = relay.location.as_ref().cloned().unwrap();
                     let hostname = relay.hostname.clone();

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 pub type CountryCode = String;
 pub type CityCode = String;
 pub type Hostname = String;
@@ -14,6 +16,7 @@ pub struct Location {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GeoIpLocation {
+    pub ip: Option<IpAddr>,
     pub country: String,
     pub city: Option<String>,
     pub latitude: f64,

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -149,12 +149,13 @@ impl TunnelState for ConnectedState {
         shared_values: &mut SharedTunnelStateValues,
         bootstrap: Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
+        let tunnel_endpoint = bootstrap.tunnel_parameters.endpoint;
         let connected_state = ConnectedState::from(bootstrap);
 
         match connected_state.set_security_policy(shared_values) {
             Ok(()) => (
                 TunnelStateWrapper::from(connected_state),
-                TunnelStateTransition::Connected,
+                TunnelStateTransition::Connected(tunnel_endpoint),
             ),
             Err(error) => {
                 error!("{}", error.display_chain());

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -283,9 +283,9 @@ impl TunnelState for ConnectingState {
         {
             None => BlockedState::enter(shared_values, BlockReason::NoMatchingRelay),
             Some(tunnel_parameters) => {
-                if let Err(error) =
-                    Self::set_security_policy(shared_values, tunnel_parameters.endpoint)
-                {
+                let tunnel_endpoint = tunnel_parameters.endpoint;
+
+                if let Err(error) = Self::set_security_policy(shared_values, tunnel_endpoint) {
                     error!("{}", error.display_chain());
                     BlockedState::enter(shared_values, BlockReason::StartTunnelError)
                 } else {
@@ -297,7 +297,7 @@ impl TunnelState for ConnectingState {
                     ) {
                         Ok(connecting_state) => (
                             TunnelStateWrapper::from(connecting_state),
-                            TunnelStateTransition::Connecting,
+                            TunnelStateTransition::Connecting(tunnel_endpoint),
                         ),
                         Err(error) => {
                             let block_reason = match *error.kind() {

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -4,7 +4,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
 /// Represents one tunnel endpoint. Address, plus extra parameters specific to tunnel protocol.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct TunnelEndpoint {
     pub address: IpAddr,
     pub tunnel: TunnelEndpointData,

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use super::net::TunnelEndpoint;
+
 /// Event resulting from a transition to a new tunnel state.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -8,9 +8,9 @@ pub enum TunnelStateTransition {
     /// No connection is established and network is unsecured.
     Disconnected,
     /// Network is secured but tunnel is still connecting.
-    Connecting,
+    Connecting(TunnelEndpoint),
     /// Tunnel is connected.
-    Connected,
+    Connected(TunnelEndpoint),
     /// Disconnecting tunnel.
     Disconnecting(ActionAfterDisconnect),
     /// Tunnel is disconnected but secured by blocking all connections.


### PR DESCRIPTION
The connect screen would previously show the IP address of the relay. That was replaced with the relay hostname because it has a higher chance of being useful to the user. However, there are cases where the IP address can be useful. This PR adds a small `MORE` button below the hostname that expands to show the relay IN address and its OUT address (once connected).

The IN address is obtained via the `TunnelStateTransition`, which now contains the `TunnelEndpoint` information for both the `Connected` and the `Connecting` states. The OUT address is obtained by calling `am.i.mullvad.net` using the `get_current_location` RPC call. That call was refactored to include the optional out-going IP address of the release.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/527)
<!-- Reviewable:end -->
