### PR TITLE
Eliminate some error chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ name = "mullvad-paths"
 version = "0.1.0"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-error-chain = "0.12"
+err-derive = "0.1.5"
 log = "0.4"
 
 [target.'cfg(any(windows, target_os = "macos"))'.dependencies]

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -22,7 +22,7 @@ pub fn get_default_cache_dir() -> Result<PathBuf> {
     }
     #[cfg(any(target_os = "macos", windows))]
     {
-        dir = dirs::cache_dir().ok_or_else(|| crate::ErrorKind::FindDirError.into())
+        dir = dirs::cache_dir().ok_or(crate::Error::FindDirError)
     }
     dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -1,5 +1,4 @@
 use crate::Result;
-
 use std::{env, path::PathBuf};
 
 /// Creates and returns the settings directory pointed to by `MULLVAD_SETTINGS_DIR`, or the default
@@ -23,7 +22,7 @@ pub fn get_default_settings_dir() -> Result<PathBuf> {
     }
     #[cfg(windows)]
     {
-        dir = dirs::data_local_dir().ok_or_else(|| crate::ErrorKind::FindDirError.into());
+        dir = dirs::data_local_dir().ok_or(crate::Error::FindDirError);
     }
     dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 atty = "0.2"
 duct = "0.12"
 error-chain = "0.12"
+err-derive = "0.1.5"
 futures = "0.1"
 jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }

--- a/talpid-core/src/ffi.rs
+++ b/talpid-core/src/ffi.rs
@@ -9,7 +9,7 @@ macro_rules! ffi_error {
         }
 
         impl $result {
-            pub fn into_result(self) -> Result<()> {
+            pub fn into_result(self) -> Result<(), Error> {
                 match self.success {
                     true => Ok(()),
                     false => Err($error),
@@ -17,8 +17,8 @@ macro_rules! ffi_error {
             }
         }
 
-        impl Into<Result<()>> for $result {
-            fn into(self) -> Result<()> {
+        impl Into<Result<(), Error>> for $result {
+            fn into(self) -> Result<(), Error> {
                 self.into_result()
             }
         }

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -77,7 +77,7 @@ pub enum FirewallPolicy {
 }
 
 impl fmt::Display for FirewallPolicy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             FirewallPolicy::Connecting {
                 peer_endpoint,
@@ -154,15 +154,15 @@ impl Firewall {
 /// Abstract firewall interaction trait. Used by the OS specific implementations.
 trait FirewallT: Sized {
     /// The error type thrown by the implementer of this trait
-    type Error: ::std::error::Error;
+    type Error: std::error::Error;
 
     /// Create new instance
-    fn new() -> ::std::result::Result<Self, Self::Error>;
+    fn new() -> Result<Self, Self::Error>;
 
     /// Enable the given FirewallPolicy
-    fn apply_policy(&mut self, policy: FirewallPolicy) -> ::std::result::Result<(), Self::Error>;
+    fn apply_policy(&mut self, policy: FirewallPolicy) -> Result<(), Self::Error>;
 
     /// Revert the system firewall state to what it was before this instance started
     /// modifying the system.
-    fn reset_policy(&mut self) -> ::std::result::Result<(), Self::Error>;
+    fn reset_policy(&mut self) -> Result<(), Self::Error>;
 }

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -1,22 +1,31 @@
 use super::{NetNode, RequiredRoutes, Route};
 
 use super::subprocess::{Exec, RunExpr};
-use std::{collections::HashSet, net::IpAddr};
+use std::{
+    collections::HashSet,
+    io,
+    net::{AddrParseError, IpAddr},
+};
 
-error_chain! {
-    errors {
-        FailedToAddRoute {
-            description("Failed to add route")
-        }
 
-        FailedToGetDefaultRoute {
-            description("Failed to get default route")
-        }
+pub type Result<T> = std::result::Result<T, Error>;
 
-        FailedToRemoveRoute {
-            description("Failed to remove route")
-        }
-    }
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    #[error(display = "Failed to add route")]
+    FailedToAddRoute(#[error(cause)] io::Error),
+
+    #[error(display = "Failed to remove route")]
+    FailedToRemoveRoute(#[error(cause)] io::Error),
+
+    #[error(display = "Error while running \"ip route\"")]
+    FailedToRunIp(#[error(cause)] io::Error),
+
+    #[error(display = "No default route in \"ip route\" output")]
+    NoDefaultRoute,
+
+    #[error(display = "Failed to parse default route as IP: {}", _0)]
+    ParseDefaultRoute(String, #[error(cause)] AddrParseError),
 }
 
 pub struct RouteManager {
@@ -51,7 +60,7 @@ impl RouteManager {
 
         cmd.into_expr()
             .run_expr()
-            .chain_err(|| ErrorKind::FailedToAddRoute)?;
+            .map_err(Error::FailedToAddRoute)?;
         self.set_routes.insert(route);
         Ok(())
     }
@@ -96,7 +105,7 @@ impl super::RoutingT for RouteManager {
                 route.prefix.to_string()
             )
             .run_expr()
-            .chain_err(|| ErrorKind::FailedToRemoveRoute);
+            .map_err(Error::FailedToRemoveRoute);
             if let Err(e) = result {
                 log::error!("failed to reset remove route: {}", e);
                 end_result = Err(e);
@@ -110,15 +119,15 @@ impl super::RoutingT for RouteManager {
     fn get_default_route_node(&mut self) -> Result<IpAddr> {
         let output = duct::cmd!("route", "-n", "get", "default")
             .stdout()
-            .chain_err(|| ErrorKind::FailedToGetDefaultRoute)?;
+            .map_err(Error::FailedToRunIp)?;
         let ip_str: &str = output
             .lines()
             .find(|line| line.trim().starts_with("gateway: "))
             .and_then(|line| line.trim().split_whitespace().skip(1).next())
-            .ok_or(Error::from(ErrorKind::FailedToGetDefaultRoute))?;
+            .ok_or(Error::NoDefaultRoute)?;
 
         ip_str
             .parse()
-            .map_err(|_| Error::from(ErrorKind::FailedToGetDefaultRoute))
+            .map_err(|e| Error::ParseDefaultRoute(ip_str.to_owned(), e))
     }
 }


### PR DESCRIPTION
The warnings from the `error_chain!` macro are quite annoying, and we have many of them. `error-chain` is now completely unmaintained and should likely be migrated away from in all aspects of life :P

Here is a slow start. I get rid of it in a few places where it was quite easy. So we can get a feel for the other way(s) of writing error types and throwing them around.

I'm open for suggestions. But my current opinion is that `failure` is probably great, for apps, not so much for libraries at the moment. As such I have used the even less magical `err-derive` here to help me define the error types. Wrapping/chaining/throwing errors I do without any help from an external library. Good old `map_err` works very well IMO.

The plan is that if you like this, I can continue a bit in the lower parts of our crates. Swapping out leaf errors and other errors from low level modules. Working my way upwards. Then we can evaluate if we want `failure` when we get to the crates that are actually binaries.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/778)
<!-- Reviewable:end -->
