### PR TITLE
Increase NumberOfFiles limit in macOS launchd config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Line wrap the file at 100 chars.                                              Th
 - Stop allowing the wrong IPv6 net fe02::/16 in the firewall when allow local network was enabled.
   Instead allow the correct multicast nets ff02::/16 and ff05::/16.
 
+#### macOS
+- Raise max number of open files for the daemon to 1024. Should prevent threads from panicking.
+
 
 ## [2019.4-beta1] - 2019-05-02
 ### Added

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -35,6 +35,12 @@ DAEMON_PLIST=$(cat <<-EOM
                 <key>KeepAlive</key>
                 <true/>
 
+                <key>SoftResourceLimits</key>
+                <dict>
+                        <key>NumberOfFiles</key>
+                        <integer>1024</integer>
+                </dict>
+
                 <key>StandardErrorPath</key>
                 <string>$LOG_DIR/stderr.log</string>
         </dict>


### PR DESCRIPTION
Users have sent us logs where the daemon has panics looking like this:
```
[2019-04-30 11:09:15.081][panic][ERROR] thread 'unnamed' panicked at 'failed to start new Runtime: Os { code: 24, kind: Other, message: "Too many open files" }': src/libcore/result.rs:997
```

The default soft limit on open files is 256. We have seen that a higher core count contribute to us having more open filedescriptors. This is likely because each thread costs a number of FDs and we run a couple of tokio runtimes which in turn spawn thread pools where the number of threads correspond to the number of cores in the machine. As such the number of CPU cores in the machine will affect the number of open FDs the daemon has. For a six core machine we have seen the daemon have ~170 open files. And on a two core machine ~80. So for high end systems with dual CPUs or similar, it's not unthinkable that we would reach 256.

Long term, we should of course make better use of fewer tokio runtimes and try to decrease the insane number of FDs/threads we spawn. But the short term solution to get rid of the panics is to increase the limit on open files.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/848)
<!-- Reviewable:end -->
