### PR TITLE
Prepare for rust2018

### DIFF
--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -1,5 +1,5 @@
 use clap::{self, value_t_or_exit};
-use {new_rpc_client, Command, Result};
+use crate::{new_rpc_client, Command, Result};
 
 use mullvad_types::account::AccountToken;
 

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -1,6 +1,6 @@
 use clap::{self, value_t_or_exit};
-use new_rpc_client;
-use {Command, Result};
+use crate::new_rpc_client;
+use crate::{Command, Result};
 
 pub struct AutoConnect;
 

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -1,6 +1,5 @@
 use clap::{self, value_t_or_exit};
-use crate::new_rpc_client;
-use crate::{Command, Result};
+use crate::{new_rpc_client, Command, Result};
 
 pub struct AutoConnect;
 

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -1,7 +1,5 @@
 use clap;
-use crate::new_rpc_client;
-use crate::Command;
-use crate::Result;
+use crate::{new_rpc_client, Command, Result};
 use error_chain::ChainedError;
 
 pub struct Connect;

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -1,8 +1,8 @@
 use clap;
+use crate::new_rpc_client;
+use crate::Command;
+use crate::Result;
 use error_chain::ChainedError;
-use new_rpc_client;
-use Command;
-use Result;
 
 pub struct Connect;
 

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -1,7 +1,5 @@
 use clap;
-use crate::new_rpc_client;
-use crate::Command;
-use crate::Result;
+use crate::{new_rpc_client, Command, Result};
 
 
 pub struct Disconnect;

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -1,7 +1,7 @@
 use clap;
-use new_rpc_client;
-use Command;
-use Result;
+use crate::new_rpc_client;
+use crate::Command;
+use crate::Result;
 
 
 pub struct Disconnect;

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -1,5 +1,5 @@
 use clap::{self, value_t_or_exit};
-use {new_rpc_client, Command, Result};
+use crate::{new_rpc_client, Command, Result};
 
 pub struct Lan;
 

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -1,5 +1,5 @@
+use crate::Command;
 use std::collections::HashMap;
-use Command;
 
 mod account;
 pub use self::account::Account;

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -1,6 +1,6 @@
 use clap::{self, value_t};
+use crate::{new_rpc_client, Command, Result, ResultExt};
 use std::str::FromStr;
-use {new_rpc_client, Command, Result, ResultExt};
 
 use mullvad_types::relay_constraints::{
     Constraint, LocationConstraint, OpenVpnConstraints, RelayConstraintsUpdate,

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -1,7 +1,7 @@
 use clap;
-use new_rpc_client;
-use Command;
-use Result;
+use crate::new_rpc_client;
+use crate::Command;
+use crate::Result;
 
 use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_types::auth_failed::AuthFailed;

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -1,7 +1,5 @@
 use clap;
-use crate::new_rpc_client;
-use crate::Command;
-use crate::Result;
+use crate::{new_rpc_client, Command, Result};
 
 use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_types::auth_failed::AuthFailed;

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -1,5 +1,5 @@
 use clap::{self, value_t};
-use {new_rpc_client, Command, Result};
+use crate::{new_rpc_client, Command, Result};
 
 use talpid_types::net::{
     LocalOpenVpnProxySettings, OpenVpnProxyAuth, OpenVpnProxySettings,

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -1,5 +1,5 @@
 use clap;
-use {new_rpc_client, Command, Result};
+use crate::{new_rpc_client, Command, Result};
 
 pub struct Version;
 

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_authors, crate_description, crate_name, App, Arg};
 use log;
 
-use version;
+use crate::version;
 
 pub struct Config {
     pub log_level: log::LevelFilter,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -41,6 +41,7 @@ mod management_interface;
 mod relays;
 mod rpc_uniqueness_check;
 
+use crate::management_interface::{BoxFuture, ManagementCommand, ManagementInterfaceServer};
 use error_chain::ChainedError;
 use futures::{
     future,
@@ -48,7 +49,6 @@ use futures::{
     Future, Sink,
 };
 use log::{debug, error, info, warn};
-use management_interface::{BoxFuture, ManagementCommand, ManagementInterfaceServer};
 use mullvad_rpc::{AccountsProxy, AppVersionProxy, HttpHandle};
 use mullvad_types::{
     account::{AccountData, AccountToken},
@@ -311,7 +311,7 @@ impl Daemon {
     }
 
     fn handle_event(&mut self, event: DaemonEvent) -> Result<()> {
-        use DaemonEvent::*;
+        use self::DaemonEvent::*;
         match event {
             TunnelStateTransition(transition) => self.handle_tunnel_state_transition(transition),
             GenerateTunnelParameters(tunnel_parameters_tx, retry_attempt) => {
@@ -412,7 +412,7 @@ impl Daemon {
     }
 
     fn handle_management_interface_event(&mut self, event: ManagementCommand) {
-        use ManagementCommand::*;
+        use self::ManagementCommand::*;
         match event {
             SetTargetState(tx, state) => self.on_set_target_state(tx, state),
             GetState(tx) => self.on_get_state(tx),

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1,3 +1,4 @@
+use crate::account_history::{AccountHistory, Error as AccountHistoryError};
 use error_chain::ChainedError;
 use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
 use jsonrpc_core::futures::{future, sync, Future};
@@ -7,28 +8,25 @@ use jsonrpc_macros::{build_rpc_trait, metadata, pubsub};
 use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, SubscriptionId};
 use mullvad_paths;
 use mullvad_rpc;
-use mullvad_types::account::{AccountData, AccountToken};
-use mullvad_types::location::GeoIpLocation;
-use mullvad_types::relay_constraints::RelaySettingsUpdate;
-use mullvad_types::relay_list::RelayList;
-use mullvad_types::settings;
-use mullvad_types::settings::Settings;
-use mullvad_types::states::TargetState;
-use mullvad_types::version;
-
+use mullvad_types::{
+    account::{AccountData, AccountToken},
+    location::GeoIpLocation,
+    relay_constraints::RelaySettingsUpdate,
+    relay_list::RelayList,
+    settings::{self, Settings},
+    states::TargetState,
+    version,
+};
 use serde;
-
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex, RwLock};
-
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    path::PathBuf,
+    sync::{Arc, Mutex, RwLock},
+};
 use talpid_core::mpsc::IntoSender;
 use talpid_ipc;
 use talpid_types::{net::OpenVpnProxySettings, tunnel::TunnelStateTransition};
 use uuid;
-
-use account_history::{AccountHistory, Error as AccountHistoryError};
 
 /// FIXME(linus): This is here just because the futures crate has deprecated it and jsonrpc_core
 /// did not introduce their own yet (https://github.com/paritytech/jsonrpc/pull/196).

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -1,4 +1,4 @@
-use Result;
+use crate::Result;
 
 use std::env;
 use std::path::PathBuf;
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 /// Creates and returns the cache directory pointed to by `MULLVAD_CACHE_DIR`, or the default
 /// one if that variable is unset.
 pub fn cache_dir() -> Result<PathBuf> {
-    ::create_and_return(get_cache_dir)
+    crate::create_and_return(get_cache_dir)
 }
 
 fn get_cache_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_CACHE_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_cache_dir().map(|dir| dir.join(::PRODUCT_NAME)),
+        None => get_default_cache_dir().map(|dir| dir.join(crate::PRODUCT_NAME)),
     }
 }
 

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -42,16 +42,16 @@ fn create_and_return(dir_fn: fn() -> Result<PathBuf>) -> Result<PathBuf> {
 }
 
 mod cache;
-pub use cache::cache_dir;
+pub use crate::cache::cache_dir;
 
 mod logs;
-pub use logs::{get_log_dir, log_dir};
+pub use crate::logs::{get_log_dir, log_dir};
 
 pub mod resources;
-pub use resources::get_resource_dir;
+pub use crate::resources::get_resource_dir;
 
 mod rpc_socket;
-pub use rpc_socket::get_rpc_socket_path;
+pub use crate::rpc_socket::get_rpc_socket_path;
 
 mod settings;
-pub use settings::settings_dir;
+pub use crate::settings::settings_dir;

--- a/mullvad-paths/src/logs.rs
+++ b/mullvad-paths/src/logs.rs
@@ -1,4 +1,4 @@
-use Result;
+use crate::Result;
 
 use std::env;
 use std::path::PathBuf;
@@ -6,14 +6,14 @@ use std::path::PathBuf;
 /// Creates and returns the logging directory pointed to by `MULLVAD_LOG_DIR`, or the default
 /// one if that variable is unset.
 pub fn log_dir() -> Result<PathBuf> {
-    ::create_and_return(get_log_dir)
+    crate::create_and_return(get_log_dir)
 }
 
 /// Get the logging directory, but don't try to create it.
 pub fn get_log_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_LOG_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_log_dir().map(|dir| dir.join(::PRODUCT_NAME)),
+        None => get_default_log_dir().map(|dir| dir.join(crate::PRODUCT_NAME)),
     }
 }
 

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -1,4 +1,4 @@
-use Result;
+use crate::Result;
 
 use std::env;
 use std::path::PathBuf;
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 /// Creates and returns the settings directory pointed to by `MULLVAD_SETTINGS_DIR`, or the default
 /// one if that variable is unset.
 pub fn settings_dir() -> Result<PathBuf> {
-    ::create_and_return(get_settings_dir)
+    crate::create_and_return(get_settings_dir)
 }
 
 fn get_settings_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_SETTINGS_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_settings_dir().map(|dir| dir.join(::PRODUCT_NAME)),
+        None => get_default_settings_dir().map(|dir| dir.join(crate::PRODUCT_NAME)),
     }
 }
 

--- a/mullvad-rpc/src/cached_dns_resolver.rs
+++ b/mullvad-rpc/src/cached_dns_resolver.rs
@@ -363,7 +363,7 @@ mod tests {
         let address = cache.resolve();
 
         assert_eq!(address, fallback_address);
-        let cache_file_path = cache_dir.join(::API_IP_CACHE_FILENAME);
+        let cache_file_path = cache_dir.join(crate::API_IP_CACHE_FILENAME);
         assert!(!cache_file_path.exists());
     }
 
@@ -377,7 +377,7 @@ mod tests {
     }
 
     fn write_invalid_address(dir: &Path) -> PathBuf {
-        let file_path = dir.join(::API_IP_CACHE_FILENAME);
+        let file_path = dir.join(crate::API_IP_CACHE_FILENAME);
         let mut file = File::create(&file_path).unwrap();
 
         writeln!(file, "400.30.12.9").unwrap();
@@ -386,7 +386,7 @@ mod tests {
     }
 
     fn write_address(dir: &Path, address: IpAddr) -> PathBuf {
-        let file_path = dir.join(::API_IP_CACHE_FILENAME);
+        let file_path = dir.join(crate::API_IP_CACHE_FILENAME);
         let mut file = File::create(&file_path).unwrap();
 
         writeln!(file, "{}", address).unwrap();
@@ -403,7 +403,7 @@ mod tests {
     }
 
     fn get_cached_address(cache_dir: &Path) -> String {
-        let cache_file_path = cache_dir.join(::API_IP_CACHE_FILENAME);
+        let cache_file_path = cache_dir.join(crate::API_IP_CACHE_FILENAME);
 
         assert!(cache_file_path.exists());
 
@@ -421,7 +421,7 @@ mod tests {
         fallback_address: Option<IpAddr>,
     ) -> CachedDnsResolver<MockDnsResolver> {
         let hostname = String::from("dummy.host");
-        let cache_file = cache_dir.join(::API_IP_CACHE_FILENAME);
+        let cache_file = cache_dir.join(crate::API_IP_CACHE_FILENAME);
         let fallback_address = fallback_address.unwrap_or(IpAddr::from([10, 0, 109, 91]));
 
         CachedDnsResolver::with_dns_resolver(

--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -60,7 +60,7 @@ impl HttpsConnectorWithSni<HttpConnector> {
     /// This uses hyper's default `HttpConnector`, and default `TlsConnector`.
     /// If you wish to use something besides the defaults, use `From::from`.
     pub fn new<P: AsRef<Path>>(ca_path: P, handle: &Handle) -> Result<Self, ErrorStack> {
-        let mut http = HttpConnector::new(::DNS_THREADS, handle);
+        let mut http = HttpConnector::new(crate::DNS_THREADS, handle);
         http.enforce_http(false);
         let mut ssl_builder = SslConnector::builder(SslMethod::tls())?;
         ssl_builder.set_ca_file(ca_path)?;

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -44,10 +44,10 @@ pub mod event_loop;
 pub mod rest;
 
 mod cached_dns_resolver;
-use cached_dns_resolver::CachedDnsResolver;
+use crate::cached_dns_resolver::CachedDnsResolver;
 
 mod https_client_with_sni;
-use https_client_with_sni::{HttpsClientWithSni, HttpsConnectorWithSni};
+use crate::https_client_with_sni::{HttpsClientWithSni, HttpsConnectorWithSni};
 
 /// Number of threads in the thread pool doing DNS resolutions.
 /// Since DNS is resolved via blocking syscall they must be run on separate threads.

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -10,7 +10,7 @@ use hyper_openssl::openssl::error::ErrorStack;
 
 use tokio_core::reactor::Handle;
 
-use HttpsConnectorWithSni;
+use crate::HttpsConnectorWithSni;
 
 error_chain! {
     errors {

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -31,4 +31,4 @@ pub mod states;
 pub mod version;
 
 mod custom_tunnel;
-pub use custom_tunnel::*;
+pub use crate::custom_tunnel::*;

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -1,5 +1,5 @@
-use location::{CityCode, CountryCode, Hostname};
-use CustomTunnelEndpoint;
+use crate::location::{CityCode, CountryCode, Hostname};
+use crate::CustomTunnelEndpoint;
 
 use std::fmt;
 

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -1,4 +1,4 @@
-use location::{CityCode, CountryCode, Location};
+use crate::location::{CityCode, CountryCode, Location};
 
 use std::net::Ipv4Addr;
 

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -1,9 +1,9 @@
 extern crate serde_json;
 
-use log::{debug, info};
-use relay_constraints::{
+use crate::relay_constraints::{
     Constraint, LocationConstraint, RelayConstraints, RelaySettings, RelaySettingsUpdate,
 };
+use log::{debug, info};
 
 use std::fs::File;
 use std::io;

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -8,12 +8,11 @@ use self::nftnl::{
     nft_expr, nft_expr_bitwise, nft_expr_cmp, nft_expr_ct, nft_expr_meta, nft_expr_payload, Batch,
     Chain, FinalizedBatch, ProtoFamily, Rule, Table,
 };
+use super::{NetworkSecurityT, SecurityPolicy};
+use crate::tunnel;
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use libc;
-use talpid_types::net::{Endpoint, TransportProtocol};
-use tunnel;
-
 use std::{
     env,
     ffi::CString,
@@ -21,8 +20,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
     path::Path,
 };
-
-use super::{NetworkSecurityT, SecurityPolicy};
+use talpid_types::net::{Endpoint, TransportProtocol};
 
 mod dns;
 use self::dns::DnsSettings;

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -60,7 +60,7 @@ pub enum SecurityPolicy {
         /// The peer endpoint that should be allowed.
         peer_endpoint: Endpoint,
         /// Metadata about the tunnel and tunnel interface.
-        tunnel: ::tunnel::TunnelMetadata,
+        tunnel: crate::tunnel::TunnelMetadata,
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
     },

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -1,5 +1,4 @@
-use mktemp;
-use process::openvpn::OpenVpnCommand;
+use crate::{mktemp, process::openvpn::OpenVpnCommand};
 
 use std::collections::HashMap;
 use std::ffi::OsString;

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -1,6 +1,7 @@
-use process::openvpn::{OpenVpnCommand, OpenVpnProcHandle};
-use process::stoppable_process::StoppableProcess;
-
+use crate::process::{
+    openvpn::{OpenVpnCommand, OpenVpnProcHandle},
+    stoppable_process::StoppableProcess,
+};
 use std::collections::HashMap;
 use std::io;
 use std::path::Path;

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -7,7 +7,7 @@ use super::{
     ConnectingState, DisconnectedState, EventConsequence, ResultExt, SharedTunnelStateValues,
     TunnelCommand, TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
-use security::SecurityPolicy;
+use crate::security::SecurityPolicy;
 
 /// No tunnel is running and all network connections are blocked.
 pub struct BlockedState;

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -9,8 +9,10 @@ use super::{
     SharedTunnelStateValues, TunnelCommand, TunnelParameters, TunnelState, TunnelStateTransition,
     TunnelStateWrapper,
 };
-use security::SecurityPolicy;
-use tunnel::{CloseHandle, TunnelEvent, TunnelMetadata};
+use crate::{
+    security::SecurityPolicy,
+    tunnel::{CloseHandle, TunnelEvent, TunnelMetadata},
+};
 
 pub struct ConnectedStateBootstrap {
     pub metadata: TunnelMetadata,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -17,9 +17,12 @@ use super::{
     EventConsequence, SharedTunnelStateValues, TunnelCommand, TunnelParameters, TunnelState,
     TunnelStateTransition, TunnelStateWrapper,
 };
-use logging;
-use security::SecurityPolicy;
-use tunnel::{self, CloseHandle, TunnelEvent, TunnelMetadata, TunnelMonitor};
+use crate::{
+    logging,
+    security::SecurityPolicy,
+    tunnel::{self, CloseHandle, TunnelEvent, TunnelMetadata, TunnelMonitor},
+};
+
 
 const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
 

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -9,7 +9,7 @@ use super::{
     BlockedState, ConnectingState, DisconnectedState, EventConsequence, ResultExt,
     SharedTunnelStateValues, TunnelCommand, TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
-use tunnel::CloseHandle;
+use crate::tunnel::CloseHandle;
 
 /// This state is active from when we manually trigger a tunnel kill until the tunnel wait
 /// operation (TunnelExit) returned.

--- a/talpid-core/src/tunnel_state_machine/macros.rs
+++ b/talpid-core/src/tunnel_state_machine/macros.rs
@@ -10,10 +10,10 @@
 macro_rules! try_handle_event {
     ($same_state:expr, $event:expr) => {
         match $event {
-            Ok(::futures::Async::Ready(Some(event))) => Ok(event),
-            Ok(::futures::Async::Ready(None)) => Err(None),
-            Ok(::futures::Async::NotReady) => {
-                return ::tunnel_state_machine::EventConsequence::NoEvents($same_state);
+            Ok(crate::futures::Async::Ready(Some(event))) => Ok(event),
+            Ok(crate::futures::Async::Ready(None)) => Err(None),
+            Ok(crate::futures::Async::NotReady) => {
+                return crate::tunnel_state_machine::EventConsequence::NoEvents($same_state);
             }
             Err(error) => Err(Some(error)),
         }

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::Mutex;
 
 
 mod processing;
-use processing::EventProcessor;
+use crate::processing::EventProcessor;
 
 
 error_chain!{
@@ -59,10 +59,10 @@ pub static INTERESTING_EVENTS: &'static [EventType] = &[
 ];
 
 openvpn_plugin!(
-    ::openvpn_open,
-    ::openvpn_close,
-    ::openvpn_event,
-    ::Mutex<EventProcessor>
+    crate::openvpn_open,
+    crate::openvpn_close,
+    crate::openvpn_event,
+    crate::Mutex<EventProcessor>
 );
 
 pub struct Arguments {

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -1,11 +1,11 @@
 extern crate futures;
 
 use super::Arguments;
+use crate::openvpn_plugin;
 use jsonrpc_client_core::{
     expand_params, jsonrpc_client, Future, Result as ClientResult, Transport,
 };
 use jsonrpc_client_ipc::IpcTransport;
-use openvpn_plugin;
 use std::{collections::HashMap, thread};
 use tokio::{reactor::Handle, runtime::Runtime};
 


### PR DESCRIPTION
I was going to try to make our crates Rust2018 compatible where possible. Turns out I could do it for all the absolute path imports (`cargo fix` did most of the work) but one thing we can't get to right now is the deprecation of anonymous parameters in traits. Rust 2018 forbids them, but the `jsonrpc_macros` crate does not allow them. However, they have recognized the problem and it looks like they are working on it. Since they want to bring their code up to speed with Rust 2018 I trust they will solve it before the release.

https://github.com/paritytech/jsonrpc/issues/328

Anyway, we could get what I have merged for now without problem. This part is compatible with both Rust 2015 and 2018.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/572)
<!-- Reviewable:end -->
