### PR TITLE
Fix macos log dir permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Line wrap the file at 100 chars.                                              Th
 - Disable keep alive on API RPC requests. Should stop reuse of invalid sockets after tunnel state
   changes.
 
+#### macOS
+- Fix permissions on log dir so problem-report tool has permission to read daemon logs.
+
 #### Windows
 - Use proper app id in the registry. This avoids false-positives with certain anti-virus software.
 - Handle sleep/resume events to quickly restore the tunnel when the machine wakes up.

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -5,6 +5,7 @@ set -eux
 LOG_DIR=/var/log/mullvad-vpn
 
 mkdir -p $LOG_DIR
+chmod 755 $LOG_DIR
 exec 2>&1 > $LOG_DIR/preinstall.log
 
 echo "Running preinstall at $(date)"

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -320,7 +320,7 @@ impl Daemon {
             }
             ManagementInterfaceEvent(event) => self.handle_management_interface_event(event),
             ManagementInterfaceExited => {
-                return Err(ErrorKind::ManagementInterfaceError("Server exited unexpectedly").into())
+                return Err(ErrorKind::ManagementInterfaceError("Server exited unexpectedly").into());
             }
             TriggerShutdown => self.handle_trigger_shutdown_event(),
         }

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 /// Creates and returns the cache directory pointed to by `MULLVAD_CACHE_DIR`, or the default
 /// one if that variable is unset.
 pub fn cache_dir() -> Result<PathBuf> {
-    crate::create_and_return(get_cache_dir)
+    crate::create_and_return(get_cache_dir, None)
 }
 
 fn get_cache_dir() -> Result<PathBuf> {

--- a/mullvad-paths/src/logs.rs
+++ b/mullvad-paths/src/logs.rs
@@ -1,12 +1,18 @@
 use crate::Result;
 
 use std::env;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 /// Creates and returns the logging directory pointed to by `MULLVAD_LOG_DIR`, or the default
 /// one if that variable is unset.
 pub fn log_dir() -> Result<PathBuf> {
-    crate::create_and_return(get_log_dir)
+    #[cfg(unix)]
+    let permissions = Some(PermissionsExt::from_mode(0o755));
+    #[cfg(not(unix))]
+    let permissions = None;
+    crate::create_and_return(get_log_dir, permissions)
 }
 
 /// Get the logging directory, but don't try to create it.

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 /// Creates and returns the settings directory pointed to by `MULLVAD_SETTINGS_DIR`, or the default
 /// one if that variable is unset.
 pub fn settings_dir() -> Result<PathBuf> {
-    crate::create_and_return(get_settings_dir)
+    crate::create_and_return(get_settings_dir, None)
 }
 
 fn get_settings_dir() -> Result<PathBuf> {


### PR DESCRIPTION
We sometimes got errors similar to these in problem reports:
```
Error: Error reading the contents of log file: /var/log/mullvad-vpn/openvpn.old.log
Caused by: Permission denied (os error 13)
```
Seems to be mostly on macOS Mojave. Turned out the `/var/log/mullvad-vpn` dir did not have execute permission for normal users and that made the tool not able to read the contents of the files in that directory.

Now I made it adjust to proper permissions both on install (macOS) and when the daemon creates the directory (all *nix platforms)

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
