### PR TITLE
New version check

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -231,10 +231,8 @@ const tunnelStateTransitionSchema = oneOf(
 
 const appVersionInfoSchema = partialObject({
   current_is_supported: boolean,
-  latest: partialObject({
-    latest_stable: string,
-    latest: string,
-  }),
+  latest_stable: string,
+  latest: string,
 });
 
 export class ConnectionObserver {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -103,10 +103,8 @@ class ApplicationMain {
 
   private upgradeVersion: IAppUpgradeInfo = {
     currentIsSupported: true,
-    latest: {
-      latestStable: '',
-      latest: '',
-    },
+    latestStable: '',
+    latest: '',
     nextUpgrade: undefined,
     upToDate: true,
   };
@@ -616,8 +614,8 @@ class ApplicationMain {
     }
 
     const currentVersionInfo = this.currentVersion;
-    const latestVersion = latestVersionInfo.latest.latest;
-    const latestStableVersion = latestVersionInfo.latest.latestStable;
+    const latestVersion = latestVersionInfo.latest;
+    const latestStableVersion = latestVersionInfo.latestStable;
 
     // the reason why we rely on daemon version here is because daemon obtains the version info
     // based on its built-in version information

--- a/gui/src/renderer/redux/version/reducers.ts
+++ b/gui/src/renderer/redux/version/reducers.ts
@@ -25,14 +25,11 @@ export default function(
   action: ReduxAction,
 ): IVersionReduxState {
   switch (action.type) {
-    case 'UPDATE_LATEST': {
-      const { latest, ...other } = action.latestInfo;
+    case 'UPDATE_LATEST':
       return {
         ...state,
-        ...other,
-        ...latest,
+        ...action.latestInfo,
       };
-    }
 
     case 'UPDATE_VERSION':
       return {

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -195,10 +195,8 @@ export interface IShadowsocksProxySettings {
 
 export interface IAppVersionInfo {
   currentIsSupported: boolean;
-  latest: {
-    latestStable: string;
-    latest: string;
-  };
+  latestStable: string;
+  latest: string;
 }
 
 export interface ISettings {

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -18,9 +18,14 @@ impl Command for Version {
         println!("Current version: {}", current_version);
         let version_info = rpc.get_version_info()?;
         println!("Supported: {}", version_info.current_is_supported);
-        println!("Latest releases:");
-        println!("\tlatest stable: {}", version_info.latest.latest_stable);
-        println!("\tlatest: {}", version_info.latest.latest);
+        if version_info.latest_stable != version_info.latest {
+            println!(
+                "Latest version: {} (latest stable: {})",
+                version_info.latest, version_info.latest_stable
+            );
+        } else {
+            println!("Latest version: {}", version_info.latest_stable);
+        }
         Ok(())
     }
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -625,14 +625,16 @@ impl Daemon {
         &mut self,
         tx: oneshot::Sender<BoxFuture<AppVersionInfo, mullvad_rpc::Error>>,
     ) {
+        #[cfg(target_os = "linux")]
+        const PLATFORM: &str = "linux";
+        #[cfg(target_os = "macos")]
+        const PLATFORM: &str = "macos";
+        #[cfg(target_os = "windows")]
+        const PLATFORM: &str = "windows";
+
         let fut = self
             .version_proxy
-            .latest_app_version()
-            .join(self.version_proxy.is_app_version_supported(&self.version))
-            .map(|(latest_versions, is_supported)| AppVersionInfo {
-                current_is_supported: is_supported,
-                latest: latest_versions,
-            });
+            .app_version_check(&self.version, PLATFORM);
         Self::oneshot_send(tx, Box::new(fut), "get_version_info response");
     }
 

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -127,8 +127,7 @@ jsonrpc_client!(pub struct RelayListProxy {
 });
 
 jsonrpc_client!(pub struct AppVersionProxy {
-    pub fn latest_app_version(&mut self) -> RpcRequest<version::LatestReleases>;
-    pub fn is_app_version_supported(&mut self, version: &version::AppVersion) -> RpcRequest<bool>;
+    pub fn app_version_check(&mut self, version: &version::AppVersion, platform: &str) -> RpcRequest<version::AppVersionInfo>;
 });
 
 jsonrpc_client!(pub struct WireguardKeyProxy {

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -5,12 +5,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppVersionInfo {
     pub current_is_supported: bool,
-    pub latest: LatestReleases,
-}
-
-/// LatestReleases represent the latest released versions of the Mullvad VPN app.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LatestReleases {
     pub latest_stable: AppVersion,
     pub latest: AppVersion,
 }


### PR DESCRIPTION
Unify the version check into one RPC call. Should cut time to do it in half (since we don't have any HTTP keep-alive and thus do the full handshake for each request)

This also changes the struct layout, since we merged it into one struct.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/718)
<!-- Reviewable:end -->
