### PR TITLE
Linux improve nm heuristics

### DIFF
--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -97,6 +97,9 @@ impl DnsSettings {
             NetworkManager(ref mut network_manager) => network_manager.reset()?,
         }
 
+        // Resetting the DNS managemer in case the previously selected one isn't valid
+        *self = DnsSettings::new()?;
+
         Ok(())
     }
 }

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -74,6 +74,10 @@ impl DnsSettings {
 
     pub fn set_dns(&mut self, interface: &str, servers: Vec<IpAddr>) -> Result<()> {
         use self::DnsSettings::*;
+        self.reset()?;
+        // Resetting the DNS managemer in case the previously selected one isn't valid
+        *self = DnsSettings::new()?;
+
 
         match self {
             Resolvconf(ref mut resolvconf) => resolvconf.set_dns(interface, servers)?,
@@ -96,9 +100,6 @@ impl DnsSettings {
             SystemdResolved(ref mut systemd_resolved) => systemd_resolved.reset()?,
             NetworkManager(ref mut network_manager) => network_manager.reset()?,
         }
-
-        // Resetting the DNS managemer in case the previously selected one isn't valid
-        *self = DnsSettings::new()?;
 
         Ok(())
     }

--- a/talpid-core/src/security/linux/dns/network_manager.rs
+++ b/talpid-core/src/security/linux/dns/network_manager.rs
@@ -7,10 +7,22 @@ use self::dbus::arg::{RefArg, Variant};
 use self::dbus::stdintf::*;
 use self::dbus::BusType;
 
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use error_chain::ChainedError;
+
 error_chain! {
     errors {
         NoNetworkManager {
             description("NetworkManager not detected")
+        }
+        NMTooOld {
+            description("NetworkManager is too old")
+        }
+        NMNotManagingDns{
+            description("NetworkManager is not managing DNS")
         }
     }
 
@@ -21,9 +33,12 @@ error_chain! {
 
 const NM_BUS: &str = "org.freedesktop.NetworkManager";
 const NM_TOP_OBJECT: &str = "org.freedesktop.NetworkManager";
+const NM_DNS_MANAGER: &str = "org.freedesktop.NetworkManager.DnsManager";
+const NM_DNS_MANAGER_PATH: &str = "/org/freedesktop/NetworkManager/DnsManager";
 const NM_OBJECT_PATH: &str = "/org/freedesktop/NetworkManager";
 const RPC_TIMEOUT_MS: i32 = 1000;
 const GLOBAL_DNS_CONF_KEY: &str = "GlobalDnsConfiguration";
+const RC_MANAGEMENT_MODE_KEY: &str = "RcManager";
 
 pub struct NetworkManager {
     dbus_connection: dbus::Connection,
@@ -35,6 +50,7 @@ impl NetworkManager {
         let dbus_connection = dbus::Connection::get_private(BusType::System)?;
         let manager = NetworkManager { dbus_connection };
         manager.ensure_network_manager_exists()?;
+        manager.ensure_resolv_conf_is_managed()?;
         Ok(manager)
     }
 
@@ -43,6 +59,36 @@ impl NetworkManager {
             .as_manager()
             .get(&NM_TOP_OBJECT, GLOBAL_DNS_CONF_KEY)
             .chain_err(|| ErrorKind::NoNetworkManager)?;
+        Ok(())
+    }
+
+    fn ensure_resolv_conf_is_managed(&self) -> Result<()> {
+        // check if NM is set to manage resolv.conf
+        let management_mode: Result<String> = self
+            .dbus_connection
+            .with_path(NM_BUS, NM_DNS_MANAGER_PATH, RPC_TIMEOUT_MS)
+            .get(NM_DNS_MANAGER, RC_MANAGEMENT_MODE_KEY)
+            .chain_err(|| ErrorKind::NMTooOld);
+
+        match management_mode {
+            Err(e) => {
+                debug!("Failed to get NM management mode - {}", e.display_chain());
+                return Err(e);
+            }
+            Ok(management_mode) => {
+                if management_mode == "unmanaged" {
+                    return Err(Error::from(ErrorKind::NMNotManagingDns));
+                }
+            }
+        }
+
+        let expected_resolv_conf = "/var/run/NetworkManager/resolv.conf";
+        let actual_resolv_conf = "/etc/resolv.conf";
+        if !compare_files(&expected_resolv_conf, &actual_resolv_conf) {
+            debug!("/etc/resolv.conf differs from reference resolv.conf, therefore NM is not manaing DNS");
+            return Err(Error::from(ErrorKind::NMNotManagingDns));
+        }
+
         Ok(())
     }
 
@@ -107,4 +153,29 @@ fn create_empty_global_settings() -> GlobalDnsConfig {
 
 fn as_variant<T: RefArg + 'static>(t: T) -> Variant<Box<RefArg>> {
     Variant(Box::new(t) as Box<RefArg>)
+}
+
+fn compare_files<P: AsRef<Path>>(a: &P, b: &P) -> bool {
+    let file_a = match File::open(&a).map(BufReader::new) {
+        Ok(file) => file,
+        Err(e) => {
+            debug!("Failed top open file {}: {}", a.as_ref().display(), e);
+            return false;
+        }
+    };
+    let file_b = match File::open(&b).map(BufReader::new) {
+        Ok(file) => file,
+        Err(e) => {
+            debug!("Failed top open file {}: {}", b.as_ref().display(), e);
+            return false;
+        }
+    };
+
+    file_a
+        .lines()
+        .zip(file_b.lines())
+        .all(|(a, b)| match (a, b) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        })
 }


### PR DESCRIPTION
The changes here improve the tests we do to see if we can use NetworkManager to manage DNS on a given device. I've also made sure to re-check which DNS mangement method we should be using after every reset.
The extra checks added for NM verify if it's running in a mode where it can manage DNS and check whether what's written to `/etc/resolv.conf` matches what NM expects to be there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/551)
<!-- Reviewable:end -->
