### PR TITLE
Eliminate more error chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,7 +2014,7 @@ dependencies = [
  "talpid-types 0.1.0",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tun 0.4.2 (git+https://github.com/pinkisemils/rust-tun?branch=add-raw-fd-traits)",
+ "tun 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2398,8 +2398,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tun"
-version = "0.4.2"
-source = "git+https://github.com/pinkisemils/rust-tun?branch=add-raw-fd-traits#6638b8545a21387eeedf429b64bd24d8447f2832"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ioctl-sys 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2841,7 +2841,7 @@ dependencies = [
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
-"checksum tun 0.4.2 (git+https://github.com/pinkisemils/rust-tun?branch=add-raw-fd-traits)" = "<none>"
+"checksum tun 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "43a6b6b51530c4ec101fcfbaf7e4b4af958cbadf419ef9e4fb199f7261c6dbec"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41d17211f887da8e4a70a45b9536f26fc5de166b81e2d5d80de4a17fd22553bd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,8 @@ name = "mullvad-rpc"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2018"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.25"
 error-chain = "0.12"
+err-derive = "0.1.5"
 fern = { version = "0.5", features = ["colored"] }
 futures = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -11,10 +11,8 @@ error_chain! {
     errors {
         NoResponse { description("The request was dropped without any response") }
     }
-    links {
-        Transport(mullvad_rpc::rest::Error, mullvad_rpc::rest::ErrorKind);
-    }
     foreign_links {
+        Transport(mullvad_rpc::rest::Error);
         Deserialize(serde_json::error::Error);
     }
 }

--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -7,14 +7,23 @@ use serde_json;
 const URI_V4: &str = "https://ipv4.am.i.mullvad.net/json";
 const URI_V6: &str = "https://ipv6.am.i.mullvad.net/json";
 
-error_chain! {
-    errors {
-        NoResponse { description("The request was dropped without any response") }
-    }
-    foreign_links {
-        Transport(mullvad_rpc::rest::Error);
-        Deserialize(serde_json::error::Error);
-    }
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// Unable to send request to HTTP client.
+    #[error(display = "Unable to send GeoIP request to HTTP client")]
+    SendRequestError,
+
+    /// The request was dropped without any response
+    #[error(display = "The GeoIP request was dropped without any response")]
+    NoResponse,
+
+    /// Error in the HTTP client when requesting GeoIP
+    #[error(display = "Failed to request GeoIP")]
+    Transport(#[error(cause)] mullvad_rpc::rest::Error),
+
+    /// Failed to deserialize GeoIP response
+    #[error(display = "Failed to deserialize GeoIP response")]
+    Deserialize(#[error(cause)] serde_json::error::Error),
 }
 
 
@@ -53,8 +62,8 @@ fn send_location_request_internal(
     let request = mullvad_rpc::rest::create_get_request(uri.parse().unwrap());
 
     futures::Sink::send(request_sender, (request, response_tx))
-        .map_err(|e| Error::with_chain(e, ErrorKind::NoResponse))
-        .and_then(|_| response_rx.map_err(|e| Error::with_chain(e, ErrorKind::NoResponse)))
-        .and_then(|response_result| response_result.map_err(Error::from))
-        .and_then(|response| serde_json::from_slice(&response).map_err(Error::from))
+        .map_err(|_| Error::SendRequestError)
+        .and_then(|_| response_rx.map_err(|_| Error::NoResponse))
+        .and_then(|response_result| response_result.map_err(Error::Transport))
+        .and_then(|response| serde_json::from_slice(&response).map_err(Error::Deserialize))
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -21,7 +21,6 @@ mod relays;
 mod rpc_uniqueness_check;
 
 use crate::management_interface::{BoxFuture, ManagementCommand, ManagementInterfaceServer};
-use error_chain::ChainedError;
 use futures::{
     future,
     sync::{mpsc::UnboundedSender, oneshot},
@@ -553,7 +552,7 @@ impl Daemon {
         geoip::send_location_request(https_handle).map_err(|e| {
             warn!(
                 "Unable to fetch GeoIP location: {}",
-                ChainedError::display_chain(&e)
+                ErrorExt::display_chain(&e)
             );
         })
     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -388,7 +388,7 @@ impl Daemon {
                 })
             });
         if let Err(e) = result {
-            error!("{}", ErrorExt::display_chain(&e));
+            error!("{}", e.display_chain());
         }
     }
 
@@ -550,10 +550,7 @@ impl Daemon {
         let https_handle = self.https_handle.clone();
 
         geoip::send_location_request(https_handle).map_err(|e| {
-            warn!(
-                "Unable to fetch GeoIP location: {}",
-                ErrorExt::display_chain(&e)
-            );
+            warn!("Unable to fetch GeoIP location: {}", e.display_chain());
         })
     }
 
@@ -618,7 +615,7 @@ impl Daemon {
                     }
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 
@@ -675,7 +672,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 
@@ -690,7 +687,7 @@ impl Daemon {
                     self.send_tunnel_command(TunnelCommand::AllowLan(allow_lan));
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 
@@ -713,7 +710,7 @@ impl Daemon {
                     ));
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 
@@ -727,7 +724,7 @@ impl Daemon {
                         .notify_settings(self.settings.clone());
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 
@@ -743,7 +740,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 
@@ -810,7 +807,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 
@@ -826,7 +823,7 @@ impl Daemon {
                     self.reconnect_tunnel();
                 }
             }
-            Err(e) => error!("{}", ErrorExt::display_chain(&e)),
+            Err(e) => error!("{}", e.display_chain()),
         }
     }
 

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-error-chain = "0.12"
+derive_more = "0.14.0"
+err-derive = "0.1.5"
 futures = "0.1.15"
 jsonrpc-client-core = "0.5"
 jsonrpc-client-http = "0.5"

--- a/mullvad-rpc/src/event_loop.rs
+++ b/mullvad-rpc/src/event_loop.rs
@@ -1,16 +1,10 @@
-use std::thread;
+use std::{io, thread};
 use tokio_core::reactor::Core;
-
-error_chain! {
-    errors {
-        CoreError { description("Error when creating event loop") }
-    }
-}
 
 /// Creates a new tokio event loop on a new thread, runs the provided `init` closure on the thread
 /// and sends back the result.
 /// Used to spawn futures on the core in the separate thread and be able to return sendable handles.
-pub fn create<F, T>(init: F) -> Result<T>
+pub fn create<F, T>(init: F) -> io::Result<T>
 where
     F: FnOnce(&mut Core) -> T + Send + 'static,
     T: Send + 'static,
@@ -28,11 +22,11 @@ where
     rx.recv().unwrap()
 }
 
-fn create_core<F, T>(init: F) -> Result<(Core, T)>
+fn create_core<F, T>(init: F) -> io::Result<(Core, T)>
 where
     F: FnOnce(&mut Core) -> T + Send + 'static,
 {
-    let mut core = Core::new().chain_err(|| ErrorKind::CoreError)?;
+    let mut core = Core::new()?;
     let out = init(&mut core);
     Ok((core, out))
 }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -8,9 +8,6 @@
 
 #![deny(rust_2018_idioms)]
 
-#[macro_use]
-extern crate error_chain;
-
 use chrono::{offset::Utc, DateTime};
 use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_client_http::{header::Host, HttpTransport, HttpTransportBuilder};

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -46,14 +46,14 @@ nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "29651f4370fdf22cc2
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"
 err-derive = "0.1.5"
-tun = { git = "https://github.com/pinkisemils/rust-tun", branch = "add-raw-fd-traits" }
+tun = "0.4.3"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # TODO: Specify 0.2.1 once the crate gets published
 pfctl = { git = "https://github.com/mullvad/pfctl-rs", rev = "9f31b5ddcab941862470075eab83bb398195f3d6" }
 system-configuration = "0.2"
-tun = { git = "https://github.com/pinkisemils/rust-tun", branch = "add-raw-fd-traits" }
+tun = "0.4.3"
 
 
 [target.'cfg(windows)'.dependencies]

--- a/talpid-ipc/tests/ipc-client-server.rs
+++ b/talpid-ipc/tests/ipc-client-server.rs
@@ -74,7 +74,7 @@ fn create_client(ipc_path: String) -> jsonrpc_client_core::ClientHandle {
 
     thread::spawn(move || {
         let (client, client_handle) =
-            jsonrpc_client_ipc::IpcTransport::new(&ipc_path, &tokio::reactor::Handle::current())
+            jsonrpc_client_ipc::IpcTransport::new(&ipc_path, &tokio::reactor::Handle::default())
                 .expect("failed to construct a transport")
                 .into_client();
         tx.send(client_handle).unwrap();


### PR DESCRIPTION
Remove `error-chain` dependency from all of `mullvad-rpc`. And at the same time update the `geoip` module in the daemon to not have `error-chain` either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/801)
<!-- Reviewable:end -->
