### PR TITLE
Increase timeout for OpenVPN to die on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Line wrap the file at 100 chars.                                              Th
 - Handle sleep/resume events to quickly restore the tunnel when the machine wakes up.
 - Add default route to fix NLA issues (Microsoft Store/Office/etc say the machine is offline).
 - Update installer to not rely on WMI when enumerating network adapters.
+- Increase timeout waiting for OpenVPN to shut down cleanly.
 
 
 ## [2018.5] - 2018-11-15

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -31,7 +31,11 @@ mod errors {
 pub use self::errors::*;
 
 
+#[cfg(unix)]
 static OPENVPN_DIE_TIMEOUT: Duration = Duration::from_secs(4);
+#[cfg(windows)]
+static OPENVPN_DIE_TIMEOUT: Duration = Duration::from_secs(30);
+
 
 /// Struct for monitoring an OpenVPN process.
 #[derive(Debug)]


### PR DESCRIPTION
Increasing the timeout for clean OpenVPN shutdown on Windows since we have seen some computers where it can't properly clean up in 4 seconds.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/621)
<!-- Reviewable:end -->
