### PR TITLE
No more macro use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -336,7 +336,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -467,7 +467,7 @@ dependencies = [
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -543,7 +543,7 @@ dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -556,7 +556,7 @@ dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -570,7 +570,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -606,7 +606,7 @@ version = "8.0.2"
 source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux#40344ea49836a6a0040c49c927610608bd3c4a8a"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -620,7 +620,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
  "jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-tokio-ipc 0.1.5 (git+https://github.com/nikvolf/parity-tokio-ipc)",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -643,7 +643,7 @@ version = "8.0.1"
 source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux#40344ea49836a6a0040c49c927610608bd3c4a8a"
 dependencies = [
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -668,7 +668,7 @@ dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -740,12 +740,12 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -756,7 +756,7 @@ name = "log-panics"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -827,7 +827,7 @@ name = "mio-named-pipes"
 version = "0.1.6"
 source = "git+https://github.com/alexcrichton/mio-named-pipes#2072ae0de5b3632dbb065fcd9c8be6c6a2fc39ae"
 dependencies = [
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,7 +880,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mnl-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -927,7 +927,7 @@ dependencies = [
  "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-panics 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-ipc-client 0.1.0",
  "mullvad-paths 0.1.0",
@@ -957,7 +957,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-paths 0.1.0",
  "mullvad-types 0.1.0",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -974,7 +974,7 @@ version = "0.1.0"
 dependencies = [
  "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1008,7 +1008,7 @@ dependencies = [
  "jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-http 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-types 0.1.0",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1043,7 +1043,7 @@ dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-paths 0.1.0",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1070,7 +1070,7 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nftnl-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1221,7 +1221,7 @@ source = "git+https://github.com/nikvolf/parity-tokio-ipc#306ea3e6ff8b8c1bb03081
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (git+https://github.com/alexcrichton/mio-named-pipes)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1238,7 +1238,7 @@ source = "git+https://github.com/NikVolf/parity-tokio-ipc?rev=master#306ea3e6ff8
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (git+https://github.com/alexcrichton/mio-named-pipes)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1652,7 +1652,7 @@ dependencies = [
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mnl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nftnl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1686,7 +1686,7 @@ dependencies = [
  "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
  "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1702,7 +1702,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
  "talpid-ipc 0.1.0",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1811,7 +1811,7 @@ dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1846,7 +1846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1894,7 +1894,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1929,7 +1929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1960,7 +1960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1976,7 +1976,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2086,7 +2086,7 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2262,7 +2262,7 @@ dependencies = [
 "checksum linked_hash_set 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7c91c4c7bbeb4f2f7c4e5be11e6a05bd6830bc37249c47ce1ad86ad453ff9c"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "61bd98ae7f7b754bc53dca7d44b604f733c6bba044ea6f41bc8d89272d8161d2"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum log-panics 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -1,4 +1,4 @@
-use clap;
+use clap::{self, value_t_or_exit};
 use {new_rpc_client, Command, Result};
 
 use mullvad_types::account::AccountToken;

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -1,4 +1,4 @@
-use clap;
+use clap::{self, value_t_or_exit};
 use new_rpc_client;
 use {Command, Result};
 

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -1,4 +1,4 @@
-use clap;
+use clap::{self, value_t_or_exit};
 use {new_rpc_client, Command, Result};
 
 pub struct Lan;

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -1,4 +1,4 @@
-use clap;
+use clap::{self, value_t};
 use std::str::FromStr;
 use {new_rpc_client, Command, Result, ResultExt};
 

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -6,7 +6,6 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-#[macro_use]
 extern crate clap;
 extern crate env_logger;
 extern crate futures;
@@ -20,7 +19,7 @@ extern crate talpid_types;
 
 mod cmds;
 
-
+use clap::{crate_authors, crate_description, crate_name, crate_version};
 use mullvad_ipc_client::{new_standalone_ipc_client, DaemonRpcClient};
 
 use std::alloc::System;

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -45,7 +45,7 @@ impl AccountHistory {
     pub fn load(&mut self) -> Result<()> {
         match File::open(&self.cache_path).map(io::BufReader::new) {
             Ok(mut file) => {
-                info!(
+                log::info!(
                     "Loading account history from {}",
                     &self.cache_path.display()
                 );
@@ -53,7 +53,7 @@ impl AccountHistory {
                 Ok(())
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-                info!("No account history file at {}", &self.cache_path.display());
+                log::info!("No account history file at {}", &self.cache_path.display());
                 Ok(())
             }
             Err(e) => Err(e).chain_err(|| ErrorKind::ReadError(self.cache_path.clone())),
@@ -93,7 +93,7 @@ impl AccountHistory {
 
     /// Serializes the account history and saves it to the file it was loaded from.
     fn save(&self) -> Result<()> {
-        debug!("Writing account history to {}", self.cache_path.display());
+        log::debug!("Writing account history to {}", self.cache_path.display());
         let mut file = File::create(&self.cache_path)
             .map(io::BufWriter::new)
             .chain_err(|| ErrorKind::WriteError(self.cache_path.clone()))?;

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg};
+use clap::{crate_authors, crate_description, crate_name, App, Arg};
 use log;
 
 use version;

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -19,9 +19,8 @@ extern crate serde;
 extern crate serde_json;
 
 extern crate jsonrpc_core;
-#[macro_use]
-extern crate jsonrpc_macros;
 extern crate jsonrpc_ipc_server;
+extern crate jsonrpc_macros;
 extern crate jsonrpc_pubsub;
 extern crate rand;
 extern crate tokio_core;

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -12,7 +12,6 @@ extern crate error_chain;
 extern crate futures;
 #[cfg(unix)]
 extern crate libc;
-#[macro_use]
 extern crate log;
 
 #[macro_use]
@@ -49,6 +48,7 @@ use futures::{
     sync::{mpsc::UnboundedSender, oneshot},
     Future, Sink,
 };
+use log::{debug, error, info, warn};
 use management_interface::{BoxFuture, ManagementCommand, ManagementInterfaceServer};
 use mullvad_rpc::{AccountsProxy, AppVersionProxy, HttpHandle};
 use mullvad_types::{

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -7,7 +7,6 @@
 //! the License, or (at your option) any later version.
 
 extern crate chrono;
-#[macro_use]
 extern crate clap;
 #[macro_use]
 extern crate error_chain;
@@ -21,7 +20,6 @@ extern crate mullvad_paths;
 extern crate talpid_core;
 
 #[cfg(windows)]
-#[macro_use]
 extern crate windows_service;
 
 use error_chain::ChainedError;

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -12,7 +12,6 @@ extern crate clap;
 extern crate error_chain;
 #[cfg(unix)]
 extern crate libc;
-#[macro_use]
 extern crate log;
 extern crate log_panics;
 extern crate mullvad_daemon;
@@ -23,6 +22,7 @@ extern crate talpid_core;
 extern crate windows_service;
 
 use error_chain::ChainedError;
+use log::{debug, error, info, warn};
 use mullvad_daemon::Daemon;
 use std::{thread, time::Duration};
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -245,7 +245,7 @@ pub struct EventBroadcaster {
 impl EventBroadcaster {
     /// Sends a new state update to all `new_state` subscribers of the management interface.
     pub fn notify_new_state(&self, new_state: TunnelStateTransition) {
-        debug!("Broadcasting new state to listeners: {:?}", new_state);
+        log::debug!("Broadcasting new state to listeners: {:?}", new_state);
         self.notify(&self.subscriptions.new_state_subscriptions, new_state);
     }
 
@@ -292,7 +292,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterface<T> {
             let id = SubscriptionId::String(uuid::Uuid::new_v4().to_string());
             if let Entry::Vacant(entry) = subscriptions.entry(id.clone()) {
                 if let Ok(sink) = subscriber.assign_id(id.clone()) {
-                    debug!("Accepting new subscription with id {:?}", id);
+                    log::debug!("Accepting new subscription with id {:?}", id);
                     entry.insert(sink);
                 }
                 break;
@@ -306,7 +306,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterface<T> {
     ) -> BoxFuture<(), Error> {
         let was_removed = subscriptions_lock.write().unwrap().remove(&id).is_some();
         let result = if was_removed {
-            debug!("Unsubscribing id {:?}", id);
+            log::debug!("Unsubscribing id {:?}", id);
             future::ok(())
         } else {
             future::err(Error {
@@ -361,14 +361,14 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
         _: Self::Metadata,
         account_token: AccountToken,
     ) -> BoxFuture<AccountData, Error> {
-        debug!("get_account_data");
+        log::debug!("get_account_data");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::GetAccountData(tx, account_token))
             .and_then(|_| rx.map_err(|_| Error::internal_error()))
             .and_then(|rpc_future| {
                 rpc_future.map_err(|error: mullvad_rpc::Error| {
-                    error!(
+                    log::error!(
                         "Unable to get account data from API: {}",
                         error.display_chain()
                     );
@@ -379,7 +379,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn get_relay_locations(&self, _: Self::Metadata) -> BoxFuture<RelayList, Error> {
-        debug!("get_relay_locations");
+        log::debug!("get_relay_locations");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::GetRelayLocations(tx))
@@ -392,7 +392,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
         _: Self::Metadata,
         account_token: Option<AccountToken>,
     ) -> BoxFuture<(), Error> {
-        debug!("set_account");
+        log::debug!("set_account");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::SetAccount(tx, account_token.clone()))
@@ -402,7 +402,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
             if let Err(e) = self.load_history().and_then(|mut account_history| {
                 account_history.add_account_token(new_account_token)
             }) {
-                error!(
+                log::error!(
                     "Unable to add an account into the account history: {}",
                     e.display_chain()
                 );
@@ -417,7 +417,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
         _: Self::Metadata,
         constraints_update: RelaySettingsUpdate,
     ) -> BoxFuture<(), Error> {
-        debug!("update_relay_settings");
+        log::debug!("update_relay_settings");
         let (tx, rx) = sync::oneshot::channel();
 
         let message = ManagementCommand::UpdateRelaySettings(tx, constraints_update);
@@ -428,7 +428,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn set_allow_lan(&self, _: Self::Metadata, allow_lan: bool) -> BoxFuture<(), Error> {
-        debug!("set_allow_lan({})", allow_lan);
+        log::debug!("set_allow_lan({})", allow_lan);
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::SetAllowLan(tx, allow_lan))
@@ -437,7 +437,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn set_auto_connect(&self, _: Self::Metadata, auto_connect: bool) -> BoxFuture<(), Error> {
-        debug!("set_auto_connect({})", auto_connect);
+        log::debug!("set_auto_connect({})", auto_connect);
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::SetAutoConnect(tx, auto_connect))
@@ -446,7 +446,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn connect(&self, _: Self::Metadata) -> BoxFuture<(), Error> {
-        debug!("connect");
+        log::debug!("connect");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::SetTargetState(tx, TargetState::Secured))
@@ -463,7 +463,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn disconnect(&self, _: Self::Metadata) -> BoxFuture<(), Error> {
-        debug!("disconnect");
+        log::debug!("disconnect");
         let (tx, _) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::SetTargetState(
@@ -475,7 +475,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn get_state(&self, _: Self::Metadata) -> BoxFuture<TunnelStateTransition, Error> {
-        debug!("get_state");
+        log::debug!("get_state");
         let (state_tx, state_rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::GetState(state_tx))
@@ -484,7 +484,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn get_current_location(&self, _: Self::Metadata) -> BoxFuture<GeoIpLocation, Error> {
-        debug!("get_current_location");
+        log::debug!("get_current_location");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::GetCurrentLocation(tx))
@@ -493,17 +493,17 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn shutdown(&self, _: Self::Metadata) -> BoxFuture<(), Error> {
-        debug!("shutdown");
+        log::debug!("shutdown");
         self.send_command_to_daemon(ManagementCommand::Shutdown)
     }
 
     fn get_account_history(&self, _: Self::Metadata) -> BoxFuture<Vec<AccountToken>, Error> {
-        debug!("get_account_history");
+        log::debug!("get_account_history");
         Box::new(future::result(
             self.load_history()
                 .map(|history| history.get_accounts().to_vec())
                 .map_err(|error| {
-                    error!("Unable to get account history: {}", error.display_chain());
+                    log::error!("Unable to get account history: {}", error.display_chain());
                     Error::internal_error()
                 }),
         ))
@@ -514,12 +514,12 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
         _: Self::Metadata,
         account_token: AccountToken,
     ) -> BoxFuture<(), Error> {
-        debug!("remove_account_from_history");
+        log::debug!("remove_account_from_history");
         Box::new(future::result(
             self.load_history()
                 .and_then(|mut history| history.remove_account_token(&account_token))
                 .map_err(|error| {
-                    error!(
+                    log::error!(
                         "Unable to remove account from history: {}",
                         error.display_chain()
                     );
@@ -529,7 +529,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn set_openvpn_mssfix(&self, _: Self::Metadata, mssfix: Option<u16>) -> BoxFuture<(), Error> {
-        debug!("set_openvpn_mssfix({:?})", mssfix);
+        log::debug!("set_openvpn_mssfix({:?})", mssfix);
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::SetOpenVpnMssfix(tx, mssfix))
@@ -539,7 +539,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn set_enable_ipv6(&self, _: Self::Metadata, enable_ipv6: bool) -> BoxFuture<(), Error> {
-        debug!("set_enable_ipv6({})", enable_ipv6);
+        log::debug!("set_enable_ipv6({})", enable_ipv6);
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::SetEnableIpv6(tx, enable_ipv6))
@@ -549,7 +549,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn get_settings(&self, _: Self::Metadata) -> BoxFuture<Settings, Error> {
-        debug!("get_settings");
+        log::debug!("get_settings");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::GetSettings(tx))
@@ -558,7 +558,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn get_current_version(&self, _: Self::Metadata) -> BoxFuture<String, Error> {
-        debug!("get_current_version");
+        log::debug!("get_current_version");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::GetCurrentVersion(tx))
@@ -568,14 +568,14 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
     }
 
     fn get_version_info(&self, _: Self::Metadata) -> BoxFuture<version::AppVersionInfo, Error> {
-        debug!("get_version_info");
+        log::debug!("get_version_info");
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(ManagementCommand::GetVersionInfo(tx))
             .and_then(|_| rx.map_err(|_| Error::internal_error()))
             .and_then(|version_future| {
                 version_future.map_err(|error| {
-                    error!(
+                    log::error!(
                         "Unable to get version data from API: {}",
                         error.display_chain()
                     );
@@ -591,22 +591,22 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
         _: Self::Metadata,
         subscriber: pubsub::Subscriber<TunnelStateTransition>,
     ) {
-        debug!("new_state_subscribe");
+        log::debug!("new_state_subscribe");
         Self::subscribe(subscriber, &self.subscriptions.new_state_subscriptions);
     }
 
     fn new_state_unsubscribe(&self, id: SubscriptionId) -> BoxFuture<(), Error> {
-        debug!("new_state_unsubscribe");
+        log::debug!("new_state_unsubscribe");
         Self::unsubscribe(&id, &self.subscriptions.new_state_subscriptions)
     }
 
     fn settings_subscribe(&self, _: Self::Metadata, subscriber: pubsub::Subscriber<Settings>) {
-        debug!("settings_subscribe");
+        log::debug!("settings_subscribe");
         Self::subscribe(subscriber, &self.subscriptions.settings_subscriptions);
     }
 
     fn settings_unsubscribe(&self, id: SubscriptionId) -> BoxFuture<(), Error> {
-        debug!("settings_unsubscribe");
+        log::debug!("settings_unsubscribe");
         Self::unsubscribe(&id, &self.subscriptions.settings_subscriptions)
     }
 }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -3,13 +3,12 @@ use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
 use jsonrpc_core::futures::{future, sync, Future};
 use jsonrpc_core::{Error, ErrorCode, MetaIoHandler, Metadata};
 use jsonrpc_ipc_server;
-use jsonrpc_macros::pubsub;
+use jsonrpc_macros::{build_rpc_trait, metadata, pubsub};
 use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, SubscriptionId};
+use mullvad_paths;
 use mullvad_rpc;
 use mullvad_types::account::{AccountData, AccountToken};
 use mullvad_types::location::GeoIpLocation;
-
-use mullvad_paths;
 use mullvad_types::relay_constraints::RelaySettingsUpdate;
 use mullvad_types::relay_list::RelayList;
 use mullvad_types::settings::Settings;

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -20,6 +20,7 @@ use std::sync::{mpsc, Arc, Mutex, MutexGuard};
 use std::time::{self, Duration, SystemTime};
 use std::{io, thread};
 
+use log::{debug, error, info, trace, warn};
 use rand::{self, Rng, ThreadRng};
 use tokio_timer::{TimeoutError, Timer};
 

--- a/mullvad-daemon/src/rpc_uniqueness_check.rs
+++ b/mullvad-daemon/src/rpc_uniqueness_check.rs
@@ -1,6 +1,5 @@
 use error_chain::ChainedError;
 
-use log::Level;
 use mullvad_ipc_client::new_standalone_ipc_client;
 use mullvad_paths;
 
@@ -15,10 +14,10 @@ pub fn is_another_instance_running() -> bool {
         Err(error) => {
             let msg =
                 "Failed to locate/connect to another daemon instance, assuming there isn't one";
-            if log_enabled!(Level::Trace) {
-                trace!("{}\n{}", msg, error.display_chain());
+            if log::log_enabled!(log::Level::Trace) {
+                log::trace!("{}\n{}", msg, error.display_chain());
             } else {
-                debug!("{}", msg);
+                log::debug!("{}", msg);
             }
             false
         }

--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -12,7 +12,7 @@ mod platform {
         F: Fn() + 'static + Send,
     {
         simple_signal::set_handler(&[Signal::Term, Signal::Int], move |s| {
-            debug!("Process received signal: {:?}", s);
+            log::debug!("Process received signal: {:?}", s);
             f();
         });
         Ok(())
@@ -30,7 +30,7 @@ mod platform {
         F: Fn() + 'static + Send,
     {
         ctrlc::set_handler(move || {
-            debug!("Process received Ctrl-c");
+            log::debug!("Process received Ctrl-c");
             f();
         })
         .chain_err(|| "Unable to attach ctrl-c handler")

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -31,7 +31,7 @@ pub fn run() -> Result<()> {
         .chain_err(|| "Failed to start a service dispatcher")
 }
 
-define_windows_service!(service_main, handle_service_main);
+windows_service::define_windows_service!(service_main, handle_service_main);
 
 pub fn handle_service_main(_arguments: Vec<OsString>) {
     info!("Service started.");

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -1,11 +1,14 @@
-use std::ffi::OsString;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{mpsc, Arc};
-use std::time::Duration;
-use std::{env, io, thread};
-
 use cli;
 use error_chain::ChainedError;
+use std::{
+    env,
+    ffi::OsString,
+    io,
+    sync::atomic::{AtomicUsize, Ordering},
+    sync::{mpsc, Arc},
+    thread,
+    time::Duration,
+};
 use windows_service::service::{
     ServiceAccess, ServiceControl, ServiceControlAccept, ServiceDependency, ServiceErrorControl,
     ServiceExitCode, ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
@@ -34,10 +37,10 @@ pub fn run() -> Result<()> {
 windows_service::define_windows_service!(service_main, handle_service_main);
 
 pub fn handle_service_main(_arguments: Vec<OsString>) {
-    info!("Service started.");
+    log::info!("Service started.");
     match run_service() {
-        Ok(()) => info!("Service stopped."),
-        Err(error) => error!("{}", error.display_chain()),
+        Ok(()) => log::info!("Service stopped."),
+        Err(error) => log::error!("{}", error.display_chain()),
     };
 }
 
@@ -188,9 +191,11 @@ impl PersistentServiceStatus {
             wait_hint: wait_hint,
         };
 
-        debug!(
+        log::debug!(
             "Update service status: {:?}, checkpoint: {}, wait_hint: {:?}",
-            service_status.current_state, service_status.checkpoint, service_status.wait_hint
+            service_status.current_state,
+            service_status.checkpoint,
+            service_status.wait_hint
         );
 
         self.status_handle.set_service_status(service_status)

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -1,6 +1,4 @@
-#[macro_use]
 extern crate log;
-
 #[macro_use]
 extern crate error_chain;
 
@@ -27,7 +25,6 @@ use mullvad_types::relay_constraints::{RelaySettings, RelaySettingsUpdate};
 use mullvad_types::relay_list::RelayList;
 use mullvad_types::settings::Settings;
 use mullvad_types::version::AppVersionInfo;
-
 use serde::{Deserialize, Serialize};
 use talpid_types::net::TunnelOptions;
 use talpid_types::tunnel::TunnelStateTransition;
@@ -98,7 +95,7 @@ pub fn new_standalone_transport<
                 .expect("Failed to send client handle");
 
             if let Err(e) = client.wait() {
-                error!("JSON-RPC client failed: {}", e.description());
+                log::error!("JSON-RPC client failed: {}", e.description());
             }
         }
     });
@@ -240,7 +237,7 @@ impl DaemonRpcClient {
                     if state != current_state {
                         current_state = state.clone();
                         if tx.send(state).is_err() {
-                            trace!("can't send new state to subscriber");
+                            log::trace!("can't send new state to subscriber");
                             return Err(jsonrpc_client_core::ErrorKind::Shutdown.into());
                         };
                     }

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate dirs;
 #[macro_use]
 extern crate error_chain;
-#[macro_use]
 extern crate log;
 
 use std::fs;

--- a/mullvad-paths/src/resources.rs
+++ b/mullvad-paths/src/resources.rs
@@ -17,7 +17,7 @@ fn get_default_resource_dir() -> PathBuf {
             path
         }
         Err(e) => {
-            error!(
+            log::error!(
                 "Failed finding the install directory. Using working directory: {}",
                 e
             );

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -6,13 +6,11 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-#[macro_use]
 extern crate clap;
 extern crate dirs;
 #[macro_use]
 extern crate error_chain;
 extern crate env_logger;
-#[macro_use]
 extern crate lazy_static;
 extern crate regex;
 extern crate uuid;
@@ -20,17 +18,21 @@ extern crate uuid;
 extern crate mullvad_paths;
 extern crate mullvad_rpc;
 
+use clap::crate_authors;
 use error_chain::ChainedError;
+use lazy_static::lazy_static;
 use regex::Regex;
 
-use std::alloc::System;
-use std::borrow::Cow;
-use std::cmp::min;
-use std::collections::{HashMap, HashSet};
-use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::{
+    alloc::System,
+    borrow::Cow,
+    cmp::min,
+    collections::{HashMap, HashSet},
+    ffi::OsStr,
+    fs::{self, File},
+    io::{self, BufWriter, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
 
 
 #[global_allocator]

--- a/mullvad-rpc/src/cached_dns_resolver.rs
+++ b/mullvad-rpc/src/cached_dns_resolver.rs
@@ -1,3 +1,4 @@
+use log::{debug, info, warn};
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, ToSocketAddrs};

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -15,7 +15,6 @@ extern crate hyper_openssl;
 #[macro_use]
 extern crate jsonrpc_client_core;
 extern crate jsonrpc_client_http;
-#[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
@@ -28,19 +27,19 @@ use chrono::offset::Utc;
 use chrono::DateTime;
 use jsonrpc_client_http::header::Host;
 use jsonrpc_client_http::{HttpTransport, HttpTransportBuilder};
+use lazy_static::lazy_static;
 use tokio_core::reactor::Handle;
 
 pub use jsonrpc_client_core::{Error, ErrorKind};
 pub use jsonrpc_client_http::{Error as HttpError, HttpHandle};
 
-use mullvad_types::account::AccountToken;
-use mullvad_types::relay_list::RelayList;
-use mullvad_types::version;
-
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr};
-use std::path::{Path, PathBuf};
-use std::time::Duration;
+use mullvad_types::{account::AccountToken, relay_list::RelayList, version};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr},
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 pub mod event_loop;
 pub mod rest;

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -12,7 +12,6 @@ extern crate error_chain;
 extern crate futures;
 extern crate hyper;
 extern crate hyper_openssl;
-#[macro_use]
 extern crate jsonrpc_client_core;
 extern crate jsonrpc_client_http;
 extern crate lazy_static;
@@ -24,6 +23,7 @@ extern crate mullvad_types;
 
 use chrono::offset::Utc;
 use chrono::DateTime;
+use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_client_http::header::Host;
 use jsonrpc_client_http::{HttpTransport, HttpTransportBuilder};
 use lazy_static::lazy_static;

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -16,7 +16,6 @@ extern crate hyper_openssl;
 extern crate jsonrpc_client_core;
 extern crate jsonrpc_client_http;
 extern crate lazy_static;
-#[macro_use]
 extern crate log;
 extern crate serde_json;
 extern crate tokio_core;
@@ -112,7 +111,7 @@ impl MullvadRpcFactory {
 
         let transport = create_transport(transport_builder)?;
         let api_uri = self.api_uri();
-        debug!("Using API URI {}", api_uri);
+        log::debug!("Using API URI {}", api_uri);
         let mut handle = transport.handle(&api_uri)?;
 
         handle.set_header(Host::new(API_HOST, None));

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -45,7 +45,7 @@ fn create_request_processing_future<CC: hyper::client::Connect>(
     client: Client<CC, hyper::Body>,
 ) -> Box<Future<Item = (), Error = ()>> {
     let f = request_rx.for_each(move |(request, response_tx)| {
-        trace!("Sending request to {}", request.uri());
+        log::trace!("Sending request to {}", request.uri());
         client
             .request(request)
             .from_err()
@@ -60,7 +60,7 @@ fn create_request_processing_future<CC: hyper::client::Connect>(
             .map(|response_chunk| response_chunk.to_vec())
             .then(move |response_result| {
                 if response_tx.send(response_result).is_err() {
-                    warn!("Unable to send response back to caller");
+                    log::warn!("Unable to send response back to caller");
                 }
                 Ok(())
             })

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate duct;
 extern crate jsonrpc_client_core;
 extern crate jsonrpc_client_ipc;
@@ -287,7 +286,7 @@ impl DaemonRunner {
 
         let rpc_socket_path = temp_dir.path().join("rpc_socket");
 
-        let expression = cmd!(DAEMON_EXECUTABLE_PATH, "-v", "--disable-log-to-file")
+        let expression = duct::cmd!(DAEMON_EXECUTABLE_PATH, "-v", "--disable-log-to-file")
             .dir("..")
             .env("MULLVAD_CACHE_DIR", cache_dir)
             .env("MULLVAD_RPC_SOCKET_PATH", rpc_socket_path.clone())

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -27,14 +27,14 @@ impl AuthFailedInner {
             Some(("EXPIRED_ACCOUNT", _)) => ExpiredAccount,
             Some(("TOO_MANY_CONNECTIONS", _)) => TooManyConnectons,
             Some((unknown_reason, message)) => {
-                warn!(
+                log::warn!(
                     "Received AUTH_FAILED message with unknown reason: {}",
                     input
                 );
                 Unknown(unknown_reason.to_string(), message.to_string())
             }
             None => {
-                warn!("Received invalid AUTH_FAILED message: {}", input);
+                log::warn!("Received invalid AUTH_FAILED message: {}", input);
                 Unknown("UNKNOWN".to_string(), input.to_string())
             }
         }

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use regex::Regex;
 
 #[derive(Debug)]

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -47,7 +47,7 @@ fn resolve_to_ip(host: &str) -> Result<IpAddr> {
 
     ipv4.pop()
         .or_else(|| {
-            info!("No IPv4 for host {}", host);
+            log::info!("No IPv4 for host {}", host);
             ipv6.pop()
         })
         .ok_or_else(|| ErrorKind::InvalidHost(host.to_owned()).into())

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -15,7 +15,6 @@ extern crate serde_derive;
 extern crate mullvad_paths;
 extern crate talpid_types;
 
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate error_chain;

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -17,11 +17,8 @@ extern crate talpid_types;
 
 #[macro_use]
 extern crate log;
-
 #[macro_use]
 extern crate error_chain;
-
-#[macro_use]
 extern crate lazy_static;
 
 

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -1,13 +1,13 @@
 extern crate serde_json;
 
+use log::{debug, info};
 use relay_constraints::{
     Constraint, LocationConstraint, RelayConstraints, RelaySettings, RelaySettingsUpdate,
 };
-use talpid_types::net::TunnelOptions;
-
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;
+use talpid_types::net::TunnelOptions;
 
 error_chain! {
     errors {

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -22,7 +22,6 @@ extern crate futures;
 #[cfg(unix)]
 extern crate ipnetwork;
 extern crate jsonrpc_core;
-#[macro_use]
 extern crate jsonrpc_macros;
 #[cfg(unix)]
 extern crate lazy_static;

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -11,7 +11,6 @@
 //! the License, or (at your option) any later version.
 
 extern crate atty;
-#[macro_use]
 extern crate duct;
 #[macro_use]
 extern crate log;
@@ -27,7 +26,6 @@ extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_macros;
 #[cfg(unix)]
-#[macro_use]
 extern crate lazy_static;
 extern crate libc;
 extern crate shell_escape;

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -12,7 +12,6 @@
 
 extern crate atty;
 extern crate duct;
-#[macro_use]
 extern crate log;
 
 #[macro_use]
@@ -41,10 +40,6 @@ extern crate winreg;
 extern crate openvpn_plugin;
 extern crate talpid_ipc;
 extern crate talpid_types;
-
-#[cfg(target_os = "linux")]
-#[macro_use]
-extern crate nftnl;
 
 #[cfg(windows)]
 mod winnet;

--- a/talpid-core/src/logging.rs
+++ b/talpid-core/src/logging.rs
@@ -11,7 +11,7 @@ pub fn rotate_log(file: &Path) -> Result<()> {
     let backup = file.with_extension("old.log");
     if let Err(error) = fs::rename(file, backup) {
         if error.kind() != io::ErrorKind::NotFound {
-            warn!("Failed to rotate log file ({})", error);
+            log::warn!("Failed to rotate log file ({})", error);
         }
     }
 

--- a/talpid-core/src/mktemp.rs
+++ b/talpid-core/src/mktemp.rs
@@ -33,7 +33,7 @@ impl Drop for TempFile {
     fn drop(&mut self) {
         if let Err(e) = fs::remove_file(&self.path) {
             if e.kind() != io::ErrorKind::NotFound {
-                error!(
+                log::error!(
                     "Unable to remove temp file {}: {:?}",
                     self.path.display(),
                     e

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -127,7 +127,7 @@ impl OpenVpnCommand {
 
     /// Build a runnable expression from the current state of the command.
     pub fn build(&self) -> duct::Expression {
-        debug!("Building expression: {}", &self);
+        log::debug!("Building expression: {}", &self);
         duct::cmd(&self.openvpn_bin, self.get_arguments()).unchecked()
     }
 

--- a/talpid-core/src/process/stoppable_process.rs
+++ b/talpid-core/src/process/stoppable_process.rs
@@ -1,3 +1,4 @@
+use log::{debug, trace, warn};
 use std::io;
 use std::thread;
 use std::time::{Duration, Instant};

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -59,7 +59,7 @@ impl DnsSettings {
             Some("network-manager") => DnsSettings::NetworkManager(NetworkManager::new()?),
             Some(_) | None => Self::with_detected_dns_manager()?,
         };
-        debug!("Managing DNS via {}", manager);
+        log::debug!("Managing DNS via {}", manager);
         Ok(manager)
     }
 

--- a/talpid-core/src/security/linux/dns/network_manager.rs
+++ b/talpid-core/src/security/linux/dns/network_manager.rs
@@ -72,7 +72,7 @@ impl NetworkManager {
 
         match management_mode {
             Err(e) => {
-                debug!("Failed to get NM management mode - {}", e.display_chain());
+                log::debug!("Failed to get NM management mode - {}", e.display_chain());
                 return Err(e);
             }
             Ok(management_mode) => {
@@ -85,7 +85,7 @@ impl NetworkManager {
         let expected_resolv_conf = "/var/run/NetworkManager/resolv.conf";
         let actual_resolv_conf = "/etc/resolv.conf";
         if !eq_file_content(&expected_resolv_conf, &actual_resolv_conf) {
-            debug!("/etc/resolv.conf differs from reference resolv.conf, therefore NM is not manaing DNS");
+            log::debug!("/etc/resolv.conf differs from reference resolv.conf, therefore NM is not manaing DNS");
             bail!(ErrorKind::NmNotManagingDns);
         }
 
@@ -159,14 +159,14 @@ fn eq_file_content<P: AsRef<Path>>(a: &P, b: &P) -> bool {
     let file_a = match File::open(a).map(BufReader::new) {
         Ok(file) => file,
         Err(e) => {
-            debug!("Failed top open file {}: {}", a.as_ref().display(), e);
+            log::debug!("Failed top open file {}: {}", a.as_ref().display(), e);
             return false;
         }
     };
     let file_b = match File::open(b).map(BufReader::new) {
         Ok(file) => file,
         Err(e) => {
-            debug!("Failed top open file {}: {}", b.as_ref().display(), e);
+            log::debug!("Failed top open file {}: {}", b.as_ref().display(), e);
             return false;
         }
     };

--- a/talpid-core/src/security/linux/dns/resolvconf.rs
+++ b/talpid-core/src/security/linux/dns/resolvconf.rs
@@ -69,7 +69,7 @@ impl Resolvconf {
                 .chain_err(|| ErrorKind::RunResolvconf)?;
 
             if !output.status.success() {
-                error!(
+                log::error!(
                     "Failed to delete 'resolvconf' record '{}':\n{}",
                     record_name,
                     String::from_utf8_lossy(&output.stderr)

--- a/talpid-core/src/security/linux/dns/resolvconf.rs
+++ b/talpid-core/src/security/linux/dns/resolvconf.rs
@@ -45,7 +45,7 @@ impl Resolvconf {
             record_contents.push('\n');
         }
 
-        let output = cmd!(&self.resolvconf, "-a", &record_name)
+        let output = duct::cmd!(&self.resolvconf, "-a", &record_name)
             .input(record_contents)
             .run()
             .chain_err(|| ErrorKind::RunResolvconf)?;
@@ -64,7 +64,7 @@ impl Resolvconf {
         let mut result = Ok(());
 
         for record_name in self.record_names.drain() {
-            let output = cmd!(&self.resolvconf, "-d", &record_name)
+            let output = duct::cmd!(&self.resolvconf, "-d", &record_name)
                 .run()
                 .chain_err(|| ErrorKind::RunResolvconf)?;
 

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -134,7 +134,7 @@ impl SystemdResolved {
     pub fn set_dns(&mut self, interface_name: &str, servers: &[IpAddr]) -> Result<()> {
         let link_object_path = self.fetch_link(interface_name)?;
         if let Err(e) = self.reset() {
-            debug!(
+            log::debug!(
                 "Failed to reset previous DNS settings - {}",
                 e.display_chain()
             );
@@ -192,7 +192,7 @@ impl SystemdResolved {
                     )
                 })?;
         } else {
-            trace!("No DNS settings to reset");
+            log::trace!("No DNS settings to reset");
         };
         Ok(())
     }
@@ -211,7 +211,7 @@ impl SystemdResolved {
                 .chain_err(|| ErrorKind::RevertDnsError),
             Err(error) => {
                 if error.name() == Some("org.freedesktop.DBus.Error.UnknownObject") {
-                    info!(
+                    log::info!(
                         "Not reseting DNS of interface {} because it no longer exists",
                         interface_name
                     );

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -1,11 +1,13 @@
 extern crate dbus;
 
-use std::fs;
-use std::net::{IpAddr, Ipv4Addr};
-use std::path::Path;
-
 use error_chain::ChainedError;
+use lazy_static::lazy_static;
 use libc::{AF_INET, AF_INET6};
+use std::{
+    fs,
+    net::{IpAddr, Ipv4Addr},
+    path::Path,
+};
 
 use self::dbus::arg::RefArg;
 use self::dbus::stdintf::*;

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -3,6 +3,7 @@ extern crate mnl;
 use error_chain::ChainedError;
 
 use ipnetwork::IpNetwork;
+use lazy_static::lazy_static;
 use libc;
 use nftnl::{
     self,

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -1,23 +1,26 @@
 extern crate mnl;
+extern crate nftnl;
 
 use error_chain::ChainedError;
 
+use self::nftnl::{
+    expr::{self, Verdict},
+    nft_expr, nft_expr_bitwise, nft_expr_cmp, nft_expr_ct, nft_expr_meta, nft_expr_payload, Batch,
+    Chain, FinalizedBatch, ProtoFamily, Rule, Table,
+};
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use libc;
-use nftnl::{
-    self,
-    expr::{self, Verdict},
-    Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table,
-};
 use talpid_types::net::{Endpoint, TransportProtocol};
 use tunnel;
 
-use std::env;
-use std::ffi::CString;
-use std::io;
-use std::net::{IpAddr, Ipv4Addr};
-use std::path::Path;
+use std::{
+    env,
+    ffi::CString,
+    io,
+    net::{IpAddr, Ipv4Addr},
+    path::Path,
+};
 
 use super::{NetworkSecurityT, SecurityPolicy};
 
@@ -101,7 +104,7 @@ impl NetworkSecurityT for NetworkSecurity {
 
     fn reset_policy(&mut self) -> Result<()> {
         if let Err(error) = self.dns_settings.reset() {
-            error!("Failed to reset DNS settings: {}", error.display_chain());
+            log::error!("Failed to reset DNS settings: {}", error.display_chain());
         }
 
         let table = Table::new(&self.table_name, ProtoFamily::Inet)?;
@@ -114,7 +117,7 @@ impl NetworkSecurityT for NetworkSecurity {
             batch.finalize()?
         };
 
-        debug!("Removing table and chain from netfilter");
+        log::debug!("Removing table and chain from netfilter");
         self.send_and_process(&batch)
     }
 }
@@ -134,10 +137,10 @@ impl NetworkSecurity {
         while let Some(message) = Self::socket_recv(&socket, &mut buffer[..])? {
             match mnl::cb_run(message, 2, portid).chain_err(|| ErrorKind::ProcessNetlinkError)? {
                 mnl::CbResult::Stop => {
-                    trace!("cb_run STOP");
+                    log::trace!("cb_run STOP");
                     break;
                 }
-                mnl::CbResult::Ok => trace!("cb_run OK"),
+                mnl::CbResult::Ok => log::trace!("cb_run OK"),
             }
         }
 
@@ -146,7 +149,7 @@ impl NetworkSecurity {
 
     fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> Result<Option<&'a [u8]>> {
         let ret = socket.recv(buf).chain_err(|| ErrorKind::NetlinkRecvError)?;
-        trace!("Read {} bytes from netlink", ret);
+        log::trace!("Read {} bytes from netlink", ret);
         if ret > 0 {
             Ok(Some(&buf[..ret]))
         } else {

--- a/talpid-core/src/security/macos/dns.rs
+++ b/talpid-core/src/security/macos/dns.rs
@@ -13,6 +13,7 @@ use self::system_configuration::{
     sys::schema_definitions::kSCPropNetDNSServerAddresses,
 };
 use error_chain::ChainedError;
+use log::{debug, trace};
 use std::{
     collections::HashMap,
     fmt,
@@ -108,7 +109,7 @@ impl DnsSettings {
             if let Some(string) = item.downcast::<CFString>() {
                 strings.push(string.to_string());
             } else {
-                error!("DNS server entry is not a string: {:?}", item);
+                log::error!("DNS server entry is not a string: {:?}", item);
                 return None;
             };
         }
@@ -148,7 +149,7 @@ impl DnsMonitor {
                 result_tx.send(Ok(())).unwrap();
                 run_dynamic_store_runloop(store);
                 // TODO(linus): This is critical. Improve later by sending error signal to Daemon
-                error!("Core Foundation main loop exited! It should run forever");
+                log::error!("Core Foundation main loop exited! It should run forever");
             }
             Err(e) => result_tx.send(Err(e)).unwrap(),
         });
@@ -257,7 +258,7 @@ fn dns_change_callback(
         }
         Some(ref mut state) => {
             if let Err(e) = dns_change_callback_internal(store, changed_keys, state) {
-                error!("{}", e.display_chain());
+                log::error!("{}", e.display_chain());
             }
         }
     }

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(unix)]
 use ipnetwork::{Ipv4Network, Ipv6Network};
+#[cfg(unix)]
+use lazy_static::lazy_static;
 use std::fmt;
 #[cfg(unix)]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -119,14 +119,14 @@ impl NetworkSecurity {
     /// Applies and starts enforcing the given `SecurityPolicy` Makes sure it is being kept in place
     /// until this method is called again with another policy, or until `reset_policy` is called.
     pub fn apply_policy(&mut self, policy: SecurityPolicy) -> Result<(), Error> {
-        info!("Applying security policy: {}", policy);
+        log::info!("Applying security policy: {}", policy);
         self.inner.apply_policy(policy)
     }
 
     /// Resets/removes any currently enforced `SecurityPolicy`. Returns the system to the same state
     /// it had before any policy was applied through this `NetworkSecurity` instance.
     pub fn reset_policy(&mut self) -> Result<(), Error> {
-        info!("Resetting security policy");
+        log::info!("Resetting security policy");
         self.inner.reset_policy()
     }
 }

--- a/talpid-core/src/security/windows/dns.rs
+++ b/talpid-core/src/security/windows/dns.rs
@@ -1,3 +1,4 @@
+use log::{debug, error, info, trace, warn};
 use std::borrow::Borrow;
 use std::net::IpAddr;
 use std::os::raw::{c_char, c_void};

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 use std::path::Path;
 use std::ptr;
 
+use log::{debug, error, trace};
 use talpid_types::net::Endpoint;
 use widestring::WideCString;
 

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -1,7 +1,5 @@
 use mktemp;
-
 use openvpn_plugin::types::OpenVpnPluginEvent;
-
 use process::openvpn::OpenVpnCommand;
 
 use std::collections::HashMap;
@@ -182,7 +180,7 @@ impl TunnelMonitor {
             }
             match TunnelEvent::from_openvpn_event(event, &env) {
                 Some(tunnel_event) => on_event(tunnel_event),
-                None => debug!("Ignoring OpenVpnEvent {:?}", event),
+                None => log::debug!("Ignoring OpenVpnEvent {:?}", event),
             }
         };
 
@@ -247,7 +245,7 @@ impl TunnelMonitor {
     fn get_openvpn_bin(resource_dir: &Path) -> Result<PathBuf> {
         let path = resource_dir.join(OPENVPN_BIN_FILENAME);
         if path.exists() {
-            trace!("Using OpenVPN at {}", path.display());
+            log::trace!("Using OpenVPN at {}", path.display());
             Ok(path)
         } else {
             bail!(ErrorKind::OpenVpnNotFound(path));
@@ -257,7 +255,7 @@ impl TunnelMonitor {
     fn get_plugin_path(resource_dir: &Path) -> Result<PathBuf> {
         let path = resource_dir.join(OPENVPN_PLUGIN_FILENAME);
         if path.exists() {
-            trace!("Using OpenVPN plugin at {}", path.display());
+            log::trace!("Using OpenVPN plugin at {}", path.display());
             Ok(path)
         } else {
             bail!(ErrorKind::PluginNotFound(path));
@@ -275,7 +273,7 @@ impl TunnelMonitor {
 
     fn create_user_pass_file(username: &str) -> io::Result<mktemp::TempFile> {
         let temp_file = mktemp::TempFile::new();
-        debug!(
+        log::debug!(
             "Writing user-pass credentials to {}",
             temp_file.as_ref().display()
         );
@@ -343,10 +341,10 @@ fn is_ipv6_enabled_in_os() -> bool {
         let enabled_on_tap = ::winnet::get_tap_interface_ipv6_status().unwrap_or(false);
 
         if !globally_enabled {
-            debug!("IPv6 disabled in tunnel interfaces");
+            log::debug!("IPv6 disabled in tunnel interfaces");
         }
         if !enabled_on_tap {
-            debug!("IPv6 disabled in TAP adapter");
+            log::debug!("IPv6 disabled in TAP adapter");
         }
 
         globally_enabled && enabled_on_tap

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -214,6 +214,7 @@ impl ProcessHandle for OpenVpnProcHandle {
 mod event_server {
     use super::OpenVpnPluginEvent;
     use jsonrpc_core::{Error, IoHandler, MetaIoHandler};
+    use jsonrpc_macros::build_rpc_trait;
     use std::collections::HashMap;
     use talpid_ipc;
     use uuid;

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -91,22 +91,22 @@ impl<C: OpenVpnBuilder> OpenVpnMonitor<C> {
         match self.wait_result() {
             WaitResult::Child(Ok(exit_status), closed) => {
                 if exit_status.success() || closed {
-                    debug!(
+                    log::debug!(
                         "OpenVPN exited, as expected, with exit status: {}",
                         exit_status
                     );
                     Ok(())
                 } else {
-                    error!("OpenVPN died unexpectedly with status: {}", exit_status);
+                    log::error!("OpenVPN died unexpectedly with status: {}", exit_status);
                     Err(ErrorKind::ChildProcessError("Died unexpectedly").into())
                 }
             }
             WaitResult::Child(Err(e), _) => {
-                error!("OpenVPN process wait error: {}", e);
+                log::error!("OpenVPN process wait error: {}", e);
                 Err(e).chain_err(|| ErrorKind::ChildProcessError("Error when waiting"))
             }
             WaitResult::EventDispatcher => {
-                error!("OpenVPN Event server exited unexpectedly");
+                log::error!("OpenVPN Event server exited unexpectedly");
                 Err(ErrorKind::EventDispatcherError.into())
             }
         }
@@ -258,7 +258,7 @@ mod event_server {
             event: OpenVpnPluginEvent,
             env: HashMap<String, String>,
         ) -> Result<(), Error> {
-            trace!("OpenVPN event {:?}", event);
+            log::trace!("OpenVPN event {:?}", event);
             (self.on_event)(event, env);
             Ok(())
         }

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -1,7 +1,6 @@
 use error_chain::ChainedError;
 use futures::sync::mpsc;
 use futures::Stream;
-
 use talpid_types::tunnel::BlockReason;
 
 use super::{
@@ -23,7 +22,7 @@ impl BlockedState {
             .apply_policy(policy)
             .chain_err(|| "Failed to apply security policy for blocked state")
         {
-            error!("{}", error.display_chain());
+            log::error!("{}", error.display_chain());
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -1,7 +1,6 @@
 use error_chain::ChainedError;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Stream};
-
 use talpid_types::tunnel::BlockReason;
 
 use super::{
@@ -66,7 +65,7 @@ impl ConnectedState {
                 match self.set_security_policy(shared_values) {
                     Ok(()) => SameState(self),
                     Err(error) => {
-                        error!("{}", error.display_chain());
+                        log::error!("{}", error.display_chain());
 
                         NewState(DisconnectingState::enter(
                             shared_values,
@@ -134,10 +133,10 @@ impl ConnectedState {
         match self.tunnel_close_event.poll() {
             Ok(Async::Ready(_)) => {}
             Ok(Async::NotReady) => return NoEvents(self),
-            Err(_cancelled) => warn!("Tunnel monitor thread has stopped unexpectedly"),
+            Err(_cancelled) => log::warn!("Tunnel monitor thread has stopped unexpectedly"),
         }
 
-        info!("Tunnel closed. Reconnecting.");
+        log::info!("Tunnel closed. Reconnecting.");
         NewState(ConnectingState::enter(shared_values, 0))
     }
 }
@@ -158,7 +157,7 @@ impl TunnelState for ConnectedState {
                 TunnelStateTransition::Connected(tunnel_endpoint),
             ),
             Err(error) => {
-                error!("{}", error.display_chain());
+                log::error!("{}", error.display_chain());
 
                 DisconnectingState::enter(
                     shared_values,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use error_chain::ChainedError;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Stream};
-
+use log::{debug, error, info, trace, warn};
 use talpid_types::net::{TunnelEndpoint, TunnelEndpointData};
 use talpid_types::tunnel::BlockReason;
 

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -1,11 +1,10 @@
-use error_chain::ChainedError;
-use futures::sync::mpsc;
-use futures::Stream;
-
 use super::{
     BlockedState, ConnectingState, Error, EventConsequence, SharedTunnelStateValues, TunnelCommand,
     TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
+use error_chain::ChainedError;
+use futures::sync::mpsc;
+use futures::Stream;
 
 /// No tunnel is running.
 pub struct DisconnectedState;
@@ -14,7 +13,7 @@ impl DisconnectedState {
     fn reset_security_policy(shared_values: &mut SharedTunnelStateValues) {
         if let Err(error) = shared_values.security.reset_policy() {
             let chained_error = Error::with_chain(error, "Failed to reset security policy");
-            error!("{}", chained_error.display_chain());
+            log::error!("{}", chained_error.display_chain());
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -3,7 +3,6 @@ use std::thread;
 use error_chain::ChainedError;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Stream};
-
 use talpid_types::tunnel::{ActionAfterDisconnect, BlockReason};
 
 use super::{
@@ -101,7 +100,7 @@ impl TunnelState for DisconnectingState {
                 .chain_err(|| "Failed to close the tunnel");
 
             if let Err(error) = close_result {
-                error!("{}", error.display_chain());
+                log::error!("{}", error.display_chain());
             }
         });
 

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -75,7 +75,7 @@ where
                 if let Err(error) = reactor.run(event_loop) {
                     let chained_error =
                         Error::with_chain(error, "Tunnel state machine exited with an error");
-                    error!("{}", chained_error.display_chain());
+                    log::error!("{}", chained_error.display_chain());
                 }
             }
             Err(startup_error) => {

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -23,9 +23,9 @@ pub type ErrorSink = extern "system" fn(msg: *const c_char, ctx: *mut c_void);
 pub extern "system" fn error_sink(msg: *const c_char, _ctx: *mut c_void) {
     use std::ffi::CStr;
     if msg.is_null() {
-        error!("Log message from FFI boundary is NULL");
+        log::error!("Log message from FFI boundary is NULL");
     } else {
-        error!("{}", unsafe { CStr::from_ptr(msg).to_string_lossy() });
+        log::error!("{}", unsafe { CStr::from_ptr(msg).to_string_lossy() });
     }
 }
 
@@ -51,7 +51,7 @@ pub fn ensure_top_metric_for_interface(interface_alias: &str) -> Result<bool> {
         2 => Err(Error::from(ErrorKind::MetricApplication)),
         // Unexpected value
         _ => {
-            error!("Unexpected return code from WinRoute_EnsureTopMetric");
+            log::error!("Unexpected return code from WinRoute_EnsureTopMetric");
             Err(Error::from(ErrorKind::MetricApplication))
         }
     }
@@ -80,7 +80,7 @@ pub fn get_tap_interface_ipv6_status() -> Result<bool> {
         2 => Err(Error::from(ErrorKind::GetIpv6Status)),
         // Unexpected value
         _ => {
-            error!("Unexpected return code from GetTapInterfaceIpv6Status");
+            log::error!("Unexpected return code from GetTapInterfaceIpv6Status");
             Err(Error::from(ErrorKind::GetIpv6Status))
         }
     }

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -3,7 +3,6 @@ extern crate env_logger;
 extern crate jsonrpc_client_core;
 extern crate jsonrpc_client_ipc;
 extern crate jsonrpc_core;
-#[macro_use]
 extern crate jsonrpc_macros;
 extern crate talpid_ipc;
 extern crate tokio;
@@ -17,6 +16,7 @@ use futures::Future;
 
 use jsonrpc_client_core::{Error as ClientError, Transport};
 use jsonrpc_core::{Error, IoHandler};
+use jsonrpc_macros::build_rpc_trait;
 use std::sync::{mpsc, Mutex};
 use std::time::Duration;
 

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate assert_matches;
 extern crate env_logger;
 extern crate jsonrpc_client_core;
@@ -12,6 +11,7 @@ extern crate uuid;
 
 extern crate futures;
 
+use assert_matches::assert_matches;
 use futures::sync::oneshot;
 use futures::Future;
 

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -11,9 +11,8 @@ extern crate env_logger;
 extern crate error_chain;
 extern crate log;
 
-#[macro_use]
-extern crate jsonrpc_client_core;
 extern crate futures;
+extern crate jsonrpc_client_core;
 extern crate jsonrpc_client_ipc;
 extern crate openvpn_plugin;
 extern crate tokio;

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -9,20 +9,21 @@
 extern crate env_logger;
 #[macro_use]
 extern crate error_chain;
-#[macro_use]
 extern crate log;
 
 #[macro_use]
 extern crate jsonrpc_client_core;
 extern crate futures;
 extern crate jsonrpc_client_ipc;
-#[macro_use]
 extern crate openvpn_plugin;
 extern crate tokio;
 extern crate tokio_reactor;
 
 use error_chain::ChainedError;
-use openvpn_plugin::types::{EventResult, OpenVpnPluginEvent};
+use openvpn_plugin::{
+    openvpn_plugin,
+    types::{EventResult, OpenVpnPluginEvent},
+};
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::Mutex;
@@ -77,10 +78,10 @@ fn openvpn_open(
     _env: HashMap<CString, CString>,
 ) -> Result<(Vec<OpenVpnPluginEvent>, Mutex<EventProcessor>)> {
     env_logger::init();
-    debug!("Initializing plugin");
+    log::debug!("Initializing plugin");
 
     let arguments = parse_args(&args)?;
-    info!(
+    log::info!(
         "Connecting back to talpid core at {}",
         arguments.ipc_socket_path
     );
@@ -104,7 +105,7 @@ fn parse_args(args: &[CString]) -> Result<Arguments> {
 
 
 fn openvpn_close(_handle: Mutex<EventProcessor>) {
-    info!("Unloading plugin");
+    log::info!("Unloading plugin");
 }
 
 fn openvpn_event(
@@ -113,7 +114,7 @@ fn openvpn_event(
     env: HashMap<CString, CString>,
     handle: &mut Mutex<EventProcessor>,
 ) -> Result<EventResult> {
-    debug!("Received event: {:?}", event);
+    log::debug!("Received event: {:?}", event);
 
     let parsed_env =
         openvpn_plugin::ffi::parse::env_utf8(&env).chain_err(|| ErrorKind::ParseEnvFailed)?;
@@ -126,7 +127,7 @@ fn openvpn_event(
     match result {
         Ok(()) => Ok(EventResult::Success),
         Err(e) => {
-            error!("{}", e.display_chain());
+            log::error!("{}", e.display_chain());
             Ok(EventResult::Failure)
         }
     }

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -1,16 +1,13 @@
-use openvpn_plugin;
-use std::collections::HashMap;
-
 extern crate futures;
 
-use jsonrpc_client_core::{Future, Result as ClientResult, Transport};
-use jsonrpc_client_ipc::IpcTransport;
-
-use tokio::reactor::Handle;
-use tokio::runtime::Runtime;
-
 use super::Arguments;
-use std::thread;
+use jsonrpc_client_core::{
+    expand_params, jsonrpc_client, Future, Result as ClientResult, Transport,
+};
+use jsonrpc_client_ipc::IpcTransport;
+use openvpn_plugin;
+use std::{collections::HashMap, thread};
+use tokio::{reactor::Handle, runtime::Runtime};
 
 error_chain! {
     errors {

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -34,7 +34,7 @@ pub struct EventProcessor {
 
 impl EventProcessor {
     pub fn new(arguments: Arguments) -> Result<EventProcessor> {
-        trace!("Creating EventProcessor");
+        log::trace!("Creating EventProcessor");
         let (start_tx, start_rx) = futures::sync::oneshot::channel();
         thread::spawn(move || {
             let mut rt = Runtime::new().expect("failed to spawn runtime");
@@ -68,7 +68,7 @@ impl EventProcessor {
         event: openvpn_plugin::types::OpenVpnPluginEvent,
         env: HashMap<String, String>,
     ) -> Result<()> {
-        trace!("Processing \"{:?}\" event", event);
+        log::trace!("Processing \"{:?}\" event", event);
         let call_future = self
             .ipc_client
             .openvpn_event(event, env)


### PR DESCRIPTION
So, Rust 1.30 is out and it introduces a new way to import macros. It's the way that will be the Rust 2018 way of importing macros. Currently both the old `#[macro_use]` and the new way works. But since Rust 2018 is out in six weeks and we will move there eventually I don't see any reason to not get used to it already?

This PR does not remove all occurrences of `#[macro_use]`, but many of them. I did not want to plow all the way through immediately, better start like this and get a feel for it I thought.

The new way requires more code, since all macros have to be enumerated in all modules they are used. So a bit more work one could say. But it eliminates the magic of always having these things in the global namespace.

I realized a serious limitation, which stopped me from using the new way or `error-chain` now. As you might see, in places where I do logging and maybe only log with `error!` I still have `use log::{error, log};`. Why is this? Because the `error!` macro in turn calls to the `log!` macro. And since macros are expanded *in our code* we must have all macros that they call also in our code's scope. This kind of worked for `log` since it was just one extra macro. But `error_chain!` calls out to like 5-6 extra macros, making the `use` statement in every module where we defined errors quite huge. I suspect that error chain will either have to fix this with an update or people might stop using it, time will tell.

An alternative to all `use log::{debug, error, log};` could be to just have `use log::log` and then do the logging with the full namespace: `log::error!("oh no");`, what do you think about that? The full namespace is only a tiny five extra chars, and it saves some importing. But it might also cause unwanted line breaks etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/552)
<!-- Reviewable:end -->
