### PR TITLE
Handle missing or disabled TAP adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix error printed from the CLI when issuing `relay update`.
 - Fix relay list update interval. Should now handle sleep better.
 
+#### Windows
+- Gracefully block when TAP adapter is missing or disabled, instead of retrying to connect.
+
 
 ## [2018.6] - 2018-12-12
 This release is identical to 2018.6-beta1

--- a/gui/packages/desktop/src/main/daemon-rpc.js
+++ b/gui/packages/desktop/src/main/daemon-rpc.js
@@ -52,7 +52,8 @@ export type BlockReason =
         | 'set_dns_error'
         | 'start_tunnel_error'
         | 'no_matching_relay'
-        | 'is_offline',
+        | 'is_offline'
+        | 'tap_adapter_problem',
     }
   | { reason: 'auth_failed', details: ?string };
 
@@ -314,6 +315,7 @@ const TunnelStateTransitionSchema = oneOf(
           'start_tunnel_error',
           'no_matching_relay',
           'is_offline',
+          'tap_adapter_problem',
         ),
       }),
       object({

--- a/gui/packages/desktop/src/renderer/components/NotificationArea.js
+++ b/gui/packages/desktop/src/renderer/components/NotificationArea.js
@@ -55,6 +55,8 @@ function getBlockReasonMessage(blockReason: BlockReason): string {
       return 'No relay server matches the current settings';
     case 'is_offline':
       return 'This device is offline, no tunnels can be established';
+    case 'tap_adapter_problem':
+      return "Unable to detect a working TAP adapter on this device. If you've disabled it, enable it again. Otherwise, please reinstall the app";
     default:
       return `Unknown error: ${(blockReason.reason: empty)}`;
   }

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -156,7 +156,7 @@ impl TunnelMonitor {
         tunnel_options: &TunnelOptions,
         tunnel_alias: Option<OsString>,
         username: &str,
-        log: Option<&Path>,
+        log: Option<PathBuf>,
         resource_dir: &Path,
         on_event: L,
     ) -> Result<Self>
@@ -181,7 +181,6 @@ impl TunnelMonitor {
                 Some(ref file) => Some(file.as_ref()),
                 _ => None,
             },
-            log,
             resource_dir,
         )?;
 
@@ -212,6 +211,7 @@ impl TunnelMonitor {
             cmd,
             on_openvpn_event,
             Self::get_plugin_path(resource_dir)?,
+            log,
         )
         .chain_err(|| ErrorKind::TunnelMonitoringError)?;
         Ok(TunnelMonitor {
@@ -242,7 +242,6 @@ impl TunnelMonitor {
         options: &TunnelOptions,
         user_pass_file: &Path,
         proxy_auth_file: Option<&Path>,
-        log: Option<&Path>,
         resource_dir: &Path,
     ) -> Result<OpenVpnCommand> {
         let mut cmd = OpenVpnCommand::new(Self::get_openvpn_bin(resource_dir)?);
@@ -261,9 +260,6 @@ impl TunnelMonitor {
             .enable_ipv6(options.enable_ipv6)
             .tunnel_alias(tunnel_alias)
             .ca(resource_dir.join("ca.crt"));
-        if let Some(log) = log {
-            cmd.log(log);
-        }
         if let Some(proxy_auth_file) = proxy_auth_file {
             cmd.proxy_auth(proxy_auth_file);
         }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -124,7 +124,7 @@ impl ConnectingState {
             &parameters.options,
             TUNNEL_INTERFACE_ALIAS.to_owned().map(OsString::from),
             &parameters.username,
-            log_file.as_ref().map(PathBuf::as_path),
+            log_file.clone(),
             resource_dir,
             on_tunnel_event,
         )?)

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -56,6 +56,8 @@ pub enum BlockReason {
     NoMatchingRelay,
     /// This device is offline, no tunnels can be established.
     IsOffline,
+    /// A problem with the TAP adapter has been detected.
+    TapAdapterProblem,
 }
 
 impl fmt::Display for BlockReason {
@@ -78,6 +80,7 @@ impl fmt::Display for BlockReason {
             StartTunnelError => "Failed to start connection to remote server",
             NoMatchingRelay => "No relay server matches the current settings",
             IsOffline => "This device is offline, no tunnels can be established",
+            TapAdapterProblem => "A problem with the TAP adapter has been detected",
         };
 
         write!(f, "{}", description)


### PR DESCRIPTION
OpenVPN's TAP adapter may be disabled or uninstalled by the user or other applications. When that happens, OpenVPN fails to connect. Previously the app would simply attempt to reconnect every time OpenVPN closed unexpectedly. This PR changes that so that a post-mortem analysis of the log is performed afterwards, in an attempt to detect if there are any known errors. Currently, the only known errors are if the TAP adapter is disabled or missing. When that happens, the app will now enter the block state with a suitable error message shown in the GUI.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/648)
<!-- Reviewable:end -->
