### PR TITLE
Add a space between adjacent toggle items

### DIFF
--- a/gui/packages/desktop/src/renderer/components/Preferences.js
+++ b/gui/packages/desktop/src/renderer/components/Preferences.js
@@ -67,6 +67,7 @@ export default class Preferences extends Component<PreferencesProps, State> {
                       <Cell.Label>Launch app on start-up</Cell.Label>
                       <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
                     </Cell.Container>
+                    <View style={styles.preferences__separator} />
 
                     <Cell.Container>
                       <Cell.Label>Auto-connect</Cell.Label>

--- a/gui/packages/desktop/src/renderer/components/PreferencesStyles.js
+++ b/gui/packages/desktop/src/renderer/components/PreferencesStyles.js
@@ -19,4 +19,7 @@ export default {
     flexShrink: 1,
     flexBasis: 'auto',
   }),
+  preferences__separator: Styles.createViewStyle({
+    height: 1,
+  }),
 };


### PR DESCRIPTION
Previous removal of the text below a toggle option caused it to be adjacent to the next toggle option. This PR simply adds a separator between them.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor GUI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/663)
<!-- Reviewable:end -->
