### PR TITLE
Run Android early, since it takes the longest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,36 @@ matrix:
         - npm run build
         - npm test
 
+    # Android
+    - language: android
+      sudo: true
+      android:
+        components:
+          - android-28
+          - build-tools-28.0.3
+      install:
+        - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+        - source $HOME/.cargo/env
+        - rustup target add aarch64-linux-android
+        - curl -sf -L -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip
+        - sudo mkdir /opt/android
+        - sudo unzip -q -d /opt/android/ /tmp/ndk.zip
+        - sudo /opt/android/android-ndk-r19b/build/tools/make-standalone-toolchain.sh --platform=android-28 --arch=arm64 --install-dir=/opt/android/toolchains/android28-aarch64
+        - |
+            cat >> $HOME/.cargo/config << EOF
+            [target.aarch64-linux-android]
+            ar = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+            linker = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
+      before_script:
+        - export RUSTFLAGS="--deny unused_imports --deny dead_code"
+        - export AR_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android-ar
+        - export CC_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android28-clang
+        - source env.sh android
+        - env
+      script:
+        - cargo build --target aarch64-linux-android --verbose
+        - cd android
+        - ./gradlew --console plain assembleDebug
 
     # Daemon - macOS
     - language: rust
@@ -70,37 +100,6 @@ matrix:
       addons: *rust_linux_addons
       before_script: *rust_before_script
       script: *rust_script
-
-    # Android
-    - language: android
-      sudo: true
-      android:
-        components:
-          - android-28
-          - build-tools-28.0.3
-      install:
-        - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
-        - source $HOME/.cargo/env
-        - rustup target add aarch64-linux-android
-        - curl -sf -L -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip
-        - sudo mkdir /opt/android
-        - sudo unzip -q -d /opt/android/ /tmp/ndk.zip
-        - sudo /opt/android/android-ndk-r19b/build/tools/make-standalone-toolchain.sh --platform=android-28 --arch=arm64 --install-dir=/opt/android/toolchains/android28-aarch64
-        - |
-            cat >> $HOME/.cargo/config << EOF
-            [target.aarch64-linux-android]
-            ar = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
-            linker = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
-      before_script:
-        - export RUSTFLAGS="--deny unused_imports --deny dead_code"
-        - export AR_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android-ar 
-        - export CC_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android28-clang
-        - source env.sh android
-        - env
-      script:
-        - cargo build --target aarch64-linux-android --verbose
-        - cd android
-        - ./gradlew --console plain assembleDebug
 
 
 notifications:


### PR DESCRIPTION
Currently, Android is the last job, and it takes the longest. About 10 minutes compared to 7 for the other Rust jobs. Since we now have more jobs than available Travis workers the last job is doomed to start later than the other jobs. So by having the longest job the last the entire build takes way longer. If we instead make the longest running jobs start first my hope is that a full build should take a bit less time.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/816)
<!-- Reviewable:end -->
