### PR TITLE
Update relay list from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 - Allow the user to view the relay in/out IP address in the GUI.
 - Add OpenVPN proxy support via CLI.
 - Allow DHCPv6 in the firewall.
+- CLI command `relay update` that triggers an update of the relay list in the daemon.
 
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -100,15 +100,21 @@ impl Command for Relay {
             .subcommand(
                 clap::SubCommand::with_name("list").about("List available countries and cities"),
             )
+            .subcommand(
+                clap::SubCommand::with_name("update")
+                    .about("Update the list of available countries and cities"),
+            )
     }
 
     fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             self.set(set_matches)
-        } else if let Some(_) = matches.subcommand_matches("get") {
+        } else if matches.subcommand_matches("get").is_some() {
             self.get()
-        } else if let Some(list_matches) = matches.subcommand_matches("list") {
-            self.list(list_matches)
+        } else if matches.subcommand_matches("list").is_some() {
+            self.list()
+        } else if matches.subcommand_matches("update").is_some() {
+            self.update()
         } else {
             unreachable!("No relay command given");
         }
@@ -210,7 +216,7 @@ impl Relay {
         Ok(())
     }
 
-    fn list(&self, _matches: &clap::ArgMatches) -> Result<()> {
+    fn list(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
         let mut locations = rpc.get_relay_locations()?;
         locations.countries.sort_by(|c1, c2| c1.name.cmp(&c2.name));
@@ -225,6 +231,12 @@ impl Relay {
             }
             println!();
         }
+        Ok(())
+    }
+
+    fn update(&self) -> Result<()> {
+        new_rpc_client()?.update_relay_locations()?;
+        println!("Updating relay list in the background...");
         Ok(())
     }
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -419,6 +419,7 @@ impl Daemon {
             GetCurrentLocation(tx) => self.on_get_current_location(tx),
             GetAccountData(tx, account_token) => self.on_get_account_data(tx, account_token),
             GetRelayLocations(tx) => self.on_get_relay_locations(tx),
+            UpdateRelayLocations => self.on_update_relay_locations(),
             SetAccount(tx, account_token) => self.on_set_account(tx, account_token),
             UpdateRelaySettings(tx, update) => self.on_update_relay_settings(tx, update),
             SetAllowLan(tx, allow_lan) => self.on_set_allow_lan(tx, allow_lan),
@@ -523,6 +524,9 @@ impl Daemon {
         Self::oneshot_send(tx, self.relay_selector.get_locations(), "relay locations");
     }
 
+    fn on_update_relay_locations(&mut self) {
+        self.relay_selector.update();
+    }
 
     fn on_set_account(&mut self, tx: oneshot::Sender<()>, account_token: Option<String>) {
         let account_token_cleared = account_token.is_none();

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -167,6 +167,10 @@ impl DaemonRpcClient {
         self.call("get_relay_locations", &NO_ARGS)
     }
 
+    pub fn update_relay_locations(&mut self) -> Result<RelayList> {
+        self.call("update_relay_locations", &NO_ARGS)
+    }
+
     pub fn get_relay_settings(&mut self) -> Result<RelaySettings> {
         self.call("get_relay_settings", &NO_ARGS)
     }


### PR DESCRIPTION
QA have requested a way to make the daemon update the relay list. It's really hard to test this since it takes two ours for it to try again. This PR adds a command to the CLI for this. It's generally more of a testing/plumbing command. But it does not hurt to expose it to everyone, it's a nice feature to have I guess.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/566)
<!-- Reviewable:end -->
