### PR TITLE
Remove relay-clearing code from preinstall scripts

### DIFF
--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -7,6 +7,3 @@ if which systemctl &> /dev/null; then
         systemctl disable mullvad-daemon.service
     fi
 fi
-
-#TODO: Remove after releasing 2019.2
-rm /var/cache/mullvad-vpn/relays.json || true

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -75,6 +75,3 @@ if [ -d "$OLD_CACHE_DIR" ]; then
     mv "$OLD_CACHE_DIR"/* "$NEW_CACHE_DIR/" || echo "Unable to migrate cache. No cache files?"
     rm -rf "$OLD_CACHE_DIR"
 fi
-
-# TODO: Remove after 2019.2 has been released
-rm "$NEW_CACHE_DIR/relays.json" || echo "Unable to remove old relay list"


### PR DESCRIPTION
Since 2019.2 has been released, most of our users should already have wireguard relays in their cached relay lists. So it's no longer required to remove the old relay list when installing our package. As such, the scripts have been adjusted to no longer remove the old relay list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/832)
<!-- Reviewable:end -->
