### PR TITLE
Add #![deny(rust_2018_idioms)] to all crates and fix errors

### DIFF
--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -32,7 +32,7 @@ impl Command for Account {
             )
     }
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             let token = value_t_or_exit!(set_matches.value_of("token"), String);
             self.set(Some(token))

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -27,7 +27,7 @@ impl Command for AutoConnect {
             )
     }
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             let auto_connect = value_t_or_exit!(set_matches.value_of("policy"), String);
             self.set(auto_connect == "on")

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -27,7 +27,7 @@ impl Command for BlockWhenDisconnected {
             )
     }
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             let block_when_disconnected = value_t_or_exit!(set_matches.value_of("policy"), String);
             self.set(block_when_disconnected == "on")

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -13,7 +13,7 @@ impl Command for Connect {
             .about("Command the client to start establishing a VPN tunnel")
     }
 
-    fn run(&self, _matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, _matches: &clap::ArgMatches<'_>) -> Result<()> {
         let mut rpc = new_rpc_client()?;
         if let Err(e) = rpc.connect() {
             eprintln!("{}", e.display_chain());

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -12,7 +12,7 @@ impl Command for Disconnect {
             .about("Command the client to disconnect the VPN tunnel")
     }
 
-    fn run(&self, _matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, _matches: &clap::ArgMatches<'_>) -> Result<()> {
         let mut rpc = new_rpc_client()?;
         rpc.disconnect()?;
         Ok(())

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -27,7 +27,7 @@ impl Command for Lan {
             )
     }
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             let allow_lan = value_t_or_exit!(set_matches.value_of("policy"), String);
             self.set(allow_lan == "allow")

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -165,7 +165,7 @@ impl Command for Relay {
             )
     }
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             self.set(set_matches)
         } else if matches.subcommand_matches("get").is_some() {
@@ -188,7 +188,7 @@ impl Relay {
         Ok(())
     }
 
-    fn set(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn set(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(custom_matches) = matches.subcommand_matches("custom") {
             self.set_custom(custom_matches)
         } else if let Some(location_matches) = matches.subcommand_matches("location") {
@@ -200,7 +200,7 @@ impl Relay {
         }
     }
 
-    fn set_custom(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn set_custom(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let custom_endpoint = match matches.subcommand() {
             ("openvpn", Some(openvpn_matches)) => Self::read_custom_openvpn_relay(openvpn_matches),
             ("wireguard", Some(wg_matches)) => Self::read_custom_wireguard_relay(wg_matches),
@@ -209,7 +209,7 @@ impl Relay {
         self.update_constraints(RelaySettingsUpdate::CustomTunnelEndpoint(custom_endpoint))
     }
 
-    fn read_custom_openvpn_relay(matches: &clap::ArgMatches) -> CustomTunnelEndpoint {
+    fn read_custom_openvpn_relay(matches: &clap::ArgMatches<'_>) -> CustomTunnelEndpoint {
         let host = value_t!(matches.value_of("host"), String).unwrap_or_else(|e| e.exit());
         let port = value_t!(matches.value_of("port"), u16).unwrap_or_else(|e| e.exit());
         let username = value_t!(matches.value_of("username"), String).unwrap_or_else(|e| e.exit());
@@ -226,7 +226,7 @@ impl Relay {
         )
     }
 
-    fn read_custom_wireguard_relay(matches: &clap::ArgMatches) -> CustomTunnelEndpoint {
+    fn read_custom_wireguard_relay(matches: &clap::ArgMatches<'_>) -> CustomTunnelEndpoint {
         let host = value_t!(matches.value_of("host"), String).unwrap_or_else(|e| e.exit());
         let port = value_t!(matches.value_of("port"), u16).unwrap_or_else(|e| e.exit());
         let addresses = values_t!(matches.values_of("addr"), IpAddr).unwrap_or_else(|e| e.exit());
@@ -288,7 +288,7 @@ impl Relay {
         key
     }
 
-    fn set_location(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn set_location(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let country = matches.value_of("country").unwrap();
         let city = matches.value_of("city");
         let hostname = matches.value_of("hostname");
@@ -327,7 +327,7 @@ impl Relay {
         }))
     }
 
-    fn set_tunnel(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn set_tunnel(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let vpn_protocol = matches.value_of("vpn protocol").unwrap();
         let port = parse_port_constraint(matches.value_of("port").unwrap())?;
         let protocol = parse_protocol_constraint(matches.value_of("transport protocol").unwrap());

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -25,7 +25,7 @@ impl Command for Status {
             )
     }
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let mut rpc = new_rpc_client()?;
         let state = rpc.get_state()?;
 

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -22,7 +22,7 @@ impl Command for Tunnel {
             .subcommand(create_ipv6_subcommand())
     }
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         match matches.subcommand() {
             ("openvpn", Some(openvpn_matches)) => Self::handle_openvpn_cmd(openvpn_matches),
             ("wireguard", Some(wg_matches)) => Self::handle_wireguard_cmd(wg_matches),
@@ -187,7 +187,7 @@ fn create_ipv6_subcommand() -> clap::App<'static, 'static> {
 }
 
 impl Tunnel {
-    fn handle_openvpn_cmd(matches: &clap::ArgMatches) -> Result<()> {
+    fn handle_openvpn_cmd(matches: &clap::ArgMatches<'_>) -> Result<()> {
         match matches.subcommand() {
             ("mssfix", Some(mssfix_matches)) => Self::handle_openvpn_mssfix_cmd(mssfix_matches),
             ("proxy", Some(proxy_matches)) => Self::handle_openvpn_proxy_cmd(proxy_matches),
@@ -195,7 +195,7 @@ impl Tunnel {
         }
     }
 
-    fn handle_openvpn_mssfix_cmd(matches: &clap::ArgMatches) -> Result<()> {
+    fn handle_openvpn_mssfix_cmd(matches: &clap::ArgMatches<'_>) -> Result<()> {
         match matches.subcommand() {
             ("get", Some(_)) => Self::process_openvpn_mssfix_get(),
             ("unset", Some(_)) => Self::process_openvpn_mssfix_unset(),
@@ -204,7 +204,7 @@ impl Tunnel {
         }
     }
 
-    fn handle_openvpn_proxy_cmd(matches: &clap::ArgMatches) -> Result<()> {
+    fn handle_openvpn_proxy_cmd(matches: &clap::ArgMatches<'_>) -> Result<()> {
         match matches.subcommand() {
             ("get", Some(_)) => Self::process_openvpn_proxy_get(),
             ("unset", Some(_)) => Self::process_openvpn_proxy_unset(),
@@ -213,7 +213,7 @@ impl Tunnel {
         }
     }
 
-    fn handle_wireguard_cmd(matches: &clap::ArgMatches) -> Result<()> {
+    fn handle_wireguard_cmd(matches: &clap::ArgMatches<'_>) -> Result<()> {
         match matches.subcommand() {
             ("mtu", Some(matches)) => match matches.subcommand() {
                 ("get", _) => Self::process_wireguard_mtu_get(),
@@ -244,7 +244,7 @@ impl Tunnel {
         Ok(())
     }
 
-    fn process_wireguard_mtu_set(matches: &clap::ArgMatches) -> Result<()> {
+    fn process_wireguard_mtu_set(matches: &clap::ArgMatches<'_>) -> Result<()> {
         let mtu = value_t!(matches.value_of("mtu"), u16).unwrap_or_else(|e| e.exit());
         let mut rpc = new_rpc_client()?;
         rpc.set_wireguard_mtu(Some(mtu))?;
@@ -281,7 +281,7 @@ impl Tunnel {
         rpc.generate_wireguard_key().map_err(|e| e.into())
     }
 
-    fn handle_ipv6_cmd(matches: &clap::ArgMatches) -> Result<()> {
+    fn handle_ipv6_cmd(matches: &clap::ArgMatches<'_>) -> Result<()> {
         if matches.subcommand_matches("get").is_some() {
             Self::process_ipv6_get()
         } else if let Some(m) = matches.subcommand_matches("set") {
@@ -315,7 +315,7 @@ impl Tunnel {
         Ok(())
     }
 
-    fn process_openvpn_mssfix_set(matches: &clap::ArgMatches) -> Result<()> {
+    fn process_openvpn_mssfix_set(matches: &clap::ArgMatches<'_>) -> Result<()> {
         let new_value = value_t!(matches.value_of("mssfix"), u16).unwrap_or_else(|e| e.exit());
         let mut rpc = new_rpc_client()?;
         rpc.set_openvpn_mssfix(Some(new_value))?;
@@ -376,7 +376,7 @@ impl Tunnel {
         Ok(())
     }
 
-    fn process_openvpn_proxy_set(matches: &clap::ArgMatches) -> Result<()> {
+    fn process_openvpn_proxy_set(matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(args) = matches.subcommand_matches("local") {
             let local_port =
                 value_t!(args.value_of("local-port"), u16).unwrap_or_else(|e| e.exit());
@@ -471,7 +471,7 @@ impl Tunnel {
         Ok(())
     }
 
-    fn process_ipv6_set(matches: &clap::ArgMatches) -> Result<()> {
+    fn process_ipv6_set(matches: &clap::ArgMatches<'_>) -> Result<()> {
         let enabled = matches.value_of("enable").unwrap() == "on";
 
         let mut rpc = new_rpc_client()?;

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -12,7 +12,7 @@ impl Command for Version {
             .about("Shows current version, and the currently supported versions")
     }
 
-    fn run(&self, _: &clap::ArgMatches) -> Result<()> {
+    fn run(&self, _: &clap::ArgMatches<'_>) -> Result<()> {
         let mut rpc = new_rpc_client()?;
         let current_version = rpc.get_current_version()?;
         println!("Current version: {}", current_version);

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -6,6 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 
@@ -76,5 +78,5 @@ pub trait Command {
 
     fn clap_subcommand(&self) -> clap::App<'static, 'static>;
 
-    fn run(&self, matches: &clap::ArgMatches) -> Result<()>;
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()>;
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -6,6 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 #[macro_use]

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -122,7 +122,7 @@ impl Formatter {
         }
     }
 
-    fn get_record_level(&self, level: log::Level) -> Box<fmt::Display> {
+    fn get_record_level(&self, level: log::Level) -> Box<dyn fmt::Display> {
         if self.output_color && cfg!(not(windows)) {
             Box::new(COLORS.color(level))
         } else {
@@ -132,9 +132,9 @@ impl Formatter {
 
     pub fn output_msg(
         &self,
-        out: fern::FormatCallback,
-        message: &fmt::Arguments,
-        record: &log::Record,
+        out: fern::FormatCallback<'_>,
+        message: &fmt::Arguments<'_>,
+        record: &log::Record<'_>,
     ) {
         let message = escape_newlines(format!("{}", message));
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -6,6 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -36,7 +36,7 @@ use uuid;
 /// FIXME(linus): This is here just because the futures crate has deprecated it and jsonrpc_core
 /// did not introduce their own yet (https://github.com/paritytech/jsonrpc/pull/196).
 /// Remove this and use the one in jsonrpc_core when that is released.
-pub type BoxFuture<T, E> = Box<Future<Item = T, Error = E> + Send>;
+pub type BoxFuture<T, E> = Box<dyn Future<Item = T, Error = E> + Send>;
 
 build_rpc_trait! {
     pub trait ManagementInterfaceApi {
@@ -702,7 +702,7 @@ impl PubSubMetadata for Meta {
 }
 
 /// Metadata extractor function for `Meta`.
-fn meta_extractor(context: &jsonrpc_ipc_server::RequestContext) -> Meta {
+fn meta_extractor(context: &jsonrpc_ipc_server::RequestContext<'_>) -> Meta {
     Meta {
         session: Some(Arc::new(Session::new(context.sender.clone()))),
     }

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -194,7 +194,7 @@ impl RelaySelector {
         self.lock_parsed_relays().locations().clone()
     }
 
-    fn lock_parsed_relays(&self) -> MutexGuard<ParsedRelays> {
+    fn lock_parsed_relays(&self) -> MutexGuard<'_, ParsedRelays> {
         self.parsed_relays
             .lock()
             .expect("Relay updater thread crashed while it held a lock to the list of relays")
@@ -628,7 +628,7 @@ impl RelayListUpdater {
             .chain_err(|| ErrorKind::SerializationError)
     }
 
-    fn lock_parsed_relays(&self) -> MutexGuard<ParsedRelays> {
+    fn lock_parsed_relays(&self) -> MutexGuard<'_, ParsedRelays> {
         self.parsed_relays
             .lock()
             .expect("A thread crashed while it held a lock to the list of relays")

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -1,8 +1,5 @@
 use crate::Result;
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::{env, path::PathBuf};
 
 /// Creates and returns the cache directory pointed to by `MULLVAD_CACHE_DIR`, or the default
 /// one if that variable is unset.
@@ -33,6 +30,6 @@ pub fn get_default_cache_dir() -> Result<PathBuf> {
     }
     #[cfg(target_os = "android")]
     {
-        Ok(Path::new(crate::APP_PATH).join("cache"))
+        Ok(std::path::Path::new(crate::APP_PATH).join("cache"))
     }
 }

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use std::{fs, io, path::PathBuf};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -6,6 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -6,6 +6,7 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
 
 #[macro_use]
 extern crate error_chain;

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -53,7 +53,7 @@ impl CustomTunnelEndpoint {
 }
 
 impl fmt::Display for CustomTunnelEndpoint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.config {
             ConnectionConfig::OpenVpn(config) => write!(
                 f,

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -6,6 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -74,7 +74,7 @@ pub enum DnsMonitorHolder {
 }
 
 impl fmt::Display for DnsMonitorHolder {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::DnsMonitorHolder::*;
         let name = match self {
             Resolvconf(..) => "resolvconf",

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -53,7 +53,7 @@ impl NetworkManager {
     }
 
     fn ensure_network_manager_exists(&self) -> Result<()> {
-        let _: Box<RefArg> = self
+        let _: Box<dyn RefArg> = self
             .as_manager()
             .get(&NM_TOP_OBJECT, GLOBAL_DNS_CONF_KEY)
             .map_err(Error::NetworkManagerNotDetected)?;
@@ -87,7 +87,7 @@ impl NetworkManager {
         Ok(())
     }
 
-    fn as_manager(&self) -> dbus::ConnPath<&dbus::Connection> {
+    fn as_manager(&self) -> dbus::ConnPath<'_, &dbus::Connection> {
         self.dbus_connection
             .with_path(NM_BUS, NM_OBJECT_PATH, RPC_TIMEOUT_MS)
     }
@@ -107,7 +107,7 @@ impl NetworkManager {
     }
 }
 
-type GlobalDnsConfig = HashMap<&'static str, Variant<Box<RefArg>>>;
+type GlobalDnsConfig = HashMap<&'static str, Variant<Box<dyn RefArg>>>;
 
 // The NetworkManager GlobalDnsConfiguration schema looks something like this
 // {
@@ -146,8 +146,8 @@ fn create_empty_global_settings() -> GlobalDnsConfig {
     HashMap::new()
 }
 
-fn as_variant<T: RefArg + 'static>(t: T) -> Variant<Box<RefArg>> {
-    Variant(Box::new(t) as Box<RefArg>)
+fn as_variant<T: RefArg + 'static>(t: T) -> Variant<Box<dyn RefArg>> {
+    Variant(Box::new(t) as Box<dyn RefArg>)
 }
 
 fn eq_file_content<P: AsRef<Path>>(a: &P, b: &P) -> bool {

--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -92,7 +92,7 @@ impl SystemdResolved {
     }
 
     fn ensure_resolved_exists(&self) -> Result<()> {
-        let _: Box<RefArg> = self
+        let _: Box<dyn RefArg> = self
             .as_manager_object()
             .get(&MANAGER_INTERFACE, "DNS")
             .map_err(Error::NoSystemdResolved)?;
@@ -130,7 +130,7 @@ impl SystemdResolved {
         }
     }
 
-    fn as_manager_object(&self) -> dbus::ConnPath<&dbus::Connection> {
+    fn as_manager_object(&self) -> dbus::ConnPath<'_, &dbus::Connection> {
         self.dbus_connection
             .with_path(RESOLVED_BUS, "/org/freedesktop/resolve1", RPC_TIMEOUT_MS)
     }

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -80,7 +80,7 @@ pub enum FirewallPolicy {
 }
 
 impl fmt::Display for FirewallPolicy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FirewallPolicy::Connecting {
                 peer_endpoint,

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(rust_2018_idioms)]
 
 //! The core components of the talpidaemon VPN client.
 //!

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -335,7 +335,7 @@ impl OpenVpnCommand {
 impl fmt::Display for OpenVpnCommand {
     /// Format the program and arguments of an `OpenVpnCommand` for display. Any non-utf8 data
     /// is lossily converted using the utf8 replacement character.
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str(&shell_escape::escape(self.openvpn_bin.to_string_lossy()))?;
         for arg in &self.get_arguments() {
             fmt.write_str(" ")?;

--- a/talpid-core/src/proxy/mod.rs
+++ b/talpid-core/src/proxy/mod.rs
@@ -22,8 +22,8 @@ pub trait ProxyMonitor: Send {
     fn port(&self) -> u16;
 }
 
-impl fmt::Debug for ProxyMonitor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl fmt::Debug for dyn ProxyMonitor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ProxyMonitor {{ port: {} }}", self.port())
     }
 }

--- a/talpid-core/src/proxy/shadowsocks.rs
+++ b/talpid-core/src/proxy/shadowsocks.rs
@@ -99,7 +99,7 @@ impl ShadowsocksCommand {
 }
 
 impl fmt::Display for ShadowsocksCommand {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str(&shell_escape::escape(
             self.shadowsocks_bin.to_string_lossy(),
         ))?;

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -53,7 +53,7 @@ pub struct WireguardMonitor {
     /// Route manager
     router: routing::RouteManager,
     /// Callback to signal tunnel events
-    event_callback: Box<Fn(TunnelEvent) + Send + Sync + 'static>,
+    event_callback: Box<dyn Fn(TunnelEvent) + Send + Sync + 'static>,
     close_msg_sender: mpsc::Sender<CloseMsg>,
     close_msg_receiver: mpsc::Receiver<CloseMsg>,
 }

--- a/talpid-ipc/src/lib.rs
+++ b/talpid-ipc/src/lib.rs
@@ -6,6 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 use futures::Future;
 use std::{io, thread};
 
@@ -102,7 +104,7 @@ impl IpcServer {
 // FIXME: This custom impl is because `Server` does not implement `Debug` yet:
 // https://github.com/paritytech/jsonrpc/pull/195
 impl fmt::Debug for IpcServer {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("IpcServer")
             .field("path", &self.path)
             .finish()

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -6,6 +6,8 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -6,5 +6,7 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
+#![deny(rust_2018_idioms)]
+
 pub mod net;
 pub mod tunnel;


### PR DESCRIPTION
We started using Rust 2018 edition a while back. And we fixed most syntax changes and idioms during the transition. But some stuff were not fixed. Currently the compiler does allow both the new and the old style without complaining. But eventually all of these will likely be hard errors by default.

By forcing us to follow the new idioms now already we will have a more consistent style. Since we must follow the new way everywhere.

If you ever run into problems with this you should be able to automatically fix it with `cargo fix --edition-idioms`. So this should be pretty painless I hope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/795)
<!-- Reviewable:end -->
