### PR TITLE
Fix missing notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix the potential reconnect loop in GUI, triggered by the timeout when receiving
   the initial state of the daemon.
 - Fix the bug which caused the account token history to remain stale after logout.
+- Fix some notifications not appearing depending on how the window is shown and hidden while the
+  tunnel state changes.
 
 #### Linux
 - Fix startup failure when network device with a hardware address that's not a MAC address is

--- a/gui/packages/desktop/src/main/index.ts
+++ b/gui/packages/desktop/src/main/index.ts
@@ -762,6 +762,11 @@ class ApplicationMain {
 
       windowController.send('window-shown');
     });
+
+    windowController.window.on('hide', () => {
+      // ensure notification guard is reset
+      this.notificationController.resetTunnelStateAnnouncements();
+    });
   }
 
   private registerIpcListeners() {

--- a/gui/packages/desktop/src/main/notification-controller.ts
+++ b/gui/packages/desktop/src/main/notification-controller.ts
@@ -113,6 +113,10 @@ export default class NotificationController {
     }
   }
 
+  public resetTunnelStateAnnouncements() {
+    this.lastTunnelStateAnnouncement = undefined;
+  }
+
   private showTunnelStateNotification(message: string) {
     const lastAnnouncement = this.lastTunnelStateAnnouncement;
     const sameAsLastNotification = lastAnnouncement && lastAnnouncement.body === message;


### PR DESCRIPTION
Under specific usage scenarios, notifications wouldn't appear. The cause is that the notification handler has a guard to avoid showing repeated notifications, but it's not reset when the window is shown and no new notifications are shown for state changes while the window is visible.

So if we transition to state A with the window hidden, a notification will appear. Showing the window will suppress further notifications, so the be on some other state when the window is hidden again. If after that the app enters state A again, no notification will be shown.

This PR fixes this by reseting the guard when the window is hidden.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/710)
<!-- Reviewable:end -->
