### PR TITLE
Fix prepare_release.sh script to handle new env.sh

### DIFF
--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -39,7 +39,7 @@ sed -i.bak -Ee "s/^version = \"[^\"]+\"\$/version = \"$SEMVER_VERSION\"/g" \
     mullvad-problem-report/Cargo.toml
 
 echo "Syncing Cargo.lock with new version numbers"
-source env.sh
+source env.sh ""
 cargo build
 
 echo "Commiting metadata changes to git..."


### PR DESCRIPTION
`prepare_release.sh` was broken. Fixing it in the same way we had to update `build.sh` a while back.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/840)
<!-- Reviewable:end -->
