### PR TITLE
Make WireGuard more wakeup friendly.

### DIFF
--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -14,7 +14,7 @@ use talpid_types::net::{openvpn as openvpn_types, GenericTunnelOptions, TunnelPa
 pub mod openvpn;
 
 #[cfg(unix)]
-mod wireguard;
+pub mod wireguard;
 
 const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
 const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use self::config::Config;
 use super::{TunnelEvent, TunnelMetadata};
 use crate::routing;

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -345,6 +345,20 @@ impl TunnelState for ConnectingState {
                         Err(error) => {
                             let block_reason = match *error.kind() {
                                 tunnel::ErrorKind::EnableIpv6Error => BlockReason::Ipv6Unavailable,
+
+                                #[cfg(unix)]
+                                tunnel::ErrorKind::WirguardTunnelMonitoringError(ref err) => {
+                                    match &err {
+                                        tunnel::wireguard::ErrorKind::PingTimeoutError => {
+                                            if crate::offline::is_offline() {
+                                                BlockReason::IsOffline
+                                            } else {
+                                                BlockReason::StartTunnelError
+                                            }
+                                        }
+                                        _ => BlockReason::StartTunnelError,
+                                    }
+                                }
                                 _ => BlockReason::StartTunnelError,
                             };
 


### PR DESCRIPTION
When running a WireGuard tunnel on MacOS, there's a race condition when the host is coming out of sleep where the tunnel can be restarted and fail to reconnect faster than the tunnel state machine will receive an event informing it that the host lost network connectivity. This leads the daemon into a blocked state, even though it most likely should be able to reconnect shortly thereafter. The hacky fix which is a part of this PR, is to check whether the wireguard tunnel failed to start because of a ping timeout, and if so, check whether we're online from within the state machine so that the tunnel start error could be turned into a _no network connectivity_ error, from which the daemon can recover without user intervention once network connectivity is re-established.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/737)
<!-- Reviewable:end -->
