### PR TITLE
Fix formatting for new rustfmt

### DIFF
--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -1,5 +1,5 @@
-use clap::{self, value_t_or_exit};
 use crate::{new_rpc_client, Command, Result};
+use clap::{self, value_t_or_exit};
 
 use mullvad_types::account::AccountToken;
 

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -1,5 +1,5 @@
-use clap::{self, value_t_or_exit};
 use crate::{new_rpc_client, Command, Result};
+use clap::{self, value_t_or_exit};
 
 pub struct AutoConnect;
 

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -1,5 +1,5 @@
-use clap::{self, value_t_or_exit};
 use crate::{new_rpc_client, Command, Result};
+use clap::{self, value_t_or_exit};
 
 pub struct BlockWhenDisconnected;
 

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -1,5 +1,5 @@
-use clap;
 use crate::{new_rpc_client, Command, Result};
+use clap;
 use error_chain::ChainedError;
 
 pub struct Connect;

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -1,5 +1,5 @@
-use clap;
 use crate::{new_rpc_client, Command, Result};
+use clap;
 
 
 pub struct Disconnect;

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -1,5 +1,5 @@
-use clap::{self, value_t_or_exit};
 use crate::{new_rpc_client, Command, Result};
+use clap::{self, value_t_or_exit};
 
 pub struct Lan;
 

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -1,5 +1,5 @@
-use clap::{self, value_t};
 use crate::{new_rpc_client, Command, Result, ResultExt};
+use clap::{self, value_t};
 use std::str::FromStr;
 
 use mullvad_types::relay_constraints::{

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -1,5 +1,5 @@
-use clap;
 use crate::{new_rpc_client, Command, Result};
+use clap;
 
 use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_types::auth_failed::AuthFailed;

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -1,5 +1,5 @@
-use clap::{self, value_t};
 use crate::{new_rpc_client, Command, Result};
+use clap::{self, value_t};
 
 use talpid_types::net::{
     LocalOpenVpnProxySettings, OpenVpnProxyAuth, OpenVpnProxySettings,

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -1,5 +1,5 @@
-use clap;
 use crate::{new_rpc_client, Command, Result};
+use clap;
 
 pub struct Version;
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -74,7 +74,7 @@ use talpid_types::{
 };
 
 
-error_chain!{
+error_chain! {
     errors {
         NoCacheDir {
             description("Unable to create cache directory")

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -35,7 +35,7 @@ mod version;
 
 const DAEMON_LOG_FILENAME: &str = "daemon.log";
 
-error_chain!{
+error_chain! {
     errors {
         LogError(msg: &'static str) {
             description("Error setting up log")

--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -1,4 +1,4 @@
-error_chain!{}
+error_chain! {}
 
 #[cfg(unix)]
 mod platform {

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -70,7 +70,7 @@ macro_rules! write_line {
     };
 }
 
-error_chain!{
+error_chain! {
     errors {
         LogDirError(path: PathBuf) {
             description("Error listing the files in the mullvad-daemon log directory")

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -98,8 +98,9 @@ impl MullvadRpcFactory {
 
     fn setup_connection<F>(&mut self, create_transport: F) -> Result<HttpHandle, HttpError>
     where
-        F: FnOnce(HttpTransportBuilder<HttpsClientWithSni>)
-            -> jsonrpc_client_http::Result<HttpTransport>,
+        F: FnOnce(
+            HttpTransportBuilder<HttpsClientWithSni>,
+        ) -> jsonrpc_client_http::Result<HttpTransport>,
     {
         let client = HttpsClientWithSni::new(API_HOST.to_owned(), self.ca_path.clone());
         let transport_builder = HttpTransportBuilder::with_client(client).timeout(RPC_TIMEOUT);

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use talpid_types::net::{TunnelEndpoint, TunnelEndpointData};
 
-error_chain!{
+error_chain! {
     errors {
         InvalidHost(host: String) {
             display("Invalid host: {}", host)

--- a/talpid-core/src/logging.rs
+++ b/talpid-core/src/logging.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::{fs, io};
 
-error_chain!{}
+error_chain! {}
 
 /// Create a new log file while backing up a previous version of it.
 ///

--- a/talpid-core/src/offline/dummy.rs
+++ b/talpid-core/src/offline/dummy.rs
@@ -1,7 +1,7 @@
 use futures::sync::mpsc::UnboundedSender;
 use tunnel_state_machine::TunnelCommand;
 
-error_chain!{}
+error_chain! {}
 
 pub struct MonitorHandle;
 

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -35,7 +35,7 @@ use tunnel_state_machine::TunnelCommand;
 const CLASS_NAME: &[u8] = b"S\0T\0A\0T\0I\0C\0\0\0";
 const REQUEST_THREAD_SHUTDOWN: UINT = WM_USER + 1;
 
-error_chain!{
+error_chain! {
     errors {
         ThreadCreationError {
             description("Unable to create listener thread")

--- a/talpid-core/src/security/windows/dns.rs
+++ b/talpid-core/src/security/windows/dns.rs
@@ -13,7 +13,7 @@ use super::system_state::SystemStateWriter;
 
 const DNS_STATE_FILENAME: &'static str = "dns-state-backup";
 
-error_chain!{
+error_chain! {
     errors{
         /// Failure to initialize WinDns
         Initialization{

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -34,7 +34,7 @@ const OPENVPN_BIN_FILENAME: &str = "openvpn";
 #[cfg(windows)]
 const OPENVPN_BIN_FILENAME: &str = "openvpn.exe";
 
-error_chain!{
+error_chain! {
     errors {
         /// An error indicating there was an error listening for events from the VPN tunnel.
         TunnelMonitoringError {

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use talpid_ipc;
 
 mod errors {
-    error_chain!{
+    error_chain! {
         errors {
             /// Unable to start, wait for or kill the OpenVPN process.
             ChildProcessError(msg: &'static str) {

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -3,7 +3,7 @@ use std::ptr;
 use libc::{c_char, c_void, wchar_t};
 use widestring::WideCString;
 
-error_chain!{
+error_chain! {
     errors{
         /// Failure to set metrics of network interfaces
         MetricApplication{

--- a/talpid-ipc/src/lib.rs
+++ b/talpid-ipc/src/lib.rs
@@ -35,7 +35,7 @@ use std::fmt;
 /// An Id created by the Ipc server that the client can use to connect to it
 pub type IpcServerId = String;
 
-error_chain!{
+error_chain! {
     errors {
         IpcServerError {
             description("Error in IPC server")

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -29,7 +29,7 @@ mod processing;
 use crate::processing::EventProcessor;
 
 
-error_chain!{
+error_chain! {
     errors {
         InitHandleFailed {
             description("Unable to initialize event processor")


### PR DESCRIPTION
As of the latest 1.32 nightly (f1e2fa8f0 2018-11-20), the formatter is again complaining about all kinds of code. This PR should fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/608)
<!-- Reviewable:end -->
