### PR TITLE
Use `relay_list_v2` RPC to fetch relays.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
@@ -1127,7 +1128,6 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-paths 0.1.0",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ platform:
   - x64
 
 cache:
-  - windows\nsis-plugins\bin
-  - windows\windns\bin
-  - windows\winfw\bin
-  - windows\winroute\bin
-  - .mtime_cache
+  # - windows\nsis-plugins\bin
+  # - windows\windns\bin
+  # - windows\winfw\bin
+  # - windows\winroute\bin
+  # - .mtime_cache
 
 environment:
   global:

--- a/build.sh
+++ b/build.sh
@@ -170,7 +170,7 @@ set -e
 JSONRPC_RESPONSE="$(curl -X POST \
     --fail \
      -H "Content-Type: application/json" \
-     -d '{"jsonrpc": "2.0", "id": "0", "method": "relay_list"}' \
+     -d '{"jsonrpc": "2.0", "id": "0", "method": "relay_list_v2"}' \
      https://api.mullvad.net/rpc/)"
 echo $JSONRPC_RESPONSE | node -e "$JSONRPC_CODE" >  dist-assets/relays.json
 

--- a/gui/packages/desktop/src/main/daemon-rpc.ts
+++ b/gui/packages/desktop/src/main/daemon-rpc.ts
@@ -94,12 +94,19 @@ const relaySettingsSchema = oneOf(
         ),
       ),
       tunnel: constraint(
-        partialObject({
-          openvpn: partialObject({
-            port: constraint(number),
-            protocol: constraint(enumeration('udp', 'tcp')),
+        oneOf(
+          object({
+            openvpn: partialObject({
+              port: constraint(number),
+              protocol: constraint(enumeration('udp', 'tcp')),
+            }),
           }),
-        }),
+          object({
+            wireguard: partialObject({
+              port: constraint(number),
+            }),
+          }),
+        ),
       ),
     }),
   }),

--- a/gui/packages/desktop/src/renderer/app.tsx
+++ b/gui/packages/desktop/src/renderer/app.tsx
@@ -319,9 +319,18 @@ export default class AppRenderer {
         payload.port = 'any';
         payload.protocol = 'any';
       } else {
-        const { port, protocol } = tunnel.only.openvpn;
-        payload.port = port === 'any' ? port : port.only;
-        payload.protocol = protocol === 'any' ? protocol : protocol.only;
+        const constraints = tunnel.only;
+        if ('openvpn' in constraints) {
+          const { port, protocol } = constraints.openvpn;
+          payload.port = port === 'any' ? port : port.only;
+          payload.protocol = protocol === 'any' ? protocol : protocol.only;
+        }
+
+        if ('wireguard' in constraints) {
+          const { port } = constraints.wireguard;
+          payload.port = port === 'any' ? port : port.only;
+          payload.protocol = 'udp';
+        }
       }
 
       actions.settings.updateRelay({

--- a/gui/packages/desktop/src/renderer/lib/relay-settings-builder.ts
+++ b/gui/packages/desktop/src/renderer/lib/relay-settings-builder.ts
@@ -88,7 +88,7 @@ class NormalRelaySettingsBuilder {
           },
         };
       } else if (typeof tunnel === 'object') {
-        const prev = (tunnel.only && tunnel.only.openvpn) || {};
+        const prev = tunnel.only && 'openvpn' in tunnel.only ? tunnel.only.openvpn : {};
         this.payload.tunnel = {
           only: {
             openvpn: { ...prev, ...next },

--- a/gui/packages/desktop/src/shared/daemon-rpc-types.ts
+++ b/gui/packages/desktop/src/shared/daemon-rpc-types.ts
@@ -57,9 +57,11 @@ export interface IOpenVpnConstraints {
   protocol: 'any' | { only: RelayProtocol };
 }
 
-interface ITunnelConstraints<TOpenVpnConstraints> {
-  openvpn: TOpenVpnConstraints;
+export interface IWireguardConstraints {
+  port: 'any' | { only: number };
 }
+
+type TunnelConstraints<OpenVpn, Wireguard> = { wireguard: Wireguard } | { openvpn: OpenVpn };
 
 interface IRelaySettingsNormal<TTunnelConstraints> {
   location:
@@ -107,7 +109,7 @@ export interface IRelaySettingsCustom {
 }
 export type RelaySettings =
   | {
-      normal: IRelaySettingsNormal<ITunnelConstraints<IOpenVpnConstraints>>;
+      normal: IRelaySettingsNormal<TunnelConstraints<IOpenVpnConstraints, IWireguardConstraints>>;
     }
   | {
       customTunnelEndpoint: IRelaySettingsCustom;
@@ -115,8 +117,11 @@ export type RelaySettings =
 
 // types describing the partial update of RelaySettings
 export type RelaySettingsNormalUpdate = Partial<
-  IRelaySettingsNormal<ITunnelConstraints<Partial<IOpenVpnConstraints>>>
+  IRelaySettingsNormal<
+    TunnelConstraints<Partial<IOpenVpnConstraints>, Partial<IWireguardConstraints>>
+  >
 >;
+
 export type RelaySettingsUpdate =
   | {
       normal: RelaySettingsNormalUpdate;

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -27,6 +27,7 @@ jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-f
 jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+ipnetwork = "0.14"
 uuid = { version = "0.6", features = ["v4"] }
 lazy_static = "1.0"
 rand = "0.5"

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -498,7 +498,7 @@ impl RelayListUpdater {
 
         let download_future = self
             .rpc_client
-            .relay_list()
+            .relay_list_v2()
             .map_err(|e| Error::with_chain(e, ErrorKind::DownloadError));
         let relay_list = Timer::default()
             .timeout(download_future, DOWNLOAD_TIMEOUT)

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -122,7 +122,7 @@ jsonrpc_client!(pub struct ProblemReportProxy {
 });
 
 jsonrpc_client!(pub struct RelayListProxy {
-    pub fn relay_list(&mut self) -> RpcRequest<RelayList>;
+    pub fn relay_list_v2(&mut self) -> RpcRequest<RelayList>;
 });
 
 jsonrpc_client!(pub struct AppVersionProxy {

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -14,7 +14,6 @@ error-chain = "0.12"
 log = "0.4"
 regex = "1"
 lazy_static = "1.1.0"
-ipnetwork = "0.14"
 
 talpid-types = { path = "../talpid-types" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-types/src/endpoint.rs
+++ b/mullvad-types/src/endpoint.rs
@@ -1,12 +1,9 @@
-use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt,
-    net::{IpAddr, SocketAddr},
-};
+use std::{fmt, net::IpAddr};
 use talpid_types::net::{wireguard, Endpoint, TransportProtocol};
 
 use crate::relay_list::{OpenVpnEndpointData, WireguardEndpointData};
+
 
 /// Contains server data needed to conenct to a single mullvad endpoint
 #[derive(Debug, Clone)]
@@ -67,45 +64,4 @@ impl fmt::Display for TunnelEndpointData {
             }
         }
     }
-}
-
-impl TunnelEndpointData {
-    pub fn to_mullvad_endpoint(self, host: IpAddr) -> MullvadEndpoint {
-        match self {
-            TunnelEndpointData::OpenVpn(metadata) => {
-                MullvadEndpoint::OpenVpn(Endpoint::new(host, metadata.port, metadata.protocol))
-            }
-            TunnelEndpointData::Wireguard(metadata) => {
-                let peer_config = wireguard::PeerConfig {
-                    public_key: metadata.peer_public_key,
-                    endpoint: SocketAddr::new(host, metadata.port),
-                    allowed_ips: all_of_the_internet(),
-                };
-                MullvadEndpoint::Wireguard {
-                    peer: peer_config,
-                    gateway: metadata.gateway,
-                }
-            }
-        }
-    }
-    pub fn port(&self) -> u16 {
-        match self {
-            TunnelEndpointData::OpenVpn(metadata) => metadata.port,
-            TunnelEndpointData::Wireguard(metadata) => metadata.port,
-        }
-    }
-
-    pub fn transport_protocol(&self) -> TransportProtocol {
-        match self {
-            TunnelEndpointData::OpenVpn(metadata) => metadata.protocol,
-            TunnelEndpointData::Wireguard(_) => TransportProtocol::Udp,
-        }
-    }
-}
-
-pub fn all_of_the_internet() -> Vec<IpNetwork> {
-    vec![
-        "0.0.0.0/0".parse().expect("Failed to parse ipv6 network"),
-        "::0/0".parse().expect("Failed to parse ipv6 network"),
-    ]
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -230,7 +230,13 @@ impl fmt::Display for WireguardConstraints {
 
 impl Match<WireguardEndpointData> for WireguardConstraints {
     fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
-        self.port.matches(&endpoint.port)
+        match self.port {
+            Constraint::Any => true,
+            Constraint::Only(port) => endpoint
+                .port_ranges
+                .iter()
+                .any(|range| (port >= range.0 && port <= range.1)),
+        }
     }
 }
 

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -162,3 +162,11 @@ pub struct GenericTunnelOptions {
     /// forwarded through the tunnel.
     pub enable_ipv6: bool,
 }
+
+/// Returns a vector of IP networks representing all of the internet.
+pub fn all_of_the_internet() -> Vec<ipnetwork::IpNetwork> {
+    vec![
+        "0.0.0.0/0".parse().expect("Failed to parse ipv6 network"),
+        "::0/0".parse().expect("Failed to parse ipv6 network"),
+    ]
+}


### PR DESCRIPTION
This PR achieves 3 things:
- Changes the code to use the newer relay list endpoint so that we can receive data about wireguard relays
- Adjusts the way we use relay constraints so that we can appropriately filter wireguard relay data and construct correct tunnel parameters for both tunnel types
- Adds functionality to the CLI to set wireguard relay constraints

The caveat with the CLI changes is that since the code for managing an wireguard keypairs isn't merged, setting a wireguard relay constraint will always force the daemon into a blocked state since it won't be able to generate wireguard parameters without any keys being set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/693)
<!-- Reviewable:end -->
