### PR TITLE
Move RPC socket removal to `management_interface`

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -300,10 +300,7 @@ impl Daemon {
     ) -> Result<ManagementInterfaceServer> {
         let server =
             ManagementInterfaceServer::start(event_tx).map_err(Error::StartManagementInterface)?;
-        info!(
-            "Mullvad management interface listening on {}",
-            server.socket_path()
-        );
+        info!("Management interface listening on {}", server.socket_path());
 
         Ok(server)
     }
@@ -314,7 +311,7 @@ impl Daemon {
     ) {
         thread::spawn(move || {
             server.wait();
-            info!("Mullvad management interface shut down");
+            info!("Management interface shut down");
             let _ = exit_tx.send(InternalDaemonEvent::ManagementInterfaceExited);
         });
     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -314,7 +314,7 @@ impl Daemon {
     ) {
         thread::spawn(move || {
             server.wait();
-            error!("Mullvad management interface shut down");
+            info!("Mullvad management interface shut down");
             let _ = exit_tx.send(InternalDaemonEvent::ManagementInterfaceExited);
         });
     }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -260,6 +260,7 @@ impl ManagementInterfaceServer {
     pub fn event_broadcaster(&self) -> EventBroadcaster {
         EventBroadcaster {
             subscriptions: self.subscriptions.clone(),
+            close_handle: self.server.close_handle(),
         }
     }
 
@@ -274,9 +275,15 @@ impl ManagementInterfaceServer {
 #[derive(Clone)]
 pub struct EventBroadcaster {
     subscriptions: Arc<RwLock<HashMap<SubscriptionId, pubsub::Sink<DaemonEvent>>>>,
+    close_handle: talpid_ipc::CloseHandle,
 }
 
 impl EventBroadcaster {
+    /// Notifies that the management interface should be closed
+    pub fn close(self) {
+        self.close_handle.close();
+    }
+
     /// Sends a new state update to all `new_state` subscribers of the management interface.
     pub fn notify_new_state(&self, new_state: TunnelStateTransition) {
         log::debug!("Broadcasting new state: {:?}", new_state);


### PR DESCRIPTION
Currently, the daemon has a Unix specific `Drop` implementation for `Daemon`. The purpose of that destructor is to ensure that the management interface socket file is removed. Since on Android the socket won't be used, this PR refactors `Daemon` and `ManagementInterface` so that the socket is removed when the `ManagementInterface` is dropped, with the help of a wrapper type.

The wrapper type is mostly so that the `wait(self)` can continue to receive `self` by move.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/858)
<!-- Reviewable:end -->
