### PR TITLE
Keep account history up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Line wrap the file at 100 chars.                                              Th
 
 - Fix the potential reconnect loop in GUI, triggered by the timeout when receiving
   the initial state of the daemon.
+- Fix the bug which caused the account token history to remain stale after logout.
 
 #### Linux
 - Fix startup failure when network device with a hardware address that's not a MAC address is

--- a/gui/packages/desktop/scripts/serve.js
+++ b/gui/packages/desktop/scripts/serve.js
@@ -27,13 +27,11 @@ function runElectron(browserSyncUrl) {
     },
     stdio: 'inherit',
   });
-  child.once('close', onCloseElectron);
+  child.once('close', () => {
+    process.exit();
+  });
 
   return child;
-}
-
-function onCloseElectron() {
-  process.exit();
 }
 
 function startBrowserSync() {
@@ -62,7 +60,7 @@ function startBrowserSync() {
       bsync
         .watch(['build/src/config.json', 'build/src/main/**/*', 'build/src/shared/**/*'])
         .on('change', () => {
-          child.removeListener('close', onCloseElectron);
+          child.removeAllListeners('close');
           child.once('close', () => {
             child = runElectron(browserSyncUrl);
           });

--- a/gui/packages/desktop/src/main/window-controller.ts
+++ b/gui/packages/desktop/src/main/window-controller.ts
@@ -213,7 +213,11 @@ export default class WindowController {
     });
   }
 
-  private onDisplayMetricsChanged = (_event: any, _display: Display, changedMetrics: string[]) => {
+  private onDisplayMetricsChanged = (
+    _event: Electron.Event,
+    _display: Display,
+    changedMetrics: string[],
+  ) => {
     if (changedMetrics.includes('workArea') && this.windowValue.isVisible()) {
       this.updatePosition();
       this.notifyUpdateWindowShape();
@@ -237,7 +241,7 @@ export default class WindowController {
     });
   }
 
-  private executeWhenWindowIsReady(closure: () => any) {
+  private executeWhenWindowIsReady(closure: () => void) {
     if (this.isWindowReady) {
       closure();
     } else {

--- a/gui/packages/desktop/src/renderer/components/ConnectStyles.tsx
+++ b/gui/packages/desktop/src/renderer/components/ConnectStyles.tsx
@@ -53,6 +53,7 @@ export default {
   error_message: Styles.createTextStyle({
     fontFamily: 'Open Sans',
     fontSize: 13,
+    lineHeight: 20,
     fontWeight: '600',
     color: colors.white,
     marginBottom: 24,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR fixes the omission which caused the account token history to remain stale even after logout.

### Why

As it was previously reported, switching the accounts didn't trigger an update for the account history, so upon logout, users would end up with the old list of account tokens on Login view.

### How

This PR moves the account history management to the main process and introduces the additional management around account history making it more transparent for the renderer process.

The main process now updates the account history when:
1. New account token is being set or unset
1. The account token is being removed from the history

Each of the aforementioned events triggers the main process to update the account history and deliver the received account history to the renderer process via IPC event.

Additionally this PR fixes a few other tiny things and fixes the `serve.js` script which mistakenly didn't remove some of the `close` event handlers on the Electron subprocess causing the entire watch script to quit in certain scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/699)
<!-- Reviewable:end -->
