### PR TITLE
Capture and log stderr from resolvconf when failing

### DIFF
--- a/talpid-core/src/security/linux/dns/resolvconf.rs
+++ b/talpid-core/src/security/linux/dns/resolvconf.rs
@@ -47,6 +47,8 @@ impl Resolvconf {
 
         let output = duct::cmd!(&self.resolvconf, "-a", &record_name)
             .input(record_contents)
+            .stderr_capture()
+            .unchecked()
             .run()
             .chain_err(|| ErrorKind::RunResolvconf)?;
 
@@ -65,6 +67,8 @@ impl Resolvconf {
 
         for record_name in self.record_names.drain() {
             let output = duct::cmd!(&self.resolvconf, "-d", &record_name)
+                .stderr_capture()
+                .unchecked()
                 .run()
                 .chain_err(|| ErrorKind::RunResolvconf)?;
 


### PR DESCRIPTION
Without `.unchecked()` duct will return an error directly from `run()`. Thus the later check, `output.status.success()` has no effect at all, because for all cases where it would be false the `run()` statement will already have returned early with an error.

Also, stderr is by default not captured. This addition captures stderr as well as makes `run()` return control to us even if the process exits with a non-zero exit code.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/636)
<!-- Reviewable:end -->
