### PR TITLE
Activate the merge_imports rustfmt feature

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -2,11 +2,13 @@ use crate::{new_rpc_client, Command, Result, ResultExt};
 use clap::value_t;
 use std::str::FromStr;
 
-use mullvad_types::relay_constraints::{
-    Constraint, LocationConstraint, OpenVpnConstraints, RelayConstraintsUpdate,
-    RelaySettingsUpdate, TunnelConstraints,
+use mullvad_types::{
+    relay_constraints::{
+        Constraint, LocationConstraint, OpenVpnConstraints, RelayConstraintsUpdate,
+        RelaySettingsUpdate, TunnelConstraints,
+    },
+    CustomTunnelEndpoint,
 };
-use mullvad_types::CustomTunnelEndpoint;
 use talpid_types::net::{
     OpenVpnEndpointData, TransportProtocol, TunnelEndpointData, WireguardEndpointData,
 };

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -1,10 +1,7 @@
 use crate::{new_rpc_client, Command, Result};
 use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_types::auth_failed::AuthFailed;
-use talpid_types::tunnel::{
-    BlockReason,
-    TunnelStateTransition::{self, *},
-};
+use talpid_types::tunnel::{BlockReason, TunnelStateTransition};
 
 pub struct Status;
 
@@ -31,6 +28,7 @@ impl Command for Status {
             for new_state in rpc.new_state_subscribe()? {
                 print_state(&new_state);
 
+                use self::TunnelStateTransition::*;
                 match new_state {
                     Connected(_) | Disconnected => print_location(&mut rpc)?,
                     _ => {}
@@ -42,6 +40,7 @@ impl Command for Status {
 }
 
 fn print_state(state: &TunnelStateTransition) {
+    use self::TunnelStateTransition::*;
     print!("Tunnel status: ");
     match state {
         Blocked(reason) => print_blocked_reason(reason),

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -1,8 +1,10 @@
 use crate::{new_rpc_client, Command, Result};
 use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_types::auth_failed::AuthFailed;
-use talpid_types::tunnel::BlockReason;
-use talpid_types::tunnel::TunnelStateTransition::{self, *};
+use talpid_types::tunnel::{
+    BlockReason,
+    TunnelStateTransition::{self, *},
+};
 
 pub struct Status;
 

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -1,7 +1,4 @@
-use std::env;
-use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
+use std::{env, fs, path::PathBuf, process::Command};
 
 #[cfg(windows)]
 extern crate winapi;

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -1,8 +1,10 @@
 extern crate serde_json;
 
-use std::fs::File;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::{
+    fs::File,
+    io,
+    path::{Path, PathBuf},
+};
 
 use mullvad_types::account::AccountToken;
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -58,8 +58,7 @@ use mullvad_types::{
         TunnelConstraints,
     },
     relay_list::{Relay, RelayList},
-    settings,
-    settings::Settings,
+    settings::{self, Settings},
     states::TargetState,
     version::{AppVersion, AppVersionInfo},
 };

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -1,13 +1,13 @@
 extern crate fern;
 
-use self::fern::colors::{Color, ColoredLevelConfig};
-use self::fern::Output;
+use self::fern::{
+    colors::{Color, ColoredLevelConfig},
+    Output,
+};
 use chrono;
 use log;
 
-use std::fmt;
-use std::io;
-use std::path::PathBuf;
+use std::{fmt, io, path::PathBuf};
 
 use talpid_core::logging::rotate_log;
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1,8 +1,13 @@
 use crate::account_history::{AccountHistory, Error as AccountHistoryError};
 use error_chain::ChainedError;
-use jsonrpc_core::futures::sync::oneshot::Sender as OneshotSender;
-use jsonrpc_core::futures::{future, sync, Future};
-use jsonrpc_core::{Error, ErrorCode, MetaIoHandler, Metadata};
+use jsonrpc_core::{
+    futures::{
+        future,
+        sync::{self, oneshot::Sender as OneshotSender},
+        Future,
+    },
+    Error, ErrorCode, MetaIoHandler, Metadata,
+};
 use jsonrpc_ipc_server;
 use jsonrpc_macros::{build_rpc_trait, metadata, pubsub};
 use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, SubscriptionId};

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -3,22 +3,28 @@ use error_chain::ChainedError;
 use futures::Future;
 
 use mullvad_rpc::{HttpHandle, RelayListProxy};
-use mullvad_types::location::Location;
-use mullvad_types::relay_constraints::{
-    Constraint, LocationConstraint, Match, OpenVpnConstraints, RelayConstraints, TunnelConstraints,
+use mullvad_types::{
+    location::Location,
+    relay_constraints::{
+        Constraint, LocationConstraint, Match, OpenVpnConstraints, RelayConstraints,
+        TunnelConstraints,
+    },
+    relay_list::{Relay, RelayList, RelayTunnels},
 };
-use mullvad_types::relay_list::{Relay, RelayList, RelayTunnels};
 
 use serde_json;
 
 use talpid_types::net::{TransportProtocol, TunnelEndpoint, TunnelEndpointData};
 
-use std::fs::File;
-use std::net::IpAddr;
-use std::path::{Path, PathBuf};
-use std::sync::{mpsc, Arc, Mutex, MutexGuard};
-use std::time::{self, Duration, SystemTime};
-use std::{io, thread};
+use std::{
+    fs::File,
+    io,
+    net::IpAddr,
+    path::{Path, PathBuf},
+    sync::{mpsc, Arc, Mutex, MutexGuard},
+    thread,
+    time::{self, Duration, SystemTime},
+};
 
 use log::{debug, error, info, trace, warn};
 use rand::{self, Rng, ThreadRng};

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -4,20 +4,23 @@ use std::{
     env,
     ffi::OsString,
     io,
-    sync::atomic::{AtomicUsize, Ordering},
-    sync::{mpsc, Arc},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Arc,
+    },
     thread,
     time::Duration,
 };
-use windows_service::service::{
-    ServiceAccess, ServiceControl, ServiceControlAccept, ServiceDependency, ServiceErrorControl,
-    ServiceExitCode, ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
+use windows_service::{
+    service::{
+        ServiceAccess, ServiceControl, ServiceControlAccept, ServiceDependency,
+        ServiceErrorControl, ServiceExitCode, ServiceInfo, ServiceStartType, ServiceState,
+        ServiceStatus, ServiceType,
+    },
+    service_control_handler::{self, ServiceControlHandlerResult, ServiceStatusHandle},
+    service_dispatcher,
+    service_manager::{ServiceManager, ServiceManagerAccess},
 };
-use windows_service::service_control_handler::{
-    self, ServiceControlHandlerResult, ServiceStatusHandle,
-};
-use windows_service::service_dispatcher;
-use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
 
 use super::{Result, ResultExt};
 use mullvad_daemon::DaemonShutdownHandle;

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -12,8 +12,7 @@ extern crate error_chain;
 
 use chrono::{offset::Utc, DateTime};
 use jsonrpc_client_core::{expand_params, jsonrpc_client};
-use jsonrpc_client_http::header::Host;
-use jsonrpc_client_http::{HttpTransport, HttpTransportBuilder};
+use jsonrpc_client_http::{header::Host, HttpTransport, HttpTransportBuilder};
 use lazy_static::lazy_static;
 use mullvad_types::{account::AccountToken, relay_list::RelayList, version};
 use std::{

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -1,5 +1,4 @@
-use self::mock_openvpn::MOCK_OPENVPN_ARGS_FILE;
-use self::platform_specific::*;
+use self::{mock_openvpn::MOCK_OPENVPN_ARGS_FILE, platform_specific::*};
 use futures::sync::oneshot;
 use jsonrpc_client_core::{Future, Transport};
 use jsonrpc_client_ipc::IpcTransport;
@@ -7,12 +6,13 @@ use mullvad_ipc_client::{DaemonRpcClient, ResultExt};
 use mullvad_paths::resources::API_CA_FILENAME;
 use notify::{RawEvent, RecommendedWatcher, RecursiveMode, Watcher};
 use std::{
+    cmp,
     collections::HashMap,
     fs::{self, File},
     path::{Path, PathBuf},
     sync::{mpsc, Arc},
+    thread,
     time::{Duration, Instant},
-    {cmp, thread},
 };
 use tempfile::TempDir;
 use tokio::reactor::Handle;

--- a/mullvad-tests/tests/account.rs
+++ b/mullvad-tests/tests/account.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "integration-tests")]
 
-use mullvad_tests::mock_openvpn::search_openvpn_args;
-use mullvad_tests::{watch_event, DaemonRunner, PathWatcher};
+use mullvad_tests::{mock_openvpn::search_openvpn_args, watch_event, DaemonRunner, PathWatcher};
 use std::{
     fs::File,
     io::{BufRead, BufReader},

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -1,5 +1,7 @@
-use crate::location::{CityCode, CountryCode, Hostname};
-use crate::CustomTunnelEndpoint;
+use crate::{
+    location::{CityCode, CountryCode, Hostname},
+    CustomTunnelEndpoint,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use talpid_types::net::{OpenVpnEndpointData, TransportProtocol, WireguardEndpointData};

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,6 +4,7 @@ use_field_init_shorthand = true
 condense_wildcard_suffixes = true
 normalize_comments = true
 wrap_comments = true
+merge_imports = true
 
 # Heavily subjective style choices
 comment_width = 100

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -1,7 +1,6 @@
 #[cfg(windows)]
 mod win {
-    use std::env;
-    use std::path::PathBuf;
+    use std::{env, path::PathBuf};
 
     pub static WINFW_BUILD_DIR: &'static str = "..\\windows\\winfw\\bin";
     pub static WINDNS_BUILD_DIR: &'static str = "..\\windows\\windns\\bin";

--- a/talpid-core/src/logging.rs
+++ b/talpid-core/src/logging.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-use std::{fs, io};
+use std::{fs, io, path::Path};
 
 error_chain! {}
 

--- a/talpid-core/src/mktemp.rs
+++ b/talpid-core/src/mktemp.rs
@@ -1,7 +1,7 @@
-use std::env;
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+};
 
 use uuid::Uuid;
 

--- a/talpid-core/src/mpsc.rs
+++ b/talpid-core/src/mpsc.rs
@@ -1,5 +1,4 @@
-use std::marker::PhantomData;
-use std::sync::mpsc;
+use std::{marker::PhantomData, sync::mpsc};
 
 /// Abstraction over an `mpsc::Sender` that first converts the value to another type before sending.
 #[derive(Debug, Clone)]
@@ -33,8 +32,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::mpsc;
-    use std::thread;
+    use std::{sync::mpsc, thread};
 
     #[derive(Debug, Eq, PartialEq)]
     enum Inner {

--- a/talpid-core/src/network_interface.rs
+++ b/talpid-core/src/network_interface.rs
@@ -1,6 +1,8 @@
 use nix::fcntl;
-use std::net::IpAddr;
-use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+use std::{
+    net::IpAddr,
+    os::unix::io::{AsRawFd, IntoRawFd, RawFd},
+};
 use tun::{platform, Configuration, Device};
 
 error_chain! {

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -2,18 +2,19 @@ extern crate iproute2;
 extern crate netlink_socket;
 extern crate rtnetlink;
 
-use std::collections::BTreeSet;
-use std::thread;
+use std::{collections::BTreeSet, thread};
 
 use error_chain::ChainedError;
 use futures::{future::Either, sync::mpsc::UnboundedSender, Future, Stream};
 use log::{error, trace, warn};
 
-use self::iproute2::Link;
-use self::netlink_socket::{Protocol, SocketAddr, TokioSocket};
-use self::rtnetlink::{
-    LinkFlags, LinkHeader, LinkLayerType, LinkMessage, NetlinkCodec, NetlinkFramed, NetlinkMessage,
-    RtnlMessage,
+use self::{
+    iproute2::Link,
+    netlink_socket::{Protocol, SocketAddr, TokioSocket},
+    rtnetlink::{
+        LinkFlags, LinkHeader, LinkLayerType, LinkMessage, NetlinkCodec, NetlinkFramed,
+        NetlinkMessage, RtnlMessage,
+    },
 };
 
 use tunnel_state_machine::TunnelCommand;

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -8,28 +8,35 @@
 
 extern crate winapi;
 
-use self::winapi::shared::basetsd::LONG_PTR;
-use self::winapi::shared::minwindef::{DWORD, LPARAM, LRESULT, UINT, WPARAM};
-use self::winapi::shared::windef::HWND;
-use self::winapi::um::handleapi::CloseHandle;
-use self::winapi::um::libloaderapi::GetModuleHandleW;
-use self::winapi::um::processthreadsapi::GetThreadId;
-use self::winapi::um::synchapi::WaitForSingleObject;
-use self::winapi::um::winbase::INFINITE;
-use self::winapi::um::winuser::{
-    CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
-    GetWindowLongPtrW, PostQuitMessage, PostThreadMessageW, SetWindowLongPtrW, GWLP_USERDATA,
-    GWLP_WNDPROC, PBT_APMRESUMEAUTOMATIC, PBT_APMSUSPEND, WM_DESTROY, WM_POWERBROADCAST, WM_USER,
+use self::winapi::{
+    shared::{
+        basetsd::LONG_PTR,
+        minwindef::{DWORD, LPARAM, LRESULT, UINT, WPARAM},
+        windef::HWND,
+    },
+    um::{
+        handleapi::CloseHandle,
+        libloaderapi::GetModuleHandleW,
+        processthreadsapi::GetThreadId,
+        synchapi::WaitForSingleObject,
+        winbase::INFINITE,
+        winuser::{
+            CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
+            GetWindowLongPtrW, PostQuitMessage, PostThreadMessageW, SetWindowLongPtrW,
+            GWLP_USERDATA, GWLP_WNDPROC, PBT_APMRESUMEAUTOMATIC, PBT_APMSUSPEND, WM_DESTROY,
+            WM_POWERBROADCAST, WM_USER,
+        },
+    },
 };
 use futures::sync::mpsc::UnboundedSender;
 use log::debug;
-use std::ffi::c_void;
-use std::mem::zeroed;
-use std::os::windows::io::IntoRawHandle;
-use std::os::windows::io::RawHandle;
-use std::ptr;
-use std::thread;
-use std::time::Duration;
+use std::{
+    ffi::c_void,
+    mem::zeroed,
+    os::windows::io::{IntoRawHandle, RawHandle},
+    ptr, thread,
+    time::Duration,
+};
 use tunnel_state_machine::TunnelCommand;
 
 const CLASS_NAME: &[u8] = b"S\0T\0A\0T\0I\0C\0\0\0";

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -2,10 +2,12 @@ use duct;
 extern crate os_pipe;
 
 use super::stoppable_process::StoppableProcess;
-use std::ffi::{OsStr, OsString};
-use std::fmt;
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::{
+    ffi::{OsStr, OsString},
+    fmt,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
 
 use self::os_pipe::{pipe, PipeWriter};
 use atty;
@@ -378,8 +380,7 @@ impl StoppableProcess for OpenVpnProcHandle {
 #[cfg(test)]
 mod tests {
     use super::OpenVpnCommand;
-    use std::ffi::OsString;
-    use std::net::Ipv4Addr;
+    use std::{ffi::OsString, net::Ipv4Addr};
     use talpid_types::net::{Endpoint, TransportProtocol};
 
     #[test]

--- a/talpid-core/src/process/stoppable_process.rs
+++ b/talpid-core/src/process/stoppable_process.rs
@@ -1,7 +1,8 @@
 use log::{debug, trace, warn};
-use std::io;
-use std::thread;
-use std::time::{Duration, Instant};
+use std::{
+    io, thread,
+    time::{Duration, Instant},
+};
 
 static POLL_INTERVAL_MS: Duration = Duration::from_millis(50);
 

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -1,8 +1,7 @@
 use super::{NetNode, RequiredRoutes};
 
 use super::subprocess::{Exec, RunExpr};
-use std::collections::HashSet;
-use std::net::IpAddr;
+use std::{collections::HashSet, net::IpAddr};
 
 
 error_chain! {

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -1,8 +1,7 @@
 use super::{NetNode, RequiredRoutes, Route};
 
 use super::subprocess::{Exec, RunExpr};
-use std::collections::HashSet;
-use std::net::IpAddr;
+use std::{collections::HashSet, net::IpAddr};
 
 error_chain! {
     errors {

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -7,10 +7,10 @@ mod systemd_resolved;
 
 use std::{env, fmt, net::IpAddr, path::Path};
 
-use self::network_manager::NetworkManager;
-use self::resolvconf::Resolvconf;
-use self::static_resolv_conf::StaticResolvConf;
-use self::systemd_resolved::SystemdResolved;
+use self::{
+    network_manager::NetworkManager, resolvconf::Resolvconf, static_resolv_conf::StaticResolvConf,
+    systemd_resolved::SystemdResolved,
+};
 
 const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 

--- a/talpid-core/src/security/linux/dns/network_manager.rs
+++ b/talpid-core/src/security/linux/dns/network_manager.rs
@@ -1,15 +1,18 @@
 extern crate dbus;
 
-use std::collections::HashMap;
-use std::net::IpAddr;
+use std::{collections::HashMap, net::IpAddr};
 
-use self::dbus::arg::{RefArg, Variant};
-use self::dbus::stdintf::*;
-use self::dbus::BusType;
+use self::dbus::{
+    arg::{RefArg, Variant},
+    stdintf::*,
+    BusType,
+};
 
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::Path,
+};
 
 use error_chain::ChainedError;
 

--- a/talpid-core/src/security/linux/dns/static_resolv_conf.rs
+++ b/talpid-core/src/security/linux/dns/static_resolv_conf.rs
@@ -1,12 +1,17 @@
 extern crate notify;
 
-use std::net::IpAddr;
-use std::sync::{mpsc, Arc, Mutex, MutexGuard};
-use std::{fs, io, thread};
+use std::{
+    fs, io,
+    net::IpAddr,
+    sync::{mpsc, Arc, Mutex, MutexGuard},
+    thread,
+};
 
 use self::notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use super::resolv_conf::{Config, ScopedIp};
-use super::RESOLV_CONF_PATH;
+use super::{
+    resolv_conf::{Config, ScopedIp},
+    RESOLV_CONF_PATH,
+};
 use error_chain::ChainedError;
 
 const RESOLV_CONF_BACKUP_PATH: &str = "/etc/resolv.conf.mullvadbackup";

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -9,12 +9,12 @@ use std::{
     path::Path,
 };
 
-use self::dbus::arg::RefArg;
-use self::dbus::stdintf::*;
-use self::dbus::{BusType, Interface, Member, Message, MessageItem, MessageItemArray, Signature};
+use self::dbus::{
+    arg::RefArg, stdintf::*, BusType, Interface, Member, Message, MessageItem, MessageItemArray,
+    Signature,
+};
 
-use super::super::iface_index;
-use super::{resolv_conf, RESOLV_CONF_PATH};
+use super::{super::iface_index, resolv_conf, RESOLV_CONF_PATH};
 
 
 error_chain! {

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -2,11 +2,9 @@
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(unix)]
 use lazy_static::lazy_static;
-use std::fmt;
-use std::net::IpAddr;
 #[cfg(unix)]
 use std::net::{Ipv4Addr, Ipv6Addr};
-use std::path::Path;
+use std::{fmt, net::IpAddr, path::Path};
 use talpid_types::net::Endpoint;
 
 

--- a/talpid-core/src/security/windows/dns.rs
+++ b/talpid-core/src/security/windows/dns.rs
@@ -1,10 +1,11 @@
 use log::{debug, error, info, trace, warn};
-use std::borrow::Borrow;
-use std::net::IpAddr;
-use std::os::raw::{c_char, c_void};
-use std::path::Path;
-use std::ptr;
-use std::slice;
+use std::{
+    borrow::Borrow,
+    net::IpAddr,
+    os::raw::{c_char, c_void},
+    path::Path,
+    ptr, slice,
+};
 
 use error_chain::ChainedError;
 use widestring::WideCString;

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -1,5 +1,4 @@
-use std::net::IpAddr;
-use std::ptr;
+use std::{net::IpAddr, ptr};
 
 use log::{debug, error, trace};
 use talpid_types::net::Endpoint;

--- a/talpid-core/src/security/windows/system_state.rs
+++ b/talpid-core/src/security/windows/system_state.rs
@@ -1,9 +1,11 @@
 //! A writer for a blob that would persistently store the system state. Useful
 //! for when the application of a secuirty policy proves to be persistent across
 //! reboots
-use std::fs::{self, File};
-use std::io::{self, Write};
-use std::path::Path;
+use std::{
+    fs::{self, File},
+    io::{self, Write},
+    path::Path,
+};
 
 /// This struct is responsible for saving a binary blob to disk. The binary blob is intended to
 /// store system state that should be resotred when the security policy is reset.

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -1,12 +1,14 @@
 use crate::{mktemp, process::openvpn::OpenVpnCommand};
 
-use std::collections::HashMap;
-use std::ffi::OsString;
-use std::fs;
-use std::io::{self, Write};
-use std::net::Ipv4Addr;
-use std::path::{Path, PathBuf};
-use std::result::Result as StdResult;
+use std::{
+    collections::HashMap,
+    ffi::OsString,
+    fs,
+    io::{self, Write},
+    net::Ipv4Addr,
+    path::{Path, PathBuf},
+    result::Result as StdResult,
+};
 
 #[cfg(target_os = "linux")]
 use failure::ResultExt as FailureResultExt;
@@ -362,8 +364,7 @@ impl CloseHandle {
 fn is_ipv6_enabled_in_os() -> bool {
     #[cfg(windows)]
     {
-        use winreg::enums::*;
-        use winreg::RegKey;
+        use winreg::{enums::*, RegKey};
 
         const IPV6_DISABLED_ON_TUNNELS_MASK: u32 = 0x01;
 

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -2,14 +2,18 @@ use crate::process::{
     openvpn::{OpenVpnCommand, OpenVpnProcHandle},
     stoppable_process::StoppableProcess,
 };
-use std::collections::HashMap;
-use std::io;
-use std::path::Path;
-use std::process::ExitStatus;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
-use std::thread;
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    io,
+    path::Path,
+    process::ExitStatus,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+    thread,
+    time::Duration,
+};
 
 use talpid_ipc;
 

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -1,6 +1,5 @@
 use error_chain::ChainedError;
-use futures::sync::mpsc;
-use futures::Stream;
+use futures::{sync::mpsc, Stream};
 use talpid_types::tunnel::BlockReason;
 
 use super::{

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -1,8 +1,12 @@
 use error_chain::ChainedError;
-use futures::sync::{mpsc, oneshot};
-use futures::{Async, Future, Stream};
-use talpid_types::net::{Endpoint, OpenVpnProxySettings, TransportProtocol};
-use talpid_types::tunnel::BlockReason;
+use futures::{
+    sync::{mpsc, oneshot},
+    Async, Future, Stream,
+};
+use talpid_types::{
+    net::{Endpoint, OpenVpnProxySettings, TransportProtocol},
+    tunnel::BlockReason,
+};
 
 use super::{
     AfterDisconnect, ConnectingState, DisconnectingState, EventConsequence, Result, ResultExt,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -1,16 +1,20 @@
-use std::ffi::OsString;
-use std::path::{Path, PathBuf};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    thread,
+    time::{Duration, Instant},
+};
 
 use error_chain::ChainedError;
-use futures::sync::{mpsc, oneshot};
-use futures::{Async, Future, Stream};
-use log::{debug, error, info, trace, warn};
-use talpid_types::net::{
-    Endpoint, OpenVpnProxySettings, TransportProtocol, TunnelEndpoint, TunnelEndpointData,
+use futures::{
+    sync::{mpsc, oneshot},
+    Async, Future, Stream,
 };
-use talpid_types::tunnel::BlockReason;
+use log::{debug, error, info, trace, warn};
+use talpid_types::{
+    net::{Endpoint, OpenVpnProxySettings, TransportProtocol, TunnelEndpoint, TunnelEndpointData},
+    tunnel::BlockReason,
+};
 
 use super::{
     AfterDisconnect, BlockedState, ConnectedState, ConnectedStateBootstrap, DisconnectingState,

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -4,8 +4,7 @@ use super::{
 };
 use crate::security::SecurityPolicy;
 use error_chain::ChainedError;
-use futures::sync::mpsc;
-use futures::Stream;
+use futures::{sync::mpsc, Stream};
 
 /// No tunnel is running.
 pub struct DisconnectedState;

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -1,8 +1,10 @@
 use std::thread;
 
 use error_chain::ChainedError;
-use futures::sync::{mpsc, oneshot};
-use futures::{Async, Future, Stream};
+use futures::{
+    sync::{mpsc, oneshot},
+    Async, Future, Stream,
+};
 use talpid_types::tunnel::{ActionAfterDisconnect, BlockReason};
 
 use super::{

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -7,23 +7,28 @@ mod connecting_state;
 mod disconnected_state;
 mod disconnecting_state;
 
-use std::path::{Path, PathBuf};
-use std::sync::mpsc as sync_mpsc;
-use std::thread;
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc as sync_mpsc,
+    thread,
+};
 
 use error_chain::ChainedError;
-use futures::sync::mpsc;
-use futures::{Async, Future, Poll, Stream};
+use futures::{sync::mpsc, Async, Future, Poll, Stream};
 use tokio_core::reactor::Core;
 
-use talpid_types::net::{TunnelEndpoint, TunnelOptions};
-use talpid_types::tunnel::{BlockReason, TunnelStateTransition};
+use talpid_types::{
+    net::{TunnelEndpoint, TunnelOptions},
+    tunnel::{BlockReason, TunnelStateTransition},
+};
 
-use self::blocked_state::BlockedState;
-use self::connected_state::{ConnectedState, ConnectedStateBootstrap};
-use self::connecting_state::ConnectingState;
-use self::disconnected_state::DisconnectedState;
-use self::disconnecting_state::{AfterDisconnect, DisconnectingState};
+use self::{
+    blocked_state::BlockedState,
+    connected_state::{ConnectedState, ConnectedStateBootstrap},
+    connecting_state::ConnectingState,
+    disconnected_state::DisconnectedState,
+    disconnecting_state::{AfterDisconnect, DisconnectingState},
+};
 use crate::{
     mpsc::IntoSender,
     offline,
@@ -249,8 +254,7 @@ enum TunnelStateMachineAction {
 
 impl<T: TunnelState> From<EventConsequence<T>> for TunnelStateMachineAction {
     fn from(event_consequence: EventConsequence<T>) -> Self {
-        use self::EventConsequence::*;
-        use self::TunnelStateMachineAction::*;
+        use self::{EventConsequence::*, TunnelStateMachineAction::*};
 
         match event_consequence {
             NewState((state_wrapper, transition)) => {

--- a/talpid-ipc/src/lib.rs
+++ b/talpid-ipc/src/lib.rs
@@ -89,8 +89,7 @@ impl IpcServer {
 
         #[cfg(unix)]
         {
-            use std::fs;
-            use std::os::unix::fs::PermissionsExt;
+            use std::{fs, os::unix::fs::PermissionsExt};
             fs::set_permissions(&path, PermissionsExt::from_mode(0o766))
                 .chain_err(|| ErrorKind::PermissionsError)?;
         }

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -14,14 +14,15 @@ extern crate uuid;
 extern crate futures;
 
 use assert_matches::assert_matches;
-use futures::sync::oneshot;
-use futures::Future;
+use futures::{sync::oneshot, Future};
 
 use jsonrpc_client_core::{Error as ClientError, Transport};
 use jsonrpc_core::{Error, IoHandler};
 use jsonrpc_macros::build_rpc_trait;
-use std::sync::{mpsc, Mutex};
-use std::time::Duration;
+use std::{
+    sync::{mpsc, Mutex},
+    time::Duration,
+};
 
 build_rpc_trait! {
     pub trait TestApi {

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -11,9 +11,7 @@ extern crate error_chain;
 
 use error_chain::ChainedError;
 use openvpn_plugin::{openvpn_plugin, EventResult, EventType};
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::sync::Mutex;
+use std::{collections::HashMap, ffi::CString, sync::Mutex};
 
 
 mod processing;


### PR DESCRIPTION
Purely a style update. So I include everyone in the PR, and unless everyone agrees we'll close this and leave it as is.

Some Rust versions back it became OK to have nested `use` statements.
```rust
// What previously had to be written:
use std::fs;
use std::io::Read;

// Could now be written:
use std::{fs, io::Read};
```
We already use this in quite a few places, but far from all of them. It's currently very mixed. I personally prefer to try to use the newer, more condensed style at all times, but that's just a taste preference.

Anyway, rustfmt have a formatting option to automatically change all `use`s to this new way. Do you think we should enable it? I have been thinking about it for quite some time now, but style is always an infected issue and I didn't want bring it up unless justified. What triggered me to open this was that @jvff expressed he would like to see this change as well :)

What I like most about it is not that it takes less vertical space, because usually it doesn't. Look at this example:
```rust
use jsonrpc_core::{
    futures::{
        future,
        sync::{self, oneshot::Sender as OneshotSender},
        Future,
    },
    Error, ErrorCode, MetaIoHandler, Metadata,
};
```
What I like about it is that all types imported in a module are now visualized more like a tree, and less like an impenetrable list of very long paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/639)
<!-- Reviewable:end -->
