### PR TITLE
Fix the display style for the remaining time left

### DIFF
--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -99,7 +99,8 @@ export default class Settings extends Component<IProps> {
         <View>
           <Cell.CellButton onPress={this.props.onViewAccount}>
             <Cell.Label>{pgettext('settings-view', 'Account')}</Cell.Label>
-            <Cell.SubText style={styles.settings__account_paid_until_label__error}>
+            <Cell.SubText
+              style={isOutOfTime ? styles.settings__account_paid_until_label__error : undefined}>
               {isOutOfTime ? outOfTimeMessage : formattedExpiry}
             </Cell.SubText>
             <Cell.Icon height={12} width={7} source="icon-chevron" />

--- a/gui/src/renderer/components/SettingsStyles.tsx
+++ b/gui/src/renderer/components/SettingsStyles.tsx
@@ -39,7 +39,6 @@ export default {
   settings__version_warning: Styles.createViewStyle({
     marginLeft: 8,
   }),
-
   settings__account_paid_until_label__error: Styles.createTextStyle({
     color: colors.red,
   }),


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes the display style used for the remaining time left on account label in Settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/721)
<!-- Reviewable:end -->
