### PR TITLE
Cancel pending notifications when app becomes visible and beyond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.
 - Make the `problem-report` tool fall back to the bundled API IP if DNS resolution fails.
+- Cancel pending system notifications when the app becomes visible.
 
 #### macOS
 - Correctly backup and restore search domains and other DNS settings.

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -124,7 +124,10 @@ export default class AppRenderer {
       }
     });
 
-    ipcRenderer.on('window-shown', () => this.updateAccountExpiry());
+    ipcRenderer.on('window-shown', () => {
+      this.updateAccountExpiry();
+      this._notificationController.cancelPendingNotifications();
+    });
 
     // disable pinch to zoom
     webFrame.setVisualZoomLevelLimits(1, 1);

--- a/gui/packages/desktop/src/renderer/lib/notification-controller.js
+++ b/gui/packages/desktop/src/renderer/lib/notification-controller.js
@@ -7,9 +7,10 @@ import config from '../../config';
 import type { TunnelStateTransition } from './daemon-rpc';
 
 export default class NotificationController {
-  _activeNotification: ?Notification;
+  _lastTunnelStateNotification: ?Notification;
   _reconnecting = false;
   _presentedNotifications = {};
+  _pendingNotifications: Array<Notification> = [];
 
   notifyTunnelState(tunnelState: TunnelStateTransition) {
     switch (tunnelState.state) {
@@ -52,10 +53,11 @@ export default class NotificationController {
     }
 
     this._presentNotificationOnce('inconsistent-version', () => {
-      new Notification(remote.app.getName(), {
+      const notification = new Notification(remote.app.getName(), {
         body: 'Inconsistent internal version information, please restart the app',
         silent: true,
       });
+      this._addPendingNotification(notification);
     });
   }
 
@@ -73,33 +75,36 @@ export default class NotificationController {
       notification.addEventListener('click', () => {
         remote.shell.openExternal(config.links.download);
       });
+
+      this._addPendingNotification(notification);
     });
   }
 
+  cancelPendingNotifications() {
+    for (const notification of this._pendingNotifications) {
+      this._closeNotification(notification);
+    }
+  }
+
   _showTunnelStateNotification(message: string) {
-    const lastNotification = this._activeNotification;
+    const lastNotification = this._lastTunnelStateNotification;
     const sameAsLastNotification = lastNotification && lastNotification.body === message;
 
     if (sameAsLastNotification || remote.getCurrentWindow().isVisible()) {
       return;
     }
 
-    const newNotification = new Notification(remote.app.getName(), { body: message, silent: true });
-
-    this._activeNotification = newNotification;
-
-    newNotification.addEventListener('show', () => {
-      // If the notification is closed too soon, it might still get shown. If that happens, close()
-      // should be called again so that it is closed immediately.
-      // Tracking issue: https://github.com/electron/electron/issues/12887
-      if (this._activeNotification !== newNotification) {
-        newNotification.close();
-      }
+    const newNotification = new Notification(remote.app.getName(), {
+      body: message,
+      silent: true,
     });
 
     if (lastNotification) {
-      lastNotification.close();
+      this._closeNotification(lastNotification);
     }
+
+    this._lastTunnelStateNotification = newNotification;
+    this._addPendingNotification(newNotification);
   }
 
   _presentNotificationOnce(notificationName: string, presentNotification: () => void) {
@@ -107,6 +112,35 @@ export default class NotificationController {
     if (!presented[notificationName]) {
       presented[notificationName] = true;
       presentNotification();
+    }
+  }
+
+  _closeNotification(notification: Notification) {
+    // If the notification is closed too soon, it might still get shown. If that happens, close()
+    // should be called again so that it is closed immediately.
+    // Tracking issue: https://github.com/electron/electron/issues/12887
+    notification.addEventListener('show', () => {
+      notification.close();
+    });
+
+    notification.close();
+  }
+
+  _addPendingNotification(notification: Notification) {
+    // Quirk: chromium postpones the 'close' event until new notifications pump the queue or window
+    // becomes visible. It's possible that there is going to be one stale notification in
+    // `_pendingNotifications` array but that shouldn't be a big deal.
+    notification.addEventListener('close', () => {
+      this._removePendingNotification(notification);
+    });
+
+    this._pendingNotifications.push(notification);
+  }
+
+  _removePendingNotification(notification: Notification) {
+    const index = this._pendingNotifications.indexOf(notification);
+    if (index !== -1) {
+      this._pendingNotifications.splice(index, 1);
     }
   }
 }

--- a/gui/packages/desktop/src/renderer/lib/notification-controller.js
+++ b/gui/packages/desktop/src/renderer/lib/notification-controller.js
@@ -47,6 +47,10 @@ export default class NotificationController {
   }
 
   notifyInconsistentVersion() {
+    if (remote.getCurrentWindow().isVisible()) {
+      return;
+    }
+
     this._presentNotificationOnce('inconsistent-version', () => {
       new Notification(remote.app.getName(), {
         body: 'Inconsistent internal version information, please restart the app',
@@ -56,6 +60,10 @@ export default class NotificationController {
   }
 
   notifyUnsupportedVersion(upgradeVersion: string) {
+    if (remote.getCurrentWindow().isVisible()) {
+      return;
+    }
+
     this._presentNotificationOnce('unsupported-version', () => {
       const notification = new Notification(remote.app.getName(), {
         body: `You are running an unsupported app version. Please upgrade to ${upgradeVersion} now to ensure your security`,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

- Prevent inconsistent and unsupported version notifications to be displayed when the app is visible.
- Dismiss pending notifications when the app becomes visible

### Why

- Currently notifications remain on screen when the app becomes visible. This very often results in the notifications overlaying the main window at least on macOS.
- Some notifications were reported to be displayed regardless the app visibility state. I assume this was in regard of version related notifications which were not constrained to app's visibility before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/571)
<!-- Reviewable:end -->
