### PR TITLE
Refactor tunnel errors to fix missing TAP adapter error handling

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -14,10 +14,6 @@ const PING_TIMEOUT: u16 = 5;
 
 error_chain! {
     errors {
-        /// Config error
-        ConfigError{
-            description("Invalid configuration")
-        }
         /// Failed to setup a tunnel device
         SetupTunnelDeviceError {
             description("Failed to create tunnel device")
@@ -41,10 +37,6 @@ error_chain! {
         /// Tunnel interface name contained null bytes
         InterfaceNameError {
             display("Tunnel interface name contains null bytes")
-        }
-        /// No private key supplied
-        NoKeyError {
-            display("Config has no keys")
         }
         /// Pinging timed out
         PingTimeoutError {


### PR DESCRIPTION
We rely on matching on the error returning by the `OpenVpnTunnelMonitor` to detect if there was an error with the TAP adapter, and handle it especially to avoid unnecessary reconnection loops. Recent changes introduced a `TunnelMonitoringError` to abstract away the difference between OpenVPN and Wireguard errors. This introduced a bug where TAP adapter problems were no longer handled as a separate case.

This PR attempts to fix this by refactoring some errors in the `talpid_core::tunnel` crate. Abstract error variants were replaced with more specific ones, and some unused error variants were removed.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/702)
<!-- Reviewable:end -->
