### PR TITLE
Add default route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Use proper app id in the registry. This avoids false-positives with certain anti-virus software.
 - Handle sleep/resume events to quickly restore the tunnel when the machine wakes up.
+- Add default route to fix NLA issues (Microsoft Store/Office/etc say the machine is offline).
 
 
 ## [2018.5] - 2018-11-15

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -219,6 +219,11 @@ impl OpenVpnCommand {
         args.extend(Self::security_arguments().iter().map(OsString::from));
         args.extend(self.proxy_arguments().iter().map(OsString::from));
 
+        #[cfg(windows)]
+        {
+            args.extend(Self::default_route_arguments().iter().map(OsString::from));
+        }
+
         args
     }
 
@@ -296,6 +301,18 @@ impl OpenVpnCommand {
             None => {}
         };
         args
+    }
+
+    fn default_route_arguments() -> Vec<String> {
+        vec![
+            "--route-gateway".to_owned(),
+            "dhcp".to_owned(),
+            "--route".to_owned(),
+            "0.0.0.0".to_owned(),
+            "0.0.0.0".to_owned(),
+            "vpn_gateway".to_owned(),
+            "1".to_owned(),
+        ]
     }
 }
 


### PR DESCRIPTION
Add default route for TAP interface, fixes NLA (Office etc believe they're offline) issues on Windows 10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/589)
<!-- Reviewable:end -->
