### PR TITLE
Check relay list cache age more often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Line wrap the file at 100 chars.                                              Th
 - Stop GUI from glitching during the short reconnect state.
 - Dismiss notifications automatically after four seconds in all platforms.
 - Fix error printed from the CLI when issuing `relay update`.
+- Fix relay list update interval. Should now handle sleep better.
 
 
 ## [2018.6-beta1] - 2018-12-05

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -33,7 +33,12 @@ use tokio_timer::{TimeoutError, Timer};
 const DATE_TIME_FORMAT_STR: &str = "[%Y-%m-%d %H:%M:%S%.3f]";
 const RELAYS_FILENAME: &str = "relays.json";
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
-const UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+/// How often the updater should wake up to check the cache of the in-memory cache of relays.
+/// This check is very cheap. The only reason to not have it very often is because if downloading
+/// constantly fails it will try very often and fill the logs etc.
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 2);
+/// How old the cached relays need to be to trigger an update
+const UPDATE_INTERVAL: Duration = Duration::from_secs(3600);
 
 error_chain! {
     errors {
@@ -436,13 +441,14 @@ impl RelayListUpdater {
     fn run(&mut self) {
         debug!("Starting relay list updater thread");
         while self.wait_for_next_iteration() {
-            trace!("Relay list updater iteration");
-            match self
-                .update()
-                .chain_err(|| "Failed to update list of relays")
-            {
-                Ok(()) => info!("Updated list of relays"),
-                Err(error) => error!("{}", error.display_chain()),
+            if self.should_update() {
+                match self
+                    .update()
+                    .chain_err(|| "Failed to update list of relays")
+                {
+                    Ok(()) => info!("Updated list of relays"),
+                    Err(error) => error!("{}", error.display_chain()),
+                }
             }
         }
         debug!("Relay list updater thread has finished");
@@ -451,10 +457,20 @@ impl RelayListUpdater {
     fn wait_for_next_iteration(&mut self) -> bool {
         use self::mpsc::RecvTimeoutError::*;
 
-        match self.close_handle.recv_timeout(UPDATE_INTERVAL) {
+        match self.close_handle.recv_timeout(UPDATE_CHECK_INTERVAL) {
             Ok(()) => true,
             Err(Timeout) => true,
             Err(Disconnected) => false,
+        }
+    }
+
+    fn should_update(&mut self) -> bool {
+        match SystemTime::now().duration_since(self.lock_parsed_relays().last_updated()) {
+            Ok(duration) => duration > UPDATE_INTERVAL,
+            // If the clock is skewed we have no idea by how much or when the last update
+            // actually was, better download again to get in sync and get a `last_updated`
+            // timestamp corresponding to the new time.
+            Err(_) => true,
         }
     }
 


### PR DESCRIPTION
This reverts commit 52cdd81d77d4922945ec4598f6799671d92b0823 basically. And modifies the durations it uses. The problem was that our one hour sleep was one hour of the computer being awake, at least on macOS. Caused the problem that on computers that are asleep quite a lot, the relay list is seldom updated. Now we will wake up and check the relay list age every two minutes, but still only update it if it's older than one hour.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/644)
<!-- Reviewable:end -->
