### PR TITLE
Fix ts watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /dist-assets/libtalpid_openvpn_plugin.so
 /dist-assets/talpid_openvpn_plugin.dll
 /dist-assets/openvpn
+/dist-assets/openvpn.exe
 /windows/**/bin/
 **/.vs/
 *.bak

--- a/gui/packages/desktop/package.json
+++ b/gui/packages/desktop/package.json
@@ -68,6 +68,7 @@
     "rimraf": "^2.5.4",
     "sinon": "^7.1.1",
     "ts-node": "^7.0.1",
+    "tsc-watch": "^2.1.1",
     "tslint": "^5.12.1",
     "typescript": "^3.3.3"
   },
@@ -75,7 +76,7 @@
     "postinstall": "electron-builder install-app-deps",
     "build": "run-s private:clean private:copy-assets private:compile",
     "lint": "tslint -t stylish -p .",
-    "develop": "cross-env run-s private:copy-assets private:compile:dev && run-p -r private:watch private:serve",
+    "develop": "cross-env run-s private:copy-assets private:watch",
     "test": "electron-mocha --renderer -R spec --require ts-node/register --require-main ts-node/register --require-main \"test/setup/main.ts\" --preload \"test/setup/renderer.ts\" \"test/*.spec.ts\" \"test/**/*.spec.ts\" \"test/**/*.spec.tsx\" || true",
     "pack:mac": "run-s build private:build:mac private:postbuild:mac",
     "pack:win": "run-s build private:build:win",
@@ -89,10 +90,8 @@
     "private:assets:main": "cross-env mkdir -p ./build/assets && cp -R ./assets ./build",
     "private:assets:html": "cross-env mkdir -p ./build/src/renderer && cp ./src/renderer/index.html ./build/src/renderer",
     "private:assets:css": "cross-env mkdir -p ./build/src/renderer/components && cp ./src/renderer/components/*.css ./build/src/renderer/components",
-    "private:watch": "cross-env yarn run private:compile:dev --watch --preserveWatchOutput",
-    "private:serve": "cross-env node scripts/serve.js",
+    "private:watch": "cross-env node \"scripts/serve.js\"",
     "private:compile": "tsc",
-    "private:compile:dev": "tsc --sourceMap",
     "private:clean": "rimraf build"
   }
 }

--- a/gui/packages/desktop/src/main/jsonrpc-client.ts
+++ b/gui/packages/desktop/src/main/jsonrpc-client.ts
@@ -128,7 +128,7 @@ export default class JsonRpcClient<T> extends EventEmitter {
       const transport = this.transport;
 
       transport.onOpen = () => {
-        log.info('ITransport is connected');
+        log.info('Transport is connected');
         this.emit('open');
 
         // Resolve the Promise

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -3308,7 +3308,7 @@ etag@1.8.1, etag@^1.8.1, etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-stream@~3.3.0:
+event-stream@=3.3.4, event-stream@~3.3.0:
   version "3.3.4"
   resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
@@ -5538,6 +5538,11 @@ nise@^1.4.6:
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
 
+node-cleanup@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
+  integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
+
 node-fetch@^1.0.1, node-fetch@^1.3.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -6324,6 +6329,13 @@ ps-tree@^1.1.0:
   integrity sha1-tCGyQUDWID8e08dplrRCewjowBQ=
   dependencies:
     event-stream "~3.3.0"
+
+ps-tree@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
+  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
+  dependencies:
+    event-stream "=3.3.4"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -7510,6 +7522,11 @@ stream-throttle@^0.1.3:
     commander "^2.2.0"
     limiter "^1.0.5"
 
+string-argv@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.1.tgz#66bd5ae3823708eaa1916fa5412703150d4ddfaf"
+  integrity sha512-El1Va5ehZ0XTj3Ekw4WFidXvTmt9SrC0+eigdojgtJMVtPkF0qbBe9fyNSl9eQf+kUHnTSQxdQYzuHfZy8V+DQ==
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -7847,6 +7864,17 @@ ts-node@^7.0.1:
     mkdirp "^0.5.1"
     source-map-support "^0.5.6"
     yn "^2.0.0"
+
+tsc-watch@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tsc-watch/-/tsc-watch-2.1.1.tgz#fdc140c31b496a3c7af7f9793ccea1346cc65069"
+  integrity sha512-YqCmAYV3KXd37L47iQqJAwaJq92u3amPOkQbNsJvm2AdjA4dgX9yT0PBkC8LJNAggJIO93uwi+w26HnH4XP1vQ==
+  dependencies:
+    cross-spawn "^5.1.0"
+    node-cleanup "^2.1.2"
+    ps-tree "^1.2.0"
+    string-argv "^0.1.1"
+    strip-ansi "^4.0.0"
 
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)


### What

This PR fixes the TypeScript watch script that would previously run the file watch along the `tsc --watch` which certainly caused false positives

### How

This PR adds a `tsc-watch` package that provides a programmatic way of detecting the first successful compilation. Once that happens, the `serve.js` starts Electron and initialises BrowserSync.

Additionally the new script forks off two `tsc-watch` instances to watch both `packages/desktop` and `packages/components` and reload the Electron process properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/696)
<!-- Reviewable:end -->
