### PR TITLE
Allow IPv6 DHCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
   unsupported or may have security issues.
 - Allow the user to view the relay in/out IP address in the GUI.
 - Add OpenVPN proxy support via CLI.
+- Allow DHCPv6 in the firewall.
 
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -2,9 +2,6 @@ extern crate pfctl;
 extern crate tokio_core;
 
 use super::{NetworkSecurityT, SecurityPolicy};
-
-use ipnetwork::IpNetwork;
-
 use std::net::Ipv4Addr;
 use std::path::Path;
 
@@ -200,38 +197,35 @@ impl NetworkSecurity {
                 .action(pfctl::FilterRuleAction::Pass)
                 .quick(true)
                 .af(pfctl::AddrFamily::Ipv4)
-                .from(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V4(*net))));
+                .from(pfctl::Ip::from(ipnetwork_compat(*net)));
             let allow_net = rule_builder
-                .to(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V4(*net))))
+                .to(pfctl::Ip::from(ipnetwork_compat(*net)))
                 .build()?;
             let allow_multicast = rule_builder
-                .to(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V4(
-                    *super::MULTICAST_NET,
-                ))))
+                .to(pfctl::Ip::from(ipnetwork_compat(*super::MULTICAST_NET)))
                 .build()?;
             let allow_ssdp = rule_builder.to(pfctl::Ip::from(*super::SSDP_IP)).build()?;
             rules.push(allow_net);
             rules.push(allow_multicast);
             rules.push(allow_ssdp);
         }
-        for net in &*super::LOCAL_INET6_NETS {
-            let mut rule_builder = pfctl::FilterRuleBuilder::default();
-            rule_builder
-                .action(pfctl::FilterRuleAction::Pass)
-                .quick(true)
-                .af(pfctl::AddrFamily::Ipv6)
-                .from(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V6(*net))));
-            let allow_net = rule_builder
-                .to(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V6(*net))))
-                .build()?;
-            let allow_multicast = rule_builder
-                .to(pfctl::Ip::from(ipnetwork_compat(IpNetwork::V6(
-                    *super::MULTICAST_INET6_NET,
-                ))))
-                .build()?;
-            rules.push(allow_net);
-            rules.push(allow_multicast);
-        }
+        let mut rule_builder = pfctl::FilterRuleBuilder::default();
+        rule_builder
+            .action(pfctl::FilterRuleAction::Pass)
+            .quick(true)
+            .af(pfctl::AddrFamily::Ipv6)
+            .from(pfctl::Ip::from(ipnetwork_compat(*super::LOCAL_INET6_NET)));
+        let allow_net = rule_builder
+            .to(pfctl::Ip::from(ipnetwork_compat(*super::LOCAL_INET6_NET)))
+            .build()?;
+        let allow_multicast = rule_builder
+            .to(pfctl::Ip::from(ipnetwork_compat(
+                *super::MULTICAST_INET6_NET,
+            )))
+            .build()?;
+        rules.push(allow_net);
+        rules.push(allow_multicast);
+
         Ok(rules)
     }
 

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -191,65 +191,92 @@ impl NetworkSecurity {
 
     fn get_allow_lan_rules() -> Result<Vec<pfctl::FilterRule>> {
         let mut rules = vec![];
+        // IPv4
         for net in &*super::PRIVATE_NETS {
             let mut rule_builder = pfctl::FilterRuleBuilder::default();
             rule_builder
                 .action(pfctl::FilterRuleAction::Pass)
                 .quick(true)
                 .af(pfctl::AddrFamily::Ipv4)
-                .from(pfctl::Ip::from(ipnetwork_compat(*net)));
-            let allow_net = rule_builder
-                .to(pfctl::Ip::from(ipnetwork_compat(*net)))
-                .build()?;
+                .from(pfctl::Ip::from(*net));
+            let allow_net = rule_builder.to(pfctl::Ip::from(*net)).build()?;
             let allow_multicast = rule_builder
-                .to(pfctl::Ip::from(ipnetwork_compat(*super::MULTICAST_NET)))
+                .to(pfctl::Ip::from(*super::MULTICAST_NET))
                 .build()?;
             let allow_ssdp = rule_builder.to(pfctl::Ip::from(*super::SSDP_IP)).build()?;
             rules.push(allow_net);
             rules.push(allow_multicast);
             rules.push(allow_ssdp);
         }
+        // IPv6
         let mut rule_builder = pfctl::FilterRuleBuilder::default();
         rule_builder
             .action(pfctl::FilterRuleAction::Pass)
             .quick(true)
             .af(pfctl::AddrFamily::Ipv6)
-            .from(pfctl::Ip::from(ipnetwork_compat(*super::LOCAL_INET6_NET)));
-        let allow_net = rule_builder
-            .to(pfctl::Ip::from(ipnetwork_compat(*super::LOCAL_INET6_NET)))
+            .from(pfctl::Ip::from(*super::LOCAL_INET6_NET));
+        let allow_net_v6 = rule_builder
+            .to(pfctl::Ip::from(*super::LOCAL_INET6_NET))
             .build()?;
-        let allow_multicast = rule_builder
-            .to(pfctl::Ip::from(ipnetwork_compat(
-                *super::MULTICAST_INET6_NET,
-            )))
+        let allow_multicast_v6 = rule_builder
+            .to(pfctl::Ip::from(*super::MULTICAST_INET6_NET))
             .build()?;
-        rules.push(allow_net);
-        rules.push(allow_multicast);
+        rules.push(allow_net_v6);
+        rules.push(allow_multicast_v6);
 
         Ok(rules)
     }
 
     fn get_allow_dhcp_rules() -> Result<Vec<pfctl::FilterRule>> {
-        let broadcast_address = Ipv4Addr::new(255, 255, 255, 255);
-        let server_port = pfctl::Port::from(67);
-        let client_port = pfctl::Port::from(68);
+        let server_port_v4 = pfctl::Port::from(67);
+        let client_port_v4 = pfctl::Port::from(68);
+        let server_port_v6 = pfctl::Port::from(547);
+        let client_port_v6 = pfctl::Port::from(546);
         let mut dhcp_rule_builder = pfctl::FilterRuleBuilder::default();
         dhcp_rule_builder
             .action(pfctl::FilterRuleAction::Pass)
-            .proto(pfctl::Proto::Udp)
             .quick(true)
-            .keep_state(pfctl::StatePolicy::Keep);
-        let allow_outgoing_dhcp = dhcp_rule_builder
+            .proto(pfctl::Proto::Udp);
+
+        let mut rules = Vec::new();
+        let allow_outgoing_dhcp_v4 = dhcp_rule_builder
             .direction(pfctl::Direction::Out)
-            .from(client_port)
-            .to(pfctl::Endpoint::new(broadcast_address, server_port))
+            .from(client_port_v4)
+            .to(pfctl::Endpoint::new(Ipv4Addr::BROADCAST, server_port_v4))
             .build()?;
-        let allow_incoming_dhcp = dhcp_rule_builder
+        rules.push(allow_outgoing_dhcp_v4);
+        let allow_incoming_dhcp_v4 = dhcp_rule_builder
+            .af(pfctl::AddrFamily::Ipv4)
             .direction(pfctl::Direction::In)
-            .from(server_port)
-            .to(client_port)
+            .from(server_port_v4)
+            .to(client_port_v4)
             .build()?;
-        Ok(vec![allow_outgoing_dhcp, allow_incoming_dhcp])
+        rules.push(allow_incoming_dhcp_v4);
+
+        for dhcpv6_server in &*super::DHCPV6_SERVER_ADDRS {
+            let allow_outgoing_dhcp_v6 = dhcp_rule_builder
+                .af(pfctl::AddrFamily::Ipv6)
+                .direction(pfctl::Direction::Out)
+                .from(pfctl::Endpoint::new(
+                    *super::LOCAL_INET6_NET,
+                    client_port_v6,
+                ))
+                .to(pfctl::Endpoint::new(*dhcpv6_server, server_port_v6))
+                .build()?;
+            rules.push(allow_outgoing_dhcp_v6);
+        }
+        let allow_incoming_dhcp_v6 = dhcp_rule_builder
+            .af(pfctl::AddrFamily::Ipv6)
+            .direction(pfctl::Direction::In)
+            .from(server_port_v6)
+            .to(pfctl::Endpoint::new(
+                *super::LOCAL_INET6_NET,
+                client_port_v6,
+            ))
+            .build()?;
+        rules.push(allow_incoming_dhcp_v6);
+
+        Ok(rules)
     }
 
     fn get_tcp_flags() -> pfctl::TcpFlags {
@@ -307,10 +334,4 @@ fn as_pfctl_proto(protocol: net::TransportProtocol) -> pfctl::Proto {
         net::TransportProtocol::Udp => pfctl::Proto::Udp,
         net::TransportProtocol::Tcp => pfctl::Proto::Tcp,
     }
-}
-
-/// Converts a network from the struct version that talpid-core uses to the version pfctl uses.
-fn ipnetwork_compat(net: ::ipnetwork::IpNetwork) -> pfctl::ipnetwork::IpNetwork {
-    pfctl::ipnetwork::IpNetwork::new(net.ip(), net.prefix())
-        .expect("IpNetwork versions not compatible")
 }

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-use ipnetwork::{Ipv4Network, Ipv6Network};
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(unix)]
 use lazy_static::lazy_static;
 use std::fmt;
@@ -26,17 +26,17 @@ pub use self::imp::{Error, ErrorKind};
 
 #[cfg(unix)]
 lazy_static! {
-    static ref PRIVATE_NETS: [Ipv4Network; 3] = [
-        Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap(),
-        Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap(),
-        Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap(),
+    static ref PRIVATE_NETS: [IpNetwork; 3] = [
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap()),
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
     ];
-    static ref LOCAL_INET6_NETS: [Ipv6Network; 1] =
-        [Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap(),];
-    static ref MULTICAST_NET: Ipv4Network =
-        Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap();
-    static ref MULTICAST_INET6_NET: Ipv6Network =
-        Ipv6Network::new(Ipv6Addr::new(0xfe02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap();
+    static ref LOCAL_INET6_NET: IpNetwork =
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap());
+    static ref MULTICAST_NET: IpNetwork =
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap());
+    static ref MULTICAST_INET6_NET: IpNetwork =
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap());
     static ref SSDP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(239, 255, 255, 250));
 }
 

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -38,6 +38,10 @@ lazy_static! {
     static ref MULTICAST_INET6_NET: IpNetwork =
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap());
     static ref SSDP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(239, 255, 255, 250));
+    static ref DHCPV6_SERVER_ADDRS: [IpAddr; 2] = [
+        IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 1, 2)),
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 1, 3)),
+    ];
 }
 
 /// A enum that describes network security strategy

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -296,7 +296,7 @@ const GUID &MullvadGuids::FilterPermitLoopback_Inbound_Ipv6()
 }
 
 //static
-const GUID &MullvadGuids::FilterPermitDhcp_Outbound_Request()
+const GUID &MullvadGuids::FilterPermitDhcpV4_Outbound_Request()
 {
 	static const GUID g =
 	{
@@ -310,7 +310,21 @@ const GUID &MullvadGuids::FilterPermitDhcp_Outbound_Request()
 }
 
 //static
-const GUID &MullvadGuids::FilterPermitDhcp_Inbound_Response()
+const GUID &MullvadGuids::FilterPermitDhcpV6_Outbound_Request()
+{
+	static const GUID g =
+	{
+		0x67bd69b0,
+		0x522d,
+		0x4631,
+		{ 0x9a, 0x8f, 0x1c, 0xee, 0xdf, 0x64, 0xb7, 0x2b }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::FilterPermitDhcpV4_Inbound_Response()
 {
 	static const GUID g =
 	{
@@ -318,6 +332,20 @@ const GUID &MullvadGuids::FilterPermitDhcp_Inbound_Response()
 		0x4108,
 		0x47ff,
 		{ 0x85, 0x99, 0xaf, 0xa5, 0xcb, 0x95, 0x9c, 0x25 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::FilterPermitDhcpV6_Inbound_Response()
+{
+	static const GUID g =
+	{
+		0x40dcfb6d,
+		0x2ee,
+		0x4531,
+		{ 0x86, 0x61, 0xc4, 0xc8, 0xa4, 0x3a, 0xf4, 0x23 }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -33,8 +33,10 @@ public:
 	static const GUID &FilterPermitLoopback_Inbound_Ipv4();
 	static const GUID &FilterPermitLoopback_Inbound_Ipv6();
 
-	static const GUID &FilterPermitDhcp_Outbound_Request();
-	static const GUID &FilterPermitDhcp_Inbound_Response();
+	static const GUID &FilterPermitDhcpV4_Outbound_Request();
+	static const GUID &FilterPermitDhcpV6_Outbound_Request();
+	static const GUID &FilterPermitDhcpV4_Inbound_Response();
+	static const GUID &FilterPermitDhcpV6_Inbound_Response();
 
 	static const GUID &FilterPermitVpnRelay();
 

--- a/windows/winfw/src/winfw/rules/permitdhcp.cpp
+++ b/windows/winfw/src/winfw/rules/permitdhcp.cpp
@@ -25,13 +25,15 @@ bool PermitDhcp::apply(IObjectInstaller &objectInstaller)
 
 	wfp::FilterBuilder filterBuilder;
 
+	wfp::IpAddress::Literal6 fe80{ 0xFE80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+
 	//
-	// #1 permit outbound DHCP request
+	// #1 permit outbound DHCPv4 request
 	//
 
 	filterBuilder
-		.key(MullvadGuids::FilterPermitDhcp_Outbound_Request())
-		.name(L"Permit outbound DHCP request")
+		.key(MullvadGuids::FilterPermitDhcpV4_Outbound_Request())
+		.name(L"Permit outbound DHCPv4 request")
 		.description(L"This filter is part of a rule that permits DHCP client traffic")
 		.provider(MullvadGuids::Provider())
 		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
@@ -54,19 +56,70 @@ bool PermitDhcp::apply(IObjectInstaller &objectInstaller)
 	}
 
 	//
-	// #2 permit inbound DHCP response
+	// #2 permit outbound DHCPv6 request
 	//
 
 	filterBuilder
-		.key(MullvadGuids::FilterPermitDhcp_Inbound_Response())
-		.name(L"Permit inbound DHCP response")
+		.key(MullvadGuids::FilterPermitDhcpV6_Outbound_Request())
+		.name(L"Permit outbound DHCPv6 response")
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+	{
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+		wfp::IpAddress::Literal6 linkLocal{ 0xFF02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x2 };
+		wfp::IpAddress::Literal6 siteLocal{ 0xFF05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x3 };
+
+		conditionBuilder.add_condition(ConditionProtocol::Udp());
+		conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
+		conditionBuilder.add_condition(ConditionIp::Remote(siteLocal));
+		conditionBuilder.add_condition(ConditionPort::Remote(547));
+		conditionBuilder.add_condition(ConditionIp::Local(fe80, uint8_t(10)));
+		conditionBuilder.add_condition(ConditionPort::Local(546));
+
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
+	}
+
+	//
+	// #3 permit inbound DHCPv4 response
+	//
+
+	filterBuilder
+		.key(MullvadGuids::FilterPermitDhcpV4_Inbound_Response())
+		.name(L"Permit inbound DHCPv4 response")
 		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4);
 
-	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4);
+	{
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4);
+
+		conditionBuilder.add_condition(ConditionProtocol::Udp());
+		conditionBuilder.add_condition(ConditionPort::Remote(67));
+		conditionBuilder.add_condition(ConditionPort::Local(68));
+
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
+	}
+
+	//
+	// #4 permit inbound DHCPv6 response
+	//
+
+	filterBuilder
+		.key(MullvadGuids::FilterPermitDhcpV6_Inbound_Response())
+		.name(L"Permit inbound DHCPv6 response")
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
 
 	conditionBuilder.add_condition(ConditionProtocol::Udp());
-	conditionBuilder.add_condition(ConditionPort::Remote(67));
-	conditionBuilder.add_condition(ConditionPort::Local(68));
+	conditionBuilder.add_condition(ConditionPort::Remote(547));
+	conditionBuilder.add_condition(ConditionIp::Local(fe80, uint8_t(10)));
+	conditionBuilder.add_condition(ConditionPort::Local(546));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }


### PR DESCRIPTION
We don't really have any reason to block local DHCP over IPv6. It's more that we did not get to full IPv6 support in local LANs yet.

To figure out what the rules should allow I used
https://en.wikipedia.org/wiki/DHCPv6 and https://tools.ietf.org/html/rfc3315#section-13
See the example exchange on wikipedia, also search the RFC for `All_DHCP_Relay_Agents_and_Servers` and `All_DHCP_Servers address`.

Might be easier to review the first commit separately first and then the rest. The first one just changes the statically defined IPs that are shared between Linux and macOS and thus that makes the code move around in those implementations in places that are not related to DHCPv6.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
