### PR TITLE
Bump network manager timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,14 @@ Line wrap the file at 100 chars.                                              Th
 - Fix startup failure when network device with a hardware address that's not a MAC address is
   present.
 
+### Changed
+#### Linux
+- Increased `NetworkManager` DBus RPC timeout from 1 second to 3 seconds.
+
+
 ## [2019.1] - 2019-01-29
 This release is identical to 2019.1-beta1
+
 
 
 ## [2019.1-beta1] - 2019-01-25

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -35,7 +35,7 @@ const NM_TOP_OBJECT: &str = "org.freedesktop.NetworkManager";
 const NM_DNS_MANAGER: &str = "org.freedesktop.NetworkManager.DnsManager";
 const NM_DNS_MANAGER_PATH: &str = "/org/freedesktop/NetworkManager/DnsManager";
 const NM_OBJECT_PATH: &str = "/org/freedesktop/NetworkManager";
-const RPC_TIMEOUT_MS: i32 = 1000;
+const RPC_TIMEOUT_MS: i32 = 3000;
 const GLOBAL_DNS_CONF_KEY: &str = "GlobalDnsConfiguration";
 const RC_MANAGEMENT_MODE_KEY: &str = "RcManager";
 


### PR DESCRIPTION
Increased the NetworkManager RPC timeout from 1 second to 3 seconds, since it seems that NetworkManager can't keep up with wireguard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/701)
<!-- Reviewable:end -->
