### PR TITLE
Simplify LAN firewall rules, fix ipv6 rules, allow NDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,21 +1254,22 @@ dependencies = [
 
 [[package]]
 name = "nftnl"
-version = "0.1.0"
-source = "git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3#29651f4370fdf22cc2e3abf5097a51f8ff17e3a3"
+version = "0.2.0"
+source = "git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401#86b30cdc38a6d4b30a900c21f7c644857d6f7401"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "nftnl-sys 0.1.0 (git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3)",
+ "nftnl-sys 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)",
 ]
 
 [[package]]
 name = "nftnl-sys"
-version = "0.1.0"
-source = "git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3#29651f4370fdf22cc2e3abf5097a51f8ff17e3a3"
+version = "0.2.0"
+source = "git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401#86b30cdc38a6d4b30a900c21f7c644857d6f7401"
 dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1996,7 +1997,7 @@ dependencies = [
  "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
  "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
  "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
- "nftnl 0.1.0 (git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3)",
+ "nftnl 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)",
  "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
@@ -2726,8 +2727,8 @@ dependencies = [
 "checksum netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)" = "<none>"
 "checksum netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)" = "<none>"
 "checksum netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)" = "<none>"
-"checksum nftnl 0.1.0 (git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3)" = "<none>"
-"checksum nftnl-sys 0.1.0 (git+https://github.com/mullvad/nftnl-rs?rev=29651f4370fdf22cc2e3abf5097a51f8ff17e3a3)" = "<none>"
+"checksum nftnl 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)" = "<none>"
+"checksum nftnl-sys 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)" = "<none>"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -44,7 +44,7 @@ rtnetlink = { git = "https://github.com/mullvad/netlink", branch = "hack-older-k
 netlink-proto = { git = "https://github.com/mullvad/netlink", branch = "hack-older-kernel-compat" }
 netlink-packet = { git = "https://github.com/mullvad/netlink", branch = "hack-older-kernel-compat" }
 netlink-sys = { git = "https://github.com/mullvad/netlink", branch = "hack-older-kernel-compat" }
-nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "29651f4370fdf22cc2e3abf5097a51f8ff17e3a3", features = ["nftnl-1-1-0"] }
+nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "86b30cdc38a6d4b30a900c21f7c644857d6f7401", features = ["nftnl-1-1-0"] }
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"
 err-derive = "0.1.5"

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -50,12 +50,22 @@ lazy_static! {
         // Site-local IPv6 multicast.
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
     ];
+    // The firewall should always allow DHCPv6 to enable automatic configuring of network adapters
+    /// The allowed source address of outbound DHCPv6 requests
     static ref DHCPV6_SRC_ADDR: Ipv6Network = Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap();
+    /// The allowed target addresses of outbound DHCPv6 requests
     static ref DHCPV6_SERVER_ADDRS: [Ipv6Addr; 2] = [
         Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 1, 2),
         Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 1, 3),
     ];
+    // The firewall needs to always allow Router Solicitation/Advertisement (part of NDP)
+    // It should only allow ICMPv6 packets on these addresses. If the platform supports it
+    // it should check that the solicitation packet has ICMP type 133, code 0 for solicitation
+    // and type 134, code 0 for advertisement.
+    static ref ROUTER_SOLICITATION_OUT_DST_ADDR: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 2);
+    static ref ROUTER_ADVERTISEMENT_IN_SRC_NET: Ipv6Network = Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap();
 }
+
 
 /// A enum that describes network security strategy
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -30,22 +30,30 @@ pub use self::imp::Error;
 
 #[cfg(unix)]
 lazy_static! {
-    static ref PRIVATE_NETS: [IpNetwork; 4] = [
+    /// When "allow local network" is enabled the app will allow traffic to and from these networks.
+    static ref ALLOWED_LAN_NETS: [IpNetwork; 5] = [
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(169, 254, 0, 0), 16).unwrap()),
+        // Link-local IPv6 addresses.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap()),
     ];
-    static ref LOCAL_INET6_NET: IpNetwork =
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap());
-    static ref MULTICAST_NET: IpNetwork =
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap());
-    static ref MULTICAST_INET6_NET: IpNetwork =
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap());
-    static ref SSDP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(239, 255, 255, 250));
-    static ref DHCPV6_SERVER_ADDRS: [IpAddr; 2] = [
-        IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 1, 2)),
-        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 1, 3)),
+    /// When "allow local network" is enabled the app will allow traffic to these networks.
+    static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 4] = [
+        // Local subnetwork multicast. Not routable
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
+        // Simple Service Discovery Protocol (SSDP) address
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 255, 250), 32).unwrap()),
+        // Link-local IPv6 multicast. IPv6 equivalent of 224.0.0.0/24
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+        // Site-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+    ];
+    static ref DHCPV6_SRC_ADDR: Ipv6Network = Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap();
+    static ref DHCPV6_SERVER_ADDRS: [Ipv6Addr; 2] = [
+        Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 1, 2),
+        Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 1, 3),
     ];
 }
 


### PR DESCRIPTION
When posting this it's still work in progress. First I want us to analyze and agree on the changes in ` talpid-core/src/firewall/mod.rs`, which is supposed to be the platform agnostic description of how the firewall is supposed to work. What it should block and what it should allow. It's far from a full description at the moment. But at least this PR adds some comments. Making it a bit more clear how the IPs/nets defined there should be used.

The plan/scope of how the rules are intended to change in this PR is the following:
* For LAN rules. Only check the destination for outbound packets and source for inbound packets. We can get away with fewer rules if we don't check both source and destination. And it should hopefully not be needed. They are unroutable anyway.
* For IPv6 we allowed the bogus `fe02::/16` network, that is not a speced IPv6 multicast network at all. I think this has always just been a typo of `ff02::/16`. So we remove that and we add the `ff02::/16` and `ff05::/16` networks to allowed outbound networks when "allow local network" is enabled.
* On IPv6 not only DHCPv6 is used. NDP is also used for local adapter configuration. Se we want to allow the part of NDP that is about router discovery also. This is done with the rules that allows router solicitation and router advertisement. You can see the following resources for some data on what addresses and ICMPv6 type/codes it is supposed to use:
   * https://en.wikipedia.org/wiki/Neighbor_Discovery_Protocol
   * https://howdoesinternetwork.com/2012/ndp-ipv6-neighbor-discovery-protocol

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
