### PR TITLE
Handle rpc simpler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Line wrap the file at 100 chars.                                              Th
 - Cancel pending system notifications when the app becomes visible.
 - Transition to connected state after all routes are configured. Avoids problems with reaching the
   internet directly after the app says it's connected.
+- Disable keep alive on API RPC requests. Should stop reuse of invalid sockets after tunnel state
+  changes.
 
 #### Windows
 - Use proper app id in the registry. This avoids false-positives with certain anti-virus software.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
  "mullvad-rpc 0.1.0",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-release 0.1.7 (git+https://github.com/mullvad/rs-release?branch=snailquote-unescape)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winres 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.5"
 error-chain = "0.12"
 lazy_static = "1.0"
 regex = "1.0"
+tokio-core = "0.1"
 uuid = { version = "0.6", features = ["v4"] }
 
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -39,7 +39,10 @@ impl ClientCreator for HttpsClientWithSni {
     fn create(&self, handle: &Handle) -> Result<Client<Self::Connect, Body>, Self::Error> {
         let mut connector = HttpsConnectorWithSni::new(&self.ca_path, handle)?;
         connector.set_sni_hostname(Some(self.sni_hostname.clone()));
-        let client = Client::configure().connector(connector).build(handle);
+        let client = Client::configure()
+            .keep_alive(false)
+            .connector(connector)
+            .build(handle);
         Ok(client)
     }
 }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -88,11 +88,6 @@ impl MullvadRpcFactory {
         }
     }
 
-    /// Spawns a tokio core on a new thread and returns a `HttpHandle` running on that core.
-    pub fn new_connection(&mut self) -> Result<HttpHandle, HttpError> {
-        self.setup_connection(HttpTransportBuilder::standalone)
-    }
-
     /// Create and returns a `HttpHandle` running on the given core handle.
     pub fn new_connection_on_event_loop(
         &mut self,


### PR DESCRIPTION
Cleaning up jsonrpc-client and friends enough to be able to throw sockets out on state changes was not very trivial. After realizing we probably don't benefit a whole lot from keep alives I decided to try to disable them instead. Trivial change and should hopefully make our RPC calls work much more stable.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/602)
<!-- Reviewable:end -->
