### PR TITLE
Filter relays in UI

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -136,6 +136,20 @@ const relayListSchema = partialObject({
               ipv4_addr_in: string,
               include_in_country: boolean,
               weight: number,
+              tunnels: partialObject({
+                openvpn: arrayOf(
+                  partialObject({
+                    port: number,
+                    protocol: string,
+                  }),
+                ),
+                wireguard: arrayOf(
+                  partialObject({
+                    port_ranges: arrayOf(arrayOf(number)),
+                    public_key: string,
+                  }),
+                ),
+              }),
             }),
           ),
         }),
@@ -343,7 +357,7 @@ export class DaemonRpc {
     try {
       return camelCaseObjectKeys(validate(relayListSchema, response)) as IRelayList;
     } catch (error) {
-      throw new ResponseParseError('Invalid response from get_relay_locations', error);
+      throw new ResponseParseError(`Invalid response from get_relay_locations: ${error}`, error);
     }
   }
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -154,6 +154,26 @@ export interface IRelayListHostname {
   ipv4AddrIn: string;
   includeInCountry: boolean;
   weight: number;
+  tunnels: IRelayTunnels;
+}
+
+export interface IRelayTunnels {
+  openvpn: IOpenVpnTunnelData[];
+  wireguard: IWireguardTunnelData[];
+}
+
+export interface IOpenVpnTunnelData {
+  port: number;
+  protocol: RelayProtocol;
+}
+
+export interface IWireguardTunnelData {
+  // Port ranges are an array of pairs, such as [[53,53], [10_000, 60_000]],
+  // which in this case translates that the specific tunnel can be connected on
+  // port 53 and ports 10'000 through 60'000.
+  portRanges: Array<[number, number]>;
+  // Public key of the tunnel.
+  publicKey: string;
 }
 
 export interface ITunnelOptions {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -99,7 +99,6 @@ impl ParsedRelays {
                         longitude,
                     });
                     relays.push(relay_with_location);
-                    relay.tunnels.clear();
                 }
             }
         }


### PR DESCRIPTION
Since now we have more than a single tunnel type and not all of our servers support both tunnel types, we have to filter the relay list we show to the user depending on the selected tunnel type. For now, the user doesn't have to be able to select a different tunnel type from the UI, but the shown relay list should be filtered appropriately.
As such, the following changes have been made:
- The relays for each city won't be cleared when sent to the UI from the daemon.
- Filter cities and relays from the relay list depending on the selected relay type.
- Update the displayed relay list whenever there's an update in the settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/730)
<!-- Reviewable:end -->
