### PR TITLE
Cleanup version

### DIFF
--- a/mullvad-cli/build.rs
+++ b/mullvad-cli/build.rs
@@ -3,10 +3,15 @@ extern crate winapi;
 #[cfg(windows)]
 extern crate winres;
 
+use std::{env, fs, path::PathBuf};
+
 fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let product_version = env!("CARGO_PKG_VERSION").replacen(".0", "", 1);
+    fs::write(out_dir.join("product-version.txt"), &product_version).unwrap();
+
     #[cfg(windows)]
     {
-        let product_version = env!("CARGO_PKG_VERSION").replacen(".0", "", 1);
         let mut res = winres::WindowsResource::new();
         res.set("ProductVersion", &product_version);
         res.set_icon("../dist-assets/icon.ico");

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -19,7 +19,7 @@ extern crate talpid_types;
 
 mod cmds;
 
-use clap::{crate_authors, crate_description, crate_name, crate_version};
+use clap::{crate_authors, crate_description, crate_name};
 use mullvad_ipc_client::{new_standalone_ipc_client, DaemonRpcClient};
 
 use std::alloc::System;
@@ -28,6 +28,8 @@ use std::io;
 
 #[global_allocator]
 static GLOBAL: System = System;
+
+pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 
 
 error_chain! {
@@ -53,7 +55,7 @@ fn run() -> Result<()> {
     let commands = cmds::get_commands();
 
     let app = clap::App::new(crate_name!())
-        .version(crate_version!())
+        .version(PRODUCT_VERSION)
         .author(crate_authors!())
         .about(crate_description!())
         .setting(clap::AppSettings::SubcommandRequired)

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -37,7 +37,7 @@ pub fn get_config() -> Config {
 
 fn create_app() -> App<'static, 'static> {
     let app = App::new(crate_name!())
-        .version(version::CURRENT)
+        .version(version::PRODUCT_VERSION)
         .author(crate_authors!())
         .about(crate_description!())
         .arg(

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -144,7 +144,7 @@ fn create_daemon(config: &cli::Config) -> Result<Daemon> {
         log_dir,
         resource_dir,
         cache_dir,
-        version::CURRENT.to_owned(),
+        version::PRODUCT_VERSION.to_owned(),
     )
     .chain_err(|| "Unable to initialize daemon")
 }
@@ -153,7 +153,7 @@ fn log_version() {
     info!(
         "Starting {} - {} {}",
         env!("CARGO_PKG_NAME"),
-        version::CURRENT,
+        version::PRODUCT_VERSION,
         version::COMMIT_DATE,
     )
 }

--- a/mullvad-daemon/src/version.rs
+++ b/mullvad-daemon/src/version.rs
@@ -1,5 +1,5 @@
 /// A string that identifies the current version of the application
-pub const CURRENT: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
+pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 
 /// Contains the date of the git commit this was built from
 pub const COMMIT_DATE: &str = include_str!(concat!(env!("OUT_DIR"), "/git-commit-date.txt"));

--- a/mullvad-problem-report/build.rs
+++ b/mullvad-problem-report/build.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 #[cfg(windows)]
 extern crate winapi;
@@ -13,7 +12,6 @@ fn main() {
 
     let product_version = env!("CARGO_PKG_VERSION").replacen(".0", "", 1);
     fs::write(out_dir.join("product-version.txt"), &product_version).unwrap();
-    fs::write(out_dir.join("git-commit-date.txt"), commit_date()).unwrap();
 
     #[cfg(windows)]
     {
@@ -26,16 +24,4 @@ fn main() {
         ));
         res.compile().expect("Unable to generate windows resources");
     }
-}
-
-
-fn commit_date() -> String {
-    let output = Command::new("git")
-        .args(&["log", "-1", "--date=short", "--pretty=format:%cd"])
-        .output()
-        .expect("Unable to get git commit date");
-    ::std::str::from_utf8(&output.stdout)
-        .unwrap()
-        .trim()
-        .to_owned()
 }

--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -2,11 +2,7 @@ use std::collections::HashMap;
 use std::process::Command;
 use uuid;
 
-pub const PRODUCT_VERSION: &str = concat!(
-    include_str!(concat!(env!("OUT_DIR"), "/product-version.txt")),
-    " ",
-    include_str!(concat!(env!("OUT_DIR"), "/git-commit-date.txt"))
-);
+pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 
 pub fn collect() -> HashMap<String, String> {
     let mut metadata = HashMap::new();


### PR DESCRIPTION
This PR is mostly about removing the commit date from the problem report. Support has expressed they have no use for it and it clobbers up graphs and other things with data we don't need. Every build product version is still uniquely identifiable.

Also cleaning up so all our CLI tools report the same version and all use `PRODUCT_VERSION` to refer to them. A bit more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/559)
<!-- Reviewable:end -->
