### PR TITLE
Convert errors in CLI away from error-chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-ipc-client 0.1.0",
  "mullvad-paths 0.1.0",

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2.32"
-error-chain = "0.12"
+err-derive = "0.1.5"
 env_logger = "0.6"
 serde = "1.0"
 futures = "0.1"

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -1,4 +1,4 @@
-use crate::{new_rpc_client, Command, Error, ErrorKind, Result, ResultExt};
+use crate::{new_rpc_client, Command, Error, Result};
 use futures::{Future, Stream};
 use mullvad_ipc_client::DaemonRpcClient;
 use mullvad_types::{auth_failed::AuthFailed, DaemonEvent};
@@ -36,9 +36,9 @@ impl Command for Status {
             let subscription = rpc
                 .daemon_event_subscribe()
                 .wait()
-                .map_err(|_err| Error::from(ErrorKind::CantSubscribe))?;
+                .map_err(Error::CantSubscribe)?;
             for event in subscription.wait() {
-                match event.chain_err(|| "Subscription failed")? {
+                match event? {
                     DaemonEvent::StateTransition(new_state) => {
                         print_state(&new_state);
                         use self::TunnelStateTransition::*;

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -8,9 +8,6 @@
 
 #![deny(rust_2018_idioms)]
 
-#[macro_use]
-extern crate error_chain;
-
 use clap::{crate_authors, crate_description, crate_name};
 use mullvad_ipc_client::{new_standalone_ipc_client, DaemonRpcClient};
 use std::io;
@@ -20,34 +17,47 @@ mod cmds;
 
 pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 
+pub type Result<T> = std::result::Result<T, Error>;
 
-error_chain! {
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    #[error(display = "Failed to connect to daemon")]
+    DaemonNotRunning(#[error(cause)] io::Error),
 
-    errors {
-        DaemonNotRunning(err: io::Error) {
-            description("Failed to connect to daemon")
-            display("Failed to connect to daemon: {}Is the daemon running?", err.display_chain())
-        }
-        CantSubscribe {
-            description("Can't subscribe to daemon states")
-        }
-    }
+    #[error(display = "Can't subscribe to daemon states")]
+    CantSubscribe(#[error(cause)] mullvad_ipc_client::PubSubError),
 
-    foreign_links {
-        Io(io::Error);
-        ParseIntError(::std::num::ParseIntError);
-        RpcClientError(mullvad_ipc_client::Error);
+    #[error(display = "Failed to communicate with mullvad-daemon over RPC")]
+    RpcClientError(#[error(cause)] mullvad_ipc_client::Error),
+
+    /// The given command is not correct in some way
+    #[error(display = "Invalid command: {}", _0)]
+    InvalidCommand(&'static str),
+}
+
+impl From<mullvad_ipc_client::Error> for Error {
+    fn from(e: mullvad_ipc_client::Error) -> Self {
+        Error::RpcClientError(e)
     }
 }
 
 pub fn new_rpc_client() -> Result<DaemonRpcClient> {
     match new_standalone_ipc_client(&mullvad_paths::get_rpc_socket_path()) {
-        Err(e) => Err(ErrorKind::DaemonNotRunning(e).into()),
+        Err(e) => Err(Error::DaemonNotRunning(e)),
         Ok(client) => Ok(client),
     }
 }
 
-quick_main!(run);
+fn main() {
+    let exit_code = match run() {
+        Ok(_) => 0,
+        Err(error) => {
+            eprintln!("{}", error.display_chain());
+            1
+        }
+    };
+    std::process::exit(exit_code);
+}
 
 fn run() -> Result<()> {
     env_logger::init();

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -23,6 +23,7 @@ static NO_ARGS: [u8; 0] = [];
 
 pub type Result<T> = std::result::Result<T, jsonrpc_client_core::Error>;
 pub use jsonrpc_client_core::Error;
+pub use jsonrpc_client_pubsub::Error as PubSubError;
 
 pub fn new_standalone_ipc_client(path: &impl AsRef<Path>) -> io::Result<DaemonRpcClient> {
     let path = path.as_ref().to_string_lossy().to_string();


### PR DESCRIPTION
Getting rid of `error-chain` in the CLI.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/818)
<!-- Reviewable:end -->
