### PR TITLE
Translation fixes

### DIFF
--- a/gui/locales/de/messages.po
+++ b/gui/locales/de/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Last-Translator: adminmullvad <admin@mullvad.net>\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
-"PO-Revision-Date: 2019-03-18 14:19\n"
+"PO-Revision-Date: 2019-03-18 15:52\n"
 
 #: src/renderer/components/SecuredLabel.tsx:40
 msgid "BLOCKED CONNECTION"
@@ -55,7 +55,7 @@ msgctxt "account-view"
 msgid "Account ID"
 msgstr "Konto-ID"
 
-#: src/renderer/components/Account.tsx:69
+#: src/renderer/components/Account.tsx:71
 msgctxt "account-view"
 msgid "Buy more credit"
 msgstr "Mehr Guthaben erwerben"
@@ -65,20 +65,25 @@ msgctxt "account-view"
 msgid "COPIED TO CLIPBOARD!"
 msgstr "IN DIE ZWISCHENABLAGE KOPIERT!"
 
-#: src/renderer/components/Account.tsx:101
+#: src/renderer/components/Account.tsx:103
 msgctxt "account-view"
 msgid "Currently unavailable"
 msgstr "Derzeit nicht verfügbar"
 
-#: src/renderer/components/Account.tsx:74
+#: src/renderer/components/Account.tsx:76
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/renderer/components/Account.tsx:93
+#: src/renderer/components/Account.tsx:95
 msgctxt "account-view"
 msgid "OUT OF TIME"
 msgstr "ZEIT ABGELAUFEN"
+
+#: src/renderer/components/Account.tsx:57
+msgctxt "account-view"
+msgid "Paid until"
+msgstr ""
 
 #. Title label in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:97

--- a/gui/locales/es/messages.po
+++ b/gui/locales/es/messages.po
@@ -1,35 +1,35 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: mullvad-app\n"
-"X-Crowdin-Language: zh-TW\n"
+"X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: messages.pot\n"
 "Project-Id-Version: mullvad-app\n"
 "Last-Translator: adminmullvad <admin@mullvad.net>\n"
-"Language-Team: Chinese Traditional\n"
-"Language: zh_TW\n"
-"PO-Revision-Date: 2019-03-18 14:19\n"
+"Language-Team: Spanish\n"
+"Language: es_ES\n"
+"PO-Revision-Date: 2019-03-18 15:52\n"
 
 #: src/renderer/components/SecuredLabel.tsx:40
 msgid "BLOCKED CONNECTION"
-msgstr "被封鎖的連線"
+msgstr "CONEXIÓN BLOQUEADA"
 
 #: src/renderer/components/SecuredLabel.tsx:43
 msgid "CREATING SECURE CONNECTION"
-msgstr "建立安全連線"
+msgstr "CREANDO CONEXIÓN SEGURA"
 
 #: src/renderer/components/SecuredLabel.tsx:37
 #: src/renderer/components/Support.tsx:282
 #: src/renderer/components/Support.tsx:317
 #: src/renderer/components/Support.tsx:342
 msgid "SECURE CONNECTION"
-msgstr "安全連線"
+msgstr "CONEXIÓN SEGURA"
 
 #: src/renderer/components/SecuredLabel.tsx:46
 msgid "UNSECURED CONNECTION"
-msgstr "不安全的連線"
+msgstr "CONEXIÓN NO SEGURA"
 
 #. The remaining time left on the account displayed across the app.
 #. Available placeholders:
@@ -37,60 +37,65 @@ msgstr "不安全的連線"
 #: src/renderer/lib/account-expiry.ts:31
 msgctxt "account-expiry"
 msgid "%(duration)s left"
-msgstr "剩餘 %(duration)s"
+msgstr "%(duration)s restantes"
 
 #. Back button in navigation bar
 #: src/renderer/components/Account.tsx:33
 msgctxt "account-nav"
 msgid "Settings"
-msgstr "設定"
+msgstr "Configuración"
 
 #: src/renderer/components/Account.tsx:39
 msgctxt "account-view"
 msgid "Account"
-msgstr "帳戶"
+msgstr "Cuenta"
 
 #: src/renderer/components/Account.tsx:46
 msgctxt "account-view"
 msgid "Account ID"
-msgstr "帳戶 ID"
+msgstr "Id. de cuenta"
 
-#: src/renderer/components/Account.tsx:69
+#: src/renderer/components/Account.tsx:71
 msgctxt "account-view"
 msgid "Buy more credit"
-msgstr "購買更多點數"
+msgstr "Comprar más crédito"
 
 #: src/renderer/components/Account.tsx:51
 msgctxt "account-view"
 msgid "COPIED TO CLIPBOARD!"
-msgstr "已複製到剪貼簿！"
+msgstr "¡COPIADO EN EL PORTAPAPELES!"
 
-#: src/renderer/components/Account.tsx:101
+#: src/renderer/components/Account.tsx:103
 msgctxt "account-view"
 msgid "Currently unavailable"
-msgstr "目前不可用"
+msgstr "No disponible actualmente"
 
-#: src/renderer/components/Account.tsx:74
+#: src/renderer/components/Account.tsx:76
 msgctxt "account-view"
 msgid "Log out"
-msgstr "登出"
+msgstr "Cerrar sesión"
 
-#: src/renderer/components/Account.tsx:93
+#: src/renderer/components/Account.tsx:95
 msgctxt "account-view"
 msgid "OUT OF TIME"
-msgstr "逾時"
+msgstr "TIEMPO AGOTADO"
+
+#: src/renderer/components/Account.tsx:57
+msgctxt "account-view"
+msgid "Paid until"
+msgstr ""
 
 #. Title label in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:97
 msgctxt "advanced-settings-nav"
 msgid "Advanced"
-msgstr "進階"
+msgstr "Avanzadas"
 
 #. Back button in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:93
 msgctxt "advanced-settings-nav"
 msgid "Settings"
-msgstr "設定"
+msgstr "Configuración"
 
 #. The title for the port selector section.
 #. Available placeholders:
@@ -98,37 +103,37 @@ msgstr "設定"
 #: src/renderer/components/AdvancedSettings.tsx:150
 msgctxt "advanced-settings-view"
 msgid "%(portType)s port"
-msgstr "%(portType)s 連接埠"
+msgstr "Puerto %(portType)s"
 
 #: src/renderer/components/AdvancedSettings.tsx:104
 msgctxt "advanced-settings-view"
 msgid "Advanced"
-msgstr "進階"
+msgstr "Avanzadas"
 
 #: src/renderer/components/AdvancedSettings.tsx:265
 msgctxt "advanced-settings-view"
 msgid "Automatic"
-msgstr "自動"
+msgstr "Automático"
 
 #: src/renderer/components/AdvancedSettings.tsx:120
 msgctxt "advanced-settings-view"
 msgid "Block when disconnected"
-msgstr "中斷連線時封鎖"
+msgstr "Bloquear cuando esté desconectado"
 
 #: src/renderer/components/AdvancedSettings.tsx:171
 msgctxt "advanced-settings-view"
 msgid "Default"
-msgstr "預設"
+msgstr "Predeterminado"
 
 #: src/renderer/components/AdvancedSettings.tsx:108
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6"
-msgstr "啟用 IPv6"
+msgstr "Habilitar IPv6"
 
 #: src/renderer/components/AdvancedSettings.tsx:112
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6 communication through the tunnel."
-msgstr "透過通道啟用 IPv6 通訊。"
+msgstr "Permite la comunicación IPv6 a través del túnel."
 
 #: src/renderer/components/AdvancedSettings.tsx:165
 msgctxt "advanced-settings-view"
@@ -138,7 +143,7 @@ msgstr "Mssfix"
 #: src/renderer/components/AdvancedSettings.tsx:136
 msgctxt "advanced-settings-view"
 msgid "Network protocols"
-msgstr "網路通訊協定"
+msgstr "Protocolos de red"
 
 #. The hint displayed below the Mssfix input field.
 #. Available placeholders:
@@ -147,32 +152,32 @@ msgstr "網路通訊協定"
 #: src/renderer/components/AdvancedSettings.tsx:187
 msgctxt "advanced-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
-msgstr "設定 OpenVPN MSS 值。有效範圍：%(min)d - %(max)d。"
+msgstr "Establezca el valor de MSS de OpenVPN. Intervalo válido: %(min)d-%(max)d."
 
 #: src/renderer/components/AdvancedSettings.tsx:128
 msgctxt "advanced-settings-view"
 msgid "Unless connected, always block all network traffic, even when you've disconnected or quit the app."
-msgstr "除非已連線，否則一律封鎖所有網路流量，即便您已中斷連線或退出應用程式亦同。"
+msgstr "Si no está conectado, bloquea siempre todo el tráfico de red, incluso al desconectar o cerrar la aplicación."
 
 #: src/renderer/lib/auth-failure.ts:80
 msgctxt "auth-failure"
 msgid "Account authentication failed."
-msgstr "帳戶驗證失敗。"
+msgstr "Error de autenticación de la cuenta."
 
 #: src/renderer/lib/auth-failure.ts:74
 msgctxt "auth-failure"
 msgid "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly."
-msgstr "此帳戶有太多的同時連線。請中斷其他裝置的連線，或是稍後再次嘗試連線。"
+msgstr "Esta cuenta tiene demasiadas conexiones simultáneas. Desconecte otro dispositivo o intente volver a conectarse más tarde."
 
 #: src/renderer/lib/auth-failure.ts:68
 msgctxt "auth-failure"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "您在此帳戶沒有更多 VPN 時間了。請登入我們的網站，購買更多點數。"
+msgstr "No le queda tiempo de VPN en esta cuenta. Inicie sesión en nuestro sitio web para comprar más crédito."
 
 #: src/renderer/lib/auth-failure.ts:62
 msgctxt "auth-failure"
 msgid "You've logged in with an account number that is not valid. Please log out and try another one."
-msgstr "您登入時使用的帳號是無效的。請登出並使用另一個。"
+msgstr "Ha iniciado la sesión con un número de cuenta no válido. Cierre la sesión y pruebe con otro número."
 
 #. The selected location label displayed on the main view, when a user selected a specific host to connect to.
 #. Example: Malmö (se-mma-001)
@@ -188,77 +193,77 @@ msgstr "%(city)s (%(hostname)s)"
 #: src/renderer/components/ExpiredAccountErrorView.tsx:157
 msgctxt "connect-view"
 msgid "Buy more credit"
-msgstr "購買更多點數"
+msgstr "Comprar más crédito"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:114
 msgctxt "connect-view"
 msgid "Disconnect and buy more credit"
-msgstr "中斷連線並購買更多點數"
+msgstr "Desconectar y comprar más crédito"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:78
 msgctxt "connect-view"
 msgid "Out of time"
-msgstr "逾時"
+msgstr "Tiempo agotado"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:150
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Before you can buy more credit on our website, you first need to turn off the app's \"Block when disconnected\" option under Advanced settings."
-msgstr "您在此帳戶沒有更多 VPN 時間了。您必須先關閉應用程式「進階」設定下的「中斷連線時封鎖」選項，再到我們網站購買更多點數。"
+msgstr "Ya no le queda más tiempo VPN en esta cuenta. Para comprar más crédito en nuestro sitio web, primero necesita desactivar la opción «Bloquear cuando esté desconectado» en la configuración avanzada de la aplicación."
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:129
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "您在此帳戶沒有更多 VPN 時間了。請登入我們的網站，購買更多點數。"
+msgstr "Ya no le queda más tiempo de VPN en esta cuenta. Inicie sesión en nuestro sitio web para comprar más crédito."
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:106
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. To buy more credit on our website, you will need to access the Internet with an unsecured connection."
-msgstr "您在此帳戶沒有更多 VPN 時間了。若要在我們網站上購買更多點數，您必須使用不安全的連線存取網際網路。"
+msgstr "Ya no le queda más tiempo de VPN en esta cuenta. Para comprar más crédito en nuestro sitio web, necesita acceder a Internet con una conexión no segura."
 
 #: src/renderer/components/NotificationArea.tsx:281
 msgctxt "in-app-notifications"
 msgid "ACCOUNT CREDIT EXPIRES SOON"
-msgstr "帳戶點數即將到期"
+msgstr "EL CRÉDITO DE SU CUENTA CADUCA PRONTO"
 
 #: src/renderer/components/NotificationArea.tsx:200
 msgctxt "in-app-notifications"
 msgid "BLOCKING INTERNET"
-msgstr "封鎖網際網路"
+msgstr "BLOQUEANDO INTERNET"
 
 #: src/renderer/components/NotificationArea.tsx:48
 msgctxt "in-app-notifications"
 msgid "Could not configure IPv6, please enable it on your system or disable it in the app"
-msgstr "無法配置 IPv6，請在我們系統啟用，或在應用程式中停用"
+msgstr "No se pudo configurar IPv6, habilítelo en el sistema o deshabilítelo en la aplicación"
 
 #: src/renderer/components/NotificationArea.tsx:53
 msgctxt "in-app-notifications"
 msgid "Failed to apply firewall rules. The device might currently be unsecured"
-msgstr "無法套用防火牆規則。裝置目前可能不安全"
+msgstr "Error al aplicar las reglas del firewall. Puede que el dispositivo no esté protegido actualmente"
 
 #: src/renderer/components/NotificationArea.tsx:58
 msgctxt "in-app-notifications"
 msgid "Failed to set system DNS server"
-msgstr "無法設定系統 DNS 伺服器"
+msgstr "No se pudo establecer el servidor DNS del sistema"
 
 #: src/renderer/components/NotificationArea.tsx:60
 msgctxt "in-app-notifications"
 msgid "Failed to start tunnel connection"
-msgstr "無法啟動通道連線"
+msgstr "No se pudo iniciar la conexión de túnel"
 
 #: src/renderer/components/NotificationArea.tsx:188
 msgctxt "in-app-notifications"
 msgid "FAILURE - UNSECURED"
-msgstr "失敗 - 不安全"
+msgstr "ERROR: NO PROTEGIDO"
 
 #: src/renderer/components/NotificationArea.tsx:215
 msgctxt "in-app-notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "內部版本資訊不一致，請重新啟動應用程式"
+msgstr "La información de la versión interna no coincide, reinicie la aplicación"
 
 #: src/renderer/components/NotificationArea.tsx:212
 msgctxt "in-app-notifications"
 msgid "INCONSISTENT VERSION"
-msgstr "版本不一致"
+msgstr "VERSIÓN INCOHERENTE"
 
 #. The in-app banner displayed to the user when the app update is available.
 #. Available placeholders:
@@ -266,32 +271,32 @@ msgstr "版本不一致"
 #: src/renderer/components/NotificationArea.tsx:262
 msgctxt "in-app-notifications"
 msgid "Install Mullvad VPN (%(version)s) to stay up to date"
-msgstr "安裝 Mullvad VPN (%(version)s) 以保持最新狀態"
+msgstr "Instale Mullvad VPN (%(version)s) para estar actualizado"
 
 #: src/renderer/components/NotificationArea.tsx:62
 msgctxt "in-app-notifications"
 msgid "No relay server matches the current settings"
-msgstr "沒有與目前設定相符的中繼伺服器"
+msgstr "Ningún servidor de retransmisión coincide con la configuración actual"
 
 #: src/renderer/components/NotificationArea.tsx:64
 msgctxt "in-app-notifications"
 msgid "This device is offline, no tunnels can be established"
-msgstr "此裝置目前離線中，無法建立通道"
+msgstr "Este dispositivo no está conectado, no puede establecerse ningún túnel"
 
 #: src/renderer/components/NotificationArea.tsx:69
 msgctxt "in-app-notifications"
 msgid "Unable to detect a working TAP adapter on this device. If you've disabled it, enable it again. Otherwise, please reinstall the app"
-msgstr "在裝置上偵測不到運作中的 TAP 配接器。如果您已停用，請再次啟用。否則，請重新安裝應用程式"
+msgstr "No se pudo detectar ningún adaptador TAP activo en este dispositivo. Si lo ha deshabilitado, vuelva a habilitarlo. De lo contrario, reinstale la aplicación"
 
 #: src/renderer/components/NotificationArea.tsx:229
 msgctxt "in-app-notifications"
 msgid "UNSUPPORTED VERSION"
-msgstr "不支援的版本"
+msgstr "VERSIÓN NO ADMITIDA"
 
 #: src/renderer/components/NotificationArea.tsx:255
 msgctxt "in-app-notifications"
 msgid "UPDATE AVAILABLE"
-msgstr "可用的更新"
+msgstr "ACTUALIZACIÓN DISPONIBLE"
 
 #. The in-app banner displayed to the user when the running app becomes unsupported.
 #. Available placeholders:
@@ -299,12 +304,12 @@ msgstr "可用的更新"
 #: src/renderer/components/NotificationArea.tsx:236
 msgctxt "in-app-notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "您正在執行不受支援的應用程式版本。請立即升級到 %(version)s，以確保您的安全"
+msgstr "Ejecuta una versión no admitida de la aplicación. Actualice a %(version)s ahora para garantizar su seguridad"
 
 #: src/renderer/components/Launch.tsx:53
 msgctxt "launch-view"
 msgid "Connecting to daemon..."
-msgstr "正在連線至精靈..."
+msgstr "Estableciendo conexión con el daemon…"
 
 #: src/renderer/components/Launch.tsx:51
 msgctxt "launch-view"
@@ -314,87 +319,87 @@ msgstr "MULLVAD VPN"
 #: src/renderer/components/Login.tsx:231
 msgctxt "login-view"
 msgid "Checking account number"
-msgstr "檢查帳號中"
+msgstr "Comprobando número de cuenta"
 
 #: src/renderer/components/Login.tsx:233
 msgctxt "login-view"
 msgid "Correct account number"
-msgstr "正確的帳號"
+msgstr "Número de cuenta correcto"
 
 #: src/renderer/components/Login.tsx:403
 msgctxt "login-view"
 msgid "Create account"
-msgstr "建立帳戶"
+msgstr "Crear cuenta"
 
 #: src/renderer/components/Login.tsx:400
 msgctxt "login-view"
 msgid "Don't have an account number?"
-msgstr "沒有帳號？"
+msgstr "¿No tiene un número de cuenta?"
 
 #: src/renderer/components/Login.tsx:235
 msgctxt "login-view"
 msgid "Enter your account number"
-msgstr "輸入您的帳號"
+msgstr "Escriba su número de cuenta"
 
 #: src/renderer/components/Login.tsx:219
 msgctxt "login-view"
 msgid "Logged in"
-msgstr "已登入"
+msgstr "Sesión iniciada"
 
 #: src/renderer/components/Login.tsx:215
 msgctxt "login-view"
 msgid "Logging in..."
-msgstr "登入中..."
+msgstr "Iniciando la sesión…"
 
 #: src/renderer/components/Login.tsx:221
 msgctxt "login-view"
 msgid "Login"
-msgstr "登入"
+msgstr "Iniciar sesión"
 
 #: src/renderer/components/Login.tsx:217
 msgctxt "login-view"
 msgid "Login failed"
-msgstr "登入失敗"
+msgstr "Error de inicio de sesión"
 
 #: src/renderer/components/Login.tsx:229
 msgctxt "login-view"
 msgid "Unknown error"
-msgstr "未知錯誤"
+msgstr "Error desconocido"
 
 #: src/main/notification-controller.ts:46
 msgctxt "notifications"
 msgid "Blocked all connections"
-msgstr "已封鎖所有連線"
+msgstr "Se bloquearon todas las conexiones"
 
 #: src/main/notification-controller.ts:29
 msgctxt "notifications"
 msgid "Connecting"
-msgstr "連線中"
+msgstr "Conectando"
 
 #: src/main/notification-controller.ts:42
 msgctxt "notifications"
 msgid "Critical failure - Unsecured"
-msgstr "嚴重失敗 - 不安全"
+msgstr "Error crítico: no protegido"
 
 #: src/main/notification-controller.ts:71
 msgctxt "notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "內部版本資訊不一致，請重新啟動應用程式"
+msgstr "La información de la versión interna no coincide, reinicie la aplicación"
 
 #: src/main/notification-controller.ts:57
 msgctxt "notifications"
 msgid "Reconnecting"
-msgstr "正在重新連線"
+msgstr "Volviendo a establecer la conexión"
 
 #: src/main/notification-controller.ts:33
 msgctxt "notifications"
 msgid "Secured"
-msgstr "安全"
+msgstr "Protegido"
 
 #: src/main/notification-controller.ts:36
 msgctxt "notifications"
 msgid "Unsecured"
-msgstr "不安全"
+msgstr "No protegido"
 
 #. The system notification displayed to the user when the running app becomes unsupported.
 #. Available placeholder:
@@ -402,255 +407,255 @@ msgstr "不安全"
 #: src/main/notification-controller.ts:90
 msgctxt "notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "您正在執行不受支援的應用程式版本。請立即升級到 %(version)s，以確保您的安全"
+msgstr "Ejecuta una versión no admitida de la aplicación. Actualice a %(version)s ahora para garantizar su seguridad"
 
 #. Title label in navigation bar
 #: src/renderer/components/Preferences.tsx:46
 msgctxt "preferences-nav"
 msgid "Preferences"
-msgstr "喜好設定"
+msgstr "Preferencias"
 
 #. Back button in navigation bar
 #: src/renderer/components/Preferences.tsx:42
 msgctxt "preferences-nav"
 msgid "Settings"
-msgstr "設定"
+msgstr "Configuración"
 
 #: src/renderer/components/Preferences.tsx:86
 msgctxt "preferences-view"
 msgid "Allows access to other devices on the same network for sharing, printing etc."
-msgstr "允許存取同一網路上的其他裝置，以進行共用、列印等。"
+msgstr "Permite el acceso a otros dispositivos de la misma red para compartir archivos, imprimir, etc."
 
 #: src/renderer/components/Preferences.tsx:66
 msgctxt "preferences-view"
 msgid "Auto-connect"
-msgstr "自動連線"
+msgstr "Conexión automática"
 
 #: src/renderer/components/Preferences.tsx:73
 msgctxt "preferences-view"
 msgid "Automatically connect to a server when the app launches."
-msgstr "啟動應用程式時，自動連線伺服器。"
+msgstr "Al iniciarse la aplicación, se conecta automáticamente a un servidor."
 
 #: src/renderer/components/Preferences.tsx:59
 msgctxt "preferences-view"
 msgid "Launch app on start-up"
-msgstr "啟動時啟動應用程式"
+msgstr "Ejecutar la aplicación al iniciar"
 
 #: src/renderer/components/Preferences.tsx:81
 msgctxt "preferences-view"
 msgid "Local network sharing"
-msgstr "本機網路分享"
+msgstr "Uso compartido de la red local"
 
 #: src/renderer/components/Preferences.tsx:130
 msgctxt "preferences-view"
 msgid "Monochromatic tray icon"
-msgstr "單色系統匣圖示"
+msgstr "Icono de la bandeja monocromático"
 
 #: src/renderer/components/Preferences.tsx:53
 msgctxt "preferences-view"
 msgid "Preferences"
-msgstr "喜好設定"
+msgstr "Preferencias"
 
 #: src/renderer/components/Preferences.tsx:163
 msgctxt "preferences-view"
 msgid "Show only the tray icon when the app starts."
-msgstr "啟動應用程式時，僅顯示系統匣圖示。"
+msgstr "Al iniciar la aplicación, solo se muestra el icono de la bandeja."
 
 #: src/renderer/components/Preferences.tsx:159
 msgctxt "preferences-view"
 msgid "Start minimized"
-msgstr "啟動時永遠最小化"
+msgstr "Iniciar minimizado"
 
 #: src/renderer/components/Preferences.tsx:134
 msgctxt "preferences-view"
 msgid "Use a monochromatic tray icon instead of a colored one."
-msgstr "使用單色系統匣圖示，而不是彩色的圖示。"
+msgstr "Usa un icono de bandeja monocromático, en lugar de un icono en color."
 
 #. Title label in navigation bar
 #: src/renderer/components/SelectLocation.tsx:118
 msgctxt "select-location-nav"
 msgid "Select location"
-msgstr "選擇位置"
+msgstr "Seleccionar ubicación"
 
 #: src/renderer/components/SelectLocation.tsx:126
 msgctxt "select-location-view"
 msgid "Select location"
-msgstr "選擇位置"
+msgstr "Seleccionar ubicación"
 
 #: src/renderer/components/SelectLocation.tsx:129
 msgctxt "select-location-view"
 msgid "While connected, your real location is masked with a private and secure location in the selected region"
-msgstr "連線時，會以所選區域中的一個私密安全位置將您的真實位置遮住。"
+msgstr "Mientras esté conectado, su ubicación real permanecerá oculta con una ubicación privada y segura en la región seleccionada"
 
 #: src/renderer/components/Settings.tsx:104
 msgctxt "settings-view"
 msgid "Account"
-msgstr "帳戶"
+msgstr "Cuenta"
 
 #: src/renderer/components/Settings.tsx:119
 msgctxt "settings-view"
 msgid "Advanced"
-msgstr "進階"
+msgstr "Avanzadas"
 
 #: src/renderer/components/Settings.tsx:165
 msgctxt "settings-view"
 msgid "App version"
-msgstr "應用程式版本"
+msgstr "Versión de la aplicación"
 
 #: src/renderer/components/Settings.tsx:186
 msgctxt "settings-view"
 msgid "FAQs & Guides"
-msgstr "常見問題集與指南"
+msgstr "Preguntas frecuentes y guías"
 
 #: src/renderer/components/Settings.tsx:131
 msgctxt "settings-view"
 msgid "Inconsistent internal version information, please restart the app."
-msgstr "內部版本資訊不一致，請重新啟動應用程式。"
+msgstr "La información de la versión interna no coincide, reinicie la aplicación."
 
 #: src/renderer/components/Settings.tsx:98
 msgctxt "settings-view"
 msgid "OUT OF TIME"
-msgstr "逾時"
+msgstr "TIEMPO AGOTADO"
 
 #: src/renderer/components/Settings.tsx:114
 msgctxt "settings-view"
 msgid "Preferences"
-msgstr "喜好設定"
+msgstr "Preferencias"
 
 #: src/renderer/components/Settings.tsx:80
 msgctxt "settings-view"
 msgid "Quit app"
-msgstr "退出應用程式"
+msgstr "Salir de la aplicación"
 
 #: src/renderer/components/Settings.tsx:181
 msgctxt "settings-view"
 msgid "Report a problem"
-msgstr "回報問題"
+msgstr "Informar de un problema"
 
 #: src/renderer/components/Settings.tsx:58
 msgctxt "settings-view"
 msgid "Settings"
-msgstr "設定"
+msgstr "Configuración"
 
 #: src/renderer/components/Settings.tsx:136
 msgctxt "settings-view"
 msgid "Update available, download to remain safe."
-msgstr "更新可用，請下載以保持安全。"
+msgstr "Actualización disponible, descárguela para garantizar su seguridad."
 
 #. Title label in navigation bar
 #: src/renderer/components/Settings.tsx:50
 msgctxt "settings-view-nav"
 msgid "Settings"
-msgstr "設定"
+msgstr "Configuración"
 
 #. Back button in navigation bar
 #: src/renderer/components/Support.tsx:146
 msgctxt "support-nav"
 msgid "Settings"
-msgstr "設定"
+msgstr "Configuración"
 
 #: src/renderer/components/Support.tsx:392
 msgctxt "support-view"
 msgid "Back"
-msgstr "返回"
+msgstr "Volver"
 
 #: src/renderer/components/Support.tsx:252
 msgctxt "support-view"
 msgid "Describe your problem"
-msgstr "描述您的問題"
+msgstr "Describa el problema"
 
 #: src/renderer/components/Support.tsx:357
 msgctxt "support-view"
 msgid "Edit message"
-msgstr "編輯訊息"
+msgstr "Editar mensaje"
 
 #: src/renderer/components/Support.tsx:345
 msgctxt "support-view"
 msgid "Failed to send"
-msgstr "無法傳送"
+msgstr "No se pudo enviar"
 
 #: src/renderer/components/Support.tsx:297
 msgctxt "support-view"
 msgid "If needed we will contact you on %(email)s"
-msgstr "如有需要，我們將以 %(email)s 與您聯繫"
+msgstr "Si es necesario, le enviaremos un mensaje a la dirección %(email)s"
 
 #: src/renderer/components/Support.tsx:123
 msgctxt "support-view"
 msgid "Report a problem"
-msgstr "回報問題"
+msgstr "Informar de un problema"
 
 #: src/renderer/components/Support.tsx:265
 msgctxt "support-view"
 msgid "Send"
-msgstr "傳送"
+msgstr "Enviar"
 
 #: src/renderer/components/Support.tsx:389
 msgctxt "support-view"
 msgid "Send anyway"
-msgstr "仍要傳送"
+msgstr "Enviar de todos modos"
 
 #: src/renderer/components/Support.tsx:285
 msgctxt "support-view"
 msgid "Sending..."
-msgstr "傳送中..."
+msgstr "Enviando…"
 
 #: src/renderer/components/Support.tsx:319
 msgctxt "support-view"
 msgid "Sent"
-msgstr "已傳送"
+msgstr "Enviado"
 
 #: src/renderer/components/Support.tsx:322
 msgctxt "support-view"
 msgid "Thanks! We will look into this."
-msgstr "謝謝！我們會對此進行調查。"
+msgstr "¡Gracias! Le echaremos un vistazo."
 
 #: src/renderer/components/Support.tsx:126
 msgctxt "support-view"
 msgid "To help you more effectively, your app's log file will be attached to this message. Your data will remain secure and private, as it is anonymised before being sent over an encrypted channel."
-msgstr "為了更有效協助您，會將應用程式的日誌檔將附加到此郵件。您的資料會保持安全和私密性，因為這些資料會先經過匿名處理，再透過加密通道傳送。"
+msgstr "Para ayudarle de una forma más eficiente, se adjuntará el archivo de registro de la aplicación a este mensaje. Sus datos permanecerán protegidos y privados, ya que se anonimizan antes de enviarse a través de un canal cifrado."
 
 #: src/renderer/components/Support.tsx:360
 msgctxt "support-view"
 msgid "Try again"
-msgstr "再試一次"
+msgstr "Volver a intentarlo"
 
 #: src/renderer/components/Support.tsx:261
 msgctxt "support-view"
 msgid "View app logs"
-msgstr "檢視應用程式日誌"
+msgstr "Ver registros de la aplicación"
 
 #: src/renderer/components/Support.tsx:383
 msgctxt "support-view"
 msgid "You are about to send the problem report without a way for us to get back to you. If you want an answer to your report you will have to enter an email address."
-msgstr "您即將傳送的問題報告未包含回覆方式資訊。如果想收到您這份報告的回覆，請輸入您的電子郵件位址。"
+msgstr "Va a enviar el informe de problemas sin indicar una forma de contacto. Para obtener una respuesta sobre el informe, necesita especificar su dirección de correo electrónico."
 
 #: src/renderer/components/Support.tsx:348
 msgctxt "support-view"
 msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
-msgstr "在重試之前，您可能需要返回應用程式的主畫面，然後按一下「中斷連線」。請不用擔心，您輸入的資訊將保留在表單中。"
+msgstr "Para volver a intentarlo, puede que necesite volver a la pantalla principal de la aplicación y hacer clic en Desconectar. No se preocupe, la información que ha especificado permanecerá en el formulario."
 
 #: src/renderer/components/Support.tsx:242
 msgctxt "support-view"
 msgid "Your email (optional)"
-msgstr "您的電子郵件 (選填)"
+msgstr "Su correo electrónico (opcional)"
 
 #: src/renderer/components/TunnelControl.tsx:121
 msgctxt "tunnel-control"
 msgid "Cancel"
-msgstr "取消"
+msgstr "Cancelar"
 
 #: src/renderer/components/TunnelControl.tsx:115
 msgctxt "tunnel-control"
 msgid "Disconnect"
-msgstr "中斷連線"
+msgstr "Desconectar"
 
 #: src/renderer/components/TunnelControl.tsx:109
 msgctxt "tunnel-control"
 msgid "Secure my connection"
-msgstr "保護我的連線"
+msgstr "Proteger mi conexión"
 
 #: src/renderer/components/TunnelControl.tsx:93
 msgctxt "tunnel-control"
 msgid "Switch location"
-msgstr "切換位置"
+msgstr "Cambiar ubicación"
 

--- a/gui/locales/fr/messages.po
+++ b/gui/locales/fr/messages.po
@@ -1,35 +1,35 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: mullvad-app\n"
-"X-Crowdin-Language: sv-SE\n"
+"X-Crowdin-Language: fr\n"
 "X-Crowdin-File: messages.pot\n"
 "Project-Id-Version: mullvad-app\n"
 "Last-Translator: adminmullvad <admin@mullvad.net>\n"
-"Language-Team: Swedish\n"
-"Language: sv_SE\n"
-"PO-Revision-Date: 2019-03-18 14:19\n"
+"Language-Team: French\n"
+"Language: fr_FR\n"
+"PO-Revision-Date: 2019-03-18 15:52\n"
 
 #: src/renderer/components/SecuredLabel.tsx:40
 msgid "BLOCKED CONNECTION"
-msgstr "ANSLUTNINGEN BLOCKERAD"
+msgstr "CONNEXION BLOQUÉE"
 
 #: src/renderer/components/SecuredLabel.tsx:43
 msgid "CREATING SECURE CONNECTION"
-msgstr "SKAPAR SÄKER ANSLUTNING"
+msgstr "CRÉATION D'UNE CONNEXION SÉCURISÉE"
 
 #: src/renderer/components/SecuredLabel.tsx:37
 #: src/renderer/components/Support.tsx:282
 #: src/renderer/components/Support.tsx:317
 #: src/renderer/components/Support.tsx:342
 msgid "SECURE CONNECTION"
-msgstr "SÄKER ANSLUTNING"
+msgstr "CONNEXION SÉCURISÉE"
 
 #: src/renderer/components/SecuredLabel.tsx:46
 msgid "UNSECURED CONNECTION"
-msgstr "OSÄKER ANSLUTNING"
+msgstr "CONNEXION NON SÉCURISÉE"
 
 #. The remaining time left on the account displayed across the app.
 #. Available placeholders:
@@ -37,60 +37,65 @@ msgstr "OSÄKER ANSLUTNING"
 #: src/renderer/lib/account-expiry.ts:31
 msgctxt "account-expiry"
 msgid "%(duration)s left"
-msgstr "%(duration)s kvar"
+msgstr "%(duration)s restant(e)s"
 
 #. Back button in navigation bar
 #: src/renderer/components/Account.tsx:33
 msgctxt "account-nav"
 msgid "Settings"
-msgstr "Inställningar"
+msgstr "Paramètres"
 
 #: src/renderer/components/Account.tsx:39
 msgctxt "account-view"
 msgid "Account"
-msgstr "Konto"
+msgstr "Compte"
 
 #: src/renderer/components/Account.tsx:46
 msgctxt "account-view"
 msgid "Account ID"
-msgstr "Konto-ID"
+msgstr "ID de compte"
 
-#: src/renderer/components/Account.tsx:69
+#: src/renderer/components/Account.tsx:71
 msgctxt "account-view"
 msgid "Buy more credit"
-msgstr "Köp mer kredit"
+msgstr "Acheter plus de crédits"
 
 #: src/renderer/components/Account.tsx:51
 msgctxt "account-view"
 msgid "COPIED TO CLIPBOARD!"
-msgstr "KOPIERAT TILL URKLIPP!"
+msgstr "COPIÉ DANS LE PRESSE-PAPIERS !"
 
-#: src/renderer/components/Account.tsx:101
+#: src/renderer/components/Account.tsx:103
 msgctxt "account-view"
 msgid "Currently unavailable"
-msgstr "Inte tillgänglig för närvarande"
+msgstr "Actuellement indisponible"
 
-#: src/renderer/components/Account.tsx:74
+#: src/renderer/components/Account.tsx:76
 msgctxt "account-view"
 msgid "Log out"
-msgstr "Logga ut"
+msgstr "Déconnexion"
 
-#: src/renderer/components/Account.tsx:93
+#: src/renderer/components/Account.tsx:95
 msgctxt "account-view"
 msgid "OUT OF TIME"
-msgstr "INGEN TID KVAR"
+msgstr "PLUS DE TEMPS"
+
+#: src/renderer/components/Account.tsx:57
+msgctxt "account-view"
+msgid "Paid until"
+msgstr ""
 
 #. Title label in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:97
 msgctxt "advanced-settings-nav"
 msgid "Advanced"
-msgstr "Avancerat"
+msgstr "Avancé"
 
 #. Back button in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:93
 msgctxt "advanced-settings-nav"
 msgid "Settings"
-msgstr "Inställningar"
+msgstr "Paramètres"
 
 #. The title for the port selector section.
 #. Available placeholders:
@@ -98,37 +103,37 @@ msgstr "Inställningar"
 #: src/renderer/components/AdvancedSettings.tsx:150
 msgctxt "advanced-settings-view"
 msgid "%(portType)s port"
-msgstr "%(portType)s port"
+msgstr "Port %(portType)s"
 
 #: src/renderer/components/AdvancedSettings.tsx:104
 msgctxt "advanced-settings-view"
 msgid "Advanced"
-msgstr "Avancerat"
+msgstr "Avancé"
 
 #: src/renderer/components/AdvancedSettings.tsx:265
 msgctxt "advanced-settings-view"
 msgid "Automatic"
-msgstr "Automatisk"
+msgstr "Automatique"
 
 #: src/renderer/components/AdvancedSettings.tsx:120
 msgctxt "advanced-settings-view"
 msgid "Block when disconnected"
-msgstr "Blockera vid frånkoppling"
+msgstr "Bloquer quand déconnecté"
 
 #: src/renderer/components/AdvancedSettings.tsx:171
 msgctxt "advanced-settings-view"
 msgid "Default"
-msgstr "Standard"
+msgstr "Par défaut"
 
 #: src/renderer/components/AdvancedSettings.tsx:108
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6"
-msgstr "Aktivera IPv6"
+msgstr "Activer IPv6"
 
 #: src/renderer/components/AdvancedSettings.tsx:112
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6 communication through the tunnel."
-msgstr "Aktivera IPv6-kommunikation genom tunneln."
+msgstr "Activer la communication IPv6 via le tunnel."
 
 #: src/renderer/components/AdvancedSettings.tsx:165
 msgctxt "advanced-settings-view"
@@ -138,7 +143,7 @@ msgstr "Mssfix"
 #: src/renderer/components/AdvancedSettings.tsx:136
 msgctxt "advanced-settings-view"
 msgid "Network protocols"
-msgstr "Nätverksprotokoll"
+msgstr "Protocoles réseau"
 
 #. The hint displayed below the Mssfix input field.
 #. Available placeholders:
@@ -147,32 +152,32 @@ msgstr "Nätverksprotokoll"
 #: src/renderer/components/AdvancedSettings.tsx:187
 msgctxt "advanced-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
-msgstr "Ange värde för OpenVPN MSS. Giltigt intervall: %(min)d-%(max)d."
+msgstr "Définir la valeur MSS OpenVPN. Plage valide : %(min)d - %(max)d."
 
 #: src/renderer/components/AdvancedSettings.tsx:128
 msgctxt "advanced-settings-view"
 msgid "Unless connected, always block all network traffic, even when you've disconnected or quit the app."
-msgstr "Om du inte är ansluten bör du alltid blockera all nätverkstrafik, även när du har kopplats från eller avslutat appen."
+msgstr "À moins d'être connecté, toujours bloquer le trafic réseau, même quand vous êtes déconnecté ou quand vous quittez l'application."
 
 #: src/renderer/lib/auth-failure.ts:80
 msgctxt "auth-failure"
 msgid "Account authentication failed."
-msgstr "Autentiseringen av kontot misslyckades."
+msgstr "Connexion au compte échouée."
 
 #: src/renderer/lib/auth-failure.ts:74
 msgctxt "auth-failure"
 msgid "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly."
-msgstr "Detta konto har för många samtidiga anslutningar. Koppla från en annan enhet eller försök att ansluta igen inom kort."
+msgstr "Trop de connexions simultanées à ce compte. Déconnectez un autre appareil ou réessayez de vous connecter dans un instant."
 
 #: src/renderer/lib/auth-failure.ts:68
 msgctxt "auth-failure"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "Du har ingen VPN-tid kvar på kontot. Logga in på vår hemsida för att köpa mer kredit."
+msgstr "Il ne vous reste plus de temps de VPN sur ce compte. Veuillez vous connecter à notre site pour acheter plus de crédits."
 
 #: src/renderer/lib/auth-failure.ts:62
 msgctxt "auth-failure"
 msgid "You've logged in with an account number that is not valid. Please log out and try another one."
-msgstr "Du har loggat in med ett konto som inte är giltigt. Logga ut och försök med ett annat."
+msgstr "Vous vous êtes connecté avec un numéro de compte non valide. Veuillez vous déconnecter et en essayer un autre."
 
 #. The selected location label displayed on the main view, when a user selected a specific host to connect to.
 #. Example: Malmö (se-mma-001)
@@ -188,77 +193,77 @@ msgstr "%(city)s (%(hostname)s)"
 #: src/renderer/components/ExpiredAccountErrorView.tsx:157
 msgctxt "connect-view"
 msgid "Buy more credit"
-msgstr "Köp mer kredit"
+msgstr "Acheter plus de crédits"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:114
 msgctxt "connect-view"
 msgid "Disconnect and buy more credit"
-msgstr "Koppla från och köp mer kredit"
+msgstr "Déconnectez-vous et achetez plus de crédits"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:78
 msgctxt "connect-view"
 msgid "Out of time"
-msgstr "Ingen tid kvar"
+msgstr "Plus de temps"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:150
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Before you can buy more credit on our website, you first need to turn off the app's \"Block when disconnected\" option under Advanced settings."
-msgstr "Du har ingen VPN-tid kvar på kontot. Innan du kan köpa mer kredit på vår hemsida måste du först stänga av alternativet ”Blockera vid frånkoppling” under appens avancerade inställningar."
+msgstr "Il ne vous reste plus de temps VPN sur ce compte. Avant de pouvoir acheter plus de crédits sur notre site, vous devez désactiver l'option \"Bloquer quand déconnecté\" de l'application dans les paramètres avancés."
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:129
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "Du har ingen VPN-tid kvar på kontot. Logga in på vår hemsida för att köpa mer kredit."
+msgstr "Il ne vous reste plus de temps de VPN sur ce compte. Veuillez vous connecter à notre site pour acheter plus de crédits."
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:106
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. To buy more credit on our website, you will need to access the Internet with an unsecured connection."
-msgstr "Du har ingen VPN-tid kvar på kontot. För att köpa mer kredit på vår hemsida behöver du åtkomst till internet med en osäker anslutning."
+msgstr "Il ne vous reste plus de temps VPN sur ce compte. Pour acheter plus de crédits sur notre site, vous devez accéder à internet avec une connexion non sécurisée."
 
 #: src/renderer/components/NotificationArea.tsx:281
 msgctxt "in-app-notifications"
 msgid "ACCOUNT CREDIT EXPIRES SOON"
-msgstr "KONTOKREDITEN GÅR SNART UT"
+msgstr "LES CRÉDITS DU COMPTE EXPIRENT BIENTÔT"
 
 #: src/renderer/components/NotificationArea.tsx:200
 msgctxt "in-app-notifications"
 msgid "BLOCKING INTERNET"
-msgstr "BLOCKERING AV INTERNET"
+msgstr "BLOCAGE D'INTERNET"
 
 #: src/renderer/components/NotificationArea.tsx:48
 msgctxt "in-app-notifications"
 msgid "Could not configure IPv6, please enable it on your system or disable it in the app"
-msgstr "IPv6 kunde inte konfigureras. Aktivera det på ditt system eller stäng av det i appen"
+msgstr "Configuration IPv6 impossible. Veuillez l'activer dans votre système ou le désactiver dans l'application"
 
 #: src/renderer/components/NotificationArea.tsx:53
 msgctxt "in-app-notifications"
 msgid "Failed to apply firewall rules. The device might currently be unsecured"
-msgstr "Det gick inte att tillämpa brandväggsregler. Enheten kan för närvarande vara osäker"
+msgstr "Échec de l'application des règles du pare-feu. L'appareil est potentiellement non sécurisé à l'heure actuelle"
 
 #: src/renderer/components/NotificationArea.tsx:58
 msgctxt "in-app-notifications"
 msgid "Failed to set system DNS server"
-msgstr "Det gick inte att ange systemets DNS-server"
+msgstr "Échec de la configuration du serveur DNS système"
 
 #: src/renderer/components/NotificationArea.tsx:60
 msgctxt "in-app-notifications"
 msgid "Failed to start tunnel connection"
-msgstr "Det gick inte att starta tunnelanslutning"
+msgstr "Échec du démarrage de la connexion tunnel"
 
 #: src/renderer/components/NotificationArea.tsx:188
 msgctxt "in-app-notifications"
 msgid "FAILURE - UNSECURED"
-msgstr "MISSLYCKADES - OSKYDDAD"
+msgstr "ÉCHEC - NON SÉCURISÉ"
 
 #: src/renderer/components/NotificationArea.tsx:215
 msgctxt "in-app-notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "Inkonsekvent intern versionsinformation, starta om appen"
+msgstr "Informations de version interne incompatibles. Veuillez redémarrer l'application"
 
 #: src/renderer/components/NotificationArea.tsx:212
 msgctxt "in-app-notifications"
 msgid "INCONSISTENT VERSION"
-msgstr "INKONSEKVENT VERSION"
+msgstr "VERSION INCOMPATIBLE"
 
 #. The in-app banner displayed to the user when the app update is available.
 #. Available placeholders:
@@ -266,32 +271,32 @@ msgstr "INKONSEKVENT VERSION"
 #: src/renderer/components/NotificationArea.tsx:262
 msgctxt "in-app-notifications"
 msgid "Install Mullvad VPN (%(version)s) to stay up to date"
-msgstr "Installera Mullvad VPN (%(version)s) för att hålla dig uppdaterad"
+msgstr "Installez Mullvad VPN (%(version)s) pour rester à jour"
 
 #: src/renderer/components/NotificationArea.tsx:62
 msgctxt "in-app-notifications"
 msgid "No relay server matches the current settings"
-msgstr "Ingen relayserver matchar de aktuella inställningarna"
+msgstr "Aucun serveur de relais ne correspond à vos paramètres actuels"
 
 #: src/renderer/components/NotificationArea.tsx:64
 msgctxt "in-app-notifications"
 msgid "This device is offline, no tunnels can be established"
-msgstr "Denna enhet är frånkopplad, inga tunnlar kan fastställas"
+msgstr "Cet appareil est hors ligne. Aucun tunnel ne peut être établi"
 
 #: src/renderer/components/NotificationArea.tsx:69
 msgctxt "in-app-notifications"
 msgid "Unable to detect a working TAP adapter on this device. If you've disabled it, enable it again. Otherwise, please reinstall the app"
-msgstr "Det går inte att upptäcka en fungerande TAP-adapter på den här enheten. Aktivera den om den är inaktiverad. Installera om appen i annat fall"
+msgstr "Impossible de détecter d'adaptateur TAP fonctionnel sur cet appareil. Si vous en avez désactivé un, veuillez le réactiver. Sinon, veuillez réinstaller l'application"
 
 #: src/renderer/components/NotificationArea.tsx:229
 msgctxt "in-app-notifications"
 msgid "UNSUPPORTED VERSION"
-msgstr "VERSION UTAN STÖD"
+msgstr "VERSION NON PRISE EN CHARGE"
 
 #: src/renderer/components/NotificationArea.tsx:255
 msgctxt "in-app-notifications"
 msgid "UPDATE AVAILABLE"
-msgstr "UPPDATERING TILLGÄNGLIG"
+msgstr "MISE À JOUR DISPONIBLE"
 
 #. The in-app banner displayed to the user when the running app becomes unsupported.
 #. Available placeholders:
@@ -299,12 +304,12 @@ msgstr "UPPDATERING TILLGÄNGLIG"
 #: src/renderer/components/NotificationArea.tsx:236
 msgctxt "in-app-notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "Du kör en appversion utan stöd. Uppgradera till %(version)s nu för att garantera din säkerhet"
+msgstr "Vous utilisez une version d'application non prise en charge. Veuillez passer maintenant à la version %(version)s pour assurer votre sécurité"
 
 #: src/renderer/components/Launch.tsx:53
 msgctxt "launch-view"
 msgid "Connecting to daemon..."
-msgstr "Ansluter till daemon..."
+msgstr "Connexion au daemon..."
 
 #: src/renderer/components/Launch.tsx:51
 msgctxt "launch-view"
@@ -314,87 +319,87 @@ msgstr "MULLVAD VPN"
 #: src/renderer/components/Login.tsx:231
 msgctxt "login-view"
 msgid "Checking account number"
-msgstr "Kontrollerar kontonummer"
+msgstr "Vérification du numéro de compte"
 
 #: src/renderer/components/Login.tsx:233
 msgctxt "login-view"
 msgid "Correct account number"
-msgstr "Korrekt kontonummer"
+msgstr "Numéro de compte correct"
 
 #: src/renderer/components/Login.tsx:403
 msgctxt "login-view"
 msgid "Create account"
-msgstr "Skapa konto"
+msgstr "Créer un compte"
 
 #: src/renderer/components/Login.tsx:400
 msgctxt "login-view"
 msgid "Don't have an account number?"
-msgstr "Har du inget kontonummer?"
+msgstr "Vous n'avez pas de numéro de compte ?"
 
 #: src/renderer/components/Login.tsx:235
 msgctxt "login-view"
 msgid "Enter your account number"
-msgstr "Ange ditt kontonummer"
+msgstr "Saisissez votre numéro de compte"
 
 #: src/renderer/components/Login.tsx:219
 msgctxt "login-view"
 msgid "Logged in"
-msgstr "Inloggad"
+msgstr "Connecté"
 
 #: src/renderer/components/Login.tsx:215
 msgctxt "login-view"
 msgid "Logging in..."
-msgstr "Loggar in..."
+msgstr "Connexion..."
 
 #: src/renderer/components/Login.tsx:221
 msgctxt "login-view"
 msgid "Login"
-msgstr "Logga in"
+msgstr "Connexion"
 
 #: src/renderer/components/Login.tsx:217
 msgctxt "login-view"
 msgid "Login failed"
-msgstr "Inloggningen misslyckades"
+msgstr "Échec de la connexion"
 
 #: src/renderer/components/Login.tsx:229
 msgctxt "login-view"
 msgid "Unknown error"
-msgstr "Okänt fel"
+msgstr "Erreur inconnue"
 
 #: src/main/notification-controller.ts:46
 msgctxt "notifications"
 msgid "Blocked all connections"
-msgstr "Blockera alla anslutningar"
+msgstr "Toutes les connexions sont bloquées"
 
 #: src/main/notification-controller.ts:29
 msgctxt "notifications"
 msgid "Connecting"
-msgstr "Ansluter"
+msgstr "Connexion"
 
 #: src/main/notification-controller.ts:42
 msgctxt "notifications"
 msgid "Critical failure - Unsecured"
-msgstr "Kritiskt fel - oskyddad"
+msgstr "Échec critique - non sécurisé"
 
 #: src/main/notification-controller.ts:71
 msgctxt "notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "Inkonsekvent intern versionsinformation, starta om appen"
+msgstr "Informations de version interne incompatibles. Veuillez redémarrer l'application"
 
 #: src/main/notification-controller.ts:57
 msgctxt "notifications"
 msgid "Reconnecting"
-msgstr "Återansluter"
+msgstr "Reconnexion"
 
 #: src/main/notification-controller.ts:33
 msgctxt "notifications"
 msgid "Secured"
-msgstr "Skyddad"
+msgstr "Sécurisé"
 
 #: src/main/notification-controller.ts:36
 msgctxt "notifications"
 msgid "Unsecured"
-msgstr "Oskyddad"
+msgstr "Non sécurisé"
 
 #. The system notification displayed to the user when the running app becomes unsupported.
 #. Available placeholder:
@@ -402,255 +407,255 @@ msgstr "Oskyddad"
 #: src/main/notification-controller.ts:90
 msgctxt "notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "Du kör en appversion utan stöd. Uppgradera till %(version)s nu för att garantera din säkerhet"
+msgstr "Vous utilisez une version d'application non prise en charge. Veuillez passer maintenant en %(version)s pour assurer votre sécurité"
 
 #. Title label in navigation bar
 #: src/renderer/components/Preferences.tsx:46
 msgctxt "preferences-nav"
 msgid "Preferences"
-msgstr "Inställningar"
+msgstr "Préférences"
 
 #. Back button in navigation bar
 #: src/renderer/components/Preferences.tsx:42
 msgctxt "preferences-nav"
 msgid "Settings"
-msgstr "Inställningar"
+msgstr "Paramètres"
 
 #: src/renderer/components/Preferences.tsx:86
 msgctxt "preferences-view"
 msgid "Allows access to other devices on the same network for sharing, printing etc."
-msgstr "Tillåter åtkomst till andra enheter i samma nätverk för delning, utskrift etc."
+msgstr "Autorise l'accès aux autres appareils sur le même réseau pour partager, imprimer, etc."
 
 #: src/renderer/components/Preferences.tsx:66
 msgctxt "preferences-view"
 msgid "Auto-connect"
-msgstr "Anslut automatiskt"
+msgstr "Connexion automatique"
 
 #: src/renderer/components/Preferences.tsx:73
 msgctxt "preferences-view"
 msgid "Automatically connect to a server when the app launches."
-msgstr "Anslut automatiskt till en server när appen startas."
+msgstr "Connexion automatique à un serveur dès le démarrage de l'application."
 
 #: src/renderer/components/Preferences.tsx:59
 msgctxt "preferences-view"
 msgid "Launch app on start-up"
-msgstr "Starta appen vid uppstart"
+msgstr "Lancement de l'application au démarrage"
 
 #: src/renderer/components/Preferences.tsx:81
 msgctxt "preferences-view"
 msgid "Local network sharing"
-msgstr "Lokal nätverksdelning"
+msgstr "Partage réseau local"
 
 #: src/renderer/components/Preferences.tsx:130
 msgctxt "preferences-view"
 msgid "Monochromatic tray icon"
-msgstr "Enfärgad systemfältsikon"
+msgstr "Icône de zone de notification monochrome"
 
 #: src/renderer/components/Preferences.tsx:53
 msgctxt "preferences-view"
 msgid "Preferences"
-msgstr "Inställningar"
+msgstr "Préférences"
 
 #: src/renderer/components/Preferences.tsx:163
 msgctxt "preferences-view"
 msgid "Show only the tray icon when the app starts."
-msgstr "Visa endast systemfältsikonen när appen startas."
+msgstr "Afficher uniquement l'icône de la zone de notification au démarrage de l'application."
 
 #: src/renderer/components/Preferences.tsx:159
 msgctxt "preferences-view"
 msgid "Start minimized"
-msgstr "Starta minimerat"
+msgstr "Démarrer réduit"
 
 #: src/renderer/components/Preferences.tsx:134
 msgctxt "preferences-view"
 msgid "Use a monochromatic tray icon instead of a colored one."
-msgstr "Använd en enfärgad systemfältsikon i stället för en flerfärgad."
+msgstr "Utiliser l'icône de zone de notification monochrome à la place de celle en couleur."
 
 #. Title label in navigation bar
 #: src/renderer/components/SelectLocation.tsx:118
 msgctxt "select-location-nav"
 msgid "Select location"
-msgstr "Välj plats"
+msgstr "Sélectionner une localisation"
 
 #: src/renderer/components/SelectLocation.tsx:126
 msgctxt "select-location-view"
 msgid "Select location"
-msgstr "Välj plats"
+msgstr "Sélectionner une localisation"
 
 #: src/renderer/components/SelectLocation.tsx:129
 msgctxt "select-location-view"
 msgid "While connected, your real location is masked with a private and secure location in the selected region"
-msgstr "Medan du är ansluten maskeras din riktiga plats med en privat och säker plats i den valda regionen"
+msgstr "Quand vous êtes connecté, votre vraie localisation est masquée par une localisation privée et sécurisée de la région sélectionnée"
 
 #: src/renderer/components/Settings.tsx:104
 msgctxt "settings-view"
 msgid "Account"
-msgstr "Konto"
+msgstr "Compte"
 
 #: src/renderer/components/Settings.tsx:119
 msgctxt "settings-view"
 msgid "Advanced"
-msgstr "Avancerat"
+msgstr "Avancé"
 
 #: src/renderer/components/Settings.tsx:165
 msgctxt "settings-view"
 msgid "App version"
-msgstr "Appversion"
+msgstr "Version de l'application"
 
 #: src/renderer/components/Settings.tsx:186
 msgctxt "settings-view"
 msgid "FAQs & Guides"
-msgstr "Vanliga frågor och guider"
+msgstr "FAQ et guides"
 
 #: src/renderer/components/Settings.tsx:131
 msgctxt "settings-view"
 msgid "Inconsistent internal version information, please restart the app."
-msgstr "Inkonsekvent intern versionsinformation, starta om appen."
+msgstr "Informations de version interne incompatibles. Veuillez redémarrer l'application."
 
 #: src/renderer/components/Settings.tsx:98
 msgctxt "settings-view"
 msgid "OUT OF TIME"
-msgstr "INGEN TID KVAR"
+msgstr "PLUS DE TEMPS"
 
 #: src/renderer/components/Settings.tsx:114
 msgctxt "settings-view"
 msgid "Preferences"
-msgstr "Inställningar"
+msgstr "Préférences"
 
 #: src/renderer/components/Settings.tsx:80
 msgctxt "settings-view"
 msgid "Quit app"
-msgstr "Avsluta appen"
+msgstr "Quitter l'application"
 
 #: src/renderer/components/Settings.tsx:181
 msgctxt "settings-view"
 msgid "Report a problem"
-msgstr "Rapportera ett problem"
+msgstr "Signaler un problème"
 
 #: src/renderer/components/Settings.tsx:58
 msgctxt "settings-view"
 msgid "Settings"
-msgstr "Inställningar"
+msgstr "Paramètres"
 
 #: src/renderer/components/Settings.tsx:136
 msgctxt "settings-view"
 msgid "Update available, download to remain safe."
-msgstr "Uppdatering tillgänglig. Ladda ned för att vara säker."
+msgstr "Mise à jour disponible. Téléchargez-la pour rester en sécurité."
 
 #. Title label in navigation bar
 #: src/renderer/components/Settings.tsx:50
 msgctxt "settings-view-nav"
 msgid "Settings"
-msgstr "Inställningar"
+msgstr "Paramètres"
 
 #. Back button in navigation bar
 #: src/renderer/components/Support.tsx:146
 msgctxt "support-nav"
 msgid "Settings"
-msgstr "Inställningar"
+msgstr "Paramètres"
 
 #: src/renderer/components/Support.tsx:392
 msgctxt "support-view"
 msgid "Back"
-msgstr "Tillbaka"
+msgstr "Retour"
 
 #: src/renderer/components/Support.tsx:252
 msgctxt "support-view"
 msgid "Describe your problem"
-msgstr "Beskriv ditt problem"
+msgstr "Décrivez votre problème"
 
 #: src/renderer/components/Support.tsx:357
 msgctxt "support-view"
 msgid "Edit message"
-msgstr "Redigera meddelande"
+msgstr "Modifier le message"
 
 #: src/renderer/components/Support.tsx:345
 msgctxt "support-view"
 msgid "Failed to send"
-msgstr "Det gick inte att skicka"
+msgstr "Échec de l'envoi"
 
 #: src/renderer/components/Support.tsx:297
 msgctxt "support-view"
 msgid "If needed we will contact you on %(email)s"
-msgstr "Om det behövs kontaktar vi dig på %(email)s"
+msgstr "Si nécessaire, nous vous contacterons sur %(email)s"
 
 #: src/renderer/components/Support.tsx:123
 msgctxt "support-view"
 msgid "Report a problem"
-msgstr "Rapportera ett problem"
+msgstr "Signaler un problème"
 
 #: src/renderer/components/Support.tsx:265
 msgctxt "support-view"
 msgid "Send"
-msgstr "Skicka"
+msgstr "Envoyer"
 
 #: src/renderer/components/Support.tsx:389
 msgctxt "support-view"
 msgid "Send anyway"
-msgstr "Skicka ändå"
+msgstr "Envoyer quand même"
 
 #: src/renderer/components/Support.tsx:285
 msgctxt "support-view"
 msgid "Sending..."
-msgstr "Skicka..."
+msgstr "Envoi..."
 
 #: src/renderer/components/Support.tsx:319
 msgctxt "support-view"
 msgid "Sent"
-msgstr "Skickat"
+msgstr "Envoyé"
 
 #: src/renderer/components/Support.tsx:322
 msgctxt "support-view"
 msgid "Thanks! We will look into this."
-msgstr "Tack! Vi kommer att undersöka detta."
+msgstr "Merci ! Nous allons nous pencher dessus."
 
 #: src/renderer/components/Support.tsx:126
 msgctxt "support-view"
 msgid "To help you more effectively, your app's log file will be attached to this message. Your data will remain secure and private, as it is anonymised before being sent over an encrypted channel."
-msgstr "För att hjälpa dig mer effektivt kommer appens loggfil att bifogas i detta meddelande. Dina uppgifter förblir säkra och privata, eftersom de anonymiseras innan de skickas över en krypterad kanal."
+msgstr "Pour mieux vous aider, le fichier journal de l'application est joint à ce message. Vos données restent privées et en sécurité dans la mesure où elles sont rendues anonymes avant d'être envoyées via un canal chiffré."
 
 #: src/renderer/components/Support.tsx:360
 msgctxt "support-view"
 msgid "Try again"
-msgstr "Försök igen"
+msgstr "Réessayer"
 
 #: src/renderer/components/Support.tsx:261
 msgctxt "support-view"
 msgid "View app logs"
-msgstr "Visa appens loggar"
+msgstr "Afficher les journaux de l'application"
 
 #: src/renderer/components/Support.tsx:383
 msgctxt "support-view"
 msgid "You are about to send the problem report without a way for us to get back to you. If you want an answer to your report you will have to enter an email address."
-msgstr "Du är på väg att skicka problemrapporten utan att vi har möjlighet att besvara dig. Om du vill ha svar på din rapport måste du ange en e-postadress."
+msgstr "Vous êtes sur le point d'envoyer un signalement de problème sans nous fournir un moyen de vous contacter. Si vous désirez une réponse à votre signalement, vous devez saisir une adresse e-mail."
 
 #: src/renderer/components/Support.tsx:348
 msgctxt "support-view"
 msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
-msgstr "Du kan behöva gå tillbaka till appens huvudskärm och klicka på Koppla från innan du försöker igen. Oroa dig inte, den information du angett i formuläret kommer att bli kvar där."
+msgstr "Vous allez peut-être devoir retourner à l'écran principal de l'application pour cliquer sur Déconnexion avant de réessayer. Ne vous inquiétez pas, les informations saisies resteront dans le formulaire."
 
 #: src/renderer/components/Support.tsx:242
 msgctxt "support-view"
 msgid "Your email (optional)"
-msgstr "Din e-postadress (valfritt)"
+msgstr "Votre e-mail (facultatif)"
 
 #: src/renderer/components/TunnelControl.tsx:121
 msgctxt "tunnel-control"
 msgid "Cancel"
-msgstr "Avbryt"
+msgstr "Annuler"
 
 #: src/renderer/components/TunnelControl.tsx:115
 msgctxt "tunnel-control"
 msgid "Disconnect"
-msgstr "Koppla från"
+msgstr "Déconnexion"
 
 #: src/renderer/components/TunnelControl.tsx:109
 msgctxt "tunnel-control"
 msgid "Secure my connection"
-msgstr "Skydda min anslutning"
+msgstr "Sécuriser ma connexion"
 
 #: src/renderer/components/TunnelControl.tsx:93
 msgctxt "tunnel-control"
 msgid "Switch location"
-msgstr "Växla plats"
+msgstr "Changer de localisation"
 

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -45,7 +45,7 @@ msgctxt "account-view"
 msgid "Account ID"
 msgstr ""
 
-#: src/renderer/components/Account.tsx:69
+#: src/renderer/components/Account.tsx:71
 msgctxt "account-view"
 msgid "Buy more credit"
 msgstr ""
@@ -55,19 +55,24 @@ msgctxt "account-view"
 msgid "COPIED TO CLIPBOARD!"
 msgstr ""
 
-#: src/renderer/components/Account.tsx:101
+#: src/renderer/components/Account.tsx:103
 msgctxt "account-view"
 msgid "Currently unavailable"
 msgstr ""
 
-#: src/renderer/components/Account.tsx:74
+#: src/renderer/components/Account.tsx:76
 msgctxt "account-view"
 msgid "Log out"
 msgstr ""
 
-#: src/renderer/components/Account.tsx:93
+#: src/renderer/components/Account.tsx:95
 msgctxt "account-view"
 msgid "OUT OF TIME"
+msgstr ""
+
+#: src/renderer/components/Account.tsx:57
+msgctxt "account-view"
+msgid "Paid until"
 msgstr ""
 
 #. Title label in navigation bar

--- a/gui/locales/sv/messages.po
+++ b/gui/locales/sv/messages.po
@@ -1,35 +1,35 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: mullvad-app\n"
-"X-Crowdin-Language: fr\n"
+"X-Crowdin-Language: sv-SE\n"
 "X-Crowdin-File: messages.pot\n"
 "Project-Id-Version: mullvad-app\n"
 "Last-Translator: adminmullvad <admin@mullvad.net>\n"
-"Language-Team: French\n"
-"Language: fr_FR\n"
-"PO-Revision-Date: 2019-03-18 14:19\n"
+"Language-Team: Swedish\n"
+"Language: sv_SE\n"
+"PO-Revision-Date: 2019-03-18 15:52\n"
 
 #: src/renderer/components/SecuredLabel.tsx:40
 msgid "BLOCKED CONNECTION"
-msgstr "CONNEXION BLOQUÉE"
+msgstr "ANSLUTNINGEN BLOCKERAD"
 
 #: src/renderer/components/SecuredLabel.tsx:43
 msgid "CREATING SECURE CONNECTION"
-msgstr "CRÉATION D'UNE CONNEXION SÉCURISÉE"
+msgstr "SKAPAR SÄKER ANSLUTNING"
 
 #: src/renderer/components/SecuredLabel.tsx:37
 #: src/renderer/components/Support.tsx:282
 #: src/renderer/components/Support.tsx:317
 #: src/renderer/components/Support.tsx:342
 msgid "SECURE CONNECTION"
-msgstr "CONNEXION SÉCURISÉE"
+msgstr "SÄKER ANSLUTNING"
 
 #: src/renderer/components/SecuredLabel.tsx:46
 msgid "UNSECURED CONNECTION"
-msgstr "CONNEXION NON SÉCURISÉE"
+msgstr "OSÄKER ANSLUTNING"
 
 #. The remaining time left on the account displayed across the app.
 #. Available placeholders:
@@ -37,60 +37,65 @@ msgstr "CONNEXION NON SÉCURISÉE"
 #: src/renderer/lib/account-expiry.ts:31
 msgctxt "account-expiry"
 msgid "%(duration)s left"
-msgstr "%(duration)s restant(e)s"
+msgstr "%(duration)s kvar"
 
 #. Back button in navigation bar
 #: src/renderer/components/Account.tsx:33
 msgctxt "account-nav"
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Inställningar"
 
 #: src/renderer/components/Account.tsx:39
 msgctxt "account-view"
 msgid "Account"
-msgstr "Compte"
+msgstr "Konto"
 
 #: src/renderer/components/Account.tsx:46
 msgctxt "account-view"
 msgid "Account ID"
-msgstr "ID de compte"
+msgstr "Konto-ID"
 
-#: src/renderer/components/Account.tsx:69
+#: src/renderer/components/Account.tsx:71
 msgctxt "account-view"
 msgid "Buy more credit"
-msgstr "Acheter plus de crédits"
+msgstr "Köp mer kredit"
 
 #: src/renderer/components/Account.tsx:51
 msgctxt "account-view"
 msgid "COPIED TO CLIPBOARD!"
-msgstr "COPIÉ DANS LE PRESSE-PAPIERS !"
+msgstr "KOPIERAT TILL URKLIPP!"
 
-#: src/renderer/components/Account.tsx:101
+#: src/renderer/components/Account.tsx:103
 msgctxt "account-view"
 msgid "Currently unavailable"
-msgstr "Actuellement indisponible"
+msgstr "Inte tillgänglig för närvarande"
 
-#: src/renderer/components/Account.tsx:74
+#: src/renderer/components/Account.tsx:76
 msgctxt "account-view"
 msgid "Log out"
-msgstr "Déconnexion"
+msgstr "Logga ut"
 
-#: src/renderer/components/Account.tsx:93
+#: src/renderer/components/Account.tsx:95
 msgctxt "account-view"
 msgid "OUT OF TIME"
-msgstr "PLUS DE TEMPS"
+msgstr "INGEN TID KVAR"
+
+#: src/renderer/components/Account.tsx:57
+msgctxt "account-view"
+msgid "Paid until"
+msgstr ""
 
 #. Title label in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:97
 msgctxt "advanced-settings-nav"
 msgid "Advanced"
-msgstr "Avancé"
+msgstr "Avancerat"
 
 #. Back button in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:93
 msgctxt "advanced-settings-nav"
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Inställningar"
 
 #. The title for the port selector section.
 #. Available placeholders:
@@ -98,37 +103,37 @@ msgstr "Paramètres"
 #: src/renderer/components/AdvancedSettings.tsx:150
 msgctxt "advanced-settings-view"
 msgid "%(portType)s port"
-msgstr "Port %(portType)s"
+msgstr "%(portType)s port"
 
 #: src/renderer/components/AdvancedSettings.tsx:104
 msgctxt "advanced-settings-view"
 msgid "Advanced"
-msgstr "Avancé"
+msgstr "Avancerat"
 
 #: src/renderer/components/AdvancedSettings.tsx:265
 msgctxt "advanced-settings-view"
 msgid "Automatic"
-msgstr "Automatique"
+msgstr "Automatisk"
 
 #: src/renderer/components/AdvancedSettings.tsx:120
 msgctxt "advanced-settings-view"
 msgid "Block when disconnected"
-msgstr "Bloquer quand déconnecté"
+msgstr "Blockera vid frånkoppling"
 
 #: src/renderer/components/AdvancedSettings.tsx:171
 msgctxt "advanced-settings-view"
 msgid "Default"
-msgstr "Par défaut"
+msgstr "Standard"
 
 #: src/renderer/components/AdvancedSettings.tsx:108
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6"
-msgstr "Activer IPv6"
+msgstr "Aktivera IPv6"
 
 #: src/renderer/components/AdvancedSettings.tsx:112
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6 communication through the tunnel."
-msgstr "Activer la communication IPv6 via le tunnel."
+msgstr "Aktivera IPv6-kommunikation genom tunneln."
 
 #: src/renderer/components/AdvancedSettings.tsx:165
 msgctxt "advanced-settings-view"
@@ -138,7 +143,7 @@ msgstr "Mssfix"
 #: src/renderer/components/AdvancedSettings.tsx:136
 msgctxt "advanced-settings-view"
 msgid "Network protocols"
-msgstr "Protocoles réseau"
+msgstr "Nätverksprotokoll"
 
 #. The hint displayed below the Mssfix input field.
 #. Available placeholders:
@@ -147,32 +152,32 @@ msgstr "Protocoles réseau"
 #: src/renderer/components/AdvancedSettings.tsx:187
 msgctxt "advanced-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
-msgstr "Définir la valeur MSS OpenVPN. Plage valide : %(min)d - %(max)d."
+msgstr "Ange värde för OpenVPN MSS. Giltigt intervall: %(min)d-%(max)d."
 
 #: src/renderer/components/AdvancedSettings.tsx:128
 msgctxt "advanced-settings-view"
 msgid "Unless connected, always block all network traffic, even when you've disconnected or quit the app."
-msgstr "À moins d'être connecté, toujours bloquer le trafic réseau, même quand vous êtes déconnecté ou quand vous quittez l'application."
+msgstr "Om du inte är ansluten bör du alltid blockera all nätverkstrafik, även när du har kopplats från eller avslutat appen."
 
 #: src/renderer/lib/auth-failure.ts:80
 msgctxt "auth-failure"
 msgid "Account authentication failed."
-msgstr "Connexion au compte échouée."
+msgstr "Autentiseringen av kontot misslyckades."
 
 #: src/renderer/lib/auth-failure.ts:74
 msgctxt "auth-failure"
 msgid "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly."
-msgstr "Trop de connexions simultanées à ce compte. Déconnectez un autre appareil ou réessayez de vous connecter dans un instant."
+msgstr "Detta konto har för många samtidiga anslutningar. Koppla från en annan enhet eller försök att ansluta igen inom kort."
 
 #: src/renderer/lib/auth-failure.ts:68
 msgctxt "auth-failure"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "Il ne vous reste plus de temps de VPN sur ce compte. Veuillez vous connecter à notre site pour acheter plus de crédits."
+msgstr "Du har ingen VPN-tid kvar på kontot. Logga in på vår hemsida för att köpa mer kredit."
 
 #: src/renderer/lib/auth-failure.ts:62
 msgctxt "auth-failure"
 msgid "You've logged in with an account number that is not valid. Please log out and try another one."
-msgstr "Vous vous êtes connecté avec un numéro de compte non valide. Veuillez vous déconnecter et en essayer un autre."
+msgstr "Du har loggat in med ett konto som inte är giltigt. Logga ut och försök med ett annat."
 
 #. The selected location label displayed on the main view, when a user selected a specific host to connect to.
 #. Example: Malmö (se-mma-001)
@@ -188,77 +193,77 @@ msgstr "%(city)s (%(hostname)s)"
 #: src/renderer/components/ExpiredAccountErrorView.tsx:157
 msgctxt "connect-view"
 msgid "Buy more credit"
-msgstr "Acheter plus de crédits"
+msgstr "Köp mer kredit"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:114
 msgctxt "connect-view"
 msgid "Disconnect and buy more credit"
-msgstr "Déconnectez-vous et achetez plus de crédits"
+msgstr "Koppla från och köp mer kredit"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:78
 msgctxt "connect-view"
 msgid "Out of time"
-msgstr "Plus de temps"
+msgstr "Ingen tid kvar"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:150
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Before you can buy more credit on our website, you first need to turn off the app's \"Block when disconnected\" option under Advanced settings."
-msgstr "Il ne vous reste plus de temps VPN sur ce compte. Avant de pouvoir acheter plus de crédits sur notre site, vous devez désactiver l'option \"Bloquer quand déconnecté\" de l'application dans les paramètres avancés."
+msgstr "Du har ingen VPN-tid kvar på kontot. Innan du kan köpa mer kredit på vår hemsida måste du först stänga av alternativet ”Blockera vid frånkoppling” under appens avancerade inställningar."
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:129
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "Il ne vous reste plus de temps de VPN sur ce compte. Veuillez vous connecter à notre site pour acheter plus de crédits."
+msgstr "Du har ingen VPN-tid kvar på kontot. Logga in på vår hemsida för att köpa mer kredit."
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:106
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. To buy more credit on our website, you will need to access the Internet with an unsecured connection."
-msgstr "Il ne vous reste plus de temps VPN sur ce compte. Pour acheter plus de crédits sur notre site, vous devez accéder à internet avec une connexion non sécurisée."
+msgstr "Du har ingen VPN-tid kvar på kontot. För att köpa mer kredit på vår hemsida behöver du åtkomst till internet med en osäker anslutning."
 
 #: src/renderer/components/NotificationArea.tsx:281
 msgctxt "in-app-notifications"
 msgid "ACCOUNT CREDIT EXPIRES SOON"
-msgstr "LES CRÉDITS DU COMPTE EXPIRENT BIENTÔT"
+msgstr "KONTOKREDITEN GÅR SNART UT"
 
 #: src/renderer/components/NotificationArea.tsx:200
 msgctxt "in-app-notifications"
 msgid "BLOCKING INTERNET"
-msgstr "BLOCAGE D'INTERNET"
+msgstr "BLOCKERING AV INTERNET"
 
 #: src/renderer/components/NotificationArea.tsx:48
 msgctxt "in-app-notifications"
 msgid "Could not configure IPv6, please enable it on your system or disable it in the app"
-msgstr "Configuration IPv6 impossible. Veuillez l'activer dans votre système ou le désactiver dans l'application"
+msgstr "IPv6 kunde inte konfigureras. Aktivera det på ditt system eller stäng av det i appen"
 
 #: src/renderer/components/NotificationArea.tsx:53
 msgctxt "in-app-notifications"
 msgid "Failed to apply firewall rules. The device might currently be unsecured"
-msgstr "Échec de l'application des règles du pare-feu. L'appareil est potentiellement non sécurisé à l'heure actuelle"
+msgstr "Det gick inte att tillämpa brandväggsregler. Enheten kan för närvarande vara osäker"
 
 #: src/renderer/components/NotificationArea.tsx:58
 msgctxt "in-app-notifications"
 msgid "Failed to set system DNS server"
-msgstr "Échec de la configuration du serveur DNS système"
+msgstr "Det gick inte att ange systemets DNS-server"
 
 #: src/renderer/components/NotificationArea.tsx:60
 msgctxt "in-app-notifications"
 msgid "Failed to start tunnel connection"
-msgstr "Échec du démarrage de la connexion tunnel"
+msgstr "Det gick inte att starta tunnelanslutning"
 
 #: src/renderer/components/NotificationArea.tsx:188
 msgctxt "in-app-notifications"
 msgid "FAILURE - UNSECURED"
-msgstr "ÉCHEC - NON SÉCURISÉ"
+msgstr "MISSLYCKADES - OSKYDDAD"
 
 #: src/renderer/components/NotificationArea.tsx:215
 msgctxt "in-app-notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "Informations de version interne incompatibles. Veuillez redémarrer l'application"
+msgstr "Inkonsekvent intern versionsinformation, starta om appen"
 
 #: src/renderer/components/NotificationArea.tsx:212
 msgctxt "in-app-notifications"
 msgid "INCONSISTENT VERSION"
-msgstr "VERSION INCOMPATIBLE"
+msgstr "INKONSEKVENT VERSION"
 
 #. The in-app banner displayed to the user when the app update is available.
 #. Available placeholders:
@@ -266,32 +271,32 @@ msgstr "VERSION INCOMPATIBLE"
 #: src/renderer/components/NotificationArea.tsx:262
 msgctxt "in-app-notifications"
 msgid "Install Mullvad VPN (%(version)s) to stay up to date"
-msgstr "Installez Mullvad VPN (%(version)s) pour rester à jour"
+msgstr "Installera Mullvad VPN (%(version)s) för att hålla dig uppdaterad"
 
 #: src/renderer/components/NotificationArea.tsx:62
 msgctxt "in-app-notifications"
 msgid "No relay server matches the current settings"
-msgstr "Aucun serveur de relais ne correspond à vos paramètres actuels"
+msgstr "Ingen relayserver matchar de aktuella inställningarna"
 
 #: src/renderer/components/NotificationArea.tsx:64
 msgctxt "in-app-notifications"
 msgid "This device is offline, no tunnels can be established"
-msgstr "Cet appareil est hors ligne. Aucun tunnel ne peut être établi"
+msgstr "Denna enhet är frånkopplad, inga tunnlar kan fastställas"
 
 #: src/renderer/components/NotificationArea.tsx:69
 msgctxt "in-app-notifications"
 msgid "Unable to detect a working TAP adapter on this device. If you've disabled it, enable it again. Otherwise, please reinstall the app"
-msgstr "Impossible de détecter d'adaptateur TAP fonctionnel sur cet appareil. Si vous en avez désactivé un, veuillez le réactiver. Sinon, veuillez réinstaller l'application"
+msgstr "Det går inte att upptäcka en fungerande TAP-adapter på den här enheten. Aktivera den om den är inaktiverad. Installera om appen i annat fall"
 
 #: src/renderer/components/NotificationArea.tsx:229
 msgctxt "in-app-notifications"
 msgid "UNSUPPORTED VERSION"
-msgstr "VERSION NON PRISE EN CHARGE"
+msgstr "VERSION UTAN STÖD"
 
 #: src/renderer/components/NotificationArea.tsx:255
 msgctxt "in-app-notifications"
 msgid "UPDATE AVAILABLE"
-msgstr "MISE À JOUR DISPONIBLE"
+msgstr "UPPDATERING TILLGÄNGLIG"
 
 #. The in-app banner displayed to the user when the running app becomes unsupported.
 #. Available placeholders:
@@ -299,12 +304,12 @@ msgstr "MISE À JOUR DISPONIBLE"
 #: src/renderer/components/NotificationArea.tsx:236
 msgctxt "in-app-notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "Vous utilisez une version d'application non prise en charge. Veuillez passer maintenant à la version %(version)s pour assurer votre sécurité"
+msgstr "Du kör en appversion utan stöd. Uppgradera till %(version)s nu för att garantera din säkerhet"
 
 #: src/renderer/components/Launch.tsx:53
 msgctxt "launch-view"
 msgid "Connecting to daemon..."
-msgstr "Connexion au daemon..."
+msgstr "Ansluter till daemon..."
 
 #: src/renderer/components/Launch.tsx:51
 msgctxt "launch-view"
@@ -314,87 +319,87 @@ msgstr "MULLVAD VPN"
 #: src/renderer/components/Login.tsx:231
 msgctxt "login-view"
 msgid "Checking account number"
-msgstr "Vérification du numéro de compte"
+msgstr "Kontrollerar kontonummer"
 
 #: src/renderer/components/Login.tsx:233
 msgctxt "login-view"
 msgid "Correct account number"
-msgstr "Numéro de compte correct"
+msgstr "Korrekt kontonummer"
 
 #: src/renderer/components/Login.tsx:403
 msgctxt "login-view"
 msgid "Create account"
-msgstr "Créer un compte"
+msgstr "Skapa konto"
 
 #: src/renderer/components/Login.tsx:400
 msgctxt "login-view"
 msgid "Don't have an account number?"
-msgstr "Vous n'avez pas de numéro de compte ?"
+msgstr "Har du inget kontonummer?"
 
 #: src/renderer/components/Login.tsx:235
 msgctxt "login-view"
 msgid "Enter your account number"
-msgstr "Saisissez votre numéro de compte"
+msgstr "Ange ditt kontonummer"
 
 #: src/renderer/components/Login.tsx:219
 msgctxt "login-view"
 msgid "Logged in"
-msgstr "Connecté"
+msgstr "Inloggad"
 
 #: src/renderer/components/Login.tsx:215
 msgctxt "login-view"
 msgid "Logging in..."
-msgstr "Connexion..."
+msgstr "Loggar in..."
 
 #: src/renderer/components/Login.tsx:221
 msgctxt "login-view"
 msgid "Login"
-msgstr "Connexion"
+msgstr "Logga in"
 
 #: src/renderer/components/Login.tsx:217
 msgctxt "login-view"
 msgid "Login failed"
-msgstr "Échec de la connexion"
+msgstr "Inloggningen misslyckades"
 
 #: src/renderer/components/Login.tsx:229
 msgctxt "login-view"
 msgid "Unknown error"
-msgstr "Erreur inconnue"
+msgstr "Okänt fel"
 
 #: src/main/notification-controller.ts:46
 msgctxt "notifications"
 msgid "Blocked all connections"
-msgstr "Toutes les connexions sont bloquées"
+msgstr "Blockera alla anslutningar"
 
 #: src/main/notification-controller.ts:29
 msgctxt "notifications"
 msgid "Connecting"
-msgstr "Connexion"
+msgstr "Ansluter"
 
 #: src/main/notification-controller.ts:42
 msgctxt "notifications"
 msgid "Critical failure - Unsecured"
-msgstr "Échec critique - non sécurisé"
+msgstr "Kritiskt fel - oskyddad"
 
 #: src/main/notification-controller.ts:71
 msgctxt "notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "Informations de version interne incompatibles. Veuillez redémarrer l'application"
+msgstr "Inkonsekvent intern versionsinformation, starta om appen"
 
 #: src/main/notification-controller.ts:57
 msgctxt "notifications"
 msgid "Reconnecting"
-msgstr "Reconnexion"
+msgstr "Återansluter"
 
 #: src/main/notification-controller.ts:33
 msgctxt "notifications"
 msgid "Secured"
-msgstr "Sécurisé"
+msgstr "Skyddad"
 
 #: src/main/notification-controller.ts:36
 msgctxt "notifications"
 msgid "Unsecured"
-msgstr "Non sécurisé"
+msgstr "Oskyddad"
 
 #. The system notification displayed to the user when the running app becomes unsupported.
 #. Available placeholder:
@@ -402,255 +407,255 @@ msgstr "Non sécurisé"
 #: src/main/notification-controller.ts:90
 msgctxt "notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "Vous utilisez une version d'application non prise en charge. Veuillez passer maintenant en %(version)s pour assurer votre sécurité"
+msgstr "Du kör en appversion utan stöd. Uppgradera till %(version)s nu för att garantera din säkerhet"
 
 #. Title label in navigation bar
 #: src/renderer/components/Preferences.tsx:46
 msgctxt "preferences-nav"
 msgid "Preferences"
-msgstr "Préférences"
+msgstr "Inställningar"
 
 #. Back button in navigation bar
 #: src/renderer/components/Preferences.tsx:42
 msgctxt "preferences-nav"
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Inställningar"
 
 #: src/renderer/components/Preferences.tsx:86
 msgctxt "preferences-view"
 msgid "Allows access to other devices on the same network for sharing, printing etc."
-msgstr "Autorise l'accès aux autres appareils sur le même réseau pour partager, imprimer, etc."
+msgstr "Tillåter åtkomst till andra enheter i samma nätverk för delning, utskrift etc."
 
 #: src/renderer/components/Preferences.tsx:66
 msgctxt "preferences-view"
 msgid "Auto-connect"
-msgstr "Connexion automatique"
+msgstr "Anslut automatiskt"
 
 #: src/renderer/components/Preferences.tsx:73
 msgctxt "preferences-view"
 msgid "Automatically connect to a server when the app launches."
-msgstr "Connexion automatique à un serveur dès le démarrage de l'application."
+msgstr "Anslut automatiskt till en server när appen startas."
 
 #: src/renderer/components/Preferences.tsx:59
 msgctxt "preferences-view"
 msgid "Launch app on start-up"
-msgstr "Lancement de l'application au démarrage"
+msgstr "Starta appen vid uppstart"
 
 #: src/renderer/components/Preferences.tsx:81
 msgctxt "preferences-view"
 msgid "Local network sharing"
-msgstr "Partage réseau local"
+msgstr "Lokal nätverksdelning"
 
 #: src/renderer/components/Preferences.tsx:130
 msgctxt "preferences-view"
 msgid "Monochromatic tray icon"
-msgstr "Icône de zone de notification monochrome"
+msgstr "Enfärgad systemfältsikon"
 
 #: src/renderer/components/Preferences.tsx:53
 msgctxt "preferences-view"
 msgid "Preferences"
-msgstr "Préférences"
+msgstr "Inställningar"
 
 #: src/renderer/components/Preferences.tsx:163
 msgctxt "preferences-view"
 msgid "Show only the tray icon when the app starts."
-msgstr "Afficher uniquement l'icône de la zone de notification au démarrage de l'application."
+msgstr "Visa endast systemfältsikonen när appen startas."
 
 #: src/renderer/components/Preferences.tsx:159
 msgctxt "preferences-view"
 msgid "Start minimized"
-msgstr "Démarrer réduit"
+msgstr "Starta minimerat"
 
 #: src/renderer/components/Preferences.tsx:134
 msgctxt "preferences-view"
 msgid "Use a monochromatic tray icon instead of a colored one."
-msgstr "Utiliser l'icône de zone de notification monochrome à la place de celle en couleur."
+msgstr "Använd en enfärgad systemfältsikon i stället för en flerfärgad."
 
 #. Title label in navigation bar
 #: src/renderer/components/SelectLocation.tsx:118
 msgctxt "select-location-nav"
 msgid "Select location"
-msgstr "Sélectionner une localisation"
+msgstr "Välj plats"
 
 #: src/renderer/components/SelectLocation.tsx:126
 msgctxt "select-location-view"
 msgid "Select location"
-msgstr "Sélectionner une localisation"
+msgstr "Välj plats"
 
 #: src/renderer/components/SelectLocation.tsx:129
 msgctxt "select-location-view"
 msgid "While connected, your real location is masked with a private and secure location in the selected region"
-msgstr "Quand vous êtes connecté, votre vraie localisation est masquée par une localisation privée et sécurisée de la région sélectionnée"
+msgstr "Medan du är ansluten maskeras din riktiga plats med en privat och säker plats i den valda regionen"
 
 #: src/renderer/components/Settings.tsx:104
 msgctxt "settings-view"
 msgid "Account"
-msgstr "Compte"
+msgstr "Konto"
 
 #: src/renderer/components/Settings.tsx:119
 msgctxt "settings-view"
 msgid "Advanced"
-msgstr "Avancé"
+msgstr "Avancerat"
 
 #: src/renderer/components/Settings.tsx:165
 msgctxt "settings-view"
 msgid "App version"
-msgstr "Version de l'application"
+msgstr "Appversion"
 
 #: src/renderer/components/Settings.tsx:186
 msgctxt "settings-view"
 msgid "FAQs & Guides"
-msgstr "FAQ et guides"
+msgstr "Vanliga frågor och guider"
 
 #: src/renderer/components/Settings.tsx:131
 msgctxt "settings-view"
 msgid "Inconsistent internal version information, please restart the app."
-msgstr "Informations de version interne incompatibles. Veuillez redémarrer l'application."
+msgstr "Inkonsekvent intern versionsinformation, starta om appen."
 
 #: src/renderer/components/Settings.tsx:98
 msgctxt "settings-view"
 msgid "OUT OF TIME"
-msgstr "PLUS DE TEMPS"
+msgstr "INGEN TID KVAR"
 
 #: src/renderer/components/Settings.tsx:114
 msgctxt "settings-view"
 msgid "Preferences"
-msgstr "Préférences"
+msgstr "Inställningar"
 
 #: src/renderer/components/Settings.tsx:80
 msgctxt "settings-view"
 msgid "Quit app"
-msgstr "Quitter l'application"
+msgstr "Avsluta appen"
 
 #: src/renderer/components/Settings.tsx:181
 msgctxt "settings-view"
 msgid "Report a problem"
-msgstr "Signaler un problème"
+msgstr "Rapportera ett problem"
 
 #: src/renderer/components/Settings.tsx:58
 msgctxt "settings-view"
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Inställningar"
 
 #: src/renderer/components/Settings.tsx:136
 msgctxt "settings-view"
 msgid "Update available, download to remain safe."
-msgstr "Mise à jour disponible. Téléchargez-la pour rester en sécurité."
+msgstr "Uppdatering tillgänglig. Ladda ned för att vara säker."
 
 #. Title label in navigation bar
 #: src/renderer/components/Settings.tsx:50
 msgctxt "settings-view-nav"
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Inställningar"
 
 #. Back button in navigation bar
 #: src/renderer/components/Support.tsx:146
 msgctxt "support-nav"
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Inställningar"
 
 #: src/renderer/components/Support.tsx:392
 msgctxt "support-view"
 msgid "Back"
-msgstr "Retour"
+msgstr "Tillbaka"
 
 #: src/renderer/components/Support.tsx:252
 msgctxt "support-view"
 msgid "Describe your problem"
-msgstr "Décrivez votre problème"
+msgstr "Beskriv ditt problem"
 
 #: src/renderer/components/Support.tsx:357
 msgctxt "support-view"
 msgid "Edit message"
-msgstr "Modifier le message"
+msgstr "Redigera meddelande"
 
 #: src/renderer/components/Support.tsx:345
 msgctxt "support-view"
 msgid "Failed to send"
-msgstr "Échec de l'envoi"
+msgstr "Det gick inte att skicka"
 
 #: src/renderer/components/Support.tsx:297
 msgctxt "support-view"
 msgid "If needed we will contact you on %(email)s"
-msgstr "Si nécessaire, nous vous contacterons sur %(email)s"
+msgstr "Om det behövs kontaktar vi dig på %(email)s"
 
 #: src/renderer/components/Support.tsx:123
 msgctxt "support-view"
 msgid "Report a problem"
-msgstr "Signaler un problème"
+msgstr "Rapportera ett problem"
 
 #: src/renderer/components/Support.tsx:265
 msgctxt "support-view"
 msgid "Send"
-msgstr "Envoyer"
+msgstr "Skicka"
 
 #: src/renderer/components/Support.tsx:389
 msgctxt "support-view"
 msgid "Send anyway"
-msgstr "Envoyer quand même"
+msgstr "Skicka ändå"
 
 #: src/renderer/components/Support.tsx:285
 msgctxt "support-view"
 msgid "Sending..."
-msgstr "Envoi..."
+msgstr "Skicka..."
 
 #: src/renderer/components/Support.tsx:319
 msgctxt "support-view"
 msgid "Sent"
-msgstr "Envoyé"
+msgstr "Skickat"
 
 #: src/renderer/components/Support.tsx:322
 msgctxt "support-view"
 msgid "Thanks! We will look into this."
-msgstr "Merci ! Nous allons nous pencher dessus."
+msgstr "Tack! Vi kommer att undersöka detta."
 
 #: src/renderer/components/Support.tsx:126
 msgctxt "support-view"
 msgid "To help you more effectively, your app's log file will be attached to this message. Your data will remain secure and private, as it is anonymised before being sent over an encrypted channel."
-msgstr "Pour mieux vous aider, le fichier journal de l'application est joint à ce message. Vos données restent privées et en sécurité dans la mesure où elles sont rendues anonymes avant d'être envoyées via un canal chiffré."
+msgstr "För att hjälpa dig mer effektivt kommer appens loggfil att bifogas i detta meddelande. Dina uppgifter förblir säkra och privata, eftersom de anonymiseras innan de skickas över en krypterad kanal."
 
 #: src/renderer/components/Support.tsx:360
 msgctxt "support-view"
 msgid "Try again"
-msgstr "Réessayer"
+msgstr "Försök igen"
 
 #: src/renderer/components/Support.tsx:261
 msgctxt "support-view"
 msgid "View app logs"
-msgstr "Afficher les journaux de l'application"
+msgstr "Visa appens loggar"
 
 #: src/renderer/components/Support.tsx:383
 msgctxt "support-view"
 msgid "You are about to send the problem report without a way for us to get back to you. If you want an answer to your report you will have to enter an email address."
-msgstr "Vous êtes sur le point d'envoyer un signalement de problème sans nous fournir un moyen de vous contacter. Si vous désirez une réponse à votre signalement, vous devez saisir une adresse e-mail."
+msgstr "Du är på väg att skicka problemrapporten utan att vi har möjlighet att besvara dig. Om du vill ha svar på din rapport måste du ange en e-postadress."
 
 #: src/renderer/components/Support.tsx:348
 msgctxt "support-view"
 msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
-msgstr "Vous allez peut-être devoir retourner à l'écran principal de l'application pour cliquer sur Déconnexion avant de réessayer. Ne vous inquiétez pas, les informations saisies resteront dans le formulaire."
+msgstr "Du kan behöva gå tillbaka till appens huvudskärm och klicka på Koppla från innan du försöker igen. Oroa dig inte, den information du angett i formuläret kommer att bli kvar där."
 
 #: src/renderer/components/Support.tsx:242
 msgctxt "support-view"
 msgid "Your email (optional)"
-msgstr "Votre e-mail (facultatif)"
+msgstr "Din e-postadress (valfritt)"
 
 #: src/renderer/components/TunnelControl.tsx:121
 msgctxt "tunnel-control"
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "Avbryt"
 
 #: src/renderer/components/TunnelControl.tsx:115
 msgctxt "tunnel-control"
 msgid "Disconnect"
-msgstr "Déconnexion"
+msgstr "Koppla från"
 
 #: src/renderer/components/TunnelControl.tsx:109
 msgctxt "tunnel-control"
 msgid "Secure my connection"
-msgstr "Sécuriser ma connexion"
+msgstr "Skydda min anslutning"
 
 #: src/renderer/components/TunnelControl.tsx:93
 msgctxt "tunnel-control"
 msgid "Switch location"
-msgstr "Changer de localisation"
+msgstr "Växla plats"
 

--- a/gui/locales/zh-TW/messages.po
+++ b/gui/locales/zh-TW/messages.po
@@ -1,35 +1,35 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: mullvad-app\n"
-"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-Language: zh-TW\n"
 "X-Crowdin-File: messages.pot\n"
 "Project-Id-Version: mullvad-app\n"
 "Last-Translator: adminmullvad <admin@mullvad.net>\n"
-"Language-Team: Spanish\n"
-"Language: es_ES\n"
-"PO-Revision-Date: 2019-03-18 14:19\n"
+"Language-Team: Chinese Traditional\n"
+"Language: zh_TW\n"
+"PO-Revision-Date: 2019-03-18 15:52\n"
 
 #: src/renderer/components/SecuredLabel.tsx:40
 msgid "BLOCKED CONNECTION"
-msgstr "CONEXIÓN BLOQUEADA"
+msgstr "被封鎖的連線"
 
 #: src/renderer/components/SecuredLabel.tsx:43
 msgid "CREATING SECURE CONNECTION"
-msgstr "CREANDO CONEXIÓN SEGURA"
+msgstr "建立安全連線"
 
 #: src/renderer/components/SecuredLabel.tsx:37
 #: src/renderer/components/Support.tsx:282
 #: src/renderer/components/Support.tsx:317
 #: src/renderer/components/Support.tsx:342
 msgid "SECURE CONNECTION"
-msgstr "CONEXIÓN SEGURA"
+msgstr "安全連線"
 
 #: src/renderer/components/SecuredLabel.tsx:46
 msgid "UNSECURED CONNECTION"
-msgstr "CONEXIÓN NO SEGURA"
+msgstr "不安全的連線"
 
 #. The remaining time left on the account displayed across the app.
 #. Available placeholders:
@@ -37,60 +37,65 @@ msgstr "CONEXIÓN NO SEGURA"
 #: src/renderer/lib/account-expiry.ts:31
 msgctxt "account-expiry"
 msgid "%(duration)s left"
-msgstr "%(duration)s restantes"
+msgstr "剩餘 %(duration)s"
 
 #. Back button in navigation bar
 #: src/renderer/components/Account.tsx:33
 msgctxt "account-nav"
 msgid "Settings"
-msgstr "Configuración"
+msgstr "設定"
 
 #: src/renderer/components/Account.tsx:39
 msgctxt "account-view"
 msgid "Account"
-msgstr "Cuenta"
+msgstr "帳戶"
 
 #: src/renderer/components/Account.tsx:46
 msgctxt "account-view"
 msgid "Account ID"
-msgstr "Id. de cuenta"
+msgstr "帳戶 ID"
 
-#: src/renderer/components/Account.tsx:69
+#: src/renderer/components/Account.tsx:71
 msgctxt "account-view"
 msgid "Buy more credit"
-msgstr "Comprar más crédito"
+msgstr "購買更多點數"
 
 #: src/renderer/components/Account.tsx:51
 msgctxt "account-view"
 msgid "COPIED TO CLIPBOARD!"
-msgstr "¡COPIADO EN EL PORTAPAPELES!"
+msgstr "已複製到剪貼簿！"
 
-#: src/renderer/components/Account.tsx:101
+#: src/renderer/components/Account.tsx:103
 msgctxt "account-view"
 msgid "Currently unavailable"
-msgstr "No disponible actualmente"
+msgstr "目前不可用"
 
-#: src/renderer/components/Account.tsx:74
+#: src/renderer/components/Account.tsx:76
 msgctxt "account-view"
 msgid "Log out"
-msgstr "Cerrar sesión"
+msgstr "登出"
 
-#: src/renderer/components/Account.tsx:93
+#: src/renderer/components/Account.tsx:95
 msgctxt "account-view"
 msgid "OUT OF TIME"
-msgstr "TIEMPO AGOTADO"
+msgstr "逾時"
+
+#: src/renderer/components/Account.tsx:57
+msgctxt "account-view"
+msgid "Paid until"
+msgstr ""
 
 #. Title label in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:97
 msgctxt "advanced-settings-nav"
 msgid "Advanced"
-msgstr "Avanzadas"
+msgstr "進階"
 
 #. Back button in navigation bar
 #: src/renderer/components/AdvancedSettings.tsx:93
 msgctxt "advanced-settings-nav"
 msgid "Settings"
-msgstr "Configuración"
+msgstr "設定"
 
 #. The title for the port selector section.
 #. Available placeholders:
@@ -98,37 +103,37 @@ msgstr "Configuración"
 #: src/renderer/components/AdvancedSettings.tsx:150
 msgctxt "advanced-settings-view"
 msgid "%(portType)s port"
-msgstr "Puerto %(portType)s"
+msgstr "%(portType)s 連接埠"
 
 #: src/renderer/components/AdvancedSettings.tsx:104
 msgctxt "advanced-settings-view"
 msgid "Advanced"
-msgstr "Avanzadas"
+msgstr "進階"
 
 #: src/renderer/components/AdvancedSettings.tsx:265
 msgctxt "advanced-settings-view"
 msgid "Automatic"
-msgstr "Automático"
+msgstr "自動"
 
 #: src/renderer/components/AdvancedSettings.tsx:120
 msgctxt "advanced-settings-view"
 msgid "Block when disconnected"
-msgstr "Bloquear cuando esté desconectado"
+msgstr "中斷連線時封鎖"
 
 #: src/renderer/components/AdvancedSettings.tsx:171
 msgctxt "advanced-settings-view"
 msgid "Default"
-msgstr "Predeterminado"
+msgstr "預設"
 
 #: src/renderer/components/AdvancedSettings.tsx:108
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6"
-msgstr "Habilitar IPv6"
+msgstr "啟用 IPv6"
 
 #: src/renderer/components/AdvancedSettings.tsx:112
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6 communication through the tunnel."
-msgstr "Permite la comunicación IPv6 a través del túnel."
+msgstr "透過通道啟用 IPv6 通訊。"
 
 #: src/renderer/components/AdvancedSettings.tsx:165
 msgctxt "advanced-settings-view"
@@ -138,7 +143,7 @@ msgstr "Mssfix"
 #: src/renderer/components/AdvancedSettings.tsx:136
 msgctxt "advanced-settings-view"
 msgid "Network protocols"
-msgstr "Protocolos de red"
+msgstr "網路通訊協定"
 
 #. The hint displayed below the Mssfix input field.
 #. Available placeholders:
@@ -147,32 +152,32 @@ msgstr "Protocolos de red"
 #: src/renderer/components/AdvancedSettings.tsx:187
 msgctxt "advanced-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
-msgstr "Establezca el valor de MSS de OpenVPN. Intervalo válido: %(min)d-%(max)d."
+msgstr "設定 OpenVPN MSS 值。有效範圍：%(min)d - %(max)d。"
 
 #: src/renderer/components/AdvancedSettings.tsx:128
 msgctxt "advanced-settings-view"
 msgid "Unless connected, always block all network traffic, even when you've disconnected or quit the app."
-msgstr "Si no está conectado, bloquea siempre todo el tráfico de red, incluso al desconectar o cerrar la aplicación."
+msgstr "除非已連線，否則一律封鎖所有網路流量，即便您已中斷連線或退出應用程式亦同。"
 
 #: src/renderer/lib/auth-failure.ts:80
 msgctxt "auth-failure"
 msgid "Account authentication failed."
-msgstr "Error de autenticación de la cuenta."
+msgstr "帳戶驗證失敗。"
 
 #: src/renderer/lib/auth-failure.ts:74
 msgctxt "auth-failure"
 msgid "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly."
-msgstr "Esta cuenta tiene demasiadas conexiones simultáneas. Desconecte otro dispositivo o intente volver a conectarse más tarde."
+msgstr "此帳戶有太多的同時連線。請中斷其他裝置的連線，或是稍後再次嘗試連線。"
 
 #: src/renderer/lib/auth-failure.ts:68
 msgctxt "auth-failure"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "No le queda tiempo de VPN en esta cuenta. Inicie sesión en nuestro sitio web para comprar más crédito."
+msgstr "您在此帳戶沒有更多 VPN 時間了。請登入我們的網站，購買更多點數。"
 
 #: src/renderer/lib/auth-failure.ts:62
 msgctxt "auth-failure"
 msgid "You've logged in with an account number that is not valid. Please log out and try another one."
-msgstr "Ha iniciado la sesión con un número de cuenta no válido. Cierre la sesión y pruebe con otro número."
+msgstr "您登入時使用的帳號是無效的。請登出並使用另一個。"
 
 #. The selected location label displayed on the main view, when a user selected a specific host to connect to.
 #. Example: Malmö (se-mma-001)
@@ -188,77 +193,77 @@ msgstr "%(city)s (%(hostname)s)"
 #: src/renderer/components/ExpiredAccountErrorView.tsx:157
 msgctxt "connect-view"
 msgid "Buy more credit"
-msgstr "Comprar más crédito"
+msgstr "購買更多點數"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:114
 msgctxt "connect-view"
 msgid "Disconnect and buy more credit"
-msgstr "Desconectar y comprar más crédito"
+msgstr "中斷連線並購買更多點數"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:78
 msgctxt "connect-view"
 msgid "Out of time"
-msgstr "Tiempo agotado"
+msgstr "逾時"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:150
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Before you can buy more credit on our website, you first need to turn off the app's \"Block when disconnected\" option under Advanced settings."
-msgstr "Ya no le queda más tiempo VPN en esta cuenta. Para comprar más crédito en nuestro sitio web, primero necesita desactivar la opción «Bloquear cuando esté desconectado» en la configuración avanzada de la aplicación."
+msgstr "您在此帳戶沒有更多 VPN 時間了。您必須先關閉應用程式「進階」設定下的「中斷連線時封鎖」選項，再到我們網站購買更多點數。"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:129
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. Please log in on our website to buy more credit."
-msgstr "Ya no le queda más tiempo de VPN en esta cuenta. Inicie sesión en nuestro sitio web para comprar más crédito."
+msgstr "您在此帳戶沒有更多 VPN 時間了。請登入我們的網站，購買更多點數。"
 
 #: src/renderer/components/ExpiredAccountErrorView.tsx:106
 msgctxt "connect-view"
 msgid "You have no more VPN time left on this account. To buy more credit on our website, you will need to access the Internet with an unsecured connection."
-msgstr "Ya no le queda más tiempo de VPN en esta cuenta. Para comprar más crédito en nuestro sitio web, necesita acceder a Internet con una conexión no segura."
+msgstr "您在此帳戶沒有更多 VPN 時間了。若要在我們網站上購買更多點數，您必須使用不安全的連線存取網際網路。"
 
 #: src/renderer/components/NotificationArea.tsx:281
 msgctxt "in-app-notifications"
 msgid "ACCOUNT CREDIT EXPIRES SOON"
-msgstr "EL CRÉDITO DE SU CUENTA CADUCA PRONTO"
+msgstr "帳戶點數即將到期"
 
 #: src/renderer/components/NotificationArea.tsx:200
 msgctxt "in-app-notifications"
 msgid "BLOCKING INTERNET"
-msgstr "BLOQUEANDO INTERNET"
+msgstr "封鎖網際網路"
 
 #: src/renderer/components/NotificationArea.tsx:48
 msgctxt "in-app-notifications"
 msgid "Could not configure IPv6, please enable it on your system or disable it in the app"
-msgstr "No se pudo configurar IPv6, habilítelo en el sistema o deshabilítelo en la aplicación"
+msgstr "無法配置 IPv6，請在我們系統啟用，或在應用程式中停用"
 
 #: src/renderer/components/NotificationArea.tsx:53
 msgctxt "in-app-notifications"
 msgid "Failed to apply firewall rules. The device might currently be unsecured"
-msgstr "Error al aplicar las reglas del firewall. Puede que el dispositivo no esté protegido actualmente"
+msgstr "無法套用防火牆規則。裝置目前可能不安全"
 
 #: src/renderer/components/NotificationArea.tsx:58
 msgctxt "in-app-notifications"
 msgid "Failed to set system DNS server"
-msgstr "No se pudo establecer el servidor DNS del sistema"
+msgstr "無法設定系統 DNS 伺服器"
 
 #: src/renderer/components/NotificationArea.tsx:60
 msgctxt "in-app-notifications"
 msgid "Failed to start tunnel connection"
-msgstr "No se pudo iniciar la conexión de túnel"
+msgstr "無法啟動通道連線"
 
 #: src/renderer/components/NotificationArea.tsx:188
 msgctxt "in-app-notifications"
 msgid "FAILURE - UNSECURED"
-msgstr "ERROR: NO PROTEGIDO"
+msgstr "失敗 - 不安全"
 
 #: src/renderer/components/NotificationArea.tsx:215
 msgctxt "in-app-notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "La información de la versión interna no coincide, reinicie la aplicación"
+msgstr "內部版本資訊不一致，請重新啟動應用程式"
 
 #: src/renderer/components/NotificationArea.tsx:212
 msgctxt "in-app-notifications"
 msgid "INCONSISTENT VERSION"
-msgstr "VERSIÓN INCOHERENTE"
+msgstr "版本不一致"
 
 #. The in-app banner displayed to the user when the app update is available.
 #. Available placeholders:
@@ -266,32 +271,32 @@ msgstr "VERSIÓN INCOHERENTE"
 #: src/renderer/components/NotificationArea.tsx:262
 msgctxt "in-app-notifications"
 msgid "Install Mullvad VPN (%(version)s) to stay up to date"
-msgstr "Instale Mullvad VPN (%(version)s) para estar actualizado"
+msgstr "安裝 Mullvad VPN (%(version)s) 以保持最新狀態"
 
 #: src/renderer/components/NotificationArea.tsx:62
 msgctxt "in-app-notifications"
 msgid "No relay server matches the current settings"
-msgstr "Ningún servidor de retransmisión coincide con la configuración actual"
+msgstr "沒有與目前設定相符的中繼伺服器"
 
 #: src/renderer/components/NotificationArea.tsx:64
 msgctxt "in-app-notifications"
 msgid "This device is offline, no tunnels can be established"
-msgstr "Este dispositivo no está conectado, no puede establecerse ningún túnel"
+msgstr "此裝置目前離線中，無法建立通道"
 
 #: src/renderer/components/NotificationArea.tsx:69
 msgctxt "in-app-notifications"
 msgid "Unable to detect a working TAP adapter on this device. If you've disabled it, enable it again. Otherwise, please reinstall the app"
-msgstr "No se pudo detectar ningún adaptador TAP activo en este dispositivo. Si lo ha deshabilitado, vuelva a habilitarlo. De lo contrario, reinstale la aplicación"
+msgstr "在裝置上偵測不到運作中的 TAP 配接器。如果您已停用，請再次啟用。否則，請重新安裝應用程式"
 
 #: src/renderer/components/NotificationArea.tsx:229
 msgctxt "in-app-notifications"
 msgid "UNSUPPORTED VERSION"
-msgstr "VERSIÓN NO ADMITIDA"
+msgstr "不支援的版本"
 
 #: src/renderer/components/NotificationArea.tsx:255
 msgctxt "in-app-notifications"
 msgid "UPDATE AVAILABLE"
-msgstr "ACTUALIZACIÓN DISPONIBLE"
+msgstr "可用的更新"
 
 #. The in-app banner displayed to the user when the running app becomes unsupported.
 #. Available placeholders:
@@ -299,12 +304,12 @@ msgstr "ACTUALIZACIÓN DISPONIBLE"
 #: src/renderer/components/NotificationArea.tsx:236
 msgctxt "in-app-notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "Ejecuta una versión no admitida de la aplicación. Actualice a %(version)s ahora para garantizar su seguridad"
+msgstr "您正在執行不受支援的應用程式版本。請立即升級到 %(version)s，以確保您的安全"
 
 #: src/renderer/components/Launch.tsx:53
 msgctxt "launch-view"
 msgid "Connecting to daemon..."
-msgstr "Estableciendo conexión con el daemon…"
+msgstr "正在連線至精靈..."
 
 #: src/renderer/components/Launch.tsx:51
 msgctxt "launch-view"
@@ -314,87 +319,87 @@ msgstr "MULLVAD VPN"
 #: src/renderer/components/Login.tsx:231
 msgctxt "login-view"
 msgid "Checking account number"
-msgstr "Comprobando número de cuenta"
+msgstr "檢查帳號中"
 
 #: src/renderer/components/Login.tsx:233
 msgctxt "login-view"
 msgid "Correct account number"
-msgstr "Número de cuenta correcto"
+msgstr "正確的帳號"
 
 #: src/renderer/components/Login.tsx:403
 msgctxt "login-view"
 msgid "Create account"
-msgstr "Crear cuenta"
+msgstr "建立帳戶"
 
 #: src/renderer/components/Login.tsx:400
 msgctxt "login-view"
 msgid "Don't have an account number?"
-msgstr "¿No tiene un número de cuenta?"
+msgstr "沒有帳號？"
 
 #: src/renderer/components/Login.tsx:235
 msgctxt "login-view"
 msgid "Enter your account number"
-msgstr "Escriba su número de cuenta"
+msgstr "輸入您的帳號"
 
 #: src/renderer/components/Login.tsx:219
 msgctxt "login-view"
 msgid "Logged in"
-msgstr "Sesión iniciada"
+msgstr "已登入"
 
 #: src/renderer/components/Login.tsx:215
 msgctxt "login-view"
 msgid "Logging in..."
-msgstr "Iniciando la sesión…"
+msgstr "登入中..."
 
 #: src/renderer/components/Login.tsx:221
 msgctxt "login-view"
 msgid "Login"
-msgstr "Iniciar sesión"
+msgstr "登入"
 
 #: src/renderer/components/Login.tsx:217
 msgctxt "login-view"
 msgid "Login failed"
-msgstr "Error de inicio de sesión"
+msgstr "登入失敗"
 
 #: src/renderer/components/Login.tsx:229
 msgctxt "login-view"
 msgid "Unknown error"
-msgstr "Error desconocido"
+msgstr "未知錯誤"
 
 #: src/main/notification-controller.ts:46
 msgctxt "notifications"
 msgid "Blocked all connections"
-msgstr "Se bloquearon todas las conexiones"
+msgstr "已封鎖所有連線"
 
 #: src/main/notification-controller.ts:29
 msgctxt "notifications"
 msgid "Connecting"
-msgstr "Conectando"
+msgstr "連線中"
 
 #: src/main/notification-controller.ts:42
 msgctxt "notifications"
 msgid "Critical failure - Unsecured"
-msgstr "Error crítico: no protegido"
+msgstr "嚴重失敗 - 不安全"
 
 #: src/main/notification-controller.ts:71
 msgctxt "notifications"
 msgid "Inconsistent internal version information, please restart the app"
-msgstr "La información de la versión interna no coincide, reinicie la aplicación"
+msgstr "內部版本資訊不一致，請重新啟動應用程式"
 
 #: src/main/notification-controller.ts:57
 msgctxt "notifications"
 msgid "Reconnecting"
-msgstr "Volviendo a establecer la conexión"
+msgstr "正在重新連線"
 
 #: src/main/notification-controller.ts:33
 msgctxt "notifications"
 msgid "Secured"
-msgstr "Protegido"
+msgstr "安全"
 
 #: src/main/notification-controller.ts:36
 msgctxt "notifications"
 msgid "Unsecured"
-msgstr "No protegido"
+msgstr "不安全"
 
 #. The system notification displayed to the user when the running app becomes unsupported.
 #. Available placeholder:
@@ -402,255 +407,255 @@ msgstr "No protegido"
 #: src/main/notification-controller.ts:90
 msgctxt "notifications"
 msgid "You are running an unsupported app version. Please upgrade to %(version)s now to ensure your security"
-msgstr "Ejecuta una versión no admitida de la aplicación. Actualice a %(version)s ahora para garantizar su seguridad"
+msgstr "您正在執行不受支援的應用程式版本。請立即升級到 %(version)s，以確保您的安全"
 
 #. Title label in navigation bar
 #: src/renderer/components/Preferences.tsx:46
 msgctxt "preferences-nav"
 msgid "Preferences"
-msgstr "Preferencias"
+msgstr "喜好設定"
 
 #. Back button in navigation bar
 #: src/renderer/components/Preferences.tsx:42
 msgctxt "preferences-nav"
 msgid "Settings"
-msgstr "Configuración"
+msgstr "設定"
 
 #: src/renderer/components/Preferences.tsx:86
 msgctxt "preferences-view"
 msgid "Allows access to other devices on the same network for sharing, printing etc."
-msgstr "Permite el acceso a otros dispositivos de la misma red para compartir archivos, imprimir, etc."
+msgstr "允許存取同一網路上的其他裝置，以進行共用、列印等。"
 
 #: src/renderer/components/Preferences.tsx:66
 msgctxt "preferences-view"
 msgid "Auto-connect"
-msgstr "Conexión automática"
+msgstr "自動連線"
 
 #: src/renderer/components/Preferences.tsx:73
 msgctxt "preferences-view"
 msgid "Automatically connect to a server when the app launches."
-msgstr "Al iniciarse la aplicación, se conecta automáticamente a un servidor."
+msgstr "啟動應用程式時，自動連線伺服器。"
 
 #: src/renderer/components/Preferences.tsx:59
 msgctxt "preferences-view"
 msgid "Launch app on start-up"
-msgstr "Ejecutar la aplicación al iniciar"
+msgstr "啟動時啟動應用程式"
 
 #: src/renderer/components/Preferences.tsx:81
 msgctxt "preferences-view"
 msgid "Local network sharing"
-msgstr "Uso compartido de la red local"
+msgstr "本機網路分享"
 
 #: src/renderer/components/Preferences.tsx:130
 msgctxt "preferences-view"
 msgid "Monochromatic tray icon"
-msgstr "Icono de la bandeja monocromático"
+msgstr "單色系統匣圖示"
 
 #: src/renderer/components/Preferences.tsx:53
 msgctxt "preferences-view"
 msgid "Preferences"
-msgstr "Preferencias"
+msgstr "喜好設定"
 
 #: src/renderer/components/Preferences.tsx:163
 msgctxt "preferences-view"
 msgid "Show only the tray icon when the app starts."
-msgstr "Al iniciar la aplicación, solo se muestra el icono de la bandeja."
+msgstr "啟動應用程式時，僅顯示系統匣圖示。"
 
 #: src/renderer/components/Preferences.tsx:159
 msgctxt "preferences-view"
 msgid "Start minimized"
-msgstr "Iniciar minimizado"
+msgstr "啟動時永遠最小化"
 
 #: src/renderer/components/Preferences.tsx:134
 msgctxt "preferences-view"
 msgid "Use a monochromatic tray icon instead of a colored one."
-msgstr "Usa un icono de bandeja monocromático, en lugar de un icono en color."
+msgstr "使用單色系統匣圖示，而不是彩色的圖示。"
 
 #. Title label in navigation bar
 #: src/renderer/components/SelectLocation.tsx:118
 msgctxt "select-location-nav"
 msgid "Select location"
-msgstr "Seleccionar ubicación"
+msgstr "選擇位置"
 
 #: src/renderer/components/SelectLocation.tsx:126
 msgctxt "select-location-view"
 msgid "Select location"
-msgstr "Seleccionar ubicación"
+msgstr "選擇位置"
 
 #: src/renderer/components/SelectLocation.tsx:129
 msgctxt "select-location-view"
 msgid "While connected, your real location is masked with a private and secure location in the selected region"
-msgstr "Mientras esté conectado, su ubicación real permanecerá oculta con una ubicación privada y segura en la región seleccionada"
+msgstr "連線時，會以所選區域中的一個私密安全位置將您的真實位置遮住。"
 
 #: src/renderer/components/Settings.tsx:104
 msgctxt "settings-view"
 msgid "Account"
-msgstr "Cuenta"
+msgstr "帳戶"
 
 #: src/renderer/components/Settings.tsx:119
 msgctxt "settings-view"
 msgid "Advanced"
-msgstr "Avanzadas"
+msgstr "進階"
 
 #: src/renderer/components/Settings.tsx:165
 msgctxt "settings-view"
 msgid "App version"
-msgstr "Versión de la aplicación"
+msgstr "應用程式版本"
 
 #: src/renderer/components/Settings.tsx:186
 msgctxt "settings-view"
 msgid "FAQs & Guides"
-msgstr "Preguntas frecuentes y guías"
+msgstr "常見問題集與指南"
 
 #: src/renderer/components/Settings.tsx:131
 msgctxt "settings-view"
 msgid "Inconsistent internal version information, please restart the app."
-msgstr "La información de la versión interna no coincide, reinicie la aplicación."
+msgstr "內部版本資訊不一致，請重新啟動應用程式。"
 
 #: src/renderer/components/Settings.tsx:98
 msgctxt "settings-view"
 msgid "OUT OF TIME"
-msgstr "TIEMPO AGOTADO"
+msgstr "逾時"
 
 #: src/renderer/components/Settings.tsx:114
 msgctxt "settings-view"
 msgid "Preferences"
-msgstr "Preferencias"
+msgstr "喜好設定"
 
 #: src/renderer/components/Settings.tsx:80
 msgctxt "settings-view"
 msgid "Quit app"
-msgstr "Salir de la aplicación"
+msgstr "退出應用程式"
 
 #: src/renderer/components/Settings.tsx:181
 msgctxt "settings-view"
 msgid "Report a problem"
-msgstr "Informar de un problema"
+msgstr "回報問題"
 
 #: src/renderer/components/Settings.tsx:58
 msgctxt "settings-view"
 msgid "Settings"
-msgstr "Configuración"
+msgstr "設定"
 
 #: src/renderer/components/Settings.tsx:136
 msgctxt "settings-view"
 msgid "Update available, download to remain safe."
-msgstr "Actualización disponible, descárguela para garantizar su seguridad."
+msgstr "更新可用，請下載以保持安全。"
 
 #. Title label in navigation bar
 #: src/renderer/components/Settings.tsx:50
 msgctxt "settings-view-nav"
 msgid "Settings"
-msgstr "Configuración"
+msgstr "設定"
 
 #. Back button in navigation bar
 #: src/renderer/components/Support.tsx:146
 msgctxt "support-nav"
 msgid "Settings"
-msgstr "Configuración"
+msgstr "設定"
 
 #: src/renderer/components/Support.tsx:392
 msgctxt "support-view"
 msgid "Back"
-msgstr "Volver"
+msgstr "返回"
 
 #: src/renderer/components/Support.tsx:252
 msgctxt "support-view"
 msgid "Describe your problem"
-msgstr "Describa el problema"
+msgstr "描述您的問題"
 
 #: src/renderer/components/Support.tsx:357
 msgctxt "support-view"
 msgid "Edit message"
-msgstr "Editar mensaje"
+msgstr "編輯訊息"
 
 #: src/renderer/components/Support.tsx:345
 msgctxt "support-view"
 msgid "Failed to send"
-msgstr "No se pudo enviar"
+msgstr "無法傳送"
 
 #: src/renderer/components/Support.tsx:297
 msgctxt "support-view"
 msgid "If needed we will contact you on %(email)s"
-msgstr "Si es necesario, le enviaremos un mensaje a la dirección %(email)s"
+msgstr "如有需要，我們將以 %(email)s 與您聯繫"
 
 #: src/renderer/components/Support.tsx:123
 msgctxt "support-view"
 msgid "Report a problem"
-msgstr "Informar de un problema"
+msgstr "回報問題"
 
 #: src/renderer/components/Support.tsx:265
 msgctxt "support-view"
 msgid "Send"
-msgstr "Enviar"
+msgstr "傳送"
 
 #: src/renderer/components/Support.tsx:389
 msgctxt "support-view"
 msgid "Send anyway"
-msgstr "Enviar de todos modos"
+msgstr "仍要傳送"
 
 #: src/renderer/components/Support.tsx:285
 msgctxt "support-view"
 msgid "Sending..."
-msgstr "Enviando…"
+msgstr "傳送中..."
 
 #: src/renderer/components/Support.tsx:319
 msgctxt "support-view"
 msgid "Sent"
-msgstr "Enviado"
+msgstr "已傳送"
 
 #: src/renderer/components/Support.tsx:322
 msgctxt "support-view"
 msgid "Thanks! We will look into this."
-msgstr "¡Gracias! Le echaremos un vistazo."
+msgstr "謝謝！我們會對此進行調查。"
 
 #: src/renderer/components/Support.tsx:126
 msgctxt "support-view"
 msgid "To help you more effectively, your app's log file will be attached to this message. Your data will remain secure and private, as it is anonymised before being sent over an encrypted channel."
-msgstr "Para ayudarle de una forma más eficiente, se adjuntará el archivo de registro de la aplicación a este mensaje. Sus datos permanecerán protegidos y privados, ya que se anonimizan antes de enviarse a través de un canal cifrado."
+msgstr "為了更有效協助您，會將應用程式的日誌檔將附加到此郵件。您的資料會保持安全和私密性，因為這些資料會先經過匿名處理，再透過加密通道傳送。"
 
 #: src/renderer/components/Support.tsx:360
 msgctxt "support-view"
 msgid "Try again"
-msgstr "Volver a intentarlo"
+msgstr "再試一次"
 
 #: src/renderer/components/Support.tsx:261
 msgctxt "support-view"
 msgid "View app logs"
-msgstr "Ver registros de la aplicación"
+msgstr "檢視應用程式日誌"
 
 #: src/renderer/components/Support.tsx:383
 msgctxt "support-view"
 msgid "You are about to send the problem report without a way for us to get back to you. If you want an answer to your report you will have to enter an email address."
-msgstr "Va a enviar el informe de problemas sin indicar una forma de contacto. Para obtener una respuesta sobre el informe, necesita especificar su dirección de correo electrónico."
+msgstr "您即將傳送的問題報告未包含回覆方式資訊。如果想收到您這份報告的回覆，請輸入您的電子郵件位址。"
 
 #: src/renderer/components/Support.tsx:348
 msgctxt "support-view"
 msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
-msgstr "Para volver a intentarlo, puede que necesite volver a la pantalla principal de la aplicación y hacer clic en Desconectar. No se preocupe, la información que ha especificado permanecerá en el formulario."
+msgstr "在重試之前，您可能需要返回應用程式的主畫面，然後按一下「中斷連線」。請不用擔心，您輸入的資訊將保留在表單中。"
 
 #: src/renderer/components/Support.tsx:242
 msgctxt "support-view"
 msgid "Your email (optional)"
-msgstr "Su correo electrónico (opcional)"
+msgstr "您的電子郵件 (選填)"
 
 #: src/renderer/components/TunnelControl.tsx:121
 msgctxt "tunnel-control"
 msgid "Cancel"
-msgstr "Cancelar"
+msgstr "取消"
 
 #: src/renderer/components/TunnelControl.tsx:115
 msgctxt "tunnel-control"
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr "中斷連線"
 
 #: src/renderer/components/TunnelControl.tsx:109
 msgctxt "tunnel-control"
 msgid "Secure my connection"
-msgstr "Proteger mi conexión"
+msgstr "保護我的連線"
 
 #: src/renderer/components/TunnelControl.tsx:93
 msgctxt "tunnel-control"
 msgid "Switch location"
-msgstr "Cambiar ubicación"
+msgstr "切換位置"
 

--- a/gui/scripts/crowdin.sh
+++ b/gui/scripts/crowdin.sh
@@ -34,18 +34,6 @@ function download_translations {
     unzip -o all.zip -d $LOCALE_DIR
     find $LOCALE_DIR -type d -exec chmod 755 {} \;
     find $LOCALE_DIR -type f -exec chmod 644 {} \;
-
-    # Rename some of the locales to align with the locale codes expected by Electron
-    # [1] https://electronjs.org/docs/api/locales
-    # [2] https://support.crowdin.com/api/language-codes/
-    rm -rf "$LOCALE_DIR/es"
-    mv "$LOCALE_DIR/es-ES" "$LOCALE_DIR/es"
-    mv "$LOCALE_DIR/es/messages-es-ES.po" "$LOCALE_DIR/es/messages-es.po"
-
-    rm -rf "$LOCALE_DIR/sv"
-    mv "$LOCALE_DIR/sv-SE" "$LOCALE_DIR/sv"
-    mv "$LOCALE_DIR/sv/messages-sv-SE.po" "$LOCALE_DIR/sv/messages-sv.po"
-
     rm all.zip
 }
 

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -53,7 +53,9 @@ export default class Account extends Component<IProps> {
                   </View>
 
                   <View style={styles.account__row}>
-                    <Text style={styles.account__row_label}>Paid until</Text>
+                    <Text style={styles.account__row_label}>
+                      {pgettext('account-view', 'Paid until')}
+                    </Text>
                     <FormattedAccountExpiry
                       expiry={this.props.accountExpiry}
                       locale={this.props.expiryLocale}

--- a/gui/src/shared/gettext.ts
+++ b/gui/src/shared/gettext.ts
@@ -47,7 +47,7 @@ export function loadTranslations(currentLocale: string) {
 }
 
 function parseTranslation(locale: string, domain: string): boolean {
-  const filename = path.join(LOCALES_DIR, locale, `${domain}-${locale}.po`);
+  const filename = path.join(LOCALES_DIR, locale, `${domain}.po`);
   let buffer: Buffer;
 
   try {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Update the localisations file structure:
    ```diff
    -locales/%locale%/messages-%locale%.po
    +locales/%locale%/messages.po
    ```

1. Add missing translations (Uploaded to Crowdin too)

1. Remove unnecessary locale mapping from bash script, since it's now being done by Crowdin. Relevant configuration options from Crowdin:

    <table>
    <tr>
    <th>File mapping</th>
    <td>
    <img width="699" alt="Screenshot 2019-03-18 at 17 21 26" src="https://user-images.githubusercontent.com/704044/54545598-46087600-49a2-11e9-9dce-fc4920f94f4e.png">
    </td>
    </tr>
    <tr>
    <th>Language mapping</th>
    <td><img width="501" alt="Screenshot 2019-03-18 at 17 22 52" src="https://user-images.githubusercontent.com/704044/54545711-78b26e80-49a2-11e9-813b-4921de65287e.png"></td>
    </tr>
    </table>

    With the configuration above, we always export the catalogues under the two-letter language code. In cases where we'd like to support the regional dialect, we should configure the language mapping. 

    That's the list of supported locales that we receive from Electron: https://electronjs.org/docs/api/locales

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/754)
<!-- Reviewable:end -->
