### PR TITLE
Mark the wireguard field as ignored for now

### DIFF
--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -50,6 +50,7 @@ pub struct Relay {
 #[serde(default)]
 pub struct RelayTunnels {
     pub openvpn: Vec<OpenVpnEndpointData>,
+    #[serde(skip)]
     pub wireguard: Vec<WireguardEndpointData>,
 }
 


### PR DESCRIPTION
Ignore the wireguard field in the relay list for now. This is so we can backport this to 2018.5 and get this change out as early as possible. The earlier our app ignores this field the earlier we can rename it back from `wireguard_` to `wireguard` basically.

So this is a temporary fix. We should of course fix so it correctly deserializes later.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/582)
<!-- Reviewable:end -->
