### PR TITLE
Fix various warnings emitted by the Clippy linter

### DIFF
--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -85,9 +85,9 @@ impl AccountHistory {
     }
 
     /// Remove account token from the account history
-    pub fn remove_account_token(&mut self, account_token: AccountToken) -> Result<()> {
+    pub fn remove_account_token(&mut self, account_token: &AccountToken) -> Result<()> {
         self.accounts
-            .retain(|existing_token| existing_token != &account_token);
+            .retain(|existing_token| existing_token != account_token);
         self.save()
     }
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -53,7 +53,7 @@ fn main() {
     let exit_code = match run() {
         Ok(_) => 0,
         Err(error) => {
-            if let &ErrorKind::LogError(_) = error.kind() {
+            if let ErrorKind::LogError(_) = error.kind() {
                 eprintln!("{}", error.display_chain());
             } else {
                 error!("{}", error.display_chain());
@@ -89,11 +89,11 @@ fn run() -> Result<()> {
         info!("Logging to {}", log_dir.display());
     }
 
-    run_platform(config)
+    run_platform(&config)
 }
 
 #[cfg(windows)]
-fn run_platform(config: cli::Config) -> Result<()> {
+fn run_platform(config: &cli::Config) -> Result<()> {
     if config.run_as_service {
         system_service::run()
     } else {
@@ -111,11 +111,11 @@ fn run_platform(config: cli::Config) -> Result<()> {
 }
 
 #[cfg(not(windows))]
-fn run_platform(config: cli::Config) -> Result<()> {
+fn run_platform(config: &cli::Config) -> Result<()> {
     run_standalone(config)
 }
 
-fn run_standalone(config: cli::Config) -> Result<()> {
+fn run_standalone(config: &cli::Config) -> Result<()> {
     if !running_as_admin() {
         warn!("Running daemon as a non-administrator user, clients might refuse to connect");
     }
@@ -133,7 +133,7 @@ fn run_standalone(config: cli::Config) -> Result<()> {
     Ok(())
 }
 
-fn create_daemon(config: cli::Config) -> Result<Daemon> {
+fn create_daemon(config: &cli::Config) -> Result<Daemon> {
     let log_dir = if config.log_to_file {
         Some(mullvad_paths::log_dir().chain_err(|| "Unable to get log directory")?)
     } else {
@@ -142,7 +142,7 @@ fn create_daemon(config: cli::Config) -> Result<Daemon> {
     let resource_dir = mullvad_paths::get_resource_dir();
     let cache_dir = mullvad_paths::cache_dir().chain_err(|| "Unable to get cache dir")?;
 
-    Daemon::new(
+    Daemon::start(
         log_dir,
         resource_dir,
         cache_dir,

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -368,7 +368,7 @@ impl RelaySelector {
         self.rng
             .choose(&tunnels.openvpn)
             .cloned()
-            .map(|openvpn_endpoint| TunnelEndpointData::OpenVpn(openvpn_endpoint))
+            .map(TunnelEndpointData::OpenVpn)
     }
 
     /// Try to read the relays, first from cache and if that fails from the resources.

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -67,7 +67,7 @@ fn run_service() -> Result<()> {
         .unwrap();
 
     let config = cli::get_config();
-    let result = ::create_daemon(config).and_then(|daemon| {
+    let result = ::create_daemon(&config).and_then(|daemon| {
         let shutdown_handle = daemon.shutdown_handle();
 
         // Register monitor that translates `ServiceControl` to Daemon events

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -105,7 +105,7 @@ pub fn new_standalone_transport<
 
     rx.wait()
         .chain_err(|| ErrorKind::TransportError)?
-        .map(|client_handle| DaemonRpcClient::new(client_handle))
+        .map(DaemonRpcClient::new)
 }
 
 fn spawn_transport<F: Send + FnOnce(String) -> Result<T>, T: jsonrpc_client_core::Transport>(

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -46,7 +46,7 @@ const REPORT_MAX_SIZE: usize = (5 * LOG_MAX_READ_BYTES) + EXTRA_BYTES;
 
 
 /// Field delimeter in generated problem report
-const LOG_DELIMITER: &'static str = "====================";
+const LOG_DELIMITER: &str = "====================";
 
 /// Line separator character sequence
 #[cfg(not(windows))]

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -59,7 +59,7 @@ fn create_request_processing_future<CC: hyper::client::Connect>(
             .and_then(|response: hyper::Response| response.body().concat2().from_err())
             .map(|response_chunk| response_chunk.to_vec())
             .then(move |response_result| {
-                if let Err(_) = response_tx.send(response_result) {
+                if response_tx.send(response_result).is_err() {
                     warn!("Unable to send response back to caller");
                 }
                 Ok(())

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -191,7 +191,7 @@ impl Settings {
         }
     }
 
-    pub fn get_tunnel_options(&self) -> &TunnelOptions {
-        &self.tunnel_options
+    pub fn get_tunnel_options(&self) -> TunnelOptions {
+        self.tunnel_options
     }
 }

--- a/talpid-core/src/security/linux/dns/network_manager.rs
+++ b/talpid-core/src/security/linux/dns/network_manager.rs
@@ -46,7 +46,7 @@ impl NetworkManager {
         Ok(())
     }
 
-    fn as_manager<'a>(&'a self) -> dbus::ConnPath<'a, &'a dbus::Connection> {
+    fn as_manager(&self) -> dbus::ConnPath<&dbus::Connection> {
         self.dbus_connection
             .with_path(NM_BUS, NM_OBJECT_PATH, RPC_TIMEOUT_MS)
     }

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -50,12 +50,12 @@ const RPC_TIMEOUT_MS: i32 = 1000;
 
 lazy_static! {
     static ref LINK_INTERFACE: Interface<'static> =
-        Interface::from_slice("org.freedesktop.resolve1.Link".as_bytes()).unwrap();
+        Interface::from_slice(b"org.freedesktop.resolve1.Link").unwrap();
     static ref MANAGER_INTERFACE: Interface<'static> =
-        Interface::from_slice("org.freedesktop.resolve1.Manager".as_bytes()).unwrap();
-    static ref GET_LINK_METHOD: Member<'static> = Member::from_slice("GetLink".as_bytes()).unwrap();
-    static ref SET_DNS_METHOD: Member<'static> = Member::from_slice("SetDNS".as_bytes()).unwrap();
-    static ref REVERT_METHOD: Member<'static> = Member::from_slice("Revert".as_bytes()).unwrap();
+        Interface::from_slice(b"org.freedesktop.resolve1.Manager").unwrap();
+    static ref GET_LINK_METHOD: Member<'static> = Member::from_slice(b"GetLink").unwrap();
+    static ref SET_DNS_METHOD: Member<'static> = Member::from_slice(b"SetDNS").unwrap();
+    static ref REVERT_METHOD: Member<'static> = Member::from_slice(b"Revert").unwrap();
 }
 
 pub struct SystemdResolved {
@@ -116,7 +116,7 @@ impl SystemdResolved {
             .any(|nameserver| nameserver == resolved_dns_server))
     }
 
-    fn as_manager_object<'a>(&'a self) -> dbus::ConnPath<'a, &'a dbus::Connection> {
+    fn as_manager_object(&self) -> dbus::ConnPath<&dbus::Connection> {
         self.dbus_connection
             .with_path(RESOLVED_BUS, "/org/freedesktop/resolve1", RPC_TIMEOUT_MS)
     }

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -102,10 +102,10 @@ impl TunnelEvent {
     /// Converts an `OpenVpnPluginEvent` to a `TunnelEvent`.
     /// Returns `None` if there is no corresponding `TunnelEvent`.
     fn from_openvpn_event(
-        event: &OpenVpnPluginEvent,
+        event: OpenVpnPluginEvent,
         env: &HashMap<String, String>,
     ) -> Option<TunnelEvent> {
-        match *event {
+        match event {
             OpenVpnPluginEvent::AuthFailed => {
                 let reason = env.get("auth_failed_reason").cloned();
                 Some(TunnelEvent::AuthFailed(reason))
@@ -148,7 +148,7 @@ pub struct TunnelMonitor {
 impl TunnelMonitor {
     /// Creates a new `TunnelMonitor` that connects to the given remote and notifies `on_event`
     /// on tunnel state changes.
-    pub fn new<L>(
+    pub fn start<L>(
         tunnel_endpoint: TunnelEndpoint,
         tunnel_options: &TunnelOptions,
         tunnel_alias: Option<OsString>,
@@ -180,13 +180,13 @@ impl TunnelMonitor {
                 // The user-pass file has been read. Try to delete it early.
                 let _ = fs::remove_file(&user_pass_file_path);
             }
-            match TunnelEvent::from_openvpn_event(&event, &env) {
+            match TunnelEvent::from_openvpn_event(event, &env) {
                 Some(tunnel_event) => on_event(tunnel_event),
                 None => debug!("Ignoring OpenVpnEvent {:?}", event),
             }
         };
 
-        let monitor = openvpn::OpenVpnMonitor::new(
+        let monitor = openvpn::OpenVpnMonitor::start(
             cmd,
             on_openvpn_event,
             Self::get_plugin_path(resource_dir)?,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -96,7 +96,7 @@ impl ConnectingState {
         };
         let log_file = Self::prepare_tunnel_log_file(&parameters, log_dir)?;
 
-        Ok(TunnelMonitor::new(
+        Ok(TunnelMonitor::start(
             parameters.endpoint,
             &parameters.options,
             TUNNEL_INTERFACE_ALIAS.to_owned().map(OsString::from),

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -76,7 +76,7 @@ fn create_server() -> (talpid_ipc::IpcServer, mpsc::Receiver<i64>) {
     } else {
         format!("/tmp/ipc-test-{}", uuid)
     };
-    let server = talpid_ipc::IpcServer::start(io.into(), ipc_path).unwrap();
+    let server = talpid_ipc::IpcServer::start(io.into(), &ipc_path).unwrap();
     (server, rx)
 }
 
@@ -93,6 +93,5 @@ fn create_client(ipc_path: String) -> jsonrpc_client_core::ClientHandle {
         client.wait().unwrap();
     });
 
-    let handle = rx.wait().expect("Failed to construct a valid client");
-    handle
+    rx.wait().expect("Failed to construct a valid client")
 }


### PR DESCRIPTION
Clippy suddenly just started working inside my IDE. Thus I became a lot more aware of the warnings it emitted. So I set out to correct a few of them.

Nothing big really. Just trying to adapt to best practices in a few more places.

If you want to see why something was changed / what clippy warned about. I would recommend you run Clippy yourself on the codebase. But most changes are arguments taken by ownership in functions that don't need to actually consume them, just borrow them. So a lot of extra `&` in order to take and pass references instead. In some places it's the other way around. Types implementing `Copy` should, according to clippy, never be passed by reference, but instead by value, so there I remove a few `&` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/546)
<!-- Reviewable:end -->
