### PR TITLE
Fix custom relay settings schema in daemon-rpc.ts

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -72,7 +72,8 @@ const customTunnelEndpointSchema = oneOf(
         allowed_ips: arrayOf(string),
         endpoint: string,
       }),
-      gateway: string,
+      ipv4_gateway: string,
+      ipv6_gateway: maybe(string),
     }),
   }),
 );

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -90,15 +90,16 @@ export type ConnectionConfig =
   | {
       wireguard: {
         tunnel: {
-          private_key: string;
+          privateKey: string;
           addresses: string[];
         };
         peer: {
-          public_key: string;
+          publicKey: string;
           addresses: string[];
           endpoint: string;
         };
-        gateway: string;
+        ipv4Gateway: string;
+        ipv6Gateway?: string;
       };
     };
 


### PR DESCRIPTION
I'm fixing a bug that I added when I changed the custom relay list to hold both v4 and v6 gateways - as it so often happens, I updated the daemon code but no the UI code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/725)
<!-- Reviewable:end -->
