### PR TITLE
Fix the state indication inconsistency when disconnecting

### DIFF
--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -674,21 +674,7 @@ const ApplicationMain = {
         return 'securing';
 
       case 'disconnecting':
-        switch (tunnelState.details) {
-          case 'reconnect':
-            return 'securing';
-
-          case 'block':
-            return 'securing';
-
-          case 'nothing':
-            // handle the same way as disconnected
-            break;
-
-          default:
-            throw new Error(`Invalid after disconnect state: ${(tunnelState.details: empty)}`);
-        }
-      // fallthrough
+        return 'securing';
 
       case 'disconnected':
         if (blockWhenDisconnected) {
@@ -698,8 +684,7 @@ const ApplicationMain = {
         }
 
       default:
-        // unreachable, but can't prove it to flow because of the fallthrough
-        throw new Error(`Invalid tunnel state: ${tunnelState.state}`);
+        throw new Error(`Invalid tunnel state: ${(tunnelState.state: empty)}`);
     }
   },
 

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -247,9 +247,6 @@ export default class AppRenderer {
   }
 
   disconnectTunnel(): Promise<void> {
-    // switch to the disconnected state ahead of time to make the app look more responsive
-    this._reduxActions.connection.disconnected();
-
     return this._daemonRpc.disconnectTunnel();
   }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

1. Remove the prediction for the next state when a user disconnects the tunnel. My assumption is that the daemon should report either the "disconnecting" or "disconnected" state via RPC shortly after receiving the RPC call to disconnect the tunnel. Therefore, any delays related to waiting for OpenVPN to shutdown should not normally affect the app responsiveness.

2.  Follow the "disconnecting" state closer and indicate it with the same tray icon we use for the blocked state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/650)
<!-- Reviewable:end -->
