### PR TITLE
Get rid of error-chain in talpid offline module

### DIFF
--- a/talpid-core/src/offline/dummy.rs
+++ b/talpid-core/src/offline/dummy.rs
@@ -1,11 +1,12 @@
 use crate::tunnel_state_machine::TunnelCommand;
 use futures::sync::mpsc::UnboundedSender;
 
-error_chain! {}
+#[derive(err_derive::Error, Debug)]
+pub struct Error(());
 
 pub struct MonitorHandle;
 
-pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
+pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle, Error> {
     Ok(MonitorHandle)
 }
 


### PR DESCRIPTION
Getting rid of `error_chain!` in `talpid-core::offline` module for all platforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/798)
<!-- Reviewable:end -->
