### PR TITLE
Add IPC event channel and type all IPC events

### DIFF
--- a/gui/packages/components/src/ConnectionInfo.tsx
+++ b/gui/packages/components/src/ConnectionInfo.tsx
@@ -30,6 +30,7 @@ const styles = {
   hostname: Styles.createTextStyle({
     fontFamily: 'Open Sans',
     fontSize: 16,
+    lineHeight: 20,
     fontWeight: '600',
     color: 'rgb(255, 255, 255)',
     flex: 1,

--- a/gui/packages/desktop/scripts/serve.js
+++ b/gui/packages/desktop/scripts/serve.js
@@ -58,7 +58,7 @@ bsync.init(
 
     let child = runElectron(browserSyncUrl);
 
-    bsync.watch('build/main/**/*').on('change', () => {
+    bsync.watch(['build/main/**/*', 'build/shared/**/*']).on('change', () => {
       child.removeListener('close', onCloseElectron);
       child.kill();
 

--- a/gui/packages/desktop/src/main/daemon-rpc.js
+++ b/gui/packages/desktop/src/main/daemon-rpc.js
@@ -638,28 +638,3 @@ function transformObjectKeys(object: Object, keyTransformer: (string) => string)
   }
   return object;
 }
-
-export function defaultSettings(): Settings {
-  return {
-    accountToken: null,
-    allowLan: false,
-    autoConnect: false,
-    relaySettings: {
-      normal: {
-        location: 'any',
-        tunnel: 'any',
-      },
-    },
-    tunnelOptions: {
-      enableIpv6: false,
-      openvpn: {
-        mssfix: null,
-      },
-      proxy: null,
-    },
-  };
-}
-
-export function defaultTunnelStateTransition(): TunnelStateTransition {
-  return { state: 'disconnected' };
-}

--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -16,13 +16,7 @@ import type { TrayIconType } from './tray-icon-controller';
 
 import IpcEventChannel from '../shared/ipc-event-channel';
 
-import {
-  DaemonRpc,
-  ConnectionObserver,
-  SubscriptionListener,
-  defaultSettings,
-  defaultTunnelStateTransition,
-} from './daemon-rpc';
+import { DaemonRpc, ConnectionObserver, SubscriptionListener } from './daemon-rpc';
 import type {
   AppVersionInfo,
   Location,
@@ -68,8 +62,25 @@ const ApplicationMain = {
   _oldLogFilePath: (null: ?string),
   _quitStage: ('unready': AppQuitStage),
 
-  _tunnelState: defaultTunnelStateTransition(),
-  _settings: defaultSettings(),
+  _tunnelState: ({ state: 'disconnected' }: TunnelStateTransition),
+  _settings: ({
+    accountToken: null,
+    allowLan: false,
+    autoConnect: false,
+    relaySettings: {
+      normal: {
+        location: 'any',
+        tunnel: 'any',
+      },
+    },
+    tunnelOptions: {
+      enableIpv6: false,
+      openvpn: {
+        mssfix: null,
+      },
+      proxy: null,
+    },
+  }: Settings),
   _location: (null: ?Location),
 
   _relays: ({ countries: [] }: RelayList),

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -37,10 +37,7 @@ import type {
   TunnelStateTransition,
 } from './lib/daemon-rpc-proxy';
 
-import DaemonRpcProxy, {
-  defaultSettings,
-  defaultTunnelStateTransition,
-} from './lib/daemon-rpc-proxy';
+import DaemonRpcProxy from './lib/daemon-rpc-proxy';
 
 import type { ReduxStore } from './redux/store';
 
@@ -59,8 +56,8 @@ export default class AppRenderer {
     },
   );
 
-  _tunnelState = defaultTunnelStateTransition();
-  _settings = defaultSettings();
+  _tunnelState: TunnelStateTransition;
+  _settings: Settings;
   _connectedToDaemon = false;
 
   constructor() {

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
@@ -28,12 +28,7 @@ export type {
   DaemonRpcProtocol,
 } from '../../main/daemon-rpc';
 
-export {
-  ConnectionObserver,
-  SubscriptionListener,
-  defaultSettings,
-  defaultTunnelStateTransition,
-} from '../../main/daemon-rpc';
+export { ConnectionObserver, SubscriptionListener } from '../../main/daemon-rpc';
 
 import type {
   AccountToken,

--- a/gui/packages/desktop/src/shared/ipc-event-channel.js
+++ b/gui/packages/desktop/src/shared/ipc-event-channel.js
@@ -1,0 +1,155 @@
+// @flow
+
+import { ipcMain, ipcRenderer } from 'electron';
+import type { WebContents } from 'electron';
+
+import type { AppUpgradeInfo, CurrentAppVersionInfo } from '../main/index';
+import type { Location, RelayList, Settings, TunnelStateTransition } from '../main/daemon-rpc';
+
+export type AppStateSnapshot = {
+  isConnected: boolean,
+  tunnelState: TunnelStateTransition,
+  settings: Settings,
+  location: ?Location,
+  relays: RelayList,
+  currentVersion: CurrentAppVersionInfo,
+  upgradeVersion: AppUpgradeInfo,
+};
+
+interface Sender<T> {
+  notify(newState: T): void;
+}
+
+interface Receiver<T> {
+  listen<T>(fn: (T) => void): void;
+}
+
+/// Events names
+
+const DAEMON_CONNECTED = 'daemon-connected';
+const DAEMON_DISCONNECTED = 'daemon-disconnected';
+const TUNNEL_STATE_CHANGED = 'tunnel-state-changed';
+const SETTINGS_CHANGED = 'settings-changed';
+const LOCATION_CHANGED = 'location-changed';
+const RELAYS_CHANGED = 'relays-changed';
+const CURRENT_VERSION_CHANGED = 'current-version-changed';
+const UPGRADE_VERSION_CHANGED = 'upgrade-version-changed';
+
+/// Typed IPC event channel
+///
+/// Static methods are meant to be provide the way to send the events from a renderer process, while
+/// instance methods are meant to be used from a main process.
+///
+export default class IpcEventChannel {
+  _webContents: WebContents;
+
+  constructor(webContents: WebContents) {
+    this._webContents = webContents;
+  }
+
+  static state = {
+    /// Should be used from the main process to process state snapshot requests
+    serve(fn: () => AppStateSnapshot) {
+      ipcMain.on('get-state', (event) => {
+        event.returnValue = fn();
+      });
+    },
+
+    /// Synchronously sends the IPC request and returns the app state snapshot
+    get(): AppStateSnapshot {
+      return ipcRenderer.sendSync('get-state');
+    },
+  };
+
+  static daemonConnected: Receiver<void> = {
+    listen: listen(DAEMON_CONNECTED),
+  };
+
+  get daemonConnected(): Sender<void> {
+    return {
+      notify: sender(this._webContents, DAEMON_CONNECTED),
+    };
+  }
+
+  static daemonDisconnected: Receiver<?string> = {
+    listen: listen(DAEMON_DISCONNECTED),
+  };
+
+  get daemonDisconnected(): Sender<?string> {
+    return {
+      notify: sender(this._webContents, DAEMON_DISCONNECTED),
+    };
+  }
+
+  static tunnelState: Receiver<TunnelStateTransition> = {
+    listen: listen(TUNNEL_STATE_CHANGED),
+  };
+
+  get tunnelState(): Sender<TunnelStateTransition> {
+    return {
+      notify: sender(this._webContents, TUNNEL_STATE_CHANGED),
+    };
+  }
+
+  static settings: Receiver<Settings> = {
+    listen: listen(SETTINGS_CHANGED),
+  };
+
+  get settings(): Sender<Settings> {
+    return {
+      notify: sender(this._webContents, SETTINGS_CHANGED),
+    };
+  }
+
+  static location: Receiver<Location> = {
+    listen: listen(LOCATION_CHANGED),
+  };
+
+  get location(): Sender<Location> {
+    return {
+      notify: sender(this._webContents, LOCATION_CHANGED),
+    };
+  }
+
+  static relays: Receiver<RelayList> = {
+    listen: listen(RELAYS_CHANGED),
+  };
+
+  get relays(): Sender<RelayList> {
+    return {
+      notify: sender(this._webContents, RELAYS_CHANGED),
+    };
+  }
+
+  static currentVersion: Receiver<CurrentAppVersionInfo> = {
+    listen: listen(CURRENT_VERSION_CHANGED),
+  };
+
+  get currentVersion(): Sender<CurrentAppVersionInfo> {
+    return {
+      notify: sender(this._webContents, CURRENT_VERSION_CHANGED),
+    };
+  }
+
+  static upgradeVersion: Receiver<AppUpgradeInfo> = {
+    listen: listen(UPGRADE_VERSION_CHANGED),
+  };
+
+  get upgradeVersion(): Sender<AppUpgradeInfo> {
+    return {
+      notify: sender(this._webContents, UPGRADE_VERSION_CHANGED),
+    };
+  }
+}
+
+function listen<T>(event: string): ((T) => void) => void {
+  return function(fn: (T) => void) {
+    ipcRenderer.on(event, (_, newState: T) => fn(newState));
+  };
+}
+
+function sender<T>(webContents: WebContents, event: string): (T) => void {
+  return function(newState: T) {
+    webContents.send(event, newState);
+  };
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR organises all Electron IPC events under IpcEventChannel that provides a convenient typed interface to listen or dispatch the IPC events. 

Apart from that, the initial state fetch was changed to a synchronous IPC call from the renderer to main process to reduce the code complexity. It has to be a fairly cheap call, given that it's only done once when window is being created I think we can afford it.

###

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/605)
<!-- Reviewable:end -->
