### PR TITLE
Remove stable toolchain from docker image used in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt install build-essential \
 	curl \
 	p7zip-full \
 	git -y
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain none
 ENV PATH="/root/.cargo/bin/:${PATH}"
 RUN mkdir /mvd
 CMD tail -f /dev/null


### PR DESCRIPTION
Due to `rustup` not being able to deal with it's root directories being spread across different mounts, the 
stable toolchain has to be uninstalled from the docker image so that it can be successfully installed during runtime of the container. 

I believe that this is related to this issue - https://github.com/rust-lang/rustup.rs/issues/1239.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/851)
<!-- Reviewable:end -->
