### PR TITLE
Add login (iOS)

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -32,6 +32,9 @@ xcuserdata/
 timeline.xctimeline
 playground.xcworkspace
 
+# CocoaPods
+Pods/
+
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		08A905C56DDB0A0A887BB5F5 /* Pods_MullvadVPN.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F506AB938C45AEB812886B4 /* Pods_MullvadVPN.framework */; };
 		543203592C79FAD36BC1E700 /* Pods_PacketTunnel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A931E0F6F380B4B3FD45D987 /* Pods_PacketTunnel.framework */; };
+		58461AD3228D622E00B72ECB /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58461AD2228D622E00B72ECB /* Account.swift */; };
 		5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */; };
 		5867A51C2248F26A005513C0 /* SegueIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5867A51B2248F26A005513C0 /* SegueIdentifier.swift */; };
 		587CBFE322807F530028DED3 /* UIColor+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587CBFE222807F530028DED3 /* UIColor+Helpers.swift */; };
@@ -34,7 +35,11 @@
 		58CE5E6E224146210008646E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 58CE5E6C224146210008646E /* LaunchScreen.storyboard */; };
 		58CE5E7C224146470008646E /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CE5E7B224146470008646E /* PacketTunnelProvider.swift */; };
 		58CE5E81224146470008646E /* PacketTunnel.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 58CE5E79224146470008646E /* PacketTunnel.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		58F19E31228B2AEB00C7710B /* JSONRequestProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E30228B2AEB00C7710B /* JSONRequestProcedure.swift */; };
+		58F19E33228B383300C7710B /* AccountVerificationProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E32228B383300C7710B /* AccountVerificationProcedure.swift */; };
+		58F19E35228C15BA00C7710B /* SpinnerActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */; };
 		58F37E7D2243ECCB00C75C97 /* HeaderBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F37E7C2243ECCB00C75C97 /* HeaderBarViewController.swift */; };
+		58FFE444228C82A00036F391 /* UserDefaultsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FFE443228C82A00036F391 /* UserDefaultsInteractor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +69,7 @@
 /* Begin PBXFileReference section */
 		3F506AB938C45AEB812886B4 /* Pods_MullvadVPN.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MullvadVPN.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		40D54D8A8B75B67DC37C5CCE /* Pods-PacketTunnel.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PacketTunnel.release.xcconfig"; path = "Target Support Files/Pods-PacketTunnel/Pods-PacketTunnel.release.xcconfig"; sourceTree = "<group>"; };
+		58461AD2228D622E00B72ECB /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslucentButtonBlurView.swift; sourceTree = "<group>"; };
 		5866F39B2243B82D00168AE5 /* MullvadVPN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MullvadVPN.entitlements; sourceTree = "<group>"; };
 		5867A51B2248F26A005513C0 /* SegueIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegueIdentifier.swift; sourceTree = "<group>"; };
@@ -94,7 +100,11 @@
 		58CE5E7B224146470008646E /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		58CE5E7D224146470008646E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		58CE5E7E224146470008646E /* PacketTunnel.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PacketTunnel.entitlements; sourceTree = "<group>"; };
+		58F19E30228B2AEB00C7710B /* JSONRequestProcedure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRequestProcedure.swift; sourceTree = "<group>"; };
+		58F19E32228B383300C7710B /* AccountVerificationProcedure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationProcedure.swift; sourceTree = "<group>"; };
+		58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerActivityIndicatorView.swift; sourceTree = "<group>"; };
 		58F37E7C2243ECCB00C75C97 /* HeaderBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBarViewController.swift; sourceTree = "<group>"; };
+		58FFE443228C82A00036F391 /* UserDefaultsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsInteractor.swift; sourceTree = "<group>"; };
 		627D4CE562B85202FCFA0EB1 /* Pods-MullvadVPN.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MullvadVPN.debug.xcconfig"; path = "Target Support Files/Pods-MullvadVPN/Pods-MullvadVPN.debug.xcconfig"; sourceTree = "<group>"; };
 		9F1362F46063B1D06EB0C685 /* Pods-PacketTunnel.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PacketTunnel.debug.xcconfig"; path = "Target Support Files/Pods-PacketTunnel/Pods-PacketTunnel.debug.xcconfig"; sourceTree = "<group>"; };
 		A931E0F6F380B4B3FD45D987 /* Pods_PacketTunnel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PacketTunnel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,8 +163,10 @@
 		58CE5E62224146200008646E /* MullvadVPN */ = {
 			isa = PBXGroup;
 			children = (
+				58461AD2228D622E00B72ECB /* Account.swift */,
 				58C3A4B122456F1A00340BDB /* AccountInputGroupView.swift */,
 				58CCA01D2242787B004F3011 /* AccountTextField.swift */,
+				58F19E32228B383300C7710B /* AccountVerificationProcedure.swift */,
 				58CCA01722426713004F3011 /* AccountViewController.swift */,
 				58CE5E63224146200008646E /* AppDelegate.swift */,
 				58CE5E6A224146210008646E /* Assets.xcassets */,
@@ -163,6 +175,7 @@
 				589AB4F8227C50D80039131E /* CustomNavigationBar.swift */,
 				58F37E7C2243ECCB00C75C97 /* HeaderBarViewController.swift */,
 				58CE5E6F224146210008646E /* Info.plist */,
+				58F19E30228B2AEB00C7710B /* JSONRequestProcedure.swift */,
 				58ADDB3B227B1BD200FAFEA7 /* JsonRpc.swift */,
 				58CE5E6C224146210008646E /* LaunchScreen.storyboard */,
 				58CE5E65224146200008646E /* LoginViewController.swift */,
@@ -176,9 +189,11 @@
 				5888AD82227B11080051EB06 /* SelectLocationCell.swift */,
 				5888AD86227B17950051EB06 /* SelectLocationController.swift */,
 				58CCA01122424D11004F3011 /* SettingsViewController.swift */,
+				58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */,
 				5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */,
 				587CBFE222807F530028DED3 /* UIColor+Helpers.swift */,
 				58CCA0152242560B004F3011 /* UIColor+Palette.swift */,
+				58FFE443228C82A00036F391 /* UserDefaultsInteractor.swift */,
 			);
 			path = MullvadVPN;
 			sourceTree = "<group>";
@@ -385,7 +400,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				58CCA010224249A1004F3011 /* ConnectViewController.swift in Sources */,
+				58461AD3228D622E00B72ECB /* Account.swift in Sources */,
 				5888AD87227B17950051EB06 /* SelectLocationController.swift in Sources */,
+				58F19E35228C15BA00C7710B /* SpinnerActivityIndicatorView.swift in Sources */,
 				58ADDB40227B1E7100FAFEA7 /* Optional+Unwrap.swift in Sources */,
 				58CCA0162242560B004F3011 /* UIColor+Palette.swift in Sources */,
 				587CBFE322807F530028DED3 /* UIColor+Helpers.swift in Sources */,
@@ -398,11 +415,14 @@
 				58ADDB3C227B1BD200FAFEA7 /* JsonRpc.swift in Sources */,
 				58CE5E64224146200008646E /* AppDelegate.swift in Sources */,
 				58CCA01222424D11004F3011 /* SettingsViewController.swift in Sources */,
+				58F19E33228B383300C7710B /* AccountVerificationProcedure.swift in Sources */,
 				58F37E7D2243ECCB00C75C97 /* HeaderBarViewController.swift in Sources */,
 				589AB4F7227B64450039131E /* BasicTableViewCell.swift in Sources */,
 				5888AD7F2279B6BF0051EB06 /* RelayStatusIndicatorView.swift in Sources */,
 				5867A51C2248F26A005513C0 /* SegueIdentifier.swift in Sources */,
+				58F19E31228B2AEB00C7710B /* JSONRequestProcedure.swift in Sources */,
 				58CCA01E2242787B004F3011 /* AccountTextField.swift in Sources */,
+				58FFE444228C82A00036F391 /* UserDefaultsInteractor.swift in Sources */,
 				5888AD89227B18C40051EB06 /* RelayList.swift in Sources */,
 				58C3A4B222456F1B00340BDB /* AccountInputGroupView.swift in Sources */,
 			);

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		08A905C56DDB0A0A887BB5F5 /* Pods_MullvadVPN.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F506AB938C45AEB812886B4 /* Pods_MullvadVPN.framework */; };
+		543203592C79FAD36BC1E700 /* Pods_PacketTunnel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A931E0F6F380B4B3FD45D987 /* Pods_PacketTunnel.framework */; };
 		5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */; };
 		5867A51C2248F26A005513C0 /* SegueIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5867A51B2248F26A005513C0 /* SegueIdentifier.swift */; };
 		587CBFE322807F530028DED3 /* UIColor+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587CBFE222807F530028DED3 /* UIColor+Helpers.swift */; };
@@ -60,6 +62,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3F506AB938C45AEB812886B4 /* Pods_MullvadVPN.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MullvadVPN.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		40D54D8A8B75B67DC37C5CCE /* Pods-PacketTunnel.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PacketTunnel.release.xcconfig"; path = "Target Support Files/Pods-PacketTunnel/Pods-PacketTunnel.release.xcconfig"; sourceTree = "<group>"; };
 		5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslucentButtonBlurView.swift; sourceTree = "<group>"; };
 		5866F39B2243B82D00168AE5 /* MullvadVPN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MullvadVPN.entitlements; sourceTree = "<group>"; };
 		5867A51B2248F26A005513C0 /* SegueIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegueIdentifier.swift; sourceTree = "<group>"; };
@@ -91,6 +95,10 @@
 		58CE5E7D224146470008646E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		58CE5E7E224146470008646E /* PacketTunnel.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PacketTunnel.entitlements; sourceTree = "<group>"; };
 		58F37E7C2243ECCB00C75C97 /* HeaderBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBarViewController.swift; sourceTree = "<group>"; };
+		627D4CE562B85202FCFA0EB1 /* Pods-MullvadVPN.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MullvadVPN.debug.xcconfig"; path = "Target Support Files/Pods-MullvadVPN/Pods-MullvadVPN.debug.xcconfig"; sourceTree = "<group>"; };
+		9F1362F46063B1D06EB0C685 /* Pods-PacketTunnel.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PacketTunnel.debug.xcconfig"; path = "Target Support Files/Pods-PacketTunnel/Pods-PacketTunnel.debug.xcconfig"; sourceTree = "<group>"; };
+		A931E0F6F380B4B3FD45D987 /* Pods_PacketTunnel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PacketTunnel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DBBD45CCF670C9D1C5C1AD03 /* Pods-MullvadVPN.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MullvadVPN.release.xcconfig"; path = "Target Support Files/Pods-MullvadVPN/Pods-MullvadVPN.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +106,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08A905C56DDB0A0A887BB5F5 /* Pods_MullvadVPN.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,18 +114,30 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				543203592C79FAD36BC1E700 /* Pods_PacketTunnel.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E15C74FDCF763609B367486 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3F506AB938C45AEB812886B4 /* Pods_MullvadVPN.framework */,
+				A931E0F6F380B4B3FD45D987 /* Pods_PacketTunnel.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		58CE5E57224146200008646E = {
 			isa = PBXGroup;
 			children = (
 				58CE5E62224146200008646E /* MullvadVPN */,
 				58CE5E7A224146470008646E /* PacketTunnel */,
 				58CE5E61224146200008646E /* Products */,
+				EA56DDD29D7312EAC382022A /* Pods */,
+				0E15C74FDCF763609B367486 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,6 +193,17 @@
 			path = PacketTunnel;
 			sourceTree = "<group>";
 		};
+		EA56DDD29D7312EAC382022A /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				627D4CE562B85202FCFA0EB1 /* Pods-MullvadVPN.debug.xcconfig */,
+				DBBD45CCF670C9D1C5C1AD03 /* Pods-MullvadVPN.release.xcconfig */,
+				9F1362F46063B1D06EB0C685 /* Pods-PacketTunnel.debug.xcconfig */,
+				40D54D8A8B75B67DC37C5CCE /* Pods-PacketTunnel.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -179,10 +211,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58CE5E72224146210008646E /* Build configuration list for PBXNativeTarget "MullvadVPN" */;
 			buildPhases = (
+				A4E72CCF49FD4D29D984E1FC /* [CP] Check Pods Manifest.lock */,
 				58CE5E5C224146200008646E /* Sources */,
 				58CE5E5D224146200008646E /* Frameworks */,
 				58CE5E5E224146200008646E /* Resources */,
 				58CE5E85224146470008646E /* Embed App Extensions */,
+				423609432954668DE7DEA7D5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -198,6 +232,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58CE5E82224146470008646E /* Build configuration list for PBXNativeTarget "PacketTunnel" */;
 			buildPhases = (
+				C8E26D766ABD05BF7B4EB4AC /* [CP] Check Pods Manifest.lock */,
 				58CE5E75224146470008646E /* Sources */,
 				58CE5E76224146470008646E /* Frameworks */,
 				58CE5E77224146470008646E /* Resources */,
@@ -274,6 +309,75 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		423609432954668DE7DEA7D5 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MullvadVPN/Pods-MullvadVPN-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/ProcedureKit/ProcedureKit.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ProcedureKit.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MullvadVPN/Pods-MullvadVPN-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A4E72CCF49FD4D29D984E1FC /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MullvadVPN-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C8E26D766ABD05BF7B4EB4AC /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PacketTunnel-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		58CE5E5C224146200008646E /* Sources */ = {
@@ -460,6 +564,7 @@
 		};
 		58CE5E73224146210008646E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 627D4CE562B85202FCFA0EB1 /* Pods-MullvadVPN.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -482,6 +587,7 @@
 		};
 		58CE5E74224146210008646E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DBBD45CCF670C9D1C5C1AD03 /* Pods-MullvadVPN.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -504,6 +610,7 @@
 		};
 		58CE5E83224146470008646E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9F1362F46063B1D06EB0C685 /* Pods-PacketTunnel.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = PacketTunnel/PacketTunnel.entitlements;
 				CODE_SIGN_STYLE = Automatic;
@@ -524,6 +631,7 @@
 		};
 		58CE5E84224146470008646E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 40D54D8A8B75B67DC37C5CCE /* Pods-PacketTunnel.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = PacketTunnel/PacketTunnel.entitlements;
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/MullvadVPN.xcworkspace/contents.xcworkspacedata
+++ b/ios/MullvadVPN.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:MullvadVPN.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios/MullvadVPN.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/MullvadVPN.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/MullvadVPN/Account.swift
+++ b/ios/MullvadVPN/Account.swift
@@ -1,0 +1,58 @@
+//
+//  Account.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 16/05/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+import ProcedureKit
+import os.log
+
+/// A class that groups the account related operations
+class Account {
+
+    enum Error: Swift.Error {
+        case invalidAccount
+    }
+
+    /// Perform the login and save the account token along with expiry (if available) to the
+    /// application preferences.
+    class func login(with accountToken: String) -> Procedure {
+        let userDefaultsInteractor = UserDefaultsInteractor.withApplicationGroupUserDefaults()
+
+        // Request account token verification
+        let verificationProcedure = AccountVerificationProcedure(accountToken: accountToken)
+
+        // Update the application preferences based on the AccountVerification result.
+        let saveAccountDataProcedure = TransformProcedure { (verification) in
+            switch verification {
+            case .verified(let expiry):
+                userDefaultsInteractor.accountToken = accountToken
+                userDefaultsInteractor.accountExpiry = expiry
+
+            case .deferred(let error):
+                userDefaultsInteractor.accountToken = accountToken
+                userDefaultsInteractor.accountExpiry = nil
+
+                os_log(.info, #"Could not request the account verification "%{private}s": %{public}s"#,
+                       accountToken, error.localizedDescription)
+
+            case .invalid:
+                throw Error.invalidAccount
+            }
+        }.injectResult(from: verificationProcedure)
+
+        return GroupProcedure(operations: [verificationProcedure, saveAccountDataProcedure])
+    }
+
+    /// Perform the logout by erasing the account token and expiry from the application preferences.
+    class func logout() {
+        let userDefaultsInteractor = UserDefaultsInteractor.withApplicationGroupUserDefaults()
+
+        userDefaultsInteractor.accountToken = nil
+        userDefaultsInteractor.accountExpiry = nil
+    }
+
+}

--- a/ios/MullvadVPN/AccountVerificationProcedure.swift
+++ b/ios/MullvadVPN/AccountVerificationProcedure.swift
@@ -1,0 +1,88 @@
+//
+//  AccountVerificationProcedure.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 14/05/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+import ProcedureKit
+
+/// Account verification result
+enum AccountVerification {
+    /// The app should attempt to verify the account token at some point later because the network
+    /// may not be available at this time.
+    case deferred(Error)
+
+    /// The app successfully verified the account token with the server
+    case verified(Date)
+
+    // Invalid token
+    case invalid
+}
+
+/// The error code returned by the API when it cannot find the given account token
+private let kAccountDoesNotExistErrorCode = -200
+
+/// The procedure that implements account verification by sending the account expiry request to the
+/// Mullvad API. This procedure is non-fallable so even in the case of network issues it will set
+/// the output and return no errors.
+class AccountVerificationProcedure: GroupProcedure, InputProcedure, OutputProcedure {
+    var input: Pending<String>
+    var output: Pending<ProcedureResult<AccountVerification>> = .pending
+
+    init(dispatchQueue underlyingQueue: DispatchQueue? = nil, accountToken: String? = nil) {
+        self.input = accountToken.flatMap { .ready($0) } ?? .pending
+
+        // Request account data from the API
+        let networkRequest = MullvadAPI.getAccountExpiry(accountToken: accountToken)
+
+        super.init(dispatchQueue: underlyingQueue, operations: [
+            // Wrap the network request into the ignoreErrorsProcedure to make sure that any network
+            // or JSON decoding errors do not get propagates. These errors will be returned along
+            // with the AccountVerification via the output.
+            IgnoreErrorsProcedure(dispatchQueue: underlyingQueue, operation: networkRequest)
+        ])
+
+        // Copy the input of the group procedure to the input of the starting procedure
+        addWillExecuteBlockObserver { [weak networkRequest] (groupProcedure, _) in
+            networkRequest?.input = groupProcedure.input
+        }
+
+        networkRequest.addWillFinishBlockObserver { [weak self] (networkRequest, error, _) in
+            guard let self = self else { return }
+
+            // Obtain the network error or the procedure result
+            guard let procedureResult = error.flatMap({ .failure($0) })
+                    ?? networkRequest.output.value else { return }
+
+            // Do not set the output if the network request was cancelled
+            if !networkRequest.isCancelled {
+                self.output = .ready(.success(self.mapResult(procedureResult)))
+            }
+        }
+    }
+
+    private func mapResult(_ procedureResult: ProcedureResult<JsonRpcResponse<Date>>) -> Output {
+        // Unwrap the result of the network request procedure
+        switch procedureResult {
+        case .success(let response):
+            // Unwrap the JSON RPC response
+            switch response.result {
+            case .success(let expiryDate):
+                return .verified(expiryDate)
+
+            case .failure(let serverError):
+                if serverError.code == kAccountDoesNotExistErrorCode {
+                    return .invalid
+                } else {
+                    return .deferred(serverError)
+                }
+            }
+        case .failure(let networkError):
+            // Check back later in case of network issues
+            return .deferred(networkError)
+        }
+    }
+}

--- a/ios/MullvadVPN/Base.lproj/Main.storyboard
+++ b/ios/MullvadVPN/Base.lproj/Main.storyboard
@@ -4,7 +4,6 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -30,6 +29,14 @@
                             <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0ZY-Kh-JiM" userLabel="Container">
                                 <rect key="frame" x="0.0" y="94" width="375" height="573"/>
                                 <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pID-oa-Rrg" customClass="SpinnerActivityIndicatorView" customModule="MullvadVPN" customModuleProvider="target">
+                                        <rect key="frame" x="163.5" y="125.5" width="48" height="48"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="48" id="2J4-Qc-ctc"/>
+                                            <constraint firstAttribute="width" constant="48" id="ohE-fk-mg9"/>
+                                        </constraints>
+                                    </view>
                                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="V3j-Lb-fSQ" userLabel="Form">
                                         <rect key="frame" x="0.0" y="203.5" width="375" height="126"/>
                                         <subviews>
@@ -85,8 +92,10 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
+                                    <constraint firstItem="V3j-Lb-fSQ" firstAttribute="top" secondItem="pID-oa-Rrg" secondAttribute="bottom" constant="30" id="2Sy-bS-AZZ"/>
                                     <constraint firstItem="V3j-Lb-fSQ" firstAttribute="centerY" secondItem="0ZY-Kh-JiM" secondAttribute="centerY" constant="-20" id="3Uk-YZ-4C3"/>
                                     <constraint firstAttribute="trailing" secondItem="V3j-Lb-fSQ" secondAttribute="trailing" id="EHy-Cx-cGj"/>
+                                    <constraint firstItem="pID-oa-Rrg" firstAttribute="centerX" secondItem="0ZY-Kh-JiM" secondAttribute="centerX" id="Ojm-D5-HnO"/>
                                     <constraint firstItem="V3j-Lb-fSQ" firstAttribute="leading" secondItem="0ZY-Kh-JiM" secondAttribute="leading" id="alr-G1-L4w"/>
                                 </constraints>
                             </view>
@@ -139,6 +148,7 @@
                     </view>
                     <connections>
                         <outlet property="accountTextField" destination="XOB-ct-yLU" id="mXd-SV-E16"/>
+                        <outlet property="activityIndicator" destination="pID-oa-Rrg" id="GG2-Hv-FWl"/>
                         <outlet property="keyboardToolbar" destination="waX-JF-VTG" id="kav-5t-mkA"/>
                         <outlet property="loginForm" destination="V3j-Lb-fSQ" id="tYu-S8-ylm"/>
                         <outlet property="loginFormWrapperBottomConstraint" destination="09L-EV-qfI" id="fYF-OK-trh"/>
@@ -529,7 +539,7 @@
         <image name="TranslucentNeutralButton" width="9" height="9"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="qKR-6L-kfz"/>
-        <segue reference="fxZ-Uq-nxv"/>
+        <segue reference="tVd-Lw-FVU"/>
+        <segue reference="RjC-Wk-Enk"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/ios/MullvadVPN/JSONRequestProcedure.swift
+++ b/ios/MullvadVPN/JSONRequestProcedure.swift
@@ -1,0 +1,47 @@
+//
+//  JSONRequestProcedure.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 14/05/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+import ProcedureKit
+
+final class JSONRequestProcedure<Input, Output: Decodable>: GroupProcedure, InputProcedure, OutputProcedure {
+
+    typealias URLRequestBuilder = (Input) throws -> URLRequest
+
+    var input: Pending<Input>
+    var output: Pending<ProcedureResult<Output>> = .pending
+
+    init(dispatchQueue underlyingQueue: DispatchQueue? = nil, input: Input? = nil, requestBuilder: @escaping URLRequestBuilder) {
+        self.input = input.flatMap { .ready($0) } ?? .pending
+
+        let createRequest = TransformProcedure { try requestBuilder($0) }
+
+        let networkRequest = NetworkProcedure {
+            NetworkDataProcedure(session: URLSession.shared)
+            }.injectResult(from: createRequest)
+
+        let payloadParsing = DecodeJSONProcedure<Output>(
+            dateDecodingStrategy: .iso8601,
+            keyDecodingStrategy: .convertFromSnakeCase
+            ).injectPayload(fromNetwork: networkRequest)
+
+        super.init(dispatchQueue: underlyingQueue, operations: [createRequest, networkRequest, payloadParsing])
+
+        bind(from: payloadParsing)
+
+        addWillExecuteBlockObserver { (procedure, _) in
+            createRequest.input = procedure.input
+        }
+    }
+}
+
+extension JSONRequestProcedure where Input == Void {
+    convenience init(requestBuilder: @escaping URLRequestBuilder) {
+        self.init(input: (), requestBuilder: requestBuilder)
+    }
+}

--- a/ios/MullvadVPN/JsonRpc.swift
+++ b/ios/MullvadVPN/JsonRpc.swift
@@ -29,20 +29,22 @@ extension JsonRpcRequest where T == NoData {
 struct NoData: Encodable {}
 
 class JsonRpcResponseError: Error, Decodable {
-    let serverErrorMessage: String
-
-    init(serverErrorMessage: String) {
-        self.serverErrorMessage = serverErrorMessage
-    }
+    let code: Int
+    let message: String
 
     var localizedDescription: String? {
-        return serverErrorMessage
+        return message
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code, message
     }
 
     required init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        serverErrorMessage = try container.decode(String.self)
+        code = try container.decode(Int.self, forKey: .code)
+        message = try container.decode(String.self, forKey: .message)
     }
 }
 

--- a/ios/MullvadVPN/SegueIdentifier.swift
+++ b/ios/MullvadVPN/SegueIdentifier.swift
@@ -19,6 +19,7 @@ struct SegueIdentifier {
     enum Login: String, SegueConvertible {
         case embedHeader = "EmbedHeaderBar"
         case showSettings = "ShowSettings"
+        case showConnect = "ShowConnect"
     }
 
     enum SelectLocation: String, SegueConvertible {

--- a/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
+++ b/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
@@ -1,0 +1,188 @@
+//
+//  SpinnerActivityIndicatorView.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 15/05/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import UIKit
+
+private let kRotationAnimationKey = "rotation"
+private let kAnimationDuration = 0.6
+
+@IBDesignable class SpinnerActivityIndicatorView: UIView {
+
+    /// Thickness of the front and back circles
+    var thickness: CGFloat = 6 {
+        didSet {
+            setLayersThickness()
+        }
+    }
+
+    /// The back circle color
+    var backCircleColor = UIColor.white.withAlphaComponent(0.2) {
+        didSet {
+            setBackCircleLayerColor()
+        }
+    }
+
+    /// The front circle color
+    var frontCircleColor: UIColor? {
+        didSet {
+            setFrontCircleLayerColor()
+        }
+    }
+
+    @IBInspectable var isAnimating: Bool = false {
+        didSet {
+            guard oldValue != isAnimating else { return }
+
+            if isAnimating {
+                startAnimating()
+            } else {
+                stopAnimating()
+            }
+        }
+    }
+
+    fileprivate let frontCircle = CAShapeLayer()
+    fileprivate let backCircle = CAShapeLayer()
+    fileprivate var startTime = CFTimeInterval(0)
+    fileprivate var stopTime = CFTimeInterval(0)
+
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: 48, height: 48)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    deinit {
+        unregisterFromAppStateNotifications()
+    }
+
+    override func layoutSublayers(of layer: CALayer) {
+        super.layoutSublayers(of: layer)
+        setupBezierPaths()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        if window != nil {
+            restartAnimationIfNeeded()
+        }
+    }
+
+    override func tintColorDidChange() {
+        super.tintColorDidChange()
+
+        setFrontCircleLayerColor()
+    }
+
+    // MARK: - Private
+
+    private func startAnimating() {
+        isHidden = false
+        addAnimation()
+    }
+
+    private func stopAnimating() {
+        isHidden = true
+        removeAnimation()
+    }
+
+    private func commonInit() {
+        registerForAppStateNotifications()
+
+        isHidden = true
+        backgroundColor = UIColor.clear
+
+        backCircle.fillColor = UIColor.clear.cgColor
+        frontCircle.fillColor = UIColor.clear.cgColor
+        frontCircle.lineCap = .round
+
+        setBackCircleLayerColor()
+        setFrontCircleLayerColor()
+        setLayersThickness()
+
+        layer.addSublayer(backCircle)
+        layer.addSublayer(frontCircle)
+    }
+
+    private func setLayersThickness() {
+        backCircle.lineWidth = thickness
+        frontCircle.lineWidth = thickness
+    }
+
+    private func setBackCircleLayerColor() {
+        backCircle.strokeColor = backCircleColor.cgColor
+    }
+
+    private func setFrontCircleLayerColor() {
+        frontCircle.strokeColor = frontCircleColor?.cgColor ?? tintColor.cgColor
+    }
+
+    private func addAnimation() {
+        let timeOffset = stopTime - startTime
+
+        let anim = animation()
+        anim.timeOffset = timeOffset
+
+        layer.add(anim, forKey: kRotationAnimationKey)
+
+        startTime = layer.convertTime(CACurrentMediaTime(), from: nil) - timeOffset
+    }
+
+    private func removeAnimation() {
+        layer.removeAnimation(forKey: kRotationAnimationKey)
+
+        stopTime = layer.convertTime(CACurrentMediaTime(), from: nil)
+    }
+
+    @objc private func restartAnimationIfNeeded() {
+        let anim = layer.animation(forKey: kRotationAnimationKey)
+
+        if isAnimating && anim == nil {
+            removeAnimation()
+            addAnimation()
+        }
+    }
+
+    private func registerForAppStateNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(restartAnimationIfNeeded), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    private func unregisterFromAppStateNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    private func animation() -> CABasicAnimation {
+        let animation = CABasicAnimation(keyPath: "transform.rotation")
+        animation.toValue = NSNumber(value: Double.pi * 2)
+        animation.duration = kAnimationDuration
+        animation.repeatCount = Float.infinity
+        animation.timingFunction = CAMediaTimingFunction(name: .linear)
+
+        return animation
+    }
+
+    private func setupBezierPaths() {
+        let center = CGPoint(x: bounds.size.width * 0.5, y: bounds.size.height * 0.5)
+        let radius = bounds.size.width * 0.5 - thickness
+        let closedRingPath = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
+        let openRingPath = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 1.5, clockwise: true)
+
+        backCircle.path = closedRingPath.cgPath
+        frontCircle.path = openRingPath.cgPath
+    }
+
+}

--- a/ios/MullvadVPN/UserDefaultsInteractor.swift
+++ b/ios/MullvadVPN/UserDefaultsInteractor.swift
@@ -1,0 +1,54 @@
+//
+//  UserDefaultsInteractor.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 15/05/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+
+/// The application group identifier used for sharing application preferences between processes
+private let kApplicationGroupIdentifier = "group.net.mullvad.MullvadVPN"
+
+/// The UserDefaults keys used to store the application preferences
+private enum UserDefaultsKeys: String {
+    case accountToken, accountExpiry
+}
+
+/// The interactor class that provides a convenient interface for accessing the Mullvad VPN
+/// preferences stored in the UserDefaults store.
+class UserDefaultsInteractor {
+    let userDefaults: UserDefaults
+
+    /// Returns the instance of UserDefaultsInteractor initialized with the application preferences
+    /// scoped to the application group.
+    class func withApplicationGroupUserDefaults() -> UserDefaultsInteractor {
+        let userDefaults = UserDefaults(suiteName: kApplicationGroupIdentifier)!
+
+        return UserDefaultsInteractor(userDefaults: userDefaults)
+    }
+
+    init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    var accountToken: String? {
+        get {
+            return userDefaults.string(forKey: UserDefaultsKeys.accountToken.rawValue)
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.accountToken.rawValue)
+        }
+    }
+
+    var accountExpiry: Date? {
+        get {
+            return userDefaults.object(forKey: UserDefaultsKeys.accountExpiry.rawValue) as? Date
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.accountExpiry.rawValue)
+        }
+    }
+
+}

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,16 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '12.0'
+
+# Disable sending stats
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+target 'MullvadVPN' do
+  use_frameworks!
+
+  pod 'ProcedureKit', '5.2.0'
+  pod 'ProcedureKit/Network', '5.2.0'
+end
+
+target 'PacketTunnel' do
+  use_frameworks!
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,21 @@
+PODS:
+  - ProcedureKit (5.2.0):
+    - ProcedureKit/Standard (= 5.2.0)
+  - ProcedureKit/Network (5.2.0):
+    - ProcedureKit/Standard
+  - ProcedureKit/Standard (5.2.0)
+
+DEPENDENCIES:
+  - ProcedureKit (= 5.2.0)
+  - ProcedureKit/Network (= 5.2.0)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - ProcedureKit
+
+SPEC CHECKSUMS:
+  ProcedureKit: deafeab083a0c5e45e4b02379e0ffa316d03db29
+
+PODFILE CHECKSUM: 60eba65d4e5de6e969c10d6886293366a3f97e23
+
+COCOAPODS: 1.6.1


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)


### What

1. Add [Cocoapods](https://cocoapods.org) package manager for iOS:
     https://guides.cocoapods.org/using/getting-started.html
     
     It's a ruby gem so you either install it system wide or in the virtual machine environment. I like RVM for managing my Ruby installation (https://rvm.io). This way I can avoid using sudo when installing gems since they would end up in the `$HOME` directory instead of the system one.
    
    Once you've installed the CocoaPods you should be able to run the `pod --version` command to verify the installation.
  
    In order to install the iOS app dependencies, you have to `cd mullvadvpn-app/ios` and run `pod install`. After it did its job, you should be able to open the newly created workspace (`MullvadVPN.xcworkspace`) in Xcode, that includes the dependencies (aka `Pods` project) and `Mullvad VPN` project itself.

1. Add [ProcedureKit](https://github.com/ProcedureKit/ProcedureKit) dependency for managing advanced operations. It comes with a bunch of handy classes for organising concurrent flows. It's build on top of Apple Foundation's `NSOperation`, beefed up with advanced features. 
    
    Essentially operations are like pipes with inputs and outputs. You do the plumbing to connect them and run them to produce the result. The execution order of operations is automatically sorted based on the relationships/dependencies between operations.

1. Add `SpinnerActivityIndicatorView` which is basically the spinner view that we have in SVG but implemented with CoreAnimation framework.

1. Add `UserDefaultsInteractor` to store `accountToken` and `accountExpiry` in the application preferences. `UserDefaults` is basically a key-value preferences store and the `UserDefaultsInteractor` is basically a nicer way of working with it as it's typed for our specific preferences.

1. Add `Account` abstraction that implements the account related business logic, such as login and logout.

1. Update `JsonRpcResponseError`, which I realised, is not a plain string but rather an object with `{code: Int, message: String}` fields.

1. Add `JSONRequestProcedure` that does the following things:

    1. Accepts `URLRequest` as input

    1. Performs a network request with the backoff/retry strategy that by default times out the request after `8s` and retries to send it `3 times` with `2s` interval which is increased by `2s` on each attempt. We can customise that but I left it as is for now as it seems OK.

    1. Parses JSON and converts it to Swift class/struct and sets the output

1. Add `AccountVerificationProcedure` to perform the account verification logic we currently have in the desktop app.
    1. It requests the Account expiry from the API.
    1. Does not fail the whole task if network errors occur.
    1. It returns the `AccountVerification.deferred(Error)` result in case of basically any network coming out of the network request procedure. Can either be a network error or JSON decoding error.
    1. It returns the `AccountVerification.invalidAccount` if the server response contains the `-200` error.
    1. It returns the `AccountVerification.verified(Date)` if it was able to receive the account expiration from the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/855)
<!-- Reviewable:end -->
