### PR TITLE
Don't include OpenVPN on Android

### DIFF
--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod dns;
 /// State machine to handle tunnel configuration.
 pub mod tunnel_state_machine;
 
+#[cfg(not(target_os = "android"))]
 /// Internal code for managing bundled proxy software.
 mod proxy;
 

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -54,6 +54,7 @@ pub mod tunnel_state_machine;
 /// Internal code for managing bundled proxy software.
 mod proxy;
 
+#[cfg(not(target_os = "android"))]
 mod mktemp;
 
 /// Misc utilities for the Linux platform.

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -135,6 +135,7 @@ pub struct TunnelMonitor {
 impl TunnelMonitor {
     /// Creates a new `TunnelMonitor` that connects to the given remote and notifies `on_event`
     /// on tunnel state changes.
+    #[cfg_attr(target_os = "android", allow(unused_variables))]
     pub fn start<L>(
         tunnel_parameters: &TunnelParameters,
         log_dir: &Option<PathBuf>,

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -194,6 +194,7 @@ impl ConnectedState {
 impl TunnelState for ConnectedState {
     type Bootstrap = ConnectedStateBootstrap;
 
+    #[cfg_attr(target_os = "android", allow(unused_variables))]
     fn enter(
         shared_values: &mut SharedTunnelStateValues,
         bootstrap: Self::Bootstrap,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -57,6 +57,7 @@ impl ConnectingState {
         shared_values.firewall.apply_policy(policy)
     }
 
+    #[cfg_attr(target_os = "android", allow(unused_variables))]
     fn start_tunnel(
         parameters: TunnelParameters,
         log_dir: &Option<PathBuf>,


### PR DESCRIPTION
This PR compiles out the `talpid_core::tunnel::openvpn` module on Android. Some functions have `unimplemented!()` markers and some functions are marked to ignore missing variable on Android. These are temporary fixes while Wireguard isn't included in the Android build.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Android version not publicly released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/853)
<!-- Reviewable:end -->
