### PR TITLE
Fix the potential reconnect loop in GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the potential reconnect loop in GUI, triggered by the timeout when receiving
+  the initial state of the daemon.
+
 
 ## [2019.1] - 2019-01-29
 This release is identical to 2019.1-beta1


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes the reconnection loop that can be triggered by the timeout in RPC communication when GUI receives the initial snapshot of the daemon state. For instance a failure to receive the daemon's version disconnects the socket, opens the new one and restarts the whole routine.

What essentially was happening is that a call to `connection.close()` to close the socket is asynchronous so apparently it was calling the same event handlers even after the new socket was open which caused a havoc and state inconsistency in JSON RPC transport.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/692)
<!-- Reviewable:end -->
