### PR TITLE
Wg rework ping

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -11,7 +11,7 @@ pub mod wireguard_go;
 pub use self::wireguard_go::WgGoTunnel;
 
 // amount of seconds to run `ping` until it returns.
-const PING_TIMEOUT: u16 = 5;
+const PING_TIMEOUT: u16 = 7;
 
 error_chain! {
     errors {

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -76,15 +76,16 @@ impl WireguardMonitor {
             close_msg_receiver,
         };
         monitor.setup_routing(&config)?;
-        monitor.start_pinger(&config);
         monitor.tunnel_up(&config);
 
         ping_monitor::ping(
             config.ipv4_gateway.into(),
             PING_TIMEOUT,
             &monitor.tunnel.get_interface_name().to_string(),
+            true,
         )
         .chain_err(|| ErrorKind::PingTimeoutError)?;
+        monitor.start_pinger(&config);
 
         Ok(monitor)
     }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -343,6 +343,7 @@ impl TunnelState for ConnectingState {
                             )
                         }
                         Err(error) => {
+                            log::error!("Failed to start tunnel: {}", error);
                             let block_reason = match *error.kind() {
                                 tunnel::ErrorKind::EnableIpv6Error => BlockReason::Ipv6Unavailable,
 


### PR DESCRIPTION
As testing has showed, our connectivity checks for wireguard are a tad too aggressive. So, I've reworked the way we do them - instead of sending a single ping every 5 seconds, now we would send one ping every second for 7 seconds. There have to be no ping responses for 7 seconds straight for the daemon to consider the tunnel disconnected, so we allow for some fault tolerance. We will however not wait for the full 7 seconds when initially starting up if we receive a valid response quicker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/741)
<!-- Reviewable:end -->
