### PR TITLE
Adjust current location rpc

### DIFF
--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -660,6 +660,11 @@ const ApplicationMain = {
 
         // Fetch the new user location
         const location = await this._daemonRpc.getLocation();
+        // If the location is currently unavailable, do nothing! This only ever
+        // happens when a custom relay is set or we are in a blocked state.
+        if (!location) {
+          return;
+        }
 
         // Cache the user location
         // Note: hostname is only set for relay servers.

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -65,7 +65,13 @@ fn print_blocked_reason(reason: &BlockReason) {
 }
 
 fn print_location(rpc: &mut DaemonRpcClient) -> Result<()> {
-    let location = rpc.get_current_location()?;
+    let location = match rpc.get_current_location()? {
+        Some(loc) => loc,
+        None => {
+            println!("Location data unavailable");
+            return Ok(());
+        }
+    };
     let city_and_country = if let Some(city) = location.city {
         format!("{}, {}", city, location.country)
     } else {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -95,7 +95,7 @@ build_rpc_trait! {
         /// Performs a geoIP lookup and returns the current location as perceived by the public
         /// internet.
         #[rpc(meta, name = "get_current_location")]
-        fn get_current_location(&self, Self::Metadata) -> BoxFuture<GeoIpLocation, Error>;
+        fn get_current_location(&self, Self::Metadata) -> BoxFuture<Option<GeoIpLocation>, Error>;
 
         /// Makes the daemon exit its main loop and quit.
         #[rpc(meta, name = "shutdown")]
@@ -168,7 +168,7 @@ pub enum ManagementCommand {
     /// Request the current state.
     GetState(OneshotSender<TunnelStateTransition>),
     /// Get the current geographical location.
-    GetCurrentLocation(OneshotSender<GeoIpLocation>),
+    GetCurrentLocation(OneshotSender<Option<GeoIpLocation>>),
     /// Request the metadata for an account.
     GetAccountData(
         OneshotSender<BoxFuture<AccountData, mullvad_rpc::Error>>,
@@ -529,7 +529,7 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
         Box::new(future)
     }
 
-    fn get_current_location(&self, _: Self::Metadata) -> BoxFuture<GeoIpLocation, Error> {
+    fn get_current_location(&self, _: Self::Metadata) -> BoxFuture<Option<GeoIpLocation>, Error> {
         log::debug!("get_current_location");
         let (tx, rx) = sync::oneshot::channel();
         let future = self

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -26,7 +26,7 @@ use std::{
     time::{self, Duration, SystemTime},
 };
 
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, info, warn};
 use rand::{self, Rng, ThreadRng};
 use tokio_timer::{TimeoutError, Timer};
 

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -148,7 +148,7 @@ impl DaemonRpcClient {
         self.call("get_auto_connect", &NO_ARGS)
     }
 
-    pub fn get_current_location(&mut self) -> Result<GeoIpLocation> {
+    pub fn get_current_location(&mut self) -> Result<Option<GeoIpLocation>> {
         self.call("get_current_location", &NO_ARGS)
     }
 


### PR DESCRIPTION
I've adjusted the `get_current_location` RPC to return a nullable location. This fixes a panic that will kill the daemon if a custom relayed is connected, and cleans up the ugliness with the RPC just failing in the blocked mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/655)
<!-- Reviewable:end -->
