### PR TITLE
Upgrade windows service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ dependencies = [
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-service 0.1.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=da48aacfce712969437a756230b9aa8213ff6fba)",
+ "windows-service 0.1.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=aab5b26beae364253802b6e5554c9ecdc6285454)",
  "winres 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2590,10 +2590,10 @@ dependencies = [
 [[package]]
 name = "windows-service"
 version = "0.1.0"
-source = "git+https://github.com/mullvad/windows-service-rs.git?rev=da48aacfce712969437a756230b9aa8213ff6fba#da48aacfce712969437a756230b9aa8213ff6fba"
+source = "git+https://github.com/mullvad/windows-service-rs.git?rev=aab5b26beae364253802b6e5554c9ecdc6285454#aab5b26beae364253802b6e5554c9ecdc6285454"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2893,7 +2893,7 @@ dependencies = [
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
-"checksum windows-service 0.1.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=da48aacfce712969437a756230b9aa8213ff6fba)" = "<none>"
+"checksum windows-service 0.1.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=aab5b26beae364253802b6e5554c9ecdc6285454)" = "<none>"
 "checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
 "checksum winres 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aea48d0b4b15ba195fc7250fdfb27736ce3bc327535db1c87a2fcb62371f9ecd"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -49,7 +49,7 @@ simple-signal = "1.1"
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"
-windows-service = { git = "https://github.com/mullvad/windows-service-rs.git", rev = "da48aacfce712969437a756230b9aa8213ff6fba" }
+windows-service = { git = "https://github.com/mullvad/windows-service-rs.git", rev = "aab5b26beae364253802b6e5554c9ecdc6285454" }
 winapi = "0.3"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -3,7 +3,6 @@ use error_chain::ChainedError;
 use std::{
     env,
     ffi::OsString,
-    io,
     sync::{
         atomic::{AtomicUsize, Ordering},
         mpsc, Arc,
@@ -135,7 +134,7 @@ impl PersistentServiceStatus {
 
     /// Tell the system that the service is pending start and provide the time estimate until
     /// initialization is complete.
-    fn set_pending_start(&mut self, wait_hint: Duration) -> io::Result<()> {
+    fn set_pending_start(&mut self, wait_hint: Duration) -> windows_service::Result<()> {
         self.report_status(
             ServiceState::StartPending,
             wait_hint,
@@ -144,7 +143,7 @@ impl PersistentServiceStatus {
     }
 
     /// Tell the system that the service is running.
-    fn set_running(&mut self) -> io::Result<()> {
+    fn set_running(&mut self) -> windows_service::Result<()> {
         self.report_status(
             ServiceState::Running,
             Duration::default(),
@@ -154,7 +153,7 @@ impl PersistentServiceStatus {
 
     /// Tell the system that the service is pending stop and provide the time estimate until the
     /// service is stopped.
-    fn set_pending_stop(&mut self, wait_hint: Duration) -> io::Result<()> {
+    fn set_pending_stop(&mut self, wait_hint: Duration) -> windows_service::Result<()> {
         self.report_status(
             ServiceState::StopPending,
             wait_hint,
@@ -163,7 +162,7 @@ impl PersistentServiceStatus {
     }
 
     /// Tell the system that the service is stopped and provide the exit code.
-    fn set_stopped(&mut self, exit_code: ServiceExitCode) -> io::Result<()> {
+    fn set_stopped(&mut self, exit_code: ServiceExitCode) -> windows_service::Result<()> {
         self.report_status(ServiceState::Stopped, Duration::default(), exit_code)
     }
 
@@ -173,7 +172,7 @@ impl PersistentServiceStatus {
         next_state: ServiceState,
         wait_hint: Duration,
         exit_code: ServiceExitCode,
-    ) -> io::Result<()> {
+    ) -> windows_service::Result<()> {
         // Automatically bump the checkpoint when updating the pending events to tell the system
         // that the service is making a progress in transition from pending to final state.
         // `wait_hint` should reflect the estimated time for transition to complete.


### PR DESCRIPTION
Upgrade our `windows-service` dependency to the latest master. Where it's a Rust 2018 crate and also has completely revamped errors without `error-chain`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/769)
<!-- Reviewable:end -->
