### PR TITLE
Eliminate daemon error chain

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -72,10 +72,8 @@ error_chain! {
             description("No wireguard private key available")
         }
     }
-    links {
-        AccountHistory(account_history::Error, account_history::ErrorKind);
-    }
     foreign_links {
+        AccountHistory(account_history::Error);
         TunnelError(tunnel_state_machine::Error);
     }
 }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -57,16 +57,16 @@ pub fn new_standalone_transport<
         }
     });
 
-    rx.wait().expect("No transport handles returned").map(
-        |(rpc_client, server_handle, executor)| {
+    rx.wait()
+        .map_err(|_| io::Error::new(io::ErrorKind::NotFound, "No transport handles returned"))?
+        .map(|(rpc_client, server_handle, executor)| {
             let subscriber =
                 jsonrpc_client_pubsub::Subscriber::new(executor, rpc_client.clone(), server_handle);
             DaemonRpcClient {
                 rpc_client,
                 subscriber,
             }
-        },
-    )
+        })
 }
 
 fn spawn_transport<


### PR DESCRIPTION
Replace a lot of the error handling in `mullvad-daemon` with more handcrafted `err-derive` errors.

Also fix the possible panic in `mullvad-ipc-client` by making it an error if the sub-thread panics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/811)
<!-- Reviewable:end -->
