### PR TITLE
IPC and logging improvements

### DIFF
--- a/gui/scripts/serve.js
+++ b/gui/scripts/serve.js
@@ -17,7 +17,7 @@ const getClientUrl = (options) => {
 };
 
 function runElectron(browserSyncUrl) {
-  const child = spawn(electron, ['.', '--enable-logging'], {
+  const child = spawn(electron, ['.'], {
     env: {
       ...{
         NODE_ENV: 'development',


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Remove `--enable-logging` flag when running Electron in development, which was causing a lot of noise in terminal with very little gain. Also, on Windows this flag opens around 5 terminals, one per process which clogs the task bar.
1. Improve some of the async IPC helpers which used to rely on the sender to be around to receive the response. Since the request processing happens asynchronously, it's entirely possible for the original sender to be destroyed by the time the request is processed. We don't destroy `BrowserWindow`s just yet for that condition to happen, but I've already started work on patching some of the rough edges with Electron on Windows an it involves killing the window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/814)
<!-- Reviewable:end -->
