### PR TITLE
Filter out relays that have tunnel endpoints

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -70,6 +70,12 @@ impl ParsedRelays {
                 let city_code = city.code.clone();
                 let latitude = city.latitude;
                 let longitude = city.longitude;
+                city.relays = city
+                    .relays
+                    .iter()
+                    .filter(|relay| !relay.tunnels.is_empty())
+                    .cloned()
+                    .collect();
                 for relay in &mut city.relays {
                     let mut relay_with_location = relay.clone();
                     relay_with_location.location = Some(Location {


### PR DESCRIPTION
Solves bug of Wireguard servers showing up in the GUI.
Also solves potential future problems if the API supplies
relays without any endpoints, they should not be selectable

I ignored adding it to the changelog. Since the API does not have zero endpoints for any relay, nor does it intend to have. And we will likely create a new `relay_list2` when we add the wireguard servers to circumvent displaying them in older apps, plus not needing to name the field `wireguard_`. So this is mostly fixing a hypothetical bug rather than one we have encountered.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/586)
<!-- Reviewable:end -->
