### PR TITLE
Improve firewall rules persistence on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Reset the tray icon padlock to the unsecured state, when losing connectivity with the daemon.
 
+### Changed
+#### Windows
+- Make the firewall rules permanent until reboot, or until the daemon removes them.
+
 ## [2019.3] - 2019-04-02
 ### Fixed
 #### Windows

--- a/talpid-core/src/firewall/android.rs
+++ b/talpid-core/src/firewall/android.rs
@@ -1,4 +1,4 @@
-use super::{FirewallPolicy, FirewallT};
+use super::{FirewallArguments, FirewallPolicy, FirewallT};
 
 /// Stub error type for Firewall errors on Android.
 #[derive(Debug, err_derive::Error)]
@@ -11,7 +11,7 @@ pub struct Firewall;
 impl FirewallT for Firewall {
     type Error = Error;
 
-    fn new() -> Result<Self, Self::Error> {
+    fn new(_args: FirewallArguments) -> Result<Self, Self::Error> {
         Ok(Firewall)
     }
 

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -1,4 +1,4 @@
-use super::{FirewallPolicy, FirewallT};
+use super::{FirewallArguments, FirewallPolicy, FirewallT};
 use crate::tunnel;
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
@@ -83,7 +83,7 @@ pub struct Firewall {
 impl FirewallT for Firewall {
     type Error = Error;
 
-    fn new() -> Result<Self> {
+    fn new(_args: FirewallArguments) -> Result<Self> {
         Ok(Firewall {
             table_name: TABLE_NAME.clone(),
         })

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -1,4 +1,4 @@
-use super::{FirewallPolicy, FirewallT};
+use super::{FirewallArguments, FirewallPolicy, FirewallT};
 use pfctl::FilterRuleAction;
 use std::{
     env,
@@ -24,7 +24,7 @@ pub struct Firewall {
 impl FirewallT for Firewall {
     type Error = Error;
 
-    fn new() -> Result<Self> {
+    fn new(_args: FirewallArguments) -> Result<Self> {
         // Allows controlling whether firewall rules should log to pflog0. Useful for debugging the
         // rules.
         let firewall_debugging = env::var("TALPID_FIREWALL_DEBUG");

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -131,11 +131,19 @@ pub struct Firewall {
     inner: imp::Firewall,
 }
 
+/// Arguments required when first initializing the firewall.
+pub struct FirewallArguments {
+    /// Determines whether the firewall should atomically enter the blocked state during init.
+    pub initialize_blocked: bool,
+    /// This argument is required for the blocked state to configure the firewall correctly.
+    pub allow_lan: Option<bool>,
+}
+
 impl Firewall {
     /// Returns a new `Firewall`, ready to apply policies.
-    pub fn new() -> Result<Self, Error> {
+    pub fn new(args: FirewallArguments) -> Result<Self, Error> {
         Ok(Firewall {
-            inner: imp::Firewall::new()?,
+            inner: imp::Firewall::new(args)?,
         })
     }
 
@@ -160,7 +168,7 @@ trait FirewallT: Sized {
     type Error: std::error::Error;
 
     /// Create new instance
-    fn new() -> Result<Self, Self::Error>;
+    fn new(args: FirewallArguments) -> Result<Self, Self::Error>;
 
     /// Enable the given FirewallPolicy
     fn apply_policy(&mut self, policy: FirewallPolicy) -> Result<(), Self::Error>;

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -14,6 +14,7 @@
 #include "rules/restrictdns.h"
 #include "libwfp/transaction.h"
 #include "libwfp/filterengine.h"
+#include "libwfp/ipaddress.h"
 #include <functional>
 #include <stdexcept>
 #include <utility>
@@ -110,7 +111,14 @@ bool FwContext::applyPolicyConnecting(const WinFwSettings &settings, const WinFw
 	return applyRuleset(ruleset);
 }
 
-bool FwContext::applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *v4Gateway, const wchar_t *v6Gateway)
+bool FwContext::applyPolicyConnected
+(
+	const WinFwSettings &settings,
+	const WinFwRelay &relay,
+	const wchar_t *tunnelInterfaceAlias,
+	const wchar_t *v4DnsHost,
+	const wchar_t *v6DnsHost
+)
 {
 	Ruleset ruleset;
 
@@ -131,11 +139,10 @@ bool FwContext::applyPolicyConnected(const WinFwSettings &settings, const WinFwR
 		tunnelInterfaceAlias
 	));
 
-	/// We currently expect DNS servers to only be ran on the tunnel gateway IPs
 	ruleset.emplace_back(std::make_unique<rules::RestrictDns>(
 		tunnelInterfaceAlias,
-		wfp::IpAddress(v4Gateway),
-		(v6Gateway != nullptr) ? std::make_unique<wfp::IpAddress>(v6Gateway) : nullptr
+		wfp::IpAddress(v4DnsHost),
+		(v6DnsHost != nullptr) ? std::make_unique<wfp::IpAddress>(v6DnsHost) : nullptr
 	));
 
 	return applyRuleset(ruleset);

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -58,7 +58,7 @@ void AppendNetBlockedRules(FwContext::Ruleset &ruleset)
 FwContext::FwContext(uint32_t timeout)
 	: m_baseline(0)
 {
-	auto engine = wfp::FilterEngine::DynamicSession(timeout);
+	auto engine = wfp::FilterEngine::StandardSession(timeout);
 
 	//
 	// Pass engine ownership to "session controller"

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "fwcontext.h"
 #include "mullvadobjects.h"
+#include "objectpurger.h"
 #include "rules/blockall.h"
 #include "rules/ifirewallrule.h"
 #include "rules/permitdhcp.h"
@@ -73,6 +74,26 @@ FwContext::FwContext(uint32_t timeout)
 	m_baseline = m_sessionController->checkpoint();
 }
 
+FwContext::FwContext(uint32_t timeout, const WinFwSettings &settings)
+	: m_baseline(0)
+{
+	auto engine = wfp::FilterEngine::StandardSession(timeout);
+
+	//
+	// Pass engine ownership to "session controller"
+	//
+	m_sessionController = std::make_unique<SessionController>(std::move(engine));
+
+	uint32_t checkpoint = 0;
+
+	if (false == applyBlockedBaseConfiguration(settings, checkpoint))
+	{
+		throw std::runtime_error("Failed to apply base configuration in BFE.");
+	}
+
+	m_baseline = checkpoint;
+}
+
 bool FwContext::applyPolicyConnecting(const WinFwSettings &settings, const WinFwRelay &relay)
 {
 	Ruleset ruleset;
@@ -122,51 +143,89 @@ bool FwContext::applyPolicyConnected(const WinFwSettings &settings, const WinFwR
 
 bool FwContext::applyPolicyBlocked(const WinFwSettings &settings)
 {
+	return applyRuleset(composePolicyBlocked(settings));
+}
+
+bool FwContext::reset()
+{
+	return m_sessionController->executeTransaction([this](SessionController &controller, wfp::FilterEngine &)
+	{
+		return controller.revert(m_baseline), true;
+	});
+}
+
+FwContext::Ruleset FwContext::composePolicyBlocked(const WinFwSettings &settings)
+{
 	Ruleset ruleset;
 
 	AppendNetBlockedRules(ruleset);
 	AppendSettingsRules(ruleset, settings);
 
-	return applyRuleset(ruleset);
-}
-
-bool FwContext::reset()
-{
-	return m_sessionController->executeTransaction([this]()
-	{
-		m_sessionController->revert(m_baseline);
-		return true;
-	});
-}
-
-bool FwContext::applyRuleset(const Ruleset &ruleset)
-{
-	return m_sessionController->executeTransaction([&]()
-	{
-		m_sessionController->revert(m_baseline);
-
-		for (const auto &rule : ruleset)
-		{
-			if (false == rule->apply(*m_sessionController))
-			{
-				return false;
-			}
-		}
-
-		return true;
-	});
+	return ruleset;
 }
 
 bool FwContext::applyBaseConfiguration()
 {
-	return m_sessionController->executeTransaction([&]()
+	return m_sessionController->executeTransaction([this](SessionController &controller, wfp::FilterEngine &engine)
 	{
-		//
-		// Install structural objects
-		//
-
-		return m_sessionController->addProvider(*MullvadObjects::Provider())
-			&& m_sessionController->addSublayer(*MullvadObjects::SublayerWhitelist())
-			&& m_sessionController->addSublayer(*MullvadObjects::SublayerBlacklist());
+		return applyCommonBaseConfiguration(controller, engine);
 	});
+}
+
+bool FwContext::applyBlockedBaseConfiguration(const WinFwSettings &settings, uint32_t &checkpoint)
+{
+	return m_sessionController->executeTransaction([&](SessionController &controller, wfp::FilterEngine &engine)
+	{
+		if (false == applyCommonBaseConfiguration(controller, engine))
+		{
+			return false;
+		}
+
+		//
+		// Record the current session state with only structural objects added.
+		// If we snapshot at a later time we'd accidentally include the blocking policy rules
+		// in the baseline checkpoint.
+		//
+		checkpoint = controller.peekCheckpoint();
+
+		return applyRulesetDirectly(composePolicyBlocked(settings), controller);
+	});
+}
+
+bool FwContext::applyCommonBaseConfiguration(SessionController &controller, wfp::FilterEngine &engine)
+{
+	//
+	// Since we're using a standard WFP session we can make no assumptions
+	// about which objects are already installed since before.
+	//
+	ObjectPurger::GetRemoveAllFunctor()(engine);
+
+	//
+	// Install structural objects
+	//
+	return controller.addProvider(*MullvadObjects::Provider())
+		&& controller.addSublayer(*MullvadObjects::SublayerWhitelist())
+		&& controller.addSublayer(*MullvadObjects::SublayerBlacklist());
+}
+
+bool FwContext::applyRuleset(const Ruleset &ruleset)
+{
+	return m_sessionController->executeTransaction([&](SessionController &controller, wfp::FilterEngine &)
+	{
+		controller.revert(m_baseline);
+		return applyRulesetDirectly(ruleset, controller);
+	});
+}
+
+bool FwContext::applyRulesetDirectly(const Ruleset &ruleset, SessionController &controller)
+{
+	for (const auto &rule : ruleset)
+	{
+		if (false == rule->apply(controller))
+		{
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -13,6 +13,9 @@ public:
 
 	FwContext(uint32_t timeout);
 
+	// This ctor applies the "blocked" policy.
+	FwContext(uint32_t timeout, const WinFwSettings &settings);
+
 	bool applyPolicyConnecting(const WinFwSettings &settings, const WinFwRelay &relay);
 	bool applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *v4DnsHosts, const wchar_t *v6DnsHost);
 	bool applyPolicyBlocked(const WinFwSettings &settings);
@@ -26,8 +29,14 @@ private:
 	FwContext(const FwContext &) = delete;
 	FwContext &operator=(const FwContext &) = delete;
 
+	Ruleset composePolicyBlocked(const WinFwSettings &settings);
+
 	bool applyBaseConfiguration();
+	bool applyBlockedBaseConfiguration(const WinFwSettings &settings, uint32_t &checkpoint);
+	bool applyCommonBaseConfiguration(SessionController &controller, wfp::FilterEngine &engine);
+
 	bool applyRuleset(const Ruleset &ruleset);
+	bool applyRulesetDirectly(const Ruleset &ruleset, SessionController &controller);
 
 	std::unique_ptr<SessionController> m_sessionController;
 

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -17,7 +17,14 @@ public:
 	FwContext(uint32_t timeout, const WinFwSettings &settings);
 
 	bool applyPolicyConnecting(const WinFwSettings &settings, const WinFwRelay &relay);
-	bool applyPolicyConnected(const WinFwSettings &settings, const WinFwRelay &relay, const wchar_t *tunnelInterfaceAlias, const wchar_t *v4DnsHosts, const wchar_t *v6DnsHost);
+	bool applyPolicyConnected
+	(
+		const WinFwSettings &settings,
+		const WinFwRelay &relay,
+		const wchar_t *tunnelInterfaceAlias,
+		const wchar_t *v4DnsHost,
+		const wchar_t *v6DnsHost
+	);
 	bool applyPolicyBlocked(const WinFwSettings &settings);
 
 	bool reset();

--- a/windows/winfw/src/winfw/guidhash.h
+++ b/windows/winfw/src/winfw/guidhash.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <guiddef.h>
+
+// Specialize std::hash
+namespace std
+{
+
+template<>
+struct hash<GUID>
+{
+	size_t operator()(const GUID &guid) const noexcept
+	{
+		static_assert(sizeof(GUID) == (2 * sizeof(uint64_t)));
+
+		// MOV on x86 supports non-aligned access.
+		auto data = reinterpret_cast<const uint64_t *>(&guid);
+
+		return hash<uint64_t>()(data[0] ^ data[1]);
+	}
+};
+
+}

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -1,5 +1,82 @@
 #include "stdafx.h"
 #include "mullvadguids.h"
+#include <algorithm>
+#include <iterator>
+
+//static
+WfpObjectRegistry MullvadGuids::BuildRegistry()
+{
+	const auto detailedRegistry = DetailedRegistry();
+	using ValueType = decltype(detailedRegistry)::const_reference;
+
+	std::unordered_set<GUID> registry;
+
+	std::transform(detailedRegistry.begin(), detailedRegistry.end(), std::inserter(registry, registry.end()), [](ValueType value)
+	{
+		return value.second;
+	});
+
+	return registry;
+}
+
+//static
+DetailedWfpObjectRegistry MullvadGuids::BuildDetailedRegistry()
+{
+	std::multimap<WfpObjectType, GUID> registry;
+
+	registry.insert(std::make_pair(WfpObjectType::Provider, Provider()));
+	registry.insert(std::make_pair(WfpObjectType::Sublayer, SublayerWhitelist()));
+	registry.insert(std::make_pair(WfpObjectType::Sublayer, SublayerBlacklist()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterBlockAll_Outbound_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterBlockAll_Outbound_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterBlockAll_Inbound_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterBlockAll_Inbound_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLan_10_8()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLan_172_16_12()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLan_192_168_16()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLan_169_254_16()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLan_Multicast()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLan_Ipv6_fe80_10()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLan_Ipv6_Multicast()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLanService_10_8()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLanService_172_16_12()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLanService_192_168_16()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLanService_169_254_16()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLanService_Ipv6_fe80_10()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLoopback_Outbound_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLoopback_Outbound_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLoopback_Inbound_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitLoopback_Inbound_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitDhcpV4_Outbound_Request()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitDhcpV6_Outbound_Request()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitDhcpV4_Inbound_Response()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitDhcpV6_Inbound_Response()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitVpnRelay()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitVpnTunnel_Outbound_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitVpnTunnel_Outbound_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Tunnel_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Tunnel_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitVpnTunnelService_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitVpnTunnelService_Ipv6()));
+
+	return registry;
+}
+
+//static
+const WfpObjectRegistry &MullvadGuids::Registry()
+{
+	static auto registry = BuildRegistry();	// TODO: Thread safety.
+	return registry;
+}
+
+//static
+const DetailedWfpObjectRegistry &MullvadGuids::DetailedRegistry()
+{
+	static auto registry = BuildDetailedRegistry();	// TODO: Thread safety.
+	return registry;
+}
 
 //static
 const GUID &MullvadGuids::Provider()

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -1,9 +1,23 @@
 #pragma once
+
+#include "wfpobjecttype.h"
+#include "guidhash.h"
 #include <guiddef.h>
+#include <unordered_set>
+#include <map>
+
+using WfpObjectRegistry = std::unordered_set<GUID>;
+using DetailedWfpObjectRegistry = std::multimap<WfpObjectType, GUID>;
 
 class MullvadGuids
 {
+	static WfpObjectRegistry BuildRegistry();
+	static DetailedWfpObjectRegistry BuildDetailedRegistry();
+
 public:
+
+	static const WfpObjectRegistry &Registry();
+	static const DetailedWfpObjectRegistry &DetailedRegistry();
 
 	MullvadGuids() = delete;
 

--- a/windows/winfw/src/winfw/objectpurger.cpp
+++ b/windows/winfw/src/winfw/objectpurger.cpp
@@ -4,6 +4,7 @@
 #include "wfpobjecttype.h"
 #include "libwfp/filterengine.h"
 #include "libwfp/objectdeleter.h"
+#include "libwfp/transaction.h"
 #include <algorithm>
 
 namespace
@@ -51,4 +52,17 @@ ObjectPurger::RemovalFunctor ObjectPurger::GetRemoveAllFunctor()
 		RemoveRange(engine, wfp::ObjectDeleter::DeleteSublayer, registry.equal_range(WfpObjectType::Sublayer));
 		RemoveRange(engine, wfp::ObjectDeleter::DeleteProvider, registry.equal_range(WfpObjectType::Provider));
 	};
+}
+
+//static
+bool ObjectPurger::Execute(RemovalFunctor f)
+{
+	auto engine = wfp::FilterEngine::StandardSession();
+
+	auto wrapper = [&]()
+	{
+		return f(*engine), true;
+	};
+
+	return wfp::Transaction::Execute(*engine, wrapper);
 }

--- a/windows/winfw/src/winfw/objectpurger.cpp
+++ b/windows/winfw/src/winfw/objectpurger.cpp
@@ -1,0 +1,54 @@
+#include "stdafx.h"
+#include "objectpurger.h"
+#include "mullvadguids.h"
+#include "wfpobjecttype.h"
+#include "libwfp/filterengine.h"
+#include "libwfp/objectdeleter.h"
+#include <algorithm>
+
+namespace
+{
+
+using ObjectDeleter = std::function<void(wfp::FilterEngine &, const GUID &)>;
+
+template<typename TRange>
+void RemoveRange(wfp::FilterEngine &engine, ObjectDeleter deleter, TRange range)
+{
+	std::for_each(range.first, range.second, [&](const auto &record)
+	{
+		const GUID &objectId = record.second;
+		deleter(engine, objectId);
+	});
+}
+
+} // anonymous namespace
+
+//static
+ObjectPurger::RemovalFunctor ObjectPurger::GetRemoveFiltersFunctor()
+{
+	return [](wfp::FilterEngine &engine)
+	{
+		const auto registry = MullvadGuids::DetailedRegistry();
+
+		// Resolve correct overload.
+		void (*deleter)(wfp::FilterEngine &, const GUID &) = wfp::ObjectDeleter::DeleteFilter;
+
+		RemoveRange(engine, deleter, registry.equal_range(WfpObjectType::Filter));
+	};
+}
+
+//static
+ObjectPurger::RemovalFunctor ObjectPurger::GetRemoveAllFunctor()
+{
+	return [](wfp::FilterEngine &engine)
+	{
+		const auto registry = MullvadGuids::DetailedRegistry();
+
+		// Resolve correct overload.
+		void(*deleter)(wfp::FilterEngine &, const GUID &) = wfp::ObjectDeleter::DeleteFilter;
+
+		RemoveRange(engine, deleter, registry.equal_range(WfpObjectType::Filter));
+		RemoveRange(engine, wfp::ObjectDeleter::DeleteSublayer, registry.equal_range(WfpObjectType::Sublayer));
+		RemoveRange(engine, wfp::ObjectDeleter::DeleteProvider, registry.equal_range(WfpObjectType::Provider));
+	};
+}

--- a/windows/winfw/src/winfw/objectpurger.h
+++ b/windows/winfw/src/winfw/objectpurger.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "winfw.h"
+#include "libwfp/filterengine.h"
+#include <cstdint>
+#include <functional>
+
+class ObjectPurger
+{
+public:
+
+	ObjectPurger() = delete;
+
+	using RemovalFunctor = std::function<void(wfp::FilterEngine &engine)>;
+
+	static RemovalFunctor GetRemoveFiltersFunctor();
+	static RemovalFunctor GetRemoveAllFunctor();
+};

--- a/windows/winfw/src/winfw/objectpurger.h
+++ b/windows/winfw/src/winfw/objectpurger.h
@@ -15,4 +15,6 @@ public:
 
 	static RemovalFunctor GetRemoveFiltersFunctor();
 	static RemovalFunctor GetRemoveAllFunctor();
+
+	static bool Execute(RemovalFunctor f);
 };

--- a/windows/winfw/src/winfw/sessioncontroller.cpp
+++ b/windows/winfw/src/winfw/sessioncontroller.cpp
@@ -227,6 +227,16 @@ uint32_t SessionController::checkpoint()
 	return m_records.back().key();
 }
 
+uint32_t SessionController::peekCheckpoint()
+{
+	if (m_transactionRecords.empty())
+	{
+		return 0;
+	}
+
+	return m_transactionRecords.back().key();
+}
+
 void SessionController::revert(uint32_t key)
 {
 	if (false == m_activeTransaction)

--- a/windows/winfw/src/winfw/sessioncontroller.cpp
+++ b/windows/winfw/src/winfw/sessioncontroller.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "sessioncontroller.h"
+#include "wfpobjecttype.h"
 #include "libwfp/objectinstaller.h"
 #include "libwfp/objectdeleter.h"
 #include "libwfp/transaction.h"
@@ -95,7 +96,7 @@ bool SessionController::addProvider(wfp::ProviderBuilder &providerBuilder)
 
 	if (status)
 	{
-		m_transactionRecords.emplace_back(SessionRecord(key, SessionRecord::ObjectType::Provider));
+		m_transactionRecords.emplace_back(SessionRecord(key, WfpObjectType::Provider));
 	}
 
 	return status;
@@ -114,7 +115,7 @@ bool SessionController::addSublayer(wfp::SublayerBuilder &sublayerBuilder)
 
 	if (status)
 	{
-		m_transactionRecords.emplace_back(SessionRecord(key, SessionRecord::ObjectType::Sublayer));
+		m_transactionRecords.emplace_back(SessionRecord(key, WfpObjectType::Sublayer));
 	}
 
 	return status;

--- a/windows/winfw/src/winfw/sessioncontroller.h
+++ b/windows/winfw/src/winfw/sessioncontroller.h
@@ -4,6 +4,7 @@
 #include "sessionrecord.h"
 #include "libwfp/filterengine.h"
 #include "libwfp/iidentifiable.h"
+#include <functional>
 #include <atomic>
 #include <memory>
 #include <vector>
@@ -19,8 +20,10 @@ public:
 	bool addSublayer(wfp::SublayerBuilder &sublayerBuilder) override;
 	bool addFilter(wfp::FilterBuilder &filterBuilder, const wfp::IConditionBuilder &conditionBuilder) override;
 
-	bool executeTransaction(std::function<bool()> operation);
-	bool executeReadOnlyTransaction(std::function<bool()> operation);
+	using TransactionFunctor = std::function<bool(SessionController &, wfp::FilterEngine &)>;
+
+	bool executeTransaction(TransactionFunctor operation);
+	bool executeReadOnlyTransaction(TransactionFunctor operation);
 
 	//
 	// Retrieve checkpoint key that can be used to restore the current session state

--- a/windows/winfw/src/winfw/sessioncontroller.h
+++ b/windows/winfw/src/winfw/sessioncontroller.h
@@ -32,6 +32,11 @@ public:
 	uint32_t checkpoint();
 
 	//
+	// Hack. Read checkpoint while currently inside a transaction.
+	//
+	uint32_t peekCheckpoint();
+
+	//
 	// Purge objects in the stack and return to an earlier state
 	// Use only inside active transaction
 	//

--- a/windows/winfw/src/winfw/sessioncontroller.h
+++ b/windows/winfw/src/winfw/sessioncontroller.h
@@ -3,6 +3,7 @@
 #include "iobjectinstaller.h"
 #include "sessionrecord.h"
 #include "libwfp/filterengine.h"
+#include "libwfp/iidentifiable.h"
 #include <atomic>
 #include <memory>
 #include <vector>

--- a/windows/winfw/src/winfw/sessionrecord.cpp
+++ b/windows/winfw/src/winfw/sessionrecord.cpp
@@ -12,7 +12,7 @@ std::atomic<uint32_t> g_keybase = 0;
 
 } // anonymous namespace
 
-SessionRecord::SessionRecord(const GUID &id, ObjectType type)
+SessionRecord::SessionRecord(const GUID &id, WfpObjectType type)
 	: m_type(type)
 	, m_id(id)
 	, m_key(g_keybase++)
@@ -20,7 +20,7 @@ SessionRecord::SessionRecord(const GUID &id, ObjectType type)
 }
 
 SessionRecord::SessionRecord(UINT64 id)
-	: m_type(ObjectType::Filter)
+	: m_type(WfpObjectType::Filter)
 	, m_filterId(id)
 	, m_key(g_keybase++)
 {
@@ -30,17 +30,17 @@ void SessionRecord::purge(wfp::FilterEngine &engine)
 {
 	switch (m_type)
 	{
-		case ObjectType::Provider:
+		case WfpObjectType::Provider:
 		{
 			wfp::ObjectDeleter::DeleteProvider(engine, m_id);
 			break;
 		}
-		case ObjectType::Sublayer:
+		case WfpObjectType::Sublayer:
 		{
 			wfp::ObjectDeleter::DeleteSublayer(engine, m_id);
 			break;
 		}
-		case ObjectType::Filter:
+		case WfpObjectType::Filter:
 		{
 			wfp::ObjectDeleter::DeleteFilter(engine, m_filterId);
 			break;

--- a/windows/winfw/src/winfw/sessionrecord.h
+++ b/windows/winfw/src/winfw/sessionrecord.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "libwfp/filterengine.h"
+#include "wfpobjecttype.h"
 #include <guiddef.h>
 #include <windows.h>
 
@@ -8,14 +9,7 @@ class SessionRecord
 {
 public:
 
-	enum class ObjectType
-	{
-		Provider,
-		Sublayer,
-		Filter
-	};
-
-	SessionRecord(const GUID &id, ObjectType type);
+	SessionRecord(const GUID &id, WfpObjectType type);
 	SessionRecord(UINT64 id);
 
 	SessionRecord(const SessionRecord &) = default;
@@ -28,7 +22,7 @@ public:
 
 private:
 
-	ObjectType m_type;
+	WfpObjectType m_type;
 
 	GUID m_id;
 	UINT64 m_filterId;

--- a/windows/winfw/src/winfw/wfpobjecttype.h
+++ b/windows/winfw/src/winfw/wfpobjecttype.h
@@ -1,0 +1,8 @@
+#pragma once
+
+enum class WfpObjectType
+{
+	Provider,
+	Sublayer,
+	Filter
+};

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -62,6 +62,53 @@ WinFw_Initialize(
 	return true;
 }
 
+extern "C"
+WINFW_LINKAGE
+bool
+WINFW_API
+WinFw_InitializeBlocked(
+	uint32_t timeout,
+	const WinFwSettings &settings,
+	WinFwErrorSink errorSink,
+	void *errorContext
+)
+{
+	if (nullptr != g_fwContext)
+	{
+		//
+		// This is an error.
+		// The existing instance may have a different timeout etc.
+		//
+		return false;
+	}
+
+	// Convert seconds to milliseconds.
+	g_timeout = timeout * 1000;
+
+	g_errorSink = errorSink;
+	g_errorContext = errorContext;
+
+	try
+	{
+		g_fwContext = new FwContext(g_timeout, settings);
+	}
+	catch (std::exception &err)
+	{
+		if (nullptr != g_errorSink)
+		{
+			g_errorSink(err.what(), g_errorContext);
+		}
+
+		return false;
+	}
+	catch (...)
+	{
+		return false;
+	}
+
+	return true;
+}
+
 WINFW_LINKAGE
 bool
 WINFW_API

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -10,8 +10,8 @@ namespace
 
 uint32_t g_timeout = 0;
 
-WinFwErrorSink g_ErrorSink = nullptr;
-void * g_ErrorContext = nullptr;
+WinFwErrorSink g_errorSink = nullptr;
+void * g_errorContext = nullptr;
 
 FwContext *g_fwContext = nullptr;
 
@@ -38,8 +38,8 @@ WinFw_Initialize(
 	// Convert seconds to milliseconds.
 	g_timeout = timeout * 1000;
 
-	g_ErrorSink = errorSink;
-	g_ErrorContext = errorContext;
+	g_errorSink = errorSink;
+	g_errorContext = errorContext;
 
 	try
 	{
@@ -47,9 +47,9 @@ WinFw_Initialize(
 	}
 	catch (std::exception &err)
 	{
-		if (nullptr != g_ErrorSink)
+		if (nullptr != g_errorSink)
 		{
-			g_ErrorSink(err.what(), g_ErrorContext);
+			g_errorSink(err.what(), g_errorContext);
 		}
 
 		return false;
@@ -97,9 +97,9 @@ WinFw_ApplyPolicyConnecting(
 	}
 	catch (std::exception &err)
 	{
-		if (nullptr != g_ErrorSink)
+		if (nullptr != g_errorSink)
 		{
-			g_ErrorSink(err.what(), g_ErrorContext);
+			g_errorSink(err.what(), g_errorContext);
 		}
 
 		return false;
@@ -132,9 +132,9 @@ WinFw_ApplyPolicyConnected(
 	}
 	catch (std::exception &err)
 	{
-		if (nullptr != g_ErrorSink)
+		if (nullptr != g_errorSink)
 		{
-			g_ErrorSink(err.what(), g_ErrorContext);
+			g_errorSink(err.what(), g_errorContext);
 		}
 
 		return false;
@@ -163,9 +163,9 @@ WinFw_ApplyPolicyBlocked(
 	}
 	catch (std::exception &err)
 	{
-		if (nullptr != g_ErrorSink)
+		if (nullptr != g_errorSink)
 		{
-			g_ErrorSink(err.what(), g_ErrorContext);
+			g_errorSink(err.what(), g_errorContext);
 		}
 
 		return false;
@@ -196,9 +196,9 @@ WinFw_Reset()
 	}
 	catch (std::exception &err)
 	{
-		if (nullptr != g_ErrorSink)
+		if (nullptr != g_errorSink)
 		{
-			g_ErrorSink(err.what(), g_ErrorContext);
+			g_errorSink(err.what(), g_errorContext);
 		}
 
 		return false;

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "winfw.h"
 #include "fwcontext.h"
+#include "objectpurger.h"
 #include "libwfp/ipaddress.h"
 #include <windows.h>
 #include <stdexcept>
@@ -228,17 +229,13 @@ bool
 WINFW_API
 WinFw_Reset()
 {
-	if (nullptr == g_fwContext)
-	{
-		//
-		// This is OK because the practical difference between having no instance
-		// and having a reset instance is negligible.
-		//
-		return true;
-	}
-
 	try
 	{
+		if (nullptr == g_fwContext)
+		{
+			return ObjectPurger::Execute(ObjectPurger::GetRemoveAllFunctor());
+		}
+
 		return g_fwContext->reset();
 	}
 	catch (std::exception &err)

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -2,7 +2,6 @@
 #include "winfw.h"
 #include "fwcontext.h"
 #include "objectpurger.h"
-#include "libwfp/ipaddress.h"
 #include <windows.h>
 #include <stdexcept>
 
@@ -165,8 +164,8 @@ WinFw_ApplyPolicyConnected(
 	const WinFwSettings &settings,
 	const WinFwRelay &relay,
 	const wchar_t *tunnelInterfaceAlias,
-	const wchar_t *v4Gateway,
-	const wchar_t *v6Gateway
+	const wchar_t *v4DnsHost,
+	const wchar_t *v6DnsHost
 )
 {
 	if (nullptr == g_fwContext)
@@ -176,7 +175,7 @@ WinFw_ApplyPolicyConnected(
 
 	try
 	{
-		return g_fwContext->applyPolicyConnected(settings, relay, tunnelInterfaceAlias, v4Gateway, v6Gateway);
+		return g_fwContext->applyPolicyConnected(settings, relay, tunnelInterfaceAlias, v4DnsHost, v6DnsHost);
 	}
 	catch (std::exception &err)
 	{

--- a/windows/winfw/src/winfw/winfw.def
+++ b/windows/winfw/src/winfw/winfw.def
@@ -2,6 +2,7 @@ LIBRARY winfw
 EXPORTS
 
 WinFw_Initialize
+WinFw_InitializeBlocked
 WinFw_Deinitialize
 WinFw_ApplyPolicyConnecting
 WinFw_ApplyPolicyConnected

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -73,6 +73,27 @@ WinFw_Initialize(
 );
 
 //
+// WinFw_InitializeBlocked
+//
+// Same as `WinFw_Initialize` with the addition that the blocked policy is
+// immediately applied, within the same initialization transaction.
+//
+// This function is preferred rather than first initializing and then applying
+// the blocked policy. Using two separate operations leaves a tiny window
+// for traffic to leak out.
+//
+extern "C"
+WINFW_LINKAGE
+bool
+WINFW_API
+WinFw_InitializeBlocked(
+	uint32_t timeout,
+	const WinFwSettings &settings,
+	WinFwErrorSink errorSink,
+	void *errorContext
+);
+
+//
 // Deinitialize:
 //
 // Call this function once before unloading WINFW or exiting the process.

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -133,7 +133,7 @@ WinFw_ApplyPolicyConnecting(
 //
 // tunnelInterfaceAlias:
 //   Friendly name of VPN tunnel interface
-// primaryDns:
+// v4DnsHost/v6DnsHost:
 //   String encoded IP address of DNS to use inside tunnel
 //
 extern "C"
@@ -144,8 +144,8 @@ WinFw_ApplyPolicyConnected(
 	const WinFwSettings &settings,
 	const WinFwRelay &relay,
 	const wchar_t *tunnelInterfaceAlias,
-	const wchar_t *v4Gateway,
-	const wchar_t *v6Gateway
+	const wchar_t *v4DnsHost,
+	const wchar_t *v6DnsHost
 );
 
 //

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -43,9 +43,11 @@
     <ClCompile Include="winfw.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="guidhash.h" />
     <ClInclude Include="iobjectinstaller.h" />
     <ClInclude Include="mullvadguids.h" />
     <ClInclude Include="mullvadobjects.h" />
+    <ClInclude Include="wfpobjecttype.h" />
     <ClInclude Include="rules\blockall.h" />
     <ClInclude Include="rules\ifirewallrule.h" />
     <ClInclude Include="rules\permitdhcp.h" />

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="mullvadguids.cpp" />
     <ClCompile Include="mullvadobjects.cpp" />
+    <ClCompile Include="objectpurger.cpp" />
     <ClCompile Include="rules\blockall.cpp" />
     <ClCompile Include="rules\permitdhcp.cpp" />
     <ClCompile Include="rules\permitlan.cpp" />
@@ -47,6 +48,7 @@
     <ClInclude Include="iobjectinstaller.h" />
     <ClInclude Include="mullvadguids.h" />
     <ClInclude Include="mullvadobjects.h" />
+    <ClInclude Include="objectpurger.h" />
     <ClInclude Include="wfpobjecttype.h" />
     <ClInclude Include="rules\blockall.h" />
     <ClInclude Include="rules\ifirewallrule.h" />

--- a/windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -77,6 +77,8 @@
     <ClInclude Include="rules\permitvpntunnelservice.h">
       <Filter>rules</Filter>
     </ClInclude>
+    <ClInclude Include="wfpobjecttype.h" />
+    <ClInclude Include="guidhash.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="rules">

--- a/windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -36,6 +36,7 @@
     <ClCompile Include="rules\permitvpntunnelservice.cpp">
       <Filter>rules</Filter>
     </ClCompile>
+    <ClCompile Include="objectpurger.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -79,6 +80,7 @@
     </ClInclude>
     <ClInclude Include="wfpobjecttype.h" />
     <ClInclude Include="guidhash.h" />
+    <ClInclude Include="objectpurger.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="rules">


### PR DESCRIPTION
Lots of changes:

* Firewall rules are installed to stick until the next reboot, or until the daemon removes them.

* We now maintain a registry with GUIDs of all the objects we might install into WFP, so we can purge them all will.

* Initialization updated to purge firewall before establishing baseline.

* Cannot install WFP objects that are not in the registry to prevent issues down the road.

* Initialization extended to atomically enter the blocked state during init, if applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/797)
<!-- Reviewable:end -->
