### PR TITLE
Add cell switch

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -15,7 +15,6 @@ import {
   TitleBarItem,
 } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
-import Switch from './Switch';
 
 const MIN_MSSFIX_VALUE = 1000;
 const MAX_MSSFIX_VALUE = 1450;
@@ -107,7 +106,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
 
                   <Cell.Container>
                     <Cell.Label>{pgettext('advanced-settings-view', 'Enable IPv6')}</Cell.Label>
-                    <Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
+                    <Cell.Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
                   </Cell.Container>
                   <Cell.Footer>
                     {pgettext(
@@ -120,7 +119,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     <Cell.Label textStyle={styles.advanced_settings__block_when_disconnected_label}>
                       {pgettext('advanced-settings-view', 'Block when disconnected')}
                     </Cell.Label>
-                    <Switch
+                    <Cell.Switch
                       isOn={this.props.blockWhenDisconnected}
                       onChange={this.props.setBlockWhenDisconnected}
                     />

--- a/gui/src/renderer/components/Cell.tsx
+++ b/gui/src/renderer/components/Cell.tsx
@@ -160,15 +160,15 @@ interface ISectionTitleProps {
   children?: React.ReactText;
 }
 
-export function SectionTitle(props: ISectionTitleProps) {
+export const SectionTitle = function CellSectionTitle(props: ISectionTitleProps) {
   return <Text style={styles.sectionTitle}>{props.children}</Text>;
-}
+};
 
 interface ISectionProps {
   children?: React.ReactNode;
 }
 
-export class Section extends Component<ISectionProps> {
+export const Section = class CellSection extends Component<ISectionProps> {
   public render() {
     return (
       <View>
@@ -178,15 +178,15 @@ export class Section extends Component<ISectionProps> {
       </View>
     );
   }
-}
+};
 
 interface IContainerProps {
   children: React.ReactNode;
 }
 
-export function Container({ children }: IContainerProps) {
+export const Container = function CellContainer({ children }: IContainerProps) {
   return <View style={styles.cellContainer}>{children}</View>;
-}
+};
 
 interface ILabelProps {
   containerStyle?: Types.ViewStyleRuleSet;
@@ -197,7 +197,7 @@ interface ILabelProps {
   children?: React.ReactNode;
 }
 
-export function Label(props: ILabelProps) {
+export const Label = function CellLabel(props: ILabelProps) {
   const {
     children,
     containerStyle,
@@ -224,7 +224,7 @@ export function Label(props: ILabelProps) {
       )}
     </CellHoverContext.Consumer>
   );
-}
+};
 
 export const Switch = function CellSwitch(props: SwitchControl['props']) {
   return (
@@ -239,13 +239,13 @@ interface InputFrameProps {
   style?: Types.StyleRuleSetRecursive<Types.ViewStyleRuleSet>;
 }
 
-export function InputFrame(props: InputFrameProps) {
+export const InputFrame = function CellInputFrame(props: InputFrameProps) {
   const { style, children } = props;
 
   return <View style={[styles.input.frame, style]}>{children}</View>;
-}
+};
 
-export const Input = React.forwardRef(function InputT(
+export const Input = React.forwardRef(function CellInput(
   props: Types.TextInputProps,
   ref?: React.Ref<TextInput>,
 ) {
@@ -268,7 +268,7 @@ type SubTextProps = Types.TextProps & {
   cellHoverStyle?: Types.ViewStyle;
 };
 
-export function SubText(props: SubTextProps) {
+export const SubText = function CellSubText(props: SubTextProps) {
   const { children, ref: _, style, cellHoverStyle, ...otherProps } = props;
 
   return (
@@ -280,9 +280,9 @@ export function SubText(props: SubTextProps) {
       )}
     </CellHoverContext.Consumer>
   );
-}
+};
 
-export function Icon(props: ImageView['props']) {
+export const Icon = function CellIcon(props: ImageView['props']) {
   const { children: _children, style, tintColor, tintHoverColor, ...otherProps } = props;
 
   return (
@@ -296,12 +296,12 @@ export function Icon(props: ImageView['props']) {
       )}
     </CellHoverContext.Consumer>
   );
-}
+};
 
-export function Footer({ children }: IContainerProps) {
+export const Footer = function CellFooter({ children }: IContainerProps) {
   return (
     <View style={styles.footer.container}>
       <Text style={styles.footer.text}>{children}</Text>
     </View>
   );
-}
+};

--- a/gui/src/renderer/components/Cell.tsx
+++ b/gui/src/renderer/components/Cell.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Button, Component, Styles, Text, TextInput, Types, View } from 'reactxp';
 import { colors } from '../../config.json';
 import ImageView from './ImageView';
+import { default as SwitchControl } from './Switch';
 
 const styles = {
   cellButton: {
@@ -62,6 +63,9 @@ const styles = {
       color: colors.white,
     }),
   },
+  switch: Styles.createViewStyle({
+    flex: 0,
+  }),
   input: {
     frame: Styles.createViewStyle({
       flexGrow: 0,
@@ -221,6 +225,14 @@ export function Label(props: ILabelProps) {
     </CellHoverContext.Consumer>
   );
 }
+
+export const Switch = function CellSwitch(props: SwitchControl['props']) {
+  return (
+    <View style={styles.switch}>
+      <SwitchControl {...props} />
+    </View>
+  );
+};
 
 interface InputFrameProps {
   children?: React.ReactNode;

--- a/gui/src/renderer/components/Preferences.tsx
+++ b/gui/src/renderer/components/Preferences.tsx
@@ -12,7 +12,6 @@ import {
 } from './NavigationBar';
 import styles from './PreferencesStyles';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
-import Switch from './Switch';
 
 export interface IPreferencesProps {
   autoStart: boolean;
@@ -59,13 +58,16 @@ export default class Preferences extends Component<IPreferencesProps> {
                       <Cell.Label>
                         {pgettext('preferences-view', 'Launch app on start-up')}
                       </Cell.Label>
-                      <Switch isOn={this.props.autoStart} onChange={this.onChangeAutoStart} />
+                      <Cell.Switch isOn={this.props.autoStart} onChange={this.onChangeAutoStart} />
                     </Cell.Container>
                     <View style={styles.preferences__separator} />
 
                     <Cell.Container>
                       <Cell.Label>{pgettext('preferences-view', 'Auto-connect')}</Cell.Label>
-                      <Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
+                      <Cell.Switch
+                        isOn={this.props.autoConnect}
+                        onChange={this.props.setAutoConnect}
+                      />
                     </Cell.Container>
                     <Cell.Footer>
                       {pgettext(
@@ -78,7 +80,7 @@ export default class Preferences extends Component<IPreferencesProps> {
                       <Cell.Label>
                         {pgettext('preferences-view', 'Local network sharing')}
                       </Cell.Label>
-                      <Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
+                      <Cell.Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
                     </Cell.Container>
                     <Cell.Footer>
                       {pgettext(
@@ -126,7 +128,7 @@ class MonochromaticIconToggle extends Component<IMonochromaticIconProps> {
         <View>
           <Cell.Container>
             <Cell.Label>{pgettext('preferences-view', 'Monochromatic tray icon')}</Cell.Label>
-            <Switch isOn={this.props.monochromaticIcon} onChange={this.props.onChange} />
+            <Cell.Switch isOn={this.props.monochromaticIcon} onChange={this.props.onChange} />
           </Cell.Container>
           <Cell.Footer>
             {pgettext(
@@ -155,7 +157,7 @@ class StartMinimizedToggle extends Component<IStartMinimizedProps> {
         <View>
           <Cell.Container>
             <Cell.Label>{pgettext('preferences-view', 'Start minimized')}</Cell.Label>
-            <Switch isOn={this.props.startMinimized} onChange={this.props.onChange} />
+            <Cell.Switch isOn={this.props.startMinimized} onChange={this.props.onChange} />
           </Cell.Container>
           <Cell.Footer>
             {pgettext('preferences-view', 'Show only the tray icon when the app starts.')}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR addresses two issues:

1. Fix `Switch` control layout when contained within Cells. The bug reveals itself when the left-hand side text has long words . Normally that's not a problem with the English UI, but can be reproduced for instance using German translations. (See the screenshot below)

<img width="322" alt="Screenshot 2019-03-14 at 09 28 51" src="https://user-images.githubusercontent.com/704044/54341986-9a76c300-463b-11e9-90bb-cda0d5c5cb0f.png">

2. Prefix classes exported from `Cell.tsx` to improve debugging. React development tools display class and function names in the React tree. Filtering the tree used to give lots of false positives just because there are plenty of views that export classes with the same names, such as `Container`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/742)
<!-- Reviewable:end -->
