### PR TITLE
Remove SocketTransports 'close' event handler when an error occurs

### DIFF
--- a/gui/packages/desktop/src/main/jsonrpc-client.js
+++ b/gui/packages/desktop/src/main/jsonrpc-client.js
@@ -438,7 +438,14 @@ export class SocketTransport implements Transport<{ path: string }> {
     if (!this.socketClosed) {
       this.socketClosed = true;
       this.onClose(err);
+      if (this.connection) {
+        // Overriding the 'close' event handler to not close the next socket, the
+        // onClose calllback is already called.
+        this.connection.removeAllListeners('close');
+      }
       this.close();
+    } else {
+      this.onClose(null);
     }
   }
 


### PR DESCRIPTION
These changes try to fix the issue with reconnection chains which can be triggered when there's a JSON-RPC error after which we close the transport. I've tried to achieve this by removing the `close` event handler from the connection when `SocketTransport._fail` is called. This way, the `onClose` callback is still invoked exactly once per transport error.