### PR TITLE
Fix the sslocal bin path in electron builder on Linux

### DIFF
--- a/gui/packages/desktop/electron-builder.yml
+++ b/gui/packages/desktop/electron-builder.yml
@@ -49,10 +49,10 @@ mac:
       to: .
     - from: ../../../dist-assets/binaries/macos/openvpn
       to: .
-    - from: ../../../dist-assets/uninstall_macos.sh
-      to: ./uninstall.sh
     - from: ../../../dist-assets/binaries/macos/sslocal
       to: .
+    - from: ../../../dist-assets/uninstall_macos.sh
+      to: ./uninstall.sh
 
 pkg:
   allowAnywhere: false
@@ -113,11 +113,11 @@ linux:
       to: .
     - from: ../../../dist-assets/binaries/linux/openvpn
       to: .
+    - from: ../../../dist-assets/binaries/linux/sslocal
+      to: .
     - from: ../../../dist-assets/linux/mullvad-daemon.conf
       to: .
     - from: ../../../dist-assets/linux/mullvad-daemon.service
-      to: .
-    - from: ../../../dist-assets/linux/sslocal
       to: .
 
 deb:


### PR DESCRIPTION
There was a missing `binaries/` inside the path for Linux, so it was looking directly in `dist-assets/linux/.

While I was at it I slightly re-arranged the paths to all `dist-assets/binaries/` paths are grouped together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/703)
<!-- Reviewable:end -->
