### PR TITLE
Fix com deinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Use proper app id in the registry. This avoids false-positives with certain anti-virus software.
+- Fix crash on Windows 7 when closing installer.
 
 ### Security
 #### Linux

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -29,6 +29,10 @@
 !define INI_GENERAL_ERROR 0
 !define INI_SUCCESS 1
 
+#Return codes from driverlogic::Initialize/Deinitialize
+!define DRIVERLOGIC_GENERAL_ERROR 0
+!define DRIVERLOGIC_SUCCESS 1
+
 #
 # BreakInstallation
 #
@@ -83,6 +87,17 @@
 	Push $0
 	Push $1
 
+	driverlogic::Initialize
+	
+	Pop $0
+	Pop $1
+	
+	${If} $0 != ${DRIVERLOGIC_SUCCESS}
+		StrCpy $R0 "Failed to initialize plugin 'driverlogic': $1"
+		log::Log $R0
+		Goto InstallDriver_return_only
+	${EndIf}
+	
 	log::Log "Listing virtual adapters"
 	nsExec::ExecToStack '"$TEMP\driver\tapinstall.exe" hwids ${TAP_HARDWARE_ID}'
 
@@ -96,7 +111,7 @@
 	${EndIf}
 
 	log::LogWithDetails "Virtual adapters listing" $1
-
+	
 	log::Log "Calling on plugin to parse adapter data"
 	driverlogic::EstablishBaseline $1
 
@@ -202,6 +217,18 @@
 	
 	InstallDriver_return:
 
+	driverlogic::Deinitialize
+	
+	Pop $0
+	Pop $1
+	
+	${If} $0 != ${DRIVERLOGIC_SUCCESS}
+		# Do not update $R0
+		log::Log "Failed to deinitialize plugin 'driverlogic': $1"
+	${EndIf}
+
+	InstallDriver_return_only:
+	
 	Pop $1
 	Pop $0
 	

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <libcommon/wmi/connection.h>
 #include <set>
 #include <string>
 
 class Context
 {
 public:
+
+	Context();
 
 	struct VirtualNic
 	{
@@ -43,8 +46,10 @@ public:
 
 private:
 
-	static std::set<VirtualNic> ParseVirtualNics(const std::wstring &textBlock);
-	static std::wstring GetNicAlias(const std::wstring &node, const std::wstring &name);
+	common::wmi::Connection m_connection;
+
+	std::set<VirtualNic> ParseVirtualNics(const std::wstring &textBlock);
+	std::wstring GetNicAlias(const std::wstring &node, const std::wstring &name);
 
 	std::set<VirtualNic> m_baseline;
 	std::set<VirtualNic> m_currentState;

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -172,6 +172,11 @@ void __declspec(dllexport) NSISCALL EstablishBaseline
 		pushstring(common::string::ToWide(err.what()).c_str());
 		pushint(EstablishBaselineStatus::GENERAL_ERROR);
 	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(EstablishBaselineStatus::GENERAL_ERROR);
+	}
 }
 
 //
@@ -216,6 +221,11 @@ void __declspec(dllexport) NSISCALL IdentifyNewInterface
 	catch (std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(IdentifyNewInterfaceStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
 		pushint(IdentifyNewInterfaceStatus::GENERAL_ERROR);
 	}
 }

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -1,12 +1,19 @@
 #include <stdafx.h>
 #include "context.h"
 #include <libcommon/string.h>
+#include <libcommon/valuemapper.h>
 #include <windows.h>
+
+// Suppress warnings caused by broken legacy code
+#pragma warning (push)
+#pragma warning (disable: 4005)
 #include <nsis/pluginapi.h>
+#pragma warning (pop)
+
 #include <string>
 #include <vector>
 
-Context g_context;
+Context *g_context = nullptr;
 
 namespace
 {
@@ -66,6 +73,53 @@ void PinDll()
 } // anonymous namespace
 
 //
+// Initialize
+//
+// Call this function once during startup.
+//
+enum class InitializeStatus
+{
+	GENERAL_ERROR = 0,
+	SUCCESS,
+};
+
+void __declspec(dllexport) NSISCALL Initialize
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	try
+	{
+		if (nullptr == g_context)
+		{
+			g_context = new Context;
+
+			PinDll();
+		}
+
+		pushstring(L"");
+		pushint(InitializeStatus::SUCCESS);
+	}
+	catch (std::exception &err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(InitializeStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(InitializeStatus::GENERAL_ERROR);
+	}
+}
+
+//
 // EstablishBaseline
 //
 // Invoke with the output from "tapinstall hwids tap0901"
@@ -91,34 +145,24 @@ void __declspec(dllexport) NSISCALL EstablishBaseline
 {
 	EXDLL_INIT();
 
+	if (nullptr == g_context)
+	{
+		pushstring(L"Initialize() function was not called or was not successful");
+		pushint(EstablishBaselineStatus::GENERAL_ERROR);
+	}
+
 	try
 	{
-		PinDll();
+		using value_type = common::ValueMapper<Context::BaselineStatus, EstablishBaselineStatus>::value_type;
 
-		auto status = EstablishBaselineStatus::GENERAL_ERROR;
-
-		switch (g_context.establishBaseline(PopString()))
+		const common::ValueMapper<Context::BaselineStatus, EstablishBaselineStatus> mapper =
 		{
-			case Context::BaselineStatus::NO_INTERFACES_PRESENT:
-			{
-				status = EstablishBaselineStatus::NO_INTERFACES_PRESENT;
-				break;
-			}
-			case Context::BaselineStatus::SOME_INTERFACES_PRESENT:
-			{
-				status = EstablishBaselineStatus::SOME_INTERFACES_PRESENT;
-				break;
-			}
-			case Context::BaselineStatus::MULLVAD_INTERFACE_PRESENT:
-			{
-				status = EstablishBaselineStatus::MULLVAD_INTERFACE_PRESENT;
-				break;
-			}
-			default:
-			{
-				throw std::runtime_error("Missing case handler in switch clause");
-			}
-		}
+			value_type(Context::BaselineStatus::NO_INTERFACES_PRESENT, EstablishBaselineStatus::NO_INTERFACES_PRESENT),
+			value_type(Context::BaselineStatus::SOME_INTERFACES_PRESENT, EstablishBaselineStatus::SOME_INTERFACES_PRESENT),
+			value_type(Context::BaselineStatus::MULLVAD_INTERFACE_PRESENT, EstablishBaselineStatus::MULLVAD_INTERFACE_PRESENT)
+		};
+
+		const auto status = mapper.map(g_context->establishBaseline(PopString()));
 
 		pushstring(L"");
 		pushint(status);
@@ -154,11 +198,17 @@ void __declspec(dllexport) NSISCALL IdentifyNewInterface
 {
 	EXDLL_INIT();
 
+	if (nullptr == g_context)
+	{
+		pushstring(L"Initialize() function was not called or was not successful");
+		pushint(EstablishBaselineStatus::GENERAL_ERROR);
+	}
+
 	try
 	{
-		g_context.recordCurrentState(PopString());
+		g_context->recordCurrentState(PopString());
 
-		auto nic = g_context.getNewAdapter();
+		auto nic = g_context->getNewAdapter();
 
 		pushstring(nic.alias.c_str());
 		pushint(IdentifyNewInterfaceStatus::SUCCESS);
@@ -168,4 +218,48 @@ void __declspec(dllexport) NSISCALL IdentifyNewInterface
 		pushstring(common::string::ToWide(err.what()).c_str());
 		pushint(IdentifyNewInterfaceStatus::GENERAL_ERROR);
 	}
+}
+
+//
+// Deinitialize
+//
+// Call this function once during shutdown.
+//
+enum class DeinitializeStatus
+{
+	GENERAL_ERROR = 0,
+	SUCCESS,
+};
+
+void __declspec(dllexport) NSISCALL Deinitialize
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	try
+	{
+		delete g_context;
+
+		pushstring(L"");
+		pushint(InitializeStatus::SUCCESS);
+	}
+	catch (std::exception &err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(DeinitializeStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(DeinitializeStatus::GENERAL_ERROR);
+	}
+
+	g_context = nullptr;
 }

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.def
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.def
@@ -2,5 +2,7 @@ LIBRARY driverlogic
 
 EXPORTS
 
+Initialize
 EstablishBaseline
 IdentifyNewInterface
+Deinitialize


### PR DESCRIPTION
This fixes the crash on Win7 when closing the installer. The issue was basically that some COM instances were being released too late in the process tear-down.

`common::wmi::Connection` has been updated with better awareness of COM init/deinit and improved error handling in its ctor.

The NSIS script has been updated to explicitly init/deinit the `driverlogic` plugin, thereby giving us controlled destruction of COM resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/570)
<!-- Reviewable:end -->
