### PR TITLE
Go from maximum to normal compression

### DIFF
--- a/gui/electron-builder.yml
+++ b/gui/electron-builder.yml
@@ -3,7 +3,6 @@ copyright: Amagicom AB
 productName: Mullvad VPN
 
 asar: true
-compression: maximum
 
 # assets bundled on all platforms
 extraResources:


### PR DESCRIPTION
I turned maximum compression on back in September of 2017. I guess I must have measured and detected it lowered the installer size, I can't remember. But it adds time to the build. And according to the docs the difference between the default `normal` and `maximum` is mostly CPU time, rarely compression ratio.

I tried this on Linux, and there the final artifacts stayed on 54MiB, so no change. Same on macOS, still 80MiB, no change. I have not measured on Windows. I don't even know if this flag is read/used there, but I don't think it will affect much, we don't have very much compressible data in the final artifacts anyway.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/719)
<!-- Reviewable:end -->
