### PR TITLE
Upgrade the remaining crates to Rust 2018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-core"
 version = "8.0.2"
-source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux#40344ea49836a6a0040c49c927610608bd3c4a8a"
+source = "git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork#9de0ea1ad4c296465f44f53050d99459ca885157"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -730,11 +730,11 @@ dependencies = [
 [[package]]
 name = "jsonrpc-ipc-server"
 version = "8.0.1"
-source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux#40344ea49836a6a0040c49c927610608bd3c4a8a"
+source = "git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork#9de0ea1ad4c296465f44f53050d99459ca885157"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-tokio-ipc 0.1.0 (git+https://github.com/nikvolf/parity-tokio-ipc)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -745,19 +745,19 @@ dependencies = [
 [[package]]
 name = "jsonrpc-macros"
 version = "8.0.1"
-source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux#40344ea49836a6a0040c49c927610608bd3c4a8a"
+source = "git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork#9de0ea1ad4c296465f44f53050d99459ca885157"
 dependencies = [
- "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-pubsub"
 version = "8.0.1"
-source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux#40344ea49836a6a0040c49c927610608bd3c4a8a"
+source = "git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork#9de0ea1ad4c296465f44f53050d99459ca885157"
 dependencies = [
- "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -778,11 +778,11 @@ dependencies = [
 [[package]]
 name = "jsonrpc-server-utils"
 version = "8.0.1"
-source = "git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux#40344ea49836a6a0040c49c927610608bd3c4a8a"
+source = "git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork#9de0ea1ad4c296465f44f53050d99459ca885157"
 dependencies = [
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1019,10 +1019,10 @@ dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1819,8 +1819,8 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iproute2 0.0.2 (git+https://github.com/mullvad/netlink?branch=best-effort-nla-parsing)",
- "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1858,10 +1858,10 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=e9dbdc80)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=e9dbdc80)",
- "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
- "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)",
+ "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
+ "jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2489,12 +2489,12 @@ dependencies = [
 "checksum jsonrpc-client-http 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e642eb74423b9dfcb4512fda167148746b76f788a823cd712fadf409f31d302"
 "checksum jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=e9dbdc80)" = "<none>"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
-"checksum jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)" = "<none>"
-"checksum jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)" = "<none>"
-"checksum jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)" = "<none>"
-"checksum jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)" = "<none>"
+"checksum jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)" = "<none>"
+"checksum jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)" = "<none>"
+"checksum jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)" = "<none>"
+"checksum jsonrpc-pubsub 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)" = "<none>"
 "checksum jsonrpc-server-utils 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "513e981828a4953ea7ddbb64c24d15d4983ecf6900dc1cd36f257d61c27138d5"
-"checksum jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=make-ipc-server-concurrent-part-deux)" = "<none>"
+"checksum jsonrpc-server-utils 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
@@ -22,10 +23,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 log-panics = "2.0.0"
-jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
-jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
-jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
-jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
+jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 uuid = { version = "0.6", features = ["v4"] }
 lazy_static = "1.0"
 rand = "0.5"

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -1,10 +1,5 @@
 use std::{env, fs, path::PathBuf, process::Command};
 
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-extern crate winres;
-
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -1,12 +1,9 @@
-extern crate serde_json;
-
+use mullvad_types::account::AccountToken;
 use std::{
     fs::File,
     io,
     path::{Path, PathBuf},
 };
-
-use mullvad_types::account::AccountToken;
 
 error_chain! {
     errors {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -6,34 +6,11 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-extern crate chrono;
 #[macro_use]
 extern crate error_chain;
-extern crate futures;
-#[cfg(unix)]
-extern crate libc;
-extern crate log;
-
 #[macro_use]
 extern crate serde;
-extern crate serde_json;
 
-extern crate jsonrpc_core;
-extern crate jsonrpc_ipc_server;
-extern crate jsonrpc_macros;
-extern crate jsonrpc_pubsub;
-extern crate rand;
-extern crate tokio_core;
-extern crate tokio_timer;
-extern crate uuid;
-
-extern crate mullvad_ipc_client;
-extern crate mullvad_paths;
-extern crate mullvad_rpc;
-extern crate mullvad_types;
-extern crate talpid_core;
-extern crate talpid_ipc;
-extern crate talpid_types;
 
 mod account_history;
 mod geoip;

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -1,14 +1,10 @@
-extern crate fern;
-
-use self::fern::{
+use chrono;
+use fern::{
     colors::{Color, ColoredLevelConfig},
     Output,
 };
-use chrono;
 use log;
-
 use std::{fmt, io, path::PathBuf};
-
 use talpid_core::logging::rotate_log;
 
 error_chain! {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -6,20 +6,9 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-extern crate chrono;
-extern crate clap;
 #[macro_use]
 extern crate error_chain;
-#[cfg(unix)]
-extern crate libc;
-extern crate log;
-extern crate log_panics;
-extern crate mullvad_daemon;
-extern crate mullvad_paths;
-extern crate talpid_core;
 
-#[cfg(windows)]
-extern crate windows_service;
 
 use error_chain::ChainedError;
 use log::{debug, error, info, warn};

--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -2,10 +2,8 @@ error_chain! {}
 
 #[cfg(unix)]
 mod platform {
-    extern crate simple_signal;
-
-    use self::simple_signal::Signal;
     use super::Result;
+    use simple_signal::Signal;
 
     pub fn set_shutdown_signal_handler<F>(f: F) -> Result<()>
     where
@@ -21,8 +19,6 @@ mod platform {
 
 #[cfg(windows)]
 mod platform {
-    extern crate ctrlc;
-
     use super::{Result, ResultExt};
 
     pub fn set_shutdown_signal_handler<F>(f: F) -> Result<()>

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -1,4 +1,4 @@
-use cli;
+use crate::cli;
 use error_chain::ChainedError;
 use std::{
     env,
@@ -73,7 +73,7 @@ fn run_service() -> Result<()> {
         .unwrap();
 
     let config = cli::get_config();
-    let result = ::create_daemon(&config).and_then(|daemon| {
+    let result = crate::create_daemon(&config).and_then(|daemon| {
         let shutdown_handle = daemon.shutdown_handle();
 
         // Register monitor that translates `ServiceControl` to Daemon events

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "Privacy preserving and secure VPN client library"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 atty = "0.2"
 duct = "0.11"
 error-chain = "0.12"
 futures = "0.1"
-jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
-jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
+jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 
 libc = "0.2.20"
 log = "0.4"

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -10,41 +10,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-extern crate atty;
-extern crate duct;
-extern crate log;
-
 #[macro_use]
 extern crate error_chain;
-#[cfg(target_os = "linux")]
-extern crate failure;
-extern crate futures;
-#[cfg(unix)]
-extern crate hex;
-#[cfg(unix)]
-extern crate ipnetwork;
-extern crate jsonrpc_core;
-extern crate jsonrpc_macros;
-#[cfg(unix)]
-extern crate lazy_static;
-extern crate libc;
-#[cfg(unix)]
-extern crate nix;
-extern crate shell_escape;
-extern crate tokio_core;
-#[cfg(unix)]
-extern crate tun;
-extern crate uuid;
-#[cfg(target_os = "linux")]
-extern crate which;
-#[cfg(windows)]
-extern crate widestring;
-#[cfg(windows)]
-extern crate winreg;
-
-extern crate openvpn_plugin;
-extern crate talpid_ipc;
-extern crate talpid_types;
 
 #[cfg(windows)]
 mod winnet;

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -1,19 +1,13 @@
-extern crate iproute2;
-extern crate netlink_socket;
-extern crate rtnetlink;
-
-use self::{
-    iproute2::Link,
-    netlink_socket::{Protocol, SocketAddr, TokioSocket},
-    rtnetlink::{
-        LinkFlags, LinkHeader, LinkLayerType, LinkMessage, NetlinkCodec, NetlinkFramed,
-        NetlinkMessage, RtnlMessage,
-    },
-};
 use crate::tunnel_state_machine::TunnelCommand;
 use error_chain::ChainedError;
 use futures::{future::Either, sync::mpsc::UnboundedSender, Future, Stream};
+use iproute2::Link;
 use log::{error, trace, warn};
+use netlink_socket::{Protocol, SocketAddr, TokioSocket};
+use rtnetlink::{
+    LinkFlags, LinkHeader, LinkLayerType, LinkMessage, NetlinkCodec, NetlinkFramed, NetlinkMessage,
+    RtnlMessage,
+};
 use std::{collections::BTreeSet, thread};
 
 error_chain! {

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -3,11 +3,9 @@ extern crate netlink_socket;
 extern crate rtnetlink;
 
 use std::{collections::BTreeSet, thread};
-
 use error_chain::ChainedError;
 use futures::{future::Either, sync::mpsc::UnboundedSender, Future, Stream};
 use log::{error, trace, warn};
-
 use self::{
     iproute2::Link,
     netlink_socket::{Protocol, SocketAddr, TokioSocket},
@@ -16,8 +14,7 @@ use self::{
         NetlinkMessage, RtnlMessage,
     },
 };
-
-use tunnel_state_machine::TunnelCommand;
+use crate::tunnel_state_machine::TunnelCommand;
 
 error_chain! {
     errors {

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -2,10 +2,6 @@ extern crate iproute2;
 extern crate netlink_socket;
 extern crate rtnetlink;
 
-use std::{collections::BTreeSet, thread};
-use error_chain::ChainedError;
-use futures::{future::Either, sync::mpsc::UnboundedSender, Future, Stream};
-use log::{error, trace, warn};
 use self::{
     iproute2::Link,
     netlink_socket::{Protocol, SocketAddr, TokioSocket},
@@ -15,6 +11,10 @@ use self::{
     },
 };
 use crate::tunnel_state_machine::TunnelCommand;
+use error_chain::ChainedError;
+use futures::{future::Either, sync::mpsc::UnboundedSender, Future, Stream};
+use log::{error, trace, warn};
+use std::{collections::BTreeSet, thread};
 
 error_chain! {
     errors {

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -1,6 +1,7 @@
-extern crate system_configuration;
-
-use self::system_configuration::{
+use futures::sync::mpsc::UnboundedSender;
+use log::{debug, trace};
+use std::{sync::mpsc, thread};
+use system_configuration::{
     core_foundation::{
         array::CFArray,
         runloop::{kCFRunLoopCommonModes, CFRunLoop},
@@ -8,10 +9,8 @@ use self::system_configuration::{
     },
     dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder, SCDynamicStoreCallBackContext},
 };
-use futures::sync::mpsc::UnboundedSender;
-use log::{debug, trace};
-use std::{sync::mpsc, thread};
 use tunnel_state_machine::TunnelCommand;
+
 
 const PRIMARY_INTERFACE_KEY: &str = "State:/Network/Global/IPv4";
 

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -1,3 +1,4 @@
+use crate::tunnel_state_machine::TunnelCommand;
 use futures::sync::mpsc::UnboundedSender;
 use log::{debug, trace};
 use std::{sync::mpsc, thread};
@@ -9,7 +10,6 @@ use system_configuration::{
     },
     dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder, SCDynamicStoreCallBackContext},
 };
-use tunnel_state_machine::TunnelCommand;
 
 
 const PRIMARY_INTERFACE_KEY: &str = "State:/Network/Global/IPv4";

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,5 +1,5 @@
-use futures::sync::mpsc::UnboundedSender;
 use crate::tunnel_state_machine::TunnelCommand;
+use futures::sync::mpsc::UnboundedSender;
 
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,5 +1,5 @@
 use futures::sync::mpsc::UnboundedSender;
-use tunnel_state_machine::TunnelCommand;
+use crate::tunnel_state_machine::TunnelCommand;
 
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -6,6 +6,7 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+use crate::tunnel_state_machine::TunnelCommand;
 use futures::sync::mpsc::UnboundedSender;
 use log::debug;
 use std::{
@@ -15,7 +16,6 @@ use std::{
     ptr, thread,
     time::Duration,
 };
-use tunnel_state_machine::TunnelCommand;
 use winapi::{
     shared::{
         basetsd::LONG_PTR,

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -6,9 +6,17 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-extern crate winapi;
-
-use self::winapi::{
+use futures::sync::mpsc::UnboundedSender;
+use log::debug;
+use std::{
+    ffi::c_void,
+    mem::zeroed,
+    os::windows::io::{IntoRawHandle, RawHandle},
+    ptr, thread,
+    time::Duration,
+};
+use tunnel_state_machine::TunnelCommand;
+use winapi::{
     shared::{
         basetsd::LONG_PTR,
         minwindef::{DWORD, LPARAM, LRESULT, UINT, WPARAM},
@@ -28,16 +36,6 @@ use self::winapi::{
         },
     },
 };
-use futures::sync::mpsc::UnboundedSender;
-use log::debug;
-use std::{
-    ffi::c_void,
-    mem::zeroed,
-    os::windows::io::{IntoRawHandle, RawHandle},
-    ptr, thread,
-    time::Duration,
-};
-use tunnel_state_machine::TunnelCommand;
 
 const CLASS_NAME: &[u8] = b"S\0T\0A\0T\0I\0C\0\0\0";
 const REQUEST_THREAD_SHUTDOWN: UINT = WM_USER + 1;

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -1,18 +1,15 @@
 use duct;
-extern crate os_pipe;
 
 use super::stoppable_process::StoppableProcess;
+use atty;
+use os_pipe::{pipe, PipeWriter};
+use shell_escape;
 use std::{
     ffi::{OsStr, OsString},
-    fmt,
+    fmt, io,
     path::{Path, PathBuf},
     sync::Mutex,
 };
-
-use self::os_pipe::{pipe, PipeWriter};
-use atty;
-use shell_escape;
-use std::io;
 use talpid_types::net;
 
 static BASE_ARGUMENTS: &[&[&str]] = &[

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -1,16 +1,14 @@
-extern crate resolv_conf;
-
 mod network_manager;
 mod resolvconf;
 mod static_resolv_conf;
 mod systemd_resolved;
 
-use std::{env, fmt, net::IpAddr, path::Path};
-
 use self::{
     network_manager::NetworkManager, resolvconf::Resolvconf, static_resolv_conf::StaticResolvConf,
-    systemd_resolved::SystemdResolved,
 };
+use std::{env, fmt, net::IpAddr, path::Path};
+use systemd_resolved::SystemdResolved;
+
 
 const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 

--- a/talpid-core/src/security/linux/dns/network_manager.rs
+++ b/talpid-core/src/security/linux/dns/network_manager.rs
@@ -1,20 +1,16 @@
-extern crate dbus;
-
-use std::{collections::HashMap, net::IpAddr};
-
-use self::dbus::{
+use dbus::{
     arg::{RefArg, Variant},
     stdintf::*,
     BusType,
 };
-
+use error_chain::ChainedError;
 use std::{
+    collections::HashMap,
     fs::File,
     io::{BufRead, BufReader},
+    net::IpAddr,
     path::Path,
 };
-
-use error_chain::ChainedError;
 
 error_chain! {
     errors {

--- a/talpid-core/src/security/linux/dns/static_resolv_conf.rs
+++ b/talpid-core/src/security/linux/dns/static_resolv_conf.rs
@@ -1,18 +1,13 @@
-extern crate notify;
-
+use super::RESOLV_CONF_PATH;
+use error_chain::ChainedError;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use resolv_conf::{Config, ScopedIp};
 use std::{
     fs, io,
     net::IpAddr,
     sync::{mpsc, Arc, Mutex, MutexGuard},
     thread,
 };
-
-use self::notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use super::{
-    resolv_conf::{Config, ScopedIp},
-    RESOLV_CONF_PATH,
-};
-use error_chain::ChainedError;
 
 const RESOLV_CONF_BACKUP_PATH: &str = "/etc/resolv.conf.mullvadbackup";
 

--- a/talpid-core/src/security/linux/dns/systemd_resolved.rs
+++ b/talpid-core/src/security/linux/dns/systemd_resolved.rs
@@ -1,5 +1,8 @@
-extern crate dbus;
-
+use super::{super::iface_index, RESOLV_CONF_PATH};
+use dbus::{
+    arg::RefArg, stdintf::*, BusType, Interface, Member, Message, MessageItem, MessageItemArray,
+    Signature,
+};
 use error_chain::ChainedError;
 use lazy_static::lazy_static;
 use libc::{AF_INET, AF_INET6};
@@ -8,13 +11,6 @@ use std::{
     net::{IpAddr, Ipv4Addr},
     path::Path,
 };
-
-use self::dbus::{
-    arg::RefArg, stdintf::*, BusType, Interface, Member, Message, MessageItem, MessageItemArray,
-    Signature,
-};
-
-use super::{super::iface_index, resolv_conf, RESOLV_CONF_PATH};
 
 
 error_chain! {

--- a/talpid-core/src/security/linux/mod.rs
+++ b/talpid-core/src/security/linux/mod.rs
@@ -1,16 +1,13 @@
-extern crate mnl;
-extern crate nftnl;
-
-use self::nftnl::{
-    expr::{self, Verdict},
-    nft_expr, nft_expr_bitwise, nft_expr_cmp, nft_expr_ct, nft_expr_meta, nft_expr_payload, Batch,
-    Chain, FinalizedBatch, ProtoFamily, Rule, Table,
-};
 use super::{NetworkSecurityT, SecurityPolicy};
 use crate::tunnel;
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use libc;
+use nftnl::{
+    expr::{self, Verdict},
+    nft_expr, nft_expr_bitwise, nft_expr_cmp, nft_expr_ct, nft_expr_meta, nft_expr_payload, Batch,
+    Chain, FinalizedBatch, ProtoFamily, Rule, Table,
+};
 use std::{
     env,
     ffi::CString,
@@ -18,6 +15,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
 };
 use talpid_types::net::{Endpoint, TransportProtocol};
+
 
 mod dns;
 pub use self::dns::{DnsMonitor, Error as DnsError};

--- a/talpid-core/src/security/macos/dns.rs
+++ b/talpid-core/src/security/macos/dns.rs
@@ -1,6 +1,14 @@
-extern crate system_configuration;
-
-use self::system_configuration::{
+use error_chain::ChainedError;
+use log::{debug, trace};
+use std::{
+    collections::HashMap,
+    fmt,
+    net::IpAddr,
+    path::Path,
+    sync::{mpsc, Arc, Mutex},
+    thread,
+};
+use system_configuration::{
     core_foundation::{
         array::CFArray,
         base::{CFType, TCFType, ToVoid},
@@ -11,16 +19,6 @@ use self::system_configuration::{
     },
     dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder, SCDynamicStoreCallBackContext},
     sys::schema_definitions::kSCPropNetDNSServerAddresses,
-};
-use error_chain::ChainedError;
-use log::{debug, trace};
-use std::{
-    collections::HashMap,
-    fmt,
-    net::IpAddr,
-    path::Path,
-    sync::{mpsc, Arc, Mutex},
-    thread,
 };
 
 error_chain! {

--- a/talpid-core/src/security/macos/mod.rs
+++ b/talpid-core/src/security/macos/mod.rs
@@ -1,15 +1,12 @@
-extern crate pfctl;
-extern crate tokio_core;
-
-use self::pfctl::FilterRuleAction;
 use super::{NetworkSecurityT, SecurityPolicy};
+use pfctl::FilterRuleAction;
 use std::{env, net::Ipv4Addr};
 use talpid_types::net;
 
 mod dns;
 pub use self::dns::{DnsMonitor, Error as DnsError};
 
-pub use self::pfctl::Error;
+pub use pfctl::Error;
 
 type Result<T> = ::std::result::Result<T, Error>;
 

--- a/talpid-core/src/security/windows/mod.rs
+++ b/talpid-core/src/security/windows/mod.rs
@@ -1,12 +1,11 @@
 use std::{net::IpAddr, ptr};
 
+use self::winfw::*;
+use super::{NetworkSecurityT, SecurityPolicy};
+use crate::winnet;
 use log::{debug, error, trace};
 use talpid_types::net::Endpoint;
 use widestring::WideCString;
-
-use self::winfw::*;
-use super::{NetworkSecurityT, SecurityPolicy};
-use winnet;
 
 #[macro_use]
 mod ffi;
@@ -144,7 +143,7 @@ impl NetworkSecurity {
         &mut self,
         endpoint: &Endpoint,
         winfw_settings: &WinFwSettings,
-        tunnel_metadata: &::tunnel::TunnelMetadata,
+        tunnel_metadata: &crate::tunnel::TunnelMetadata,
     ) -> Result<()> {
         trace!("Applying 'connected' firewall policy");
         let ip_str = Self::widestring_ip(&endpoint.address.ip());
@@ -189,11 +188,10 @@ impl NetworkSecurity {
 
 #[allow(non_snake_case)]
 mod winfw {
+    use super::{ErrorKind, Result};
+    use crate::winnet;
     use libc;
     use talpid_types::net::TransportProtocol;
-
-    use super::{ErrorKind, Result};
-    use winnet;
 
     #[repr(C)]
     pub struct WinFwRelay {

--- a/talpid-core/src/security/windows/system_state.rs
+++ b/talpid-core/src/security/windows/system_state.rs
@@ -59,8 +59,6 @@ impl SystemStateWriter {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
-
     use super::*;
 
     #[test]

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     ffi::OsString,
-    fs, io,
+    io,
     net::IpAddr,
     path::{Path, PathBuf},
 };
@@ -291,7 +291,7 @@ fn is_ipv6_enabled_in_os() -> bool {
                 (ipv6_disabled_bits & IPV6_DISABLED_ON_TUNNELS_MASK) == 0
             })
             .unwrap_or(true);
-        let enabled_on_tap = ::winnet::get_tap_interface_ipv6_status().unwrap_or(false);
+        let enabled_on_tap = crate::winnet::get_tap_interface_ipv6_status().unwrap_or(false);
 
         if !globally_enabled {
             log::debug!("IPv6 disabled in tunnel interfaces");
@@ -304,7 +304,7 @@ fn is_ipv6_enabled_in_os() -> bool {
     }
     #[cfg(target_os = "linux")]
     {
-        fs::read_to_string("/proc/sys/net/ipv6/conf/all/disable_ipv6")
+        std::fs::read_to_string("/proc/sys/net/ipv6/conf/all/disable_ipv6")
             .map(|disable_ipv6| disable_ipv6.trim() == "0")
             .unwrap_or(false)
     }

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -1,9 +1,13 @@
 use super::TunnelEvent;
-use crate::process::{
-    openvpn::{OpenVpnCommand, OpenVpnProcHandle},
-    stoppable_process::StoppableProcess,
+use crate::{
+    mktemp,
+    process::{
+        openvpn::{OpenVpnCommand, OpenVpnProcHandle},
+        stoppable_process::StoppableProcess,
+    },
 };
-use mktemp;
+#[cfg(target_os = "linux")]
+use failure::ResultExt as FailureResultExt;
 use std::{
     collections::HashMap,
     ffi::OsString,
@@ -20,9 +24,6 @@ use std::{
 };
 use talpid_ipc;
 use talpid_types::net::{Endpoint, OpenVpnProxySettings, TunnelOptions};
-
-#[cfg(target_os = "linux")]
-use failure::ResultExt as FailureResultExt;
 #[cfg(target_os = "linux")]
 use which;
 
@@ -526,10 +527,11 @@ mod event_server {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::{Path, PathBuf};
-
-    use mktemp::TempFile;
-    use std::sync::{Arc, Mutex};
+    use crate::mktemp::TempFile;
+    use std::{
+        path::{Path, PathBuf},
+        sync::{Arc, Mutex},
+    };
 
     #[derive(Debug, Default, Clone)]
     struct TestOpenVpnBuilder {

--- a/talpid-core/src/tunnel_state_machine/macros.rs
+++ b/talpid-core/src/tunnel_state_machine/macros.rs
@@ -10,9 +10,9 @@
 macro_rules! try_handle_event {
     ($same_state:expr, $event:expr) => {
         match $event {
-            Ok(crate::futures::Async::Ready(Some(event))) => Ok(event),
-            Ok(crate::futures::Async::Ready(None)) => Err(None),
-            Ok(crate::futures::Async::NotReady) => {
+            Ok(futures::Async::Ready(Some(event))) => Ok(event),
+            Ok(futures::Async::Ready(None)) => Err(None),
+            Ok(futures::Async::NotReady) => {
                 return crate::tunnel_state_machine::EventConsequence::NoEvents($same_state);
             }
             Err(error) => Err(Some(error)),

--- a/talpid-ipc/Cargo.toml
+++ b/talpid-ipc/Cargo.toml
@@ -4,15 +4,16 @@ version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>"]
 description = "IPC client and server for talpid"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 error-chain = "0.12"
 serde = "1.0"
 serde_json = "1.0"
 log = "0.4"
-jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
-jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
-jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
+jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 tokio = "0.1"
 futures = "0.1"
 
@@ -22,7 +23,7 @@ jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs", rev
 [dev-dependencies]
 assert_matches = "1.0"
 env_logger = "0.5"
-jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "make-ipc-server-concurrent-part-deux" }
+jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 uuid = { version = "0.6", features = ["v4"] }
 futures = "0.1.23"
 tokio = "0.1"

--- a/talpid-ipc/src/lib.rs
+++ b/talpid-ipc/src/lib.rs
@@ -11,17 +11,6 @@
 #[macro_use]
 extern crate error_chain;
 
-extern crate serde;
-extern crate serde_json;
-
-extern crate jsonrpc_core;
-extern crate jsonrpc_ipc_server;
-extern crate jsonrpc_pubsub;
-
-extern crate futures;
-extern crate jsonrpc_client_core;
-extern crate jsonrpc_client_ipc;
-extern crate tokio;
 
 use futures::Future;
 use std::thread;

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -1,18 +1,6 @@
 // TODO fix these tests on Windows
 #![cfg(not(windows))]
 
-extern crate assert_matches;
-extern crate env_logger;
-extern crate jsonrpc_client_core;
-extern crate jsonrpc_client_ipc;
-extern crate jsonrpc_core;
-extern crate jsonrpc_macros;
-extern crate talpid_ipc;
-extern crate tokio;
-extern crate uuid;
-
-extern crate futures;
-
 use assert_matches::assert_matches;
 use futures::{sync::oneshot, Future};
 


### PR DESCRIPTION
After finally backporting the Rust 2018 compatibility fix for the JSON-RPC crate (https://github.com/mullvad/jsonrpc/pull/1) I was finally able to upgrade the remaining crates to Rust 2018.

So now we can make use of NLL and new macro import style as well as get rid of almost all remaining extern crate statements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/671)
<!-- Reviewable:end -->
