### PR TITLE
Allow DHCPv4 server traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for roaming between connections when using wireguard
 - Allow mDNS/discover to 239.255.255.251 when local network sharing is enabled. This change fixes
   the Wi-Fi calling via iPhone when both devices are on the same network.
+- Allow incoming DHCPv4 requests and outgoing responses if allow local network is enabled. Enables
+  being a DHCPv4 server.
 
 #### Linux
 - Add standard window decorations to the application window.

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -89,6 +89,9 @@ const DHCPV6_CLIENT_PORT: u16 = 546;
 /// 4. If `allow_lan` is enabled, all policies should allow the following traffic:
 ///    * Outgoing to, and incoming from, any IP in the networks listed in ALLOWED_LAN_NETS
 ///    * Outgoing to any IP in the networks listed in ALLOWED_LAN_MULTICAST_NETS
+///    * Incoming DHCPv4 requests and outgoing responses (be a DHCPv4 server):
+///      * Incoming from *:DHCPV4_CLIENT_PORT to 255.255.255.255:DHCPV4_SERVER_PORT
+///      * Outgoing from *:DHCPV4_SERVER_PORT to *:DHCPV4_CLIENT_PORT
 ///
 /// ## Policy specific rules
 ///


### PR DESCRIPTION
Continues your work on allowing being a DHCPv4 server.

I changed it so it's only allowed when allow local network is enabled. We should aim to be as isolated as possible, but still functioning, when LAN communication is disabled. People need to be able to trust that they are as isolated as possible when running this app on an untrusted network.

* Added implementation for macOS.
* Added to changelog
* Documented behavior in firewall description in `mod.rs`


Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/850)
<!-- Reviewable:end -->
