### PR TITLE
Minor aesthetic updates to Android UI

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
@@ -37,6 +37,11 @@ class AccountInput(val parentView: View, val context: Context) {
         input.addTextChangedListener(InputWatcher())
         button.setOnClickListener { onLogin?.invoke(input.text.toString()) }
         setButtonEnabled(false)
+
+        parentView.findViewById<View>(R.id.account_input_container)?.apply {
+            clipToOutline = true
+            outlineProvider = AccountInputOutlineProvider(context)
+        }
     }
 
     private fun initialState() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInputOutlineProvider.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInputOutlineProvider.kt
@@ -1,0 +1,14 @@
+package net.mullvad.mullvadvpn
+
+import android.content.Context
+import android.graphics.Outline
+import android.view.View
+import android.view.ViewOutlineProvider
+
+class AccountInputOutlineProvider(private val context: Context) : ViewOutlineProvider() {
+    private val cornerRadius = context.resources.getDimension(R.dimen.account_input_corner_radius)
+
+    override fun getOutline(view: View, outline: Outline) {
+        outline.setRoundRect(0, 0, view.width, view.height, cornerRadius)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
@@ -4,15 +4,34 @@ import android.view.View
 
 class NotificationBanner(val parentView: View) {
     private val banner: View = parentView.findViewById(R.id.notification_banner)
+    private var visible = false
 
     var state = ConnectionState.Disconnected
         set(value) {
             when (value) {
-                ConnectionState.Disconnected -> banner.visibility = View.GONE
-                ConnectionState.Connecting -> banner.visibility = View.VISIBLE
-                ConnectionState.Connected -> banner.visibility = View.GONE
+                ConnectionState.Disconnected -> hide()
+                ConnectionState.Connecting -> show()
+                ConnectionState.Connected -> hide()
             }
 
             field = value
         }
+
+    private fun show() {
+        if (!visible) {
+            visible = true
+            banner.visibility = View.VISIBLE
+            banner.translationY = -banner.height.toFloat()
+            banner.animate().translationY(0.0F).setDuration(350).start()
+        }
+    }
+
+    private fun hide() {
+        if (visible) {
+            visible = false
+            banner.animate().translationY(-banner.height.toFloat()).setDuration(350).withEndAction {
+                banner.visibility = View.INVISIBLE
+            }
+        }
+    }
 }

--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -13,6 +13,7 @@
             android:gravity="center_vertical"
             android:padding="12dp"
             android:background="@color/red"
+            android:elevation="0.5dp"
             >
         <ImageView
                 android:layout_width="49dp"
@@ -38,7 +39,7 @@
             android:background="@color/darkBlue"
             android:orientation="horizontal"
             android:gravity="center"
-            android:visibility="gone"
+            android:visibility="invisible"
             >
         <ImageView
                 android:layout_width="wrap_content"

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -95,7 +95,7 @@
                 android:textSize="13sp"
                 android:text="@string/login_description"
                 />
-        <LinearLayout
+        <LinearLayout android:id="@+id/account_input_container"
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
                 android:orientation="horizontal"

--- a/android/src/main/res/values/dimensions.xml
+++ b/android/src/main/res/values/dimensions.xml
@@ -3,4 +3,5 @@
     <dimen name="city_row_padding">40dp</dimen>
     <dimen name="relay_row_padding">60dp</dimen>
     <dimen name="relay_list_divider">1dp</dimen>
+    <dimen name="account_input_corner_radius">4dp</dimen>
 </resources>


### PR DESCRIPTION
Two small updates to the Android UI:

1. Animate the notification banner with the "Blocking internet" message
2. Make the corners of the account input round

I also attempted to set the border color of the account input area, but the simple solution lead to some artifacts resulting from anti-aliasing, so a more complex solution will be necessary. Since it's not a priority, it will be on hold for now.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not included in the changelog because the Android app is not publicly released yet, so changes aren't user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/756)
<!-- Reviewable:end -->
