### PR TITLE
Revamp transition container

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -73,7 +73,7 @@
     "prettier": "1.16.4",
     "rimraf": "^2.5.4",
     "sinon": "^7.1.1",
-    "ts-node": "^7.0.1",
+    "ts-node": "^8.0.3",
     "tsc-watch": "^2.1.1",
     "tslint": "^5.12.1",
     "tslint-config-prettier": "^1.18.0",

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -11,7 +11,7 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { InvalidAccountError } from '../main/errors';
-import makeRoutes from './routes';
+import AppRoutes from './routes';
 
 import accountActions from './redux/account/actions';
 import connectionActions from './redux/connection/actions';
@@ -181,10 +181,12 @@ export default class AppRenderer {
     return (
       <Provider store={this.reduxStore}>
         <ConnectedRouter history={this.memoryHistory}>
-          {makeRoutes({
-            app: this,
-            locale: this.locale,
-          })}
+          <AppRoutes
+            sharedProps={{
+              app: this,
+              locale: this.locale,
+            }}
+          />
         </ConnectedRouter>
       </Provider>
     );

--- a/gui/src/renderer/components/PlatformWindow.tsx
+++ b/gui/src/renderer/components/PlatformWindow.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import { Component, Styles, View } from 'reactxp';
+import { Component, Styles, Types, View } from 'reactxp';
 
 interface IProps {
   arrowPosition?: number;
 }
 
+const containerStyle = Styles.createViewStyle({ flex: 1 });
+
 export default class PlatformWindow extends Component<IProps> {
   public render() {
-    let style;
+    return <View style={[containerStyle, this.platformStyle()]}>{this.props.children}</View>;
+  }
 
+  private platformStyle(): Types.ViewStyleRuleSet {
     if (process.platform === 'darwin') {
       const arrowPosition = this.props.arrowPosition;
       let arrowPositionCss = '50%';
@@ -24,10 +28,15 @@ export default class PlatformWindow extends Component<IProps> {
         `url(../../assets/images/app-header-backdrop.svg) no-repeat`,
       ];
 
-      // @ts-ignore
-      style = Styles.createViewStyle({ WebkitMask: webkitMask.join(',') }, false);
+      return Styles.createViewStyle(
+        {
+          // @ts-ignore
+          WebkitMask: webkitMask.join(','),
+        },
+        false,
+      );
+    } else {
+      return undefined;
     }
-
-    return <View style={style}>{this.props.children}</View>;
   }
 }

--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -1,229 +1,376 @@
 import * as React from 'react';
-import { Animated, Component, Styles, Types, UserInterface, View } from 'reactxp';
+import { Animated, Component, Styles, Types, View } from 'reactxp';
 import { ITransitionGroupProps } from '../transitions';
 
+interface ITransitioningViewProps {
+  viewId: string;
+}
+
+type TransitioningView = React.ReactElement<ITransitioningViewProps>;
+
+interface ITransitionQueueItem {
+  view: TransitioningView;
+  transition: ITransitionGroupProps;
+}
+
 interface IProps extends ITransitionGroupProps {
-  children: React.ReactNode;
+  children: TransitioningView;
 }
 
 interface IState {
-  previousChildren?: React.ReactNode;
-  childrenAnimation?: Types.AnimatedViewStyleRuleSet;
-  previousChildrenAnimation?: Types.AnimatedViewStyleRuleSet;
-  dimensions: Types.Dimensions;
-  isAnimating: boolean;
+  currentItem?: ITransitionQueueItem;
+  nextItem?: ITransitionQueueItem;
+  itemQueue: ITransitionQueueItem[];
+  currentItemStyle?: Array<Types.StyleRuleSet<Types.AnimatedViewStyle>>;
+  nextItemStyle?: Array<Types.StyleRuleSet<Types.AnimatedViewStyle>>;
 }
 
-const dimensions = UserInterface.measureWindow();
 const styles = {
-  animationDefaultStyle: Styles.createViewStyle({
+  animatedContainer: Styles.createViewStyle({
     position: 'absolute',
-    width: dimensions.width,
-    height: dimensions.height,
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
   }),
-  allowPointerEventsStyle: Styles.createViewStyle({
+  transitionView: Styles.createViewStyle({
+    flex: 1,
+  }),
+  userInteractionBlocker: Styles.createViewStyle({
     // @ts-ignore
-    pointerEvents: 'auto',
+    zIndex: 2,
   }),
-  transitionContainerStyle: Styles.createViewStyle({
-    width: dimensions.width,
-    height: dimensions.height,
+  transitionContainer: Styles.createViewStyle({
+    flex: 1,
+  }),
+  orderFront: Styles.createViewStyle({
+    // @ts-ignore
+    zIndex: 1,
+  }),
+  orderBack: Styles.createViewStyle({
+    // @ts-ignore
+    zIndex: 0,
   }),
 };
 
-export default class TransitionContainer extends Component<IProps, IState> {
-  public state: IState = {
-    dimensions: UserInterface.measureWindow(),
-    isAnimating: false,
-  };
-
-  public UNSAFE_componentWillReceiveProps(nextProps: IProps) {
-    switch (nextProps.name) {
-      case 'slide-up':
-        this.slideUpTransition(nextProps);
-        break;
-      case 'slide-down':
-        this.slideDownTransition(nextProps);
-        break;
-      case 'push':
-        this.pushTransition(nextProps);
-        break;
-      case 'pop':
-        this.popTransition(nextProps);
-        break;
-      default:
-        break;
-    }
-  }
-
-  public onFinishedAnimation = (_result: Types.Animated.EndResult) => {
-    this.setState({
-      childrenAnimation: styles.allowPointerEventsStyle,
-      previousChildren: null,
-      isAnimating: false,
-    });
-  };
-
-  public slideUpTransition(nextProps: IProps) {
-    const currentTranslationValue = Animated.createValue(this.state.dimensions.height);
-    this.setState(
-      {
-        previousChildren: this.props.children,
-        childrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 1,
-          transform: [{ translateY: currentTranslationValue }],
-        }),
-        previousChildrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 0,
-          transform: [{ translateY: Animated.createValue(0) }],
-        }),
-        isAnimating: true,
-      },
-      () => {
-        Animated.timing(currentTranslationValue, {
-          toValue: 0,
-          easing: Animated.Easing.InOut(),
-          duration: nextProps.duration,
-        }).start(this.onFinishedAnimation);
-      },
-    );
-  }
-
-  public slideDownTransition(nextProps: IProps) {
-    const previousTranslationValue = Animated.createValue(0);
-    this.setState(
-      {
-        previousChildren: this.props.children,
-        childrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 0,
-          transform: [{ translateY: Animated.createValue(0) }],
-        }),
-        previousChildrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 1,
-          transform: [{ translateY: previousTranslationValue }],
-        }),
-        isAnimating: true,
-      },
-      () => {
-        Animated.timing(previousTranslationValue, {
-          toValue: this.state.dimensions.height,
-          easing: Animated.Easing.InOut(),
-          duration: nextProps.duration,
-        }).start(this.onFinishedAnimation);
-      },
-    );
-  }
-
-  public pushTransition(nextProps: IProps) {
-    const currentTranslationValue = Animated.createValue(this.state.dimensions.width);
-    const previousTranslationValue = Animated.createValue(0);
-    this.setState(
-      {
-        previousChildren: this.props.children,
-        childrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 1,
-          transform: [{ translateX: currentTranslationValue }],
-        }),
-        previousChildrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 0,
-          transform: [{ translateX: previousTranslationValue }],
-        }),
-        isAnimating: true,
-      },
-      () => {
-        const compositeAnimation = Animated.parallel([
-          Animated.timing(currentTranslationValue, {
-            toValue: 0,
-            easing: Animated.Easing.InOut(),
-            duration: nextProps.duration,
-          }),
-          Animated.timing(previousTranslationValue, {
-            toValue: -this.state.dimensions.width / 2,
-            easing: Animated.Easing.InOut(),
-            duration: nextProps.duration,
-          }),
-        ]);
-        compositeAnimation.start(this.onFinishedAnimation);
-      },
-    );
-  }
-
-  public popTransition(nextProps: IProps) {
-    const currentTranslationValue = Animated.createValue(-this.state.dimensions.width / 2);
-    const previousTranslationValue = Animated.createValue(0);
-    this.setState(
-      {
-        previousChildren: this.props.children,
-        childrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 0,
-          transform: [{ translateX: currentTranslationValue }],
-        }),
-        previousChildrenAnimation: Styles.createAnimatedViewStyle({
-          // @ts-ignore
-          zIndex: 1,
-          transform: [{ translateX: previousTranslationValue }],
-        }),
-        isAnimating: true,
-      },
-      () => {
-        const compositeAnimation = Animated.parallel([
-          Animated.timing(currentTranslationValue, {
-            toValue: 0,
-            easing: Animated.Easing.InOut(),
-            duration: nextProps.duration,
-          }),
-          Animated.timing(previousTranslationValue, {
-            toValue: this.state.dimensions.width,
-            easing: Animated.Easing.InOut(),
-            duration: nextProps.duration,
-          }),
-        ]);
-        compositeAnimation.start(this.onFinishedAnimation);
-      },
-    );
-  }
-
+export class TransitionView extends Component<ITransitioningViewProps> {
   public render() {
-    const { children } = this.props;
-    const {
-      isAnimating,
-      previousChildren,
-      childrenAnimation,
-      previousChildrenAnimation,
-    } = this.state;
-
-    return (
-      <View style={styles.transitionContainerStyle} ignorePointerEvents={isAnimating}>
-        {previousChildren && (
-          <Animated.View
-            key={getChildKey(previousChildren)}
-            style={[styles.animationDefaultStyle, previousChildrenAnimation]}>
-            {previousChildren}
-          </Animated.View>
-        )}
-
-        <Animated.View
-          key={getChildKey(children)}
-          style={[styles.animationDefaultStyle, childrenAnimation]}>
-          {children}
-        </Animated.View>
-      </View>
-    );
+    return <View style={styles.transitionView}>{this.props.children}</View>;
   }
 }
 
-function getChildKey(child?: React.ReactNode): string | number | undefined {
-  return child &&
-    typeof child === 'object' &&
-    'key' in child &&
-    (typeof child.key === 'string' || typeof child.key === 'number')
-    ? child.key
-    : undefined;
+export default class TransitionContainer extends Component<IProps, IState> {
+  public state: IState = {
+    itemQueue: [],
+  };
+
+  private containerSize = { width: 0, height: 0 };
+
+  private animation?: Types.Animated.CompositeAnimation;
+  private isCycling = false;
+
+  private slideValueA = Animated.createValue(0);
+  private slideAnimationStyleA = Styles.createAnimatedViewStyle({
+    transform: [{ translateY: this.slideValueA }],
+  });
+
+  private slideValueB = Animated.createValue(0);
+  private slideAnimationStyleB = Styles.createAnimatedViewStyle({
+    transform: [{ translateY: this.slideValueB }],
+  });
+
+  private pushValueA = Animated.createValue(0);
+  private pushStyleA = Styles.createAnimatedViewStyle({
+    transform: [{ translateX: this.pushValueA }],
+  });
+
+  private pushValueB = Animated.createValue(0);
+  private pushStyleB = Styles.createAnimatedViewStyle({
+    transform: [{ translateX: this.pushValueB }],
+  });
+
+  constructor(props: IProps) {
+    super(props);
+
+    this.state.currentItem = this.makeItem(props);
+  }
+
+  public UNSAFE_componentWillReceiveProps(nextProps: IProps) {
+    const candidate = nextProps.children;
+
+    if (candidate && this.state.currentItem) {
+      // synchronize updates to the last added child.
+      const itemQueueCount = this.state.itemQueue.length;
+      const lastItemInQueue =
+        itemQueueCount > 0 ? this.state.itemQueue[itemQueueCount - 1] : undefined;
+
+      if (lastItemInQueue && lastItemInQueue.view.props.viewId === candidate.props.viewId) {
+        this.setState({
+          itemQueue: [...this.state.itemQueue.slice(0, -1), this.makeItem(nextProps)],
+        });
+      } else if (
+        itemQueueCount === 0 &&
+        this.state.nextItem &&
+        this.state.nextItem.view.props.viewId === candidate.props.viewId
+      ) {
+        this.setState({
+          nextItem: this.makeItem(nextProps),
+        });
+      } else if (
+        itemQueueCount === 0 &&
+        !this.state.nextItem &&
+        this.state.currentItem.view.props.viewId === candidate.props.viewId
+      ) {
+        this.setState({
+          currentItem: this.makeItem(nextProps),
+        });
+      } else {
+        // add new item
+        this.setState({
+          itemQueue: [...this.state.itemQueue, this.makeItem(nextProps)],
+        });
+      }
+    } else if (candidate && !this.state.currentItem) {
+      this.setState({ currentItem: this.makeItem(nextProps) });
+    }
+  }
+
+  public componentDidUpdate() {
+    this.cycle();
+  }
+
+  public componentWillUnmount() {
+    if (this.animation) {
+      this.animation.stop();
+    }
+  }
+
+  public render() {
+    const disableUserInteraction =
+      this.state.itemQueue.length > 0 || this.state.nextItem ? true : false;
+
+    return (
+      <View style={styles.transitionContainer} onLayout={this.onLayout}>
+        {this.state.currentItem && (
+          <Animated.View
+            key={this.state.currentItem.view.props.viewId}
+            style={[styles.animatedContainer, this.state.currentItemStyle]}>
+            {this.state.currentItem.view}
+          </Animated.View>
+        )}
+
+        {this.state.nextItem && (
+          <Animated.View
+            key={this.state.nextItem.view.props.viewId}
+            style={[styles.animatedContainer, this.state.nextItemStyle]}>
+            {this.state.nextItem.view}
+          </Animated.View>
+        )}
+
+        {disableUserInteraction && (
+          <View style={[styles.animatedContainer, styles.userInteractionBlocker]} />
+        )}
+      </View>
+    );
+  }
+
+  private onLayout = (event: Types.ViewOnLayoutEvent) => {
+    this.containerSize = { width: event.width, height: event.height };
+  };
+
+  private cycle() {
+    if (!this.isCycling) {
+      this.isCycling = true;
+      this.cycleUnguarded(() => {
+        this.isCycling = false;
+      });
+    }
+  }
+
+  private cycleUnguarded(onFinish: () => void) {
+    const itemQueue = this.state.itemQueue;
+
+    const continueCycling = () => {
+      this.makeNextItemCurrent(() => {
+        this.cycleUnguarded(onFinish);
+      });
+    };
+
+    if (itemQueue.length > 0) {
+      const nextItem = itemQueue[0];
+      const transition = nextItem.transition;
+
+      switch (transition.name) {
+        case 'slide-up':
+          this.slideUp(transition.duration, continueCycling);
+          break;
+
+        case 'slide-down':
+          this.slideDown(transition.duration, continueCycling);
+          break;
+
+        case 'push':
+          this.push(transition.duration, continueCycling);
+          break;
+
+        case 'pop':
+          this.pop(transition.duration, continueCycling);
+          break;
+
+        default:
+          this.replace(() => {
+            this.cycleUnguarded(onFinish);
+          });
+          break;
+      }
+    } else {
+      this.animation = undefined;
+      onFinish();
+    }
+  }
+
+  private makeItem(props: IProps): ITransitionQueueItem {
+    return {
+      transition: {
+        name: props.name,
+        duration: props.duration,
+      },
+      view: React.cloneElement(props.children),
+    };
+  }
+
+  private makeNextItemCurrent(completion: () => void) {
+    this.setState(
+      (state) => ({
+        currentItem: state.nextItem,
+        nextItem: undefined,
+        currentItemStyle: [],
+        nextItemStyle: [],
+      }),
+      completion,
+    );
+  }
+
+  private slideUp(duration: number, completion: Types.Animated.EndCallback) {
+    this.slideValueA.setValue(0);
+    this.slideValueB.setValue(this.containerSize.height);
+
+    this.setState(
+      (state) => ({
+        nextItem: state.itemQueue[0],
+        itemQueue: state.itemQueue.slice(1),
+        currentItemStyle: [this.slideAnimationStyleA, styles.orderBack],
+        nextItemStyle: [this.slideAnimationStyleB, styles.orderFront],
+      }),
+      () => {
+        const animation = Animated.timing(this.slideValueB, {
+          toValue: 0,
+          easing: Animated.Easing.InOut(),
+          duration,
+        });
+
+        animation.start(completion);
+        this.animation = animation;
+      },
+    );
+  }
+
+  private slideDown(duration: number, completion: Types.Animated.EndCallback) {
+    this.slideValueA.setValue(0);
+    this.slideValueB.setValue(0);
+
+    this.setState(
+      (state) => ({
+        nextItem: state.itemQueue[0],
+        itemQueue: state.itemQueue.slice(1),
+        currentItemStyle: [this.slideAnimationStyleA, styles.orderFront],
+        nextItemStyle: [this.slideAnimationStyleB, styles.orderBack],
+      }),
+      () => {
+        const animation = Animated.timing(this.slideValueA, {
+          toValue: this.containerSize.height,
+          easing: Animated.Easing.InOut(),
+          duration,
+        });
+
+        animation.start(completion);
+        this.animation = animation;
+      },
+    );
+  }
+
+  private push(duration: number, completion: Types.Animated.EndCallback) {
+    this.pushValueA.setValue(0);
+    this.pushValueB.setValue(this.containerSize.width);
+
+    this.setState(
+      (state) => ({
+        nextItem: state.itemQueue[0],
+        itemQueue: state.itemQueue.slice(1),
+        currentItemStyle: [this.pushStyleA, styles.orderBack],
+        nextItemStyle: [this.pushStyleB, styles.orderFront],
+      }),
+      () => {
+        const animation = Animated.parallel([
+          Animated.timing(this.pushValueA, {
+            toValue: -this.containerSize.width * 0.5,
+            easing: Animated.Easing.InOut(),
+            duration,
+          }),
+          Animated.timing(this.pushValueB, {
+            toValue: 0,
+            easing: Animated.Easing.InOut(),
+            duration,
+          }),
+        ]);
+
+        animation.start(completion);
+        this.animation = animation;
+      },
+    );
+  }
+
+  private pop(duration: number, completion: Types.Animated.EndCallback) {
+    this.pushValueA.setValue(-this.containerSize.width * 0.5);
+    this.pushValueB.setValue(0);
+
+    this.setState(
+      (state) => ({
+        nextItem: state.itemQueue[0],
+        itemQueue: state.itemQueue.slice(1),
+        currentItemStyle: [this.pushStyleB, styles.orderFront],
+        nextItemStyle: [this.pushStyleA, styles.orderBack],
+      }),
+      () => {
+        const animation = Animated.parallel([
+          Animated.timing(this.pushValueA, {
+            toValue: 0,
+            easing: Animated.Easing.InOut(),
+            duration,
+          }),
+          Animated.timing(this.pushValueB, {
+            toValue: this.containerSize.width,
+            easing: Animated.Easing.InOut(),
+            duration,
+          }),
+        ]);
+
+        animation.start(completion);
+        this.animation = animation;
+      },
+    );
+  }
+
+  private replace(completion: () => void) {
+    this.setState(
+      (state) => ({
+        currentItem: state.itemQueue[0],
+        nextItem: undefined,
+        itemQueue: state.itemQueue.slice(1),
+        currentItemStyle: [],
+        nextItemStyle: [],
+      }),
+      completion,
+    );
+  }
 }

--- a/gui/src/shared/gettext.ts
+++ b/gui/src/shared/gettext.ts
@@ -12,7 +12,7 @@ const LOCALES_DIR = path.resolve(__dirname, '../../locales');
 // the errors are handled separately in the "error" handler below
 const catalogue = new Gettext({ debug: false });
 catalogue.setTextDomain('messages');
-catalogue.on('error', (error: string) => {
+catalogue.on('error', (error) => {
   // Filter out the "no translation was found" errors for the source language
   if (SELECTED_LANGUAGE === SOURCE_LANGUAGE && error.indexOf('No translation was found') !== -1) {
     return;

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -13,30 +13,31 @@
   integrity sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA=
 
 "@babel/runtime@^7.1.2":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
-  integrity sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
-  integrity sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.1":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/formatio@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.1.0.tgz#6ac9d1eb1821984d84c4996726e45d1646d8cce5"
-  integrity sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==
+"@sinonjs/formatio@^3.1.0", "@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
   dependencies:
-    "@sinonjs/samsam" "^2 || ^3"
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
 
-"@sinonjs/samsam@^2 || ^3", "@sinonjs/samsam@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.2.0.tgz#58c62b5f1f42e46d039d073d0ae2753da676bf0c"
-  integrity sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.2.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.0.tgz#9557ea89cd39dbc94ffbd093c8085281cac87416"
+  integrity sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==
   dependencies:
     "@sinonjs/commons" "^1.0.2"
     array-from "^2.1.1"
@@ -72,9 +73,9 @@
   integrity sha512-q6LuBI0t5u04f0Q4/R+cGBqIbZMtJkVvCSF+nTfFBBdQqQvJR/mNHeWjRkszyLl7oyf2rDoKUYMEjTw5AV0hiw==
 
 "@types/d3-geo@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-1.11.0.tgz#f7921c5c50d1a43df928846d8a7e47140455687f"
-  integrity sha512-/IbMHRG9cur+6hkWvBrRg3DnnUWtaSW8Bl6nu1OO1J8K25BxRYyLslyjIBbwlK0kV0haztlAR2LCIRuDc/U2LA==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-1.11.1.tgz#e96ec91f16221d87507fec66b2cc889f52d2493e"
+  integrity sha512-Ox8WWOG3igDRoep/dNsGbOiSJYdUG3ew/6z0ETvHyAtXZVBjOE0S96zSSmzgl0gqQ3RdZjn2eeJOj9oRcMZPkQ==
   dependencies:
     "@types/geojson" "*"
 
@@ -107,9 +108,9 @@
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
 "@types/geojson@*":
-  version "7946.0.5"
-  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.5.tgz#9aea839ea5af4b1bc079f1d9fa977d48665e02b0"
-  integrity sha512-rLlMXpd3rdlrp0+xsrda/hFfOpIxgqFcRpk005UKbHtcdFK+QXAjhBAPnvO58qF4O1LdDXrcaiJxMgstCIlcaw==
+  version "7946.0.6"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.6.tgz#416f388a06b227784a2d91a88a53f14de05cd54b"
+  integrity sha512-f6qai3iR62QuMPPdgyH+LyiXTL2n9Rf62UniJjV7KHrbiwzLTZUKsdq0mFSTxAHbO7JvwxwC4tH0m1UnweuLrA==
 
 "@types/glob@5 - 7":
   version "7.1.1"
@@ -124,6 +125,13 @@
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
   integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
+
+"@types/hoist-non-react-statics@*":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#a59c0c995cc885bef1b8ec2241b114f9b35b517b"
+  integrity sha512-O2OGyW9wlO2bbDmZRH17MecArQfsIa1g//ve2IJk6BnmwEglFz5kdhP1BlgeqjVNH5IHIhsc83DWFo8StCe8+Q==
+  dependencies:
+    "@types/react" "*"
 
 "@types/lodash@4.14.118":
   version "4.14.118"
@@ -148,9 +156,9 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node-gettext@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node-gettext/-/node-gettext-2.0.0.tgz#b4d7fdf8311c19eb3d828051745310a4365472eb"
-  integrity sha512-70HykF9FKN8sMTlmSCiwqEzTwHMwZeJ/6tHt7qQaRqFx5czIvu2HQ0ipSWu+YTINe9AT9sKHCJ5jQT2SLtCjxQ==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/node-gettext/-/node-gettext-2.0.1.tgz#5cad8c8bc52e6a8f355a71950628172cb3b34408"
+  integrity sha512-5UCSuDsP7zBwQtBPoJ9Ni0T96+Fuxus7/cF39ZoP319aj7kdsvFR5Zhu5P1IpA3X8PEvED/e8OnFOlFigqfg5A==
 
 "@types/node@*":
   version "11.9.5"
@@ -173,11 +181,9 @@
   integrity sha512-J5D3z703XTDIGQFYXsnU9uRCW9e9mMEFO0Kpe6kykyiboqziru/RlZ0hM2P+PKTG4NHG1SjLrqae/NrV2iJApQ==
 
 "@types/prop-types@*":
-  version "15.5.5"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
-  integrity sha512-mOrlCEdwX3seT3n0AXNt4KNPAZZxcsABUHwBgFXOt+nvFUXkxCAO6UBJHPrDxWEa2KDMil86355fjo8jbZ+K0Q==
-  dependencies:
-    "@types/react" "*"
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
+  integrity sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==
 
 "@types/rbush@^2.0.2":
   version "2.0.2"
@@ -200,25 +206,26 @@
     "@types/react" "*"
 
 "@types/react-redux@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.0.tgz#8aaba50fb43739462c40e65e85f96eb8a550d494"
-  integrity sha512-p5/vXqS4+Gq7EYzNv4SMi/yy7cM/BUbZORlPXY6F8wCyo5EfPa3Gpf6CEQX+UtbK5g2mqgERqVYyutzZYKIpaQ==
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.3.tgz#b8dc3faa954b7f28e4b0209bcf9209b45251ed6b"
+  integrity sha512-6qsIHHNwF41viooUgR2lXHL81v3uyeJsugq9YCMYE4g2bDyG710G/I/w5nbn7AQ9XfuOLUwrWfm3edV7gDJ9AQ==
   dependencies:
+    "@types/hoist-non-react-statics" "*"
     "@types/react" "*"
     redux "^4.0.0"
 
 "@types/react-router@^4.4.3":
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.3.tgz#ea68b4021cb576866f83365b2201411537423d50"
-  integrity sha512-8GmjakEBFNCLJbpg9jtDp1EDvFP0VkIPPKBpVwmB3Q+9whFoHu8rluMUXUE5SoGkEQvVOtgJzWmUsJojNpFMQQ==
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.5.tgz#1166997dc7eef2917b5ebce890ebecb32ee5c1b3"
+  integrity sha512-12+VOu1+xiC8RPc9yrgHCyLI79VswjtuqeS2gPrMcywH6tkc8rGIUhs4LaL3AJPqo5d+RPnfRpNKiJ7MK2Qhcg==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*":
-  version "16.4.11"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.11.tgz#330f3d864300f71150dc2d125e48644c098f8770"
-  integrity sha512-1DQnmwO8u8N3ucvRX2ZLDEjQ2VctkAvL/rpbm2ev4uaZA0z4ysU+I0tk+K8ZLblC6p7MCgFyF+cQlSNIPUHzeQ==
+  version "16.8.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.7.tgz#7b1c0223dd5494f9b4501ad2a69aa6acb350a29b"
+  integrity sha512-0xbkIyrDNKUn4IJVf8JaCn+ucao/cq6ZB8O6kSzhrJub1cVSqgTArtG0qCfdERWKMEIvUbrwLXeQMqWEsyr9dA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -231,9 +238,9 @@
     csstype "^2.2.0"
 
 "@types/sinon@^7.0.5":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.5.tgz#f7dea19400c193a3b36a804a7f1f4b26dacf452b"
-  integrity sha512-4DShbH857bZVOY4tPi1RQJNrLcf89hEtU0klZ9aYTMbtt95Ok4XdPqqcbtGOHIbAHMLSzQP8Uw/6qtBBqyloww==
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.9.tgz#981593ea396a4fb1b69e3d8ba04de0a420fd4b16"
+  integrity sha512-PS102Fj4BAa9B8C0qLp677UiW9sdI+9ZhsD6GdPbcNKNdymyKKRJ1Bsc5Uk5pQV7jTtLozTQdxzgnQx+aH8Pvg==
 
 "@types/sprintf-js@^1.1.2":
   version "1.1.2"
@@ -320,7 +327,7 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -382,6 +389,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
+  integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -460,11 +472,6 @@ arraybuffer.slice@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
-
-arrify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
 asap@~2.0.3:
   version "2.0.6"
@@ -788,7 +795,7 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
-buffer-from@^1.0.0, buffer-from@^1.1.0:
+buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -921,7 +928,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
+chalk@^2.0.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -1205,7 +1212,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.4, cross-spawn@^6.0.5:
+cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -1247,9 +1254,9 @@ css-what@2.1:
   integrity sha1-lGfQMsOM+u+58teVASUwYvh/ob0=
 
 csstype@^2.2.0:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.6.tgz#2ae1db2319642d8b80a668d2d025c6196071e788"
-  integrity sha512-tKPyhy0FmfYD2KQYXD5GzkvAYLYj96cMLXr648CKGd3wBe0QqoPipImjGiLze9c8leJK8J3n7ap90tpk3E6HGQ==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.3.tgz#b701e5968245bf9b08d54ac83d00b624e622a9fa"
+  integrity sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1759,7 +1766,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.10.0, es-abstract@^1.4.3, es-abstract@^1.5.0, es-abstract@^1.6.1:
+es-abstract@^1.10.0, es-abstract@^1.5.0, es-abstract@^1.6.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   integrity sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
@@ -1770,14 +1777,26 @@ es-abstract@^1.10.0, es-abstract@^1.4.3, es-abstract@^1.5.0, es-abstract@^1.6.1:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
-es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
-  integrity sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=
+es-abstract@^1.4.3:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
   dependencies:
-    is-callable "^1.1.1"
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.1.1, es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
     is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
+    is-symbol "^1.0.2"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -1804,7 +1823,7 @@ etag@1.8.1, etag@^1.8.1, etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-stream@=3.3.4, event-stream@~3.3.0:
+event-stream@=3.3.4:
   version "3.3.4"
   resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
@@ -2270,10 +2289,15 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+
+graceful-fs@^4.1.2:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 growl@1.10.5:
   version "1.10.5"
@@ -2386,12 +2410,12 @@ hoist-non-react-statics@^2.5.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
-  integrity sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==
+hoist-non-react-statics@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
   dependencies:
-    react-is "^16.3.2"
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   version "2.7.1"
@@ -2568,7 +2592,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3, is-callable@^1.1.4:
+is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
@@ -2801,10 +2825,12 @@ is-subset@^0.1.1:
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
   integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
 
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
-  integrity sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2966,9 +2992,9 @@ jsonparse@^1.2.0:
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsonrpc-lite@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jsonrpc-lite/-/jsonrpc-lite-2.0.1.tgz#c1510a526989928c692a987b688bccee79e690f2"
-  integrity sha512-kwebGXQxzmzsN7DSvEkkRSzl9xZI6wnZQ7WG5pxXS6hNLWB/3DZ1rDusWF94T9fIslHGiZVdcB/FqlEgBN3SyA==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/jsonrpc-lite/-/jsonrpc-lite-2.0.4.tgz#a8f8e9db2830d1a383d21ee97bd259c3321cff25"
+  integrity sha512-vr78eFnTrluTljM3lEydW9qDclgfGGpRoRDe1y/0i650oSx5fiTefW3PwDMUQ/+uJN76wG7yGPwTh0BVFaBP4Q==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -3431,9 +3457,9 @@ negotiator@0.6.1:
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
 nice-try@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
-  integrity sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 nise@^1.4.10:
   version "1.4.10"
@@ -3514,7 +3540,17 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.4.0:
+normalize-package-data@^2.3.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+normalize-package-data@^2.3.4, normalize-package-data@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   integrity sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
@@ -3545,16 +3581,16 @@ npm-packlist@^1.1.6:
     npm-bundled "^1.0.1"
 
 npm-run-all@^4.0.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.3.tgz#49f15b55a66bb4101664ce270cb18e7103f8f185"
-  integrity sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
   dependencies:
-    ansi-styles "^3.2.0"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.4"
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
     memorystream "^0.3.1"
     minimatch "^3.0.4"
-    ps-tree "^1.1.0"
+    pidtree "^0.3.0"
     read-pkg "^3.0.0"
     shell-quote "^1.6.1"
     string.prototype.padend "^3.0.0"
@@ -3641,10 +3677,15 @@ object-is@^1.0.1:
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
   integrity sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-keys@^1.0.11:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
   integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+
+object-keys@^1.0.12:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-keys@~0.4.0:
   version "0.4.0"
@@ -3952,6 +3993,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+pidtree@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
+  integrity sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -4053,7 +4099,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -4061,12 +4107,14 @@ prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-ps-tree@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
-  integrity sha1-tCGyQUDWID8e08dplrRCewjowBQ=
+prop-types@^15.6.1:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
-    event-stream "~3.3.0"
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 ps-tree@^1.2.0:
   version "1.2.0"
@@ -4186,15 +4234,20 @@ react-dom@^16.5.0:
     prop-types "^15.6.2"
     scheduler "^0.12.0"
 
-react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.1:
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.1.tgz#f77b1c3d901be300abe8d58645b7a59e794e5982"
-  integrity sha512-wOKsGtvTMYs7WAscmwwdM8sfRRvE17Ym30zFj3n37Qx5tHRfhenPKEPILHaHob6WoLFADmQm1ZNrE5xMCM6sCw==
-
 react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
   integrity sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg==
+
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
+  integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
+
+react-is@^16.6.1:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.1.tgz#f77b1c3d901be300abe8d58645b7a59e794e5982"
+  integrity sha512-wOKsGtvTMYs7WAscmwwdM8sfRRvE17Ym30zFj3n37Qx5tHRfhenPKEPILHaHob6WoLFADmQm1ZNrE5xMCM6sCw==
 
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"
@@ -4202,12 +4255,12 @@ react-lifecycles-compat@^3.0.0:
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-redux@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.0.tgz#948b1e2686473d1999092bcfb32d0dc43d33f667"
-  integrity sha512-CRMpEx8+ccpoVxQrQDkG1obExNYpj6dZ1Ni7lUNFB9wcxOhy02tIqpFo4IUXc0kYvCGMu6ABj9A4imEX2VGZJQ==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.1.tgz#88e368682c7fa80e34e055cd7ac56f5936b0f52f"
+  integrity sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    hoist-non-react-statics "^3.0.0"
+    hoist-non-react-statics "^3.1.0"
     invariant "^2.2.4"
     loose-envify "^1.1.0"
     prop-types "^15.6.1"
@@ -4484,7 +4537,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.10, resolve@^1.3.2:
+resolve@^1.1.10, resolve@^1.10.0, resolve@^1.3.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -4587,15 +4640,15 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
-  integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
-
-semver@^5.3.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^5.0.3, semver@^5.1.0, semver@^5.4.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+  integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
 
 send@0.16.2:
   version "0.16.2"
@@ -4719,12 +4772,12 @@ single-line-log@^1.1.2:
     string-width "^1.0.1"
 
 sinon@^7.1.1:
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.5.tgz#1a4e4a819b59ed1dc0054b469981c72849fab43f"
-  integrity sha512-1c2KK6g5NQr9XNYCEcUbeFtBpKZD1FXEw0VX7gNhWUBtkchguT2lNdS7XmS7y64OpQWfSNeeV/f8py3NNcQ63Q==
+  version "7.2.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.7.tgz#ee90f83ce87d9a6bac42cf32a3103d8c8b1bfb68"
+  integrity sha512-rlrre9F80pIQr3M36gOdoCEWzFAMDgHYD8+tocqOw+Zw9OZ8F84a80Ds69eZfcjnzDqqG88ulFld0oin/6rG/g==
   dependencies:
-    "@sinonjs/commons" "^1.3.0"
-    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/commons" "^1.3.1"
+    "@sinonjs/formatio" "^3.2.1"
     "@sinonjs/samsam" "^3.2.0"
     diff "^3.5.0"
     lolex "^3.1.0"
@@ -4819,9 +4872,9 @@ source-map-resolve@^0.5.0:
     urix "^0.1.0"
 
 source-map-support@^0.5.6:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
-  integrity sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.11.tgz#efac2ce0800355d026326a0ca23e162aeac9a4e2"
+  integrity sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -4850,17 +4903,17 @@ source-map@^0.6.0:
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spdx-correct@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
-  integrity sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
+  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
-  integrity sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
+  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
 
 spdx-expression-parse@^3.0.0:
   version "3.0.0"
@@ -4871,9 +4924,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
-  integrity sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
+  integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
 
 speedometer@~0.1.2:
   version "0.1.4"
@@ -5229,19 +5282,16 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-ts-node@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
-  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+ts-node@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.0.3.tgz#aa60b836a24dafd8bf21b54766841a232fdbc641"
+  integrity sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==
   dependencies:
-    arrify "^1.0.0"
-    buffer-from "^1.1.0"
+    arg "^4.1.0"
     diff "^3.1.0"
     make-error "^1.1.1"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
     source-map-support "^0.5.6"
-    yn "^2.0.0"
+    yn "^3.0.0"
 
 tsc-watch@^2.1.1:
   version "2.1.2"
@@ -5272,9 +5322,9 @@ tslint-react@^3.6.0:
     tsutils "^2.13.1"
 
 tslint@^5.12.1:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.13.0.tgz#239a2357c36b620d72d86744754b6fc088a25359"
-  integrity sha512-ECOOQRxXCYnUUePG5h/+Z1Zouobk3KFpIHA9aKBB/nnMxs97S1JJPDGt5J4cGm1y9U9VmVlfboOxA8n1kSNzGw==
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.13.1.tgz#fbc0541c425647a33cd9108ce4fd4cd18d7904ed"
+  integrity sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -5723,7 +5773,7 @@ yeast@0.1.2:
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
-yn@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
-  integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
+yn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.0.0.tgz#0073c6b56e92aed652fbdfd62431f2d6b9a7a091"
+  integrity sha512-+Wo/p5VRfxUgBUGy2j/6KX2mj9AYJWOHuhMjMcbBFc3y54o9/4buK1ksBvuiK01C3kby8DH9lSmJdSxw+4G/2Q==


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR revamps the transition container and adds support for animation queues. This PR also fixes a bug introduced on master that allowed user interaction during screen transitions.

### Why

The initial implementation of `TransitionContainer` was error prone to multiple requests to animate children because `props.children` was always directly so basically replacing it during the active animation could break things.

### How

The new implementation of `TransitionContainer` captures `props.children` and animates between the last two captured child nodes at a time. 

Each child node uses the unique ID enforced via the `viewId` prop. Using this key, the transition container can tell updates from transitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/739)
<!-- Reviewable:end -->
