### PR TITLE
Implement offline check for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+#### Linux
+- Detect if the computer is offline. If so, don't sit in a reconnect loop, instead block and show
+  an error message.
+
 ### Fixed
 - Stop GUI from glitching during the short reconnect state.
 - Dismiss notifications automatically after four seconds in all platforms.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "eui48"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +575,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iproute2"
+version = "0.0.2"
+source = "git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing#132ab47bcbb32079ba4ededaa76a3d7b6257da40"
+dependencies = [
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eui48 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
+ "rtnetlink 0.0.3 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1086,6 +1112,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-socket"
+version = "0.0.2"
+source = "git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing#132ab47bcbb32079ba4ededaa76a3d7b6257da40"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nftnl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,8 +1509,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtnetlink"
+version = "0.0.3"
+source = "git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing#132ab47bcbb32079ba4ededaa76a3d7b6257da40"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
+ "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1705,6 +1763,7 @@ dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iproute2 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1718,6 +1777,7 @@ dependencies = [
  "os_pipe 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pfctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rtnetlink 0.0.3 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "system-configuration 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
@@ -2317,6 +2377,7 @@ dependencies = [
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
+"checksum eui48 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4970a61eb89c625299a850532620d811b70afac4cd8304cb2e9bf7e63e83ad56"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fern 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "57915fe00a83af935983eb2d00b0ecc62419c4741b28c207ecbf98fd4a1b94c8"
@@ -2343,6 +2404,7 @@ dependencies = [
 "checksum ioctl-sys 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2c4b26352496eaaa8ca7cfa9bd99e93419d3f7983dc6e99c2a35fe9e33504a"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d1d8b990621b5b0806fac3dbf71d1833a4c0a9e25702d10bd8b2c629c7ae01c"
+"checksum iproute2 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)" = "<none>"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=e9dbdc80)" = "<none>"
 "checksum jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f29cb249837420fb0cee7fb0fbf1d22679e121b160e71bb5e0d90b9df241c23e"
@@ -2380,6 +2442,7 @@ dependencies = [
 "checksum mnl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ddf564b33717090dd6127325e590b13176b2346589c392a0cb274f2e5f8b8f7"
 "checksum mnl-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7cb01017fef6e68b6c437aed2b7601264dc94759f4c2b41f820f13854d41b3"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)" = "<none>"
 "checksum nftnl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e05c68d4e54cf42fc4ef946a3bbe7779adfa1c1ce4868f06d0ee48479e8cba87"
 "checksum nftnl-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c2b00ddf077770bde037202e75296aecc5a0f94351196a5c46219c1c8c3a48c8"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
@@ -2421,7 +2484,9 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum resolv-conf 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c62bd95a41841efdf7fca2ae9951e64a8d8eae7e5da196d8ce489a2241491a92"
 "checksum rs-release 0.1.7 (git+https://github.com/mullvad/rs-release?branch=snailquote-unescape)" = "<none>"
+"checksum rtnetlink 0.0.3 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)" = "<none>"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,7 @@ dependencies = [
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mnl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
  "nftnl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -41,6 +41,8 @@ const SILENCED_CRATES: &[&str] = &[
     "ws",
     "mio",
     "hyper",
+    "rtnetlink",
+    "iproute2",
 ];
 const SLIGHTLY_SILENCED_CRATES: &[&str] = &["mnl", "nftnl"];
 

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -34,6 +34,7 @@ nix = "0.12"
 dbus = "0.6"
 failure = "0.1"
 iproute2 = { git = "https://github.com/mullvad/netlink", branch = "best-effort-nla-parsing" }
+netlink-socket = { git = "https://github.com/mullvad/netlink", branch = "best-effort-nla-parsing" }
 notify = "4.0"
 resolv-conf = "0.6.1"
 rtnetlink = { git = "https://github.com/mullvad/netlink", branch = "best-effort-nla-parsing" }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -33,8 +33,10 @@ nix = "0.12"
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.6"
 failure = "0.1"
+iproute2 = { git = "https://github.com/mullvad/netlink", branch = "best-effort-nla-parsing" }
 notify = "4.0"
 resolv-conf = "0.6.1"
+rtnetlink = { git = "https://github.com/mullvad/netlink", branch = "best-effort-nla-parsing" }
 nftnl = { version = "0.1", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.1", features = ["mnl-1-0-4"] }
 which = "2.0"

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -1,12 +1,20 @@
 extern crate iproute2;
+extern crate netlink_socket;
 extern crate rtnetlink;
 
+use std::collections::BTreeSet;
+use std::thread;
+
 use error_chain::ChainedError;
-use futures::{future::Either, sync::mpsc::UnboundedSender, Future};
-use log::warn;
+use futures::{future::Either, sync::mpsc::UnboundedSender, Future, Stream};
+use log::{error, trace, warn};
 
 use self::iproute2::Link;
-use self::rtnetlink::LinkLayerType;
+use self::netlink_socket::{Protocol, SocketAddr, TokioSocket};
+use self::rtnetlink::{
+    LinkFlags, LinkHeader, LinkLayerType, LinkMessage, NetlinkCodec, NetlinkFramed, NetlinkMessage,
+    RtnlMessage,
+};
 
 use tunnel_state_machine::TunnelCommand;
 
@@ -18,6 +26,9 @@ error_chain! {
         NetlinkConnectionError {
             description("Failed to connect to netlink socket")
         }
+        NetlinkBindError {
+            description("Failed to start listening on netlink socket")
+        }
         NetlinkError {
             description("Error while communicating on the netlink socket")
         }
@@ -27,9 +38,28 @@ error_chain! {
     }
 }
 
+const RTMGRP_NOTIFY: u32 = 1;
+const RTMGRP_LINK: u32 = 2;
+
 pub struct MonitorHandle;
 
-pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
+pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
+    let mut socket =
+        TokioSocket::new(Protocol::Route).chain_err(|| ErrorKind::NetlinkConnectionError)?;
+    socket
+        .bind(&SocketAddr::new(0, RTMGRP_NOTIFY | RTMGRP_LINK))
+        .chain_err(|| ErrorKind::NetlinkBindError)?;
+
+    let channel = NetlinkFramed::new(socket, NetlinkCodec::<NetlinkMessage>::new());
+    let link_monitor = LinkMonitor::new(sender)?;
+
+    thread::spawn(|| {
+        if let Err(error) = monitor_event_loop(channel, link_monitor) {
+            let chained_error = error.chain_err(|| "Error running link monitor event loop");
+            error!("{}", chained_error.display_chain());
+        }
+    });
+
     Ok(MonitorHandle)
 }
 
@@ -49,7 +79,7 @@ fn list_links_providing_connectivity() -> Result<impl Iterator<Item = Link>> {
     Ok(list_links()?.into_iter().filter(link_provides_connectivity))
 }
 
-fn link_provides_connectivity(link: &Link) -> bool {
+fn link_provides_connectivity(link: &impl BasicLinkInfo) -> bool {
     // Some tunnels have the link layer type set to None
     link.link_layer_type() != LinkLayerType::Loopback
         && link.link_layer_type() != LinkLayerType::None
@@ -69,5 +99,115 @@ fn list_links() -> Result<Vec<Link>> {
             failure::Fail::compat(error),
             ErrorKind::GetLinksError,
         )),
+    }
+}
+
+fn monitor_event_loop(
+    channel: NetlinkFramed<NetlinkCodec<NetlinkMessage>>,
+    mut link_monitor: LinkMonitor,
+) -> Result<()> {
+    channel
+        .for_each(|(message, _address)| {
+            let (_header, payload) = message.into_parts();
+
+            match payload {
+                RtnlMessage::NewLink(link_message) => link_monitor.new_link(link_message),
+                RtnlMessage::DelLink(link_message) => link_monitor.del_link(link_message),
+                _ => trace!("Ignoring unknown link message"),
+            }
+
+            Ok(())
+        })
+        .wait()
+        .map_err(|error| {
+            Error::with_chain(failure::Fail::compat(error), ErrorKind::NetlinkError)
+        })?;
+
+    Ok(())
+}
+
+struct LinkMonitor {
+    is_offline: bool,
+    running_links: BTreeSet<u32>,
+    sender: UnboundedSender<TunnelCommand>,
+}
+
+impl LinkMonitor {
+    pub fn new(sender: UnboundedSender<TunnelCommand>) -> Result<Self> {
+        let links: Vec<Link> = list_links_providing_connectivity()?.collect();
+        let is_offline = links.is_empty();
+        let running_links = links.into_iter().map(|link| link.index()).collect();
+
+        Ok(LinkMonitor {
+            is_offline,
+            running_links,
+            sender,
+        })
+    }
+
+    pub fn new_link(&mut self, link_message: LinkMessage) {
+        if self.is_offline && link_provides_connectivity(link_message.header()) {
+            self.set_is_offline(false);
+        }
+
+        if let Ok(link) = Link::from_link_message(link_message) {
+            if link_provides_connectivity(&link) {
+                self.insert_link(link.index());
+            } else {
+                self.remove_link(link.index());
+            }
+        }
+    }
+
+    pub fn del_link(&mut self, link_message: LinkMessage) {
+        if let Ok(link) = Link::from_link_message(link_message) {
+            self.remove_link(link.index());
+        }
+    }
+
+    fn set_is_offline(&mut self, is_offline: bool) {
+        if self.is_offline != is_offline {
+            self.is_offline = is_offline;
+            let _ = self
+                .sender
+                .unbounded_send(TunnelCommand::IsOffline(is_offline));
+        }
+    }
+
+    fn insert_link(&mut self, link_index: u32) {
+        self.running_links.insert(link_index);
+        self.set_is_offline(false);
+    }
+
+    fn remove_link(&mut self, link_index: u32) {
+        self.running_links.remove(&link_index);
+        if self.running_links.is_empty() {
+            self.set_is_offline(true);
+        }
+    }
+}
+
+trait BasicLinkInfo {
+    fn flags(&self) -> LinkFlags;
+    fn link_layer_type(&self) -> LinkLayerType;
+}
+
+impl BasicLinkInfo for Link {
+    fn flags(&self) -> LinkFlags {
+        self.flags()
+    }
+
+    fn link_layer_type(&self) -> LinkLayerType {
+        self.link_layer_type()
+    }
+}
+
+impl BasicLinkInfo for LinkHeader {
+    fn flags(&self) -> LinkFlags {
+        self.flags()
+    }
+
+    fn link_layer_type(&self) -> LinkLayerType {
+        self.link_layer_type()
     }
 }

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -1,0 +1,73 @@
+extern crate iproute2;
+extern crate rtnetlink;
+
+use error_chain::ChainedError;
+use futures::{future::Either, sync::mpsc::UnboundedSender, Future};
+use log::warn;
+
+use self::iproute2::Link;
+use self::rtnetlink::LinkLayerType;
+
+use tunnel_state_machine::TunnelCommand;
+
+error_chain! {
+    errors {
+        GetLinksError {
+            description("Failed to get list of IP links")
+        }
+        NetlinkConnectionError {
+            description("Failed to connect to netlink socket")
+        }
+        NetlinkError {
+            description("Error while communicating on the netlink socket")
+        }
+        NetlinkDisconnected {
+            description("Netlink connection has unexpectedly disconnected")
+        }
+    }
+}
+
+pub struct MonitorHandle;
+
+pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
+    Ok(MonitorHandle)
+}
+
+pub fn is_offline() -> bool {
+    check_if_offline().unwrap_or_else(|error| {
+        let chained_error = error.chain_err(|| "Failed to check for internet connection");
+        warn!("{}", chained_error.display_chain());
+        false
+    })
+}
+
+fn check_if_offline() -> Result<bool> {
+    Ok(list_links_providing_connectivity()?.next().is_none())
+}
+
+fn list_links_providing_connectivity() -> Result<impl Iterator<Item = Link>> {
+    Ok(list_links()?.into_iter().filter(link_provides_connectivity))
+}
+
+fn link_provides_connectivity(link: &Link) -> bool {
+    // Some tunnels have the link layer type set to None
+    link.link_layer_type() != LinkLayerType::Loopback
+        && link.link_layer_type() != LinkLayerType::None
+        && link.flags().is_running()
+}
+
+fn list_links() -> Result<Vec<Link>> {
+    let (connection, connection_handle) =
+        iproute2::new_connection().chain_err(|| ErrorKind::NetlinkConnectionError)?;
+    let links_request = connection_handle.link().get().execute();
+
+    match connection.select2(links_request).wait() {
+        Ok(Either::A(_)) => bail!(ErrorKind::NetlinkDisconnected),
+        Ok(Either::B((links, _))) => Ok(links),
+        Err(Either::A((error, _))) => Err(Error::with_chain(error, ErrorKind::NetlinkError)),
+        Err(Either::B((error, _))) => Err(Error::with_chain(
+            failure::Fail::compat(error),
+            ErrorKind::GetLinksError,
+        )),
+    }
+}

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -9,7 +9,11 @@ mod imp;
 #[path = "windows.rs"]
 mod imp;
 
-#[cfg(not(any(windows, target_os = "macos")))]
+#[cfg(target_os = "linux")]
+#[path = "linux.rs"]
+mod imp;
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 #[path = "dummy.rs"]
 mod imp;
 


### PR DESCRIPTION
Off-line check is currently only implemented for macOS. This PR implements the check and the connectivity monitor for Linux, so that on that platform it can also block when necessary instead of performing a reconnection loop.

The connectivity check is made by using the `netlink` interface for communicating with the kernel. A list of links is obtained, and if there's at least one that's running and isn't either a loopback interface or `None` link interface (which is the type created by OpenVPN tunnels), the system is considered on-line.

The connectivity monitor works by listening to link events on a `netlink` socket. It keeps track of which links provide connectivity, and as long as there is at least one, the system is considered on-line.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/629)
<!-- Reviewable:end -->
