### PR TITLE
Deny some warnings in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
       os: osx
       before_script: &rust_before_script
         - source env.sh
+        - export RUSTFLAGS="--deny unused_imports --deny dead_code"
         - env
       script: &rust_script
         - cargo build --verbose
@@ -90,10 +91,13 @@ matrix:
             [target.aarch64-linux-android]
             ar = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
             linker = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
-      script:
+      before_script:
+        - export RUSTFLAGS="--deny unused_imports --deny dead_code"
         - export AR_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android-ar 
         - export CC_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android28-clang
         - source env.sh android
+        - env
+      script:
         - cargo build --target aarch64-linux-android --verbose
         - cd android
         - ./gradlew --console plain assembleDebug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
   # overridden on a case by case basis down below
     RUST_VERSION: stable
     RUST_BACKTRACE: "1"
+    RUSTFLAGS: "--deny unused_imports --deny dead_code"
     CPP_BUILD_MODES: "Debug"
     OPENSSL_STATIC: "1"
 

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -15,6 +15,7 @@ mod imp;
 
 pub use self::imp::Error;
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 mod subprocess;
 
 /// A single route

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -361,8 +361,6 @@ impl<C: OpenVpnBuilder + 'static> OpenVpnMonitor<C> {
     fn postmortem(&mut self) -> Error {
         #[cfg(windows)]
         {
-            use std::fs;
-
             if let Some(log_path) = self.log_path.take() {
                 if let Ok(log) = fs::read_to_string(log_path) {
                     if log.contains("There are no TAP-Windows adapters on this system") {


### PR DESCRIPTION
We build for many platforms. And it's really easy to accidentally introduce warnings on platforms you are not actively building on yourself. Compiler warnings are annoying and bad, so here I try to eliminate merging code that has warnings, by making some warnings into hard errors in the CI. Also fixes the already existing warnings of these types.

Suggestions for exactly which warnings we make into errors are welcome. But I started out with the ones I thought would be the most common, both related to unused code basically.

I did not want any type of warning that risks regressing by itself. Such as deprecated functions. Because then the CI can start breaking on nightly/beta without us actually doing anything to the code, and that would be a bit annoying to maintain. We should of course stop using deprecated code, but we can do that over a longer period of time.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/815)
<!-- Reviewable:end -->
