### PR TITLE
Update dependencies for offline detection on Linux.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,14 +405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eui48"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,15 +645,6 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ipnetwork"
 version = "0.14.0"
 source = "git+https://github.com/mullvad/ipnetwork?branch=fix-deserialization#10d12cd94509f98cbc0d60d9f42380615faee638"
 dependencies = [
@@ -674,24 +657,6 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "iproute2"
-version = "0.0.2"
-source = "git+https://github.com/mullvad/netlink?branch=ignore-hw-address#670b33f535107497ae5c32d02c92de62c5e800ba"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "eui48 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
- "rtnetlink 0.0.3 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1238,9 +1203,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet"
+version = "0.1.1"
+source = "git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9#f752af0ccf313b2834fd90794028c3f3e86b2ba9"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netlink-sys 0.1.0 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.1.1"
+source = "git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9#f752af0ccf313b2834fd90794028c3f3e86b2ba9"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netlink-packet 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
+ "netlink-sys 0.1.0 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "netlink-socket"
 version = "0.0.2"
 source = "git+https://github.com/mullvad/netlink?branch=ignore-hw-address#670b33f535107497ae5c32d02c92de62c5e800ba"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.1.0"
+source = "git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9#f752af0ccf313b2834fd90794028c3f3e86b2ba9"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1733,27 +1736,20 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.0.3"
-source = "git+https://github.com/mullvad/netlink?branch=ignore-hw-address#670b33f535107497ae5c32d02c92de62c5e800ba"
+version = "0.1.1"
+source = "git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9#f752af0ccf313b2834fd90794028c3f3e86b2ba9"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netlink-packet 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
+ "netlink-proto 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
 ]
 
 [[package]]
 name = "rustc-demangle"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1990,14 +1986,16 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iproute2 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)",
+ "netlink-packet 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
+ "netlink-proto 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
  "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
+ "netlink-sys 0.1.0 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
  "nftnl 0.1.0 (git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3)",
  "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2007,7 +2005,7 @@ dependencies = [
  "pfctl 0.2.1 (git+https://github.com/mullvad/pfctl-rs?rev=9f31b5ddcab941862470075eab83bb398195f3d6)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rtnetlink 0.0.3 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
+ "rtnetlink 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "system-configuration 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
@@ -2656,7 +2654,6 @@ dependencies = [
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
-"checksum eui48 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4970a61eb89c625299a850532620d811b70afac4cd8304cb2e9bf7e63e83ad56"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "29d26fa0f4d433d1956746e66ec10d6bf4d6c8b93cd39965cceea7f7cc78c7dd"
@@ -2684,10 +2681,8 @@ dependencies = [
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum ioctl-sys 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2c4b26352496eaaa8ca7cfa9bd99e93419d3f7983dc6e99c2a35fe9e33504a"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum ipnetwork 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d1d8b990621b5b0806fac3dbf71d1833a4c0a9e25702d10bd8b2c629c7ae01c"
 "checksum ipnetwork 0.14.0 (git+https://github.com/mullvad/ipnetwork?branch=fix-deserialization)" = "<none>"
 "checksum ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
-"checksum iproute2 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)" = "<none>"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)" = "<none>"
 "checksum jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f29cb249837420fb0cee7fb0fbf1d22679e121b160e71bb5e0d90b9df241c23e"
@@ -2727,7 +2722,10 @@ dependencies = [
 "checksum mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
 "checksum mnl-sys 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum netlink-packet 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)" = "<none>"
+"checksum netlink-proto 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)" = "<none>"
 "checksum netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)" = "<none>"
+"checksum netlink-sys 0.1.0 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)" = "<none>"
 "checksum nftnl 0.1.0 (git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3)" = "<none>"
 "checksum nftnl-sys 0.1.0 (git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3)" = "<none>"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
@@ -2779,9 +2777,8 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rs-release 0.1.7 (git+https://github.com/mullvad/rs-release?branch=snailquote-unescape)" = "<none>"
-"checksum rtnetlink 0.0.3 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)" = "<none>"
+"checksum rtnetlink 0.1.1 (git+https://github.com/little-dude/netlink?rev=f752af0ccf313b2834fd90794028c3f3e86b2ba9)" = "<none>"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -37,11 +37,13 @@ nix = "0.13"
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.6"
 failure = "0.1"
-iproute2 = { git = "https://github.com/mullvad/netlink", branch = "ignore-hw-address" }
 netlink-socket = { git = "https://github.com/mullvad/netlink", branch = "ignore-hw-address" }
 notify = "4.0"
 resolv-conf = "0.6.1"
-rtnetlink = { git = "https://github.com/mullvad/netlink", branch = "ignore-hw-address" }
+rtnetlink = { git = "https://github.com/little-dude/netlink", rev = "f752af0ccf313b2834fd90794028c3f3e86b2ba9" }
+netlink-proto = { git = "https://github.com/little-dude/netlink", rev = "f752af0ccf313b2834fd90794028c3f3e86b2ba9" }
+netlink-packet = { git = "https://github.com/little-dude/netlink", rev = "f752af0ccf313b2834fd90794028c3f3e86b2ba9" }
+netlink-sys = { git = "https://github.com/little-dude/netlink", rev = "f752af0ccf313b2834fd90794028c3f3e86b2ba9" }
 nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "29651f4370fdf22cc2e3abf5097a51f8ff17e3a3", features = ["nftnl-1-1-0"] }
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -1,19 +1,21 @@
 use crate::tunnel_state_machine::TunnelCommand;
 use futures::{future::Either, sync::mpsc::UnboundedSender, Future, Stream};
-use iproute2::{Address, Connection, ConnectionHandle, Link, NetlinkIpError};
 use log::{error, warn};
-use netlink_socket::{Protocol, SocketAddr, TokioSocket};
-use rtnetlink::{LinkLayerType, NetlinkCodec, NetlinkFramed, NetlinkMessage};
+use netlink_packet::{AddressMessage, LinkLayerType, LinkMessage, NetlinkMessage};
+use netlink_sys::SocketAddr;
+use rtnetlink::{
+    constants::{RTMGRP_IPV4_IFADDR, RTMGRP_IPV6_IFADDR, RTMGRP_LINK, RTMGRP_NOTIFY},
+    Connection, Handle,
+};
 use std::{collections::BTreeSet, io, thread};
 use talpid_types::ErrorExt;
-
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "Failed to get list of IP links")]
-    GetLinksError(#[error(cause)] failure::Compat<iproute2::NetlinkIpError>),
+    GetLinksError(#[error(cause)] failure::Compat<rtnetlink::Error>),
 
     #[error(display = "Failed to connect to netlink socket")]
     NetlinkConnectionError(#[error(cause)] io::Error),
@@ -22,36 +24,38 @@ pub enum Error {
     NetlinkBindError(#[error(cause)] io::Error),
 
     #[error(display = "Error while communicating on the netlink socket")]
-    NetlinkError(#[error(cause)] io::Error),
+    NetlinkError(#[error(cause)] netlink_proto::Error),
 
     #[error(display = "Error while processing netlink messages")]
-    MonitorNetlinkError(#[error(cause)] failure::Compat<rtnetlink::Error>),
+    MonitorNetlinkError,
 
     #[error(display = "Netlink connection has unexpectedly disconnected")]
     NetlinkDisconnected,
 }
 
-const RTMGRP_NOTIFY: u32 = 1;
-const RTMGRP_LINK: u32 = 2;
-const RTMGRP_IPV4_IFADDR: u32 = 0x10;
-const RTMGRP_IPV6_IFADDR: u32 = 0x100;
+// const RTMGRP_NOTIFY: u32 = 1;
+// const RTMGRP_LINK: u32 = 2;
+// const RTMGRP_IPV4_IFADDR: u32 = 0x10;
+// const RTMGRP_IPV6_IFADDR: u32 = 0x100;
 
 pub struct MonitorHandle;
 
 pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle> {
-    let mut socket = TokioSocket::new(Protocol::Route).map_err(Error::NetlinkConnectionError)?;
-    socket
-        .bind(&SocketAddr::new(
-            0,
-            RTMGRP_NOTIFY | RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR,
-        ))
+    let socket = SocketAddr::new(
+        0,
+        RTMGRP_NOTIFY | RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR,
+    );
+
+    let (mut connection, _, messages) = rtnetlink::new_connection_with_messages().unwrap();
+    connection
+        .socket_mut()
+        .bind(&socket)
         .map_err(Error::NetlinkBindError)?;
 
-    let channel = NetlinkFramed::new(socket, NetlinkCodec::<NetlinkMessage>::new());
     let link_monitor = LinkMonitor::new(sender);
 
     thread::spawn(|| {
-        if let Err(error) = monitor_event_loop(channel, link_monitor) {
+        if let Err(error) = monitor_event_loop(messages, link_monitor) {
             error!(
                 "{}",
                 error.display_chain_with_msg("Error running link monitor event loop")
@@ -85,35 +89,35 @@ fn check_if_offline() -> Result<bool> {
         Ok(connection
             .addresses()?
             .into_iter()
-            .all(|address| !interfaces.contains(&address.index())))
+            .all(|address| !interfaces.contains(&address.header.index)))
     }
 }
 
 struct NetlinkConnection {
     connection: Option<Connection>,
-    connection_handle: ConnectionHandle,
+    handle: Handle,
 }
 
 impl NetlinkConnection {
     /// Open a connection on the netlink socket.
     pub fn new() -> Result<Self> {
-        let (connection, connection_handle) =
-            iproute2::new_connection().map_err(Error::NetlinkConnectionError)?;
+        let (connection, handle) =
+            rtnetlink::new_connection().map_err(Error::NetlinkConnectionError)?;
 
         Ok(NetlinkConnection {
             connection: Some(connection),
-            connection_handle,
+            handle,
         })
     }
 
     /// List all IP addresses assigned to all interfaces.
-    pub fn addresses(&mut self) -> Result<Vec<Address>> {
-        self.execute_request(self.connection_handle.address().get().execute())
+    pub fn addresses(&mut self) -> Result<Vec<AddressMessage>> {
+        self.execute_request(self.handle.address().get().execute().collect())
     }
 
     /// List all links registered on the system.
-    fn links(&mut self) -> Result<Vec<Link>> {
-        self.execute_request(self.connection_handle.link().get().execute())
+    fn links(&mut self) -> Result<Vec<LinkMessage>> {
+        self.execute_request(self.handle.link().get().execute().collect())
     }
 
     /// List all unique interface indices that have a running link.
@@ -123,14 +127,14 @@ impl NetlinkConnection {
         Ok(links
             .into_iter()
             .filter(link_provides_connectivity)
-            .map(|link| link.index())
+            .map(|link| link.header.index)
             .collect())
     }
 
     /// Helper function to execute an asynchronous request synchronously.
     fn execute_request<R>(&mut self, request: R) -> Result<R::Item>
     where
-        R: Future<Error = NetlinkIpError>,
+        R: Future<Error = rtnetlink::Error>,
     {
         let connection = self.connection.take().ok_or(Error::NetlinkDisconnected)?;
 
@@ -149,24 +153,24 @@ impl NetlinkConnection {
     }
 }
 
-fn link_provides_connectivity(link: &Link) -> bool {
+fn link_provides_connectivity(link: &LinkMessage) -> bool {
     // Some tunnels have the link layer type set to None
-    link.link_layer_type() != LinkLayerType::Loopback
-        && link.link_layer_type() != LinkLayerType::None
-        && link.flags().is_running()
+    link.header.link_layer_type != LinkLayerType::Loopback
+        && link.header.link_layer_type != LinkLayerType::None
+        && link.header.flags.is_running()
 }
 
 fn monitor_event_loop(
-    channel: NetlinkFramed<NetlinkCodec<NetlinkMessage>>,
+    channel: impl Stream<Item = NetlinkMessage, Error = ()>,
     mut link_monitor: LinkMonitor,
 ) -> Result<()> {
     channel
-        .for_each(|(_message, _address)| {
+        .for_each(|_message| {
             link_monitor.update();
             Ok(())
         })
         .wait()
-        .map_err(|error| Error::MonitorNetlinkError(failure::Fail::compat(error)))?;
+        .map_err(|_| Error::MonitorNetlinkError)?;
 
     Ok(())
 }


### PR DESCRIPTION
I've updated the offline check code for Linux to depend on mainline `netlink-*` and `rtnetlink` crates. This is in preparation for the changes to the routing code, which will use the newer netlink crates to listen for changes. I've also slightly improved connectivity check to only consider network interfaces that can actually provide connectivity on their own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/821)
<!-- Reviewable:end -->
