### PR TITLE
Handle being offline on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Line wrap the file at 100 chars.                                              Th
 - Allow DHCPv6 in the firewall.
 - CLI command `relay update` that triggers an update of the relay list in the daemon.
 
+# macOS
+- Detect if the computer is offline. If so, don't sit in a reconnect loop, instead block and show
+  an error message.
+
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.
 - Make the `problem-report` tool fall back to the bundled API IP if DNS resolution fails.

--- a/gui/packages/desktop/src/renderer/components/NotificationArea.js
+++ b/gui/packages/desktop/src/renderer/components/NotificationArea.js
@@ -45,6 +45,8 @@ function getBlockReasonMessage(blockReason: BlockReason): string {
       return 'Failed to start tunnel connection';
     case 'no_matching_relay':
       return 'No relay server matches the current settings';
+    case 'is_offline':
+      return 'This device is offline, no tunnels can be established';
     default:
       return `Unknown error: ${(blockReason.reason: empty)}`;
   }

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -50,7 +50,8 @@ export type BlockReason =
         | 'ipv6_unavailable'
         | 'set_security_policy_error'
         | 'start_tunnel_error'
-        | 'no_matching_relay',
+        | 'no_matching_relay'
+        | 'is_offline',
     }
   | { reason: 'auth_failed', details: ?string };
 
@@ -310,6 +311,7 @@ const TunnelStateTransitionSchema = oneOf(
           'set_security_policy_error',
           'start_tunnel_error',
           'no_matching_relay',
+          'is_offline',
         ),
       }),
       object({

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -43,6 +43,8 @@ extern crate talpid_types;
 #[cfg(windows)]
 mod winnet;
 
+mod offline;
+
 /// Working with processes.
 pub mod process;
 

--- a/talpid-core/src/offline/dummy.rs
+++ b/talpid-core/src/offline/dummy.rs
@@ -1,0 +1,12 @@
+use futures::sync::mpsc::UnboundedSender;
+use tunnel_state_machine::TunnelCommand;
+
+error_chain!{}
+
+pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<()> {
+    Ok(())
+}
+
+pub fn is_offline() -> bool {
+    false
+}

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -1,0 +1,83 @@
+extern crate system_configuration;
+
+use self::system_configuration::{
+    core_foundation::{
+        array::CFArray,
+        runloop::{kCFRunLoopCommonModes, CFRunLoop},
+        string::CFString,
+    },
+    dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder, SCDynamicStoreCallBackContext},
+};
+use futures::sync::mpsc::UnboundedSender;
+use log::{debug, trace};
+use std::{sync::mpsc, thread};
+use tunnel_state_machine::TunnelCommand;
+
+const PRIMARY_INTERFACE_KEY: &str = "State:/Network/Global/IPv4";
+
+error_chain! {
+    errors {
+        DynamicStoreInitError { description("Failed to initialize dynamic store") }
+    }
+}
+
+pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<()> {
+    let (result_tx, result_rx) = mpsc::channel();
+    thread::spawn(move || match create_dynamic_store(sender) {
+        Ok(store) => {
+            result_tx.send(Ok(())).unwrap();
+            run_dynamic_store_runloop(store);
+            log::error!("Core Foundation main loop exited! It should run forever");
+        }
+        Err(e) => result_tx.send(Err(e)).unwrap(),
+    });
+    result_rx.recv().unwrap()
+}
+
+pub fn is_offline() -> bool {
+    let store = SCDynamicStoreBuilder::new("talpid-primary-interface").build();
+    let is_offline = store.get(CFString::new(PRIMARY_INTERFACE_KEY)).is_none();
+    is_offline
+}
+
+fn create_dynamic_store(sender: UnboundedSender<TunnelCommand>) -> Result<SCDynamicStore> {
+    let callback_context = SCDynamicStoreCallBackContext {
+        callout: primary_interface_change_callback,
+        info: sender,
+    };
+
+    let store = SCDynamicStoreBuilder::new("talpid-primary-interface")
+        .callback_context(callback_context)
+        .build();
+
+    let watch_keys = CFArray::from_CFTypes(&[CFString::new(PRIMARY_INTERFACE_KEY)]);
+    let watch_patterns: CFArray<CFString> = CFArray::from_CFTypes(&[]);
+
+    if store.set_notification_keys(&watch_keys, &watch_patterns) {
+        trace!("Registered for dynamic store notifications");
+        Ok(store)
+    } else {
+        bail!(ErrorKind::DynamicStoreInitError)
+    }
+}
+
+fn run_dynamic_store_runloop(store: SCDynamicStore) {
+    let run_loop_source = store.create_run_loop_source();
+    CFRunLoop::get_current().add_source(&run_loop_source, unsafe { kCFRunLoopCommonModes });
+
+    trace!("Entering primary interface CFRunLoop");
+    CFRunLoop::run_current();
+}
+
+fn primary_interface_change_callback(
+    store: SCDynamicStore,
+    _changed_keys: CFArray<CFString>,
+    state: &mut UnboundedSender<TunnelCommand>,
+) {
+    let is_offline = store.get(CFString::new(PRIMARY_INTERFACE_KEY)).is_none();
+    debug!(
+        "Computer went {}",
+        if is_offline { "offline" } else { "online" }
+    );
+    let _ = state.unbounded_send(TunnelCommand::IsOffline(is_offline));
+}

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(target_os = "macos")]
+#[path = "macos.rs"]
+mod imp;
+
+#[cfg(not(target_os = "macos"))]
+#[path = "dummy.rs"]
+mod imp;
+
+pub use self::imp::{is_offline, spawn_monitor};

--- a/talpid-core/src/security/macos/dns.rs
+++ b/talpid-core/src/security/macos/dns.rs
@@ -218,7 +218,7 @@ fn create_dynamic_store(state: Arc<Mutex<Option<State>>>) -> Result<SCDynamicSto
         info: state,
     };
 
-    let store = SCDynamicStoreBuilder::new("mullvad-dns-monitor")
+    let store = SCDynamicStoreBuilder::new("talpid-dns-monitor")
         .callback_context(callback_context)
         .build();
 
@@ -240,7 +240,7 @@ fn run_dynamic_store_runloop(store: SCDynamicStore) {
     let run_loop_source = store.create_run_loop_source();
     CFRunLoop::get_current().add_source(&run_loop_source, unsafe { kCFRunLoopCommonModes });
 
-    trace!("Entering CFRunLoop");
+    trace!("Entering DNS CFRunLoop");
     CFRunLoop::run_current();
 }
 

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -94,6 +94,21 @@ impl ConnectedState {
                     }
                 }
             }
+            Ok(TunnelCommand::IsOffline(is_offline)) => {
+                shared_values.is_offline = is_offline;
+                if is_offline {
+                    NewState(DisconnectingState::enter(
+                        shared_values,
+                        (
+                            self.close_handle,
+                            self.tunnel_close_event,
+                            AfterDisconnect::Block(BlockReason::IsOffline),
+                        ),
+                    ))
+                } else {
+                    SameState(self)
+                }
+            }
             Ok(TunnelCommand::Connect) => NewState(DisconnectingState::enter(
                 shared_values,
                 (

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -45,6 +45,10 @@ impl TunnelState for DisconnectedState {
                 shared_values.allow_lan = allow_lan;
                 SameState(self)
             }
+            Ok(TunnelCommand::IsOffline(is_offline)) => {
+                shared_values.is_offline = is_offline;
+                SameState(self)
+            }
             Ok(TunnelCommand::Connect) => NewState(ConnectingState::enter(shared_values, 0)),
             Ok(TunnelCommand::Block(reason)) => {
                 NewState(BlockedState::enter(shared_values, reason))

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -33,6 +33,10 @@ impl DisconnectingState {
                     shared_values.allow_lan = allow_lan;
                     AfterDisconnect::Nothing
                 }
+                Ok(TunnelCommand::IsOffline(is_offline)) => {
+                    shared_values.is_offline = is_offline;
+                    AfterDisconnect::Nothing
+                }
                 Ok(TunnelCommand::Connect) => AfterDisconnect::Reconnect(0),
                 Ok(TunnelCommand::Block(reason)) => AfterDisconnect::Block(reason),
                 _ => AfterDisconnect::Nothing,
@@ -41,6 +45,14 @@ impl DisconnectingState {
                 Ok(TunnelCommand::AllowLan(allow_lan)) => {
                     shared_values.allow_lan = allow_lan;
                     AfterDisconnect::Block(reason)
+                }
+                Ok(TunnelCommand::IsOffline(is_offline)) => {
+                    shared_values.is_offline = is_offline;
+                    if !is_offline && reason == BlockReason::IsOffline {
+                        AfterDisconnect::Reconnect(0)
+                    } else {
+                        AfterDisconnect::Block(reason)
+                    }
                 }
                 Ok(TunnelCommand::Connect) => AfterDisconnect::Reconnect(0),
                 Ok(TunnelCommand::Disconnect) => AfterDisconnect::Nothing,
@@ -51,6 +63,14 @@ impl DisconnectingState {
                 Ok(TunnelCommand::AllowLan(allow_lan)) => {
                     shared_values.allow_lan = allow_lan;
                     AfterDisconnect::Reconnect(retry_attempt)
+                }
+                Ok(TunnelCommand::IsOffline(is_offline)) => {
+                    shared_values.is_offline = is_offline;
+                    if is_offline {
+                        AfterDisconnect::Block(BlockReason::IsOffline)
+                    } else {
+                        AfterDisconnect::Reconnect(retry_attempt)
+                    }
                 }
                 Ok(TunnelCommand::Connect) => AfterDisconnect::Reconnect(retry_attempt),
                 Ok(TunnelCommand::Disconnect) | Err(_) => AfterDisconnect::Nothing,

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -52,14 +52,17 @@ pub enum BlockReason {
     StartTunnelError,
     /// No relay server matching the current filter parameters.
     NoMatchingRelay,
+    /// This device is offline, no tunnels can be established.
+    IsOffline,
 }
 
 impl fmt::Display for BlockReason {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::BlockReason::*;
         let description = match *self {
-            BlockReason::AuthFailed(ref reason) => {
+            AuthFailed(ref reason) => {
                 return write!(
-                    formatter,
+                    f,
                     "Authentication with remote server failed: {}",
                     match reason {
                         Some(ref reason) => reason.as_str(),
@@ -67,14 +70,13 @@ impl fmt::Display for BlockReason {
                     }
                 );
             }
-            BlockReason::Ipv6Unavailable => {
-                "Failed to configure IPv6 because it's disabled in the platform"
-            }
-            BlockReason::SetSecurityPolicyError => "Failed to set security policy",
-            BlockReason::StartTunnelError => "Failed to start connection to remote server",
-            BlockReason::NoMatchingRelay => "No relay server matches the current settings",
+            Ipv6Unavailable => "Failed to configure IPv6 because it's disabled in the platform",
+            SetSecurityPolicyError => "Failed to set security policy",
+            StartTunnelError => "Failed to start connection to remote server",
+            NoMatchingRelay => "No relay server matches the current settings",
+            IsOffline => "This device is offline, no tunnels can be established",
         };
 
-        write!(formatter, "{}", description)
+        write!(f, "{}", description)
     }
 }


### PR DESCRIPTION
We have long talked about detecting if the device is offline. If it is we don't need to sit in the CPU intensive and useless indefinite reconnect loop. Here I add code to detect if the computer has no primary network interface. If so we bring the app to a new blocked state.

This explicitly checks for IPv4. I don't know how this would work on an IPv6 only connected computer. But on the other hand, we currently don't allow connecting to VPN relays over IPv4, so the computer running the app must have IPv4 connectivity. As such, I think this solution is enough, at least for now.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/574)
<!-- Reviewable:end -->
