### PR TITLE
Improve gui help texts

### DIFF
--- a/gui/packages/desktop/src/renderer/components/Preferences.js
+++ b/gui/packages/desktop/src/renderer/components/Preferences.js
@@ -52,13 +52,17 @@ export default class Preferences extends Component<PreferencesProps, State> {
                   <Cell.Label>Auto-connect</Cell.Label>
                   <Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
                 </Cell.Container>
-                <Cell.Footer>Automatically connect the VPN when the computer starts.</Cell.Footer>
+                <Cell.Footer>
+                  Automatically connect to the VPN at the earliest moment during computer boot-up.
+                </Cell.Footer>
 
                 <Cell.Container>
-                  <Cell.Label>Auto-start</Cell.Label>
+                  <Cell.Label>Auto-launch</Cell.Label>
                   <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
                 </Cell.Container>
-                <Cell.Footer>Automatically open Mullvad VPN at login to the system.</Cell.Footer>
+                <Cell.Footer>
+                  Automatically launch the app when logging in to the computer.
+                </Cell.Footer>
 
                 <Cell.Container>
                   <Cell.Label>Local network sharing</Cell.Label>

--- a/gui/packages/desktop/src/renderer/components/Support.js
+++ b/gui/packages/desktop/src/renderer/components/Support.js
@@ -309,6 +309,11 @@ export default class Support extends Component<SupportProps, SupportState> {
             </View>
             <Text style={styles.support__status_security__secure}>{'SECURE CONNECTION'}</Text>
             <Text style={styles.support__send_status}>{'Failed to send'}</Text>
+            <Text style={styles.support__sent_message}>
+              {
+                "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
+              }
+            </Text>
           </View>
         </View>
         <View style={styles.support__footer}>


### PR DESCRIPTION
Adding/changing the texts as discussed on Slack. Should hopefully make the distinction between auto-connect and auto-start clearer. Also renamed Auto-start to Auto-launch in the GUI, but all the code behind it still calls it `auto-start`.

And added the help text for when sending problem reports fail. Now it's being shown even if the app already is in the disconnected state, but I don't think that's a big deal, better we try to help people at all.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/554)
<!-- Reviewable:end -->
