### PR TITLE
Add extra 'After' directives to daemon's unit file

### DIFF
--- a/dist-assets/linux/mullvad-daemon.service
+++ b/dist-assets/linux/mullvad-daemon.service
@@ -4,6 +4,8 @@
 Description=Mullvad VPN daemon
 Wants=network.target
 After=network-online.target
+After=NetworkManager.service
+After=systemd-resolved.service
 StartLimitBurst=5
 StartLimitIntervalSec=20
 


### PR DESCRIPTION
To help us not pick the absolutely wrong way of manging DNS during early boot scenarios, I've added extra `After` directives to the systemd unit file. Turns out these are optional dependencies, i.e. our service will only wait until these units are ready only if the units are actually enabled. This means that this unit file won't break anything for users who don't use either NetworkManager or SystemD's resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/653)
<!-- Reviewable:end -->
