### PR TITLE
Fix deserialization of old account history

### DIFF
--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -69,10 +69,16 @@ impl AccountHistory {
     }
 
     fn try_old_format(reader: &mut io::BufReader<fs::File>) -> Result<Vec<AccountToken>> {
+        #[derive(Deserialize)]
+        struct OldFormat {
+            accounts: Vec<AccountToken>,
+        }
         reader
             .seek(io::SeekFrom::Start(0))
             .chain_err(|| ErrorKind::ReadError)?;
-        Ok(serde_json::from_reader(reader).unwrap_or(vec![]))
+        Ok(serde_json::from_reader(reader)
+            .map(|old_format: OldFormat| old_format.accounts)
+            .unwrap_or(vec![]))
     }
 
     /// Gets account data for a certain account id and bumps it's entry to the top of the list if


### PR DESCRIPTION
This fixes a bug with account history where if the old format is still being used in the account history file, now it will be deserialized properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/723)
<!-- Reviewable:end -->
