### PR TITLE
Upgrade towards rust2018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,6 @@ dependencies = [
  "mullvad-paths 0.1.0",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-types 0.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "openvpn-plugin"
 version = "0.3.0"
-source = "git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event#bb82d84f7a464b2d7313cc7521bc6e6048409f94"
+source = "git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event#c989d7a43de59e4207c31355be7952251273236b"
 dependencies = [
  "derive-try-from-primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,6 @@ name = "talpid-types"
 version = "0.1.0"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Mullvad VPN application paths and directories"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 error-chain = "0.12"

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -1,7 +1,5 @@
 use crate::Result;
-
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 /// Creates and returns the cache directory pointed to by `MULLVAD_CACHE_DIR`, or the default
 /// one if that variable is unset.
@@ -24,7 +22,7 @@ pub fn get_default_cache_dir() -> Result<PathBuf> {
     }
     #[cfg(any(target_os = "macos", windows))]
     {
-        dir = ::dirs::cache_dir().ok_or_else(|| ::ErrorKind::FindDirError.into())
+        dir = dirs::cache_dir().ok_or_else(|| crate::ErrorKind::FindDirError.into())
     }
     dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -1,11 +1,7 @@
-#[cfg(any(windows, target_os = "macos"))]
-extern crate dirs;
 #[macro_use]
 extern crate error_chain;
-extern crate log;
 
-use std::fs;
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 error_chain! {
     errors {

--- a/mullvad-paths/src/logs.rs
+++ b/mullvad-paths/src/logs.rs
@@ -1,9 +1,8 @@
 use crate::Result;
 
-use std::env;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 /// Creates and returns the logging directory pointed to by `MULLVAD_LOG_DIR`, or the default
 /// one if that variable is unset.
@@ -31,7 +30,7 @@ pub fn get_default_log_dir() -> Result<PathBuf> {
     }
     #[cfg(windows)]
     {
-        dir = ::get_allusersprofile_dir();
+        dir = crate::get_allusersprofile_dir();
     }
     dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-paths/src/resources.rs
+++ b/mullvad-paths/src/resources.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 pub const API_CA_FILENAME: &str = "api_root_ca.pem";
 

--- a/mullvad-paths/src/rpc_socket.rs
+++ b/mullvad-paths/src/rpc_socket.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 pub fn get_rpc_socket_path() -> PathBuf {
     match env::var_os("MULLVAD_RPC_SOCKET_PATH") {

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -1,7 +1,6 @@
 use crate::Result;
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 /// Creates and returns the settings directory pointed to by `MULLVAD_SETTINGS_DIR`, or the default
 /// one if that variable is unset.
@@ -24,7 +23,7 @@ pub fn get_default_settings_dir() -> Result<PathBuf> {
     }
     #[cfg(windows)]
     {
-        dir = ::dirs::data_local_dir().ok_or_else(|| ::ErrorKind::FindDirError.into());
+        dir = dirs::data_local_dir().ok_or_else(|| crate::ErrorKind::FindDirError.into());
     }
     dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Common base data structures for Mullvad VPN client"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-serde_derive = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 error-chain = "0.12"
 log = "0.4"

--- a/mullvad-types/src/account.rs
+++ b/mullvad-types/src/account.rs
@@ -1,5 +1,5 @@
-use chrono::offset::Utc;
-use chrono::DateTime;
+use chrono::{offset::Utc, DateTime};
+use serde::{Deserialize, Serialize};
 
 pub type AccountToken = String;
 

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -50,7 +50,7 @@ impl<'a> From<&'a str> for AuthFailed {
 }
 
 impl ::std::fmt::Display for AuthFailed {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         use self::AuthFailedInner::*;
         match self.reason {
             InvalidAccount => write!(f, "{}", INVALID_ACCOUNT_MSG),

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::{
     fmt,
     net::{IpAddr, ToSocketAddrs},
@@ -29,7 +30,7 @@ impl CustomTunnelEndpoint {
 }
 
 impl fmt::Display for CustomTunnelEndpoint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} over {}", self.host, self.tunnel)
     }
 }

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -6,20 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-extern crate chrono;
-extern crate regex;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-
-extern crate mullvad_paths;
-extern crate talpid_types;
-
-extern crate log;
 #[macro_use]
 extern crate error_chain;
-extern crate lazy_static;
-
 
 pub mod account;
 pub mod auth_failed;

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
 pub type CountryCode = String;

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -1,8 +1,7 @@
 use crate::location::{CityCode, CountryCode, Hostname};
 use crate::CustomTunnelEndpoint;
-
+use serde::{Deserialize, Serialize};
 use std::fmt;
-
 use talpid_types::net::{OpenVpnEndpointData, TransportProtocol, WireguardEndpointData};
 
 
@@ -58,7 +57,7 @@ pub enum RelaySettings {
 }
 
 impl fmt::Display for RelaySettings {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             RelaySettings::CustomTunnelEndpoint(endpoint) => {
                 write!(f, "custom endpoint {}", endpoint)
@@ -107,7 +106,7 @@ impl RelayConstraints {
 }
 
 impl fmt::Display for RelayConstraints {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.tunnel {
             Constraint::Any => write!(f, "any relay")?,
             Constraint::Only(ref tunnel_constraint) => tunnel_constraint.fmt(f)?,
@@ -133,7 +132,7 @@ pub enum LocationConstraint {
 }
 
 impl fmt::Display for LocationConstraint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             LocationConstraint::Country(country) => write!(f, "country {}", country),
             LocationConstraint::City(country, city) => write!(f, "city {}, {}", city, country),
@@ -154,7 +153,7 @@ pub enum TunnelConstraints {
 }
 
 impl fmt::Display for TunnelConstraints {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             TunnelConstraints::OpenVpn(openvpn_constraints) => {
                 write!(f, "OpenVPN over ")?;
@@ -193,7 +192,7 @@ pub struct OpenVpnConstraints {
 }
 
 impl fmt::Display for OpenVpnConstraints {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.port {
             Constraint::Any => write!(f, "any port")?,
             Constraint::Only(port) => write!(f, "port {}", port)?,
@@ -218,7 +217,7 @@ pub struct WireguardConstraints {
 }
 
 impl fmt::Display for WireguardConstraints {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.port {
             Constraint::Any => write!(f, "any port"),
             Constraint::Only(port) => write!(f, "port {}", port),

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -1,7 +1,6 @@
 use crate::location::{CityCode, CountryCode, Location};
-
+use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
-
 use talpid_types::net::{OpenVpnEndpointData, WireguardEndpointData};
 
 

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -1,13 +1,10 @@
-extern crate serde_json;
-
 use crate::relay_constraints::{
     Constraint, LocationConstraint, RelayConstraints, RelaySettings, RelaySettingsUpdate,
 };
 use log::{debug, info};
-
-use std::fs::File;
-use std::io;
-use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::{fs::File, io, path::PathBuf};
 use talpid_types::net::{OpenVpnProxySettings, OpenVpnProxySettingsValidation, TunnelOptions};
 
 error_chain! {

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Represents the state the client strives towards.
 /// When in `Secured`, the client should keep the computer from leaking and try to
 /// establish a VPN tunnel if it is not up.

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// AppVersionInfo represents the current stable and the current latest release versions of the
 /// Mullvad VPN app.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 description = "OpenVPN shared library plugin for relaying OpenVPN events to talpid_core"
 license = "GPL-3.0"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/talpid-openvpn-plugin/build.rs
+++ b/talpid-openvpn-plugin/build.rs
@@ -1,8 +1,3 @@
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-extern crate winres;
-
 fn main() {
     #[cfg(windows)]
     {

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -6,17 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-extern crate env_logger;
 #[macro_use]
 extern crate error_chain;
-extern crate log;
-
-extern crate futures;
-extern crate jsonrpc_client_core;
-extern crate jsonrpc_client_ipc;
-extern crate openvpn_plugin;
-extern crate tokio;
-extern crate tokio_reactor;
 
 use error_chain::ChainedError;
 use openvpn_plugin::{openvpn_plugin, EventResult, EventType};

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -1,7 +1,4 @@
-extern crate futures;
-
 use super::Arguments;
-use crate::openvpn_plugin;
 use jsonrpc_client_core::{
     expand_params, jsonrpc_client, Future, Result as ClientResult, Transport,
 };

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Common base structures for talpid"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
-serde_derive = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -6,8 +6,5 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-#[macro_use]
-extern crate serde_derive;
-
 pub mod net;
 pub mod tunnel;

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -1,10 +1,10 @@
+use serde::{Deserialize, Serialize};
 use std::{
     error::Error,
     fmt,
     net::{IpAddr, SocketAddr},
     str::FromStr,
 };
-use serde::{Deserialize, Serialize};
 
 /// Represents one tunnel endpoint. Address, plus extra parameters specific to tunnel protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -1,7 +1,10 @@
-use std::error::Error;
-use std::fmt;
-use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
+use std::{
+    error::Error,
+    fmt,
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
+use serde::{Deserialize, Serialize};
 
 /// Represents one tunnel endpoint. Address, plus extra parameters specific to tunnel protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -34,7 +37,7 @@ pub enum TunnelEndpointData {
 }
 
 impl fmt::Display for TunnelEndpointData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             TunnelEndpointData::OpenVpn(openvpn_data) => {
                 write!(f, "OpenVPN ")?;
@@ -71,7 +74,7 @@ pub struct OpenVpnEndpointData {
 }
 
 impl fmt::Display for OpenVpnEndpointData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{} port {}", self.protocol, self.port)
     }
 }
@@ -82,7 +85,7 @@ pub struct WireguardEndpointData {
 }
 
 impl fmt::Display for WireguardEndpointData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "port {}", self.port)
     }
 }
@@ -108,7 +111,7 @@ impl Endpoint {
 }
 
 impl fmt::Display for Endpoint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}:{}", self.address, self.protocol)
     }
 }
@@ -136,7 +139,7 @@ impl FromStr for TransportProtocol {
 }
 
 impl fmt::Display for TransportProtocol {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             TransportProtocol::Udp => "UDP".fmt(fmt),
             TransportProtocol::Tcp => "TCP".fmt(fmt),
@@ -148,7 +151,7 @@ impl fmt::Display for TransportProtocol {
 pub struct TransportProtocolParseError;
 
 impl fmt::Display for TransportProtocolParseError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str(self.description())
     }
 }

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,6 +1,6 @@
+use super::net::TunnelEndpoint;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use super::net::TunnelEndpoint;
 
 /// Event resulting from a transition to a new tunnel state.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
-
 use super::net::TunnelEndpoint;
 
 /// Event resulting from a transition to a new tunnel state.
@@ -59,7 +59,7 @@ pub enum BlockReason {
 }
 
 impl fmt::Display for BlockReason {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::BlockReason::*;
         let description = match *self {
             AuthFailed(ref reason) => {


### PR DESCRIPTION
Looking into upgrading towards Rust 2018 to get the benefits it brings. I started slow with some low level crates we have and that are not too big. I also included everyone in the review to make this a good opportunity to see what this upgrade looks like and to ask questions if anything is unclear. Before we move everything over. It's not that we are in a hurry to upgrade really. But the sooner we can reap the ergonomic benefits the better I guess :)

I did this upgrade by doing the following for each crate:
* Run `cargo fix --edition` <- makes the code compatible with both 2015 and 2018. Did nothing since I had a PR doing this preparation a while back
* Add `edition = "2018"` to `Cargo.toml`
* Run `cargo fix --edition-idioms` to make cargo automatically update some code to follow Rust 2018 recommendations and idioms.
* Manually converting a few `#[macro_use] extern crate foo;` into the new macro import style.
* Manually fixed a few small things.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/637)
<!-- Reviewable:end -->
