### PR TITLE
Next level kill switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - CLI command `relay update` that triggers an update of the relay list in the daemon.
+- Add extra level of kill-switch called "block when disconnected". Blocks all network traffic even
+  in the disconnected state. Not activated by default and can be changed via the CLI subcommand
+  `block-when-disconnected`.
 
 #### macOS
 - Detect if the computer is offline. If so, don't sit in a reconnect loop, instead block and show

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -1,0 +1,63 @@
+use clap::{self, value_t_or_exit};
+use crate::{new_rpc_client, Command, Result};
+
+pub struct BlockWhenDisconnected;
+
+impl Command for BlockWhenDisconnected {
+    fn name(&self) -> &'static str {
+        "block-when-disconnected"
+    }
+
+    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
+        clap::SubCommand::with_name(self.name())
+            .about("Control if the system service should block network access when disconnected from VPN")
+            .setting(clap::AppSettings::SubcommandRequired)
+            .subcommand(
+                clap::SubCommand::with_name("set")
+                    .about("Change the block when disconnected setting")
+                    .arg(
+                        clap::Arg::with_name("policy")
+                            .required(true)
+                            .possible_values(&["on", "off"]),
+                    ),
+            )
+            .subcommand(
+                clap::SubCommand::with_name("get")
+                    .about("Display the current block when disconnected setting"),
+            )
+    }
+
+    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+        if let Some(set_matches) = matches.subcommand_matches("set") {
+            let block_when_disconnected = value_t_or_exit!(set_matches.value_of("policy"), String);
+            self.set(block_when_disconnected == "on")
+        } else if let Some(_matches) = matches.subcommand_matches("get") {
+            self.get()
+        } else {
+            unreachable!("No block-when-disconnected command given");
+        }
+    }
+}
+
+impl BlockWhenDisconnected {
+    fn set(&self, block_when_disconnected: bool) -> Result<()> {
+        let mut rpc = new_rpc_client()?;
+        rpc.set_block_when_disconnected(block_when_disconnected)?;
+        println!("Changed block when disconnected setting");
+        Ok(())
+    }
+
+    fn get(&self) -> Result<()> {
+        let mut rpc = new_rpc_client()?;
+        let block_when_disconnected = rpc.get_settings()?.get_block_when_disconnected();
+        println!(
+            "Network traffic will be {} when the VPN is disconnected",
+            if block_when_disconnected {
+                "blocked"
+            } else {
+                "allowed"
+            }
+        );
+        Ok(())
+    }
+}

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -16,6 +16,9 @@ pub use self::connect::Connect;
 mod disconnect;
 pub use self::disconnect::Disconnect;
 
+mod block_when_disconnected;
+pub use self::block_when_disconnected::BlockWhenDisconnected;
+
 mod relay;
 pub use self::relay::Relay;
 
@@ -33,11 +36,12 @@ pub fn get_commands() -> HashMap<&'static str, Box<Command>> {
     let commands: Vec<Box<Command>> = vec![
         Box::new(Account),
         Box::new(AutoConnect),
-        Box::new(Status),
+        Box::new(BlockWhenDisconnected),
         Box::new(Connect),
         Box::new(Disconnect),
-        Box::new(Relay),
         Box::new(Lan),
+        Box::new(Relay),
+        Box::new(Status),
         Box::new(Tunnel),
         Box::new(Version),
     ];

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -143,6 +143,10 @@ impl DaemonRpcClient {
         self.call("set_allow_lan", &[allow_lan])
     }
 
+    pub fn set_block_when_disconnected(&mut self, block_when_disconnected: bool) -> Result<()> {
+        self.call("set_block_when_disconnected", &[block_when_disconnected])
+    }
+
     pub fn get_allow_lan(&mut self) -> Result<bool> {
         self.call("get_allow_lan", &NO_ARGS)
     }

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -44,6 +44,9 @@ pub struct Settings {
     relay_settings: RelaySettings,
     /// If the daemon should allow communication with private (LAN) networks.
     allow_lan: bool,
+    /// Extra level of kill switch. When this setting is on, the disconnected state will block
+    /// the firewall to not allow any traffic in or out.
+    block_when_disconnected: bool,
     /// If the daemon should connect the VPN tunnel directly on start or not.
     auto_connect: bool,
     /// Options that should be applied to tunnels of a specific type regardless of where the relays
@@ -60,6 +63,7 @@ impl Default for Settings {
                 tunnel: Constraint::Any,
             }),
             allow_lan: false,
+            block_when_disconnected: false,
             auto_connect: false,
             tunnel_options: TunnelOptions::default(),
         }
@@ -159,6 +163,19 @@ impl Settings {
     pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<bool> {
         if allow_lan != self.allow_lan {
             self.allow_lan = allow_lan;
+            self.save().map(|_| true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn get_block_when_disconnected(&self) -> bool {
+        self.block_when_disconnected
+    }
+
+    pub fn set_block_when_disconnected(&mut self, block_when_disconnected: bool) -> Result<bool> {
+        if block_when_disconnected != self.block_when_disconnected {
+            self.block_when_disconnected = block_when_disconnected;
             self.save().map(|_| true)
         } else {
             Ok(false)

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -58,6 +58,10 @@ impl TunnelState for BlockedState {
                 Self::set_security_policy(shared_values);
                 SameState(self)
             }
+            Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                shared_values.block_when_disconnected = block_when_disconnected;
+                SameState(self)
+            }
             Ok(TunnelCommand::IsOffline(is_offline)) => {
                 shared_values.is_offline = is_offline;
                 if !is_offline && self.block_reason == BlockReason::IsOffline {

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -94,6 +94,10 @@ impl ConnectedState {
                     }
                 }
             }
+            Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                shared_values.block_when_disconnected = block_when_disconnected;
+                SameState(self)
+            }
             Ok(TunnelCommand::IsOffline(is_offline)) => {
                 shared_values.is_offline = is_offline;
                 if is_offline {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -211,6 +211,10 @@ impl ConnectingState {
                     }
                 }
             }
+            Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                shared_values.block_when_disconnected = block_when_disconnected;
+                SameState(self)
+            }
             Ok(TunnelCommand::IsOffline(is_offline)) => {
                 shared_values.is_offline = is_offline;
                 if is_offline {

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -1,7 +1,8 @@
 use super::{
-    BlockedState, ConnectingState, Error, EventConsequence, SharedTunnelStateValues, TunnelCommand,
-    TunnelState, TunnelStateTransition, TunnelStateWrapper,
+    BlockedState, ConnectingState, EventConsequence, ResultExt, SharedTunnelStateValues,
+    TunnelCommand, TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
+use crate::security::SecurityPolicy;
 use error_chain::ChainedError;
 use futures::sync::mpsc;
 use futures::Stream;
@@ -10,10 +11,23 @@ use futures::Stream;
 pub struct DisconnectedState;
 
 impl DisconnectedState {
-    fn reset_security_policy(shared_values: &mut SharedTunnelStateValues) {
-        if let Err(error) = shared_values.security.reset_policy() {
-            let chained_error = Error::with_chain(error, "Failed to reset security policy");
-            log::error!("{}", chained_error.display_chain());
+    fn set_security_policy(shared_values: &mut SharedTunnelStateValues) {
+        let result = if shared_values.block_when_disconnected {
+            let policy = SecurityPolicy::Blocked {
+                allow_lan: shared_values.allow_lan,
+            };
+            shared_values
+                .security
+                .apply_policy(policy)
+                .chain_err(|| "Failed to apply blocking security policy for disconnected state")
+        } else {
+            shared_values
+                .security
+                .reset_policy()
+                .chain_err(|| "Failed to reset security policy")
+        };
+        if let Err(error) = result {
+            log::error!("{}", error.display_chain());
         }
     }
 }
@@ -25,8 +39,7 @@ impl TunnelState for DisconnectedState {
         shared_values: &mut SharedTunnelStateValues,
         _: Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
-        Self::reset_security_policy(shared_values);
-
+        Self::set_security_policy(shared_values);
         (
             TunnelStateWrapper::from(DisconnectedState),
             TunnelStateTransition::Disconnected,
@@ -42,7 +55,19 @@ impl TunnelState for DisconnectedState {
 
         match try_handle_event!(self, commands.poll()) {
             Ok(TunnelCommand::AllowLan(allow_lan)) => {
+                let changed = shared_values.allow_lan != allow_lan;
                 shared_values.allow_lan = allow_lan;
+                if changed {
+                    Self::set_security_policy(shared_values);
+                }
+                SameState(self)
+            }
+            Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                let changed = shared_values.block_when_disconnected != block_when_disconnected;
+                shared_values.block_when_disconnected = block_when_disconnected;
+                if changed {
+                    Self::set_security_policy(shared_values);
+                }
                 SameState(self)
             }
             Ok(TunnelCommand::IsOffline(is_offline)) => {

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -55,17 +55,15 @@ impl TunnelState for DisconnectedState {
 
         match try_handle_event!(self, commands.poll()) {
             Ok(TunnelCommand::AllowLan(allow_lan)) => {
-                let changed = shared_values.allow_lan != allow_lan;
-                shared_values.allow_lan = allow_lan;
-                if changed {
+                if shared_values.allow_lan != allow_lan {
+                    shared_values.allow_lan = allow_lan;
                     Self::set_security_policy(shared_values);
                 }
                 SameState(self)
             }
             Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
-                let changed = shared_values.block_when_disconnected != block_when_disconnected;
-                shared_values.block_when_disconnected = block_when_disconnected;
-                if changed {
+                if shared_values.block_when_disconnected != block_when_disconnected {
+                    shared_values.block_when_disconnected = block_when_disconnected;
                     Self::set_security_policy(shared_values);
                 }
                 SameState(self)

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -33,6 +33,10 @@ impl DisconnectingState {
                     shared_values.allow_lan = allow_lan;
                     AfterDisconnect::Nothing
                 }
+                Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                    shared_values.block_when_disconnected = block_when_disconnected;
+                    AfterDisconnect::Nothing
+                }
                 Ok(TunnelCommand::IsOffline(is_offline)) => {
                     shared_values.is_offline = is_offline;
                     AfterDisconnect::Nothing
@@ -44,6 +48,10 @@ impl DisconnectingState {
             AfterDisconnect::Block(reason) => match event {
                 Ok(TunnelCommand::AllowLan(allow_lan)) => {
                     shared_values.allow_lan = allow_lan;
+                    AfterDisconnect::Block(reason)
+                }
+                Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                    shared_values.block_when_disconnected = block_when_disconnected;
                     AfterDisconnect::Block(reason)
                 }
                 Ok(TunnelCommand::IsOffline(is_offline)) => {
@@ -62,6 +70,10 @@ impl DisconnectingState {
             AfterDisconnect::Reconnect(retry_attempt) => match event {
                 Ok(TunnelCommand::AllowLan(allow_lan)) => {
                     shared_values.allow_lan = allow_lan;
+                    AfterDisconnect::Reconnect(retry_attempt)
+                }
+                Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                    shared_values.block_when_disconnected = block_when_disconnected;
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Ok(TunnelCommand::IsOffline(is_offline)) => {


### PR DESCRIPTION
Should solve #522.

Adds an extra daemon setting called `block_when_disconnected`. This defaults to `false` and when `false` the app should work identical to how it works today. But when set to `true` it will block the firewall in in the same way it does when in blocked state, but also in the disconnected state.

This has the result that if a user explicitly clicks disconnect or exits the app GUI they will have all their internet access blocked until they connect the VPN tunnel again via the CLI or GUI.

Should add an extra level of safety for those afraid of accidentally clicking the disconnect button or those exiting the GUI and still expect to not leak for example.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/581)
<!-- Reviewable:end -->
