### PR TITLE
Disable http keep-alive on location requests

### DIFF
--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -33,7 +33,10 @@ type RequestReceiver = mpsc::UnboundedReceiver<(Request, oneshot::Sender<Result<
 
 pub fn create_https_client<P: AsRef<Path>>(ca_path: P, handle: &Handle) -> Result<RequestSender> {
     let connector = HttpsConnectorWithSni::new(ca_path, handle)?;
-    let client = Client::configure().connector(connector).build(handle);
+    let client = Client::configure()
+        .keep_alive(false)
+        .connector(connector)
+        .build(handle);
 
     let (request_tx, request_rx) = mpsc::unbounded();
     handle.spawn(create_request_processing_future(request_rx, client));


### PR DESCRIPTION
We earlier disabled HTTP keep-alive for API requests (#602) but I forgot it for the location request HTTP client. A very common problem is that people don't get their exit IP after connecting, this should maybe be improved by not having keep alive, thus creating new sockets all the time.

Already in changelog since the other PR.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
