### PR TITLE
Fix call to `env.sh` from `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ RUSTC_VERSION=`rustc +stable --version`
 PRODUCT_VERSION=$(node -p "require('./gui/package.json').version" | sed -Ee 's/\.0//g')
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$SCRIPT_DIR/target"}
 
-source env.sh
+source env.sh ""
 
 if [[ "${1:-""}" != "--dev-build" ]]; then
     if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then

--- a/env.sh
+++ b/env.sh
@@ -4,6 +4,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ -n "$1" ]; then
     PLATFORM="$1"
+else
+    PLATFORM=""
 fi
 
 if [ -z "$PLATFORM" ]; then


### PR DESCRIPTION
Recent changes to `env.sh` allow it receive an optional parameter to specify the target platform. However, when `build.sh` sources the script, its command line arguments are sent to the sourced script, which leads to the usage of an invalid argument value.

This PR changes `build.sh` to pass an empty parameter, so that its parameters aren't forwarded instead.

It also fixes `env.sh` to not have any unbound variables when called by `build.sh`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that wasn't released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/793)
<!-- Reviewable:end -->
