### PR TITLE
Move Windows default route arguments to BASE_ARGUMENTS

### DIFF
--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -31,6 +31,16 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--fast-io"],
     &["--cipher", "AES-256-CBC"],
     &["--verb", "3"],
+    #[cfg(windows)]
+    &[
+        "--route-gateway",
+        "dhcp",
+        "--route",
+        "0.0.0.0",
+        "0.0.0.0",
+        "vpn_gateway",
+        "1",
+    ],
 ];
 
 static ALLOWED_TLS_CIPHERS: &[&str] = &[
@@ -219,11 +229,6 @@ impl OpenVpnCommand {
         args.extend(Self::security_arguments().iter().map(OsString::from));
         args.extend(self.proxy_arguments().iter().map(OsString::from));
 
-        #[cfg(windows)]
-        {
-            args.extend(Self::default_route_arguments().iter().map(OsString::from));
-        }
-
         args
     }
 
@@ -301,18 +306,6 @@ impl OpenVpnCommand {
             None => {}
         };
         args
-    }
-
-    fn default_route_arguments() -> Vec<String> {
-        vec![
-            "--route-gateway".to_owned(),
-            "dhcp".to_owned(),
-            "--route".to_owned(),
-            "0.0.0.0".to_owned(),
-            "0.0.0.0".to_owned(),
-            "vpn_gateway".to_owned(),
-            "1".to_owned(),
-        ]
     }
 }
 


### PR DESCRIPTION
Gets rid of the unused function warning on non-windows. And simplifies things a bit since it's only static strings anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/593)
<!-- Reviewable:end -->
