### PR TITLE
Fix ping args for Linux

### DIFF
--- a/talpid-core/src/tunnel/wireguard/ping_monitor.rs
+++ b/talpid-core/src/tunnel/wireguard/ping_monitor.rs
@@ -79,7 +79,11 @@ fn ping_cmd(
         &ip,
     ];
     if exit_on_first_reply {
-        args.push("-o");
+        if cfg!(target_os = "macos") {
+            args.push("-o");
+        } else {
+            args.extend_from_slice(&["-c", "1"])
+        }
     }
     duct::cmd("ping", args)
         .stdin_null()


### PR DESCRIPTION
Whilst changing ping behavior to exit on first ping on OSX, I was too naive and expected that the `-o` flag would also work on Linux. It does not. So I've amended the code to work the same-ish way on both Linux and MacOS. These changes I did actually test on 18.04 and Fedora 28.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/751)
<!-- Reviewable:end -->
