### PR TITLE
Added a dependcony on iputils-ping for deb packages

### DIFF
--- a/gui/electron-builder.yml
+++ b/gui/electron-builder.yml
@@ -128,6 +128,8 @@ deb:
        ]
   afterInstall: ../dist-assets/linux/after-install.sh
   afterRemove: ../dist-assets/linux/after-remove.sh
+  depends:
+    - iputils-ping
 
 rpm:
   fpm: ["--before-install", "../dist-assets/linux/before-install.sh",


### PR DESCRIPTION
On Debian and it's derrivatives, multiple kinds of `ping` packages are available. I've come to notice that we rely on a specific one, which allows us to specify the network interface which should be used to send and receive the ICMP packets, so I've added it as a dependency for our deb package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/734)
<!-- Reviewable:end -->
