### PR TITLE
Delete the incremental folder before caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,12 @@ matrix:
       before_script: &rust_before_script
         - source env.sh
         - env
+        - du -sh target || true
       script: &rust_script
         - cargo build --verbose
         - cargo test --verbose
+      before_cache: &rust_before_cache
+        - rm -rf target/debug/incremental/
 
     # Daemon - Linux
     - language: rust
@@ -72,6 +75,7 @@ matrix:
         - rustup component add rustfmt-preview
         - cargo fmt --version || true
         - cargo fmt -- --check --unstable-features
+      before_cache: *rust_before_cache
 
     - language: rust
       rust: beta
@@ -80,6 +84,7 @@ matrix:
       cache: cargo
       before_script: *rust_before_script
       script: *rust_script
+      before_cache: *rust_before_cache
 
     - language: rust
       rust: stable
@@ -88,6 +93,7 @@ matrix:
       cache: cargo
       before_script: *rust_before_script
       script: *rust_script
+      before_cache: *rust_before_cache
 
 
 notifications:


### PR DESCRIPTION
The incremental folder takes a couple of hundred megabytes, and does not seem to be of any use. After removing it rebuilds are still cheap. Should speed up down- and uploading the cache on each build job.

We probably still have to periodically remove all the travis caches, but hopefully it should grow a bit slower now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/627)
<!-- Reviewable:end -->
