### PR TITLE
Add {v4,v6}_gateway fields to TunnelMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix the bug which caused the account token history to remain stale after logout.
 - Fix some notifications not appearing depending on how the window is shown and hidden while the
   tunnel state changes.
+- Fix DNS when using IPv6.
 
 #### Linux
 - Fix startup failure when network device with a hardware address that's not a MAC address is

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -391,7 +391,11 @@ impl Daemon {
                 generic_options: tunnel_options.generic,
             }
             .into()),
-            MullvadEndpoint::Wireguard { peer, gateway } => {
+            MullvadEndpoint::Wireguard {
+                peer,
+                ipv4_gateway,
+                ipv6_gateway,
+            } => {
                 let wg_data = self
                     .account_history
                     .get(&account_token)?
@@ -408,7 +412,8 @@ impl Daemon {
                     connection: wireguard::ConnectionConfig {
                         tunnel,
                         peer,
-                        gateway,
+                        ipv4_gateway,
+                        ipv6_gateway: Some(ipv6_gateway),
                     },
                     options: tunnel_options.wireguard,
                     generic_options: tunnel_options.generic,

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -423,7 +423,8 @@ impl RelaySelector {
         };
         Some(MullvadEndpoint::Wireguard {
             peer: peer_config,
-            gateway: data.ipv4_gateway.into(),
+            ipv4_gateway: data.ipv4_gateway,
+            ipv6_gateway: data.ipv6_gateway,
         })
     }
 

--- a/mullvad-types/src/endpoint.rs
+++ b/mullvad-types/src/endpoint.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{fmt, net::IpAddr};
+use std::{
+    fmt,
+    net::{Ipv4Addr, Ipv6Addr},
+};
 use talpid_types::net::{wireguard, Endpoint, TransportProtocol};
 
 use crate::relay_list::{OpenVpnEndpointData, WireguardEndpointData};
@@ -11,7 +14,8 @@ pub enum MullvadEndpoint {
     OpenVpn(Endpoint),
     Wireguard {
         peer: wireguard::PeerConfig,
-        gateway: IpAddr,
+        ipv4_gateway: Ipv4Addr,
+        ipv6_gateway: Ipv6Addr,
     },
 }
 
@@ -20,7 +24,11 @@ impl MullvadEndpoint {
     pub fn to_endpoint(&self) -> Endpoint {
         match self {
             MullvadEndpoint::OpenVpn(endpoint) => *endpoint,
-            MullvadEndpoint::Wireguard { peer, gateway: _ } => Endpoint::new(
+            MullvadEndpoint::Wireguard {
+                peer,
+                ipv4_gateway: _,
+                ipv6_gateway: _,
+            } => Endpoint::new(
                 peer.endpoint.ip(),
                 peer.endpoint.port(),
                 TransportProtocol::Udp,

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -45,7 +45,7 @@ mod win {
 
 #[cfg(windows)]
 fn main() {
-    use win::*;
+    use crate::win::*;
 
     const WINFW_DIR_VAR: &str = "WINFW_LIB_DIR";
     const WINDNS_DIR_VAR: &str = "WINDNS_LIB_DIR";

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -100,7 +100,7 @@ impl fmt::Display for FirewallPolicy {
                 allow_lan,
             } => write!(
                 f,
-                "Connected to {} over \"{}\" (ip: {}, gw: {}), {} LAN",
+                "Connected to {} over \"{}\" (ip: {}, v4 gw: {}, v6 gw; {:?}), {} LAN",
                 peer_endpoint,
                 tunnel.interface,
                 tunnel
@@ -109,7 +109,8 @@ impl fmt::Display for FirewallPolicy {
                     .map(|ip| ip.to_string())
                     .collect::<Vec<_>>()
                     .join(","),
-                tunnel.gateway,
+                tunnel.ipv4_gateway,
+                tunnel.ipv6_gateway,
                 if *allow_lan { "Allowing" } else { "Blocking" }
             ),
             FirewallPolicy::Blocked { allow_lan } => write!(

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -141,7 +141,7 @@ impl Firewall {
     ) -> Result<()> {
         trace!("Applying 'connected' firewall policy");
         let ip_str = Self::widestring_ip(&endpoint.address.ip());
-        let gateway_str = Self::widestring_ip(&tunnel_metadata.gateway.into());
+        let gateway_str = Self::widestring_ip(&tunnel_metadata.ipv4_gateway.into());
 
         let tunnel_alias =
             WideCString::new(tunnel_metadata.interface.encode_utf16().collect::<Vec<_>>()).unwrap();

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -57,6 +57,5 @@ mod proxy;
 mod mktemp;
 
 /// Misc utilities for the Linux platform.
-///
 #[cfg(target_os = "linux")]
 mod linux;

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -57,5 +57,6 @@ mod proxy;
 mod mktemp;
 
 /// Misc utilities for the Linux platform.
+///
 #[cfg(target_os = "linux")]
 mod linux;

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -1,7 +1,7 @@
 use self::config::Config;
 use super::{TunnelEvent, TunnelMetadata};
 use crate::routing;
-use std::{path::Path, sync::mpsc};
+use std::{net::IpAddr, path::Path, sync::mpsc};
 
 pub mod config;
 mod ping_monitor;
@@ -79,7 +79,7 @@ impl WireguardMonitor {
         monitor.tunnel_up(&config);
 
         ping_monitor::ping(
-            config.gateway,
+            config.ipv4_gateway.into(),
             PING_TIMEOUT,
             &monitor.tunnel.get_interface_name().to_string(),
         )
@@ -152,7 +152,7 @@ impl WireguardMonitor {
         let close_sender = self.close_msg_sender.clone();
 
         ping_monitor::spawn_ping_monitor(
-            config.gateway,
+            IpAddr::from(config.ipv4_gateway),
             PING_TIMEOUT,
             self.tunnel.get_interface_name().to_string(),
             move || {
@@ -166,7 +166,8 @@ impl WireguardMonitor {
         let metadata = TunnelMetadata {
             interface: interface_name.to_string(),
             ips: config.tunnel.addresses.clone(),
-            gateway: config.gateway,
+            ipv4_gateway: config.ipv4_gateway,
+            ipv6_gateway: config.ipv6_gateway,
         };
         (self.event_callback)(TunnelEvent::Up(metadata));
     }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -72,9 +72,14 @@ impl ConnectedState {
     }
 
     fn set_dns(&self, shared_values: &mut SharedTunnelStateValues) -> Result<()> {
+        let mut dns_ips = vec![self.metadata.ipv4_gateway.into()];
+        if let Some(ipv6_gateway) = self.metadata.ipv6_gateway {
+            dns_ips.push(ipv6_gateway.into());
+        };
+
         shared_values
             .dns_monitor
-            .set(&self.metadata.interface, &[self.metadata.gateway.into()])
+            .set(&self.metadata.interface, &dns_ips)
             .chain_err(|| "Failed to set system DNS settings")
     }
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -372,7 +372,13 @@ impl TunnelState for ConnectingState {
 
 fn gateway_list_from_params(params: &TunnelParameters) -> Vec<IpAddr> {
     match params {
-        TunnelParameters::Wireguard(params) => vec![params.connection.gateway],
+        TunnelParameters::Wireguard(params) => {
+            let mut gateways = vec![params.connection.ipv4_gateway.into()];
+            if let Some(ipv6_gateway) = params.connection.ipv6_gateway {
+                gateways.push(ipv6_gateway.into())
+            };
+            gateways
+        }
         // No gateway list required when connecting to openvpn
         TunnelParameters::OpenVpn(_) => vec![],
     }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -3,7 +3,7 @@ use ipnetwork::IpNetwork;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     fmt,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
 use rand::RngCore;
@@ -21,7 +21,8 @@ pub struct TunnelParameters {
 pub struct ConnectionConfig {
     pub tunnel: TunnelConfig,
     pub peer: PeerConfig,
-    pub gateway: IpAddr,
+    pub ipv4_gateway: Ipv4Addr,
+    pub ipv6_gateway: Option<Ipv6Addr>,
 }
 
 impl ConnectionConfig {

--- a/windows/windns/src/windns/windns.cpp
+++ b/windows/windns/src/windns/windns.cpp
@@ -104,8 +104,6 @@ WinDns_Set(
 	if (nullptr == g_Context
 		|| nullptr == ipv4Servers
 		|| 0 == numIpv4Servers
-		|| nullptr == ipv6Servers
-		|| 0 == numIpv6Servers
 		|| nullptr == recoverySink)
 	{
 		return false;

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -89,7 +89,7 @@ bool FwContext::applyPolicyConnecting(const WinFwSettings &settings, const WinFw
 	return applyRuleset(ruleset);
 }
 
-bool FwContext::applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *primaryDns)
+bool FwContext::applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *v4Gateway, const wchar_t *v6Gateway)
 {
 	Ruleset ruleset;
 
@@ -110,9 +110,11 @@ bool FwContext::applyPolicyConnected(const WinFwSettings &settings, const WinFwR
 		tunnelInterfaceAlias
 	));
 
+	/// We currently expect DNS servers to only be ran on the tunnel gateway IPs
 	ruleset.emplace_back(std::make_unique<rules::RestrictDns>(
 		tunnelInterfaceAlias,
-		wfp::IpAddress(primaryDns)
+		wfp::IpAddress(v4Gateway),
+		(v6Gateway != nullptr) ? &wfp::IpAddress(v6Gateway) : nullptr
 	));
 
 	return applyRuleset(ruleset);

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -14,7 +14,7 @@ public:
 	FwContext(uint32_t timeout);
 
 	bool applyPolicyConnecting(const WinFwSettings &settings, const WinFwRelay &relay);
-	bool applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *primaryDns);
+	bool applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *v4DnsHosts, const wchar_t *v6DnsHost);
 	bool applyPolicyBlocked(const WinFwSettings &settings);
 
 	bool reset();

--- a/windows/winfw/src/winfw/rules/restrictdns.h
+++ b/windows/winfw/src/winfw/rules/restrictdns.h
@@ -11,14 +11,16 @@ class RestrictDns : public IFirewallRule
 {
 public:
 
-	RestrictDns(const std::wstring &tunnelInterfaceAlias, const wfp::IpAddress &dns);
+	RestrictDns(const std::wstring &tunnelInterfaceAlias, const wfp::IpAddress v4DnsHost, wfp::IpAddress *v6DnsHost);
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
 
 	const std::wstring m_tunnelInterfaceAlias;
-	const wfp::IpAddress m_dns;
+	const wfp::IpAddress m_v4DnsHost;
+	const wfp::IpAddress *m_v6DnsHost;
+
 };
 
 }

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -117,7 +117,8 @@ WinFw_ApplyPolicyConnected(
 	const WinFwSettings &settings,
 	const WinFwRelay &relay,
 	const wchar_t *tunnelInterfaceAlias,
-	const wchar_t *primaryDns
+	const wchar_t *v4Gateway,
+	const wchar_t *v6Gateway
 )
 {
 	if (nullptr == g_fwContext)
@@ -127,7 +128,7 @@ WinFw_ApplyPolicyConnected(
 
 	try
 	{
-		return g_fwContext->applyPolicyConnected(settings, relay, tunnelInterfaceAlias, primaryDns);
+		return g_fwContext->applyPolicyConnected(settings, relay, tunnelInterfaceAlias, v4Gateway, v6Gateway);
 	}
 	catch (std::exception &err)
 	{

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -123,7 +123,8 @@ WinFw_ApplyPolicyConnected(
 	const WinFwSettings &settings,
 	const WinFwRelay &relay,
 	const wchar_t *tunnelInterfaceAlias,
-	const wchar_t *primaryDns
+	const wchar_t *v4Gateway,
+	const wchar_t *v6Gateway
 );
 
 //


### PR DESCRIPTION
I've replaced the `gateway` field on `talpid-core::tunnel::TunnelMetadata` with a pair of `v{4,6}_gateway` with the V6 version being optional. This allows us to properly set DNS servers. I've tested this on all platforms and, after enabling IPv6, I can ping all the V6 DNS servers now. Not much has been done to allow any other traffic to flow to the V6 gateway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/708)
<!-- Reviewable:end -->
