### PR TITLE
Fix connection screen status message

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectionStatus.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectionStatus.kt
@@ -27,14 +27,14 @@ class ConnectionStatus(val parentView: View, val context: Context) {
         spinner.visibility = View.GONE
 
         text.setTextColor(disconnectedTextColor)
-        text.setText(R.string.creating_secure_connection)
+        text.setText(R.string.unsecured_connection)
     }
 
     private fun connecting() {
         spinner.visibility = View.VISIBLE
 
         text.setTextColor(connectingTextColor)
-        text.setText(R.string.unsecured_connection)
+        text.setText(R.string.creating_secure_connection)
     }
 
     private fun connected() {


### PR DESCRIPTION
The initial implementation of the Connect screen had a small bug when transitioning states. The status message of the disconnected state was swapped with the status message of the connecting state. This PR fixes that.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fix for a change that hasn't been publicly released yet, so not included in the changelog.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/755)
<!-- Reviewable:end -->
