### PR TITLE
Fix UI state on reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Fixed
+- Stop GUI from glitching during the short reconnect state.
 
 
 ## [2018.6-beta1] - 2018-12-05

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -170,7 +170,7 @@ export default class Connect extends Component<Props> {
           ) : null}
 
           <TunnelControl
-            tunnelState={this.props.connection.status.state}
+            tunnelState={this.props.connection.status}
             selectedRelayName={this.props.selectedRelayName}
             city={this.props.connection.city}
             country={this.props.connection.country}

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -89,8 +89,9 @@ export default class Connect extends Component<Props> {
     if (typeof longitude === 'number' && typeof latitude === 'number') {
       return {
         center: [longitude, latitude],
-        // do not show the marker when connecting
-        showMarker: state !== 'connecting',
+        // do not show the marker when connecting or reconnecting
+        showMarker:
+          state !== 'connecting' && !(state === 'disconnecting' && status.details === 'reconnect'),
         markerStyle: this._getMarkerStyle(),
         // zoom in when connected
         zoomLevel: state === 'connected' ? 'low' : 'medium',

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -30,6 +30,8 @@ type Props = {
   onToggleConnectionInfo: (boolean) => void,
 };
 
+type MarkerOrSpinner = 'marker' | 'spinner';
+
 export default class Connect extends Component<Props> {
   render() {
     const error = this.checkForErrors();
@@ -90,8 +92,7 @@ export default class Connect extends Component<Props> {
       return {
         center: [longitude, latitude],
         // do not show the marker when connecting or reconnecting
-        showMarker:
-          state !== 'connecting' && !(state === 'disconnecting' && status.details === 'reconnect'),
+        showMarker: this._showMarkerOrSpinner() === 'marker',
         markerStyle: this._getMarkerStyle(),
         // zoom in when connected
         zoomLevel: state === 'connected' ? 'low' : 'medium',
@@ -136,12 +137,20 @@ export default class Connect extends Component<Props> {
     }
   }
 
+  _showMarkerOrSpinner(): MarkerOrSpinner {
+    const state = this.props.connection.status.state;
+    const details = this.props.connection.status.details;
+
+    if (state === 'connecting' || (state === 'disconnecting' && details === 'reconnect')) {
+      return 'spinner';
+    } else {
+      return 'marker';
+    }
+  }
+
   renderMap() {
     const tunnelState = this.props.connection.status.state;
     const details = this.props.connection.status.details;
-
-    const showSpinner =
-      tunnelState === 'connecting' || (tunnelState === 'disconnecting' && details === 'reconnect');
 
     const relayOutAddress: RelayOutAddress = {
       ipv4: this.props.connection.ip,
@@ -164,7 +173,7 @@ export default class Connect extends Component<Props> {
         </View>
         <View style={styles.container}>
           {/* show spinner when connecting */}
-          {showSpinner ? (
+          {this._showMarkerOrSpinner() === 'spinner' ? (
             <View style={styles.status_icon}>
               <ImageView source="icon-spinner" height={60} width={60} alt="" />
             </View>

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -139,6 +139,9 @@ export default class Connect extends Component<Props> {
     const tunnelState = this.props.connection.status.state;
     const details = this.props.connection.status.details;
 
+    const showSpinner =
+      tunnelState === 'connecting' || (tunnelState === 'disconnecting' && details === 'reconnect');
+
     const relayOutAddress: RelayOutAddress = {
       ipv4: this.props.connection.ip,
       ipv6: null,
@@ -160,7 +163,7 @@ export default class Connect extends Component<Props> {
         </View>
         <View style={styles.container}>
           {/* show spinner when connecting */}
-          {tunnelState === 'connecting' ? (
+          {showSpinner ? (
             <View style={styles.status_icon}>
               <ImageView source="icon-spinner" height={60} width={60} alt="" />
             </View>

--- a/gui/packages/desktop/src/renderer/components/NotificationArea.js
+++ b/gui/packages/desktop/src/renderer/components/NotificationArea.js
@@ -79,6 +79,16 @@ export default class NotificationArea extends Component<Props, State> {
           reason: getBlockReasonMessage(tunnelState.details),
         };
 
+      case 'disconnecting':
+        if (tunnelState.details === 'reconnect') {
+          return {
+            visible: true,
+            type: 'blocking',
+            reason: '',
+          };
+        }
+      // fallthrough
+
       default:
         if (!version.consistent) {
           return {

--- a/gui/packages/desktop/src/renderer/components/TunnelControl.js
+++ b/gui/packages/desktop/src/renderer/components/TunnelControl.js
@@ -6,7 +6,7 @@ import { ConnectionInfo, SecuredLabel, SecuredDisplayStyle, ImageView } from '@m
 import * as AppButton from './AppButton';
 import { colors } from '../../config';
 
-import type { TunnelState, RelayProtocol } from '../lib/daemon-rpc-proxy';
+import type { TunnelStateTransition, RelayProtocol } from '../lib/daemon-rpc-proxy';
 
 export type RelayInAddress = {
   ip: string,
@@ -20,7 +20,7 @@ export type RelayOutAddress = {
 };
 
 type TunnelControlProps = {
-  tunnelState: TunnelState,
+  tunnelState: TunnelStateTransition,
   selectedRelayName: string,
   city: ?string,
   country: ?string,
@@ -135,7 +135,23 @@ export default class TunnelControl extends Component<TunnelControlProps> {
       />
     );
 
-    switch (this.props.tunnelState) {
+    let state = this.props.tunnelState.state;
+
+    if (state === 'disconnecting') {
+      switch (this.props.tunnelState.details) {
+        case 'block':
+          state = 'blocked';
+          break;
+        case 'reconnect':
+          state = 'connecting';
+          break;
+        default:
+          state = 'disconnecting';
+          break;
+      }
+    }
+
+    switch (state) {
       case 'connecting':
         return (
           <Wrapper>


### PR DESCRIPTION
Since the `disconnecting` state has extra `details` about what will be the next state it the daemon will enter, the UI can be updated to handle the extra information in order to reduce quick flashes of state change. This happens mostly when reconnecting, so this PR handles the `disconnecting` state when `details` says that it will `reconnect` afterwards.

The changes are:
* the marker will not be shown when reconnecting, but the spinner will be shown in its place;
* the action buttons in the Connect screen will now be the same as `connecting`, so the reconnection attempt can be cancelled, for example;
* the notification banner with the "blocking internet" message will be shown.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/630)
<!-- Reviewable:end -->
