### PR TITLE
Port 2018.5 beta1 updates to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- CLI command `relay update` that triggers an update of the relay list in the daemon.
+
+#### macOS
+- Detect if the computer is offline. If so, don't sit in a reconnect loop, instead block and show
+  an error message.
+
+### Fixed
+- Cancel pending system notifications when the app becomes visible.
+
+#### Windows
+- Use proper app id in the registry. This avoids false-positives with certain anti-virus software.
+
+
+## [2018.5-beta1] - 2018-11-12
+### Added
 - Fall back and try to connect over TCP port 443 if protocol is set to automatic and two attempts
   with UDP fail in a row. If that also fails, alternate between UDP and TCP with random ports.
 - Add new system and in-app notifications to inform the user when the app becomes outdated,
@@ -31,16 +46,10 @@ Line wrap the file at 100 chars.                                              Th
 - Allow the user to view the relay in/out IP address in the GUI.
 - Add OpenVPN proxy support via CLI.
 - Allow DHCPv6 in the firewall.
-- CLI command `relay update` that triggers an update of the relay list in the daemon.
-
-# macOS
-- Detect if the computer is offline. If so, don't sit in a reconnect loop, instead block and show
-  an error message.
 
 ### Fixed
 - Pick new random relay for each reconnect attempt instead of just retrying with the same one.
 - Make the `problem-report` tool fall back to the bundled API IP if DNS resolution fails.
-- Cancel pending system notifications when the app becomes visible.
 
 #### macOS
 - Correctly backup and restore search domains and other DNS settings.
@@ -52,7 +61,6 @@ Line wrap the file at 100 chars.                                              Th
 - Set DNS search domain when using the systemd-resolved. Makes it work on Ubuntu 18.10.
 
 #### Windows
-- Use proper app id in the registry. This avoids false-positives with certain anti-virus software.
 - Fix crash on Windows 7 when closing installer.
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "mullvad-cli"
-version = "2018.4.0"
+version = "2018.5.0-beta1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "mullvad-daemon"
-version = "2018.4.0"
+version = "2018.5.0-beta1"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "mullvad-problem-report"
-version = "2018.4.0"
+version = "2018.5.0-beta1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gui/packages/desktop/package.json
+++ b/gui/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "2018.4.0",
+  "version": "2018.5.0-beta1",
   "productName": "Mullvad VPN",
   "private": true,
   "description": "Mullvad VPN client",

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mullvad-cli"
-version = "2018.4.0"
+version = "2018.5.0-beta1"
 authors = [
     "Mullvad VPN <admin@mullvad.net>",
     "Andrej Mihajlov <and@mullvad.net>",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mullvad-daemon"
-version = "2018.4.0"
+version = "2018.5.0-beta1"
 authors = [
     "Mullvad VPN <admin@mullvad.net>",
     "Andrej Mihajlov <and@mullvad.net>",

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mullvad-problem-report"
-version = "2018.4.0"
+version = "2018.5.0-beta1"
 authors = [
     "Mullvad VPN <admin@mullvad.net>",
     "Andrej Mihajlov <and@mullvad.net>",

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -39,7 +39,8 @@ sed -i.bak -Ee "s/^version = \"[^\"]+\"\$/version = \"$SEMVER_VERSION\"/g" \
     mullvad-problem-report/Cargo.toml
 
 echo "Syncing Cargo.lock with new version numbers"
-cargo update --package mullvad-daemon
+source env.sh
+cargo build
 
 echo "Commiting metadata changes to git..."
 git commit -S -m "Updating version in package files" \


### PR DESCRIPTION
Porting the changelog and version changes from the release branch to master.

Updating the `prepare_release.sh` script since it did not work well. `cargo update` would update all our git dependencies to the latest version and thus not stay on the desired revision. This costs an extra build, but works better and makes releasing much easier for me. The `cargo build` will trigger the lockfile sync I need.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/577)
<!-- Reviewable:end -->
