### PR TITLE
Add env section to CLI help

### DIFF
--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -38,13 +38,23 @@ pub fn get_config() -> Config {
 fn create_app() -> App<'static, 'static> {
     let app = App::new(crate_name!())
         .version(version::PRODUCT_VERSION)
-        .author(crate_authors!())
+        .author(crate_authors!(", "))
         .about(crate_description!())
+        .after_help(
+"ENV:
+
+    MULLVAD_RESOURCE_DIR       Resource directory (i.e used to locate a root CA certificate)
+    MULLVAD_SETTINGS_DIR       Directory path for storing settings
+    MULLVAD_CACHE_DIR          Directory path for storing cache
+    MULLVAD_RPC_SOCKET_PATH    Location of the management interface device.
+                               It refers to Unix domain socket on Unix based platforms, and named pipe on Windows
+
+")
         .arg(
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
-                .help("Sets the level of verbosity."),
+                .help("Sets the level of verbosity"),
         )
         .arg(
             Arg::with_name("disable_log_to_file")


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR adds environment variables section to the output of`mullvad-daemon --help` and fixes the output of authors, which is until this PR was a colon-separated list of our names and emails.

### Why

Because it's hard to remember all of the available env variables.

### How

I am forced to use the `after_help` section because `clap` does not support standalone environment variables. It does support variables tight to specific arguments and we used to have separate arguments for what we use the env variables only now, but I realised that we removed those arguments for a reason so not going to bring this back, instead putting together a text help that mimics other sections generated by clamp, for instance `SUBCOMMANDS` section (we don't have it in our binary) looks alike and uses the same indentation.

The new output:

```
mullvad-daemon 2018.5-beta1
Mullvad VPN <admin@mullvad.net>, Andrej Mihajlov <and@mullvad.net>, Emīls Piņķis <emils@mullvad.net>, Erik Larkö
<erik@mullvad.net>, Janito Vaqueiro Ferreira Filho <janito@mullvad.net>, Linus Färnstrand <linus@mullvad.net>
Mullvad VPN daemon. Runs and controls the VPN tunnels

USAGE:
    mullvad-daemon [FLAGS]

FLAGS:
        --disable-log-to-file          Disable logging to file
        --disable-stdout-timestamps    Don't log timestamps when logging to stdout, useful when running as a systemd
                                       service
    -h, --help                         Prints help information
    -v                                 Sets the level of verbosity
    -V, --version                      Prints version information

ENV:

    MULLVAD_RESOURCE_DIR       Resources directory (i.e used for locating root certificate)
    MULLVAD_SETTINGS_DIR       Settings directory
    MULLVAD_CACHE_DIR          Caches directory
    MULLVAD_RPC_SOCKET_PATH    RPC socket path
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/578)
<!-- Reviewable:end -->