### PR TITLE
Reset the tray icon when losing connectivity with the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - When IPv6 is enabled, get both exit IP versions from am.i.mullvad.net and show in UI.
 
+### Fixed
+- Reset the tray icon padlock to the unsecured state, when losing connectivity with the daemon.
 
 ## [2019.3] - 2019-04-02
 ### Fixed

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -446,6 +446,9 @@ class ApplicationMain {
       // stop periodic updates
       this.stopLatestVersionPeriodicUpdates();
 
+      // update the tray icon to indicate that the computer is not secure anymore
+      this.updateTrayIcon({ state: 'disconnected' }, false);
+
       // notify renderer process
       if (this.windowController) {
         IpcMainEventChannel.daemonDisconnected.notify(


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR resets the tray icon to the unsecured state when losing connectivity with daemon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/789)
<!-- Reviewable:end -->
