### PR TITLE
UI support for "block when disconnected" setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Handle "block when disconnected" extra kill-switch level in the UI, showing the disconnected state
+  as blocked when appropriate and also having a toggle switch for the setting in the Advanced
+  Settings screen.
 
 
 ## [2018.6-beta1] - 2018-12-05

--- a/gui/packages/desktop/src/main/daemon-rpc.js
+++ b/gui/packages/desktop/src/main/daemon-rpc.js
@@ -406,6 +406,7 @@ export interface DaemonRpcProtocol {
   updateRelaySettings(RelaySettingsUpdate): Promise<void>;
   setAllowLan(boolean): Promise<void>;
   setEnableIpv6(boolean): Promise<void>;
+  setBlockWhenDisconnected(boolean): Promise<void>;
   setOpenVpnMssfix(?number): Promise<void>;
   setAutoConnect(boolean): Promise<void>;
   connectTunnel(): Promise<void>;
@@ -507,6 +508,10 @@ export class DaemonRpc implements DaemonRpcProtocol {
 
   async setEnableIpv6(enableIpv6: boolean): Promise<void> {
     await this._transport.send('set_enable_ipv6', [enableIpv6]);
+  }
+
+  async setBlockWhenDisconnected(blockWhenDisconnected: boolean): Promise<void> {
+    await this._transport.send('set_block_when_disconnected', [blockWhenDisconnected]);
   }
 
   async setOpenVpnMssfix(mssfix: ?number): Promise<void> {

--- a/gui/packages/desktop/src/main/daemon-rpc.js
+++ b/gui/packages/desktop/src/main/daemon-rpc.js
@@ -383,6 +383,7 @@ export type Settings = {
   accountToken: ?AccountToken,
   allowLan: boolean,
   autoConnect: boolean,
+  blockWhenDisconnected: boolean,
   relaySettings: RelaySettings,
   tunnelOptions: TunnelOptions,
 };
@@ -391,6 +392,7 @@ const SettingsSchema = partialObject({
   account_token: maybe(string),
   allow_lan: boolean,
   auto_connect: boolean,
+  block_when_disconnected: boolean,
   relay_settings: RelaySettingsSchema,
   tunnel_options: TunnelOptionsSchema,
 });

--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -22,7 +22,6 @@ import type {
   Location,
   RelayList,
   Settings,
-  TunnelState,
   TunnelStateTransition,
 } from './daemon-rpc';
 
@@ -456,7 +455,7 @@ const ApplicationMain = {
 
   _setTunnelState(newState: TunnelStateTransition) {
     this._tunnelState = newState;
-    this._updateTrayIcon(newState.state);
+    this._updateTrayIcon(newState, this._settings.blockWhenDisconnected);
     this._updateLocation();
 
     if (!this._shouldSuppressNotifications()) {
@@ -470,6 +469,7 @@ const ApplicationMain = {
 
   _setSettings(newSettings: Settings) {
     this._settings = newSettings;
+    this._updateTrayIcon(this._tunnelState, newSettings.blockWhenDisconnected);
 
     if (this._ipcEventChannel) {
       this._ipcEventChannel.settings.notify(newSettings);
@@ -650,13 +650,48 @@ const ApplicationMain = {
     }
   },
 
-  _updateTrayIcon(tunnelState: TunnelState) {
-    const iconTypes: { [TunnelState]: TrayIconType } = {
-      connected: 'secured',
-      connecting: 'securing',
-      blocked: 'securing',
-    };
-    const type = iconTypes[tunnelState] || 'unsecured';
+  _trayIconType(tunnelState: TunnelStateTransition, blockWhenDisconnected: boolean): TrayIconType {
+    switch (tunnelState.state) {
+      case 'connected':
+        return 'secured';
+
+      case 'connecting':
+      // fallthrough
+      case 'blocked':
+        return 'securing';
+
+      case 'disconnecting':
+        switch (tunnelState.details) {
+          case 'reconnect':
+          // fallthrough
+          case 'block':
+            return 'securing';
+
+          case 'nothing':
+            // handle the same way as disconnected
+            break;
+
+          default:
+            // unrechable, but can't prove it to flow because of the fallthrough
+            return 'unsecured';
+        }
+      // fallthrough
+
+      case 'disconnected':
+        if (blockWhenDisconnected) {
+          return 'securing';
+        } else {
+          return 'unsecured';
+        }
+
+      default:
+        // unrechable, but can't prove it to flow because of the fallthrough
+        return 'unsecured';
+    }
+  },
+
+  _updateTrayIcon(tunnelState: TunnelStateTransition, blockWhenDisconnected: boolean) {
+    const type = this._trayIconType(tunnelState, blockWhenDisconnected);
 
     if (this._trayIconController) {
       this._trayIconController.animateToIcon(type);

--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -67,6 +67,7 @@ const ApplicationMain = {
     accountToken: null,
     allowLan: false,
     autoConnect: false,
+    blockWhenDisconnected: false,
     relaySettings: {
       normal: {
         location: 'any',

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -325,6 +325,12 @@ export default class AppRenderer {
     actions.settings.updateEnableIpv6(enableIpv6);
   }
 
+  async setBlockWhenDisconnected(blockWhenDisconnected: boolean) {
+    const actions = this._reduxActions;
+    await this._daemonRpc.setBlockWhenDisconnected(blockWhenDisconnected);
+    actions.settings.updateBlockWhenDisconnected(blockWhenDisconnected);
+  }
+
   async setOpenVpnMssfix(mssfix: ?number) {
     const actions = this._reduxActions;
     actions.settings.updateOpenVpnMssfix(mssfix);

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -474,6 +474,7 @@ export default class AppRenderer {
     reduxSettings.updateAllowLan(newSettings.allowLan);
     reduxSettings.updateAutoConnect(newSettings.autoConnect);
     reduxSettings.updateEnableIpv6(newSettings.tunnelOptions.enableIpv6);
+    reduxSettings.updateBlockWhenDisconnected(newSettings.blockWhenDisconnected);
     reduxSettings.updateOpenVpnMssfix(newSettings.tunnelOptions.openvpn.mssfix);
 
     this._setRelaySettings(newSettings.relaySettings);

--- a/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
+++ b/gui/packages/desktop/src/renderer/components/AdvancedSettings.js
@@ -21,10 +21,12 @@ const MAX_MSSFIX_VALUE = 1450;
 
 type Props = {
   enableIpv6: boolean,
+  blockWhenDisconnected: boolean,
   protocol: string,
   mssfix: ?number,
   port: string | number,
   setEnableIpv6: (boolean) => void,
+  setBlockWhenDisconnected: (boolean) => void,
   setOpenVpnMssfix: (?number) => void,
   onUpdate: (protocol: string, port: string | number) => void,
   onClose: () => void,
@@ -97,6 +99,17 @@ export class AdvancedSettings extends Component<Props, State> {
                     <Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
                   </Cell.Container>
                   <Cell.Footer>Enable IPv6 communication through the tunnel.</Cell.Footer>
+
+                  <Cell.Container>
+                    <Cell.Label>Block when disconnected</Cell.Label>
+                    <Switch
+                      isOn={this.props.blockWhenDisconnected}
+                      onChange={this.props.setBlockWhenDisconnected}
+                    />
+                  </Cell.Container>
+                  <Cell.Footer>
+                    Block all network traffic when the tunnel is disconnected by the user.
+                  </Cell.Footer>
 
                   <View style={styles.advanced_settings__content}>
                     <Selector

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -22,6 +22,7 @@ type Props = {
   accountExpiry: ?string,
   selectedRelayName: string,
   connectionInfoOpen: boolean,
+  blockWhenDisconnected: boolean,
   onSettings: () => void,
   onSelectLocation: () => void,
   onConnect: () => void,
@@ -186,6 +187,7 @@ export default class Connect extends Component<Props> {
             tunnelState={this.props.connection.status}
             version={this.props.version}
             openExternalLink={this.props.onExternalLink}
+            blockWhenDisconnected={this.props.blockWhenDisconnected}
           />
         </View>
       </View>

--- a/gui/packages/desktop/src/renderer/components/NotificationArea.js
+++ b/gui/packages/desktop/src/renderer/components/NotificationArea.js
@@ -20,6 +20,7 @@ type Props = {
   tunnelState: TunnelStateTransition,
   version: VersionReduxState,
   openExternalLink: (string) => void,
+  blockWhenDisconnected: boolean,
 };
 
 type NotificationAreaPresentation =
@@ -62,7 +63,7 @@ export default class NotificationArea extends Component<Props, State> {
   };
 
   static getDerivedStateFromProps(props: Props, state: State) {
-    const { version, tunnelState } = props;
+    const { version, tunnelState, blockWhenDisconnected } = props;
 
     switch (tunnelState.state) {
       case 'connecting':
@@ -78,6 +79,18 @@ export default class NotificationArea extends Component<Props, State> {
           type: 'blocking',
           reason: getBlockReasonMessage(tunnelState.details),
         };
+
+      case 'disconnecting':
+      // fallthrough
+      case 'disconnected':
+        if (blockWhenDisconnected) {
+          return {
+            visible: true,
+            type: 'blocking',
+            reason: '',
+          };
+        }
+      // fallthrough
 
       default:
         if (!version.consistent) {

--- a/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
+++ b/gui/packages/desktop/src/renderer/containers/AdvancedSettingsPage.js
@@ -16,6 +16,7 @@ const mapStateToProps = (state: ReduxState) => {
 
   return {
     enableIpv6: state.settings.enableIpv6,
+    blockWhenDisconnected: state.settings.blockWhenDisconnected,
     mssfix: state.settings.openVpn.mssfix,
     ...protocolAndPort,
   };
@@ -70,6 +71,14 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
         await props.app.setEnableIpv6(enableIpv6);
       } catch (e) {
         log.error('Failed to update enable IPv6', e.message);
+      }
+    },
+
+    setBlockWhenDisconnected: async (blockWhenDisconnected) => {
+      try {
+        await props.app.setBlockWhenDisconnected(blockWhenDisconnected);
+      } catch (e) {
+        log.error('Failed to update block when disconnected', e.message);
       }
     },
 

--- a/gui/packages/desktop/src/renderer/containers/ConnectPage.js
+++ b/gui/packages/desktop/src/renderer/containers/ConnectPage.js
@@ -63,6 +63,7 @@ const mapStateToProps = (state: ReduxState) => {
     connection: state.connection,
     version: state.version,
     connectionInfoOpen: state.userInterface.connectionInfoOpen,
+    blockWhenDisconnected: state.settings.blockWhenDisconnected,
   };
 };
 

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
@@ -122,6 +122,10 @@ export default class DaemonRpcProxy implements DaemonRpcProtocol {
     return this._sendMessage('setEnableIpv6', enableIpv6);
   }
 
+  setBlockWhenDisconnected(blockWhenDisconnected: boolean): Promise<void> {
+    return this._sendMessage('setBlockWhenDisconnected', blockWhenDisconnected);
+  }
+
   setOpenVpnMssfix(mssfix: ?number): Promise<void> {
     return this._sendMessage('setOpenVpnMssfix', mssfix);
   }

--- a/gui/packages/desktop/src/renderer/redux/settings/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/actions.js
@@ -27,6 +27,11 @@ export type UpdateEnableIpv6Action = {
   enableIpv6: boolean,
 };
 
+export type UpdateBlockWhenDisconnectedAction = {
+  type: 'UPDATE_BLOCK_WHEN_DISCONNECTED',
+  blockWhenDisconnected: boolean,
+};
+
 export type UpdateOpenVpnMssfixAction = {
   type: 'UPDATE_OPENVPN_MSSFIX',
   mssfix: ?number,
@@ -38,6 +43,7 @@ export type SettingsAction =
   | UpdateAutoConnectAction
   | UpdateAllowLanAction
   | UpdateEnableIpv6Action
+  | UpdateBlockWhenDisconnectedAction
   | UpdateOpenVpnMssfixAction;
 
 function updateRelay(relay: RelaySettingsRedux): UpdateRelayAction {
@@ -77,6 +83,15 @@ function updateEnableIpv6(enableIpv6: boolean): UpdateEnableIpv6Action {
   };
 }
 
+function updateBlockWhenDisconnected(
+  blockWhenDisconnected: boolean,
+): UpdateBlockWhenDisconnectedAction {
+  return {
+    type: 'UPDATE_BLOCK_WHEN_DISCONNECTED',
+    blockWhenDisconnected,
+  };
+}
+
 function updateOpenVpnMssfix(mssfix: ?number): UpdateOpenVpnMssfixAction {
   return {
     type: 'UPDATE_OPENVPN_MSSFIX',
@@ -90,5 +105,6 @@ export default {
   updateAutoConnect,
   updateAllowLan,
   updateEnableIpv6,
+  updateBlockWhenDisconnected,
   updateOpenVpnMssfix,
 };

--- a/gui/packages/desktop/src/renderer/redux/settings/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/reducers.js
@@ -49,6 +49,7 @@ export type SettingsReduxState = {
   autoConnect: boolean,
   allowLan: boolean,
   enableIpv6: boolean,
+  blockWhenDisconnected: boolean,
   openVpn: {
     mssfix: ?number,
   },
@@ -66,6 +67,7 @@ const initialState: SettingsReduxState = {
   autoConnect: false,
   allowLan: false,
   enableIpv6: true,
+  blockWhenDisconnected: false,
   openVpn: {
     mssfix: null,
   },
@@ -104,6 +106,12 @@ export default function(
       return {
         ...state,
         enableIpv6: action.enableIpv6,
+      };
+
+    case 'UPDATE_BLOCK_WHEN_DISCONNECTED':
+      return {
+        ...state,
+        blockWhenDisconnected: action.blockWhenDisconnected,
       };
 
     case 'UPDATE_OPENVPN_MSSFIX':


### PR DESCRIPTION
The daemon already has support for an "extra level kill-switch", which will basically keep the firewall up even if the user disconnects the tunnel. There is already a CLI command for changing this setting. This PR adds support for the setting in the GUI. This includes:

* having a toggle button in the Advanced Settings screen to change the setting
* show the blocking internet banner when disconnected but the setting is active
* using the "securing" state tray icon (green with red dot) when disconnected but the setting is active

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
