### PR TITLE
Remove redundant calls to af()

### DIFF
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -252,10 +252,7 @@ impl Firewall {
         let mut rules = vec![];
         for net in &*super::ALLOWED_LAN_NETS {
             let mut rule_builder = self.create_rule_builder(FilterRuleAction::Pass);
-            rule_builder.quick(true).af(match net {
-                IpNetwork::V4(_) => pfctl::AddrFamily::Ipv4,
-                IpNetwork::V6(_) => pfctl::AddrFamily::Ipv6,
-            });
+            rule_builder.quick(true);
             let allow_out = rule_builder
                 .direction(pfctl::Direction::Out)
                 .from(pfctl::Ip::Any)
@@ -274,10 +271,6 @@ impl Firewall {
                 .create_rule_builder(FilterRuleAction::Pass)
                 .quick(true)
                 .direction(pfctl::Direction::Out)
-                .af(match multicast_net {
-                    IpNetwork::V4(_) => pfctl::AddrFamily::Ipv4,
-                    IpNetwork::V6(_) => pfctl::AddrFamily::Ipv6,
-                })
                 .to(pfctl::Ip::from(*multicast_net))
                 .build()?;
             rules.push(allow_multicast_out);


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR simplifies firewall rules by removing explicit address family assignment. Basically the address family is automatically inferred when either of source or destination IPs is set. This is apparently not true for cases when we only have port set in the endpoint. I am not sure how much the explicit vs implicit AF matters though and if we should be merging this change, but in terms of lines of code, it removes some of them.

The ruleset diff before and after, which as you can see remains the same:

<img width="1655" alt="Screenshot 2019-05-14 at 14 22 48" src="https://user-images.githubusercontent.com/704044/57697529-c3bfc980-7653-11e9-905b-8ced7f053b0a.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/849)
<!-- Reviewable:end -->
