### PR TITLE
Allow mDNS discover packets to enable Wi-Fi calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add support for roaming between connections when using wireguard
+- Allow mDNS/discover to 239.255.255.251 when local network sharing is enabled. This change fixes
+  the Wi-Fi calling via iPhone when both devices are on the same network.
 
 #### Linux
 - Add standard window decorations to the application window.

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -39,11 +39,13 @@ lazy_static! {
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap()),
     ];
     /// When "allow local network" is enabled the app will allow traffic to these networks.
-    static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 4] = [
+    static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 5] = [
         // Local subnetwork multicast. Not routable
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
         // Simple Service Discovery Protocol (SSDP) address
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 255, 250), 32).unwrap()),
+        // mDNS Service Discovery address
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 255, 251), 32).unwrap()),
         // Link-local IPv6 multicast. IPv6 equivalent of 224.0.0.0/24
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
         // Site-local IPv6 multicast.


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### What

This PR addresses the issue of making the Wi-Fi calls or sending text messages from macOS via iPhone on the same Wi-Fi network. (Fixes #613)

### How

After doing some network traffic monitoring, I found that the Wi-Fi calling triggers packets to `239.255.255.251`. Hence adding a rule to allow traffic to the aforementioned address made Wi-Fi calling work. This address is also mentioned in the RFC for mDNS: https://tools.ietf.org/html/rfc6804#page-6

### mDNS IPv6

The original PR also included a patch for mDNS IPv6 range, however I've decided to exclude it. 

I found that while we whitelist the IPv4 range for mDNS, the IPv6 lacks the rules for the following addresses:

1. `FE02::FB`, UDP port `5353`
2. `FE05::FB`, UDP port `5353`

The address space is described in https://en.wikipedia.org/wiki/Multicast_DNS

This is similar to the rules we have for DHCP over IPv6. I am not sure how critical it is to fix it now, but since I did this work already, the patch is attached below to give a clue how to fix this:

```diff
From 3b2438855da5e2119d7a977b1b6e9aced5ac3ba5 Mon Sep 17 00:00:00 2001
From: Andrej Mihajlov <and@mullvad.net>
Date: Mon, 29 Apr 2019 22:13:53 +0200
Subject: [PATCH] Add mDNS v6 rules

---
 talpid-core/src/firewall/macos.rs | 12 ++++++++++++
 talpid-core/src/firewall/mod.rs   |  4 ++++
 2 files changed, 16 insertions(+)

diff --git a/talpid-core/src/firewall/macos.rs b/talpid-core/src/firewall/macos.rs
index ba920d4e..4c8d764e 100644
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -280,6 +280,18 @@ impl Firewall {
         rules.push(allow_net_v6);
         rules.push(allow_multicast_v6);
 
+        let mdns_port = pfctl::Port::from(5353);
+        for mdns6_address in &*super::MDNS_INET6_ADDRS {
+            let allow_mdns_v6 = rule_builder
+                .to(pfctl::Endpoint::new(
+                    pfctl::Ip::from(*mdns6_address),
+                    mdns_port,
+                ))
+                .proto(pfctl::Proto::Udp)
+                .build()?;
+            rules.push(allow_mdns_v6);
+        }
+
         Ok(rules)
     }
 
diff --git a/talpid-core/src/firewall/mod.rs b/talpid-core/src/firewall/mod.rs
index c86ac65b..988a6233 100644
--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -42,6 +42,10 @@ lazy_static! {
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap());
     static ref MULTICAST_INET6_NET: IpNetwork =
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap());
+    static ref MDNS_INET6_ADDRS: [IpAddr; 2] = [
+        IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb)),
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0xfb)),
+    ];
     static ref SSDP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(239, 255, 255, 250));
     static ref DHCPV6_SERVER_ADDRS: [IpAddr; 2] = [
         IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 1, 2)),
-- 
2.20.1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/838)
<!-- Reviewable:end -->
