### PR TITLE
Fix WireGuard logging

### DIFF
--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -1,8 +1,5 @@
 use super::{Config, ErrorKind, Result, ResultExt, Tunnel};
-use crate::{
-    logging,
-    network_interface::{NetworkInterface, TunnelDevice},
-};
+use crate::network_interface::{NetworkInterface, TunnelDevice};
 use std::{ffi::CString, fs, os::unix::io::AsRawFd, path::Path};
 
 
@@ -62,13 +59,8 @@ impl WgGoTunnel {
 }
 
 fn prepare_log_file(log_path: Option<&Path>) -> Result<fs::File> {
-    match log_path {
-        Some(path) => {
-            logging::rotate_log(path).chain_err(|| ErrorKind::PrepareLogFileError)?;
-            fs::File::open(&path).chain_err(|| ErrorKind::PrepareLogFileError)
-        }
-        None => fs::File::open("/dev/null").chain_err(|| ErrorKind::PrepareLogFileError),
-    }
+    fs::File::create(log_path.unwrap_or("/dev/null".as_ref()))
+        .chain_err(|| ErrorKind::PrepareLogFileError)
 }
 
 impl Tunnel for WgGoTunnel {


### PR DESCRIPTION
The reason the old code was not logging was that the log file was opened in read-only mode. So, now we'll open the log file in write-only mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/727)
<!-- Reviewable:end -->
