### PR TITLE
Add documentation to ffi_error macro

### DIFF
--- a/talpid-core/src/security/windows/ffi.rs
+++ b/talpid-core/src/security/windows/ffi.rs
@@ -1,3 +1,4 @@
+/// Creates a new result type that returns the given result variant on error.
 #[macro_export]
 macro_rules! ffi_error {
     ($result:ident, $error:expr) => {


### PR DESCRIPTION
Seems like nightly rustc started honoring `#![deny(missing_docs)]` for macros as well. Adding documentation and let's see if that makes AppVeyor happier.