### PR TITLE
Add missing `ip` field in `NEW_LOCATION` action

### DIFF
--- a/gui/src/renderer/redux/connection/actions.ts
+++ b/gui/src/renderer/redux/connection/actions.ts
@@ -1,4 +1,9 @@
-import { AfterDisconnect, BlockReason, ITunnelEndpoint } from '../../../shared/daemon-rpc-types';
+import {
+  AfterDisconnect,
+  BlockReason,
+  ILocation,
+  ITunnelEndpoint,
+} from '../../../shared/daemon-rpc-types';
 
 interface IConnectingAction {
   type: 'CONNECTING';
@@ -26,14 +31,7 @@ interface IBlockedAction {
 
 interface INewLocationAction {
   type: 'NEW_LOCATION';
-  newLocation: {
-    country: string;
-    city?: string;
-    latitude: number;
-    longitude: number;
-    mullvadExitIp: boolean;
-    hostname?: string;
-  };
+  newLocation: ILocation;
 }
 
 interface IOnlineAction {
@@ -88,7 +86,7 @@ function blocked(reason: BlockReason): IBlockedAction {
   };
 }
 
-function newLocation(location: INewLocationAction['newLocation']): INewLocationAction {
+function newLocation(location: ILocation): INewLocationAction {
   return {
     type: 'NEW_LOCATION',
     newLocation: location,

--- a/gui/src/renderer/redux/connection/reducers.ts
+++ b/gui/src/renderer/redux/connection/reducers.ts
@@ -31,8 +31,7 @@ export default function(
 ): IConnectionReduxState {
   switch (action.type) {
     case 'NEW_LOCATION':
-      const { hostname, latitude, longitude, city, country } = action.newLocation;
-      return { ...state, hostname, latitude, longitude, city, country };
+      return { ...state, ...action.newLocation };
 
     case 'CONNECTING':
       return {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes the omission of `ip` field in the `NEW_LOCATION` action.

Before the transition to TypeScript, the `ip` field used to leak into Redux state because we used to pass the result of `get_current_location` straight into Redux bypassing the type checks from what I can tell.

It seems that I stumbled upon this during the migration to TypeScript and for some reason did the following change:

```diff
+      const { hostname, latitude, longitude, city, country } = action.newLocation;
+      return { ...state, hostname, latitude, longitude, city, country };
-      return { ...state, ...action.newLocation };
```

Effectively preventing the `ip` from leaking into redux state at runtime which caused the public IP from appearing in GUI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/720)
<!-- Reviewable:end -->
