### PR TITLE
Silence netlink_proto in the mullvad-daemon logger

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -39,6 +39,7 @@ const SILENCED_CRATES: &[&str] = &[
     "mio",
     "hyper",
     "rtnetlink",
+    "netlink_proto",
     "iproute2",
 ];
 const SLIGHTLY_SILENCED_CRATES: &[&str] = &["mnl", "nftnl"];


### PR DESCRIPTION
This crate is screaming really really loud on the `DEBUG` log level. So I'm silencing it so it will only print warnings and more serious stuff.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/833)
<!-- Reviewable:end -->
