### PR TITLE
Refactor to simplify `KeyframeAnimation`

### DIFF
--- a/gui/packages/desktop/src/main/keyframe-animation.js
+++ b/gui/packages/desktop/src/main/keyframe-animation.js
@@ -67,7 +67,7 @@ export default class KeyframeAnimation {
     this._reverse = newValue;
   }
   get reverse(): boolean {
-    return this._repeat;
+    return this._reverse;
   }
 
   // alternates the animation direction when it reaches the end

--- a/gui/packages/desktop/src/main/keyframe-animation.js
+++ b/gui/packages/desktop/src/main/keyframe-animation.js
@@ -1,9 +1,6 @@
 // @flow
 
-import { nativeImage } from 'electron';
-import type { NativeImage } from 'electron';
-
-export type OnFrameFn = (image: NativeImage) => void;
+export type OnFrameFn = (frame: number) => void;
 export type OnFinishFn = (void) => void;
 export type KeyframeAnimationOptions = {
   startFrame?: number,
@@ -20,7 +17,6 @@ export default class KeyframeAnimation {
   _onFrame: ?OnFrameFn;
   _onFinish: ?OnFinishFn;
 
-  _nativeImages: Array<NativeImage>;
   _frameRange: KeyframeAnimationRange;
   _numFrames: number;
   _currentFrame: number = 0;
@@ -61,49 +57,13 @@ export default class KeyframeAnimation {
     return this._reverse;
   }
 
-  get nativeImages(): Array<NativeImage> {
-    return this._nativeImages.slice();
-  }
   get isFinished(): boolean {
     return this._isFinished;
   }
 
-  // create animation from files matching filename pattern. i.e (bubble-frame-{}.png)
-  static fromFilePattern(filePattern: string, range: KeyframeAnimationRange): KeyframeAnimation {
-    const images: Array<NativeImage> = [];
-
-    if (range.length !== 2 || range[0] > range[1]) {
-      throw new Error('the animation range is invalid');
-    }
-
-    for (let i = range[0]; i <= range[1]; i++) {
-      const filePath = filePattern.replace('{}', i.toString());
-      const image = nativeImage.createFromPath(filePath);
-      images.push(image);
-    }
-    return new KeyframeAnimation(images);
-  }
-
-  static fromFileSequence(files: Array<string>): KeyframeAnimation {
-    const images: Array<NativeImage> = files.map((filePath) =>
-      nativeImage.createFromPath(filePath),
-    );
-    return new KeyframeAnimation(images);
-  }
-
-  constructor(images: Array<NativeImage>) {
-    const len = images.length;
-    if (len < 1) {
-      throw new Error('too few images in animation');
-    }
-
-    this._nativeImages = images.slice();
-    this._numFrames = len;
-    this._frameRange = [0, len];
-  }
-
-  get currentImage(): NativeImage {
-    return this._nativeImages[this._currentFrame];
+  constructor(numFrames: number) {
+    this._numFrames = numFrames;
+    this._frameRange = [0, numFrames];
   }
 
   play(options: KeyframeAnimationOptions = {}) {
@@ -166,7 +126,7 @@ export default class KeyframeAnimation {
 
   _render() {
     if (this._onFrame) {
-      this._onFrame(this._nativeImages[this._currentFrame]);
+      this._onFrame(this._currentFrame);
     }
   }
 

--- a/gui/packages/desktop/src/main/keyframe-animation.js
+++ b/gui/packages/desktop/src/main/keyframe-animation.js
@@ -15,7 +15,6 @@ export type KeyframeAnimationRange = [number, number];
 
 export default class KeyframeAnimation {
   _speed: number = 200; // ms
-  _repeat: boolean = false;
   _reverse: boolean = false;
 
   _onFrame: ?OnFrameFn;
@@ -39,7 +38,7 @@ export default class KeyframeAnimation {
     return this._onFrame;
   }
 
-  // called when animation finished for non-repeating animations.
+  // called when animation finished
   set onFinish(newValue: ?OnFinishFn) {
     this._onFinish = newValue;
   }
@@ -53,13 +52,6 @@ export default class KeyframeAnimation {
   }
   get speed(): number {
     return this._speed;
-  }
-
-  set repeat(newValue: boolean) {
-    this._repeat = newValue;
-  }
-  get repeat(): boolean {
-    return this._repeat;
   }
 
   set reverse(newValue: boolean) {
@@ -209,13 +201,7 @@ export default class KeyframeAnimation {
 
     const lastFrame = this._frameRange[this._reverse ? 0 : 1];
     if (this._currentFrame === lastFrame) {
-      // mark animation as finished if it's not repeating
-      if (!this._repeat) {
-        this._didFinish();
-        return;
-      }
-
-      this._currentFrame = this._frameRange[this._reverse ? 1 : 0];
+      this._didFinish();
     } else {
       this._currentFrame = this._nextFrame(this._currentFrame, this._frameRange, this._reverse);
     }

--- a/gui/packages/desktop/src/main/keyframe-animation.js
+++ b/gui/packages/desktop/src/main/keyframe-animation.js
@@ -17,7 +17,6 @@ export default class KeyframeAnimation {
   _speed: number = 200; // ms
   _repeat: boolean = false;
   _reverse: boolean = false;
-  _alternate: boolean = false;
 
   _onFrame: ?OnFrameFn;
   _onFinish: ?OnFinishFn;
@@ -68,15 +67,6 @@ export default class KeyframeAnimation {
   }
   get reverse(): boolean {
     return this._reverse;
-  }
-
-  // alternates the animation direction when it reaches the end
-  // only for repeating animations
-  set alternate(newValue: boolean) {
-    this._alternate = !!newValue;
-  }
-  get alternate(): boolean {
-    return this._alternate;
   }
 
   get nativeImages(): Array<NativeImage> {
@@ -225,14 +215,7 @@ export default class KeyframeAnimation {
         return;
       }
 
-      // change animation direction if marked for alternation
-      if (this._alternate) {
-        this._reverse = !this._reverse;
-
-        this._currentFrame = this._nextFrame(this._currentFrame, this._frameRange, this._reverse);
-      } else {
-        this._currentFrame = this._frameRange[this._reverse ? 1 : 0];
-      }
+      this._currentFrame = this._frameRange[this._reverse ? 1 : 0];
     } else {
       this._currentFrame = this._nextFrame(this._currentFrame, this._frameRange, this._reverse);
     }

--- a/gui/packages/desktop/src/main/tray-icon-controller.js
+++ b/gui/packages/desktop/src/main/tray-icon-controller.js
@@ -14,15 +14,15 @@ export default class TrayIconController {
 
   constructor(tray: Tray, initialType: TrayIconType) {
     this._loadImages();
+    this._iconType = initialType;
 
-    const animation = new KeyframeAnimation(this._iconImages.length);
+    const initialFrame = this._targetFrame();
+    const animation = new KeyframeAnimation();
     animation.speed = 100;
     animation.onFrame = (frameNumber) => tray.setImage(this._iconImages[frameNumber]);
-    animation.reverse = this._isReverseAnimation(initialType);
-    animation.play({ advanceTo: 'end' });
+    animation.play({ start: initialFrame, end: initialFrame });
 
     this._animation = animation;
-    this._iconType = initialType;
   }
 
   dispose() {
@@ -41,16 +41,12 @@ export default class TrayIconController {
       return;
     }
 
-    const animation = this._animation;
-    if (type === 'secured') {
-      animation.reverse = true;
-      animation.play({ beginFromCurrentState: true, startFrame: 8, endFrame: 9 });
-    } else {
-      animation.reverse = this._isReverseAnimation(type);
-      animation.play({ beginFromCurrentState: true });
-    }
-
     this._iconType = type;
+
+    const animation = this._animation;
+    const frame = this._targetFrame();
+
+    animation.play({ end: frame });
   }
 
   _loadImages() {
@@ -62,7 +58,16 @@ export default class TrayIconController {
     );
   }
 
-  _isReverseAnimation(type: TrayIconType): boolean {
-    return type === 'unsecured';
+  _targetFrame(): number {
+    switch (this._iconType) {
+      case 'unsecured':
+        return 0;
+      case 'securing':
+        return 9;
+      case 'secured':
+        return 8;
+      default:
+        throw new Error(`Unknown tray icon type: ${(this._iconType: empty)}`);
+    }
   }
 }

--- a/gui/packages/desktop/test/keyframe-animation.spec.js
+++ b/gui/packages/desktop/test/keyframe-animation.spec.js
@@ -1,14 +1,12 @@
 // @flow
 
 import KeyframeAnimation from '../src/main/keyframe-animation';
-import { nativeImage } from 'electron';
 
 describe('lib/keyframe-animation', function() {
   this.timeout(1000);
 
   const newAnimation = () => {
-    const images = [1, 2, 3, 4, 5].map(() => nativeImage.createEmpty());
-    const animation = new KeyframeAnimation(images);
+    const animation = new KeyframeAnimation();
     animation.speed = 1;
     return animation;
   };
@@ -16,8 +14,8 @@ describe('lib/keyframe-animation', function() {
   it('should play sequence', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([0, 1, 2, 3, 4]);
@@ -25,14 +23,14 @@ describe('lib/keyframe-animation', function() {
       done();
     };
 
-    animation.play();
+    animation.play({ end: 4 });
   });
 
   it('should play one frame', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([3]);
@@ -40,14 +38,14 @@ describe('lib/keyframe-animation', function() {
       done();
     };
 
-    animation.play({ startFrame: 3, endFrame: 3 });
+    animation.play({ start: 3, end: 3 });
   });
 
   it('should play sequence with custom frames', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([2, 3, 4]);
@@ -55,17 +53,14 @@ describe('lib/keyframe-animation', function() {
       done();
     };
 
-    animation.play({
-      startFrame: 2,
-      endFrame: 4,
-    });
+    animation.play({ start: 2, end: 4 });
   });
 
   it('should play sequence with custom frames in reverse', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([4, 3, 2]);
@@ -73,18 +68,14 @@ describe('lib/keyframe-animation', function() {
       done();
     };
 
-    animation.reverse = true;
-    animation.play({
-      startFrame: 4,
-      endFrame: 2,
-    });
+    animation.play({ start: 4, end: 2 });
   });
 
   it('should begin from current state starting below range', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([0, 1, 2, 3, 4]);
@@ -93,43 +84,14 @@ describe('lib/keyframe-animation', function() {
     };
 
     animation._currentFrame = 0;
-    animation._isFirstRun = false;
-
-    animation.play({
-      beginFromCurrentState: true,
-      startFrame: 3,
-      endFrame: 4,
-    });
-  });
-
-  it('should begin from current state starting below range reverse', (done) => {
-    const seq = [];
-    const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
-    };
-    animation.onFinish = () => {
-      expect(seq).to.be.deep.equal([0, 1, 2, 3]);
-      expect(animation._currentFrame).to.be.equal(3);
-      done();
-    };
-
-    animation._currentFrame = 0;
-    animation._isFirstRun = false;
-    animation.reverse = true;
-
-    animation.play({
-      beginFromCurrentState: true,
-      startFrame: 3,
-      endFrame: 4,
-    });
+    animation.play({ end: 4 });
   });
 
   it('should begin from current state starting above range', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([4, 3, 2]);
@@ -138,20 +100,14 @@ describe('lib/keyframe-animation', function() {
     };
 
     animation._currentFrame = 4;
-    animation._isFirstRun = false;
-
-    animation.play({
-      beginFromCurrentState: true,
-      startFrame: 1,
-      endFrame: 2,
-    });
+    animation.play({ end: 2 });
   });
 
   it('should begin from current state starting above range reverse', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([4, 3, 2, 1]);
@@ -160,21 +116,14 @@ describe('lib/keyframe-animation', function() {
     };
 
     animation._currentFrame = 4;
-    animation._isFirstRun = false;
-    animation.reverse = true;
-
-    animation.play({
-      beginFromCurrentState: true,
-      startFrame: 1,
-      endFrame: 3,
-    });
+    animation.play({ end: 1 });
   });
 
   it('should play sequence in reverse', (done) => {
     const seq = [];
     const animation = newAnimation();
-    animation.onFrame = () => {
-      seq.push(animation._currentFrame);
+    animation.onFrame = (frame) => {
+      seq.push(frame);
     };
     animation.onFinish = () => {
       expect(seq).to.be.deep.equal([4, 3, 2, 1, 0]);
@@ -182,7 +131,6 @@ describe('lib/keyframe-animation', function() {
       done();
     };
 
-    animation.reverse = true;
-    animation.play();
+    animation.play({ start: 4, end: 0 });
   });
 });

--- a/gui/packages/desktop/test/keyframe-animation.spec.js
+++ b/gui/packages/desktop/test/keyframe-animation.spec.js
@@ -224,45 +224,4 @@ describe('lib/keyframe-animation', function() {
     animation.reverse = true;
     animation.play();
   });
-
-  it('should alternate sequence', (done) => {
-    const seq = [];
-    const animation = newAnimation();
-    const expectedFrames = [0, 1, 2, 3, 4, 3, 2, 1, 0];
-
-    animation.onFrame = () => {
-      if (seq.length === expectedFrames.length) {
-        animation.stop();
-        expect(seq).to.be.deep.equal(expectedFrames);
-        done();
-      } else {
-        seq.push(animation._currentFrame);
-      }
-    };
-
-    animation.repeat = true;
-    animation.alternate = true;
-    animation.play();
-  });
-
-  it('should alternate reverse sequence', (done) => {
-    const seq = [];
-    const animation = newAnimation();
-    const expectedFrames = [4, 3, 2, 1, 0, 1, 2, 3, 4];
-
-    animation.onFrame = () => {
-      if (seq.length === expectedFrames.length) {
-        animation.stop();
-        expect(seq).to.be.deep.equal(expectedFrames);
-        done();
-      } else {
-        seq.push(animation._currentFrame);
-      }
-    };
-
-    animation.repeat = true;
-    animation.reverse = true;
-    animation.alternate = true;
-    animation.play();
-  });
 });

--- a/gui/packages/desktop/test/keyframe-animation.spec.js
+++ b/gui/packages/desktop/test/keyframe-animation.spec.js
@@ -185,43 +185,4 @@ describe('lib/keyframe-animation', function() {
     animation.reverse = true;
     animation.play();
   });
-
-  it('should play sequence on repeat', (done) => {
-    const seq = [];
-    const animation = newAnimation();
-    const expectedFrames = [0, 1, 2, 3, 4, 0, 1, 2, 3, 4];
-
-    animation.onFrame = () => {
-      if (seq.length === expectedFrames.length) {
-        animation.stop();
-        expect(seq).to.be.deep.equal(expectedFrames);
-        done();
-      } else {
-        seq.push(animation._currentFrame);
-      }
-    };
-
-    animation.repeat = true;
-    animation.play();
-  });
-
-  it('should play sequence on repeat in reverse', (done) => {
-    const seq = [];
-    const animation = newAnimation();
-    const expectedFrames = [4, 3, 2, 1, 0, 4, 3, 2, 1, 0];
-
-    animation.onFrame = () => {
-      if (seq.length === expectedFrames.length) {
-        animation.stop();
-        expect(seq).to.be.deep.equal(expectedFrames);
-        done();
-      } else {
-        seq.push(animation._currentFrame);
-      }
-    };
-
-    animation.repeat = true;
-    animation.reverse = true;
-    animation.play();
-  });
 });


### PR DESCRIPTION
While implementing monochromatic tray icon support, I had to spend some time studying the `KeyframeAnimation` class. There were a few features it supported that apparently aren't used anymore, and made it harder to make it flexible enough to support two sets of animations images. I then decided to simplify the class so that it only has the used features, and also reduced it's internal state to only contain the current frame and the target frame. That removes the need for tracking which is the animation direction and the start/end frames. I also moved out the image handling, so that the class becomes as much as possible a generic animation event generator and the tray icon controller can load as many animation image sets as it wants.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, not user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/646)
<!-- Reviewable:end -->
