### PR TITLE
Add Android build to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,34 @@ matrix:
       before_script: *rust_before_script
       script: *rust_script
 
+    # Android
+    - language: android
+      sudo: true
+      android:
+        components:
+          - android-28
+          - build-tools-28.0.3
+      install:
+        - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+        - source $HOME/.cargo/env
+        - rustup target add aarch64-linux-android
+        - curl -sf -L -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip
+        - sudo mkdir /opt/android
+        - sudo unzip -q -d /opt/android/ /tmp/ndk.zip
+        - sudo /opt/android/android-ndk-r19b/build/tools/make-standalone-toolchain.sh --platform=android-28 --arch=arm64 --install-dir=/opt/android/toolchains/android28-aarch64
+        - |
+            cat >> $HOME/.cargo/config << EOF
+            [target.aarch64-linux-android]
+            ar = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+            linker = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
+      script:
+        - export AR_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android-ar 
+        - export CC_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android28-clang
+        - source env.sh android
+        - cargo build --target aarch64-linux-android --verbose
+        - cd android
+        - ./gradlew --console plain assembleDebug
+
 
 notifications:
   email:

--- a/talpid-core/src/offline/dummy.rs
+++ b/talpid-core/src/offline/dummy.rs
@@ -2,7 +2,8 @@ use crate::tunnel_state_machine::TunnelCommand;
 use futures::sync::mpsc::UnboundedSender;
 
 #[derive(err_derive::Error, Debug)]
-pub struct Error(());
+#[error(display = "Dummy offline check error")]
+pub struct Error;
 
 pub struct MonitorHandle;
 

--- a/talpid-core/src/routing/android.rs
+++ b/talpid-core/src/routing/android.rs
@@ -1,11 +1,5 @@
-use super::{
-    subprocess::{Exec, RunExpr},
-    NetNode, RequiredRoutes,
-};
-use std::{
-    collections::HashSet,
-    net::{IpAddr, Ipv4Addr},
-};
+use super::RequiredRoutes;
+use std::net::{IpAddr, Ipv4Addr};
 
 /// Stub error type for routing errors on Android.
 #[derive(Debug, err_derive::Error)]

--- a/talpid-core/src/routing/android.rs
+++ b/talpid-core/src/routing/android.rs
@@ -17,7 +17,7 @@ pub struct RouteManager;
 impl super::RoutingT for RouteManager {
     type Error = Error;
 
-    fn new() -> Result<Self> {
+    fn new() -> Result<Self, Self::Error> {
         Ok(RouteManager)
     }
 


### PR DESCRIPTION
This PR adds an Android continuous integration build on Travis. This allows to test both if the Android app is compiling correctly as well as if the Rust code cross-compiles correctly for Android.

For the builds to pass, the binaries sub-module was updated so that it includes the Android OpenSSL binaries and some fixes were made to the Rust code.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Not a user visible change.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/806)
<!-- Reviewable:end -->
