### PR TITLE
Print MULLVAD_ path variable defaults in help text

### DIFF
--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -43,6 +43,7 @@ lazy_static::lazy_static! {
                                [Default: {}]
     MULLVAD_SETTINGS_DIR       Directory path for storing settings. [Default: {}]
     MULLVAD_CACHE_DIR          Directory path for storing cache. [Default: {}]
+    MULLVAD_LOG_DIR            Directory path for storing logs. [Default: {}]
     MULLVAD_RPC_SOCKET_PATH    Location of the management interface device.
                                It refers to Unix domain socket on Unix based platforms, and named pipe on Windows.
                                [Default: {}]
@@ -51,6 +52,7 @@ lazy_static::lazy_static! {
         mullvad_paths::get_default_resource_dir().display(),
         mullvad_paths::get_default_settings_dir().expect("Unable to get settings dir").display(),
         mullvad_paths::get_default_cache_dir().expect("Unable to get cache dir").display(),
+        mullvad_paths::get_default_log_dir().expect("Unable to get log dir").display(),
         mullvad_paths::get_default_rpc_socket_path().display());
 }
 

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -35,21 +35,31 @@ pub fn get_config() -> Config {
     }
 }
 
+lazy_static::lazy_static! {
+    static ref ENV_DESC: String = format!(
+"ENV:
+
+    MULLVAD_RESOURCE_DIR       Resource directory (i.e used to locate a root CA certificate)
+                               [Default: {}]
+    MULLVAD_SETTINGS_DIR       Directory path for storing settings. [Default: {}]
+    MULLVAD_CACHE_DIR          Directory path for storing cache. [Default: {}]
+    MULLVAD_RPC_SOCKET_PATH    Location of the management interface device.
+                               It refers to Unix domain socket on Unix based platforms, and named pipe on Windows.
+                               [Default: {}]
+
+",
+        mullvad_paths::get_default_resource_dir().display(),
+        mullvad_paths::get_default_settings_dir().expect("Unable to get settings dir").display(),
+        mullvad_paths::get_default_cache_dir().expect("Unable to get cache dir").display(),
+        mullvad_paths::get_default_rpc_socket_path().display());
+}
+
 fn create_app() -> App<'static, 'static> {
     let app = App::new(crate_name!())
         .version(version::PRODUCT_VERSION)
         .author(crate_authors!(", "))
         .about(crate_description!())
-        .after_help(
-"ENV:
-
-    MULLVAD_RESOURCE_DIR       Resource directory (i.e used to locate a root CA certificate)
-    MULLVAD_SETTINGS_DIR       Directory path for storing settings
-    MULLVAD_CACHE_DIR          Directory path for storing cache
-    MULLVAD_RPC_SOCKET_PATH    Location of the management interface device.
-                               It refers to Unix domain socket on Unix based platforms, and named pipe on Windows
-
-")
+        .after_help(ENV_DESC.as_str())
         .arg(
             Arg::with_name("v")
                 .short("v")

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -12,17 +12,19 @@ pub fn cache_dir() -> Result<PathBuf> {
 fn get_cache_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_CACHE_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_cache_dir().map(|dir| dir.join(crate::PRODUCT_NAME)),
+        None => get_default_cache_dir(),
     }
 }
 
-fn get_default_cache_dir() -> Result<PathBuf> {
+pub fn get_default_cache_dir() -> Result<PathBuf> {
+    let dir;
     #[cfg(target_os = "linux")]
     {
-        Ok(PathBuf::from("/var/cache"))
+        dir = Ok(PathBuf::from("/var/cache"))
     }
     #[cfg(any(target_os = "macos", windows))]
     {
-        ::dirs::cache_dir().ok_or_else(|| ::ErrorKind::FindDirError.into())
+        dir = ::dirs::cache_dir().ok_or_else(|| ::ErrorKind::FindDirError.into())
     }
+    dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -42,16 +42,16 @@ fn create_and_return(dir_fn: fn() -> Result<PathBuf>) -> Result<PathBuf> {
 }
 
 mod cache;
-pub use crate::cache::cache_dir;
+pub use crate::cache::{cache_dir, get_default_cache_dir};
 
 mod logs;
 pub use crate::logs::{get_log_dir, log_dir};
 
 pub mod resources;
-pub use crate::resources::get_resource_dir;
+pub use crate::resources::{get_default_resource_dir, get_resource_dir};
 
 mod rpc_socket;
-pub use crate::rpc_socket::get_rpc_socket_path;
+pub use crate::rpc_socket::{get_default_rpc_socket_path, get_rpc_socket_path};
 
 mod settings;
-pub use crate::settings::settings_dir;
+pub use crate::settings::{get_default_settings_dir, settings_dir};

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -45,7 +45,7 @@ mod cache;
 pub use crate::cache::{cache_dir, get_default_cache_dir};
 
 mod logs;
-pub use crate::logs::{get_log_dir, log_dir};
+pub use crate::logs::{get_default_log_dir, get_log_dir, log_dir};
 
 pub mod resources;
 pub use crate::resources::{get_default_resource_dir, get_resource_dir};

--- a/mullvad-paths/src/logs.rs
+++ b/mullvad-paths/src/logs.rs
@@ -13,17 +13,19 @@ pub fn log_dir() -> Result<PathBuf> {
 pub fn get_log_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_LOG_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_log_dir().map(|dir| dir.join(crate::PRODUCT_NAME)),
+        None => get_default_log_dir(),
     }
 }
 
-fn get_default_log_dir() -> Result<PathBuf> {
+pub fn get_default_log_dir() -> Result<PathBuf> {
+    let dir;
     #[cfg(unix)]
     {
-        Ok(PathBuf::from("/var/log"))
+        dir = Ok(PathBuf::from("/var/log"));
     }
     #[cfg(windows)]
     {
-        ::get_allusersprofile_dir()
+        dir = ::get_allusersprofile_dir();
     }
+    dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-paths/src/resources.rs
+++ b/mullvad-paths/src/resources.rs
@@ -10,7 +10,7 @@ pub fn get_resource_dir() -> PathBuf {
     }
 }
 
-fn get_default_resource_dir() -> PathBuf {
+pub fn get_default_resource_dir() -> PathBuf {
     match env::current_exe() {
         Ok(mut path) => {
             path.pop();

--- a/mullvad-paths/src/rpc_socket.rs
+++ b/mullvad-paths/src/rpc_socket.rs
@@ -4,9 +4,17 @@ use std::path::PathBuf;
 pub fn get_rpc_socket_path() -> PathBuf {
     match env::var_os("MULLVAD_RPC_SOCKET_PATH") {
         Some(path) => PathBuf::from(path),
-        #[cfg(unix)]
-        None => PathBuf::from("/var/run/mullvad-vpn"),
-        #[cfg(windows)]
-        None => PathBuf::from("//./pipe/Mullvad VPN"),
+        None => get_default_rpc_socket_path(),
+    }
+}
+
+pub fn get_default_rpc_socket_path() -> PathBuf {
+    #[cfg(unix)]
+    {
+        PathBuf::from("/var/run/mullvad-vpn")
+    }
+    #[cfg(windows)]
+    {
+        PathBuf::from("//./pipe/Mullvad VPN")
     }
 }

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -12,17 +12,19 @@ pub fn settings_dir() -> Result<PathBuf> {
 fn get_settings_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_SETTINGS_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
-        None => get_default_settings_dir().map(|dir| dir.join(crate::PRODUCT_NAME)),
+        None => get_default_settings_dir(),
     }
 }
 
-fn get_default_settings_dir() -> Result<PathBuf> {
+pub fn get_default_settings_dir() -> Result<PathBuf> {
+    let dir;
     #[cfg(unix)]
     {
-        Ok(PathBuf::from("/etc"))
+        dir = Ok(PathBuf::from("/etc"));
     }
     #[cfg(windows)]
     {
-        ::dirs::data_local_dir().ok_or_else(|| ::ErrorKind::FindDirError.into())
+        dir = ::dirs::data_local_dir().ok_or_else(|| ::ErrorKind::FindDirError.into());
     }
+    dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }


### PR DESCRIPTION
Thought it made sense to print the default value of things that has default values. Could potentially help support a bit. Partially by making it easier for support to find the default values, but also for users to, by themselves, find out where our paths point to.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/596)
<!-- Reviewable:end -->
