### PR TITLE
Apply border color to the account input

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
@@ -45,7 +45,9 @@ class AccountInput(val parentView: View, val context: Context) {
 
         input.apply {
             addTextChangedListener(InputWatcher())
-            onFocusChangeListener = OnFocusChangeListener { _, hasFocus -> updateBorder(hasFocus) }
+            onFocusChangeListener = OnFocusChangeListener { view, hasFocus ->
+                updateBorder(hasFocus && view.isEnabled())
+            }
         }
 
         container.apply {
@@ -73,6 +75,7 @@ class AccountInput(val parentView: View, val context: Context) {
             setTextColor(disabledTextColor)
             setEnabled(false)
             visibility = View.VISIBLE
+            clearFocus()
         }
     }
 
@@ -87,6 +90,7 @@ class AccountInput(val parentView: View, val context: Context) {
         button.visibility = View.VISIBLE
 
         input.apply {
+            findFocus()
             setTextColor(errorTextColor)
             setEnabled(true)
             visibility = View.VISIBLE

--- a/android/src/main/res/drawable/account_input_background.xml
+++ b/android/src/main/res/drawable/account_input_background.xml
@@ -7,14 +7,12 @@
         <inset
                 android:insetTop="1dp"
                 android:insetBottom="1dp"
+                android:insetLeft="1dp"
                 android:insetRight="1dp"
                 >
             <shape android:shape="rectangle">
-                <corners
-                        android:bottomRightRadius="@dimen/account_input_corner_radius"
-                        android:topRightRadius="@dimen/account_input_corner_radius"
-                        />
-                <solid android:color="@color/white"/>
+                <corners android:radius="@dimen/account_input_corner_radius"/>
+                <solid android:color="@color/white20"/>
             </shape>
         </inset>
     </item>
@@ -23,14 +21,14 @@
         <inset
                 android:insetTop="1dp"
                 android:insetBottom="1dp"
-                android:insetRight="1dp"
+                android:insetLeft="1dp"
                 >
             <shape android:shape="rectangle">
                 <corners
-                        android:bottomRightRadius="@dimen/account_input_corner_radius"
-                        android:topRightRadius="@dimen/account_input_corner_radius"
+                        android:bottomLeftRadius="@dimen/account_input_corner_radius"
+                        android:topLeftRadius="@dimen/account_input_corner_radius"
                         />
-                <solid android:color="@color/green"/>
+                <solid android:color="@color/white"/>
             </shape>
         </inset>
     </item>

--- a/android/src/main/res/drawable/account_input_border_error.xml
+++ b/android/src/main/res/drawable/account_input_border_error.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="rectangle"
+        >
+    <corners android:radius="@dimen/account_input_corner_radius"/>
+    <stroke android:width="2dp" android:color="@color/red"/>
+</shape>

--- a/android/src/main/res/drawable/account_input_border_focused.xml
+++ b/android/src/main/res/drawable/account_input_border_focused.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="rectangle"
+        >
+    <corners android:radius="@dimen/account_input_corner_radius"/>
+    <stroke android:width="2dp" android:color="@color/darkBlue"/>
+</shape>

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -106,7 +106,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:paddingHorizontal="12dp"
-                    android:background="@color/white"
+                    android:background="@drawable/account_input_background"
                     android:inputType="number"
                     android:singleLine="true"
                     android:imeOptions="flagNoPersonalizedLearning"


### PR DESCRIPTION
Following the original app design screens, this PR implements a border color to the account input view. When selected, the border is dark blue. When login fails, the border is red. Otherwise, the border is removed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not included in changelog because the Android app isn't public yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/759)
<!-- Reviewable:end -->
