### PR TITLE
Remove explicitly setting the system allocator

### DIFF
--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -12,12 +12,9 @@ extern crate error_chain;
 use clap::{crate_authors, crate_description, crate_name};
 use error_chain::ChainedError;
 use mullvad_ipc_client::{new_standalone_ipc_client, DaemonRpcClient};
-use std::{alloc::System, io};
+use std::io;
 
 mod cmds;
-
-#[global_allocator]
-static GLOBAL: System = System;
 
 pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -14,7 +14,6 @@ use error_chain::ChainedError;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::{
-    alloc::System,
     borrow::Cow,
     cmp::min,
     collections::{HashMap, HashSet},
@@ -24,10 +23,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use tokio_core::reactor::Core;
-
-
-#[global_allocator]
-static GLOBAL: System = System;
 
 
 mod metadata;


### PR DESCRIPTION
The system allocator is the default since Rust 1.32. So while this code does not hurt, it also does absolutely nothing anymore. Dead code is bad code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/670)
<!-- Reviewable:end -->
