### PR TITLE
Consider CARGO_TARGET_DIR in build.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@
 .DS_Store
 *.log
 /dist-assets/relays.json
+/dist-assets/mullvad
+/dist-assets/mullvad-daemon
+/dist-assets/problem-report
+/dist-assets/libtalpid_openvpn_plugin.dylib
+/dist-assets/libtalpid_openvpn_plugin.so
+/dist-assets/talpid_openvpn_plugin.dll
+/dist-assets/openvpn
 /windows/**/bin/
 **/.vs/
 *.bak

--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -39,13 +39,13 @@ mac:
     LSUIElement: true
     NSUserNotificationAlertStyle: alert
   extraResources:
-    - from: ../../../target/release/mullvad
+    - from: ../../../dist-assets/mullvad
       to: .
-    - from: ../../../target/release/problem-report
+    - from: ../../../dist-assets/problem-report
       to: .
-    - from: ../../../target/release/mullvad-daemon
+    - from: ../../../dist-assets/mullvad-daemon
       to: .
-    - from: ../../../target/release/libtalpid_openvpn_plugin.dylib
+    - from: ../../../dist-assets/libtalpid_openvpn_plugin.dylib
       to: .
     - from: ../../../dist-assets/binaries/macos/openvpn
       to: .
@@ -77,13 +77,13 @@ win:
     - sha256
   signDlls: true
   extraResources:
-    - from: ../../../target/release/mullvad.exe
+    - from: ../../../dist-assets/mullvad.exe
       to: .
-    - from: ../../../target/release/problem-report.exe
+    - from: ../../../dist-assets/problem-report.exe
       to: .
-    - from: ../../../target/release/mullvad-daemon.exe
+    - from: ../../../dist-assets/mullvad-daemon.exe
       to: .
-    - from: ../../../target/release/talpid_openvpn_plugin.dll
+    - from: ../../../dist-assets/talpid_openvpn_plugin.dll
       to: .
     - from: ../../../windows/winfw/bin/x64-Release/winfw.dll
       to: .
@@ -101,11 +101,11 @@ linux:
   artifactName: MullvadVPN-${version}_${arch}.${ext}
   category: Network
   extraResources:
-    - from: ../../../target/release/problem-report
+    - from: ../../../dist-assets/problem-report
       to: .
-    - from: ../../../target/release/mullvad-daemon
+    - from: ../../../dist-assets/mullvad-daemon
       to: .
-    - from: ../../../target/release/libtalpid_openvpn_plugin.so
+    - from: ../../../dist-assets/libtalpid_openvpn_plugin.so
       to: .
     - from: ../../../dist-assets/binaries/linux/openvpn
       to: .
@@ -119,7 +119,7 @@ deb:
        "--before-remove", "../../../dist-assets/linux/before-remove.sh",
        "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.service",
        "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.conf",
-       "../../../target/release/mullvad=/usr/bin/",
+       "../../../dist-assets/mullvad=/usr/bin/",
        ]
   afterInstall: ../../../dist-assets/linux/after-install.sh
   afterRemove: ../../../dist-assets/linux/after-remove.sh
@@ -130,7 +130,7 @@ rpm:
        "--rpm-posttrans", "../../../dist-assets/linux/post-transaction.sh",
        "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.service",
        "--config-files", "/opt/Mullvad VPN/resources/mullvad-daemon.conf",
-       "../../../target/release/mullvad=/usr/bin/",
+       "../../../dist-assets/mullvad=/usr/bin/",
        ]
   afterInstall: ../../../dist-assets/linux/after-install.sh
   afterRemove: ../../../dist-assets/linux/after-remove.sh


### PR DESCRIPTION
If you set the environment variable `CARGO_TARGET_DIR` then cargo will build into that instead of `./target`. Our `build.sh` script did not account for this, and as such it produces broken installers or crashes if this variable is set.

I usually set this variable. That way I have one global cargo cache in `~/.cargo/build_cache/` and can save a lot of disk space and sometimes compile times. This PR makes it possible to use `build.sh` with such a setup.

Since we have to hardcode the path to the binaries in `electron-builder.yml` and now the location in variable I modified the strip debug symbols step to write the binaries into a known good location. And for binaries/platforms that can't strip I just copy.

This opens up for future possibilities to improve the build script even more, not not be hardcoded to `$CARGO_TARGET_DIR/release/` and thus it could be used to build debug releases etc. But that can come later if we need it.

This PR also includes the OpenVPN plugin in the strip/copy part. So it is being stripped on Linux, where debug symbols can be stripped from shared libraries. Cuts the size in half almost. So that's a good outcome as well.

Git checklist:

I did not feel this justified a changelog entry? The only thing that changed about the actual product is that the `libtalpid_openvpn_plugin.so` file is now being stripped for release builds.
* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/683)
<!-- Reviewable:end -->
