### PR TITLE
Upgrade to Electron 3.0.4

### DIFF
--- a/gui/packages/desktop/package.json
+++ b/gui/packages/desktop/package.json
@@ -49,7 +49,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "cross-env": "^5.1.3",
-    "electron": "^3.0.0",
+    "electron": "^3.0.4",
     "electron-builder": "^20.28",
     "electron-devtools-installer": "^2.2.1",
     "electron-mocha": "^6.0.4",

--- a/gui/packages/desktop/src/renderer/components/SettingsHeader.js
+++ b/gui/packages/desktop/src/renderer/components/SettingsHeader.js
@@ -15,9 +15,6 @@ const styles = {
       paddingLeft: 24,
       paddingBottom: 24,
     }),
-    linux: Styles.createViewStyle({
-      WebkitAppRegion: 'drag',
-    }),
   },
   title: Styles.createTextStyle({
     fontFamily: 'DINPro',
@@ -40,11 +37,7 @@ const styles = {
 
 export default class SettingsHeader extends Component {
   render() {
-    return (
-      <View style={[styles.header.default, styles.header[process.platform], this.props.style]}>
-        {this.props.children}
-      </View>
-    );
+    return <View style={[styles.header.default, this.props.style]}>{this.props.children}</View>;
   }
 }
 

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -3403,10 +3403,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.0.0.tgz#d41e671b1057aee12021c63a5db242075d6dc685"
-  integrity sha512-QN9X5vYa4kzJKniwhXlJwioX9qw2fDehdqxN/00KCLz/qnOz/IHLAHGikFjRwfEF2xnkmHxf61F8wn2LePPXXQ==
+electron@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.0.4.tgz#9b45a0171ac424d4c134721c9cf2a891b99e80f2"
+  integrity sha512-GuZ4xCmV8wNNfkUAOdmOmgkYYaTQj5LATzc2i/b3MGhoXghnjECCgxo5yW+G2BeKM+R30cg69KA03tRzmIFxxQ==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^4.1.0"


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Despite the anticipated fix for the auto-start feature, it's still broken in Electron 3.0.4 and I hope that 3.0.5 will include it given that the patch has already landed in their master.

This PR simply bumps Electron to 3.0.4 because 3.0.0 had broken hotkeys in dev tools and it totally breaks my ability to copy/paste in console and debug our app :/

I haven't noticed any other changes.

Also this PR fixes the bug related to not being able to hit the back button in settings when the content is scrolled up because the heading title had `WebkitAppRegion` set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/534)
<!-- Reviewable:end -->
