### PR TITLE
Account time running out warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 - Handle "block when disconnected" extra kill-switch level in the GUI, showing the disconnected
   state as blocked when appropriate and also having a toggle switch for the setting in the Advanced
   Settings screen.
+- Add a drop-down warning to notify the user when the account credits are running low.
 
 #### Linux
 - Detect if the computer is offline. If so, don't sit in a reconnect loop, instead block and show

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -199,6 +199,7 @@ export default class Connect extends Component<Props> {
             style={styles.notification_area}
             tunnelState={this.props.connection.status}
             version={this.props.version}
+            accountExpiry={this.props.accountExpiry}
             openExternalLink={this.props.onExternalLink}
             blockWhenDisconnected={this.props.blockWhenDisconnected}
           />

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -1,6 +1,5 @@
 // @flow
 
-import moment from 'moment';
 import * as React from 'react';
 import { Component, View } from 'reactxp';
 import { SettingsBarButton, Brand, HeaderBarStyle, ImageView } from '@mullvad/components';
@@ -13,13 +12,14 @@ import styles from './ConnectStyles';
 import { NoCreditError, NoInternetError } from '../../main/errors';
 
 import type { RelayOutAddress, RelayInAddress } from './TunnelControl';
+import type AccountExpiry from '../lib/account-expiry';
 import type { ConnectionReduxState } from '../redux/connection/reducers';
 import type { VersionReduxState } from '../redux/version/reducers';
 
 type Props = {
   connection: ConnectionReduxState,
   version: VersionReduxState,
-  accountExpiry: ?string,
+  accountExpiry: ?AccountExpiry,
   selectedRelayName: string,
   connectionInfoOpen: boolean,
   blockWhenDisconnected: boolean,
@@ -240,8 +240,7 @@ export default class Connect extends Component<Props> {
     }
 
     // No credit?
-    const expiry = this.props.accountExpiry;
-    if (expiry && moment(expiry).isSameOrBefore(moment())) {
+    if (this.props.accountExpiry && this.props.accountExpiry.hasExpired()) {
       return new NoCreditError();
     }
 

--- a/gui/packages/desktop/src/renderer/components/NotificationArea.js
+++ b/gui/packages/desktop/src/renderer/components/NotificationArea.js
@@ -133,7 +133,7 @@ export default class NotificationArea extends Component<Props, State> {
           return {
             visible: true,
             type: 'expires-soon',
-            timeLeft: accountExpiry.remainingTime(),
+            timeLeft: NotificationArea._capitalizeFirstLetter(accountExpiry.remainingTime()),
           };
         }
 
@@ -142,6 +142,12 @@ export default class NotificationArea extends Component<Props, State> {
           visible: false,
         };
     }
+  }
+
+  static _capitalizeFirstLetter(initialString: string): string {
+    return initialString.length > 0
+      ? initialString.charAt(0).toUpperCase() + initialString.slice(1)
+      : '';
   }
 
   render() {

--- a/gui/packages/desktop/src/renderer/components/NotificationBanner.js
+++ b/gui/packages/desktop/src/renderer/components/NotificationBanner.js
@@ -226,6 +226,7 @@ export class NotificationBanner extends Component<
     } else {
       this._didFinishFirstLayoutPass = true;
       if (this.props.visible) {
+        this._stopAnimation();
         this._heightValue.setValue(height);
       }
     }
@@ -237,10 +238,7 @@ export class NotificationBanner extends Component<
       return;
     }
 
-    if (this._animation) {
-      this._animation.stop();
-      this._animation = null;
-    }
+    this._stopAnimation();
 
     // calculate the animation duration based on travel distance
     const layout = await UserInterface.measureLayoutRelativeToWindow(containerView);
@@ -263,5 +261,12 @@ export class NotificationBanner extends Component<
         this.setState({ contentPinnedToBottom: false });
       }
     });
+  }
+
+  _stopAnimation() {
+    if (this._animation) {
+      this._animation.stop();
+      this._animation = null;
+    }
   }
 }

--- a/gui/packages/desktop/src/renderer/components/Settings.js
+++ b/gui/packages/desktop/src/renderer/components/Settings.js
@@ -1,6 +1,5 @@
 // @flow
 
-import moment from 'moment';
 import * as React from 'react';
 import { Component, Text, View } from 'reactxp';
 import { ImageView, SettingsHeader, HeaderTitle } from '@mullvad/components';
@@ -15,6 +14,7 @@ import {
   TitleBarItem,
 } from './NavigationBar';
 import styles from './SettingsStyles';
+import AccountExpiry from '../lib/account-expiry';
 import { colors } from '../../config';
 
 import type { LoginState } from '../redux/account/reducers';
@@ -74,15 +74,9 @@ export default class Settings extends Component<Props> {
       return null;
     }
 
-    let isOutOfTime = false;
-    let formattedExpiry = '';
-
-    const expiryIso = this.props.accountExpiry;
-    if (isLoggedIn && expiryIso) {
-      const expiry = moment(expiryIso);
-      isOutOfTime = expiry.isSameOrBefore(moment());
-      formattedExpiry = (expiry.fromNow(true) + ' left').toUpperCase();
-    }
+    const expiry = this.props.accountExpiry ? new AccountExpiry(this.props.accountExpiry) : null;
+    const isOutOfTime = expiry ? expiry.hasExpired() : false;
+    const formattedExpiry = expiry ? expiry.remainingTime().toUpperCase() : '';
 
     return (
       <View>

--- a/gui/packages/desktop/src/renderer/containers/ConnectPage.js
+++ b/gui/packages/desktop/src/renderer/containers/ConnectPage.js
@@ -7,6 +7,7 @@ import { bindActionCreators } from 'redux';
 import { push } from 'connected-react-router';
 import { links } from '../../config';
 import Connect from '../components/Connect';
+import AccountExpiry from '../lib/account-expiry';
 import userInterfaceActions from '../redux/userinterface/actions';
 
 import type { ReduxState, ReduxDispatch } from '../redux/store';
@@ -58,7 +59,7 @@ function getRelayName(
 
 const mapStateToProps = (state: ReduxState) => {
   return {
-    accountExpiry: state.account.expiry,
+    accountExpiry: state.account.expiry ? new AccountExpiry(state.account.expiry) : null,
     selectedRelayName: getRelayName(state.settings.relaySettings, state.settings.relayLocations),
     connection: state.connection,
     version: state.version,

--- a/gui/packages/desktop/src/renderer/lib/account-expiry.js
+++ b/gui/packages/desktop/src/renderer/lib/account-expiry.js
@@ -1,0 +1,19 @@
+// @flow
+
+import moment from 'moment';
+
+export default class AccountExpiry {
+  _expiry: moment;
+
+  constructor(expiry: string) {
+    this._expiry = moment(expiry);
+  }
+
+  hasExpired(): boolean {
+    return this._expiry.isSameOrBefore(moment());
+  }
+
+  remainingTime(): string {
+    return this._expiry.fromNow(true) + ' left';
+  }
+}

--- a/gui/packages/desktop/src/renderer/lib/account-expiry.js
+++ b/gui/packages/desktop/src/renderer/lib/account-expiry.js
@@ -10,7 +10,11 @@ export default class AccountExpiry {
   }
 
   hasExpired(): boolean {
-    return this._expiry.isSameOrBefore(moment());
+    return this.willHaveExpiredIn(moment());
+  }
+
+  willHaveExpiredIn(time: moment): boolean {
+    return this._expiry.isSameOrBefore(time);
   }
 
   remainingTime(): string {

--- a/gui/packages/desktop/test/components/NotificationArea.spec.js
+++ b/gui/packages/desktop/test/components/NotificationArea.spec.js
@@ -1,5 +1,6 @@
 // @flow
 
+import moment from 'moment';
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import NotificationArea from '../../src/renderer/components/NotificationArea';
@@ -169,6 +170,26 @@ describe('components/NotificationArea', () => {
 
     expect(component.state('type')).to.be.equal('update-available');
     expect(component.state('upgradeVersion')).to.be.equal('2018.4-beta3');
+    expect(component.state('visible')).to.be.true;
+  });
+
+  it('handles time running low', () => {
+    const expiry = new AccountExpiry(
+      moment()
+        .add(2, 'days')
+        .format(),
+    );
+    const component = shallow(
+      <NotificationArea
+        tunnelState={{
+          state: 'disconnected',
+        }}
+        version={defaultVersion}
+        accountExpiry={expiry}
+      />,
+    );
+
+    expect(component.state('type')).to.be.equal('expires-soon');
     expect(component.state('visible')).to.be.true;
   });
 });

--- a/gui/packages/desktop/test/components/NotificationArea.spec.js
+++ b/gui/packages/desktop/test/components/NotificationArea.spec.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import NotificationArea from '../../src/renderer/components/NotificationArea';
+import AccountExpiry from '../../src/renderer/lib/account-expiry';
 
 describe('components/NotificationArea', () => {
   const defaultVersion = {
@@ -15,6 +16,12 @@ describe('components/NotificationArea', () => {
     nextUpgrade: null,
   };
 
+  const defaultExpiry = new AccountExpiry(
+    moment()
+      .add(1, 'year')
+      .format(),
+  );
+
   it('handles disconnecting state', () => {
     for (const reason of ['nothing', 'block', 'reconnect']) {
       const component = shallow(
@@ -24,6 +31,7 @@ describe('components/NotificationArea', () => {
             details: { reason },
           }}
           version={defaultVersion}
+          accountExpiry={defaultExpiry}
         />,
       );
       expect(component.state('visible')).to.be.false;
@@ -38,6 +46,7 @@ describe('components/NotificationArea', () => {
             state,
           }}
           version={defaultVersion}
+          accountExpiry={defaultExpiry}
         />,
       );
 
@@ -52,6 +61,7 @@ describe('components/NotificationArea', () => {
           state: 'connecting',
         }}
         version={defaultVersion}
+        accountExpiry={defaultExpiry}
       />,
     );
 
@@ -69,6 +79,7 @@ describe('components/NotificationArea', () => {
           },
         }}
         version={defaultVersion}
+        accountExpiry={defaultExpiry}
       />,
     );
 
@@ -86,6 +97,7 @@ describe('components/NotificationArea', () => {
           ...defaultVersion,
           consistent: false,
         }}
+        accountExpiry={defaultExpiry}
       />,
     );
 
@@ -106,6 +118,7 @@ describe('components/NotificationArea', () => {
           current: '2018.1',
           nextUpgrade: '2018.2',
         }}
+        accountExpiry={defaultExpiry}
       />,
     );
 
@@ -127,6 +140,7 @@ describe('components/NotificationArea', () => {
           latestStable: '2018.3',
           nextUpgrade: '2018.3',
         }}
+        accountExpiry={defaultExpiry}
       />,
     );
 
@@ -149,6 +163,7 @@ describe('components/NotificationArea', () => {
           latestStable: '2018.3',
           nextUpgrade: '2018.4-beta3',
         }}
+        accountExpiry={defaultExpiry}
       />,
     );
 


### PR DESCRIPTION
This PR adds a drop-down warning for when the account time is running out. Currently, this is configured as 3 days before the expiration date. This is a reminder for the user so that he can buy credits before they expire and prevent loss of connectivity.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/635)
<!-- Reviewable:end -->
