### PR TITLE
Fix account token verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Stop allowing the wrong IPv6 net fe02::/16 in the firewall when allow local network was enabled.
   Instead allow the correct multicast nets ff02::/16 and ff05::/16.
+- Fix the regression that allowed to get past the login screen using the invalid account token.
 
 #### macOS
 - Raise max number of open files for the daemon to 1024. Should prevent threads from panicking.

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -243,7 +243,7 @@ export default class AppRenderer {
       this.accountDataCache.fetch(accountToken, {
         onFinish: () => resolve({ status: 'verified' }),
         onError: (error): AccountFetchRetryAction => {
-          if (error instanceof InvalidAccountError) {
+          if (error.message === new InvalidAccountError().message) {
             reject(error);
             return AccountFetchRetryAction.stop;
           } else {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

There was a point in time when we moved the daemon RPC to the main process and migrated to use Electron IPC to feed the renderer with the data it needed. 

I never got around fixing the account data cache so it kept running the same requests via IPC, however since account verification uses some of the `Error` subclasses and the instances of complex classes cannot be passed via IPC, it seems that account verification got silently broken, because all of the error subclasses were turned into generic `Error`s after being passed through the Electron IPC. Thus the following code stopped working:

```ts
if (error instanceof InvalidAccountError) { // always false
  reject(error);
  return AccountFetchRetryAction.stop;
}
```

This PR quickly patches the issue, but ultimately we have to address this at the higher level. Such as I would move the account data cache into the main process and add a few endpoints to handle the login process from the renderer, but I don't really want to focus much on that right now. :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/852)
<!-- Reviewable:end -->
