### PR TITLE
Reset dns more often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Changed
 - Replace OpenVPN root CA certificate bundled with the app to the new Mullvad root CA.
+- Split DNS management from Firewall management to allow restoring DNS earlier and showing more
+  detailed errors to users.
 
 ### Fixed
 - Cancel pending system notifications when the app becomes visible.

--- a/gui/packages/desktop/src/renderer/components/NotificationArea.js
+++ b/gui/packages/desktop/src/renderer/components/NotificationArea.js
@@ -41,6 +41,8 @@ function getBlockReasonMessage(blockReason: BlockReason): string {
       return 'Could not configure IPv6, please enable it on your system or disable it in the app';
     case 'set_security_policy_error':
       return 'Failed to apply security policy';
+    case 'set_dns_error':
+      return 'Failed to set system DNS server';
     case 'start_tunnel_error':
       return 'Failed to start tunnel connection';
     case 'no_matching_relay':

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc.js
@@ -49,6 +49,7 @@ export type BlockReason =
       reason:
         | 'ipv6_unavailable'
         | 'set_security_policy_error'
+        | 'set_dns_error'
         | 'start_tunnel_error'
         | 'no_matching_relay'
         | 'is_offline',
@@ -309,6 +310,7 @@ const TunnelStateTransitionSchema = oneOf(
         reason: enumeration(
           'ipv6_unavailable',
           'set_security_policy_error',
+          'set_dns_error',
           'start_tunnel_error',
           'no_matching_relay',
           'is_offline',

--- a/talpid-core/src/security/linux/dns/resolvconf.rs
+++ b/talpid-core/src/security/linux/dns/resolvconf.rs
@@ -35,7 +35,7 @@ impl Resolvconf {
         })
     }
 
-    pub fn set_dns(&mut self, interface: &str, servers: Vec<IpAddr>) -> Result<()> {
+    pub fn set_dns(&mut self, interface: &str, servers: &[IpAddr]) -> Result<()> {
         let record_name = format!("{}.mullvad", interface);
         let mut record_contents = String::new();
 

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -1,8 +1,6 @@
 extern crate mnl;
 extern crate nftnl;
 
-use error_chain::ChainedError;
-
 use self::nftnl::{
     expr::{self, Verdict},
     nft_expr, nft_expr_bitwise, nft_expr_cmp, nft_expr_ct, nft_expr_meta, nft_expr_payload, Batch,
@@ -23,7 +21,7 @@ use std::{
 use talpid_types::net::{Endpoint, TransportProtocol};
 
 mod dns;
-use self::dns::DnsSettings;
+pub use self::dns::{DnsMonitor, Error as DnsError};
 
 error_chain! {
     errors {
@@ -42,7 +40,6 @@ error_chain! {
         }
     }
     links {
-        DnsSettings(self::dns::Error, self::dns::ErrorKind) #[doc = "DNS error"];
         Nftnl(nftnl::Error, nftnl::ErrorKind) #[doc = "Error in nftnl"];
     }
 }
@@ -75,7 +72,6 @@ enum End {
 
 /// The Linux implementation for the firewall and DNS.
 pub struct NetworkSecurity {
-    dns_settings: DnsSettings,
     table_name: CString,
 }
 
@@ -84,27 +80,17 @@ impl NetworkSecurityT for NetworkSecurity {
 
     fn new(_cache_dir: impl AsRef<Path>) -> Result<Self> {
         Ok(NetworkSecurity {
-            dns_settings: DnsSettings::new()?,
             table_name: TABLE_NAME.clone(),
         })
     }
 
     fn apply_policy(&mut self, policy: SecurityPolicy) -> Result<()> {
-        if let SecurityPolicy::Connected { ref tunnel, .. } = policy {
-            self.dns_settings
-                .set_dns(&tunnel.interface, vec![tunnel.gateway.into()])?;
-        }
-
         let table = Table::new(&self.table_name, ProtoFamily::Inet)?;
         let batch = PolicyBatch::new(&table)?.finalize(&policy)?;
         self.send_and_process(&batch)
     }
 
     fn reset_policy(&mut self) -> Result<()> {
-        if let Err(error) = self.dns_settings.reset() {
-            log::error!("Failed to reset DNS settings: {}", error.display_chain());
-        }
-
         let table = Table::new(&self.table_name, ProtoFamily::Inet)?;
         let batch = {
             let mut batch = Batch::new()?;

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -16,7 +16,6 @@ use std::{
     ffi::CString,
     io,
     net::{IpAddr, Ipv4Addr},
-    path::Path,
 };
 use talpid_types::net::{Endpoint, TransportProtocol};
 
@@ -78,7 +77,7 @@ pub struct NetworkSecurity {
 impl NetworkSecurityT for NetworkSecurity {
     type Error = Error;
 
-    fn new(_cache_dir: impl AsRef<Path>) -> Result<Self> {
+    fn new() -> Result<Self> {
         Ok(NetworkSecurity {
             table_name: TABLE_NAME.clone(),
         })

--- a/talpid-core/src/security/macos/dns.rs
+++ b/talpid-core/src/security/macos/dns.rs
@@ -17,10 +17,10 @@ use log::{debug, trace};
 use std::{
     collections::HashMap,
     fmt,
+    net::IpAddr,
+    path::Path,
     sync::{mpsc, Arc, Mutex},
     thread,
-    path::Path,
-    net::IpAddr,
 };
 
 error_chain! {

--- a/talpid-core/src/security/macos/dns.rs
+++ b/talpid-core/src/security/macos/dns.rs
@@ -163,7 +163,6 @@ impl DnsMonitor {
             None => {
                 let backup = read_all_dns(&self.store);
                 trace!("Backup of DNS settings: {:#?}", backup);
-                debug!("Setting DNS to [{}]", servers.join(", "));
                 for service_path in backup.keys() {
                     settings.save(&self.store, service_path.as_str())?;
                 }
@@ -174,7 +173,6 @@ impl DnsMonitor {
             }
             Some(state) => {
                 if servers != state.dns_settings.server_addresses() {
-                    debug!("Changing DNS to [{}]", servers.join(", "));
                     for service_path in state.backup.keys() {
                         settings.save(&self.store, service_path.as_str())?;
                     }

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -3,7 +3,6 @@ extern crate tokio_core;
 
 use super::{NetworkSecurityT, SecurityPolicy};
 use std::net::Ipv4Addr;
-use std::path::Path;
 use talpid_types::net;
 
 mod dns;
@@ -26,7 +25,7 @@ pub struct NetworkSecurity {
 impl NetworkSecurityT for NetworkSecurity {
     type Error = Error;
 
-    fn new(_cache_dir: impl AsRef<Path>) -> Result<Self> {
+    fn new() -> Result<Self> {
         Ok(NetworkSecurity {
             pf: pfctl::PfCtl::new()?,
             pf_was_enabled: None,

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -3,9 +3,9 @@ use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(unix)]
 use lazy_static::lazy_static;
 use std::fmt;
+use std::net::IpAddr;
 #[cfg(unix)]
 use std::net::{Ipv4Addr, Ipv6Addr};
-use std::net::IpAddr;
 use std::path::Path;
 use talpid_types::net::Endpoint;
 
@@ -115,9 +115,9 @@ pub struct NetworkSecurity {
 
 impl NetworkSecurity {
     /// Returns a new `NetworkSecurity`, ready to apply policies.
-    pub fn new(cache_dir: impl AsRef<Path>) -> Result<Self, Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(NetworkSecurity {
-            inner: imp::NetworkSecurity::new(cache_dir)?,
+            inner: imp::NetworkSecurity::new()?,
         })
     }
 
@@ -176,7 +176,7 @@ trait NetworkSecurityT: Sized {
     type Error: ::std::error::Error;
 
     /// Create new instance
-    fn new(cache_dir: impl AsRef<Path>) -> ::std::result::Result<Self, Self::Error>;
+    fn new() -> ::std::result::Result<Self, Self::Error>;
 
     /// Enable the given SecurityPolicy
     fn apply_policy(&mut self, policy: SecurityPolicy) -> ::std::result::Result<(), Self::Error>;

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -4,7 +4,8 @@ use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use lazy_static::lazy_static;
 use std::fmt;
 #[cfg(unix)]
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::IpAddr;
 use std::path::Path;
 use talpid_types::net::Endpoint;
 

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -21,7 +21,7 @@ mod imp;
 #[path = "windows/mod.rs"]
 mod imp;
 
-pub use self::imp::{DnsError, Error, ErrorKind};
+pub use self::imp::{DnsError, Error};
 
 
 #[cfg(unix)]

--- a/talpid-core/src/security/windows/dns.rs
+++ b/talpid-core/src/security/windows/dns.rs
@@ -42,12 +42,14 @@ error_chain!{
     }
 }
 
-pub struct WinDns {
+pub struct DnsMonitor {
     backup_writer: SystemStateWriter,
 }
 
-impl WinDns {
-    pub fn new<P: AsRef<Path>>(cache_dir: P) -> Result<Self> {
+impl super::super::DnsMonitorT for DnsMonitor {
+    type Error = Error;
+
+    fn new(cache_dir: impl AsRef<Path>) -> Result<Self> {
         unsafe { WinDns_Initialize(Some(log_sink), ptr::null_mut()).into_result()? };
 
         let backup_writer = SystemStateWriter::new(
@@ -56,7 +58,7 @@ impl WinDns {
                 .join(DNS_STATE_FILENAME)
                 .into_boxed_path(),
         );
-        let mut dns = WinDns { backup_writer };
+        let mut dns = DnsMonitor { backup_writer };
         if let Err(error) = dns
             .restore_system_backup()
             .chain_err(|| "Failed to restore DNS backup")
@@ -66,7 +68,7 @@ impl WinDns {
         Ok(dns)
     }
 
-    pub fn set_dns(&mut self, servers: &[IpAddr]) -> Result<()> {
+    fn set(&mut self, _interface: &str, servers: &[IpAddr]) -> Result<()> {
         let ipv4 = servers
             .iter()
             .filter(|ip| ip.is_ipv4())
@@ -107,7 +109,7 @@ impl WinDns {
         }
     }
 
-    pub fn reset_dns(&mut self) -> Result<()> {
+    fn reset(&mut self) -> Result<()> {
         unsafe { WinDns_Reset().into_result()? };
 
         if let Err(e) = self.backup_writer.remove_backup() {
@@ -115,7 +117,9 @@ impl WinDns {
         }
         Ok(())
     }
+}
 
+impl DnsMonitor {
     fn restore_dns_settings(&mut self, data: &[u8]) -> Result<()> {
         unsafe { WinDns_Recover(data.as_ptr(), data.len() as u32) }.into_result()
     }
@@ -188,7 +192,7 @@ extern "system" fn log_sink(
     }
 }
 
-impl Drop for WinDns {
+impl Drop for DnsMonitor {
     fn drop(&mut self) {
         if unsafe { WinDns_Deinitialize().into_result().is_ok() } {
             trace!("Successfully deinitialized WinDns");

--- a/talpid-core/src/security/windows/dns.rs
+++ b/talpid-core/src/security/windows/dns.rs
@@ -67,15 +67,6 @@ impl WinDns {
     }
 
     pub fn set_dns(&mut self, servers: &[IpAddr]) -> Result<()> {
-        info!(
-            "Setting DNS servers - {}",
-            servers
-                .iter()
-                .map(|ip| ip.to_string())
-                .collect::<Vec<String>>()
-                .join(", ")
-        );
-
         let ipv4 = servers
             .iter()
             .filter(|ip| ip.is_ipv4())
@@ -117,7 +108,6 @@ impl WinDns {
     }
 
     pub fn reset_dns(&mut self) -> Result<()> {
-        trace!("Resetting DNS");
         unsafe { WinDns_Reset().into_result()? };
 
         if let Err(e) = self.backup_writer.remove_backup() {

--- a/talpid-core/src/security/windows/dns.rs
+++ b/talpid-core/src/security/windows/dns.rs
@@ -93,8 +93,8 @@ impl super::super::DnsMonitorT for DnsMonitor {
             .map(|ip_cstr| ip_cstr.as_ptr())
             .collect::<Vec<_>>();
 
-        debug!("ipv4 ips - {:?} - {}", ipv4_addresses, ipv4_addresses.len());
-        debug!("ipv6 ips - {:?} - {}", ipv6_addresses, ipv6_addresses.len());
+        trace!("ipv4 ips - {:?} - {}", ipv4_addresses, ipv4_addresses.len());
+        trace!("ipv6 ips - {:?} - {}", ipv6_addresses, ipv6_addresses.len());
 
         unsafe {
             WinDns_Set(
@@ -141,7 +141,7 @@ impl DnsMonitor {
                 .chain_err(|| "Failed to remove backed up DNS state after restoring it")?;
             debug!("DNS recovery file removed!");
         } else {
-            trace!("No dns state to restore");
+            trace!("No DNS state to restore");
         }
         Ok(())
     }
@@ -186,7 +186,7 @@ extern "system" fn log_sink(
             match log_level {
                 0x01 => error!("{}", message),
                 0x02 => info!("{}", message),
-                _ => error!("unknwon log level - {}", message),
+                _ => error!("Unknwon log level - {}", message),
             }
         }
     }

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -1,5 +1,4 @@
 use std::net::IpAddr;
-use std::path::Path;
 use std::ptr;
 
 use log::{debug, error, trace};
@@ -65,7 +64,7 @@ pub struct NetworkSecurity(());
 impl NetworkSecurityT for NetworkSecurity {
     type Error = Error;
 
-    fn new(_cache_dir: impl AsRef<Path>) -> Result<Self> {
+    fn new() -> Result<Self> {
         unsafe {
             WinFw_Initialize(
                 WINFW_TIMEOUT_SECONDS,

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -6,7 +6,6 @@ use log::{debug, error, trace};
 use talpid_types::net::Endpoint;
 use widestring::WideCString;
 
-use self::dns::WinDns;
 use self::winfw::*;
 use super::{NetworkSecurityT, SecurityPolicy};
 use winnet;
@@ -15,6 +14,8 @@ use winnet;
 mod ffi;
 
 mod dns;
+pub use self::dns::{DnsMonitor, Error as DnsError};
+
 mod system_state;
 
 error_chain! {
@@ -54,24 +55,17 @@ error_chain! {
             description("Unable to set TAP adapter metric")
         }
     }
-
-    links {
-        WinDns(dns::Error, dns::ErrorKind) #[doc = "WinDNS failure"];
-    }
 }
 
 const WINFW_TIMEOUT_SECONDS: u32 = 2;
 
 /// The Windows implementation for the firewall and DNS.
-pub struct NetworkSecurity {
-    dns: WinDns,
-}
+pub struct NetworkSecurity(());
 
 impl NetworkSecurityT for NetworkSecurity {
     type Error = Error;
 
-    fn new(cache_dir: impl AsRef<Path>) -> Result<Self> {
-        let windns = WinDns::new(cache_dir)?;
+    fn new(_cache_dir: impl AsRef<Path>) -> Result<Self> {
         unsafe {
             WinFw_Initialize(
                 WINFW_TIMEOUT_SECONDS,
@@ -81,7 +75,7 @@ impl NetworkSecurityT for NetworkSecurity {
             .into_result()?
         };
         trace!("Successfully initialized windows firewall module");
-        Ok(NetworkSecurity { dns: windns })
+        Ok(NetworkSecurity(()))
     }
 
     fn apply_policy(&mut self, policy: SecurityPolicy) -> Result<()> {
@@ -109,7 +103,6 @@ impl NetworkSecurityT for NetworkSecurity {
     }
 
     fn reset_policy(&mut self) -> Result<()> {
-        self.dns.reset_dns()?;
         unsafe { WinFw_Reset().into_result() }?;
         Ok(())
     }
@@ -168,8 +161,6 @@ impl NetworkSecurity {
             port: endpoint.address.port(),
             protocol: WinFwProt::from(endpoint.protocol),
         };
-
-        self.dns.set_dns(&vec![tunnel_metadata.gateway.into()])?;
 
         let metrics_set = winnet::ensure_top_metric_for_interface(&tunnel_metadata.interface)
             .chain_err(|| ErrorKind::SetTapMetric)?;

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -191,8 +191,7 @@ impl TunnelStateMachine {
         cache_dir: impl AsRef<Path>,
         commands: mpsc::UnboundedReceiver<TunnelCommand>,
     ) -> Result<Self> {
-        let security =
-            NetworkSecurity::new(&cache_dir).chain_err(|| ErrorKind::NetworkSecurityError)?;
+        let security = NetworkSecurity::new().chain_err(|| ErrorKind::NetworkSecurityError)?;
         let dns_monitor = DnsMonitor::new(cache_dir).chain_err(|| ErrorKind::DnsMonitorError)?;
         let mut shared_values = SharedTunnelStateValues {
             security,

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -24,13 +24,21 @@ use self::connected_state::{ConnectedState, ConnectedStateBootstrap};
 use self::connecting_state::ConnectingState;
 use self::disconnected_state::DisconnectedState;
 use self::disconnecting_state::{AfterDisconnect, DisconnectingState};
-use crate::{mpsc::IntoSender, offline, security::NetworkSecurity};
+use crate::{
+    mpsc::IntoSender,
+    offline,
+    security::{DnsMonitor, NetworkSecurity},
+};
 
 error_chain! {
     errors {
         /// An error occurred while setting up the network security.
         NetworkSecurityError {
             description("Network security error")
+        }
+        /// Unable to start the DNS settings monitor and enforcer.
+        DnsMonitorError {
+            description("Unable to start the DNS settings enforcer and monitor")
         }
         /// An error occurred while attempting to set up the event loop for the tunnel state
         /// machine.
@@ -184,9 +192,11 @@ impl TunnelStateMachine {
         commands: mpsc::UnboundedReceiver<TunnelCommand>,
     ) -> Result<Self> {
         let security =
-            NetworkSecurity::new(cache_dir).chain_err(|| ErrorKind::NetworkSecurityError)?;
+            NetworkSecurity::new(&cache_dir).chain_err(|| ErrorKind::NetworkSecurityError)?;
+        let dns_monitor = DnsMonitor::new(cache_dir).chain_err(|| ErrorKind::DnsMonitorError)?;
         let mut shared_values = SharedTunnelStateValues {
             security,
+            dns_monitor,
             allow_lan,
             block_when_disconnected,
             is_offline,
@@ -265,6 +275,7 @@ pub trait TunnelParametersGenerator: Send + 'static {
 /// Values that are common to all tunnel states.
 struct SharedTunnelStateValues {
     security: NetworkSecurity,
+    dns_monitor: DnsMonitor,
     /// Should LAN access be allowed outside the tunnel.
     allow_lan: bool,
     /// Should network access be allowed when in the disconnected state.

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -48,6 +48,8 @@ pub enum BlockReason {
     Ipv6Unavailable,
     /// Failed to set security policy.
     SetSecurityPolicyError,
+    /// Failed to set system DNS server.
+    SetDnsError,
     /// Failed to start connection to remote server.
     StartTunnelError,
     /// No relay server matching the current filter parameters.
@@ -72,6 +74,7 @@ impl fmt::Display for BlockReason {
             }
             Ipv6Unavailable => "Failed to configure IPv6 because it's disabled in the platform",
             SetSecurityPolicyError => "Failed to set security policy",
+            SetDnsError => "Failed to set system DNS server",
             StartTunnelError => "Failed to start connection to remote server",
             NoMatchingRelay => "No relay server matches the current settings",
             IsOffline => "This device is offline, no tunnels can be established",


### PR DESCRIPTION
Remove DNS management from the `NetworkSecurity` struct and move into a separate `DnsMonitor` type. Now the `Connected` state is the only place where we do anything DNS related. This state will set DNS upon entry and make sure it's reset just before the state machine transitions out from it.

## Possible future work
* We could now rename `NetworkSecurity` back to `Firewall` or something. But not sure we want that and don't want to do too much in the same PR
* We can move the `DnsMonitor` type and modules out directly to `talpid_core::dns` since it's not directly security related and does not need to reside in there. But again, don't want to do too much at the same time.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/584)
<!-- Reviewable:end -->
