### PR TITLE
Listen to the RouteUp instead of the Up plugin event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Cancel pending system notifications when the app becomes visible.
+- Transition to connected state after all routes are configured. Avoids problems with reaching the
+  internet directly after the app says it's connected.
 
 #### Windows
 - Use proper app id in the registry. This avoids false-positives with certain anti-virus software.

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -409,7 +409,7 @@ impl MockOpenVpnPluginRpcClient {
         env.insert("ifconfig_local".to_owned(), "10.0.0.10".to_owned());
         env.insert("route_vpn_gateway".to_owned(), "10.0.0.1".to_owned());
 
-        self.send_event(openvpn_plugin::EventType::Up, env)
+        self.send_event(openvpn_plugin::EventType::RouteUp, env)
     }
 
     pub fn route_predown(&mut self) -> Result<()> {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -109,7 +109,7 @@ impl TunnelEvent {
                 let reason = env.get("auth_failed_reason").cloned();
                 Some(TunnelEvent::AuthFailed(reason))
             }
-            openvpn_plugin::EventType::Up => {
+            openvpn_plugin::EventType::RouteUp => {
                 let interface = env
                     .get("dev")
                     .expect("No \"dev\" in tunnel up event")
@@ -191,7 +191,7 @@ impl TunnelMonitor {
         };
 
         let on_openvpn_event = move |event, env| {
-            if event == openvpn_plugin::EventType::Up {
+            if event == openvpn_plugin::EventType::RouteUp {
                 // The user-pass file has been read. Try to delete it early.
                 let _ = fs::remove_file(&user_pass_file_path);
 

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -54,7 +54,7 @@ error_chain!{
 /// events.
 pub static INTERESTING_EVENTS: &'static [EventType] = &[
     EventType::AuthFailed,
-    EventType::Up,
+    EventType::RouteUp,
     EventType::RoutePredown,
 ];
 


### PR DESCRIPTION
We have had a lot of problems with not being able to reach the network directly after we transition into the `Connected` state. The problem here has been that the routes are not ready directly. This is because we were listening to the `PLUGIN_UP` event in OpenVPN, which is fired directly when the tun interface comes up, before routes are set. This PR changes so we listen to the `PLUGIN_ROUTE_UP` event instead, this is fired directly after the routes are set up, so the network should be more ready at this point.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/592)
<!-- Reviewable:end -->
