### PR TITLE
Eliminate error chain in talpid-core and openvpn plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,6 @@ dependencies = [
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,13 +2046,14 @@ name = "talpid-openvpn-plugin"
 version = "0.1.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
  "talpid-ipc 0.1.0",
+ "talpid-types 0.1.0",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 atty = "0.2"
 derive_more = "0.14"
 duct = "0.12"
-error-chain = "0.12"
 err-derive = "0.1.5"
 futures = "0.1"
 jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }

--- a/talpid-core/src/dns/linux/static_resolv_conf.rs
+++ b/talpid-core/src/dns/linux/static_resolv_conf.rs
@@ -1,5 +1,4 @@
 use super::RESOLV_CONF_PATH;
-use error_chain::ChainedError;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::Mutex;
 use resolv_conf::{Config, ScopedIp};
@@ -9,27 +8,28 @@ use std::{
     sync::{mpsc, Arc},
     thread,
 };
+use talpid_types::ErrorExt;
 
 const RESOLV_CONF_BACKUP_PATH: &str = "/etc/resolv.conf.mullvadbackup";
 
-error_chain! {
-    errors {
-        WatchResolvConf {
-            description("Failed to watch /etc/resolv.conf for changes")
-        }
+pub type Result<T> = std::result::Result<T, Error>;
 
-        WriteResolvConf {
-            description("Failed to write to /etc/resolv.conf")
-        }
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    #[error(display = "Failed to watch /etc/resolv.conf for changes")]
+    WatchResolvConf(#[error(cause)] notify::Error),
 
-        BackupResolvConf {
-            description("Failed to create backup of /etc/resolv.conf")
-        }
+    #[error(display = "Failed to write to {}", _0)]
+    WriteResolvConf(&'static str, #[error(cause)] io::Error),
 
-        RestoreResolvConf {
-            description("Failed to restore /etc/resolv.conf from backup")
-        }
-    }
+    #[error(display = "Failed to read from {}", _0)]
+    ReadResolvConf(&'static str, #[error(cause)] io::Error),
+
+    #[error(display = "resolv.conf at {} could not be parsed", _0)]
+    ParseError(&'static str, #[error(cause)] resolv_conf::ParseError),
+
+    #[error(display = "Failed to remove stale resolv.conf backup at {}", _0)]
+    RemoveBackup(&'static str, #[error(cause)] io::Error),
 }
 
 pub struct StaticResolvConf {
@@ -39,7 +39,7 @@ pub struct StaticResolvConf {
 
 impl StaticResolvConf {
     pub fn new() -> Result<Self> {
-        restore_from_backup().chain_err(|| ErrorKind::RestoreResolvConf)?;
+        restore_from_backup()?;
 
         let state = Arc::new(Mutex::new(None));
         let watcher = DnsWatcher::start(state.clone())?;
@@ -54,8 +54,8 @@ impl StaticResolvConf {
         let mut state = self.state.lock();
         let new_state = match state.take() {
             None => {
-                let backup = read_config().chain_err(|| ErrorKind::BackupResolvConf)?;
-                write_backup(&backup).chain_err(|| ErrorKind::BackupResolvConf)?;
+                let backup = read_config()?;
+                write_backup(&backup)?;
 
                 State {
                     backup,
@@ -111,11 +111,11 @@ struct DnsWatcher {
 impl DnsWatcher {
     fn start(state: Arc<Mutex<Option<State>>>) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::channel();
-        let mut watcher = notify::raw_watcher(event_tx).chain_err(|| ErrorKind::WatchResolvConf)?;
+        let mut watcher = notify::raw_watcher(event_tx).map_err(Error::WatchResolvConf)?;
 
         watcher
             .watch(RESOLV_CONF_PATH, RecursiveMode::NonRecursive)
-            .chain_err(|| ErrorKind::WatchResolvConf)?;
+            .map_err(Error::WatchResolvConf)?;
 
         thread::spawn(move || Self::event_loop(event_rx, &state));
 
@@ -127,9 +127,12 @@ impl DnsWatcher {
             let mut locked_state = state.lock();
 
             if let Err(error) = Self::update(locked_state.as_mut()) {
-                let chained_error = error
-                    .chain_err(|| "Failed to update DNS state after DNS settings have changed.");
-                log::error!("{}", chained_error.display_chain());
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg(
+                        "Failed to update DNS state after DNS settings changed"
+                    )
+                );
             }
         }
     }
@@ -153,7 +156,7 @@ impl DnsWatcher {
                 new_config.nameservers.append(&mut state.backup.nameservers);
                 state.backup = new_config;
 
-                write_backup(&state.backup).chain_err(|| "Failed to update /etc/resolv.conf backup")
+                write_backup(&state.backup)
             }
         } else {
             Ok(())
@@ -162,22 +165,21 @@ impl DnsWatcher {
 }
 
 fn read_config() -> Result<Config> {
-    let contents =
-        fs::read_to_string(RESOLV_CONF_PATH).chain_err(|| "Failed to read /etc/resolv.conf")?;
-    let config =
-        Config::parse(&contents).chain_err(|| "Failed to parse contents of /etc/resolv.conf")?;
+    let contents = fs::read_to_string(RESOLV_CONF_PATH)
+        .map_err(|e| Error::ReadResolvConf(RESOLV_CONF_PATH, e))?;
+    let config = Config::parse(&contents).map_err(|e| Error::ParseError(RESOLV_CONF_PATH, e))?;
 
     Ok(config)
 }
 
 fn write_config(config: &Config) -> Result<()> {
     fs::write(RESOLV_CONF_PATH, config.to_string().as_bytes())
-        .chain_err(|| ErrorKind::WriteResolvConf)
+        .map_err(|e| Error::WriteResolvConf(RESOLV_CONF_PATH, e))
 }
 
 fn write_backup(backup: &Config) -> Result<()> {
     fs::write(RESOLV_CONF_BACKUP_PATH, backup.to_string().as_bytes())
-        .chain_err(|| "Failed to write to /etc/resolv.conf backup file")
+        .map_err(|e| Error::WriteResolvConf(RESOLV_CONF_BACKUP_PATH, e))
 }
 
 fn restore_from_backup() -> Result<()> {
@@ -185,20 +187,17 @@ fn restore_from_backup() -> Result<()> {
         Ok(backup) => {
             log::info!("Restoring DNS state from backup");
             let config = Config::parse(&backup)
-                .chain_err(|| "Backup of /etc/resolv.conf could not be parsed")?;
+                .map_err(|e| Error::ParseError(RESOLV_CONF_BACKUP_PATH, e))?;
 
             write_config(&config)?;
 
             fs::remove_file(RESOLV_CONF_BACKUP_PATH)
-                .chain_err(|| "Failed to remove stale backup of /etc/resolv.conf")
+                .map_err(|e| Error::RemoveBackup(RESOLV_CONF_BACKUP_PATH, e))
         }
         Err(ref error) if error.kind() == io::ErrorKind::NotFound => {
             log::debug!("No DNS state backup to restore");
             Ok(())
         }
-        Err(error) => Err(Error::with_chain(
-            error,
-            "Failed to read /etc/resolv.conf backup",
-        )),
+        Err(error) => Err(Error::ReadResolvConf(RESOLV_CONF_BACKUP_PATH, error)),
     }
 }

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -164,7 +164,7 @@ impl Firewall {
                     "Expected '{}' netfilter table to be set, but it is not",
                     expected_table.to_string_lossy()
                 );
-                bail!(Error::NetfilterTableNotSetError)
+                return Err(Error::NetfilterTableNotSetError);
             }
         }
         Ok(())

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -11,9 +11,6 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-#[macro_use]
-extern crate error_chain;
-
 /// Misc FFI utilities.
 #[cfg(windows)]
 #[macro_use]

--- a/talpid-core/src/routing/android.rs
+++ b/talpid-core/src/routing/android.rs
@@ -7,7 +7,10 @@ use std::{
     net::{IpAddr, Ipv4Addr},
 };
 
-error_chain! {}
+/// Stub error type for routing errors on Android.
+#[derive(Debug, err_derive::Error)]
+#[error(display = "Unknown Android routing error")]
+pub struct Error;
 
 pub struct RouteManager;
 
@@ -18,15 +21,15 @@ impl super::RoutingT for RouteManager {
         Ok(RouteManager)
     }
 
-    fn add_routes(&mut self, _required_routes: RequiredRoutes) -> Result<()> {
+    fn add_routes(&mut self, _required_routes: RequiredRoutes) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn delete_routes(&mut self) -> Result<()> {
+    fn delete_routes(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn get_default_route_node(&mut self) -> Result<IpAddr> {
+    fn get_default_route_node(&mut self) -> Result<IpAddr, Self::Error> {
         Ok(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
     }
 }

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -9,20 +9,26 @@ use std::{
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Errors that can happen in the Linux routing integration
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
+    /// Failed to add route.
     #[error(display = "Failed to add route")]
     FailedToAddRoute(#[error(cause)] io::Error),
 
+    /// Failed to remove route.
     #[error(display = "Failed to remove route")]
     FailedToRemoveRoute(#[error(cause)] io::Error),
 
+    /// Error while running "ip route".
     #[error(display = "Error while running \"ip route\"")]
     FailedToRunIp(#[error(cause)] io::Error),
 
+    /// No default route in "ip route" output.
     #[error(display = "No default route in \"ip route\" output")]
     NoDefaultRoute,
 
+    /// Failed to parse default route as IP.
     #[error(display = "Failed to parse default route as IP: {}", _0)]
     ParseDefaultRoute(String, #[error(cause)] AddrParseError),
 }

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -10,20 +10,26 @@ use std::{
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Errors that can happen in the macOS routing integration.
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
+    /// Failed to add route.
     #[error(display = "Failed to add route")]
     FailedToAddRoute(#[error(cause)] io::Error),
 
+    /// Failed to remove route.
     #[error(display = "Failed to remove route")]
     FailedToRemoveRoute(#[error(cause)] io::Error),
 
+    /// Error while running "ip route".
     #[error(display = "Error while running \"ip route\"")]
     FailedToRunIp(#[error(cause)] io::Error),
 
+    /// No default route in "ip route" output.
     #[error(display = "No default route in \"ip route\" output")]
     NoDefaultRoute,
 
+    /// Failed to parse default route as IP.
     #[error(display = "Failed to parse default route as IP: {}", _0)]
     ParseDefaultRoute(String, #[error(cause)] AddrParseError),
 }

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -13,6 +13,8 @@ mod imp;
 #[path = "android.rs"]
 mod imp;
 
+pub use self::imp::Error;
+
 mod subprocess;
 
 /// A single route
@@ -53,24 +55,24 @@ pub struct RouteManager {
 
 impl RouteManager {
     /// Creates a new RouteManager.
-    pub fn new() -> Result<Self, imp::Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(RouteManager {
             inner: imp::RouteManager::new()?,
         })
     }
 
     /// Set routes in the routing table.
-    pub fn add_routes(&mut self, required_routes: RequiredRoutes) -> Result<(), imp::Error> {
+    pub fn add_routes(&mut self, required_routes: RequiredRoutes) -> Result<(), Error> {
         self.inner.add_routes(required_routes)
     }
 
     /// Remove previously set routes from the routing table.
-    pub fn delete_routes(&mut self) -> Result<(), imp::Error> {
+    pub fn delete_routes(&mut self) -> Result<(), Error> {
         self.inner.delete_routes()
     }
 
     /// Retrieves the gateway for the default route.
-    pub fn get_default_route_node(&mut self) -> Result<std::net::IpAddr, imp::Error> {
+    pub fn get_default_route_node(&mut self) -> Result<std::net::IpAddr, Error> {
         // use routing::RoutingT;
         self.inner.get_default_route_node()
     }
@@ -87,7 +89,7 @@ impl Drop for RouteManager {
 /// This trait unifies platform specific implementations of route managers
 pub trait RoutingT: Sized {
     /// Error type of the implementation
-    type Error: ::std::error::Error;
+    type Error: std::error::Error;
 
     /// Creates a new router
     fn new() -> Result<Self, Self::Error>;

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -19,36 +19,36 @@ pub mod wireguard;
 const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
 const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";
 
+/// Results from operations in the tunnel module.
+pub type Result<T> = std::result::Result<T, Error>;
 
-error_chain! {
-    errors {
-        /// Tunnel can't have IPv6 enabled because the system has disabled IPv6 support.
-        EnableIpv6Error {
-            description("Can't enable IPv6 on tunnel interface because IPv6 is disabled")
-        }
-        /// Running on an operating system which is not supported yet.
-        UnsupportedPlatform {
-            description("Tunnel type not supported on this operating system")
-        }
-        /// Failed to rotate tunnel log file
-        RotateLogError {
-            description("Failed to rotate tunnel log file")
-        }
-        /// Failure to build Wireguard configuration.
-        WireguardConfigError {
-            description("Failed to configure Wireguard with the given parameters")
-        }
-    }
+/// Errors that can occur in the [`TunnelMonitor`].
+#[derive(err_derive::Error, Debug, derive_more::From)]
+pub enum Error {
+    /// Tunnel can't have IPv6 enabled because the system has disabled IPv6 support.
+    #[error(display = "Can't enable IPv6 on tunnel interface because IPv6 is disabled")]
+    EnableIpv6Error,
 
-    links {
-        OpenVpnTunnelMonitoringError(openvpn::Error, openvpn::ErrorKind)
-        /// There was an error listening for events from the OpenVPN tunnel
-        ;
-        WirguardTunnelMonitoringError(wireguard::Error, wireguard::ErrorKind)
-        /// There was an error listening for events from the OpenVPN tunnel
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        ;
-    }
+    /// Running on an operating system which is not supported yet.
+    #[error(display = "Tunnel type not supported on this operating system")]
+    UnsupportedPlatform,
+
+    /// Failed to rotate tunnel log file
+    #[error(display = "Failed to rotate tunnel log file")]
+    RotateLogError(#[error(cause)] crate::logging::RotateLogError),
+
+    /// Failure to build Wireguard configuration.
+    #[error(display = "Failed to configure Wireguard with the given parameters")]
+    WireguardConfigError(#[error(cause)] self::wireguard::config::Error),
+
+    /// There was an error listening for events from the OpenVPN tunnel
+    #[error(display = "Failed while listening for events from the OpenVPN tunnel")]
+    OpenVpnTunnelMonitoringError(#[error(cause)] openvpn::Error),
+
+    /// There was an error listening for events from the Wireguard tunnel
+    #[cfg(unix)]
+    #[error(display = "Failed while listening for events from the Wireguard tunnel")]
+    WirguardTunnelMonitoringError(#[error(cause)] wireguard::Error),
 }
 
 
@@ -151,7 +151,7 @@ impl TunnelMonitor {
                 Self::start_wireguard_tunnel(&config, log_file, on_event)
             }
             #[cfg(any(windows, target_os = "android"))]
-            TunnelParameters::Wireguard(_) => bail!(ErrorKind::UnsupportedPlatform),
+            TunnelParameters::Wireguard(_) => Err(Error::UnsupportedPlatform),
         }
     }
 
@@ -164,8 +164,7 @@ impl TunnelMonitor {
     where
         L: Fn(TunnelEvent) + Send + Sync + Clone + 'static,
     {
-        let config = wireguard::config::Config::from_parameters(&params)
-            .chain_err(|| ErrorKind::WireguardConfigError)?;
+        let config = wireguard::config::Config::from_parameters(&params)?;
         let monitor = wireguard::WireguardMonitor::start(
             &config,
             log.as_ref().map(|p| p.as_path()),
@@ -195,7 +194,7 @@ impl TunnelMonitor {
 
     fn ensure_ipv6_can_be_used_if_enabled(tunnel_options: &GenericTunnelOptions) -> Result<()> {
         if tunnel_options.enable_ipv6 && !is_ipv6_enabled_in_os() {
-            bail!(ErrorKind::EnableIpv6Error);
+            Err(Error::EnableIpv6Error)
         } else {
             Ok(())
         }
@@ -211,7 +210,7 @@ impl TunnelMonitor {
                 TunnelParameters::Wireguard(_) => WIREGUARD_LOG_FILENAME,
             };
             let tunnel_log = log_dir.join(filename);
-            logging::rotate_log(&tunnel_log).chain_err(|| ErrorKind::RotateLogError)?;
+            logging::rotate_log(&tunnel_log)?;
             Ok(Some(tunnel_log))
         } else {
             Ok(None)

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -38,6 +38,7 @@ pub enum Error {
     RotateLogError(#[error(cause)] crate::logging::RotateLogError),
 
     /// Failure to build Wireguard configuration.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[error(display = "Failed to configure Wireguard with the given parameters")]
     WireguardConfigError(#[error(cause)] self::wireguard::config::Error),
 
@@ -46,7 +47,7 @@ pub enum Error {
     OpenVpnTunnelMonitoringError(#[error(cause)] openvpn::Error),
 
     /// There was an error listening for events from the Wireguard tunnel
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[error(display = "Failed while listening for events from the Wireguard tunnel")]
     WirguardTunnelMonitoringError(#[error(cause)] wireguard::Error),
 }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -351,8 +351,8 @@ impl TunnelState for ConnectingState {
                         }
                         Err(error) => {
                             log::error!("Failed to start tunnel: {}", error);
-                            let block_reason = match *error.kind() {
-                                tunnel::ErrorKind::EnableIpv6Error => BlockReason::Ipv6Unavailable,
+                            let block_reason = match error {
+                                tunnel::Error::EnableIpv6Error => BlockReason::Ipv6Unavailable,
                                 _ => BlockReason::StartTunnelError,
                             };
                             BlockedState::enter(shared_values, block_reason)

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -126,17 +126,11 @@ impl ConnectingState {
             }
             Err(error) => match error {
                 #[cfg(windows)]
-                error @ tunnel::Error(
-                    tunnel::ErrorKind::OpenVpnTunnelMonitoringError(
-                        tunnel::openvpn::ErrorKind::DisabledTapAdapter,
-                    ),
-                    _,
+                error @ tunnel::Error::OpenVpnTunnelMonitoringError(
+                    tunnel::openvpn::Error::DisabledTapAdapter,
                 )
-                | error @ tunnel::Error(
-                    tunnel::ErrorKind::OpenVpnTunnelMonitoringError(
-                        tunnel::openvpn::ErrorKind::MissingTapAdapter,
-                    ),
-                    _,
+                | error @ tunnel::Error::OpenVpnTunnelMonitoringError(
+                    tunnel::openvpn::Error::MissingTapAdapter,
                 ) => {
                     warn!(
                         "{}",

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-error-chain = "0.12"
+err-derive = "0.1.5"
 log = "0.4"
 env_logger = "0.6"
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs", rev = "68aac55b" }
@@ -28,6 +28,7 @@ futures = "0.1"
 
 openvpn-plugin = { git = "https://github.com/mullvad/openvpn-plugin-rs", branch = "auth-failed-event", features = ["serde", "log"] }
 talpid-ipc = { path = "../talpid-ipc" }
+talpid-types = { path = "../talpid-types" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -21,7 +21,7 @@ pub enum Error {
     #[error(display = "No core server id given as first argument")]
     MissingCoreServerId,
 
-    #[error(display = "Failed to sending an event to daemon over the IPC channel")]
+    #[error(display = "Failed to send an event to daemon over the IPC channel")]
     SendEvent(#[error(cause)] jsonrpc_client_core::Error),
 
     #[error(display = "Connection is shut down")]

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -8,36 +8,36 @@
 
 #![deny(rust_2018_idioms)]
 
-#[macro_use]
-extern crate error_chain;
-
-use error_chain::ChainedError;
 use openvpn_plugin::{openvpn_plugin, EventResult, EventType};
-use std::{collections::HashMap, ffi::CString, sync::Mutex};
-
+use std::{collections::HashMap, ffi::CString, io, sync::Mutex};
+use talpid_types::ErrorExt;
 
 mod processing;
 use crate::processing::EventProcessor;
 
 
-error_chain! {
-    errors {
-        InitHandleFailed {
-            description("Unable to initialize event processor")
-        }
-        InvalidEventType {
-            description("Invalid event type constant")
-        }
-        ParseEnvFailed {
-            description("Unable to parse environment variables from OpenVPN")
-        }
-        ParseArgsFailed {
-            description("Unable to parse arguments from OpenVPN")
-        }
-        EventProcessingFailed {
-            description("Failed to process the event")
-        }
-    }
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    #[error(display = "No core server id given as first argument")]
+    MissingCoreServerId,
+
+    #[error(display = "Failed to sending an event to daemon over the IPC channel")]
+    SendEvent(#[error(cause)] jsonrpc_client_core::Error),
+
+    #[error(display = "Connection is shut down")]
+    Shutdown,
+
+    #[error(display = "Unable to start Tokio runtime")]
+    CreateRuntime(#[error(cause)] io::Error),
+
+    #[error(display = "Unable to create IPC transport")]
+    CreateTransport(#[error(cause)] io::Error),
+
+    #[error(display = "Unable to parse environment variables from OpenVPN")]
+    ParseEnvFailed(#[error(cause)] std::str::Utf8Error),
+
+    #[error(display = "Unable to parse arguments from OpenVPN")]
+    ParseArgsFailed(#[error(cause)] std::str::Utf8Error),
 }
 
 
@@ -63,7 +63,7 @@ pub struct Arguments {
 fn openvpn_open(
     args: Vec<CString>,
     _env: HashMap<CString, CString>,
-) -> Result<(Vec<EventType>, Mutex<EventProcessor>)> {
+) -> Result<(Vec<EventType>, Mutex<EventProcessor>), Error> {
     env_logger::init();
     log::debug!("Initializing plugin");
 
@@ -72,20 +72,18 @@ fn openvpn_open(
         "Connecting back to talpid core at {}",
         arguments.ipc_socket_path
     );
-    let processor = EventProcessor::new(arguments).chain_err(|| ErrorKind::InitHandleFailed)?;
+    let processor = EventProcessor::new(arguments)?;
 
     Ok((INTERESTING_EVENTS.to_vec(), Mutex::new(processor)))
 }
 
-fn parse_args(args: &[CString]) -> Result<Arguments> {
+fn parse_args(args: &[CString]) -> Result<Arguments, Error> {
     let mut args_iter = openvpn_plugin::ffi::parse::string_array_utf8(args)
-        .chain_err(|| ErrorKind::ParseArgsFailed)?
+        .map_err(Error::ParseArgsFailed)?
         .into_iter();
 
     let _plugin_path = args_iter.next();
-    let ipc_socket_path: String = args_iter
-        .next()
-        .ok_or_else(|| ErrorKind::Msg("No core server id given as first argument".to_owned()))?;
+    let ipc_socket_path: String = args_iter.next().ok_or_else(|| Error::MissingCoreServerId)?;
 
     Ok(Arguments { ipc_socket_path })
 }
@@ -100,17 +98,15 @@ fn openvpn_event(
     _args: Vec<CString>,
     env: HashMap<CString, CString>,
     handle: &mut Mutex<EventProcessor>,
-) -> Result<EventResult> {
+) -> Result<EventResult, Error> {
     log::debug!("Received event: {:?}", event);
 
-    let parsed_env =
-        openvpn_plugin::ffi::parse::env_utf8(&env).chain_err(|| ErrorKind::ParseEnvFailed)?;
+    let parsed_env = openvpn_plugin::ffi::parse::env_utf8(&env).map_err(Error::ParseEnvFailed)?;
 
     let result = handle
         .lock()
         .expect("failed to obtain mutex for EventProcessor")
-        .process_event(event, parsed_env)
-        .chain_err(|| ErrorKind::EventProcessingFailed);
+        .process_event(event, parsed_env);
     match result {
         Ok(()) => Ok(EventResult::Success),
         Err(e) => {

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -1,23 +1,10 @@
-use super::Arguments;
+use super::{Arguments, Error};
 use jsonrpc_client_core::{
     expand_params, jsonrpc_client, Future, Result as ClientResult, Transport,
 };
 use jsonrpc_client_ipc::IpcTransport;
 use std::{collections::HashMap, sync::mpsc, thread};
 use tokio::{reactor::Handle, runtime::Runtime};
-
-error_chain! {
-    errors {
-        IpcSendingError {
-            description("Failed while sending an event over the IPC channel")
-        }
-
-        Shutdown {
-            description("Connection is shut down")
-        }
-
-    }
-}
 
 
 /// Struct processing OpenVPN events and notifies listeners over IPC
@@ -27,23 +14,37 @@ pub struct EventProcessor {
 }
 
 impl EventProcessor {
-    pub fn new(arguments: Arguments) -> Result<EventProcessor> {
+    pub fn new(arguments: Arguments) -> Result<EventProcessor, Error> {
         log::trace!("Creating EventProcessor");
         let (start_tx, start_rx) = mpsc::channel();
         let (client_result_tx, client_result_rx) = mpsc::channel();
         thread::spawn(move || {
-            let mut rt = Runtime::new().expect("failed to spawn runtime");
-
+            let mut rt = match Runtime::new().map_err(Error::CreateRuntime) {
+                Err(e) => {
+                    let _ = start_tx.send(Err(e));
+                    return;
+                }
+                Ok(rt) => rt,
+            };
             let (client, client_handle) =
-                IpcTransport::new(&arguments.ipc_socket_path, &Handle::default())
-                    .expect("Unable to create IPC transport")
-                    .into_client();
+                match IpcTransport::new(&arguments.ipc_socket_path, &Handle::default())
+                    .map_err(Error::CreateTransport)
+                    .map(|transport| transport.into_client())
+                {
+                    Err(e) => {
+                        let _ = start_tx.send(Err(e));
+                        return;
+                    }
+                    Ok((client, client_handle)) => (client, client_handle),
+                };
 
-            let _ = start_tx.send(client_handle);
+            let _ = start_tx.send(Ok(client_handle));
             let _ = client_result_tx.send(rt.block_on(client));
         });
 
-        let client_handle = start_rx.recv().chain_err(|| ErrorKind::Shutdown)?;
+        let client_handle = start_rx
+            .recv()
+            .expect("No start result from EventProcessor thread")?;
         let ipc_client = EventProxy::new(client_handle);
 
         Ok(EventProcessor {
@@ -56,22 +57,22 @@ impl EventProcessor {
         &mut self,
         event: openvpn_plugin::EventType,
         env: HashMap<String, String>,
-    ) -> Result<()> {
+    ) -> Result<(), Error> {
         log::trace!("Processing \"{:?}\" event", event);
         let call_future = self
             .ipc_client
             .openvpn_event(event, env)
-            .map_err(|e| Error::with_chain(e, ErrorKind::IpcSendingError));
+            .map_err(Error::SendEvent);
         call_future.wait()?;
         self.check_client_status()
     }
 
-    fn check_client_status(&mut self) -> Result<()> {
+    fn check_client_status(&mut self) -> Result<(), Error> {
         use std::sync::mpsc::TryRecvError::*;
         match self.client_result_rx.try_recv() {
             Err(Empty) => Ok(()),
-            Err(Disconnected) | Ok(Ok(())) => Err(ErrorKind::Shutdown.into()),
-            Ok(Err(e)) => Err(Error::with_chain(e, ErrorKind::IpcSendingError)),
+            Err(Disconnected) | Ok(Ok(())) => Err(Error::Shutdown),
+            Ok(Err(e)) => Err(Error::SendEvent(e)),
         }
     }
 }

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -35,7 +35,7 @@ impl EventProcessor {
             let mut rt = Runtime::new().expect("failed to spawn runtime");
 
             let (client, client_handle) =
-                IpcTransport::new(&arguments.ipc_socket_path, &Handle::current())
+                IpcTransport::new(&arguments.ipc_socket_path, &Handle::default())
                     .expect("Unable to create IPC transport")
                     .into_client();
 


### PR DESCRIPTION
Get rid of the last parts of `error-chain` inside `talpid-core` and also `talpid-openvpn-plugin`.

The error handling is a bit different. Since it's a bit harder/uglier to create `err-derive` errors that can arbitrarily chain on itself. And I did not see the direct benefit of the exact chains we had. So I redesigned it slightly. For example, in the `static_resolv_conf.rs` DNS handler it will now not have an error that is `BackupResolvConf -> WriteError` it will instead just directly be a `WriteError` that will specify which file it failed to write and the source IO error. The path itself in the error output should give away if it's about writing the backup or not. So the extra layer would not add very much.

Also fixed the long standing warning around `Handle::current`. The fix was super simple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/799)
<!-- Reviewable:end -->
