### PR TITLE
Remove cached relay list during installation

### DIFF
--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -7,3 +7,6 @@ if which systemctl &> /dev/null; then
         systemctl disable mullvad-daemon.service
     fi
 fi
+
+#TODO: Remove after releasing 2019.2
+rm /var/cache/mullvad-vpn/relays.json || true

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -75,3 +75,6 @@ if [ -d "$OLD_CACHE_DIR" ]; then
     mv "$OLD_CACHE_DIR"/* "$NEW_CACHE_DIR/" || echo "Unable to migrate cache. No cache files?"
     rm -rf "$OLD_CACHE_DIR"
 fi
+
+# TODO: Remove after 2019.2 has been released
+rm "$NEW_CACHE_DIR/relays.json" || echo "Unable to remove old relay list"


### PR DESCRIPTION
To alleviate issues with the relay list not containing any wireguard relays, I've edited the preinstall scripts for the installers on Linux and MacOS. The Windows installer has not been changed since it's harder to change and we're not releasing WireGuard on Windows as soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/764)
<!-- Reviewable:end -->
