### PR TITLE
Slightly improve uninstaller script for Linux.

### DIFF
--- a/dist-assets/linux/before-remove.sh
+++ b/dist-assets/linux/before-remove.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -eu
 
+is_number_re='^[0-9]+$'
 # Check if we're running during an upgrade step on Fedora
 # https://fedoraproject.org/wiki/Packaging:Scriptlets#Syntax
-if [ $1 -gt 0 ]; then
+if [[ "$1" =~ $is_number_re ]] && [ $1 -gt 0 ]; then
     echo not running
     exit 0;
 fi


### PR DESCRIPTION
Whilst investigating issues with our daemon's unit file not being installed correctly on Debian 9, I came to notice that our pre-remove script wasn't being ran properly on Debian. The underlying issue is that the script was expecting parameters, which it would receive on RPM systems, but wouldn't on debian based ones. So, now, the script checks if it has a parameter that is a number - _because of course opaque numbers are what tell the script in which lifecycle phase it's being executed in an RPM package installation context_, and if the parameter is not a number, then we execute the pre-removal script anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/665)
<!-- Reviewable:end -->
