### PR TITLE
Fix clippy warnings

### DIFF
--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -59,7 +59,7 @@ fn print_blocked_reason(reason: &BlockReason) {
                 .as_ref()
                 .map(|s| s.as_str())
                 .unwrap_or("Account authentication failed");
-            println!("Blocked: {}", AuthFailed::from_str(auth_failure_str));
+            println!("Blocked: {}", AuthFailed::from(auth_failure_str));
         }
         other => println!("Blocked: {}", other),
     }

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -287,7 +287,7 @@ impl Tunnel {
 
             let proxy = RemoteOpenVpnProxySettings {
                 address: SocketAddr::new(remote_ip, remote_port),
-                auth: auth,
+                auth,
             };
 
             let packed_proxy = OpenVpnProxySettings::Remote(proxy);

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -199,14 +199,14 @@ fn collect_report(
                             other_logs.push(path);
                         }
                     }
-                    Err(error) => problem_report.add_error("Unable to get log path", error),
+                    Err(error) => problem_report.add_error("Unable to get log path", &error),
                 }
             }
             for other_log in other_logs {
                 problem_report.add_log(&other_log);
             }
         }
-        Err(error) => problem_report.add_error("Failed to list logs in log directory", error),
+        Err(error) => problem_report.add_error("Failed to list logs in log directory", &error),
     };
 
     problem_report.add_logs(extra_logs);
@@ -329,13 +329,8 @@ impl ProblemReport {
     }
 
     /// Attach an error to the report.
-    pub fn add_error<S, E>(&mut self, message: S, error: E)
-    where
-        S: ToString,
-        E: ChainedError,
-    {
+    pub fn add_error(&mut self, message: &'static str, error: &impl ChainedError) {
         let redacted_error = self.redact(&error.display_chain().to_string());
-
         self.logs.push((message.to_string(), redacted_error));
     }
 

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -381,7 +381,6 @@ impl MockOpenVpnPluginRpcClient {
                     tx.send(Ok(client_handle)).unwrap();
                     tokio::run(client.map_err(|e| {
                         println!("RPC client failed: {}", e);
-                        ()
                     }));
                 }
                 Err(e) => tx.send(Err(e)).unwrap(),

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -19,32 +19,32 @@ const INVALID_ACCOUNT_MSG: &str = "You've logged in with an account number that 
 const EXPIRED_ACCOUNT_MSG: &str = "You have no more VPN time left on this account. Please log in on our website to buy more credit.";
 const TOO_MANY_CONNECTIONS_MSG: &str = "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly.";
 
-impl AuthFailedInner {
-    fn from_str(input: &str) -> AuthFailedInner {
+impl<'a> From<&'a str> for AuthFailedInner {
+    fn from(reason: &'a str) -> AuthFailedInner {
         use self::AuthFailedInner::*;
-        match parse_string(input) {
+        match parse_string(reason) {
             Some(("INVALID_ACCOUNT", _)) => InvalidAccount,
             Some(("EXPIRED_ACCOUNT", _)) => ExpiredAccount,
             Some(("TOO_MANY_CONNECTIONS", _)) => TooManyConnectons,
             Some((unknown_reason, message)) => {
                 log::warn!(
                     "Received AUTH_FAILED message with unknown reason: {}",
-                    input
+                    reason
                 );
                 Unknown(unknown_reason.to_string(), message.to_string())
             }
             None => {
-                log::warn!("Received invalid AUTH_FAILED message: {}", input);
-                Unknown("UNKNOWN".to_string(), input.to_string())
+                log::warn!("Received invalid AUTH_FAILED message: {}", reason);
+                Unknown("UNKNOWN".to_string(), reason.to_string())
             }
         }
     }
 }
 
-impl AuthFailed {
-    pub fn from_str(reason: &str) -> AuthFailed {
+impl<'a> From<&'a str> for AuthFailed {
+    fn from(reason: &'a str) -> AuthFailed {
         AuthFailed {
-            reason: AuthFailedInner::from_str(reason),
+            reason: AuthFailedInner::from(reason),
         }
     }
 }
@@ -66,7 +66,7 @@ impl ::std::fmt::Display for AuthFailed {
 // * "INVALID_ACCOUNT" - the ID of the failure reason.
 // * "This is not a valid Mullvad account" - the human readable message of the failure reason.
 // In the case that the message has preceeding whitespace, it will be trimmed.
-fn parse_string<'a>(reason: &'a str) -> Option<(&'a str, &'a str)> {
+fn parse_string(reason: &str) -> Option<(&str, &str)> {
     lazy_static! {
         static ref REASON_REGEX: Regex = Regex::new(r"^\[(\w+)\]\s*(.*)$").unwrap();
     }

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -275,7 +275,7 @@ fn ip_address_to_message_item(address: &IpAddr) -> MessageItem {
 
 fn bytes_to_message_item_array(bytes: &[u8]) -> MessageItemArray {
     MessageItemArray::new(
-        bytes.into_iter().cloned().map(MessageItem::Byte).collect(),
+        bytes.iter().cloned().map(MessageItem::Byte).collect(),
         Signature::make::<Vec<u8>>(),
     )
     .expect("Invalid construction of DBus array of bytes argument")


### PR DESCRIPTION
Just some very minor stuff. Cleaning up stuff Clippy wanted to help us with.

Clippy don't like that you name a method `from_str` then it thinks you should implement that trait instead. But our conversion is infallible, ours is not, so just `From<&str>` was more appropriate in this case.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/598)
<!-- Reviewable:end -->
