### PR TITLE
Remove check that rustc matches a given version on production builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,16 +19,6 @@ PRODUCT_VERSION=$(node -p "require('./gui/packages/desktop/package.json').versio
 source env.sh
 
 if [[ "${1:-""}" != "--dev-build" ]]; then
-
-    REQUIRED_RUSTC_VERSION="rustc 1.30.0 (da5f414c2 2018-10-24)"
-
-    if [[ $RUSTC_VERSION != $REQUIRED_RUSTC_VERSION ]]; then
-        echo "You are running the wrong Rust compiler version."
-        echo "You are running $RUSTC_VERSION, but this project requires $REQUIRED_RUSTC_VERSION"
-        echo "for release builds."
-        exit 1
-    fi
-
     if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
         echo "Dirty working directory!"
         echo "You should only build releases in clean working directories in order to make it"


### PR DESCRIPTION
Don't force rustc to be a specific version on production builds. I don't think this check ever actually gave us any benefits. Instead it has caused the build server to not be so automatic any more, since whenever a new Rust version comes out there is more manual work involved and upgrades need to be done in the correct order etc.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/585)
<!-- Reviewable:end -->
