### PR TITLE
Make problem report work without dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.
 - Disable GPU acceleration on Linux to fix App on Ubuntu 14.04 and other older distributions.
+- Make the `problem-report` tool fall back to the bundled API IP if DNS resolution fails.
 
 #### macOS
 - Correctly backup and restore search domains and other DNS settings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,7 @@ version = "2018.4.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-paths 0.1.0",

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "2.25"
 dirs = "1.0"
+env_logger = "0.5"
 error-chain = "0.12"
 lazy_static = "1.0"
 regex = "1.0"

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -161,11 +161,11 @@ fn run() -> Result<()> {
     if let Some(collect_matches) = matches.subcommand_matches("collect") {
         let redact_custom_strings = collect_matches
             .values_of_lossy("redact")
-            .unwrap_or(Vec::new());
+            .unwrap_or_else(Vec::new);
         let extra_logs = collect_matches
             .values_of_os("extra_logs")
             .map(|os_values| os_values.map(Path::new).collect())
-            .unwrap_or(Vec::new());
+            .unwrap_or_else(Vec::new);
         let output_path = Path::new(collect_matches.value_of_os("output").unwrap());
         collect_report(&extra_logs, output_path, redact_custom_strings)
     } else if let Some(send_matches) = matches.subcommand_matches("send") {
@@ -209,7 +209,7 @@ fn collect_report(
 
     problem_report.add_logs(extra_logs);
 
-    write_problem_report(&output_path, problem_report)
+    write_problem_report(&output_path, &problem_report)
         .chain_err(|| ErrorKind::WriteReportError(output_path.to_path_buf()))
 }
 
@@ -267,7 +267,7 @@ fn send_problem_report(user_email: &str, user_message: &str, report_path: &Path)
         .chain_err(|| ErrorKind::RpcError)
 }
 
-fn write_problem_report(path: &Path, problem_report: ProblemReport) -> io::Result<()> {
+fn write_problem_report(path: &Path, problem_report: &ProblemReport) -> io::Result<()> {
     let file = File::create(path)?;
     let mut permissions = file.metadata()?.permissions();
     permissions.set_readonly(true);

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -11,6 +11,7 @@ extern crate clap;
 extern crate dirs;
 #[macro_use]
 extern crate error_chain;
+extern crate env_logger;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
@@ -91,6 +92,7 @@ error_chain!{
 quick_main!(run);
 
 fn run() -> Result<()> {
+    env_logger::init();
     let app = clap::App::new("problem-report")
         .version(metadata::PRODUCT_VERSION)
         .author(crate_authors!())


### PR DESCRIPTION
A serious limitation in the app was that the problem-report tool tried to send the reports directly using `https://api.mullvad.net/rpc`. So it depended on DNS working properly. A lot of users who do have issues are having issues with DNS for example. This caused them to not be able to send reports.

This fix makes the problem-report tool use the same DNS cache fallback mechanism as the daemon. Thus, if DNS resolution fails it simply uses the bundled IP instead.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/547)
<!-- Reviewable:end -->
