### PR TITLE
Fix nightly build breakage on Windows.

### DIFF
--- a/talpid-core/src/security/windows/ffi.rs
+++ b/talpid-core/src/security/windows/ffi.rs
@@ -1,5 +1,7 @@
 /// Creates a new result type that returns the given result variant on error.
 #[macro_export]
+/// Defines a type to be used by FFI functions that return a boolean value to indicate a failure.
+/// If the return value is true, the result unwraps to an `Ok(())`, otherwise `Err(ErrorType)`.
 macro_rules! ffi_error {
     ($result:ident, $error:expr) => {
         #[repr(C)]


### PR DESCRIPTION
Recent nightly change creates a lint message for missing docstrings on macros, which breaks talpid-core on Windows. This fixes build breakage on nightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/660)
<!-- Reviewable:end -->
