### PR TITLE
Cross-compile Rust code for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ The settings directory can be changed by setting the `MULLVAD_SETTINGS_DIR` envi
 |----------|------|
 | Linux | `/etc/mullvad-vpn/` |
 | macOS | `/etc/mullvad-vpn/` |
-| Windows | `%LOCALAPPDATA%\Mullvad VPN\`
+| Windows | `%LOCALAPPDATA%\Mullvad VPN\` |
+| Android | `/data/data/net.mullvad.mullvadvpn/` |
 
 #### Logs
 
@@ -352,6 +353,7 @@ The log directory can be changed by setting the `MULLVAD_LOG_DIR` environment va
 | Linux | `/var/log/mullvad-vpn/` + systemd |
 | macOS | `/var/log/mullvad-vpn/` |
 | Windows | `C:\ProgramData\Mullvad VPN\` |
+| Android | `/data/data/net.mullvad.mullvadvpn/` |
 
 #### Cache
 
@@ -362,6 +364,7 @@ The cache directory can be changed by setting the `MULLVAD_CACHE_DIR` environmen
 | Linux | `/var/cache/mullvad-vpn/` |
 | macOS | `/var/root/Library/Caches/mullvad-vpn/` |
 | Windows | `%LOCALAPPDATA%\Mullvad VPN\` |
+| Android | `/data/data/net.mullvad.mullvadvpn/cache` |
 
 #### RPC address file
 
@@ -373,6 +376,7 @@ environment variable.
 | Linux | `/var/run/mullvad-vpn` |
 | macOS | `/var/run/mullvad-vpn` |
 | Windows | `//./pipe/Mullvad VPN` |
+| Android | `/data/data/net.mullvad.mullvadvpn/rpc-socket` |
 
 ### GUI
 
@@ -384,6 +388,7 @@ The GUI has a specific settings file that is configured for each user. The path 
 | Linux | `$XDG_CONFIG_HOME/Mullvad VPN/gui_settings.json` |
 | macOS | `~/Library/Application Support/Mullvad VPN/gui_settings.json` |
 | Windows | `%LOCALAPPDATA%\Mullvad VPN\gui_settings.json` |
+| Android | Present in Android's `logcat` |
 
 ## Audits, pentests and external security reviews
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -645,6 +645,8 @@ impl Daemon {
         const PLATFORM: &str = "macos";
         #[cfg(target_os = "windows")]
         const PLATFORM: &str = "windows";
+        #[cfg(target_os = "android")]
+        const PLATFORM: &str = "android";
 
         let fut = self
             .version_proxy

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -19,7 +19,7 @@ pub enum Error {
     NoProgramDataDir,
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 const PRODUCT_NAME: &str = "mullvad-vpn";
 
 #[cfg(windows)]

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -25,6 +25,8 @@ const PRODUCT_NAME: &str = "mullvad-vpn";
 #[cfg(windows)]
 const PRODUCT_NAME: &str = "Mullvad VPN";
 
+#[cfg(target_os = "android")]
+const APP_PATH: &str = "/data/data/net.mullvad.mullvadvpn";
 
 #[cfg(windows)]
 fn get_allusersprofile_dir() -> Result<PathBuf> {

--- a/mullvad-paths/src/logs.rs
+++ b/mullvad-paths/src/logs.rs
@@ -23,14 +23,21 @@ pub fn get_log_dir() -> Result<PathBuf> {
 }
 
 pub fn get_default_log_dir() -> Result<PathBuf> {
-    let dir;
-    #[cfg(unix)]
+    #[cfg(not(target_os = "android"))]
     {
-        dir = Ok(PathBuf::from("/var/log"));
+        let dir;
+        #[cfg(unix)]
+        {
+            dir = Ok(PathBuf::from("/var/log"));
+        }
+        #[cfg(windows)]
+        {
+            dir = crate::get_allusersprofile_dir();
+        }
+        dir.map(|dir| dir.join(crate::PRODUCT_NAME))
     }
-    #[cfg(windows)]
+    #[cfg(target_os = "android")]
     {
-        dir = crate::get_allusersprofile_dir();
+        Ok(PathBuf::from(crate::APP_PATH))
     }
-    dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-paths/src/resources.rs
+++ b/mullvad-paths/src/resources.rs
@@ -10,18 +10,25 @@ pub fn get_resource_dir() -> PathBuf {
 }
 
 pub fn get_default_resource_dir() -> PathBuf {
-    match env::current_exe() {
-        Ok(mut path) => {
-            path.pop();
-            path
+    #[cfg(not(target_os = "android"))]
+    {
+        match env::current_exe() {
+            Ok(mut path) => {
+                path.pop();
+                path
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed finding the install directory. Using working directory: {}",
+                    e
+                );
+                PathBuf::from(".")
+            }
         }
-        Err(e) => {
-            log::error!(
-                "Failed finding the install directory. Using working directory: {}",
-                e
-            );
-            PathBuf::from(".")
-        }
+    }
+    #[cfg(target_os = "android")]
+    {
+        PathBuf::from(crate::APP_PATH)
     }
 }
 

--- a/mullvad-paths/src/rpc_socket.rs
+++ b/mullvad-paths/src/rpc_socket.rs
@@ -8,12 +8,16 @@ pub fn get_rpc_socket_path() -> PathBuf {
 }
 
 pub fn get_default_rpc_socket_path() -> PathBuf {
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         PathBuf::from("/var/run/mullvad-vpn")
     }
     #[cfg(windows)]
     {
         PathBuf::from("//./pipe/Mullvad VPN")
+    }
+    #[cfg(target_os = "android")]
+    {
+        PathBuf::from(format!("{}/rpc-socket", crate::APP_PATH))
     }
 }

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -15,14 +15,21 @@ fn get_settings_dir() -> Result<PathBuf> {
 }
 
 pub fn get_default_settings_dir() -> Result<PathBuf> {
-    let dir;
-    #[cfg(unix)]
+    #[cfg(not(target_os = "android"))]
     {
-        dir = Ok(PathBuf::from("/etc"));
+        let dir;
+        #[cfg(unix)]
+        {
+            dir = Ok(PathBuf::from("/etc"));
+        }
+        #[cfg(windows)]
+        {
+            dir = dirs::data_local_dir().ok_or_else(|| crate::Error::FindDirError);
+        }
+        dir.map(|dir| dir.join(crate::PRODUCT_NAME))
     }
-    #[cfg(windows)]
+    #[cfg(target_os = "android")]
     {
-        dir = dirs::data_local_dir().ok_or(crate::Error::FindDirError);
+        Ok(PathBuf::from(crate::APP_PATH))
     }
-    dir.map(|dir| dir.join(crate::PRODUCT_NAME))
 }

--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -109,6 +109,27 @@ mod os {
     }
 }
 
+#[cfg(target_os = "android")]
+mod os {
+    pub fn version() -> String {
+        let manufacturer = get_prop("ro.product.manufacturer").unwrap_or_else(String::new);
+        let product = get_prop("ro.product.model").unwrap_or_else(String::new);
+        let build = get_prop("ro.build.display.id").unwrap_or_else(String::new);
+        let api_level = get_prop("ro.build.version.sdk")
+            .map(|api| format!("(API level: {})", api))
+            .unwrap_or_else(String::new);
+
+        format!(
+            "Android {} {} {} {}",
+            manufacturer, product, build, api_level
+        )
+    }
+
+    fn get_prop(property: &str) -> Option<String> {
+        super::command_stdout_lossy("getprop", &[property])
+    }
+}
+
 /// Helper for getting stdout of some command as a String. Ignores the exit code of the command.
 fn command_stdout_lossy(cmd: &str, args: &[&str]) -> Option<String> {
     Command::new(cmd)

--- a/mullvad-tests/src/bin/mock_openvpn.rs
+++ b/mullvad-tests/src/bin/mock_openvpn.rs
@@ -1,70 +1,84 @@
-use mullvad_tests::{watch_event, PathWatcher};
-use std::{
-    env,
-    fs::{self, File},
-    io::{self, Read, Write},
-    path::PathBuf,
-    sync::mpsc,
-    thread,
-    time::Duration,
-};
-
-
-const MAX_EVENT_TIME: Duration = Duration::from_secs(60);
+use crate::mock_openvpn::run;
 
 fn main() {
-    let (file, path) = create_args_file();
-    let (finished_tx, finished_rx) = mpsc::channel();
-    let watcher = PathWatcher::watch(&path).expect("Failed to watch file for events");
-
-    write_command_line(file);
-
-    wait_thread(wait_for_stdin_to_be_closed, finished_tx.clone());
-    wait_thread(
-        move || wait_for_file_to_be_deleted(watcher, MAX_EVENT_TIME),
-        finished_tx,
-    );
-
-    let _ = finished_rx.recv();
-    let _ = fs::remove_file(path);
+    run();
 }
 
-fn create_args_file() -> (File, PathBuf) {
-    let path = PathBuf::from(
-        env::var_os("MOCK_OPENVPN_ARGS_FILE").expect("Missing mock OpenVPN arguments file path"),
-    );
-    let file = File::create(&path).expect("Failed to create mock OpenVPN arguments file");
-
-    (file, path)
+#[cfg(target_os = "android")]
+mod mock_openvpn {
+    pub fn run() {}
 }
 
-fn write_command_line(mut file: File) {
-    for argument in env::args() {
-        let escaped_argument = argument
-            .replace("\\", "\\\\")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r");
+#[cfg(not(target_os = "android"))]
+mod mock_openvpn {
+    use mullvad_tests::{watch_event, PathWatcher};
+    use std::{
+        env,
+        fs::{self, File},
+        io::{self, Read, Write},
+        path::PathBuf,
+        sync::mpsc,
+        thread,
+        time::Duration,
+    };
 
-        writeln!(file, "{}", escaped_argument).expect("Failed to write argument to file");
+    const MAX_EVENT_TIME: Duration = Duration::from_secs(60);
+
+    pub fn run() {
+        let (file, path) = create_args_file();
+        let (finished_tx, finished_rx) = mpsc::channel();
+        let watcher = PathWatcher::watch(&path).expect("Failed to watch file for events");
+
+        write_command_line(file);
+
+        wait_thread(wait_for_stdin_to_be_closed, finished_tx.clone());
+        wait_thread(
+            move || wait_for_file_to_be_deleted(watcher, MAX_EVENT_TIME),
+            finished_tx,
+        );
+
+        let _ = finished_rx.recv();
+        let _ = fs::remove_file(path);
     }
-}
 
-fn wait_thread<F>(function: F, finished_tx: mpsc::Sender<()>)
-where
-    F: FnOnce() + Send + 'static,
-{
-    thread::spawn(move || {
-        function();
-        let _ = finished_tx.send(());
-    });
-}
+    fn create_args_file() -> (File, PathBuf) {
+        let path = PathBuf::from(
+            env::var_os("MOCK_OPENVPN_ARGS_FILE")
+                .expect("Missing mock OpenVPN arguments file path"),
+        );
+        let file = File::create(&path).expect("Failed to create mock OpenVPN arguments file");
 
-fn wait_for_stdin_to_be_closed() {
-    let _ignore_bytes = io::stdin().bytes().last();
-}
+        (file, path)
+    }
 
-fn wait_for_file_to_be_deleted(mut watcher: PathWatcher, timeout: Duration) {
-    let _ignore_event = watcher
-        .set_timeout(timeout)
-        .find(|&event| event == watch_event::REMOVE);
+    fn write_command_line(mut file: File) {
+        for argument in env::args() {
+            let escaped_argument = argument
+                .replace("\\", "\\\\")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
+
+            writeln!(file, "{}", escaped_argument).expect("Failed to write argument to file");
+        }
+    }
+
+    fn wait_thread<F>(function: F, finished_tx: mpsc::Sender<()>)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        thread::spawn(move || {
+            function();
+            let _ = finished_tx.send(());
+        });
+    }
+
+    fn wait_for_stdin_to_be_closed() {
+        let _ignore_bytes = io::stdin().bytes().last();
+    }
+
+    fn wait_for_file_to_be_deleted(mut watcher: PathWatcher, timeout: Duration) {
+        let _ignore_event = watcher
+            .set_timeout(timeout)
+            .find(|&event| event == watch_event::REMOVE);
+    }
 }

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "android"))]
+
 use self::{mock_openvpn::MOCK_OPENVPN_ARGS_FILE, platform_specific::*};
 use futures::sync::oneshot;
 use jsonrpc_client_core::{Future, Transport};

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -32,7 +32,6 @@ uuid = { version = "0.7", features = ["v4"] }
 hex = "0.3"
 ipnetwork = "0.14"
 lazy_static = "1.0"
-tun = { git = "https://github.com/pinkisemils/rust-tun", branch = "add-raw-fd-traits" }
 nix = "0.13"
 
 
@@ -48,12 +47,14 @@ nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "29651f4370fdf22cc2
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"
 err-derive = "0.1.5"
+tun = { git = "https://github.com/pinkisemils/rust-tun", branch = "add-raw-fd-traits" }
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # TODO: Specify 0.2.1 once the crate gets published
 pfctl = { git = "https://github.com/mullvad/pfctl-rs", rev = "9f31b5ddcab941862470075eab83bb398195f3d6" }
 system-configuration = "0.2"
+tun = { git = "https://github.com/pinkisemils/rust-tun", branch = "add-raw-fd-traits" }
 
 
 [target.'cfg(windows)'.dependencies]

--- a/talpid-core/src/dns/android.rs
+++ b/talpid-core/src/dns/android.rs
@@ -1,0 +1,24 @@
+use std::{net::IpAddr, path::Path};
+
+/// Stub error type for DNS errors on Android.
+#[derive(Debug, err_derive::Error)]
+#[error(display = "Unknown Android DNS error")]
+pub struct Error;
+
+pub struct DnsMonitor;
+
+impl super::DnsMonitorT for DnsMonitor {
+    type Error = Error;
+
+    fn new(_cache_dir: impl AsRef<Path>) -> Result<Self, Self::Error> {
+        Ok(DnsMonitor)
+    }
+
+    fn set(&mut self, _interface: &str, _servers: &[IpAddr]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn reset(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -12,6 +12,10 @@ mod imp;
 #[path = "windows/mod.rs"]
 mod imp;
 
+#[cfg(target_os = "android")]
+#[path = "android.rs"]
+mod imp;
+
 pub use self::imp::Error;
 
 /// Sets and monitors system DNS settings. Makes sure the desired DNS servers are being used.

--- a/talpid-core/src/firewall/android.rs
+++ b/talpid-core/src/firewall/android.rs
@@ -1,0 +1,25 @@
+use super::{FirewallPolicy, FirewallT};
+
+/// Stub error type for Firewall errors on Android.
+#[derive(Debug, err_derive::Error)]
+#[error(display = "Unknown Android Firewall error")]
+pub struct Error;
+
+/// The Android stub implementation for the firewall.
+pub struct Firewall;
+
+impl FirewallT for Firewall {
+    type Error = Error;
+
+    fn new() -> Result<Self, Self::Error> {
+        Ok(Firewall)
+    }
+
+    fn apply_policy(&mut self, _policy: FirewallPolicy) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn reset_policy(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -22,8 +22,11 @@ mod imp;
 #[path = "windows.rs"]
 mod imp;
 
-pub use self::imp::Error;
+#[cfg(target_os = "android")]
+#[path = "android.rs"]
+mod imp;
 
+pub use self::imp::Error;
 
 #[cfg(unix)]
 lazy_static! {

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -21,7 +21,7 @@ mod ffi;
 #[cfg(windows)]
 mod winnet;
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 /// Working with IP interface devices
 pub mod network_interface;
 #[cfg(unix)]

--- a/talpid-core/src/offline/dummy.rs
+++ b/talpid-core/src/offline/dummy.rs
@@ -1,5 +1,5 @@
+use crate::tunnel_state_machine::TunnelCommand;
 use futures::sync::mpsc::UnboundedSender;
-use tunnel_state_machine::TunnelCommand;
 
 error_chain! {}
 

--- a/talpid-core/src/routing/android.rs
+++ b/talpid-core/src/routing/android.rs
@@ -1,0 +1,32 @@
+use super::{
+    subprocess::{Exec, RunExpr},
+    NetNode, RequiredRoutes,
+};
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr},
+};
+
+error_chain! {}
+
+pub struct RouteManager;
+
+impl super::RoutingT for RouteManager {
+    type Error = Error;
+
+    fn new() -> Result<Self> {
+        Ok(RouteManager)
+    }
+
+    fn add_routes(&mut self, _required_routes: RequiredRoutes) -> Result<()> {
+        Ok(())
+    }
+
+    fn delete_routes(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_default_route_node(&mut self) -> Result<IpAddr> {
+        Ok(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
+    }
+}

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -9,8 +9,11 @@ mod imp;
 #[path = "linux.rs"]
 mod imp;
 
-mod subprocess;
+#[cfg(target_os = "android")]
+#[path = "android.rs"]
+mod imp;
 
+mod subprocess;
 
 /// A single route
 #[derive(Hash, Eq, PartialEq)]

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -316,7 +316,7 @@ fn is_ipv6_enabled_in_os() -> bool {
             .map(|disable_ipv6| disable_ipv6.trim() == "0")
             .unwrap_or(false)
     }
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "android"))]
     {
         true
     }

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -85,7 +85,7 @@ static OPENVPN_DIE_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[cfg(target_os = "macos")]
 const OPENVPN_PLUGIN_FILENAME: &str = "libtalpid_openvpn_plugin.dylib";
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const OPENVPN_PLUGIN_FILENAME: &str = "libtalpid_openvpn_plugin.so";
 #[cfg(windows)]
 const OPENVPN_PLUGIN_FILENAME: &str = "talpid_openvpn_plugin.dll";


### PR DESCRIPTION
This PR updates the Rust code to support the `cfg(target_os = "android")`. This allows the code to compile with `cargo build --target aarch64-linux-android`.

Certain things are disabled (like Wireguard and OpenVPN), some things are stubbed (like the firewall implementation) and some things are properly configured (like file paths).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Android version not publicly released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/790)
<!-- Reviewable:end -->
