### PR TITLE
Unify daemon subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-ipc-client 0.1.0",
  "mullvad-paths 0.1.0",
+ "mullvad-types 0.1.0",
  "notify 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
  "talpid-ipc 0.1.0",

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -41,6 +41,8 @@ export interface ITunnelEndpoint {
   tunnel: TunnelType;
 }
 
+export type DaemonEvent = { stateTransition: TunnelStateTransition } | { settings: ISettings };
+
 export type TunnelStateTransition =
   | { state: 'disconnected' }
   | { state: 'connecting'; details?: ITunnelEndpoint }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -11,6 +11,7 @@ use mullvad_types::{
     relay_list::RelayList,
     settings::{Settings, TunnelOptions},
     version::AppVersionInfo,
+    DaemonEvent,
 };
 use serde::{Deserialize, Serialize};
 use std::{path::Path, thread};
@@ -248,16 +249,16 @@ impl DaemonRpcClient {
             .chain_err(|| ErrorKind::RpcCallError(method.to_owned()))
     }
 
-    pub fn new_state_subscribe(
+    pub fn daemon_event_subscribe(
         &mut self,
     ) -> impl Future<
-        Item = jsonrpc_client_pubsub::Subscription<TunnelStateTransition>,
+        Item = jsonrpc_client_pubsub::Subscription<DaemonEvent>,
         Error = jsonrpc_client_pubsub::Error,
     > {
         self.subscriber.subscribe(
-            "new_state_subscribe".to_string(),
-            "new_state_unsubscribe".to_string(),
-            "new_state".to_string(),
+            "daemon_event_subscribe".to_string(),
+            "daemon_event_unsubscribe".to_string(),
+            "daemon_event".to_string(),
             0,
             &NO_ARGS,
         )

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -13,6 +13,7 @@ integration-tests = []
 duct = "0.12"
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-paths = { path = "../mullvad-paths" }
+mullvad-types = { path = "../mullvad-types" }
 notify = "4.0"
 openvpn-plugin = { git = "https://github.com/mullvad/openvpn-plugin-rs", branch = "auth-failed-event", features = ["serde"] }
 talpid-ipc = { path = "../talpid-ipc" }

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -22,3 +22,14 @@ pub mod wireguard;
 
 mod custom_tunnel;
 pub use crate::custom_tunnel::*;
+
+/// An event sent out from the daemon to frontends.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonEvent {
+    /// The daemon transitioned into a new state.
+    StateTransition(talpid_types::tunnel::TunnelStateTransition),
+
+    /// The daemon settings changed.
+    Settings(settings::Settings),
+}


### PR DESCRIPTION
Here we merge the two subscriptions into one. Where each of the two types of updates are represented as an enum variant. This PR should not change any real functionality, it should work as before. But it will allow us to add more updates from the daemon to frontends without much hassle. It's quite a lot of boiler plate to set up a subscription and everything around it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/771)
<!-- Reviewable:end -->
