### PR TITLE
Replace WMI code in installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Line wrap the file at 100 chars.                                              Th
 - Use proper app id in the registry. This avoids false-positives with certain anti-virus software.
 - Handle sleep/resume events to quickly restore the tunnel when the machine wakes up.
 - Add default route to fix NLA issues (Microsoft Store/Office/etc say the machine is offline).
+- Update installer to not rely on WMI when enumerating network adapters.
 
 
 ## [2018.5] - 2018-11-15

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -1,82 +1,76 @@
 #include "stdafx.h"
 #include "context.h"
 #include <libcommon/string.h>
-#include <libcommon/wmi/connection.h>
-#include <libcommon/wmi/resultset.h>
-#include <libcommon/wmi/wmi.h>
+#include <libcommon/error.h>
 #include <log/log.h>
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <iphlpapi.h>
+#include <windows.h>
 #include <vector>
+#include <list>
 #include <stdexcept>
-#include <algorithm>
-#include <memory>
-#include <sstream>
-
-using namespace common;
 
 namespace
 {
 
-std::vector<std::wstring> BlockToRows(const std::wstring &textBlock)
+std::set<Context::NetworkAdapter> GetAllAdapters()
 {
-	//
-	// This is such a hack :-(
-	//
-	// It only works because the tokenizer is greedy and because we don't care about
-	// empty lines for this usage.
-	//
-	return common::string::Tokenize(textBlock, L"\r\n");
-}
+	ULONG bufferSize = 0;
 
-void LogAllAdapters(wmi::Connection &connection)
-{
-	auto resultset = connection.query(L"SELECT * from Win32_NetworkAdapter");
+	const ULONG flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
 
-	struct NetworkAdapter
+	auto status = GetAdaptersAddresses(AF_INET, flags, nullptr, nullptr, &bufferSize);
+
+	THROW_UNLESS(ERROR_BUFFER_OVERFLOW, status, "Probe for adapter listing buffer size");
+
+	// Memory is cheap, this avoids a looping construct.
+	bufferSize *= 2;
+
+	std::vector<uint8_t> buffer(bufferSize);
+
+	status = GetAdaptersAddresses(AF_INET, flags, nullptr,
+		reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buffer[0]), &bufferSize);
+
+	THROW_UNLESS(ERROR_SUCCESS, status, "Retrieve adapter listing");
+
+	std::set<Context::NetworkAdapter> adapters;
+
+	for (auto it = (PIP_ADAPTER_ADDRESSES)&buffer[0]; nullptr != it; it = it->Next)
 	{
-		size_t interfaceIndex;
-		std::wstring manufacturer;
-		std::wstring name;
-		std::wstring pnpDeviceId;
-		std::wstring alias;
-	};
-
-	std::vector<NetworkAdapter> adapters;
-
-	//
-	// Find all adapters and extract the most important data.
-	//
-
-	auto StringOrNa = [](const _variant_t &variant)
-	{
-		if (VT_BSTR == V_VT(&variant))
-		{
-			return std::wstring(V_BSTR(&variant));
-		}
-
-		return std::wstring(L"n/a");
-	};
-
-	while(resultset.advance())
-	{
-		auto interfaceIndex = wmi::WmiGetPropertyAlways(resultset.result(), L"InterfaceIndex");
-		auto manufacturer = wmi::WmiGetProperty(resultset.result(), L"Manufacturer");
-		auto name = wmi::WmiGetProperty(resultset.result(), L"Name");
-		auto pnpDeviceId = wmi::WmiGetProperty(resultset.result(), L"PNPDeviceID");
-		auto alias = wmi::WmiGetProperty(resultset.result(), L"NetConnectionID");
-
-		NetworkAdapter adapter;
-
-		adapter.interfaceIndex = static_cast<size_t>(V_UI8(&interfaceIndex));
-		adapter.manufacturer = StringOrNa(manufacturer);
-		adapter.name = StringOrNa(name);
-		adapter.pnpDeviceId = StringOrNa(pnpDeviceId);
-		adapter.alias = StringOrNa(alias);
-
-		adapters.emplace_back(adapter);
+		adapters.emplace(Context::NetworkAdapter(common::string::ToWide(it->AdapterName),
+			it->Description, it->FriendlyName));
 	}
 
+	return adapters;
+}
+
+std::set<Context::NetworkAdapter> GetTapAdapters(const std::set<Context::NetworkAdapter> &adapters)
+{
+	std::set<Context::NetworkAdapter> tapAdapters;
+
+	for (const auto &adapter : adapters)
+	{
+		static const wchar_t name[] = L"TAP-Windows Adapter V9";
+
+		//
+		// Compare partial name, because once you start having more TAP adapters
+		// they're named "TAP-Windows Adapter V9 #2" and so on.
+		//
+
+		if (0 == adapter.name.compare(0, _countof(name) - 1, name))
+		{
+			tapAdapters.insert(adapter);
+		}
+	}
+
+	return tapAdapters;
+}
+
+void LogAdapters(const std::wstring &description, const std::set<Context::NetworkAdapter> &adapters)
+{
 	//
-	// Flatten the adapter information so we can log it more easily.
+	// Flatten the information so we can log it more easily.
 	//
 
 	std::vector<std::wstring> details;
@@ -85,159 +79,64 @@ void LogAllAdapters(wmi::Connection &connection)
 	{
 		details.emplace_back(L"Adapter");
 
-		{
-			std::wstringstream ss;
-
-			ss << L"    InterfaceIndex: " << adapter.interfaceIndex;
-
-			details.emplace_back(ss.str());
-		}
-
-		details.emplace_back(std::wstring(L"    Manufacturer: ").append(adapter.manufacturer));
+		details.emplace_back(std::wstring(L"    Guid: ").append(adapter.guid));
 		details.emplace_back(std::wstring(L"    Name: ").append(adapter.name));
-		details.emplace_back(std::wstring(L"    PnpDeviceId: ").append(adapter.pnpDeviceId));
 		details.emplace_back(std::wstring(L"    Alias: ").append(adapter.alias));
 	}
 
-	PluginLogWithDetails(L"Adapters known to WMI", details);
-}
-
-std::wstring DoubleBackslashes(const std::wstring &str)
-{
-	auto result(str);
-
-	size_t offset = 0;
-
-	for (size_t index = 0; index < str.size(); ++index)
-	{
-		if (L'\\' == str[index])
-		{
-			result.insert(index + offset, 1, L'\\');
-			++offset;
-		}
-	}
-
-	return result;
+	PluginLogWithDetails(description, details);
 }
 
 } // anonymous namespace
 
-Context::Context()
-	: m_connection(wmi::Connection::Namespace::Cimv2)
+Context::BaselineStatus Context::establishBaseline()
 {
-}
+	m_baseline = GetAllAdapters();
 
-Context::BaselineStatus Context::establishBaseline(const std::wstring &textBlock)
-{
-	m_baseline = ParseVirtualNics(textBlock);
+	auto tapAdapters = GetTapAdapters(m_baseline);
 
-	if (m_baseline.empty())
+	if (tapAdapters.empty())
 	{
-		return BaselineStatus::NO_INTERFACES_PRESENT;
+		return BaselineStatus::NO_TAP_ADAPTERS_PRESENT;
 	}
 
-	for (const auto &nic : m_baseline)
+	for (const auto &adapter : tapAdapters)
 	{
-		if (0 == _wcsicmp(nic.alias.c_str(), L"mullvad"))
+		if (0 == _wcsicmp(adapter.alias.c_str(), L"mullvad"))
 		{
-			return BaselineStatus::MULLVAD_INTERFACE_PRESENT;
+			return BaselineStatus::MULLVAD_ADAPTER_PRESENT;
 		}
 	}
 
-	return BaselineStatus::SOME_INTERFACES_PRESENT;
+	return BaselineStatus::SOME_TAP_ADAPTERS_PRESENT;
 }
 
-void Context::recordCurrentState(const std::wstring &textBlock)
+void Context::recordCurrentState()
 {
-	m_currentState = ParseVirtualNics(textBlock);
+	m_currentState = GetAllAdapters();
 }
 
-Context::VirtualNic Context::getNewAdapter()
+Context::NetworkAdapter Context::getNewAdapter()
 {
-	std::vector<VirtualNic> added;
+	std::list<NetworkAdapter> added;
 
-	for (const auto &nic : m_currentState)
+	const auto baselineTaps = GetTapAdapters(m_baseline);
+	const auto currentTaps = GetTapAdapters(m_currentState);
+
+	for (const auto &adapter : currentTaps)
 	{
-		if (m_baseline.end() == m_baseline.find(nic))
+		if (baselineTaps.end() == baselineTaps.find(adapter))
 		{
-			added.push_back(nic);
+			added.push_back(adapter);
 		}
 	}
 
 	if (added.size() != 1)
 	{
-		throw std::runtime_error("Unable to identify newly added virtual adapter");
+		LogAdapters(L"Enumerable network adapters", m_currentState);
+
+		throw std::runtime_error("Unable to identify recently added TAP adapter");
 	}
 
-	return added[0];
-}
-
-std::set<Context::VirtualNic> Context::ParseVirtualNics(const std::wstring &textBlock)
-{
-	// ROOT\NET\0000
-	//     Name: TAP - Windows Adapter V9
-	//     Hardware IDs :
-	//         tap0901
-	// 1 matching device(s) found.
-
-	std::set<VirtualNic> nics;
-
-	auto text = BlockToRows(textBlock);
-
-	size_t line = 0;
-
-	while (nullptr != wcschr(text.at(line).c_str(), L'\\'))
-	{
-		auto nameDelimiter = wcschr(text.at(line + 1).c_str(), L':');
-
-		if (nullptr == nameDelimiter)
-		{
-			throw std::runtime_error("Unexpected formatting in input data");
-		}
-
-		VirtualNic nic;
-
-		nic.node = text.at(line);
-		nic.name = std::wstring(nameDelimiter + 2);
-		nic.alias = GetNicAlias(nic.node, nic.name);
-
-		nics.emplace(std::move(nic));
-		line += 4;
-	}
-
-	return nics;
-}
-
-std::wstring Context::GetNicAlias(const std::wstring &node, const std::wstring &name)
-{
-	//
-	// The name cannot be used when querying WMI, because WMI sometimes normalizes the
-	// names in its dataset, thereby destroying their uniqueness.
-	//
-	// E.g. if a network interface has a name of "TAP-Windows Adapter V9 #2" it will
-	// sometimes be reported by WMI as "TAP-Windows Adapter V9".
-	//
-	// Also, the node string cannot be used as-is. We have to double the backslashes in it
-	// or the string will be rejected by WMI.
-	//
-
-	const auto formattedNode = DoubleBackslashes(node);
-
-	std::wstringstream ss;
-
-	ss << L"SELECT * FROM Win32_NetworkAdapter WHERE PNPDeviceID = \"" << formattedNode << L"\"";
-
-	auto resultset = m_connection.query(ss.str().c_str());
-
-	if (false == resultset.advance())
-	{
-		PluginLog(std::wstring(L"WMI query failed for adapter: ").append(name));
-		LogAllAdapters(m_connection);
-
-		throw std::runtime_error("Unable to look up virtual adapter using WMI");
-	}
-
-	auto alias = wmi::WmiGetPropertyAlways(resultset.result(), L"NetConnectionID");
-
-	return V_BSTR(&alias);
+	return *added.begin();
 }

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <libcommon/wmi/connection.h>
 #include <set>
 #include <string>
 
@@ -8,49 +7,47 @@ class Context
 {
 public:
 
-	Context();
-
-	struct VirtualNic
+	Context()
 	{
-		std::wstring node;
+	}
+
+	struct NetworkAdapter
+	{
+		std::wstring guid;
 		std::wstring name;
 		std::wstring alias;
 
-		bool operator<(const VirtualNic &rhs) const
+		NetworkAdapter(std::wstring _guid, std::wstring _name, std::wstring _alias)
+			: guid(_guid)
+			, name(_name)
+			, alias(_alias)
 		{
-			return _wcsicmp(node.c_str(), rhs.node.c_str()) < 0;
+		}
+
+		bool operator<(const NetworkAdapter &rhs) const
+		{
+			return _wcsicmp(guid.c_str(), rhs.guid.c_str()) < 0;
 		}
 	};
 
 	enum class BaselineStatus
 	{
-		NO_INTERFACES_PRESENT,
-		SOME_INTERFACES_PRESENT,
-		MULLVAD_INTERFACE_PRESENT
+		NO_TAP_ADAPTERS_PRESENT,
+		SOME_TAP_ADAPTERS_PRESENT,
+		MULLVAD_ADAPTER_PRESENT
 	};
 
-	//
-	// Invoke with the output from "tapinstall hwids tap0901"
-	//
-	BaselineStatus establishBaseline(const std::wstring &textBlock);
+	BaselineStatus establishBaseline();
+
+	void recordCurrentState();
 
 	//
-	// Invoke with the output from "tapinstall hwids tap0901"
+	// Identify a single new TAP adapter
 	//
-	void recordCurrentState(const std::wstring &textBlock);
-
-	//
-	// Identify a single new interface
-	//
-	VirtualNic getNewAdapter();
+	NetworkAdapter getNewAdapter();
 
 private:
 
-	common::wmi::Connection m_connection;
-
-	std::set<VirtualNic> ParseVirtualNics(const std::wstring &textBlock);
-	std::wstring GetNicAlias(const std::wstring &node, const std::wstring &name);
-
-	std::set<VirtualNic> m_baseline;
-	std::set<VirtualNic> m_currentState;
+	std::set<NetworkAdapter> m_baseline;
+	std::set<NetworkAdapter> m_currentState;
 };

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.def
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.def
@@ -4,5 +4,5 @@ EXPORTS
 
 Initialize
 EstablishBaseline
-IdentifyNewInterface
+IdentifyNewAdapter
 Deinitialize

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.vcxproj
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.vcxproj
@@ -70,7 +70,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <AdditionalLibraryDirectories>$(ProjectDir)../../../../dist-assets/binaries/windows/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>iphlpapi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>driverlogic.def</ModuleDefinitionFile>
     </Link>
@@ -96,7 +96,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <AdditionalLibraryDirectories>$(ProjectDir)../../../../dist-assets/binaries/windows/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>iphlpapi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>driverlogic.def</ModuleDefinitionFile>
     </Link>


### PR DESCRIPTION
Rather than taking the output from `tapinstall`, and complementing that data with additional data retrieved using WMI, I've now changed the code to use the WinAPI directly for network adapter enumeration.

The largest benefits of this approach is not having to do text parsing and also not having to rely on WMI. A potential drawback is that the current method doesn't consider any details about the driver backing a given adapter. That's because this information is not easily available using any of the WinAPI functions I've tested.

However, that's mostly a theoretical drawback. I estimate that the new code will be more successful on average.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/600)
<!-- Reviewable:end -->
