### PR TITLE
Get rid of error-chain in mullvad-types and talpid-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,7 +1214,7 @@ name = "mullvad-types"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.14.0 (git+https://github.com/mullvad/ipnetwork?branch=fix-deserialization)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2065,7 +2065,6 @@ name = "talpid-types"
 version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -50,6 +50,7 @@ use talpid_core::{
 use talpid_types::{
     net::{openvpn, wireguard, TransportProtocol, TunnelParameters},
     tunnel::{BlockReason, TunnelStateTransition},
+    ErrorExt,
 };
 
 
@@ -387,8 +388,8 @@ impl Daemon {
                         .map_err(|_| Error::from("Tunnel parameters receiver stopped listening"))
                 })
             });
-        if let Err(error) = result {
-            error!("{}", error.display_chain());
+        if let Err(e) = result {
+            error!("{}", ErrorExt::display_chain(&e));
         }
     }
 
@@ -550,7 +551,10 @@ impl Daemon {
         let https_handle = self.https_handle.clone();
 
         geoip::send_location_request(https_handle).map_err(|e| {
-            warn!("Unable to fetch GeoIP location: {}", e.display_chain());
+            warn!(
+                "Unable to fetch GeoIP location: {}",
+                ChainedError::display_chain(&e)
+            );
         })
     }
 
@@ -615,7 +619,7 @@ impl Daemon {
                     }
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 
@@ -672,7 +676,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 
@@ -687,7 +691,7 @@ impl Daemon {
                     self.send_tunnel_command(TunnelCommand::AllowLan(allow_lan));
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 
@@ -710,7 +714,7 @@ impl Daemon {
                     ));
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 
@@ -724,7 +728,7 @@ impl Daemon {
                         .notify_settings(self.settings.clone());
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 
@@ -740,7 +744,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 
@@ -807,7 +811,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 
@@ -823,7 +827,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", e.display_chain()),
+            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
         }
     }
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -544,9 +544,9 @@ impl<T: From<ManagementCommand> + 'static + Send> ManagementInterfaceApi
             .send_command_to_daemon(ManagementCommand::SetOpenVpnProxy(tx, proxy))
             .and_then(|_| rx.map_err(|_| Error::internal_error()))
             .and_then(|settings_result| {
-                settings_result.map_err(|err| match err.kind() {
-                    settings::ErrorKind::InvalidProxyData(msg) => {
-                        Error::invalid_params(msg.to_owned())
+                settings_result.map_err(|error| match error {
+                    settings::Error::InvalidProxyData(reason) => {
+                        Error::invalid_params(reason.to_owned())
                     }
                     _ => Error::internal_error(),
                 })

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-error-chain = "0.12"
+err-derive = "0.1.5"
 ipnetwork = { git = "https://github.com/mullvad/ipnetwork", branch = "fix-deserialization" }
+lazy_static = "1.1.0"
 log = "0.4"
 regex = "1"
-lazy_static = "1.1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 talpid-types = { path = "../talpid-types" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -1,20 +1,19 @@
 use crate::settings::TunnelOptions;
 use serde::{Deserialize, Serialize};
 use std::{
-    fmt,
+    fmt, io,
     net::{IpAddr, SocketAddr, ToSocketAddrs},
 };
 use talpid_types::net::{openvpn, wireguard, TunnelParameters};
 
-error_chain! {
-    errors {
-        InvalidHost(host: String) {
-            display("Invalid host: {}", host)
-        }
-        Unsupported {
-            description("Tunnel type not supported")
-        }
-    }
+
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    #[error(display = "Invalid host/domain: {}", _0)]
+    InvalidHost(String, #[error(cause)] io::Error),
+
+    #[error(display = "Host has no IPv4 address: {}", _0)]
+    HostHasNoIpv4(String),
 }
 
 
@@ -29,7 +28,10 @@ impl CustomTunnelEndpoint {
         Self { host, config }
     }
 
-    pub fn to_tunnel_parameters(&self, tunnel_options: TunnelOptions) -> Result<TunnelParameters> {
+    pub fn to_tunnel_parameters(
+        &self,
+        tunnel_options: TunnelOptions,
+    ) -> Result<TunnelParameters, Error> {
         let ip = resolve_to_ip(&self.host)?;
         let mut config = self.config.clone();
         config.set_ip(ip);
@@ -76,10 +78,10 @@ impl fmt::Display for CustomTunnelEndpoint {
 /// Returns the first IPv4 address if one exists, otherwise the first IPv6 address.
 /// Rust only provides means to resolve a socket addr, not just a host, for some reason. So
 /// because of this we do the resolving with port zero and then pick out the IPs.
-fn resolve_to_ip(host: &str) -> Result<IpAddr> {
+fn resolve_to_ip(host: &str) -> Result<IpAddr, Error> {
     let (mut ipv4, mut ipv6): (Vec<IpAddr>, Vec<IpAddr>) = (host, 0)
         .to_socket_addrs()
-        .chain_err(|| ErrorKind::InvalidHost(host.to_owned()))?
+        .map_err(|e| Error::InvalidHost(host.to_owned(), e))?
         .map(|addr| addr.ip())
         .partition(|addr| addr.is_ipv4());
 
@@ -88,7 +90,7 @@ fn resolve_to_ip(host: &str) -> Result<IpAddr> {
             log::info!("No IPv4 for host {}", host);
             ipv6.pop()
         })
-        .ok_or_else(|| ErrorKind::InvalidHost(host.to_owned()).into())
+        .ok_or_else(|| Error::HostHasNoIpv4(host.to_owned()))
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -8,9 +8,6 @@
 
 #![deny(rust_2018_idioms)]
 
-#[macro_use]
-extern crate error_chain;
-
 pub mod account;
 pub mod auth_failed;
 pub mod endpoint;

--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -1,5 +1,5 @@
 use super::RESOLV_CONF_PATH;
-use crate::{linux::iface_index, ErrorExt as _};
+use crate::linux::iface_index;
 use dbus::{
     arg::RefArg, stdintf::*, BusType, Interface, Member, Message, MessageItem, MessageItemArray,
     Signature,
@@ -11,6 +11,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
     path::Path,
 };
+use talpid_types::ErrorExt as _;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -60,34 +60,3 @@ mod mktemp;
 /// Misc utilities for the Linux platform.
 #[cfg(target_os = "linux")]
 mod linux;
-
-
-trait ErrorExt {
-    /// Creates a string representation of the entire error chain.
-    fn display_chain(&self) -> String;
-
-    /// Like [`display_chain`] but with an extra message at the start of the chain
-    fn display_chain_with_msg(&self, msg: &str) -> String;
-}
-
-impl<E: std::error::Error> ErrorExt for E {
-    fn display_chain(&self) -> String {
-        let mut s = format!("Error: {}", self);
-        let mut source = self.source();
-        while let Some(error) = source {
-            s.push_str(&format!("\nCaused by: {}", error));
-            source = error.source();
-        }
-        s
-    }
-
-    fn display_chain_with_msg(&self, msg: &str) -> String {
-        let mut s = format!("Error: {}\nCaused by: {}", msg, self);
-        let mut source = self.source();
-        while let Some(error) = source {
-            s.push_str(&format!("\nCaused by: {}", error));
-            source = error.source();
-        }
-        s
-    }
-}

--- a/talpid-core/src/tunnel_state_machine/blocked_state.rs
+++ b/talpid-core/src/tunnel_state_machine/blocked_state.rs
@@ -2,9 +2,9 @@ use super::{
     ConnectingState, DisconnectedState, EventConsequence, SharedTunnelStateValues, TunnelCommand,
     TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
-use crate::{firewall::FirewallPolicy, ErrorExt};
+use crate::firewall::FirewallPolicy;
 use futures::{sync::mpsc, Stream};
-use talpid_types::tunnel::BlockReason;
+use talpid_types::{tunnel::BlockReason, ErrorExt};
 
 /// No tunnel is running and all network connections are blocked.
 pub struct BlockedState {

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -5,7 +5,6 @@ use super::{
 use crate::{
     firewall::FirewallPolicy,
     tunnel::{CloseHandle, TunnelEvent, TunnelMetadata},
-    ErrorExt,
 };
 use futures::{
     sync::{mpsc, oneshot},
@@ -14,6 +13,7 @@ use futures::{
 use talpid_types::{
     net::{Endpoint, TunnelParameters},
     tunnel::BlockReason,
+    ErrorExt,
 };
 
 pub struct ConnectedStateBootstrap {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -6,7 +6,6 @@ use super::{
 use crate::{
     firewall::FirewallPolicy,
     tunnel::{self, CloseHandle, TunnelEvent, TunnelMetadata, TunnelMonitor},
-    ErrorExt,
 };
 use futures::{
     sync::{mpsc, oneshot},
@@ -23,6 +22,7 @@ use std::{
 use talpid_types::{
     net::{openvpn, TunnelParameters},
     tunnel::BlockReason,
+    ErrorExt,
 };
 
 

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -2,8 +2,9 @@ use super::{
     BlockedState, ConnectingState, EventConsequence, SharedTunnelStateValues, TunnelCommand,
     TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
-use crate::{firewall::FirewallPolicy, ErrorExt};
+use crate::firewall::FirewallPolicy;
 use futures::{sync::mpsc, Stream};
+use talpid_types::ErrorExt;
 
 /// No tunnel is running.
 pub struct DisconnectedState;

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -2,13 +2,16 @@ use super::{
     BlockedState, ConnectingState, DisconnectedState, EventConsequence, SharedTunnelStateValues,
     TunnelCommand, TunnelState, TunnelStateTransition, TunnelStateWrapper,
 };
-use crate::{tunnel::CloseHandle, ErrorExt};
+use crate::tunnel::CloseHandle;
 use futures::{
     sync::{mpsc, oneshot},
     Async, Future, Stream,
 };
 use std::thread;
-use talpid_types::tunnel::{ActionAfterDisconnect, BlockReason};
+use talpid_types::{
+    tunnel::{ActionAfterDisconnect, BlockReason},
+    ErrorExt,
+};
 
 /// This state is active from when we manually trigger a tunnel kill until the tunnel wait
 /// operation (TunnelExit) returned.

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -14,7 +14,7 @@ use self::{
     disconnected_state::DisconnectedState,
     disconnecting_state::{AfterDisconnect, DisconnectingState},
 };
-use crate::{dns::DnsMonitor, firewall::Firewall, mpsc::IntoSender, offline, ErrorExt};
+use crate::{dns::DnsMonitor, firewall::Firewall, mpsc::IntoSender, offline};
 use futures::{sync::mpsc, Async, Future, Poll, Stream};
 use std::{
     io,
@@ -25,6 +25,7 @@ use std::{
 use talpid_types::{
     net::TunnelParameters,
     tunnel::{BlockReason, TunnelStateTransition},
+    ErrorExt,
 };
 use tokio_core::reactor::Core;
 

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -11,6 +11,5 @@ serde = { version = "1.0", features = ["derive"] }
 ipnetwork = "0.14"
 base64 = "0.10"
 hex = "0.3"
-error-chain = "0.12"
 x25519-dalek = { version = "0.4.5", features = [ "std", "u64_backend" ], default-features = false }
 rand = "0.6"

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -10,3 +10,34 @@
 
 pub mod net;
 pub mod tunnel;
+
+
+pub trait ErrorExt {
+    /// Creates a string representation of the entire error chain.
+    fn display_chain(&self) -> String;
+
+    /// Like [`display_chain`] but with an extra message at the start of the chain
+    fn display_chain_with_msg(&self, msg: &str) -> String;
+}
+
+impl<E: std::error::Error> ErrorExt for E {
+    fn display_chain(&self) -> String {
+        let mut s = format!("Error: {}", self);
+        let mut source = self.source();
+        while let Some(error) = source {
+            s.push_str(&format!("\nCaused by: {}", error));
+            source = error.source();
+        }
+        s
+    }
+
+    fn display_chain_with_msg(&self, msg: &str) -> String {
+        let mut s = format!("Error: {}\nCaused by: {}", msg, self);
+        let mut source = self.source();
+        while let Some(error) = source {
+            s.push_str(&format!("\nCaused by: {}", error));
+            source = error.source();
+        }
+        s
+    }
+}


### PR DESCRIPTION
Getting rid of `error-chain` in two more crates. `talpid-types` actually already did not use it, but it still specified it as a dependency.

Moving our `ErrorExt` to `taplid-types` which is the crate everyone else depend on directly or indirectly. So it's presumably the best place to place the extension trait so everyone can access it.

In modules where we now have both `ChainedError` and `ErrorExt` we have to call `display_chain` like `ChainedError::display_chain(&e)` in order to tell it which one to use. As we get rid of the last `error_chain!` types this can go back to normal again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/796)
<!-- Reviewable:end -->
