### PR TITLE
Eliminate even more error-chain

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -71,8 +71,10 @@ error_chain! {
         }
     }
     links {
-        TunnelError(tunnel_state_machine::Error, tunnel_state_machine::ErrorKind);
         AccountHistory(account_history::Error, account_history::ErrorKind);
+    }
+    foreign_links {
+        TunnelError(tunnel_state_machine::Error);
     }
 }
 

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -14,10 +14,8 @@ error_chain! {
             display("Unable to open log file for writing: {}", path.display())
         }
     }
-    links {
-        RotateLog(::talpid_core::logging::Error, ::talpid_core::logging::ErrorKind);
-    }
     foreign_links {
+        RotateLog(::talpid_core::logging::RotateLogError);
         SetLoggerError(log::SetLoggerError);
         Io(io::Error);
     }

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -62,12 +62,26 @@ mod linux;
 
 
 trait ErrorExt {
+    /// Creates a string representation of the entire error chain.
     fn display_chain(&self) -> String;
+
+    /// Like [`display_chain`] but with an extra message at the start of the chain
+    fn display_chain_with_msg(&self, msg: &str) -> String;
 }
 
 impl<E: std::error::Error> ErrorExt for E {
     fn display_chain(&self) -> String {
         let mut s = format!("Error: {}", self);
+        let mut source = self.source();
+        while let Some(error) = source {
+            s.push_str(&format!("\nCaused by: {}", error));
+            source = error.source();
+        }
+        s
+    }
+
+    fn display_chain_with_msg(&self, msg: &str) -> String {
+        let mut s = format!("Error: {}\nCaused by: {}", msg, self);
         let mut source = self.source();
         while let Some(error) = source {
             s.push_str(&format!("\nCaused by: {}", error));

--- a/talpid-core/src/logging.rs
+++ b/talpid-core/src/logging.rs
@@ -1,19 +1,25 @@
 use std::{fs, io, path::Path};
 
-error_chain! {}
+/// Unable to create new log file
+#[derive(err_derive::Error, Debug)]
+#[error(display = "Unable to create new log file")]
+pub struct RotateLogError(#[error(cause)] io::Error);
 
 /// Create a new log file while backing up a previous version of it.
 ///
 /// A new log file is created with the given file name, but if a file with that name already exists
 /// it is backed up with the extension changed to `.old.log`.
-pub fn rotate_log(file: &Path) -> Result<()> {
+pub fn rotate_log(file: &Path) -> Result<(), RotateLogError> {
     let backup = file.with_extension("old.log");
-    if let Err(error) = fs::rename(file, backup) {
+    if let Err(error) = fs::rename(file, &backup) {
         if error.kind() != io::ErrorKind::NotFound {
-            log::warn!("Failed to rotate log file ({})", error);
+            log::warn!(
+                "Failed to rotate log file to {}: {}",
+                backup.display(),
+                error
+            );
         }
     }
 
-    fs::File::create(file).chain_err(|| "Unable to create new log file")?;
-    Ok(())
+    fs::File::create(file).map(|_| ()).map_err(RotateLogError)
 }

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -17,10 +17,10 @@ mod imp;
 #[path = "dummy.rs"]
 mod imp;
 
-pub use self::imp::is_offline;
+pub use self::imp::{is_offline, Error};
 
 pub struct MonitorHandle(imp::MonitorHandle);
 
-pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle, imp::Error> {
+pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle, Error> {
     Ok(MonitorHandle(imp::spawn_monitor(sender)?))
 }


### PR DESCRIPTION
Follow up to #779 and #778 

Removing a few more uses of `error_chain!`.

Also introduces my own solution for the cases where you want to just log an error, but you want to add one more layer to the chain first. I thought this was nicer and simpler than adding some `StringError` type that could be composed into the chain and then rendered to text.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/786)
<!-- Reviewable:end -->
