### PR TITLE
Add wireguard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +155,14 @@ dependencies = [
  "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clear_on_drop"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -221,6 +237,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dbus"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +284,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "digest"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -452,6 +489,14 @@ version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "generic-array"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "globset"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +519,11 @@ dependencies = [
  "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "httparse"
@@ -1690,6 +1740,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "subtle"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1816,7 @@ dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iproute2 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
@@ -1835,7 +1891,10 @@ dependencies = [
 name = "talpid-types"
 version = "0.1.0"
 dependencies = [
+ "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x25519-dalek 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2146,6 +2205,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2400,15 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "x25519-dalek"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curve25519-dalek 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -2346,6 +2419,7 @@ dependencies = [
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -2356,6 +2430,7 @@ dependencies = [
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
@@ -2365,10 +2440,12 @@ dependencies = [
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e"
+"checksum curve25519-dalek 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "15d6d81c070d8090389f752510ce22c7d571100a78fa4e7c06e6f6d95585bb49"
 "checksum dbus 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d975a175aa2dced1a6cd410b89a1bf23918f301eab2b6f7c5e608291b757639"
 "checksum derive-try-from-primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81dbd65eb15734b6d50dc6ac86f14f928462be0a5df6bda17761e909071ede5d"
 "checksum derive_builder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c998e6ab02a828dd9735c18f154e14100e674ed08cb4e1938f0e4177543f439"
 "checksum derive_builder_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "735e24ee9e5fa8e16b86da5007856e97d592e11867e45d76e0c0d0a164a0b757"
+"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
 "checksum duct 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f87f5af80601599209bff21146e4113e8c54471151049deebc37e75b78e42729"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
@@ -2392,8 +2469,10 @@ dependencies = [
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum globset 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90d069fe6beb9be359ef505650b3f73228c5591a3c4b1f32be2f4f44459ffa3a"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
+"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)" = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
@@ -2509,6 +2588,7 @@ dependencies = [
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum subtle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5938f1b89f10d6356339f071eca74209deeae0b6891c2678d655feb78637e369"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -2543,6 +2623,7 @@ dependencies = [
 "checksum toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4a2ecc31b0351ea18b3fe11274b8db6e4d82bce861bbb22e6dbed40417902c65"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum tun 0.4.2 (git+https://github.com/pinkisemils/rust-tun?branch=add-raw-fd-traits)" = "<none>"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
 "checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
@@ -2571,3 +2652,4 @@ dependencies = [
 "checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
 "checksum winres 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f07dabda4e79413ecac65bc9a2234ad3d85dc49f9d289f868cd9d8611d88f28d"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum x25519-dalek 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "538296831e9794ec5b3ec9d4a1a8c3e3c86271e9635a0e776e3214fec9c727de"

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -151,7 +151,8 @@ impl Relay {
                 port,
                 protocol: value_t!(matches.value_of("protocol"), TransportProtocol).unwrap(),
             }),
-            "wireguard" => TunnelEndpointData::Wireguard(WireguardEndpointData { port }),
+            // TODO: Gather all the data to build a WireguardEndpointData properly.
+            // "wireguard" => TunnelEndpointData::Wireguard(WireguardEndpointData { port }),
             _ => unreachable!("Invalid tunnel protocol"),
         };
         self.update_constraints(RelaySettingsUpdate::CustomTunnelEndpoint(

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -26,7 +26,7 @@ use std::{
     time::{self, Duration, SystemTime},
 };
 
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, info, warn};
 use rand::{self, Rng, ThreadRng};
 use tokio_timer::{TimeoutError, Timer};
 

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -24,7 +24,7 @@ impl CustomTunnelEndpoint {
     pub fn to_tunnel_endpoint(&self) -> Result<TunnelEndpoint> {
         Ok(TunnelEndpoint {
             address: resolve_to_ip(&self.host)?,
-            tunnel: self.tunnel,
+            tunnel: self.tunnel.clone(),
         })
     }
 }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -25,6 +25,7 @@ talpid-ipc = { path = "../talpid-ipc" }
 talpid-types = { path = "../talpid-types" }
 
 [target.'cfg(unix)'.dependencies]
+hex = "0.3"
 ipnetwork = "0.13"
 lazy_static = "1.0"
 tun = { git = "https://github.com/pinkisemils/rust-tun", branch = "add-raw-fd-traits" }

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -1,5 +1,14 @@
+use std::{env, path::PathBuf};
+
+fn manifest_dir() -> PathBuf {
+    env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .expect("CARGO_MANIFEST_DIR env var not set")
+}
+
 #[cfg(windows)]
 mod win {
+    use super::manifest_dir;
     use std::{env, path::PathBuf};
 
     pub static WINFW_BUILD_DIR: &'static str = "..\\windows\\winfw\\bin";
@@ -19,12 +28,6 @@ mod win {
             _ => panic!("uncrecognized target: {}", target),
         };
         target_dir.into()
-    }
-
-    fn manifest_dir() -> PathBuf {
-        env::var("CARGO_MANIFEST_DIR")
-            .map(PathBuf::from)
-            .expect("CARGO_MANIFEST_DIR env var not set")
     }
 
     fn get_build_mode() -> &'static str {
@@ -59,4 +62,12 @@ fn main() {
 }
 
 #[cfg(not(windows))]
-fn main() {}
+fn main() {
+    let lib_dir = if cfg!(target_os = "macos") {
+        manifest_dir().join("../dist-assets/binaries/macos")
+    } else {
+        manifest_dir().join("../dist-assets/binaries/linux")
+    };
+    println!("cargo:rustc-link-search={}", &lib_dir.display());
+    println!("cargo:rustc-link-lib=static=wg");
+}

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -20,6 +20,8 @@ extern crate error_chain;
 extern crate failure;
 extern crate futures;
 #[cfg(unix)]
+extern crate hex;
+#[cfg(unix)]
 extern crate ipnetwork;
 extern crate jsonrpc_core;
 extern crate jsonrpc_macros;

--- a/talpid-core/src/network_interface.rs
+++ b/talpid-core/src/network_interface.rs
@@ -89,6 +89,7 @@ impl NetworkInterface for TunnelDevice {
                 {
                     duct::cmd!(
                         "ip",
+                        "-6",
                         "addr",
                         "add",
                         ipv6.to_string(),
@@ -121,7 +122,6 @@ impl NetworkInterface for TunnelDevice {
             .enabled(up)
             .chain_err(|| ErrorKind::ToggleDeviceError)
     }
-
 
     fn set_mtu(&mut self, mtu: u16) -> Result<()> {
         self.dev

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -43,6 +43,7 @@ pub struct RequiredRoutes {
     pub routes: Vec<Route>,
     /// Optionally apply the routes to a specific table and only apply routes when a firewall mark
     /// is not used. Currently only used on Linux.
+    #[cfg(target_os = "linux")]
     pub fwmark: Option<String>,
 }
 

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -298,7 +298,7 @@ impl<'a> PolicyBatch<'a> {
 
         check_iface(&mut allow_rule, Direction::Out, &tunnel.interface[..])?;
         check_port(&mut allow_rule, protocol, End::Dst, 53)?;
-        check_l3proto(&mut allow_rule, IpAddr::V4(tunnel.gateway))?;
+        check_l3proto(&mut allow_rule, tunnel.gateway)?;
 
         allow_rule.add_expr(&nft_expr!(payload ipv4 daddr))?;
         allow_rule.add_expr(&nft_expr!(cmp == tunnel.gateway))?;

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -92,7 +92,12 @@ impl fmt::Display for SecurityPolicy {
                 "Connected to {} over \"{}\" (ip: {}, gw: {}), {} LAN",
                 peer_endpoint,
                 tunnel.interface,
-                tunnel.ip,
+                tunnel
+                    .ips
+                    .iter()
+                    .map(|ip| ip.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
                 tunnel.gateway,
                 if *allow_lan { "Allowing" } else { "Blocking" }
             ),

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -5,7 +5,7 @@ use std::{
     ffi::OsString,
     fs,
     io::{self, Write},
-    net::Ipv4Addr,
+    net::IpAddr,
     path::{Path, PathBuf},
     result::Result as StdResult,
 };
@@ -22,7 +22,9 @@ use talpid_types::net::{
 /// A module for all OpenVPN related tunnel management.
 pub mod openvpn;
 
-use self::openvpn::{OpenVpnCloseHandle, OpenVpnMonitor};
+#[cfg(unix)]
+mod wireguard;
+
 
 #[cfg(target_os = "macos")]
 const OPENVPN_PLUGIN_FILENAME: &str = "libtalpid_openvpn_plugin.dylib";
@@ -38,7 +40,11 @@ const OPENVPN_BIN_FILENAME: &str = "openvpn.exe";
 
 error_chain! {
     errors {
-        /// There was an error preparing to listen for events from the VPN tunnel.
+        /// Failed to monitor the tunnel
+        TunnelMonitoringError {
+            description("Failed to monitor tunnel")
+        }
+        /// There was an error whilst preparing to listen for events from the VPN tunnel.
         TunnelMonitorSetUpError {
             description("Error while setting up to listen for events from the VPN tunnel")
         }
@@ -67,11 +73,7 @@ error_chain! {
         }
         /// Running on an operating system which is not supported yet.
         UnsupportedPlatform {
-            description("Running on an unsupported operating system")
-        }
-        /// This type of VPN tunnel is not supported.
-        UnsupportedTunnelProtocol {
-            description("This tunnel protocol is not supported")
+            description("Tunnel type not supported on this operating system")
         }
     }
 
@@ -99,10 +101,10 @@ pub enum TunnelEvent {
 pub struct TunnelMetadata {
     /// The name of the device which the tunnel is running on.
     pub interface: String,
-    /// The local IP on the tunnel interface.
-    pub ip: Ipv4Addr,
+    /// The local IPs on the tunnel interface.
+    pub ips: Vec<IpAddr>,
     /// The IP to the default gateway on the tunnel interface.
-    pub gateway: Ipv4Addr,
+    pub gateway: IpAddr,
 }
 
 impl TunnelEvent {
@@ -122,11 +124,11 @@ impl TunnelEvent {
                     .get("dev")
                     .expect("No \"dev\" in tunnel up event")
                     .to_owned();
-                let ip = env
+                let ips = vec![env
                     .get("ifconfig_local")
                     .expect("No \"ifconfig_local\" in tunnel up event")
                     .parse()
-                    .expect("Tunnel IP not in valid format");
+                    .expect("Tunnel IP not in valid format")];
                 let gateway = env
                     .get("route_vpn_gateway")
                     .expect("No \"route_vpn_gateway\" in tunnel up event")
@@ -134,7 +136,7 @@ impl TunnelEvent {
                     .expect("Tunnel gateway IP not in valid format");
                 Some(TunnelEvent::Up(TunnelMetadata {
                     interface,
-                    ip,
+                    ips,
                     gateway,
                 }))
             }
@@ -144,16 +146,41 @@ impl TunnelEvent {
     }
 }
 
+enum InternalTunnelMonitor {
+    OpenVpn(openvpn::OpenVpnMonitor),
+    #[cfg(unix)]
+    Wireguard(wireguard::WireguardMonitor),
+}
+
+impl InternalTunnelMonitor {
+    fn close_handle(&self) -> CloseHandle {
+        match self {
+            InternalTunnelMonitor::OpenVpn(tun) => CloseHandle::OpenVpn(tun.close_handle()),
+            #[cfg(unix)]
+            InternalTunnelMonitor::Wireguard(tun) => CloseHandle::Wireguard(tun.close_handle()),
+        }
+    }
+
+    fn wait(self) -> Result<()> {
+        match self {
+            InternalTunnelMonitor::OpenVpn(tun) => {
+                tun.wait().chain_err(|| ErrorKind::TunnelMonitoringError)
+            }
+            #[cfg(unix)]
+            InternalTunnelMonitor::Wireguard(tun) => {
+                tun.wait().chain_err(|| ErrorKind::TunnelMonitoringError)
+            }
+        }
+    }
+}
+
 
 /// Abstraction for monitoring a generic VPN tunnel.
 pub struct TunnelMonitor {
-    monitor: OpenVpnMonitor,
-    /// Keep the `TempFile` for the user-pass file in the struct, so it's removed on drop.
-    _user_pass_file: mktemp::TempFile,
-    /// Keep the 'TempFile' for the proxy user-pass file in the struct, so it's removed on drop.
-    _proxy_auth_file: Option<mktemp::TempFile>,
+    monitor: InternalTunnelMonitor,
 }
 
+// TODO(emilsp) move most of the openvpn tunnel details to OpenVpnTunnelMonitor
 impl TunnelMonitor {
     /// Creates a new `TunnelMonitor` that connects to the given remote and notifies `on_event`
     /// on tunnel state changes.
@@ -169,9 +196,67 @@ impl TunnelMonitor {
     where
         L: Fn(TunnelEvent) + Send + Sync + 'static,
     {
-        Self::ensure_endpoint_is_openvpn(&tunnel_endpoint)?;
         Self::ensure_ipv6_can_be_used_if_enabled(tunnel_options)?;
+        match &tunnel_endpoint.tunnel {
+            TunnelEndpointData::OpenVpn(_) => Self::start_openvpn_tunnel(
+                tunnel_endpoint,
+                tunnel_options,
+                tunnel_alias,
+                username,
+                log,
+                resource_dir,
+                on_event,
+            ),
+            #[cfg(unix)]
+            TunnelEndpointData::Wireguard(_) => {
+                Self::start_wireguard_tunnel(tunnel_endpoint, tunnel_options, log, on_event)
+            }
+            #[cfg(windows)]
+            TunnelEndpointData::Wireguard(_) => bail!(ErrorKind::UnsupportedPlatform),
+        }
+    }
 
+    #[cfg(unix)]
+    fn start_wireguard_tunnel<L>(
+        tunnel_endpoint: TunnelEndpoint,
+        tunnel_options: &TunnelOptions,
+        log: Option<PathBuf>,
+        on_event: L,
+    ) -> Result<Self>
+    where
+        L: Fn(TunnelEvent) + Send + Sync + 'static,
+    {
+        let TunnelEndpoint { address, tunnel } = tunnel_endpoint;
+        let data = match tunnel {
+            TunnelEndpointData::Wireguard(data) => data,
+            _ => unreachable!("expected wireguard endpoint data"),
+        };
+
+        let monitor = wireguard::WireguardMonitor::start(
+            address,
+            data,
+            tunnel_options,
+            log.as_ref().map(|p| p.as_path()),
+            on_event,
+        )
+        .chain_err(|| ErrorKind::TunnelMonitoringError)?;
+        Ok(TunnelMonitor {
+            monitor: InternalTunnelMonitor::Wireguard(monitor),
+        })
+    }
+
+    fn start_openvpn_tunnel<L>(
+        tunnel_endpoint: TunnelEndpoint,
+        tunnel_options: &TunnelOptions,
+        tunnel_alias: Option<OsString>,
+        username: &str,
+        log: Option<PathBuf>,
+        resource_dir: &Path,
+        on_event: L,
+    ) -> Result<Self>
+    where
+        L: Fn(TunnelEvent) + Send + Sync + 'static,
+    {
         let user_pass_file = Self::create_credentials_file(username, "-")
             .chain_err(|| ErrorKind::CredentialsWriteError)?;
 
@@ -218,20 +303,13 @@ impl TunnelMonitor {
             on_openvpn_event,
             Self::get_plugin_path(resource_dir)?,
             log,
+            user_pass_file,
+            proxy_auth_file,
         )
         .chain_err(|| ErrorKind::TunnelMonitorSetUpError)?;
         Ok(TunnelMonitor {
-            monitor,
-            _user_pass_file: user_pass_file,
-            _proxy_auth_file: proxy_auth_file,
+            monitor: InternalTunnelMonitor::OpenVpn(monitor),
         })
-    }
-
-    fn ensure_endpoint_is_openvpn(endpoint: &TunnelEndpoint) -> Result<()> {
-        match endpoint.tunnel {
-            TunnelEndpointData::OpenVpn(_) => Ok(()),
-            TunnelEndpointData::Wireguard(_) => bail!(ErrorKind::UnsupportedTunnelProtocol),
-        }
     }
 
     fn ensure_ipv6_can_be_used_if_enabled(tunnel_options: &TunnelOptions) -> Result<()> {
@@ -341,7 +419,7 @@ impl TunnelMonitor {
     /// thread
     /// is blocked in `wait`.
     pub fn close_handle(&self) -> CloseHandle {
-        CloseHandle(self.monitor.close_handle())
+        self.monitor.close_handle()
     }
 
     /// Consumes the monitor and blocks until the tunnel exits or there is an error.
@@ -352,12 +430,25 @@ impl TunnelMonitor {
 
 
 /// A handle to a `TunnelMonitor`
-pub struct CloseHandle(OpenVpnCloseHandle);
+pub enum CloseHandle {
+    /// OpenVpn close handle
+    OpenVpn(openvpn::OpenVpnCloseHandle),
+    #[cfg(unix)]
+    /// Wireguard close handle
+    Wireguard(Box<wireguard::CloseHandle>),
+}
 
 impl CloseHandle {
     /// Closes the underlying tunnel, making the `TunnelMonitor::wait` method return.
     pub fn close(self) -> io::Result<()> {
-        self.0.close()
+        match self {
+            CloseHandle::OpenVpn(handle) => handle.close(),
+            #[cfg(unix)]
+            CloseHandle::Wireguard(mut handle) => {
+                handle.close();
+                Ok(())
+            }
+        }
     }
 }
 

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -59,7 +59,7 @@ impl Config {
             addresses: data.addresses,
             mtu: options.wireguard.mtu.unwrap_or(DEFAULT_MTU),
             #[cfg(target_os = "linux")]
-            fwmark: options.wireguard.fwmark.ok_or(ErrorKind::NoFwmarkError)?,
+            fwmark: options.wireguard.fwmark,
             peers: vec![peer],
         };
 

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -1,0 +1,153 @@
+use super::{ErrorKind, Result};
+use ipnetwork::IpNetwork;
+use std::{
+    borrow::Cow,
+    net::{IpAddr, SocketAddr},
+};
+use talpid_types::net::{TunnelOptions, WgPrivateKey, WgPublicKey, WireguardEndpointData};
+
+pub struct PeerConfig {
+    pub public_key: WgPublicKey,
+    pub allowed_ips: Vec<IpNetwork>,
+    pub endpoint: SocketAddr,
+}
+
+pub struct TunnelConfig {
+    pub private_key: WgPrivateKey,
+    pub addresses: Vec<IpAddr>,
+    #[cfg(target_os = "linux")]
+    pub fwmark: i32,
+    pub mtu: u16,
+    pub peers: Vec<PeerConfig>,
+}
+
+pub struct Config {
+    pub interface: TunnelConfig,
+    pub gateway: IpAddr,
+    pub preferred_name: Option<String>,
+}
+
+fn all_of_the_internet() -> Vec<IpNetwork> {
+    vec![
+        "::0/0".parse().expect("Failed to parse ipv6 network"),
+        "0.0.0.0/0".parse().expect("Failed to parse ipv4 network"),
+    ]
+}
+
+// Smallest MTU that supports IPv6
+const DEFAULT_MTU: u16 = 1420;
+
+impl Config {
+    pub fn from_data(
+        ip: IpAddr,
+        data: WireguardEndpointData,
+        options: &TunnelOptions,
+    ) -> Result<Config> {
+        let private_key = match data.client_private_key {
+            Some(private_key) => private_key,
+            None => bail!(ErrorKind::NoKeyError),
+        };
+
+        let peer = PeerConfig {
+            public_key: data.peer_public_key,
+            allowed_ips: all_of_the_internet(),
+            endpoint: SocketAddr::new(ip, data.port),
+        };
+
+        let tunnel_config = TunnelConfig {
+            private_key,
+            addresses: data.addresses,
+            mtu: options.wireguard.mtu.unwrap_or(DEFAULT_MTU),
+            #[cfg(target_os = "linux")]
+            fwmark: options.wireguard.fwmark.ok_or(ErrorKind::NoFwmarkError)?,
+            peers: vec![peer],
+        };
+
+        Ok(Config {
+            interface: tunnel_config,
+            gateway: data.gateway,
+            preferred_name: Some("talpid".to_string()),
+        })
+    }
+
+    // should probably take a flag that alters between additive and overwriting conf
+    pub fn get_wg_config(&self) -> Vec<u8> {
+        // the order of insertion matters, public key entry denotes a new peer entry
+        let mut wg_conf = WgConfigBuffer::new();
+        wg_conf
+            .add(
+                "private_key",
+                self.interface.private_key.as_bytes().as_ref(),
+            )
+            .add("listen_port", "0");
+
+        #[cfg(target_os = "linux")]
+        {
+            wg_conf.add("fwmark", self.interface.fwmark.to_string().as_str());
+        }
+
+        wg_conf.add("replace_peers", "true");
+
+        for peer in &self.interface.peers {
+            wg_conf
+                .add("public_key", peer.public_key.as_bytes().as_ref())
+                .add("endpoint", peer.endpoint.to_string().as_str())
+                .add("replace_allowed_ips", "true");
+            for addr in &peer.allowed_ips {
+                wg_conf.add("allowed_ip", addr.to_string().as_str());
+            }
+        }
+
+        wg_conf.to_config()
+    }
+}
+
+pub enum ConfValue<'a> {
+    String(&'a str),
+    Bytes(&'a [u8]),
+}
+
+impl<'a> From<&'a str> for ConfValue<'a> {
+    fn from(s: &'a str) -> ConfValue<'a> {
+        ConfValue::String(s)
+    }
+}
+
+impl<'a> From<&'a [u8]> for ConfValue<'a> {
+    fn from(s: &'a [u8]) -> ConfValue<'a> {
+        ConfValue::Bytes(s)
+    }
+}
+
+
+impl<'a> ConfValue<'a> {
+    fn to_bytes(&self) -> Cow<'a, [u8]> {
+        match self {
+            ConfValue::String(s) => s.as_bytes().into(),
+            ConfValue::Bytes(bytes) => Cow::Owned(hex::encode(bytes).into_bytes()),
+        }
+    }
+}
+
+pub struct WgConfigBuffer {
+    buf: Vec<u8>,
+}
+
+impl WgConfigBuffer {
+    pub fn new() -> WgConfigBuffer {
+        WgConfigBuffer { buf: Vec::new() }
+    }
+
+    pub fn add<'a, C: Into<ConfValue<'a>> + 'a>(&mut self, key: &str, value: C) -> &mut Self {
+        self.buf.extend(key.as_bytes());
+        self.buf.extend(b"=");
+        self.buf.extend(value.into().to_bytes().as_ref());
+        self.buf.extend(b"\n");
+        self
+    }
+
+    pub fn to_config(mut self) -> Vec<u8> {
+        self.buf.push(b'\n');
+        self.buf
+    }
+}

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -1,0 +1,182 @@
+use super::super::routing;
+use talpid_types::net::{TunnelOptions, WireguardEndpointData};
+
+use super::{TunnelEvent, TunnelMetadata};
+use std::{net::IpAddr, path::Path};
+
+pub mod config;
+mod ping_monitor;
+pub mod wireguard_go;
+
+use self::config::Config;
+pub use self::wireguard_go::WgGoTunnel;
+
+// amount of seconds to run `ping` until it returns.
+const PING_TIMEOUT: u16 = 5;
+
+error_chain! {
+    errors {
+        /// Failed to setup a tunnel device
+        SetupTunnelDeviceError {
+            description("Failed to create tunnel device")
+        }
+
+        /// Failed to setup wireguard tunnel
+        StartWireguardError(status: i32) {
+            display("Failed to start wireguard tunnel - {}", status)
+        }
+        /// Failed to tear down wireguard tunnel
+        StopWireguardError(status: i32) {
+            display("Failed to stop wireguard tunnel - {}", status)
+        }
+        /// Failed to set up routing
+        SetupRoutingError {
+            display("Failed to setup routing")
+        }
+
+        /// Failed to move or craete a log file
+        PrepareLogFileError {
+            display("Failed to setup a logging file")
+        }
+
+        /// No private key supplied
+        NoKeyError {
+            display("Config has no keys")
+        }
+
+        /// Failed to run
+        PingError {
+            display("Failed to run ping")
+        }
+
+        /// Pinging timed out
+        PingTimeoutError {
+            display("Ping timed out")
+        }
+
+        #[cfg(target_os = "linux")]
+        /// No firewall mark in supplied tunnel options
+        NoFwmarkError {
+            display("Supplied tunnel options did not have a firewall mark set")
+        }
+    }
+}
+
+pub trait CloseHandle: Sync + Send {
+    fn close(&mut self);
+    fn close_with_error(&mut self, err: Error);
+}
+
+pub trait Tunnel: Send {
+    fn get_interface_name(&self) -> &str;
+    fn close_handle(&self) -> Box<dyn CloseHandle>;
+    fn wait(self: Box<Self>) -> Result<()>;
+}
+
+/// Spawns and monitors a wireguard tunnel
+pub struct WireguardMonitor {
+    /// Tunnel implementation
+    tunnel: Box<Tunnel>,
+    /// Route manager
+    router: routing::RouteManager,
+    /// Callback to signal tunnel events
+    event_callback: Box<Fn(TunnelEvent) + Send + Sync + 'static>,
+}
+
+impl WireguardMonitor {
+    pub fn start<F: Fn(TunnelEvent) + Send + Sync + 'static>(
+        address: IpAddr,
+        data: WireguardEndpointData,
+        options: &TunnelOptions,
+        log_path: Option<&Path>,
+        on_event: F,
+    ) -> Result<WireguardMonitor> {
+        let config = Config::from_data(address, data.clone(), options)?;
+        let tunnel = Box::new(WgGoTunnel::start_tunnel(&config, log_path)?);
+        let router = routing::RouteManager::new().chain_err(|| ErrorKind::SetupRoutingError)?;
+        let event_callback = Box::new(on_event);
+
+        let mut monitor = WireguardMonitor {
+            tunnel,
+            router,
+            event_callback,
+        };
+        monitor.setup_routing(&config)?;
+        monitor.start_pinger(&config);
+        monitor.tunnel_up(data);
+
+        Ok(monitor)
+    }
+
+    pub fn close_handle(&self) -> Box<CloseHandle> {
+        self.tunnel.close_handle()
+    }
+
+    pub fn wait(self) -> Result<()> {
+        let result = self.tunnel.wait();
+        (self.event_callback)(TunnelEvent::Down);
+        result
+    }
+
+    #[allow(unused_mut)]
+    fn setup_routing(&mut self, config: &Config) -> Result<()> {
+        let iface_name = self.tunnel.get_interface_name();
+        let mut routes: Vec<_> = config
+            .interface
+            .peers
+            .iter()
+            .flat_map(|peer| peer.allowed_ips.iter())
+            .cloned()
+            .map(|allowed_ip| {
+                routing::Route::new(allowed_ip, routing::NetNode::Device(iface_name.to_string()))
+            })
+            .collect();
+
+        #[cfg(target_os = "macos")]
+        {
+            // To survive network roaming on osx, we should listen for new routes and reapply them
+            // here - probably would need RouteManager be extended. Or maybe RouteManager can deal
+            // with it on it's own
+            let default_node = self
+                .router
+                .get_default_route_node()
+                .chain_err(|| ErrorKind::SetupRoutingError)?;
+            // route endpoints with specific routes
+            for peer in config.interface.peers.iter() {
+                let default_route = routing::Route::new(
+                    peer.endpoint.ip().clone().into(),
+                    routing::NetNode::Address(default_node.clone()),
+                );
+                routes.push(default_route);
+            }
+        }
+
+        let required_routes = routing::RequiredRoutes {
+            routes,
+            #[cfg(target_os = "linux")]
+            fwmark: Some(config.interface.fwmark.to_string()),
+        };
+        self.router
+            .add_routes(required_routes)
+            .chain_err(|| ErrorKind::SetupRoutingError)
+    }
+
+    fn start_pinger(&self, config: &Config) {
+        ping_monitor::spawn_ping_monitor(
+            config.gateway,
+            PING_TIMEOUT,
+            self.tunnel.get_interface_name().to_string(),
+            self.tunnel.close_handle(),
+        );
+    }
+
+    fn tunnel_up(&self, data: WireguardEndpointData) {
+        let interface_name = self.tunnel.get_interface_name();
+        let metadata = TunnelMetadata {
+            interface: interface_name.to_string(),
+            ips: data.addresses,
+            gateway: data.gateway,
+        };
+        (self.event_callback)(TunnelEvent::Up(metadata));
+    }
+}

--- a/talpid-core/src/tunnel/wireguard/ping_monitor.rs
+++ b/talpid-core/src/tunnel/wireguard/ping_monitor.rs
@@ -1,0 +1,60 @@
+use super::{CloseHandle, ErrorKind, Result, ResultExt};
+use std::{net::IpAddr, thread, time};
+
+
+pub fn spawn_ping_monitor(
+    ip: IpAddr,
+    timeout_secs: u16,
+    interface: String,
+    mut close_handle: Box<dyn CloseHandle>,
+) {
+    thread::spawn(move || loop {
+        let start = time::Instant::now();
+        if let Err(e) = ping(ip, timeout_secs, &interface) {
+            close_handle.close_with_error(e);
+            return;
+        }
+        let elapsed = time::Instant::now() - start;
+        if let Some(remaining) = time::Duration::from_secs(timeout_secs.into()).checked_sub(elapsed)
+        {
+            thread::sleep(remaining);
+        }
+    });
+}
+
+pub fn ping(ip: IpAddr, timeout_secs: u16, interface: &str) -> Result<()> {
+    let output = ping_cmd(ip, timeout_secs, interface)
+        .run()
+        .chain_err(|| ErrorKind::PingError)?;
+    if !output.status.success() {
+        bail!(ErrorKind::PingTimeoutError);
+    }
+    Ok(())
+}
+
+fn ping_cmd(ip: IpAddr, timeout_secs: u16, interface: &str) -> duct::Expression {
+    let interface_flag = if cfg!(target_os = "linux") {
+        "-I"
+    } else {
+        "-b"
+    };
+    let timeout_flag = if cfg!(target_os = "linux") {
+        "-w"
+    } else {
+        "-t"
+    };
+    duct::cmd!(
+        "ping",
+        "-n",
+        "-c",
+        "1",
+        &interface_flag,
+        &interface,
+        timeout_flag,
+        &timeout_secs.to_string(),
+        ip.to_string()
+    )
+    .stdin_null()
+    .stdout_null()
+    .unchecked()
+}

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -1,0 +1,261 @@
+use super::{
+    super::super::network_interface::{NetworkInterface, TunnelDevice},
+    CloseHandle, Config, Error, ErrorKind, Result, ResultExt, Tunnel,
+};
+use crate::logging;
+use std::{
+    ffi::CString,
+    fs,
+    os::unix::io::AsRawFd,
+    path::Path,
+    sync::{Arc, Condvar, Mutex},
+};
+
+type WgLogLevel = i32;
+// wireguard-go supports log levels 0 through 3 with 3 being the most verbose
+const WG_GO_LOG_DEBUG: WgLogLevel = 3;
+
+
+pub struct WgGoTunnel {
+    handle: WgHandle,
+    interface_name: String,
+    // keeping ahold of the tunnel device and the log file ensures that
+    // the associated file handles live long enough and get closed when the tunnel is stopped
+    _tunnel_device: TunnelDevice,
+    _log_file: fs::File,
+}
+
+impl WgGoTunnel {
+    pub fn start_tunnel(config: &Config, log_path: Option<&Path>) -> Result<Self> {
+        let mut tunnel_device =
+            TunnelDevice::new().chain_err(|| ErrorKind::SetupTunnelDeviceError)?;
+
+        for ip in config.interface.addresses.iter() {
+            tunnel_device
+                .set_ip(*ip)
+                .chain_err(|| ErrorKind::SetupTunnelDeviceError)?;
+        }
+
+        tunnel_device
+            .set_up(true)
+            .chain_err(|| ErrorKind::SetupTunnelDeviceError)?;
+
+        let interface_name: String = tunnel_device.get_name().to_string();
+        let fd = tunnel_device.as_raw_fd();
+        let log_file = prepare_log_file(log_path)?;
+        let handle = WgHandle::new(
+            &interface_name,
+            config,
+            fd,
+            log_file.as_raw_fd(),
+            WG_GO_LOG_DEBUG,
+        )?;
+
+        Ok(WgGoTunnel {
+            handle,
+            interface_name,
+            _tunnel_device: tunnel_device,
+            _log_file: log_file,
+        })
+    }
+}
+
+fn prepare_log_file(base_path: Option<&Path>) -> Result<fs::File> {
+    match base_path {
+        Some(path) => {
+            logging::rotate_log(path).chain_err(|| ErrorKind::PrepareLogFileError)?;
+            fs::File::open(&path).chain_err(|| ErrorKind::PrepareLogFileError)
+        }
+        None => fs::File::open("/dev/null").chain_err(|| ErrorKind::PrepareLogFileError),
+    }
+}
+
+impl Tunnel for WgGoTunnel {
+    fn close_handle(&self) -> Box<dyn CloseHandle> {
+        Box::new(self.handle.clone())
+    }
+
+    fn get_interface_name(&self) -> &str {
+        &self.interface_name
+    }
+
+    fn wait(mut self: Box<Self>) -> Result<()> {
+        self.handle.wait()
+    }
+}
+
+#[derive(Clone)]
+struct WgHandle {
+    handle: Arc<(Mutex<WgHandleInner>, Condvar)>,
+}
+
+impl WgHandle {
+    fn new(
+        interface_name: &str,
+        config: &Config,
+        fd: handle::Descriptor,
+        log_fd: handle::Descriptor,
+        log_level: WgLogLevel,
+    ) -> Result<WgHandle> {
+        let inner = WgHandleInner::new(interface_name, config, fd, log_fd, log_level)?;
+        Ok(Self {
+            handle: Arc::new((Mutex::new(inner), Condvar::new())),
+        })
+    }
+
+    fn wait(&mut self) -> Result<()> {
+        let (mutex, condition) = self.handle.as_ref();
+        let mut handle = mutex
+            .lock()
+            .expect("wireguard-go handle mutex got poisoned");
+        loop {
+            // checking if handle has been removed
+            if handle.has_stopped() {
+                return handle.consume_error();
+            }
+
+            handle = condition
+                .wait(handle)
+                .expect("wireguard-go handle mutex got poisoned");
+        }
+    }
+}
+
+impl CloseHandle for WgHandle {
+    fn close(&mut self) {
+        let (mutex, condition) = &self.handle.as_ref();
+        mutex
+            .lock()
+            .expect("wireguard-go handle mutex got poisoned")
+            .close();
+        condition.notify_all();
+    }
+
+    fn close_with_error(&mut self, err: Error) {
+        let (mutex, condition) = &self.handle.as_ref();
+        mutex
+            .lock()
+            .expect("wireguard-go handle mutex got poisoned")
+            .close_with_error(err);
+        condition.notify_all();
+    }
+}
+
+#[cfg(unix)]
+mod handle {
+    pub type Descriptor = std::os::unix::io::RawFd;
+}
+
+#[cfg(windows)]
+mod handle {
+    pub type Descriptor = std::os::windows::io::RawHandle;
+}
+
+
+#[link(name = "wg", kind = "static")]
+extern "C" {
+    fn wgTurnOnWithFd(
+        iface_name: *const i8,
+        mtu: i64,
+        settings: *const i8,
+        fd: handle::Descriptor,
+        log_fd: handle::Descriptor,
+        logLevel: WgLogLevel,
+    ) -> i32;
+    fn wgTurnOff(handle: i32) -> i32;
+}
+
+
+struct WgHandleInner {
+    handle: Option<i32>,
+    error: Option<Error>,
+}
+
+impl WgHandleInner {
+    fn new(
+        interface_name: &str,
+        config: &Config,
+        fd: handle::Descriptor,
+        log_fd: handle::Descriptor,
+        log_level: WgLogLevel,
+    ) -> Result<WgHandleInner> {
+        let wg_config_str = CString::new(config.get_wg_config()).expect("Found \\0 in wg config");
+        let iface_name =
+            CString::new(interface_name.as_bytes()).expect("Found \\0 in interface name");
+        let handle = unsafe {
+            wgTurnOnWithFd(
+                iface_name.as_ptr(),
+                config.interface.mtu as i64,
+                wg_config_str.as_ptr(),
+                fd,
+                log_fd,
+                log_level,
+            )
+        };
+        if handle < 0 {
+            bail!(ErrorKind::StartWireguardError(handle));
+        };
+        Ok(Self {
+            handle: Some(handle),
+            error: None,
+        })
+    }
+
+    fn has_stopped(&self) -> bool {
+        self.handle.is_none()
+    }
+
+    fn consume_error(&mut self) -> Result<()> {
+        self.error.take().map(Err).unwrap_or(Ok(()))
+    }
+
+    fn close(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            let status = unsafe { wgTurnOff(handle) };
+            if status < 0 {
+                if self.error.is_none() {
+                    self.error = Some(ErrorKind::StopWireguardError(status).into());
+                } else {
+                    log::error!(
+                        "Failed to stop wireguard-go successfully - {}",
+                        ErrorKind::StopWireguardError(status)
+                    );
+                }
+            };
+        }
+    }
+
+    fn close_with_error(&mut self, err: Error) {
+        // if we're already shut down, there's nothing to do
+        if self.has_stopped() {
+            return;
+        }
+
+        // if there's an error that's already set, there's not much to do here.
+        if let Some(set_err) = self.error.as_ref() {
+            log::trace!(
+                "Wireguard handle error already set - '{}', dropping another one - {}",
+                set_err,
+                err
+            );
+            return;
+        }
+
+        self.error = Some(err);
+        self.close();
+    }
+}
+
+impl Drop for WgHandleInner {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle {
+            let status = unsafe { wgTurnOff(handle) };
+            if status < 0 {
+                log::trace!(
+                    "Wireguard tunnel returned non-zero status when shutting down - {}",
+                    status
+                );
+            }
+        }
+    }
+}

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -192,7 +192,7 @@ impl TunnelState for ConnectedState {
         shared_values: &mut SharedTunnelStateValues,
         bootstrap: Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
-        let tunnel_endpoint = bootstrap.tunnel_parameters.endpoint;
+        let tunnel_endpoint = bootstrap.tunnel_parameters.endpoint.clone();
         let connected_state = ConnectedState::from(bootstrap);
 
         if let Err(error) = connected_state.set_security_policy(shared_values) {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -120,7 +120,7 @@ impl ConnectingState {
         let log_file = Self::prepare_tunnel_log_file(&parameters, log_dir)?;
 
         Ok(TunnelMonitor::start(
-            parameters.endpoint,
+            parameters.endpoint.clone(),
             &parameters.options,
             TUNNEL_INTERFACE_ALIAS.to_owned().map(OsString::from),
             &parameters.username,
@@ -229,7 +229,7 @@ impl ConnectingState {
                 match Self::set_security_policy(
                     shared_values,
                     &self.tunnel_parameters.options.openvpn.proxy,
-                    self.tunnel_parameters.endpoint,
+                    self.tunnel_parameters.endpoint.clone(),
                 ) {
                     Ok(()) => SameState(self),
                     Err(error) => {
@@ -367,11 +367,11 @@ impl TunnelState for ConnectingState {
         {
             None => BlockedState::enter(shared_values, BlockReason::NoMatchingRelay),
             Some(tunnel_parameters) => {
-                let tunnel_endpoint = tunnel_parameters.endpoint;
+                let tunnel_endpoint = tunnel_parameters.endpoint.clone();
                 if let Err(error) = Self::set_security_policy(
                     shared_values,
                     &tunnel_parameters.options.openvpn.proxy,
-                    tunnel_endpoint,
+                    tunnel_endpoint.clone(),
                 ) {
                     error!("{}", error.display_chain());
                     BlockedState::enter(shared_values, BlockReason::StartTunnelError)

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+ipnetwork = "0.13"
+base64 = "0.10"
+x25519-dalek = { version = "0.3", default-features = false, features = ["u64_backend"]}

--- a/talpid-types/src/net.rs
+++ b/talpid-types/src/net.rs
@@ -193,7 +193,6 @@ impl Error for TransportProtocolParseError {
 /// TunnelOptions holds optional settings for tunnels, that are to be applied to any tunnel of the
 /// appropriate type.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
 pub struct TunnelOptions {
     /// openvpn holds OpenVPN specific tunnel options.
     pub openvpn: OpenVpnTunnelOptions,
@@ -202,16 +201,6 @@ pub struct TunnelOptions {
     /// Enable configuration of IPv6 on the tunnel interface, allowing IPv6 communication to be
     /// forwarded through the tunnel. By default, this is set to `true`.
     pub enable_ipv6: bool,
-}
-
-impl Default for TunnelOptions {
-    fn default() -> Self {
-        TunnelOptions {
-            openvpn: OpenVpnTunnelOptions::default(),
-            wireguard: WireguardTunnelOptions::default(),
-            enable_ipv6: false,
-        }
-    }
 }
 
 
@@ -285,13 +274,14 @@ impl OpenVpnProxySettingsValidation {
 }
 
 /// Wireguard tunnel options
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct WireguardTunnelOptions {
     /// MTU for the wireguard tunnel
     pub mtu: Option<u16>,
     /// firewall mark
-    pub fwmark: Option<i32>,
+    #[cfg(target_os = "linux")]
+    pub fwmark: i32,
 }
 
 /// Wireguard x25519 private key


### PR DESCRIPTION
This PR adds wireguard support to `talpid-core`, which brings us closer still to supporting wireguard in the app. The noteworthy additions here are the wireguard tunnel monitor, some scaffolding code around WireGuard and `talpid-types`, and the use of `wireguard-go` to establish a WireGuard tunnel. 



`talpid-core::tunnel::wireguard` is mostly written with the hope that we'll support the kernel module quite soon. The code is still rough around the edges, but all criticism will be appreciated. I'll rebase this up into multiple smaller commits once the review is starting to settle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/649)
<!-- Reviewable:end -->
