### PR TITLE
Add auto-sizing input container for mssfix field

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -164,16 +164,18 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                   <Cell.Container>
                     <Cell.Label>{pgettext('advanced-settings-view', 'Mssfix')}</Cell.Label>
                     <Cell.InputFrame style={styles.advanced_settings__mssfix_frame}>
-                      <Cell.Input
-                        keyboardType={'numeric'}
-                        maxLength={4}
-                        placeholder={pgettext('advanced-settings-view', 'Default')}
-                        value={mssfixValue ? mssfixValue.toString() : ''}
-                        style={mssfixStyle}
-                        onChangeText={this.onMssfixChange}
-                        onFocus={this.onMssfixFocus}
-                        onBlur={this.onMssfixBlur}
-                      />
+                      <Cell.AutoSizingTextInputContainer>
+                        <Cell.Input
+                          keyboardType={'numeric'}
+                          maxLength={4}
+                          placeholder={pgettext('advanced-settings-view', 'Default')}
+                          value={mssfixValue ? mssfixValue.toString() : ''}
+                          style={[styles.advanced_settings__mssfix_input, mssfixStyle]}
+                          onChangeText={this.onMssfixChange}
+                          onFocus={this.onMssfixFocus}
+                          onBlur={this.onMssfixBlur}
+                        />
+                      </Cell.AutoSizingTextInputContainer>
                     </Cell.InputFrame>
                   </Cell.Container>
                   <Cell.Footer>

--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -37,10 +37,11 @@ export default {
     color: colors.white,
     flex: 0,
   }),
+  advanced_settings__mssfix_input: Styles.createTextInputStyle({
+    minWidth: 80,
+  }),
   advanced_settings__mssfix_frame: Styles.createViewStyle({
-    flexGrow: 0,
-    flexShrink: 0,
-    flexBasis: 80,
+    flex: 0,
   }),
   advanced_settings__mssfix_valid_value: Styles.createTextStyle({
     color: colors.white,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR adds a self-sizing input field, primarily to make sure that mssfix automatically resizes itself to make the placeholder text fully visible.

### Why

The mssfix field used to have a fixed 80px width which didn't quite work for languages where the word Default is more than 7 letters long.

### How

By adding a hidden replica text node for measuring the placeholder width and then applying it to the text input field. The minimum width is still capped at 80px to make sure that it can fit. 4 digits.

<table>
<tr>
<th>Chinese</th>
<th>Spanish</th>
<th>German</th>
</tr>
<tr>
<td>
<img width="432" alt="Screenshot 2019-03-15 at 16 09 34" src="https://user-images.githubusercontent.com/704044/54442836-acda2500-473f-11e9-8e96-3b4b4a29dd03.png">
</td>
<td>
<img width="432" alt="Screenshot 2019-03-15 at 16 11 42" src="https://user-images.githubusercontent.com/704044/54442837-ad72bb80-473f-11e9-8a2d-2db93f9e35d5.png">
</td>
<td>
<img width="432" alt="Screenshot 2019-03-15 at 16 12 05" src="https://user-images.githubusercontent.com/704044/54442838-ad72bb80-473f-11e9-8811-1356bb4c14af.png">
</td>
</tr>
</table>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/746)
<!-- Reviewable:end -->
