### PR TITLE
Rework IPC interface

### DIFF
--- a/gui/flow-libs/electron.js.flow
+++ b/gui/flow-libs/electron.js.flow
@@ -115,11 +115,20 @@ declare module 'electron' {
 
   // http://electron.atom.io/docs/api/ipc-renderer
 
+  declare type IpcRendererEvent = {
+    senderId: number;
+  }
+
   declare class IpcRenderer extends EventEmitter {
     send(channel: string, ...args: Array<mixed>): void;
   }
 
   // http://electron.atom.io/docs/api/ipc-main
+
+  declare type IpcMainEvent = {
+    sender: WebContents;
+    returnValue?: any;
+  }
 
   declare class IpcMain extends EventEmitter {}
 

--- a/gui/packages/desktop/src/main/window-controller.js
+++ b/gui/packages/desktop/src/main/window-controller.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { screen } from 'electron';
-import type { BrowserWindow, Tray, Display } from 'electron';
+import type { BrowserWindow, Tray, Display, WebContents } from 'electron';
 
 type Position = { x: number, y: number };
 
@@ -137,6 +137,10 @@ export default class WindowController {
 
   get window(): BrowserWindow {
     return this._window;
+  }
+
+  get webContents(): WebContents {
+    return this._window.webContents;
   }
 
   constructor(window: BrowserWindow, tray: Tray) {

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
@@ -176,11 +176,11 @@ export default class DaemonRpcProxy implements DaemonRpcProtocol {
   }
 
   getAccountHistory(): Promise<Array<AccountToken>> {
-    return this._sendMessage('getAccountHistory');
+    throw new Error('Do not use this method');
   }
 
-  removeAccountFromHistory(accountToken: AccountToken): Promise<void> {
-    return this._sendMessage('removeAccountFromHistory', accountToken);
+  removeAccountFromHistory(_accountToken: AccountToken): Promise<void> {
+    throw new Error('Do not use this method');
   }
 
   getCurrentVersion(): Promise<string> {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Change `GuiSettings` to dispatch the change events with new and old state which can be used to determine the changes by the listeners.
1. Split `IpcEventChannel` on two:
   1. `IpcMainEventChannel` - the IPC counterpart that shall be used from the main process
   1. `IpcRendererEventChannel` - the IPC counterpart that shall be used from the renderer process
1. Add a boilerplate for the async request/response IPC. Relevant for account history and similar calls that request something from the daemon that's not always or immediately available in the main process. The same boilerplate can be used to migrate the rest of IPC calls, that are currently proxied using the `DaemonRpcProxy` which was a quick hack to make it possible to move the `DaemonRpc` to the main process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/651)
<!-- Reviewable:end -->
