### PR TITLE
Fix connecting state for WireGuard

### DIFF
--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -137,7 +137,7 @@ impl TunnelMonitor {
         on_event: L,
     ) -> Result<Self>
     where
-        L: Fn(TunnelEvent) + Send + Sync + 'static,
+        L: Fn(TunnelEvent) + Send + Clone + Sync + 'static,
     {
         Self::ensure_ipv6_can_be_used_if_enabled(&tunnel_parameters.get_generic_options())?;
         let log_file = Self::prepare_tunnel_log_file(&tunnel_parameters, log_dir)?;
@@ -162,7 +162,7 @@ impl TunnelMonitor {
         on_event: L,
     ) -> Result<Self>
     where
-        L: Fn(TunnelEvent) + Send + Sync + 'static,
+        L: Fn(TunnelEvent) + Send + Sync + Clone + 'static,
     {
         let config = wireguard::config::Config::from_parameters(&params)
             .chain_err(|| ErrorKind::WireguardConfigError)?;

--- a/talpid-core/src/tunnel/wireguard/ping_monitor.rs
+++ b/talpid-core/src/tunnel/wireguard/ping_monitor.rs
@@ -12,25 +12,16 @@ error_chain! {
     }
 }
 
-pub fn spawn_ping_monitor<F: FnOnce() + Send + 'static>(
-    ip: IpAddr,
-    timeout_secs: u16,
-    interface: String,
-    on_fail: F,
-) {
-    thread::spawn(move || loop {
+pub fn monitor_ping(ip: IpAddr, timeout_secs: u16, interface: &str) -> Result<()> {
+    loop {
         let start = time::Instant::now();
-        if let Err(e) = ping(ip, timeout_secs, &interface, false) {
-            log::debug!("ping failed - {}", e);
-            on_fail();
-            return;
-        }
+        ping(ip, timeout_secs, &interface, false)?;
         if let Some(remaining) =
             time::Duration::from_secs(timeout_secs.into()).checked_sub(start.elapsed())
         {
             thread::sleep(remaining);
         }
-    });
+    }
 }
 
 pub fn ping(

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -346,26 +346,8 @@ impl TunnelState for ConnectingState {
                             log::error!("Failed to start tunnel: {}", error);
                             let block_reason = match *error.kind() {
                                 tunnel::ErrorKind::EnableIpv6Error => BlockReason::Ipv6Unavailable,
-
-                                #[cfg(unix)]
-                                tunnel::ErrorKind::WirguardTunnelMonitoringError(ref err) => {
-                                    match &err {
-                                        tunnel::wireguard::ErrorKind::PingTimeoutError => {
-                                            if crate::offline::is_offline() {
-                                                BlockReason::IsOffline
-                                            } else {
-                                                BlockReason::StartTunnelError
-                                            }
-                                        }
-                                        _ => BlockReason::StartTunnelError,
-                                    }
-                                }
                                 _ => BlockReason::StartTunnelError,
                             };
-
-                            let chained_error = error.chain_err(|| "Failed to start tunnel");
-                            error!("{}", chained_error.display_chain());
-
                             BlockedState::enter(shared_values, block_reason)
                         }
                     }


### PR DESCRIPTION
After working on certain issues with WireGuard, it occurred to me that the inital ping check for a WireGuard tunnel was blocking the tunnel state machine loop. As such, I've moved it to the same thread that monitors the tunnel for the whole of it's lifetime. As such, I've removed the hacky workaround of checking whether the daemon failed to start the tunnel because of a ping timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/752)
<!-- Reviewable:end -->
