### PR TITLE
Don't cargo clean in dev builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,6 @@ if [[ "${1:-""}" != "--dev-build" ]]; then
         unset CSC_LINK CSC_KEY_PASSWORD
         export CSC_IDENTITY_AUTO_DISCOVERY=false
     fi
-
-    cargo +stable clean
 else
     echo "!! Development build. Not for general distribution !!"
     unset CSC_LINK CSC_KEY_PASSWORD
@@ -56,6 +54,9 @@ if [[ "${1:-""}" == "--dev-build" || $(git describe) != "$PRODUCT_VERSION" ]]; t
     GIT_COMMIT=$(git rev-parse --short HEAD)
     PRODUCT_VERSION="$PRODUCT_VERSION-dev-$GIT_COMMIT"
     echo "Modifying product version to $PRODUCT_VERSION"
+else
+    echo "Removing old Rust build artifacts"
+    cargo +stable clean
 fi
 
 echo "Building Mullvad VPN $PRODUCT_VERSION"


### PR DESCRIPTION
Change the logic slightly. Previously the `cargo clean` was triggered every time the `--dev-build` flag was omitted. But all builds without the `--dev-build` flag that are not built directly no a git tag still get the `-dev-<hash>` version suffix and are in a sense dev builds, just that they are also signed.

Our build server runs `./build.sh` without `--dev-build` in order to sign all builds. But then it also does a fresh build on each push. This takes an insane amount of time and CPU power for virtually no reason. Re-using old build artifacts should be safe. It's just that we want official releases to be pedantically rebuilt from the start. Thus I here change the logic so the `cargo clean` is only run on builds built without `--dev-build` directly on a git tag, in other words, our official releases.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/590)
<!-- Reviewable:end -->
