### PR TITLE
Eliminate more error chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +1981,7 @@ version = "0.1.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2633,6 +2645,7 @@ dependencies = [
 "checksum derive-try-from-primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81dbd65eb15734b6d50dc6ac86f14f928462be0a5df6bda17761e909071ede5d"
 "checksum derive_builder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c998e6ab02a828dd9735c18f154e14100e674ed08cb4e1938f0e4177543f439"
 "checksum derive_builder_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "735e24ee9e5fa8e16b86da5007856e97d592e11867e45d76e0c0d0a164a0b757"
+"checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3640af123c78bedc20c1d3928e43cc0621e57011899d1ef917900c12fdb7a1ee"

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -231,7 +231,7 @@ pub struct ManagementInterfaceServer {
 }
 
 impl ManagementInterfaceServer {
-    pub fn start<T>(tunnel_tx: IntoSender<ManagementCommand, T>) -> talpid_ipc::Result<Self>
+    pub fn start<T>(tunnel_tx: IntoSender<ManagementCommand, T>) -> Result<Self, talpid_ipc::Error>
     where
         T: From<ManagementCommand> + 'static + Send,
     {

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 atty = "0.2"
+derive_more = "0.14"
 duct = "0.12"
 error-chain = "0.12"
 err-derive = "0.1.5"

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -59,3 +59,20 @@ mod mktemp;
 /// Misc utilities for the Linux platform.
 #[cfg(target_os = "linux")]
 mod linux;
+
+
+trait ErrorExt {
+    fn display_chain(&self) -> String;
+}
+
+impl<E: std::error::Error> ErrorExt for E {
+    fn display_chain(&self) -> String {
+        let mut s = format!("Error: {}", self);
+        let mut source = self.source();
+        while let Some(error) = source {
+            s.push_str(&format!("\nCaused by: {}", error));
+            source = error.source();
+        }
+        s
+    }
+}

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -569,7 +569,7 @@ mod event_server {
     use uuid;
 
     /// Construct and start the IPC server with the given event listener callback.
-    pub fn start<L>(on_event: L) -> talpid_ipc::Result<talpid_ipc::IpcServer>
+    pub fn start<L>(on_event: L) -> std::result::Result<talpid_ipc::IpcServer, talpid_ipc::Error>
     where
         L: Fn(openvpn_plugin::EventType, HashMap<String, String>) + Send + Sync + 'static,
     {

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -3,19 +3,17 @@ use std::ptr;
 use libc::{c_char, c_void, wchar_t};
 use widestring::WideCString;
 
-error_chain! {
-    errors{
-        /// Failure to set metrics of network interfaces
-        MetricApplication{
-            description("Failed to set the metrics for a network interface")
-        }
-        InvalidInterfaceAlias{
-            description("Supplied interface alias is invalid")
-        }
-        GetIpv6Status {
-            description("Failed to read IPv6 status on the TAP network interface")
-        }
-    }
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// Failure to set metrics of network interfaces
+    #[error(display = "Failed to set the metrics for a network interface")]
+    MetricApplication,
+
+    #[error(display = "Supplied interface alias is invalid")]
+    InvalidInterfaceAlias(#[error(cause)] widestring::NulError<u16>),
+
+    #[error(display = "Failed to read IPv6 status on the TAP network interface")]
+    GetIpv6Status,
 }
 
 pub type ErrorSink = extern "system" fn(msg: *const c_char, ctx: *mut c_void);
@@ -30,9 +28,9 @@ pub extern "system" fn error_sink(msg: *const c_char, _ctx: *mut c_void) {
 }
 
 /// Returns true if metrics were changed, false otherwise
-pub fn ensure_top_metric_for_interface(interface_alias: &str) -> Result<bool> {
+pub fn ensure_top_metric_for_interface(interface_alias: &str) -> Result<bool, Error> {
     let interface_alias_ws =
-        WideCString::from_str(interface_alias).chain_err(|| ErrorKind::InvalidInterfaceAlias)?;
+        WideCString::from_str(interface_alias).map_err(Error::InvalidInterfaceAlias)?;
 
     let metric_result = unsafe {
         WinRoute_EnsureTopMetric(
@@ -48,11 +46,14 @@ pub fn ensure_top_metric_for_interface(interface_alias: &str) -> Result<bool> {
         // Metrics changed
         1 => Ok(true),
         // Failure
-        2 => Err(Error::from(ErrorKind::MetricApplication)),
+        2 => Err(Error::MetricApplication),
         // Unexpected value
-        _ => {
-            log::error!("Unexpected return code from WinRoute_EnsureTopMetric");
-            Err(Error::from(ErrorKind::MetricApplication))
+        i => {
+            log::error!(
+                "Unexpected return code from WinRoute_EnsureTopMetric: {}",
+                i
+            );
+            Err(Error::MetricApplication)
         }
     }
 }
@@ -68,7 +69,7 @@ extern "system" {
 
 
 /// Checks if IPv6 is enabled for the TAP interface
-pub fn get_tap_interface_ipv6_status() -> Result<bool> {
+pub fn get_tap_interface_ipv6_status() -> Result<bool, Error> {
     let tap_ipv6_status = unsafe { GetTapInterfaceIpv6Status(Some(error_sink), ptr::null_mut()) };
 
     match tap_ipv6_status {
@@ -77,11 +78,14 @@ pub fn get_tap_interface_ipv6_status() -> Result<bool> {
         // Disabled
         1 => Ok(false),
         // Failure
-        2 => Err(Error::from(ErrorKind::GetIpv6Status)),
+        2 => Err(Error::GetIpv6Status),
         // Unexpected value
-        _ => {
-            log::error!("Unexpected return code from GetTapInterfaceIpv6Status");
-            Err(Error::from(ErrorKind::GetIpv6Status))
+        i => {
+            log::error!(
+                "Unexpected return code from GetTapInterfaceIpv6Status: {}",
+                i
+            );
+            Err(Error::GetIpv6Status)
         }
     }
 }

--- a/talpid-ipc/Cargo.toml
+++ b/talpid-ipc/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-error-chain = "0.12"
+err-derive = "0.1.5"
 serde = "1.0"
 serde_json = "1.0"
 log = "0.4"


### PR DESCRIPTION
This is the follow up to #778. Eliminating yet some more `error-chain`.

This one turned out to be a bit more complex/involved:
* `derive_more`. Another crate that is not related to errors. But it's a proceducal macro that can be applied to an enum to make it automatically generate `From` impls for all the variants that have unique attached types to them. I found this useful in one location in this PR.
* Errors don't map over 1:1 to their previous counterpart. Error chain used dynamic dispatch a bit more, so we could easily chain an error variant on top of a number of different errors and they would all work seamlessly. I guess it would be fully possible to do do the same here by manually giving the cause field ad `#[error(cause)] Box<dyn std::error::Error>`. It's maybe nothing wrong with that. But I have instead tried to think through the errors and why they happen and if they would make more sense as split up into one variant per underlying error type, at least.
* I had to re-invent the `display_chain` stuff from `error_chain`. But that was quite painless.
* The `systemd_resolved` DNS module became complex and messy. It has a lot of errors, and they map differently than before. But I hope this should be somewhat acceptable representation.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/779)
<!-- Reviewable:end -->
