### PR TITLE
Remove firewall mark based routing for linux

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -470,8 +470,6 @@ impl Daemon {
             SetOpenVpnMssfix(tx, mssfix_arg) => self.on_set_openvpn_mssfix(tx, mssfix_arg),
             SetOpenVpnProxy(tx, proxy) => self.on_set_openvpn_proxy(tx, proxy),
             SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6),
-            #[cfg(target_os = "linux")]
-            SetWireguardFwmark(tx, fwmark) => self.on_set_wireguard_fwmark(tx, fwmark),
             SetWireguardMtu(tx, mtu) => self.on_set_wireguard_mtu(tx, mtu),
             GetSettings(tx) => self.on_get_settings(tx),
             GenerateWireguardKey(tx) => self.on_generate_wireguard_key(tx),
@@ -786,23 +784,6 @@ impl Daemon {
                     self.management_interface_broadcaster
                         .notify_settings(&self.settings);
                     info!("Initiating tunnel restart because the enable IPv6 setting changed");
-                    self.reconnect_tunnel();
-                }
-            }
-            Err(e) => error!("{}", e.display_chain()),
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    fn on_set_wireguard_fwmark(&mut self, tx: oneshot::Sender<()>, fwmark: i32) {
-        let save_result = self.settings.set_wireguard_fwmark(fwmark);
-        match save_result.chain_err(|| "Unable to save settings") {
-            Ok(settings_changed) => {
-                Self::oneshot_send(tx, (), "set_wireguard_fwmark response");
-                if settings_changed {
-                    self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
-                    info!("Initiating tunnel restart because the WireGuard fwmark setting changed");
                     self.reconnect_tunnel();
                 }
             }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -221,10 +221,6 @@ impl DaemonRpcClient {
         self.call("set_wireguard_mtu", &[mtu])
     }
 
-    pub fn set_wireguard_fwmark(&mut self, fwmark: i32) -> Result<()> {
-        self.call("set_wireguard_fwmark", &[fwmark])
-    }
-
     pub fn set_openvpn_mssfix(&mut self, mssfix: Option<u16>) -> Result<()> {
         self.call("set_openvpn_mssfix", &[mssfix])
     }

--- a/mullvad-types/src/settings.rs
+++ b/mullvad-types/src/settings.rs
@@ -225,16 +225,6 @@ impl Settings {
         }
     }
 
-    #[cfg(target_os = "linux")]
-    pub fn set_wireguard_fwmark(&mut self, fwmark: i32) -> Result<bool> {
-        if self.tunnel_options.wireguard.fwmark != fwmark {
-            self.tunnel_options.wireguard.fwmark = fwmark;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
     pub fn set_wireguard_mtu(&mut self, mtu: Option<u16>) -> Result<bool> {
         if self.tunnel_options.wireguard.mtu != mtu {
             self.tunnel_options.wireguard.mtu = mtu;
@@ -265,11 +255,7 @@ impl Default for TunnelOptions {
     fn default() -> Self {
         TunnelOptions {
             openvpn: openvpn::TunnelOptions::default(),
-            wireguard: wireguard::TunnelOptions {
-                mtu: None,
-                #[cfg(target_os = "linux")]
-                fwmark: 78_78_78,
-            },
+            wireguard: wireguard::TunnelOptions { mtu: None },
             generic: GenericTunnelOptions { enable_ipv6: false },
         }
     }

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -1,4 +1,4 @@
-use super::{NetNode, RequiredRoutes};
+use super::{NetNode, RequiredRoutes, Route};
 
 use super::subprocess::{Exec, RunExpr};
 use std::{collections::HashSet, net::IpAddr};
@@ -12,181 +12,88 @@ error_chain! {
         FailedToRemoveRoute {
             description("Failed to remove route")
         }
-
-        FailedToRemoveTable {
-            description("Failed to remove table")
-        }
-
-        FailedToAdjustMainRoutingTable {
-            description("Failed to adjust main routing table")
-        }
-
-        FailedToSetRuleForFwmark {
-            description("Failed to set rule for fwmark")
-        }
-        NoDefaultRoute {
-            description("No default route")
-        }
-
         FailedToGetDefaultRoute {
             description("Failed to get default route")
         }
     }
 }
 
-#[derive(Hash, Eq, PartialEq)]
-enum IpVersion {
-    V4,
-    V6,
-}
-
-impl IpVersion {
-    fn new(ip: IpAddr) -> Self {
-        if ip.is_ipv4() {
-            IpVersion::V4
-        } else {
-            IpVersion::V6
-        }
-    }
-
-    fn is_ipv4(&self) -> bool {
-        match self {
-            IpVersion::V4 => true,
-            _ => false,
-        }
-    }
-}
-
-impl From<IpAddr> for IpVersion {
-    fn from(ip: IpAddr) -> IpVersion {
-        Self::new(ip)
-    }
-}
-
-impl AsRef<str> for IpVersion {
-    fn as_ref(&self) -> &str {
-        match self {
-            IpVersion::V4 => "-4",
-            IpVersion::V6 => "-6",
-        }
-    }
-}
-
-// A record of a table being set by a RouteManager.
-#[derive(Hash, Eq, PartialEq)]
-struct Table {
-    version: IpVersion,
-    fwmark: String,
-}
 
 pub struct RouteManager {
     added_routes: HashSet<super::Route>,
-    added_tables: HashSet<Table>,
-    // the main routing table only has to be adjusted for default routes
-    main_table_suppress_by_prefix_set_v4: bool,
-    main_table_suppress_by_prefix_set_v6: bool,
 }
 
 impl RouteManager {
-    // This function adjusts main routing table to not make any routing decisions based on rules
-    // with a prefix of 0. This is to bypass the main table for default routes.
-    fn set_suppress_prefix_length_on_main_routing_table(
-        &mut self,
-        version: IpVersion,
-        set_rule: bool,
-    ) -> Result<()> {
-        if (version.is_ipv4() && (set_rule == self.main_table_suppress_by_prefix_set_v4))
-            || (!version.is_ipv4() && (set_rule == self.main_table_suppress_by_prefix_set_v6))
-        {
-            return Ok(());
-        }
-        duct::cmd!(
-            "ip",
-            version.as_ref(),
-            "rule",
-            if set_rule { "add" } else { "delete" },
-            "table",
-            "main",
-            "suppress_prefixlength",
-            "0"
-        )
-        .run_expr()
-        .chain_err(|| ErrorKind::FailedToAdjustMainRoutingTable)?;
-        if version.is_ipv4() {
-            self.main_table_suppress_by_prefix_set_v4 = set_rule;
-        } else {
-            self.main_table_suppress_by_prefix_set_v6 = set_rule;
-        }
-        Ok(())
-    }
-
-    fn add_route(&mut self, route: super::Route, fwmark: &Option<String>) -> Result<()> {
+    fn add_route(&mut self, route: super::Route) -> Result<()> {
         if route.prefix.prefix() == 0 {
-            self.set_suppress_prefix_length_on_main_routing_table(route.prefix.ip().into(), true)?;
+            return if route.prefix.is_ipv4() {
+                self.add_route(Route::new("0.0.0.0/1".parse().unwrap(), route.node.clone()))?;
+                self.add_route(Route::new(
+                    "128.0.0.0/1".parse().unwrap(),
+                    route.node.clone(),
+                ))
+            } else {
+                self.add_route(Route::new("::/1".parse().unwrap(), route.node.clone()))?;
+                self.add_route(Route::new("8000::/1".parse().unwrap(), route.node.clone()))
+            };
         }
 
-        let version = IpVersion::new(route.prefix.ip());
-
-        let mut cmd = Exec::cmd("ip")
-            .arg(version.as_ref())
-            .arg("route")
-            .arg("add")
-            .arg(route.prefix.to_string());
-        cmd = match &route.node {
-            NetNode::Address(ref addr) => cmd.arg(addr.to_string()),
-            NetNode::Device(ref device) => cmd.arg("dev").arg(device),
-        };
-
-        if let Some(ref fwmark) = &fwmark {
-            cmd = cmd.arg("table").arg(fwmark);
-        }
+        let cmd = Self::add_route_cmd(&route);
 
         cmd.into_expr()
             .run_expr()
             .chain_err(|| ErrorKind::FailedToAddRoute)?;
 
-        if let Some(fwmark) = &fwmark {
-            self.ensure_table_rules(Table {
-                version,
-                fwmark: fwmark.to_string(),
-            })?;
-        } else {
-            self.added_routes.insert(route);
+        self.added_routes.insert(route);
+        Ok(())
+    }
+
+    fn add_route_cmd(route: &Route) -> Exec {
+        let cmd = Exec::cmd("ip")
+            .arg(ip_vers(&route))
+            .arg("route")
+            .arg("add")
+            .arg(route.prefix.to_string());
+        match &route.node {
+            NetNode::Address(ref addr) => cmd.arg("via").arg(addr.to_string()),
+            NetNode::Device(ref device) => cmd.arg("dev").arg(device),
+        }
+    }
+}
+
+fn ip_vers(route: &Route) -> &'static str {
+    if route.prefix.is_ipv4() {
+        "-4"
+    } else {
+        "-6"
+    }
+}
+
+
+impl super::RoutingT for RouteManager {
+    type Error = Error;
+    fn new() -> Result<Self> {
+        Ok(RouteManager {
+            added_routes: HashSet::new(),
+        })
+    }
+
+    fn add_routes(&mut self, required_routes: RequiredRoutes) -> Result<()> {
+        for route in required_routes.routes.into_iter() {
+            if let Err(e) = self.add_route(route) {
+                let _ = self.delete_routes();
+                return Err(e);
+            }
         }
         Ok(())
     }
 
-    // if a route we're applying is set to a specific table, that table should have it's rules set
-    fn ensure_table_rules(&mut self, added_table: Table) -> Result<()> {
-        if self.added_tables.contains(&added_table) {
-            return Ok(());
-        }
-        duct::cmd!(
-            "ip",
-            added_table.version.as_ref(),
-            "rule",
-            "add",
-            "not",
-            "fwmark",
-            &added_table.fwmark,
-            "table",
-            &added_table.fwmark
-        )
-        .run_expr()
-        .chain_err(|| ErrorKind::FailedToSetRuleForFwmark)?;
-
-
-        self.added_tables.insert(added_table);
-        Ok(())
-    }
-
-    fn clear_routes(&mut self) -> Result<()> {
+    fn delete_routes(&mut self) -> Result<()> {
         let mut end_result = Ok(());
         for route in self.added_routes.drain() {
-            let ip_vers: IpVersion = route.prefix.ip().into();
             let result = duct::cmd!(
                 "ip",
-                ip_vers.as_ref(),
+                ip_vers(&route),
                 "route",
                 "delete",
                 route.prefix.to_string()
@@ -199,85 +106,6 @@ impl RouteManager {
             }
         }
         end_result
-    }
-
-    fn clear_tables(&mut self) -> Result<()> {
-        let mut end_result = Ok(());
-        for table in self.added_tables.drain() {
-            let result = duct::cmd!(
-                "ip",
-                table.version.as_ref(),
-                "rule",
-                "delete",
-                "table",
-                &table.fwmark
-            )
-            .run_expr()
-            .chain_err(|| ErrorKind::FailedToRemoveTable);
-
-            if let Err(e) = result {
-                log::error!("Failed to remove routing table {} - {}", &table.fwmark, e);
-                end_result = Err(e);
-            }
-        }
-
-        if self.main_table_suppress_by_prefix_set_v4 {
-            if let Err(e) =
-                self.set_suppress_prefix_length_on_main_routing_table(IpVersion::V4, false)
-            {
-                log::error!(
-                    "Failed to remove prefix limit for main routing table - {}",
-                    e
-                );
-                end_result = Err(e);
-            } else {
-                self.main_table_suppress_by_prefix_set_v4 = false;
-            }
-        }
-
-        if self.main_table_suppress_by_prefix_set_v6 {
-            if let Err(e) =
-                self.set_suppress_prefix_length_on_main_routing_table(IpVersion::V6, false)
-            {
-                log::error!(
-                    "Failed to remove prefix limit for main routing table - {}",
-                    e
-                );
-                end_result = Err(e);
-            } else {
-                self.main_table_suppress_by_prefix_set_v6 = false;
-            }
-        }
-        end_result
-    }
-}
-
-impl super::RoutingT for RouteManager {
-    type Error = Error;
-    fn new() -> Result<Self> {
-        Ok(RouteManager {
-            added_routes: HashSet::new(),
-            added_tables: HashSet::new(),
-            // the main routing table only has to be adjusted for default routes
-            main_table_suppress_by_prefix_set_v4: false,
-            main_table_suppress_by_prefix_set_v6: false,
-        })
-    }
-
-    fn add_routes(&mut self, required_routes: RequiredRoutes) -> Result<()> {
-        for route in required_routes.routes.into_iter() {
-            if let Err(e) = self.add_route(route, &required_routes.fwmark) {
-                let _ = self.delete_routes();
-                return Err(e);
-            }
-        }
-        Ok(())
-    }
-
-    fn delete_routes(&mut self) -> Result<()> {
-        let result = self.clear_routes();
-        let other_result = self.clear_tables();
-        result.and_then(|_| other_result)
     }
 
     /// Retrieves the gateway for the default route

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -41,10 +41,6 @@ pub enum NetNode {
 pub struct RequiredRoutes {
     /// List of routes to be applied to the routing table.
     pub routes: Vec<Route>,
-    /// Optionally apply the routes to a specific table and only apply routes when a firewall mark
-    /// is not used. Currently only used on Linux.
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<String>,
 }
 
 /// Manages adding and removing routes from the routing table.
@@ -72,6 +68,7 @@ impl RouteManager {
 
     /// Retrieves the gateway for the default route.
     pub fn get_default_route_node(&mut self) -> Result<std::net::IpAddr, imp::Error> {
+        // use routing::RoutingT;
         self.inner.get_default_route_node()
     }
 }

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -11,8 +11,6 @@ pub struct Config {
     pub ipv4_gateway: Ipv4Addr,
     pub ipv6_gateway: Option<Ipv6Addr>,
     pub mtu: u16,
-    #[cfg(target_os = "linux")]
-    pub fwmark: i32,
 }
 
 /// Smallest MTU that supports IPv6
@@ -90,8 +88,6 @@ impl Config {
                 None
             },
             mtu,
-            #[cfg(target_os = "linux")]
-            fwmark: wg_options.fwmark,
         })
     }
 
@@ -102,11 +98,6 @@ impl Config {
         wg_conf
             .add("private_key", self.tunnel.private_key.as_bytes().as_ref())
             .add("listen_port", "0");
-
-        #[cfg(target_os = "linux")]
-        {
-            wg_conf.add("fwmark", self.fwmark.to_string().as_str());
-        }
 
         wg_conf.add("replace_peers", "true");
 

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -56,9 +56,6 @@ pub struct TunnelConfig {
 pub struct TunnelOptions {
     /// MTU for the wireguard tunnel
     pub mtu: Option<u16>,
-    /// firewall mark
-    #[cfg(target_os = "linux")]
-    pub fwmark: i32,
 }
 
 /// Wireguard x25519 private key


### PR DESCRIPTION
This PR removes firewall mark based routing that was used on Linux with WireGuard previously. Doing so implicitly fixes LAN traffic with WireGuard on Linux, and removes a lot of code and makes a lot of code simpler. One could even make a case for merging `talpid-core/routing/{linux.rs,macos.rs}` files now - but I'm tentatively leaving them as is, as there might be some more platform specific magic required later once we start listening for changes to the routing table - this is so that the tunnel can survive roaming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/713)
<!-- Reviewable:end -->
