### PR TITLE
Prepare for cross-compile support in env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -2,18 +2,39 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-case "$(uname -s)" in
-  Linux*)
+if [ -n "$1" ]; then
+    PLATFORM="$1"
+fi
+
+if [ -z "$PLATFORM" ]; then
+    case "$(uname -s)" in
+      Linux*)
+        PLATFORM="linux"
+        ;;
+      Darwin*)
+        PLATFORM="macos"
+        ;;
+      MINGW*|MSYS_NT*)
+        PLATFORM="windows"
+        ;;
+    esac
+fi
+
+case "$PLATFORM" in
+  linux)
     export LIBMNL_LIB_DIR="$SCRIPT_DIR/dist-assets/binaries/linux"
     export LIBNFTNL_LIB_DIR="$SCRIPT_DIR/dist-assets/binaries/linux"
-    PLATFORM="linux"
     ;;
-  Darwin*)
+  macos)
     export MACOSX_DEPLOYMENT_TARGET="10.7"
-    PLATFORM="macos"
     ;;
-  MINGW*|MSYS_NT*)
-    PLATFORM="windows"
+  windows)
+    ;;
+  android*)
+    ;;
+  *)
+    echo "Unknown target platform \"$PLATFORM\"" >&2
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
This PR changes the `env.sh` script to prepare it to support cross-compiling for Android. The major change is to allow the `PLATFORM` environment variable to be specified either externally or from a command line parameter (i.e., by running `./env.sh android`).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Android version is not yet publicly released.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/788)
<!-- Reviewable:end -->
