### PR TITLE
Reset DNS on daemon start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Line wrap the file at 100 chars.                                              Th
 
 - Fix the potential reconnect loop in GUI, triggered by the timeout when receiving
   the initial state of the daemon.
+- The daemon will again try and rest the DNS configuration on startup.
 
 #### Linux
 - Fix startup failure when network device with a hardware address that's not a MAC address is

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -35,7 +35,7 @@ const NM_TOP_OBJECT: &str = "org.freedesktop.NetworkManager";
 const NM_DNS_MANAGER: &str = "org.freedesktop.NetworkManager.DnsManager";
 const NM_DNS_MANAGER_PATH: &str = "/org/freedesktop/NetworkManager/DnsManager";
 const NM_OBJECT_PATH: &str = "/org/freedesktop/NetworkManager";
-const RPC_TIMEOUT_MS: i32 = 1000;
+const RPC_TIMEOUT_MS: i32 = 3000;
 const GLOBAL_DNS_CONF_KEY: &str = "GlobalDnsConfiguration";
 const RC_MANAGEMENT_MODE_KEY: &str = "RcManager";
 

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -182,7 +182,10 @@ impl TunnelStateMachine {
         commands: mpsc::UnboundedReceiver<TunnelCommand>,
     ) -> Result<Self> {
         let firewall = Firewall::new().chain_err(|| ErrorKind::FirewallError)?;
-        let dns_monitor = DnsMonitor::new(cache_dir).chain_err(|| ErrorKind::DnsMonitorError)?;
+        let mut dns_monitor = DnsMonitor::new(cache_dir).chain_err(|| ErrorKind::DnsMonitorError)?;
+        if let Err(e) = dns_monitor.reset() {
+            log::error!("Failed to reset DNS on startup - {}", e.display_chain());
+        }
         let mut shared_values = SharedTunnelStateValues {
             firewall,
             dns_monitor,


### PR DESCRIPTION
I've made the daemon attempt to reset the DNS configuration on startup of the daemon to have a better user experience. I've also bumped the network manager RPC timeout, since I see it failing far more often when using wireguard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/700)
<!-- Reviewable:end -->
