### PR TITLE
Fix return type of update_relay_locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Stop GUI from glitching during the short reconnect state.
 - Dismiss notifications automatically after four seconds in all platforms.
+- Fix error printed from the CLI when issuing `relay update`.
 
 
 ## [2018.6-beta1] - 2018-12-05

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -160,7 +160,7 @@ impl DaemonRpcClient {
         self.call("get_relay_locations", &NO_ARGS)
     }
 
-    pub fn update_relay_locations(&mut self) -> Result<RelayList> {
+    pub fn update_relay_locations(&mut self) -> Result<()> {
         self.call("update_relay_locations", &NO_ARGS)
     }
 


### PR DESCRIPTION
The return types did not match between the daemon and the client definition. Causing a de serialize error like this:
```
$ mullvad relay update
Error: Failed to call RPC method "update_relay_locations"
Caused by: Unable to deserialize response
Caused by: invalid type: null, expected struct RelayList
```

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/642)
<!-- Reviewable:end -->
