### PR TITLE
Add setting for starting minimized on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Detect if the computer is offline. If so, don't sit in a reconnect loop, instead block and show
   an error message.
+- Add a toggle switch to allow the app to start minimized on Linux, so that only the tray icon is
+  initially visible.
 
 ### Fixed
 - Stop GUI from glitching during the short reconnect state.

--- a/README.md
+++ b/README.md
@@ -359,6 +359,17 @@ environment variable.
 | macOS | `/var/run/mullvad-vpn` |
 | Windows | `//./pipe/Mullvad VPN` |
 
+### GUI
+
+The GUI has a specific settings file that is configured for each user. The path is set in the
+`gui/packages/desktop/main/gui-settings.js` file.
+
+| Platform | Path |
+|----------|------|
+| Linux | `$XDG_CONFIG_HOME/Mullvad VPN/gui_settings.json` |
+| macOS | `~/Library/Application Support/Mullvad VPN/gui_settings.json` |
+| Windows | `%LOCALAPPDATA%\Mullvad VPN\gui_settings.json` |
+
 ## Audits, pentests and external security reviews
 
 Mullvad has used external pentesting companies to carry out security audits of this VPN app. Read

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -36,5 +36,11 @@ fi
 read -p "Do you want to delete the Mullvad VPN settings? (y/n) "
 if [[ "$REPLY" =~ [Yy]$ ]]; then
     sudo rm -rf /etc/mullvad-vpn
+    for user in /Users/*; do
+        user_settings_dir="$user/Library/Application Support/Mullvad VPN"
+        if [[ -d "$user_settings_dir" ]]; then
+            echo "Deleting GUI settings at $user_settings_dir"
+            sudo rm -rf "$user_settings_dir"
+        fi
+    done
 fi
-

--- a/gui/packages/desktop/src/main/gui-settings.js
+++ b/gui/packages/desktop/src/main/gui-settings.js
@@ -5,9 +5,7 @@ import log from 'electron-log';
 import path from 'path';
 import { app } from 'electron';
 
-export type GuiSettingsState = {
-  startMinimized: boolean,
-};
+import type { GuiSettingsState } from '../shared/gui-settings-state';
 
 export default class GuiSettings {
   _state: GuiSettingsState = {

--- a/gui/packages/desktop/src/main/gui-settings.js
+++ b/gui/packages/desktop/src/main/gui-settings.js
@@ -1,0 +1,50 @@
+// @flow
+
+import fs from 'fs';
+import log from 'electron-log';
+import path from 'path';
+import { app } from 'electron';
+
+export type GuiSettingsState = {
+  startMinimized: boolean,
+};
+
+export default class GuiSettings {
+  _state: GuiSettingsState = {
+    startMinimized: false,
+  };
+
+  load() {
+    try {
+      const settingsFile = this._filePath();
+      const contents = fs.readFileSync(settingsFile, 'utf8');
+      const settings = JSON.parse(contents);
+
+      this._state.startMinimized = settings.startMinimized || false;
+    } catch (error) {
+      log.error(`Failed to read GUI settings file: ${error}`);
+    }
+  }
+
+  store() {
+    try {
+      const settingsFile = this._filePath();
+
+      fs.writeFileSync(settingsFile, JSON.stringify(this._state));
+    } catch (error) {
+      log.error(`Failed to write GUI settings file: ${error}`);
+    }
+  }
+
+  get state(): GuiSettingsState {
+    return this._state;
+  }
+
+  get startMinimized(): boolean {
+    return this._state.startMinimized;
+  }
+
+  _filePath() {
+    return path.join(app.getPath('userData'), 'gui_settings.json');
+  }
+}

--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -287,6 +287,8 @@ const ApplicationMain = {
     this._trayIconController = trayIconController;
     this._ipcEventChannel = new IpcEventChannel(window.webContents);
 
+    this._guiSettings.registerIpcHandlers(this._ipcEventChannel);
+
     if (process.env.NODE_ENV === 'development') {
       await this._installDevTools();
       window.openDevTools({ mode: 'detach' });
@@ -749,6 +751,7 @@ const ApplicationMain = {
         relays: this._relays,
         currentVersion: this._currentVersion,
         upgradeVersion: this._upgradeVersion,
+        guiSettings: this._guiSettings.state,
       };
     });
 

--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -302,6 +302,10 @@ const ApplicationMain = {
         break;
     }
 
+    if (this._shouldShowWindowOnStart() || process.env.NODE_ENV === 'development') {
+      windowController.show();
+    }
+
     window.loadFile(path.resolve(path.join(__dirname, '../renderer/index.html')));
   },
 
@@ -987,7 +991,6 @@ const ApplicationMain = {
     tray.on('click', () => {
       windowController.toggle();
     });
-    windowController.show();
   },
 
   _installLinuxWindowCloseHandler(windowController: WindowController) {
@@ -997,6 +1000,28 @@ const ApplicationMain = {
         windowController.hide();
       }
     });
+  },
+
+  _shouldShowWindowOnStart(): boolean {
+    switch (process.platform) {
+      case 'win32':
+        return false;
+      case 'darwin':
+        return false;
+      case 'linux':
+        try {
+          const settingsFile = path.join(app.getPath('userData'), 'gui_settings.json');
+          const contents = fs.readFileSync(settingsFile, 'utf8');
+          const settings = JSON.parse(contents);
+
+          return !settings.startMinimized;
+        } catch (error) {
+          log.error(`Failed to read if window should start minimized or not: ${error}`);
+          return true;
+        }
+      default:
+        return true;
+    }
   },
 };
 

--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -25,6 +25,7 @@ import type {
   TunnelStateTransition,
 } from './daemon-rpc';
 
+import GuiSettings from './gui-settings';
 import ReconnectionBackoff from './reconnection-backoff';
 import { resolveBin } from './proc';
 
@@ -35,10 +36,6 @@ const DAEMON_RPC_PATH =
   process.platform === 'win32' ? '//./pipe/Mullvad VPN' : '/var/run/mullvad-vpn';
 
 type AppQuitStage = 'unready' | 'initiated' | 'ready';
-
-type GuiSettings = {
-  startMinimized: boolean,
-};
 
 export type CurrentAppVersionInfo = {
   gui: string,
@@ -85,9 +82,7 @@ const ApplicationMain = {
       proxy: null,
     },
   }: Settings),
-  _guiSettings: ({
-    startMinimized: false,
-  }: GuiSettings),
+  _guiSettings: new GuiSettings(),
   _location: (null: ?Location),
   _lastDisconnectedLocation: (null: ?Location),
 
@@ -132,7 +127,7 @@ const ApplicationMain = {
     }
 
     if (process.platform === 'linux') {
-      this._loadGuiSettings();
+      this._guiSettings.load();
     }
 
     app.on('activate', () => this._onActivate());
@@ -213,18 +208,6 @@ const ApplicationMain = {
       log.transports.file.file = this._logFilePath;
 
       log.debug(`Logging to ${this._logFilePath}`);
-    }
-  },
-
-  _loadGuiSettings() {
-    try {
-      const settingsFile = path.join(app.getPath('userData'), 'gui_settings.json');
-      const contents = fs.readFileSync(settingsFile, 'utf8');
-      const settings = JSON.parse(contents);
-
-      this._guiSettings.startMinimized = settings.startMinimized || false;
-    } catch (error) {
-      log.error(`Failed to read GUI settings file: ${error}`);
     }
   },
 

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -24,6 +24,7 @@ import userInterfaceActions from './redux/userinterface/actions';
 
 import type { WindowShapeParameters } from '../main/window-controller';
 import type { CurrentAppVersionInfo, AppUpgradeInfo } from '../main';
+import type { GuiSettingsState } from '../shared/gui-settings-state';
 import IpcEventChannel from '../shared/ipc-event-channel';
 
 import type {
@@ -124,6 +125,10 @@ export default class AppRenderer {
       this._setUpgradeVersion(upgradeVersion);
     });
 
+    IpcEventChannel.guiSettings.listen((guiSettings: GuiSettingsState) => {
+      this._setGuiSettings(guiSettings);
+    });
+
     // Request the initial state from the main process
     const initialState = IpcEventChannel.state.get();
 
@@ -137,6 +142,7 @@ export default class AppRenderer {
     this._setRelays(initialState.relays);
     this._setCurrentVersion(initialState.currentVersion);
     this._setUpgradeVersion(initialState.upgradeVersion);
+    this._setGuiSettings(initialState.guiSettings);
 
     if (initialState.isConnected) {
       this._onDaemonConnected();
@@ -516,6 +522,10 @@ export default class AppRenderer {
 
   _setUpgradeVersion(upgradeVersion: AppUpgradeInfo) {
     this._reduxActions.version.updateLatest(upgradeVersion);
+  }
+
+  _setGuiSettings(guiSettings: GuiSettingsState) {
+    this._reduxActions.settings.updateGuiSettings(guiSettings);
   }
 }
 

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -351,6 +351,10 @@ export default class AppRenderer {
     actions.settings.updateAutoConnect(autoConnect);
   }
 
+  async setStartMinimized(startMinimized: boolean) {
+    IpcEventChannel.guiSettings.setStartMinimized(startMinimized);
+  }
+
   async _onDaemonConnected() {
     this._connectedToDaemon = true;
 

--- a/gui/packages/desktop/src/renderer/components/Preferences.js
+++ b/gui/packages/desktop/src/renderer/components/Preferences.js
@@ -5,17 +5,25 @@ import { Component, View } from 'reactxp';
 import { SettingsHeader, HeaderTitle } from '@mullvad/components';
 import * as Cell from './Cell';
 import { Layout, Container } from './Layout';
-import { NavigationBar, BackBarItem } from './NavigationBar';
+import {
+  NavigationBar,
+  NavigationContainer,
+  NavigationScrollbars,
+  BackBarItem,
+} from './NavigationBar';
 import Switch from './Switch';
 import styles from './PreferencesStyles';
 
 export type PreferencesProps = {
   autoConnect: boolean,
   allowLan: boolean,
+  enableStartMinimizedToggle: boolean,
+  startMinimized: boolean,
   getAutoStart: () => boolean,
   setAutoStart: (boolean) => void,
   setAutoConnect: (boolean) => void,
   setAllowLan: (boolean) => void,
+  setStartMinimized: (boolean) => void,
   onClose: () => void,
 };
 
@@ -38,41 +46,52 @@ export default class Preferences extends Component<PreferencesProps, State> {
       <Layout>
         <Container>
           <View style={styles.preferences}>
-            <NavigationBar>
-              <BackBarItem action={this.props.onClose} title={'Settings'} />
-            </NavigationBar>
+            <NavigationContainer>
+              <NavigationBar>
+                <BackBarItem action={this.props.onClose} title={'Settings'} />
+              </NavigationBar>
 
-            <View style={styles.preferences__container}>
-              <SettingsHeader>
-                <HeaderTitle>Preferences</HeaderTitle>
-              </SettingsHeader>
+              <View style={styles.preferences__container}>
+                <NavigationScrollbars>
+                  <SettingsHeader>
+                    <HeaderTitle>Preferences</HeaderTitle>
+                  </SettingsHeader>
 
-              <View style={styles.preferences__content}>
-                <Cell.Container>
-                  <Cell.Label>Auto-connect</Cell.Label>
-                  <Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
-                </Cell.Container>
-                <Cell.Footer>
-                  Automatically connect to the VPN at the earliest moment during computer boot-up.
-                </Cell.Footer>
+                  <View style={styles.preferences__content}>
+                    <Cell.Container>
+                      <Cell.Label>Auto-connect</Cell.Label>
+                      <Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
+                    </Cell.Container>
+                    <Cell.Footer>
+                      Automatically connect to the VPN at the earliest moment during computer
+                      boot-up.
+                    </Cell.Footer>
 
-                <Cell.Container>
-                  <Cell.Label>Auto-launch</Cell.Label>
-                  <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
-                </Cell.Container>
-                <Cell.Footer>
-                  Automatically launch the app when logging in to the computer.
-                </Cell.Footer>
+                    <Cell.Container>
+                      <Cell.Label>Auto-launch</Cell.Label>
+                      <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
+                    </Cell.Container>
+                    <Cell.Footer>
+                      Automatically launch the app when logging in to the computer.
+                    </Cell.Footer>
 
-                <Cell.Container>
-                  <Cell.Label>Local network sharing</Cell.Label>
-                  <Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
-                </Cell.Container>
-                <Cell.Footer>
-                  Allows access to other devices on the same network for sharing, printing etc.
-                </Cell.Footer>
+                    <Cell.Container>
+                      <Cell.Label>Local network sharing</Cell.Label>
+                      <Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
+                    </Cell.Container>
+                    <Cell.Footer>
+                      Allows access to other devices on the same network for sharing, printing etc.
+                    </Cell.Footer>
+
+                    <StartMinimizedToggle
+                      enable={this.props.enableStartMinimizedToggle}
+                      startMinimized={this.props.startMinimized}
+                      onChange={this.props.setStartMinimized}
+                    />
+                  </View>
+                </NavigationScrollbars>
               </View>
-            </View>
+            </NavigationContainer>
           </View>
         </Container>
       </Layout>
@@ -84,4 +103,28 @@ export default class Preferences extends Component<PreferencesProps, State> {
     // TODO: Handle failure to set auto-start
     this.setState({ autoStart });
   };
+}
+
+type StartMinimizedProps = {
+  enable: boolean,
+  startMinimized: boolean,
+  onChange: (boolean) => void,
+};
+
+class StartMinimizedToggle extends Component<StartMinimizedProps> {
+  render() {
+    if (this.props.enable) {
+      return (
+        <View>
+          <Cell.Container>
+            <Cell.Label>Start minimized</Cell.Label>
+            <Switch isOn={this.props.startMinimized} onChange={this.props.onChange} />
+          </Cell.Container>
+          <Cell.Footer>Show only the tray icon when the app starts.</Cell.Footer>
+        </View>
+      );
+    } else {
+      return null;
+    }
+  }
 }

--- a/gui/packages/desktop/src/renderer/containers/PreferencesPage.js
+++ b/gui/packages/desktop/src/renderer/containers/PreferencesPage.js
@@ -13,6 +13,7 @@ import type { SharedRouteProps } from '../routes';
 const mapStateToProps = (state: ReduxState) => ({
   autoConnect: state.settings.autoConnect,
   allowLan: state.settings.allowLan,
+  startMinimized: state.settings.guiSettings.startMinimized,
 });
 
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) => {
@@ -41,6 +42,10 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
     setAllowLan: (allowLan) => {
       props.app.setAllowLan(allowLan);
     },
+    setStartMinimized: (startMinimized) => {
+      props.app.setStartMinimized(startMinimized);
+    },
+    enableStartMinimizedToggle: process.platform === 'linux',
   };
 };
 

--- a/gui/packages/desktop/src/renderer/redux/settings/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/actions.js
@@ -1,6 +1,12 @@
 // @flow
 
 import type { RelaySettingsRedux, RelayLocationRedux } from './reducers';
+import type { GuiSettingsState } from '../../../shared/gui-settings-state';
+
+export type UpdateGuiSettingsAction = {
+  type: 'UPDATE_GUI_SETTINGS',
+  guiSettings: GuiSettingsState,
+};
 
 export type UpdateRelayAction = {
   type: 'UPDATE_RELAY',
@@ -38,6 +44,7 @@ export type UpdateOpenVpnMssfixAction = {
 };
 
 export type SettingsAction =
+  | UpdateGuiSettingsAction
   | UpdateRelayAction
   | UpdateRelayLocationsAction
   | UpdateAutoConnectAction
@@ -45,6 +52,13 @@ export type SettingsAction =
   | UpdateEnableIpv6Action
   | UpdateBlockWhenDisconnectedAction
   | UpdateOpenVpnMssfixAction;
+
+function updateGuiSettings(guiSettings: GuiSettingsState): UpdateGuiSettingsAction {
+  return {
+    type: 'UPDATE_GUI_SETTINGS',
+    guiSettings,
+  };
+}
 
 function updateRelay(relay: RelaySettingsRedux): UpdateRelayAction {
   return {
@@ -100,6 +114,7 @@ function updateOpenVpnMssfix(mssfix: ?number): UpdateOpenVpnMssfixAction {
 }
 
 export default {
+  updateGuiSettings,
   updateRelay,
   updateRelayLocations,
   updateAutoConnect,

--- a/gui/packages/desktop/src/renderer/redux/settings/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/reducers.js
@@ -2,6 +2,7 @@
 
 import type { ReduxAction } from '../store';
 import type { RelayProtocol, RelayLocation } from '../../lib/daemon-rpc-proxy';
+import type { GuiSettingsState } from '../../../shared/gui-settings-state';
 
 export type RelaySettingsRedux =
   | {|
@@ -44,6 +45,7 @@ export type RelayLocationRedux = {
 };
 
 export type SettingsReduxState = {
+  guiSettings: GuiSettingsState,
   relaySettings: RelaySettingsRedux,
   relayLocations: Array<RelayLocationRedux>,
   autoConnect: boolean,
@@ -56,6 +58,9 @@ export type SettingsReduxState = {
 };
 
 const initialState: SettingsReduxState = {
+  guiSettings: {
+    startMinimized: false,
+  },
   relaySettings: {
     normal: {
       location: 'any',
@@ -78,6 +83,12 @@ export default function(
   action: ReduxAction,
 ): SettingsReduxState {
   switch (action.type) {
+    case 'UPDATE_GUI_SETTINGS':
+      return {
+        ...state,
+        guiSettings: action.guiSettings,
+      };
+
     case 'UPDATE_RELAY':
       return {
         ...state,

--- a/gui/packages/desktop/src/shared/gui-settings-state.js
+++ b/gui/packages/desktop/src/shared/gui-settings-state.js
@@ -1,0 +1,5 @@
+// @flow
+
+export type GuiSettingsState = {
+  startMinimized: boolean,
+};

--- a/gui/packages/desktop/src/shared/ipc-event-channel.js
+++ b/gui/packages/desktop/src/shared/ipc-event-channel.js
@@ -3,6 +3,8 @@
 import { ipcMain, ipcRenderer } from 'electron';
 import type { WebContents } from 'electron';
 
+import type { GuiSettingsState } from './gui-settings-state';
+
 import type { AppUpgradeInfo, CurrentAppVersionInfo } from '../main/index';
 import type { Location, RelayList, Settings, TunnelStateTransition } from '../main/daemon-rpc';
 
@@ -14,6 +16,7 @@ export type AppStateSnapshot = {
   relays: RelayList,
   currentVersion: CurrentAppVersionInfo,
   upgradeVersion: AppUpgradeInfo,
+  guiSettings: GuiSettingsState,
 };
 
 interface Sender<T> {
@@ -34,6 +37,7 @@ const LOCATION_CHANGED = 'location-changed';
 const RELAYS_CHANGED = 'relays-changed';
 const CURRENT_VERSION_CHANGED = 'current-version-changed';
 const UPGRADE_VERSION_CHANGED = 'upgrade-version-changed';
+const GUI_SETTINGS_CHANGED = 'gui-settings-changed';
 
 /// Typed IPC event channel
 ///
@@ -138,6 +142,16 @@ export default class IpcEventChannel {
   get upgradeVersion(): Sender<AppUpgradeInfo> {
     return {
       notify: sender(this._webContents, UPGRADE_VERSION_CHANGED),
+    };
+  }
+
+  static guiSettings: Receiver<GuiSettingsState> & GuiSettingsMethods = {
+    listen: listen(GUI_SETTINGS_CHANGED),
+  };
+
+  get guiSettings(): Sender<GuiSettingsState> & GuiSettingsHandlers {
+    return {
+      notify: sender(this._webContents, GUI_SETTINGS_CHANGED),
     };
   }
 }

--- a/gui/packages/desktop/test/components/Preferences.spec.js
+++ b/gui/packages/desktop/test/components/Preferences.spec.js
@@ -22,8 +22,11 @@ function makeProps(props) {
     setAutoStart: (_autoStart) => Promise.resolve(),
     getAutoStart: () => false,
     setAllowLan: () => {},
+    getStartMinimized: () => Promise.resolve(false),
+    setStartMinimized: () => {},
     allowAutoConnect: false,
     allowLan: false,
+    enableStartMinimizedToggle: false,
     ...props,
   };
 }


### PR DESCRIPTION
Some Linux distributions don't use window managers with tray icon support. To prevent not being accessible to the user, the app always starts visible on Linux. However, this means that if the tray icon is available, the user has to dismiss the screen. This PR adds a setting only available on Linux that allows the app to start minimized no matter what. This setting is stored in a separate user-specific GUI settings file.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/641)
<!-- Reviewable:end -->
