### PR TITLE
Dont cache travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,12 @@ matrix:
     - language: rust
       rust: stable
       os: osx
-      cache: cargo
       before_script: &rust_before_script
         - source env.sh
         - env
-        - du -sh target || true
       script: &rust_script
         - cargo build --verbose
         - cargo test --verbose
-      before_cache: &rust_before_cache
-        - rm -rf target/debug/incremental/
 
     # Daemon - Linux
     - language: rust
@@ -51,7 +47,6 @@ matrix:
          packages:
           - binutils
           - libdbus-1-dev
-      cache: cargo
       before_script: *rust_before_script
       script:
         - cargo build --verbose
@@ -60,25 +55,20 @@ matrix:
         - rustup component add rustfmt-preview
         - cargo fmt --version || true
         - cargo fmt -- --check --unstable-features
-      before_cache: *rust_before_cache
 
     - language: rust
       rust: beta
       os: linux
       addons: *rust_linux_addons
-      cache: cargo
       before_script: *rust_before_script
       script: *rust_script
-      before_cache: *rust_before_cache
 
     - language: rust
       rust: stable
       os: linux
       addons: *rust_linux_addons
-      cache: cargo
       before_script: *rust_before_script
       script: *rust_script
-      before_cache: *rust_before_cache
 
 
 notifications:

--- a/env.sh
+++ b/env.sh
@@ -12,7 +12,7 @@ case "$(uname -s)" in
     export MACOSX_DEPLOYMENT_TARGET="10.7"
     PLATFORM="macos"
     ;;
-  MINGW*)
+  MINGW*|MSYS_NT*)
     PLATFORM="windows"
     ;;
 esac


### PR DESCRIPTION
These are some extra things from my old PR to #535 that we never merge because running Rust builds on Windows on Travis is still way slower than on Appveyor. But these extra felt worth getting merged, so I picked them out.

First commit just makes `env.sh` compatible with more Windows bash versions. MSYS is what Windows on Travis uses, so we'll eventually need it for that, but does not hurt to increase compatibility now.

Then comes cache removal from Travis. One would assume caching is good for build times. But from all the numbers I see the download+extraction and compression+upload of the cache takes way longer than just doing a clean build every time. If you look at the [Travis history](https://www.travis-ci.org/mullvad/mullvadvpn-app/builds/501986708), you see that all builds up until this PR takes roughly ~51 minutes of total VM running time (each Rust build being ~11-13 minutes). Then you check the builds that this branch has ([1](https://www.travis-ci.org/mullvad/mullvadvpn-app/builds/501983538), [2](https://www.travis-ci.org/mullvad/mullvadvpn-app/builds/501986708), [3](https://www.travis-ci.org/mullvad/mullvadvpn-app/builds/501993664)), they use ~31 minutes of total time and each build takes around 7 minutes (With macOS having a very off number on the second build).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/722)
<!-- Reviewable:end -->
