### PR TITLE
Allow the 169.254.0.0/16 network when LAN sharing is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Line wrap the file at 100 chars.                                              Th
   state as blocked when appropriate and also having a toggle switch for the setting in the Advanced
   Settings screen.
 - Add a drop-down warning to notify the user when the account credits are running low.
+- Allow the 169.254.0.0/16 private network in addition to the other networks allowed when local
+  network sharing is enabled.
 
 #### macOS
 - Add a monochromatic tray icon option for the GUI.

--- a/talpid-core/src/security/mod.rs
+++ b/talpid-core/src/security/mod.rs
@@ -25,10 +25,11 @@ pub use self::imp::{DnsError, Error};
 
 #[cfg(unix)]
 lazy_static! {
-    static ref PRIVATE_NETS: [IpNetwork; 3] = [
+    static ref PRIVATE_NETS: [IpNetwork; 4] = [
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(169, 254, 0, 0), 16).unwrap()),
     ];
     static ref LOCAL_INET6_NET: IpNetwork =
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap());

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -142,6 +142,20 @@ const GUID &MullvadGuids::FilterPermitLan_192_168_16()
 }
 
 //static
+const GUID &MullvadGuids::FilterPermitLan_169_254_16()
+{
+	static const GUID g =
+	{
+		0x58718a9e,
+		0x7ec1,
+		0x4dee,
+		{ 0x8d, 0x3f, 0x16, 0x5b, 0x95, 0x5d, 0xb5, 0x42 }
+	};
+
+	return g;
+}
+
+//static
 const GUID &MullvadGuids::FilterPermitLan_Multicast()
 {
 	static const GUID g =
@@ -220,6 +234,20 @@ const GUID &MullvadGuids::FilterPermitLanService_192_168_16()
 		0x9bf0,
 		0x47f2,
 		{ 0x98, 0x69, 0xd1, 0x5e, 0xf3, 0x5c, 0x3a, 0x8 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::FilterPermitLanService_169_254_16()
+{
+	static const GUID g =
+	{
+		0x39d9b695,
+		0x5c27,
+		0x42a6,
+		{ 0xba, 0xea, 0x8c, 0x4b, 0xe0, 0x7e, 0x66, 0x3e }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -19,6 +19,7 @@ public:
 	static const GUID &FilterPermitLan_10_8();
 	static const GUID &FilterPermitLan_172_16_12();
 	static const GUID &FilterPermitLan_192_168_16();
+	static const GUID &FilterPermitLan_169_254_16();
 	static const GUID &FilterPermitLan_Multicast();
 	static const GUID &FilterPermitLan_Ipv6_fe80_10();
 	static const GUID &FilterPermitLan_Ipv6_Multicast();
@@ -26,6 +27,7 @@ public:
 	static const GUID &FilterPermitLanService_10_8();
 	static const GUID &FilterPermitLanService_172_16_12();
 	static const GUID &FilterPermitLanService_192_168_16();
+	static const GUID &FilterPermitLanService_169_254_16();
 	static const GUID &FilterPermitLanService_Ipv6_fe80_10();
 
 	static const GUID &FilterPermitLoopback_Outbound_Ipv4();

--- a/windows/winfw/src/winfw/rules/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/permitlan.cpp
@@ -81,7 +81,25 @@ bool PermitLan::applyIpv4(IObjectInstaller &objectInstaller) const
 	}
 
 	//
-	// #4 LAN to multicast
+	// #4 locally-initiated on 169.254/16
+	//
+
+	filterBuilder
+		.key(MullvadGuids::FilterPermitLan_169_254_16())
+		.name(L"Permit locally-initiated traffic on 169.254/16");
+
+	conditionBuilder.reset();
+
+	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 169, 254, 0, 0 }), uint8_t(16)));
+	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 169, 254, 0, 0 }), uint8_t(16)));
+
+	if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+	{
+		return false;
+	}
+
+	//
+	// #5 LAN to multicast
 	//
 
 	filterBuilder
@@ -93,6 +111,7 @@ bool PermitLan::applyIpv4(IObjectInstaller &objectInstaller) const
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 10, 0, 0, 0 }), uint8_t(8)));
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 172, 16, 0, 0 }), uint8_t(12)));
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 192, 168, 0, 0 }), uint8_t(16)));
+	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 169, 254, 0, 0 }), uint8_t(16)));
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 224, 0, 0, 0 }), uint8_t(24)));
 
 	// Special multicast for SSDP.

--- a/windows/winfw/src/winfw/rules/permitlanservice.cpp
+++ b/windows/winfw/src/winfw/rules/permitlanservice.cpp
@@ -75,6 +75,24 @@ bool PermitLanService::applyIpv4(IObjectInstaller &objectInstaller) const
 	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 192, 168, 0, 0 }), uint8_t(16)));
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 192, 168, 0, 0 }), uint8_t(16)));
 
+	if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+	{
+		return false;
+	}
+
+	//
+	// #4 incoming request on 169.254/16
+	//
+
+	filterBuilder
+		.key(MullvadGuids::FilterPermitLanService_169_254_16())
+		.name(L"Permit incoming requests on 169.254/16");
+
+	conditionBuilder.reset();
+
+	conditionBuilder.add_condition(ConditionIp::Local(wfp::IpAddress::Literal({ 169, 254, 0, 0 }), uint8_t(16)));
+	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpAddress::Literal({ 169, 254, 0, 0 }), uint8_t(16)));
+
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }
 


### PR DESCRIPTION
Albeit not very frequently used, 169.254.0.0/16 is a private network. Mostly used for zero config in the absence of a DHCP server. Some hardware vendors, for example certain NASes, default to this network. Allowing traffic to and from it when "local network sharing" is enabled should allow these things to work without needing to disconnect the VPN in some cases.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/661)
<!-- Reviewable:end -->
