### PR TITLE
Fix encoding issues when reading PO files

### DIFF
--- a/gui/src/shared/gettext.ts
+++ b/gui/src/shared/gettext.ts
@@ -35,10 +35,10 @@ export function loadTranslations(currentLocale: string, catalogue: Gettext) {
 
 function parseTranslation(locale: string, domain: string, catalogue: Gettext): boolean {
   const filename = path.join(LOCALES_DIR, locale, `${domain}.po`);
-  let buffer: Buffer;
+  let contents: string;
 
   try {
-    buffer = fs.readFileSync(filename);
+    contents = fs.readFileSync(filename, { encoding: 'utf8' });
   } catch (error) {
     if (error.code !== 'ENOENT') {
       log.error(`Cannot read the gettext file "${filename}": ${error.message}`);
@@ -48,7 +48,7 @@ function parseTranslation(locale: string, domain: string, catalogue: Gettext): b
 
   let translations: object;
   try {
-    translations = po.parse(buffer);
+    translations = po.parse(contents);
   } catch (error) {
     log.error(`Cannot parse the gettext file "${filename}": ${error.message}`);
     return false;


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This tiny PR fixes the encoding when reading PO files. I don't exactly recall any issues when running Electron 3, but with Electron 4 I saw that the encoding was messed up for Chinese translations. This is a tiny patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/804)
<!-- Reviewable:end -->
