### PR TITLE
Fix warnings

### DIFF
--- a/talpid-core/src/offline/dummy.rs
+++ b/talpid-core/src/offline/dummy.rs
@@ -3,8 +3,10 @@ use tunnel_state_machine::TunnelCommand;
 
 error_chain!{}
 
-pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<()> {
-    Ok(())
+pub struct MonitorHandle;
+
+pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
+    Ok(MonitorHandle)
 }
 
 pub fn is_offline() -> bool {

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -21,7 +21,9 @@ error_chain! {
     }
 }
 
-pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<()> {
+pub struct MonitorHandle;
+
+pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
     let (result_tx, result_rx) = mpsc::channel();
     thread::spawn(move || match create_dynamic_store(sender) {
         Ok(store) => {
@@ -31,7 +33,7 @@ pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<()> {
         }
         Err(e) => result_tx.send(Err(e)).unwrap(),
     });
-    result_rx.recv().unwrap()
+    result_rx.recv().unwrap().map(|_| MonitorHandle)
 }
 
 pub fn is_offline() -> bool {

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,3 +1,6 @@
+use futures::sync::mpsc::UnboundedSender;
+use tunnel_state_machine::TunnelCommand;
+
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]
 mod imp;
@@ -10,4 +13,10 @@ mod imp;
 #[path = "dummy.rs"]
 mod imp;
 
-pub use self::imp::{is_offline, spawn_monitor};
+pub use self::imp::is_offline;
+
+pub struct MonitorHandle(imp::MonitorHandle);
+
+pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle, imp::Error> {
+    Ok(MonitorHandle(imp::spawn_monitor(sender)?))
+}

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -162,7 +162,9 @@ impl Drop for BroadcastListener {
     }
 }
 
-pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<BroadcastListener> {
+pub type MonitorHandle = BroadcastListener;
+
+pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
     let listener =
         BroadcastListener::start(move |message: UINT, wparam: WPARAM, _lparam: LPARAM| {
             if message == WM_POWERBROADCAST {

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -1,3 +1,6 @@
+// TODO fix these tests on Windows
+#![cfg(not(windows))]
+
 extern crate assert_matches;
 extern crate env_logger;
 extern crate jsonrpc_client_core;
@@ -38,8 +41,6 @@ impl TestApi for ApiImpl {
     }
 }
 
-// TODO fix this test on Windows
-#[cfg(not(windows))]
 #[test]
 fn can_call_rpcs_on_server() {
     env_logger::init();
@@ -56,8 +57,6 @@ fn can_call_rpcs_on_server() {
     server.close_handle().close();
 }
 
-// TODO fix this test on Windows
-#[cfg(not(windows))]
 #[test]
 #[should_panic]
 fn ipc_client_invalid_url() {


### PR DESCRIPTION
Finally getting rid of those compiler warnings on Windows.

Also took care a clippy lint "error" in the new offline monitor handle. Since the "handle" type was unity (`()`) on non-windows it meant that we called `mem::drop(())` on those platforms. Clippy does not like this since `()` implements the `Copy` trait, and it does not make sense to drop a copy type since it does not have a lifetime in the same sense as regular types. Thus I fixed that by wrapping all "handles" in a specific type that does *not* implement `Copy` and thus make clippy happy.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/594)
<!-- Reviewable:end -->
