### PR TITLE
Migrate autostart to main

### DIFF
--- a/gui/packages/desktop/src/main/autostart.js
+++ b/gui/packages/desktop/src/main/autostart.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
-import { remote } from 'electron';
+import { app } from 'electron';
 import log from 'electron-log';
 
 const DESKTOP_FILE_NAME = 'mullvad-vpn.desktop';
@@ -16,7 +16,7 @@ const unlinkAsync = promisify(fs.unlink);
 export function getOpenAtLogin() {
   if (process.platform === 'linux') {
     try {
-      const autostartDir = path.join(remote.app.getPath('appData'), 'autostart');
+      const autostartDir = path.join(app.getPath('appData'), 'autostart');
       const autostartFilePath = path.join(autostartDir, DESKTOP_FILE_NAME);
 
       fs.accessSync(autostartFilePath);
@@ -27,7 +27,7 @@ export function getOpenAtLogin() {
       return false;
     }
   } else {
-    return remote.app.getLoginItemSettings().openAtLogin;
+    return app.getLoginItemSettings().openAtLogin;
   }
 }
 
@@ -35,7 +35,7 @@ export async function setOpenAtLogin(openAtLogin: boolean) {
   if (process.platform === 'linux') {
     try {
       const desktopFilePath = path.join('/usr/share/applications', DESKTOP_FILE_NAME);
-      const autostartDir = path.join(remote.app.getPath('appData'), 'autostart');
+      const autostartDir = path.join(app.getPath('appData'), 'autostart');
       const autostartFilePath = path.join(autostartDir, DESKTOP_FILE_NAME);
 
       if (openAtLogin) {
@@ -48,7 +48,7 @@ export async function setOpenAtLogin(openAtLogin: boolean) {
       log.error(`Failed to set auto-start: ${error.message}`);
     }
   } else {
-    remote.app.setLoginItemSettings({ openAtLogin });
+    app.setLoginItemSettings({ openAtLogin });
   }
 }
 

--- a/gui/packages/desktop/src/main/autostart.js
+++ b/gui/packages/desktop/src/main/autostart.js
@@ -23,7 +23,7 @@ export function getOpenAtLogin() {
 
       return true;
     } catch (error) {
-      log.debug(`Failed to check autostart file: ${error.message}`);
+      log.error(`Failed to check autostart file: ${error.message}`);
       return false;
     }
   } else {
@@ -67,7 +67,7 @@ const createDirIfNecessary = async (directory: string) => {
     try {
       await unlinkAsync(directory);
     } catch (error) {
-      log.debug(`Failed to remove path before creating a directory for it: ${error.message}`);
+      log.error(`Failed to remove path before creating a directory for it: ${error.message}`);
     }
 
     return mkdirAsync(directory);

--- a/gui/packages/desktop/src/renderer/app.js
+++ b/gui/packages/desktop/src/renderer/app.js
@@ -171,7 +171,7 @@ export default class AppRenderer {
     const actions = this._reduxActions;
     actions.account.startLogin(accountToken);
 
-    log.debug('Logging in');
+    log.info('Logging in');
 
     this._doingLogin = true;
 
@@ -179,7 +179,7 @@ export default class AppRenderer {
       const verification = await this.verifyAccount(accountToken);
 
       if (verification.status === 'deferred') {
-        log.debug(`Failed to get account data, logging in anyway: ${verification.error.message}`);
+        log.warn(`Failed to get account data, logging in anyway: ${verification.error.message}`);
       }
 
       await IpcRendererEventChannel.account.set(accountToken);
@@ -189,7 +189,7 @@ export default class AppRenderer {
         this._memoryHistory.replace('/connect');
 
         try {
-          log.debug('Auto-connecting the tunnel');
+          log.info('Auto-connecting the tunnel');
           await this.connectTunnel();
         } catch (error) {
           log.error(`Failed to auto-connect the tunnel: ${error.message}`);
@@ -389,13 +389,13 @@ export default class AppRenderer {
 
   async _autoConnect() {
     if (process.env.NODE_ENV === 'development') {
-      log.debug('Skip autoconnect in development');
+      log.info('Skip autoconnect in development');
     } else if (this._autoConnected) {
-      log.debug('Skip autoconnect because it was done before');
+      log.info('Skip autoconnect because it was done before');
     } else if (this._settings.accountToken) {
       if (this._guiSettings.autoConnect) {
         try {
-          log.debug('Autoconnect the tunnel');
+          log.info('Autoconnect the tunnel');
 
           await this.connectTunnel();
 
@@ -404,10 +404,10 @@ export default class AppRenderer {
           log.error(`Failed to autoconnect the tunnel: ${error.message}`);
         }
       } else {
-        log.debug('Skip autoconnect because GUI setting is disabled');
+        log.info('Skip autoconnect because GUI setting is disabled');
       }
     } else {
-      log.debug('Skip autoconnect because account token is not set');
+      log.info('Skip autoconnect because account token is not set');
     }
   }
 
@@ -632,7 +632,7 @@ export class AccountDataCache {
 
     const delay = Math.min(2048, 1 << (this._fetchAttempt + 2)) * 1000;
 
-    log.debug(`Failed to fetch account data. Retrying in ${delay} ms`);
+    log.warn(`Failed to fetch account data. Retrying in ${delay} ms`);
 
     this._fetchRetryTimeout = setTimeout(() => {
       this._fetchRetryTimeout = null;

--- a/gui/packages/desktop/src/renderer/components/Preferences.js
+++ b/gui/packages/desktop/src/renderer/components/Preferences.js
@@ -16,13 +16,13 @@ import Switch from './Switch';
 import styles from './PreferencesStyles';
 
 export type PreferencesProps = {
+  autoStart: boolean,
   autoConnect: boolean,
   allowLan: boolean,
   monochromaticIcon: boolean,
   startMinimized: boolean,
   enableMonochromaticIconToggle: boolean,
   enableStartMinimizedToggle: boolean,
-  getAutoStart: () => boolean,
   setAutoStart: (boolean) => void,
   setAutoConnect: (boolean) => void,
   setAllowLan: (boolean) => void,
@@ -31,20 +31,7 @@ export type PreferencesProps = {
   onClose: () => void,
 };
 
-type State = {
-  autoStart: boolean,
-};
-
-export default class Preferences extends Component<PreferencesProps, State> {
-  state = {
-    autoStart: false,
-  };
-
-  constructor(props: PreferencesProps) {
-    super();
-    this.state.autoStart = props.getAutoStart();
-  }
-
+export default class Preferences extends Component<PreferencesProps> {
   render() {
     return (
       <Layout>
@@ -65,7 +52,7 @@ export default class Preferences extends Component<PreferencesProps, State> {
                   <View style={styles.preferences__content}>
                     <Cell.Container>
                       <Cell.Label>Launch app on start-up</Cell.Label>
-                      <Switch isOn={this.state.autoStart} onChange={this._onChangeAutoStart} />
+                      <Switch isOn={this.props.autoStart} onChange={this._onChangeAutoStart} />
                     </Cell.Container>
                     <View style={styles.preferences__separator} />
 
@@ -108,8 +95,6 @@ export default class Preferences extends Component<PreferencesProps, State> {
 
   _onChangeAutoStart = (autoStart: boolean) => {
     this.props.setAutoStart(autoStart);
-    // TODO: Handle failure to set auto-start
-    this.setState({ autoStart });
   };
 }
 

--- a/gui/packages/desktop/src/renderer/containers/PreferencesPage.js
+++ b/gui/packages/desktop/src/renderer/containers/PreferencesPage.js
@@ -5,12 +5,12 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { goBack } from 'connected-react-router';
 import Preferences from '../components/Preferences';
-import { getOpenAtLogin } from '../lib/autostart';
 
 import type { ReduxState, ReduxDispatch } from '../redux/store';
 import type { SharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: ReduxState) => ({
+  autoStart: state.settings.autoStart,
   autoConnect: state.settings.guiSettings.autoConnect,
   allowLan: state.settings.allowLan,
   monochromaticIcon: state.settings.guiSettings.monochromaticIcon,
@@ -22,9 +22,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: SharedRouteProps) =>
   return {
     onClose: () => {
       history.goBack();
-    },
-    getAutoStart: () => {
-      return getOpenAtLogin();
     },
     setAutoStart: async (autoStart) => {
       try {

--- a/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
+++ b/gui/packages/desktop/src/renderer/lib/daemon-rpc-proxy.js
@@ -130,8 +130,8 @@ export default class DaemonRpcProxy implements DaemonRpcProtocol {
     return this._sendMessage('setOpenVpnMssfix', mssfix);
   }
 
-  setAutoConnect(autoConnect: boolean): Promise<void> {
-    return this._sendMessage('setAutoConnect', autoConnect);
+  setAutoConnect(_autoConnect: boolean): Promise<void> {
+    throw new Error('Do not call this method.');
   }
 
   connectTunnel(): Promise<void> {

--- a/gui/packages/desktop/src/renderer/redux/settings/actions.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/actions.js
@@ -43,6 +43,11 @@ export type UpdateOpenVpnMssfixAction = {
   mssfix: ?number,
 };
 
+export type UpdateAutoStartAction = {
+  type: 'UPDATE_AUTO_START',
+  autoStart: boolean,
+};
+
 export type SettingsAction =
   | UpdateGuiSettingsAction
   | UpdateRelayAction
@@ -51,7 +56,8 @@ export type SettingsAction =
   | UpdateAllowLanAction
   | UpdateEnableIpv6Action
   | UpdateBlockWhenDisconnectedAction
-  | UpdateOpenVpnMssfixAction;
+  | UpdateOpenVpnMssfixAction
+  | UpdateAutoStartAction;
 
 function updateGuiSettings(guiSettings: GuiSettingsState): UpdateGuiSettingsAction {
   return {
@@ -113,6 +119,13 @@ function updateOpenVpnMssfix(mssfix: ?number): UpdateOpenVpnMssfixAction {
   };
 }
 
+function updateAutoStart(autoStart: boolean): UpdateAutoStartAction {
+  return {
+    type: 'UPDATE_AUTO_START',
+    autoStart,
+  };
+}
+
 export default {
   updateGuiSettings,
   updateRelay,
@@ -122,4 +135,5 @@ export default {
   updateEnableIpv6,
   updateBlockWhenDisconnected,
   updateOpenVpnMssfix,
+  updateAutoStart,
 };

--- a/gui/packages/desktop/src/renderer/redux/settings/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/settings/reducers.js
@@ -45,6 +45,7 @@ export type RelayLocationRedux = {
 };
 
 export type SettingsReduxState = {
+  autoStart: boolean,
   guiSettings: GuiSettingsState,
   relaySettings: RelaySettingsRedux,
   relayLocations: Array<RelayLocationRedux>,
@@ -57,6 +58,7 @@ export type SettingsReduxState = {
 };
 
 const initialState: SettingsReduxState = {
+  autoStart: false,
   guiSettings: {
     autoConnect: true,
     monochromaticIcon: false,
@@ -132,6 +134,12 @@ export default function(
           ...state.openVpn,
           mssfix: action.mssfix,
         },
+      };
+
+    case 'UPDATE_AUTO_START':
+      return {
+        ...state,
+        autoStart: action.autoStart,
       };
 
     default:

--- a/gui/packages/desktop/src/shared/ipc-event-channel.js
+++ b/gui/packages/desktop/src/shared/ipc-event-channel.js
@@ -17,6 +17,7 @@ import type {
 
 export type AppStateSnapshot = {
   isConnected: boolean,
+  autoStart: boolean,
   tunnelState: TunnelStateTransition,
   settings: Settings,
   location: ?Location,
@@ -66,6 +67,15 @@ interface AccountHistoryMethods {
   removeItem(token: AccountToken): Promise<void>;
 }
 
+interface AutoStartMethods {
+  listen(fn: (boolean) => void): void;
+  set(autoStart: boolean): Promise<void>;
+}
+
+interface AutoStartHandlers {
+  handleSet: ((boolean) => Promise<void>) => void;
+}
+
 /// Events names
 
 const DAEMON_CONNECTED = 'daemon-connected';
@@ -76,16 +86,22 @@ const LOCATION_CHANGED = 'location-changed';
 const RELAYS_CHANGED = 'relays-changed';
 const CURRENT_VERSION_CHANGED = 'current-version-changed';
 const UPGRADE_VERSION_CHANGED = 'upgrade-version-changed';
-const GUI_SETTINGS_CHANGED = 'gui-settings-changed';
 
+const GUI_SETTINGS_CHANGED = 'gui-settings-changed';
 const SET_AUTO_CONNECT = 'set-auto-connect';
 const SET_MONOCHROMATIC_ICON = 'set-monochromatic-icon';
 const SET_START_MINIMIZED = 'set-start-minimized';
+
 const GET_APP_STATE = 'get-app-state';
+
 const GET_ACCOUNT_HISTORY = 'get-account-history';
 const REMOVE_ACCOUNT_HISTORY_ITEM = 'remove-account-history-item';
+
 const SET_ACCOUNT = 'set-account';
 const UNSET_ACCOUNT = 'unset-account';
+
+const AUTO_START_CHANGED = 'auto-start-changed';
+const SET_AUTO_START = 'set-auto-start';
 
 /// Typed IPC event channel
 ///
@@ -137,6 +153,11 @@ export class IpcRendererEventChannel {
     setAutoConnect: set(SET_AUTO_CONNECT),
     setMonochromaticIcon: set(SET_MONOCHROMATIC_ICON),
     setStartMinimized: set(SET_START_MINIMIZED),
+  };
+
+  static autoStart: Receiver<boolean> & AutoStartMethods = {
+    listen: listen(AUTO_START_CHANGED),
+    set: requestSender(SET_AUTO_START),
   };
 
   static account: AccountMethods = {
@@ -196,6 +217,11 @@ export class IpcMainEventChannel {
     handleAutoConnect: handler(SET_AUTO_CONNECT),
     handleMonochromaticIcon: handler(SET_MONOCHROMATIC_ICON),
     handleStartMinimized: handler(SET_START_MINIMIZED),
+  };
+
+  static autoStart: Sender<boolean> & AutoStartHandlers = {
+    notify: sender(AUTO_START_CHANGED),
+    handleSet: requestHandler(SET_AUTO_START),
   };
 
   static account: AccountHandlers = {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR moves the auto-start management from the renderer to main process.

### Why

The main process has a direct access to `GuiSettings`, `DaemonRpc`, and Electron APIs so it's reasonable to maintain the daemon's auto-connect logic in the main process since it depends on GUI settings too.

### How

1. Add a method to manipulate and get notified on changes to the autostart function
2. Add the `autoStart` field to the `SettingsReduxState`.
3. Move the `set_auto_connect` call to daemon and the corresponding logic to the main process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/676)
<!-- Reviewable:end -->
