### PR TITLE
Replace unwrap with expect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "notify 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
  "os_pipe 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pfctl 0.2.1 (git+https://github.com/mullvad/pfctl-rs?rev=9f31b5ddcab941862470075eab83bb398195f3d6)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -13,18 +13,18 @@ error-chain = "0.12"
 futures = "0.1"
 jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
-
 libc = "0.2.20"
 log = "0.4"
 openvpn-plugin = { git = "https://github.com/mullvad/openvpn-plugin-rs", branch = "auth-failed-event", features = ["serde"] }
 os_pipe = "0.7"
+parking_lot = "0.7"
+regex = "1.1.0"
 shell-escape = "0.1"
+talpid-ipc = { path = "../talpid-ipc" }
+talpid-types = { path = "../talpid-types" }
 tokio-core = "0.1"
 uuid = { version = "0.6", features = ["v4"] }
 
-talpid-ipc = { path = "../talpid-ipc" }
-talpid-types = { path = "../talpid-types" }
-regex = "1.1.0"
 
 [target.'cfg(unix)'.dependencies]
 hex = "0.3"
@@ -32,6 +32,7 @@ ipnetwork = "0.14"
 lazy_static = "1.0"
 tun = { git = "https://github.com/pinkisemils/rust-tun", branch = "add-raw-fd-traits" }
 nix = "0.12"
+
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.6"
@@ -46,15 +47,18 @@ mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffae
 which = "2.0"
 err-derive = "0.1.5"
 
+
 [target.'cfg(target_os = "macos")'.dependencies]
 # TODO: Specify 0.2.1 once the crate gets published
 pfctl = { git = "https://github.com/mullvad/pfctl-rs", rev = "9f31b5ddcab941862470075eab83bb398195f3d6" }
 system-configuration = "0.2"
 
+
 [target.'cfg(windows)'.dependencies]
 widestring = "0.3"
 winreg = "0.5"
 winapi = { version = "0.3.6", features = ["handleapi", "libloaderapi", "synchapi", "winbase", "winuser"] }
+
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -3,12 +3,12 @@ use duct;
 use super::stoppable_process::StoppableProcess;
 use atty;
 use os_pipe::{pipe, PipeWriter};
+use parking_lot::Mutex;
 use shell_escape;
 use std::{
     ffi::{OsStr, OsString},
     fmt, io,
     path::{Path, PathBuf},
-    sync::Mutex,
 };
 use talpid_types::net;
 
@@ -378,10 +378,9 @@ impl OpenVpnProcHandle {
 impl StoppableProcess for OpenVpnProcHandle {
     /// Closes STDIN to stop the openvpn process
     fn stop(&self) {
-        let mut stdin = self.stdin.lock().unwrap();
         // Dropping our stdin handle so that it is closed once. Closing the handle should
         // gracefully stop our openvpn child process.
-        let _ = stdin.take();
+        let _ = self.stdin.lock().take();
     }
 
     fn kill(&self) -> io::Result<()> {

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -153,7 +153,7 @@ impl OpenVpnMonitor<OpenVpnCommand> {
         };
 
         let log_dir: Option<PathBuf> = if let Some(ref log_path) = log_path {
-            Some(log_path.parent().unwrap().into())
+            Some(log_path.parent().expect("log_path has no parent").into())
         } else {
             None
         };
@@ -256,7 +256,7 @@ impl<C: OpenVpnBuilder + 'static> OpenVpnMonitor<C> {
                 let _ = tunnel_close_handle.close();
             });
 
-            let result = rx.recv().unwrap();
+            let result = rx.recv().expect("wait got no result");
             let _ = rx.recv();
 
             match result {
@@ -324,7 +324,7 @@ impl<C: OpenVpnBuilder + 'static> OpenVpnMonitor<C> {
         let child_wait_handle = self.child.clone();
         let closed_handle = self.closed.clone();
         let child_close_handle = self.close_handle();
-        let event_dispatcher = self.event_dispatcher.take().unwrap();
+        let event_dispatcher = self.event_dispatcher.take().expect("No event_dispatcher");
         let dispatcher_handle = event_dispatcher.close_handle();
 
         let (child_tx, rx) = mpsc::channel();
@@ -342,8 +342,8 @@ impl<C: OpenVpnBuilder + 'static> OpenVpnMonitor<C> {
             let _ = child_close_handle.close();
         });
 
-        let result = rx.recv().unwrap();
-        let _ = rx.recv().unwrap();
+        let result = rx.recv().expect("inner_wait_tunnel no result");
+        let _ = rx.recv().expect("inner_wait_tunnel no second result");
         result
     }
 

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -620,9 +620,10 @@ mod event_server {
 mod tests {
     use super::*;
     use crate::mktemp::TempFile;
+    use parking_lot::Mutex;
     use std::{
         path::{Path, PathBuf},
-        sync::{Arc, Mutex},
+        sync::Arc,
     };
 
     #[derive(Debug, Default, Clone)]
@@ -636,12 +637,12 @@ mod tests {
         type ProcessHandle = TestProcessHandle;
 
         fn plugin(&mut self, path: impl AsRef<Path>, _args: Vec<String>) -> &mut Self {
-            *self.plugin.lock().unwrap() = Some(path.as_ref().to_path_buf());
+            *self.plugin.lock() = Some(path.as_ref().to_path_buf());
             self
         }
 
         fn log(&mut self, log: Option<impl AsRef<Path>>) -> &mut Self {
-            *self.log.lock().unwrap() = log.as_ref().map(|path| path.as_ref().to_path_buf());
+            *self.log.lock() = log.as_ref().map(|path| path.as_ref().to_path_buf());
             self
         }
 
@@ -686,7 +687,7 @@ mod tests {
         );
         assert_eq!(
             Some(PathBuf::from("./my_test_plugin")),
-            *builder.plugin.lock().unwrap()
+            *builder.plugin.lock()
         );
     }
 
@@ -704,7 +705,7 @@ mod tests {
         );
         assert_eq!(
             Some(PathBuf::from("./my_test_log_file")),
-            *builder.log.lock().unwrap()
+            *builder.log.lock()
         );
     }
 


### PR DESCRIPTION
In the wake of hitting a thread panic in the daemon, and all the panic said was that it failed in `Result::unwrap()`, I wanted to reduce the number of unwraps. If we either had backtraces turned on, or `expect`s instead of `unwrap`s it would be much easier to find the problem.

For mutex locking I replaced some mutexes with the one from `parking_lot`. Since it does not have poisoning no unwrap is needed at all.

So this PR does not really help solve any problem now. But it reduces the number of unwraps. Potentially helping us find bugs later.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/760)
<!-- Reviewable:end -->
