### PR TITLE
Remove duplicate entry of tokio-core form talpid-core dependencies.

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -40,7 +40,6 @@ which = "2.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 pfctl = "0.2"
 system-configuration = "0.2"
-tokio-core = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "0.3"


### PR DESCRIPTION
I noticed that we list a duplicate entry for `tokio-core` in `talpid-core/Cargo.toml`, so I removed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/555)
<!-- Reviewable:end -->
