### PR TITLE
Use stable Debian as a source image in CI's build Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build . -t mullvadvpn/mullvadvpn-app-build
 # To push the image to our docker hub:
 # docker push mullvadvpn/mullvadvpn-app-build
-FROM debian:unstable
+FROM debian:stable@sha256:75f7d0590b45561bfa443abad0b3e0f86e2811b1fc176f786cd30eb078d1846f
 RUN apt update -y
 RUN apt install build-essential \
 	gcc \


### PR DESCRIPTION
Previously, the Docker image used for building the app in CI was based on unstable Debian because it needed a newer version of Binutils in order to properly link in the Wireguard static library. The library's binary has since been updated in the `mullvadvpn-app-binaries` repository, so the build can be changed to use the stable version of Debian.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Change does not impact the user.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/856)
<!-- Reviewable:end -->
