### PR TITLE
Remove unused wmi

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -37,6 +37,9 @@
 !define PTI_GENERAL_ERROR 0
 !define PTI_SUCCESS 1
 
+# Windows error codes
+!define ERROR_SERVICE_DEPENDENCY_DELETED 1075
+
 #
 # BreakInstallation
 #
@@ -314,7 +317,11 @@
 
 	${If} $0 != ${SERVICE_STARTED}
 	${AndIf} $0 != ${SERVICE_START_PENDING}
-		StrCpy $R0 "Failed to start Mullvad service: error $0"
+		${If} $0 == ${ERROR_SERVICE_DEPENDENCY_DELETED}
+			StrCpy $R0 'Failed to start Mullvad service: The firewall service "Base Filtering Engine" is missing or unavailable.'
+		${Else}
+			StrCpy $R0 "Failed to start Mullvad service: error $0"
+		${EndIf}
 		log::LogWithDetails $R0 $1
 		Goto InstallService_return
 	${EndIf}

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -245,8 +245,6 @@ fn get_service_info() -> ServiceInfo {
         dependencies: vec![
             // Base Filter Engine
             ServiceDependency::Service(OsString::from("BFE")),
-            // Windows Management Instrumentation (WMI)
-            ServiceDependency::Service(OsString::from("winmgmt")),
         ],
         account_name: None, // run as System
         account_password: None,


### PR DESCRIPTION
Remove WMI code (actually not in this repo, but the `windows-libraries` repo) and stop registering the service as having a WMI dependency.

Also improve the error message used in the installer in case the service cannot launch because of a missing dependency. I'm not super happy with this change, since it will have to be reverted whenever (if ever) the service starts having more dependencies again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/843)
<!-- Reviewable:end -->
