### PR TITLE
Automatically dismiss notifications after four seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Fixed
 - Stop GUI from glitching during the short reconnect state.
+- Dismiss notifications automatically after four seconds in all platforms.
 
 
 ## [2018.6-beta1] - 2018-12-05

--- a/gui/packages/desktop/src/main/notification-controller.js
+++ b/gui/packages/desktop/src/main/notification-controller.js
@@ -111,6 +111,8 @@ export default class NotificationController {
     this._addPendingNotification(notification);
 
     notification.show();
+
+    setTimeout(() => notification.close(), 4000);
   }
 
   _addPendingNotification(notification: Notification) {


### PR DESCRIPTION
Currently, notifications are dismissed either manually or by the operating system. This leads to some inconsistent behavior, where in some OS (e.g., macOS) the notifications need to be dismissed manually. This PR changes this so that all notifications are visible for a maximum of four seconds.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/634)
<!-- Reviewable:end -->
