### PR TITLE
Notify about relay list updates

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -303,6 +303,9 @@ const daemonEventSchema = oneOf(
   object({
     settings: settingsSchema,
   }),
+  object({
+    relay_list: relayListSchema,
+  }),
 );
 
 export class ResponseParseError extends Error {

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -41,7 +41,10 @@ export interface ITunnelEndpoint {
   tunnel: TunnelType;
 }
 
-export type DaemonEvent = { stateTransition: TunnelStateTransition } | { settings: ISettings };
+export type DaemonEvent =
+  | { stateTransition: TunnelStateTransition }
+  | { settings: ISettings }
+  | { relayList: IRelayList };
 
 export type TunnelStateTransition =
   | { state: 'disconnected' }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -585,7 +585,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "set_account response");
                 if account_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     match account_token {
                         Some(token) => {
                             if let Err(e) = self.account_history.bump_history(&token) {
@@ -651,7 +651,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "update_relay_settings response");
                 if settings_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     info!("Initiating tunnel restart because the relay settings changed");
                     self.reconnect_tunnel();
                 }
@@ -667,7 +667,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "set_allow_lan response");
                 if settings_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     self.send_tunnel_command(TunnelCommand::AllowLan(allow_lan));
                 }
             }
@@ -688,7 +688,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "set_block_when_disconnected response");
                 if settings_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(
                         block_when_disconnected,
                     ));
@@ -705,7 +705,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "set auto-connect response");
                 if settings_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                 }
             }
             Err(e) => error!("{}", e.display_chain()),
@@ -719,7 +719,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "set_openvpn_mssfix response");
                 if settings_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     info!("Initiating tunnel restart because the OpenVPN mssfix setting changed");
                     self.reconnect_tunnel();
                 }
@@ -744,7 +744,7 @@ impl Daemon {
                 Self::oneshot_send(tx, Ok(()), "set_openvpn_proxy response");
                 if proxy_changed || constraints_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     info!("Initiating tunnel restart because the OpenVPN proxy setting changed");
                     self.reconnect_tunnel();
                 }
@@ -786,7 +786,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "set_enable_ipv6 response");
                 if settings_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     info!("Initiating tunnel restart because the enable IPv6 setting changed");
                     self.reconnect_tunnel();
                 }
@@ -802,7 +802,7 @@ impl Daemon {
                 Self::oneshot_send(tx, (), "set_wireguard_mtu response");
                 if settings_changed {
                     self.management_interface_broadcaster
-                        .notify_settings(&self.settings);
+                        .notify_settings(self.settings.clone());
                     info!("Initiating tunnel restart because the WireGuard MTU setting changed");
                     self.reconnect_tunnel();
                 }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -271,6 +271,7 @@ impl ManagementInterfaceServer {
 }
 
 /// A handle that allows broadcasting messages to all subscribers of the management interface.
+#[derive(Clone)]
 pub struct EventBroadcaster {
     subscriptions: Arc<RwLock<HashMap<SubscriptionId, pubsub::Sink<DaemonEvent>>>>,
 }
@@ -286,6 +287,12 @@ impl EventBroadcaster {
     pub fn notify_settings(&self, settings: Settings) {
         log::debug!("Broadcasting new settings");
         self.notify(DaemonEvent::Settings(settings));
+    }
+
+    /// Sends settings to all `settings` subscribers of the management interface.
+    pub fn notify_relay_list(&self, relay_list: RelayList) {
+        log::debug!("Broadcasting new relay list");
+        self.notify(DaemonEvent::RelayList(relay_list));
     }
 
     fn notify(&self, value: DaemonEvent) {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -283,9 +283,9 @@ impl EventBroadcaster {
     }
 
     /// Sends settings to all `settings` subscribers of the management interface.
-    pub fn notify_settings(&self, settings: &Settings) {
+    pub fn notify_settings(&self, settings: Settings) {
         log::debug!("Broadcasting new settings");
-        self.notify(DaemonEvent::Settings(settings.clone()));
+        self.notify(DaemonEvent::Settings(settings));
     }
 
     fn notify(&self, value: DaemonEvent) {

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -32,4 +32,7 @@ pub enum DaemonEvent {
 
     /// The daemon settings changed.
     Settings(settings::Settings),
+
+    /// The daemon got an updated relay list.
+    RelayList(relay_list::RelayList),
 }


### PR DESCRIPTION
Add a new type of event to our daemon event subscription enum. Now it will broadcast to all registered frontends as soon as it downloads a new relay list. This should allow us to stop polling for it every X minutes in the GUI. But instead get it instantly.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/774)
<!-- Reviewable:end -->
