### PR TITLE
Adding Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The host has to have the following installed:
 # For building the daemon
 sudo apt install gcc libdbus-1-dev
 # For running the frontend app
-sudo apt install libappindicator1 gconf2
+sudo apt install gconf2
 # For building the installer
 sudo apt install rpm
 ```

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -136,7 +136,6 @@ rpm:
   afterRemove: ../../../dist-assets/linux/after-remove.sh
   depends:
       - libXScrnSaver
-      - libappindicator
       - libnotify
       - libnsl
       - dbus-libs


### PR DESCRIPTION
Adding Fedora specific instructions for what needs to be installed to build the product.

I know `libappindicator` is listed as a dependency on our rpm, but I'm able to run the GUI in development mode without that package. And I'd rather the readme is missing some information than it's telling you to install a number of packages that you don't really need. :thinking: 

Also added the `rpm` package to Debian, which is needed for the `rpmbuild` binary which is needed to build the installer. For me this package was already present, but I'm not sure how it is from a vanilla install of Debian/Ubuntu so better list it?

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/640)
<!-- Reviewable:end -->
