### PR TITLE
Remove error-chain from mullvad-ipc-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ dependencies = [
 name = "mullvad-ipc-client"
 version = "0.1.0"
 dependencies = [
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -1,5 +1,5 @@
 use crate::{new_rpc_client, Command, Result};
-use error_chain::ChainedError;
+use talpid_types::ErrorExt;
 
 pub struct Connect;
 

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -12,9 +12,9 @@
 extern crate error_chain;
 
 use clap::{crate_authors, crate_description, crate_name};
-use error_chain::ChainedError;
 use mullvad_ipc_client::{new_standalone_ipc_client, DaemonRpcClient};
 use std::io;
+use talpid_types::ErrorExt;
 
 mod cmds;
 
@@ -24,7 +24,7 @@ pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/produc
 error_chain! {
 
     errors {
-        DaemonNotRunning(err: mullvad_ipc_client::Error) {
+        DaemonNotRunning(err: io::Error) {
             description("Failed to connect to daemon")
             display("Failed to connect to daemon: {}Is the daemon running?", err.display_chain())
         }
@@ -36,10 +36,7 @@ error_chain! {
     foreign_links {
         Io(io::Error);
         ParseIntError(::std::num::ParseIntError);
-    }
-
-    links {
-        RpcClientError(mullvad_ipc_client::Error, mullvad_ipc_client::ErrorKind);
+        RpcClientError(mullvad_ipc_client::Error);
     }
 }
 

--- a/mullvad-daemon/src/rpc_uniqueness_check.rs
+++ b/mullvad-daemon/src/rpc_uniqueness_check.rs
@@ -1,8 +1,6 @@
-use error_chain::ChainedError;
-
 use mullvad_ipc_client::new_standalone_ipc_client;
 use mullvad_paths;
-
+use talpid_types::ErrorExt;
 
 /// Checks if there is another instance of the daemon running.
 ///

--- a/mullvad-ipc-client/Cargo.toml
+++ b/mullvad-ipc-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-error-chain = "0.12"
+err-derive = "0.1.5"
 mullvad-types = { path = "../mullvad-types" }
 serde = "1.0"
 talpid-ipc = { path = "../talpid-ipc" }

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -4,7 +4,7 @@ use self::{mock_openvpn::MOCK_OPENVPN_ARGS_FILE, platform_specific::*};
 use futures::sync::oneshot;
 use jsonrpc_client_core::{Future, Transport};
 use jsonrpc_client_ipc::IpcTransport;
-use mullvad_ipc_client::{DaemonRpcClient, ResultExt};
+use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_paths::resources::API_CA_FILENAME;
 use notify::{RawEvent, RecommendedWatcher, RecursiveMode, Watcher};
 use std::{
@@ -303,8 +303,8 @@ impl DaemonRunner {
         let socket_path: String = self.rpc_socket_path.to_string_lossy().to_string();
         mullvad_ipc_client::new_standalone_transport(socket_path, |path| {
             IpcTransport::new(&path, &Handle::default())
-                .chain_err(|| mullvad_ipc_client::ErrorKind::TransportError)
         })
+        .map_err(|e| e.to_string())
         .map_err(|e| format!("Failed to construct an RPC client - {}", e))
     }
 


### PR DESCRIPTION
Get rid of `error-chain` dependency in `mullvad-ipc-client`. Turned out most error variants were not even used at all to begin with. In the end, there were two errors left. And they were completely separated between creation of the transport, and the usage of it. No single method/function could fail in both ways. So I did not even create a new error. I just directly send the underlying ones through in the appropriate places.

So when creating an IPC client now you get an `io::Error`. And later when using it you would get an `jsonrpc_client_core::Error` if anything fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/802)
<!-- Reviewable:end -->
