### PR TITLE
Prepare for easier usage of daemon as a library

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -18,6 +18,7 @@ pub mod logging;
 mod management_interface;
 mod relays;
 mod rpc_uniqueness_check;
+pub mod version;
 
 use crate::management_interface::{BoxFuture, ManagementCommand, ManagementInterfaceServer};
 use futures::{

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -14,6 +14,7 @@ extern crate serde;
 
 mod account_history;
 mod geoip;
+pub mod logging;
 mod management_interface;
 mod relays;
 mod rpc_uniqueness_check;

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -20,7 +20,8 @@ mod relays;
 mod rpc_uniqueness_check;
 pub mod version;
 
-use crate::management_interface::{BoxFuture, ManagementCommand, ManagementInterfaceServer};
+pub use crate::management_interface::ManagementCommand;
+use crate::management_interface::{BoxFuture, ManagementInterfaceServer};
 use futures::{
     future,
     sync::{mpsc::UnboundedSender, oneshot},
@@ -58,6 +59,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error(display = "Another instance of the daemon is already running")]
     DaemonIsAlreadyRunning,
+
+    #[error(display = "Failed to send command to daemon because it is not running")]
+    DaemonUnavailable,
 
     #[error(display = "Unable to initialize network event loop")]
     InitIoEventLoop(#[error(cause)] io::Error),
@@ -162,6 +166,17 @@ impl DaemonExecutionState {
     }
 }
 
+pub struct DaemonCommandSender(IntoSender<ManagementCommand, InternalDaemonEvent>);
+
+impl DaemonCommandSender {
+    pub(crate) fn new(internal_event_sender: mpsc::Sender<InternalDaemonEvent>) -> Self {
+        DaemonCommandSender(IntoSender::from(internal_event_sender))
+    }
+
+    pub fn send(&self, command: ManagementCommand) -> Result<()> {
+        self.0.send(command).map_err(|_| Error::DaemonUnavailable)
+    }
+}
 
 pub struct Daemon {
     tunnel_command_tx: SyncUnboundedSender<TunnelCommand>,
@@ -307,6 +322,11 @@ impl Daemon {
             error!("Mullvad management interface shut down");
             let _ = exit_tx.send(InternalDaemonEvent::ManagementInterfaceExited);
         });
+    }
+
+    /// Retrieve a channel for sending daemon commands.
+    pub fn command_sender(&self) -> DaemonCommandSender {
+        DaemonCommandSender::new(self.tx.clone())
     }
 
     /// Consume the `Daemon` and run the main event loop. Blocks until an error happens or a

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -9,7 +9,7 @@
 #![deny(rust_2018_idioms)]
 
 use log::{debug, error, info, warn};
-use mullvad_daemon::{logging, Daemon};
+use mullvad_daemon::{logging, version, Daemon};
 use std::{path::PathBuf, thread, time::Duration};
 use talpid_types::ErrorExt;
 
@@ -17,7 +17,6 @@ mod cli;
 mod shutdown;
 #[cfg(windows)]
 mod system_service;
-mod version;
 
 const DAEMON_LOG_FILENAME: &str = "daemon.log";
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -9,12 +9,11 @@
 #![deny(rust_2018_idioms)]
 
 use log::{debug, error, info, warn};
-use mullvad_daemon::Daemon;
+use mullvad_daemon::{logging, Daemon};
 use std::{path::PathBuf, thread, time::Duration};
 use talpid_types::ErrorExt;
 
 mod cli;
-mod logging;
 mod shutdown;
 #[cfg(windows)]
 mod system_service;


### PR DESCRIPTION
This is a preparation PR for Android.

First, it moves the `logging` and `version` modules from the executable to the library, so that other crates can use them as helpers.

Second, it creates a `DaemonCommandSender` wrapper type to allow sending `management_interface::ManagementCommand`s to the daemon using an `mpsc::Sender`. The wrapper type exists so that the `InternalDaemonEvent` doesn't have to be made public.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Android version not released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/857)
<!-- Reviewable:end -->
