### PR TITLE
Activate the use_field_init_shorthand rustfmt option

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -74,7 +74,7 @@ pub fn init_logger(
     }
 
     let stdout_formatter = Formatter {
-        output_timestamp: output_timestamp,
+        output_timestamp,
         output_color: true,
     };
     let stdout_dispatcher = fern::Dispatch::new()

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -186,9 +186,9 @@ impl PersistentServiceStatus {
             service_type: SERVICE_TYPE,
             current_state: next_state,
             controls_accepted: accepted_controls_by_state(next_state),
-            exit_code: exit_code,
+            exit_code,
             checkpoint: checkpoint as u32,
-            wait_hint: wait_hint,
+            wait_hint,
         };
 
         log::debug!(

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,6 @@
 # Activation of features, almost objectively better ;)
 use_try_shorthand = true
+use_field_init_shorthand = true
 condense_wildcard_suffixes = true
 normalize_comments = true
 wrap_comments = true

--- a/talpid-core/src/mpsc.rs
+++ b/talpid-core/src/mpsc.rs
@@ -24,7 +24,7 @@ where
 {
     fn from(sender: mpsc::Sender<U>) -> Self {
         IntoSender {
-            sender: sender,
+            sender,
             _marker: PhantomData,
         }
     }


### PR DESCRIPTION
I think this is a new formatting option, not seen it before. But it shortens all field inits like `foo: foo` to just `foo`. We use this almost exclusively already, only four places where we did not. So should likely not be a biggie to activate? Just slightly more enforces the style we already use.
