### PR TITLE
Handle set security policy errors as being insecure

### DIFF
--- a/gui/packages/desktop/src/main/index.js
+++ b/gui/packages/desktop/src/main/index.js
@@ -693,7 +693,12 @@ const ApplicationMain = {
         return 'securing';
 
       case 'blocked':
-        return 'securing';
+        switch (tunnelState.details.reason) {
+          case 'set_security_policy_error':
+            return 'unsecured';
+          default:
+            return 'securing';
+        }
 
       case 'disconnecting':
         return 'securing';

--- a/gui/packages/desktop/src/main/notification-controller.js
+++ b/gui/packages/desktop/src/main/notification-controller.js
@@ -26,7 +26,14 @@ export default class NotificationController {
         this._showTunnelStateNotification('Unsecured');
         break;
       case 'blocked':
-        this._showTunnelStateNotification('Blocked all connections');
+        switch (tunnelState.details.reason) {
+          case 'set_security_policy_error':
+            this._showTunnelStateNotification('Unsecured');
+            break;
+          default:
+            this._showTunnelStateNotification('Blocked all connections');
+            break;
+        }
         break;
       case 'disconnecting':
         switch (tunnelState.details) {

--- a/gui/packages/desktop/src/renderer/components/Connect.js
+++ b/gui/packages/desktop/src/renderer/components/Connect.js
@@ -123,8 +123,14 @@ export default class Connect extends Component<Props> {
     switch (status.state) {
       case 'connecting':
       case 'connected':
-      case 'blocked':
         return 'secure';
+      case 'blocked':
+        switch (status.details.reason) {
+          case 'set_security_policy_error':
+            return 'unsecure';
+          default:
+            return 'secure';
+        }
       case 'disconnected':
         return 'unsecure';
       case 'disconnecting':
@@ -221,8 +227,14 @@ export default class Connect extends Component<Props> {
         return HeaderBarStyle.error;
       case 'connecting':
       case 'connected':
-      case 'blocked':
         return HeaderBarStyle.success;
+      case 'blocked':
+        switch (status.details.reason) {
+          case 'set_security_policy_error':
+            return HeaderBarStyle.error;
+          default:
+            return HeaderBarStyle.success;
+        }
       case 'disconnecting':
         switch (status.details) {
           case 'block':

--- a/gui/packages/desktop/src/renderer/components/TunnelControl.js
+++ b/gui/packages/desktop/src/renderer/components/TunnelControl.js
@@ -137,18 +137,31 @@ export default class TunnelControl extends Component<TunnelControlProps> {
 
     let state = this.props.tunnelState.state;
 
-    if (state === 'disconnecting') {
-      switch (this.props.tunnelState.details) {
-        case 'block':
-          state = 'blocked';
-          break;
-        case 'reconnect':
-          state = 'connecting';
-          break;
-        default:
-          state = 'disconnecting';
-          break;
-      }
+    switch (state) {
+      case 'blocked':
+        switch (this.props.tunnelState.details.reason) {
+          case 'set_security_policy_error':
+            state = 'disconnected';
+            break;
+          default:
+            state = 'blocked';
+            break;
+        }
+        break;
+
+      case 'disconnecting':
+        switch (this.props.tunnelState.details) {
+          case 'block':
+            state = 'blocked';
+            break;
+          case 'reconnect':
+            state = 'connecting';
+            break;
+          default:
+            state = 'disconnecting';
+            break;
+        }
+        break;
     }
 
     switch (state) {

--- a/gui/packages/desktop/src/renderer/redux/connection/reducers.js
+++ b/gui/packages/desktop/src/renderer/redux/connection/reducers.js
@@ -58,7 +58,11 @@ export default function(
       };
 
     case 'BLOCKED':
-      return { ...state, status: { state: 'blocked', details: action.reason }, isBlocked: true };
+      return {
+        ...state,
+        status: { state: 'blocked', details: action.reason },
+        isBlocked: action.reason.reason !== 'set_security_policy_error',
+      };
 
     case 'ONLINE':
       return { ...state, isOnline: true };

--- a/talpid-core/src/security/linux/dns/mod.rs
+++ b/talpid-core/src/security/linux/dns/mod.rs
@@ -5,9 +5,9 @@ mod systemd_resolved;
 
 use self::{
     network_manager::NetworkManager, resolvconf::Resolvconf, static_resolv_conf::StaticResolvConf,
+    systemd_resolved::SystemdResolved,
 };
 use std::{env, fmt, net::IpAddr, path::Path};
-use systemd_resolved::SystemdResolved;
 
 
 const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";


### PR DESCRIPTION
Previously any set security policy would be treated as a low priority issue, since there isn't much that can be done. However, when that happens, the user was still shown as being secured, even though that's not the case. This PR changes that, giving a higher priority to the set security policy error, and showing to the user that he is insecure when such error occurs.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
