### PR TITLE
Add better offline detection on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Raise max number of open files for the daemon to 1024. Should prevent threads from panicking.
 
+#### Windows
+- Add better offline detection
+
 
 ## [2019.4] - 2019-05-08
 This release is identical to 2019.4-beta1

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -6,17 +6,20 @@
 //! GNU General Public License as published by the Free Software Foundation, either version 3 of
 //! the License, or (at your option) any later version.
 
-use crate::tunnel_state_machine::TunnelCommand;
+use crate::{tunnel_state_machine::TunnelCommand, winnet};
 use futures::sync::mpsc::UnboundedSender;
-use log::debug;
+use parking_lot::Mutex;
 use std::{
     ffi::c_void,
     io,
     mem::zeroed,
     os::windows::io::{IntoRawHandle, RawHandle},
-    ptr, thread,
+    ptr,
+    sync::Arc,
+    thread,
     time::Duration,
 };
+use talpid_types::ErrorExt;
 use winapi::{
     shared::{
         basetsd::LONG_PTR,
@@ -46,32 +49,61 @@ const REQUEST_THREAD_SHUTDOWN: UINT = WM_USER + 1;
 pub enum Error {
     #[error(display = "Unable to create listener thread")]
     ThreadCreationError(#[error(cause)] io::Error),
+    #[error(display = "Failed to start connectivity monitor")]
+    ConnectivityMonitorError,
 }
 
 
 pub struct BroadcastListener {
     thread_handle: RawHandle,
     thread_id: DWORD,
+    _system_state: Arc<Mutex<SystemState>>,
 }
 
 unsafe impl Send for BroadcastListener {}
 
 impl BroadcastListener {
-    pub fn start<F>(client_callback: F) -> Result<Self, Error>
-    where
-        F: Fn(UINT, WPARAM, LPARAM) + 'static + Send,
-    {
+    pub fn start(sender: UnboundedSender<TunnelCommand>) -> Result<Self, Error> {
+        let mut system_state = Arc::new(Mutex::new(SystemState {
+            network_connectivity: false,
+            suspended: false,
+            daemon_channel: sender,
+        }));
+
+        let power_broadcast_state_ref = system_state.clone();
+
+        let power_broadcast_callback = move |message: UINT, wparam: WPARAM, _lparam: LPARAM| {
+            let state = power_broadcast_state_ref.clone();
+            if message == WM_POWERBROADCAST {
+                if wparam == PBT_APMSUSPEND {
+                    log::debug!("Machine is preparing to enter sleep mode");
+                    apply_system_state_change(state, StateChange::Suspended(true));
+                } else if wparam == PBT_APMRESUMEAUTOMATIC {
+                    log::debug!("Machine is returning from sleep mode");
+                    thread::spawn(move || {
+                        // TAP will be unavailable for approximately 2 seconds on a healthy machine.
+                        thread::sleep(Duration::from_secs(5));
+                        log::debug!("TAP is presumed to have been re-initialized");
+                        apply_system_state_change(state, StateChange::Suspended(false));
+                    });
+                }
+            }
+        };
+
         let join_handle = thread::Builder::new()
             .spawn(move || unsafe {
-                Self::message_pump(client_callback);
+                Self::message_pump(power_broadcast_callback);
             })
             .map_err(Error::ThreadCreationError)?;
 
         let real_handle = join_handle.into_raw_handle();
 
+        unsafe { Self::setup_network_connectivity_listener(&mut system_state)? };
+
         Ok(BroadcastListener {
             thread_handle: real_handle,
             thread_id: unsafe { GetThreadId(real_handle) },
+            _system_state: system_state,
         })
     }
 
@@ -156,6 +188,33 @@ impl BroadcastListener {
 
         DefWindowProcW(window, message, wparam, lparam)
     }
+
+    /// The caller must make sure the `system_state` reference is valid
+    /// until after `WinNet_DeactivateConnectivityMonitor` has been called.
+    unsafe fn setup_network_connectivity_listener(
+        system_state: &Mutex<SystemState>,
+    ) -> Result<(), Error> {
+        let callback_context = system_state as *const _ as *mut libc::c_void;
+        let mut state = system_state.lock();
+        let mut current_connectivity = true;
+        if !winnet::WinNet_ActivateConnectivityMonitor(
+            Some(Self::connectivity_callback),
+            callback_context,
+            &mut current_connectivity as *mut _,
+            Some(winnet::error_sink),
+            ptr::null_mut(),
+        ) {
+            return Err(Error::ConnectivityMonitorError);
+        }
+        state.network_connectivity = current_connectivity;
+        Ok(())
+    }
+
+    unsafe extern "system" fn connectivity_callback(connectivity: bool, context: *mut c_void) {
+        let state_lock: &mut Mutex<SystemState> = &mut *(context as *mut _);
+        let mut state = state_lock.lock();
+        state.apply_change(StateChange::NetworkConnectivity(connectivity));
+    }
 }
 
 impl Drop for BroadcastListener {
@@ -164,35 +223,74 @@ impl Drop for BroadcastListener {
             PostThreadMessageW(self.thread_id, REQUEST_THREAD_SHUTDOWN, 0, 0);
             WaitForSingleObject(self.thread_handle, INFINITE);
             CloseHandle(self.thread_handle);
+            if !winnet::WinNet_DeactivateConnectivityMonitor() {
+                log::error!("Failed to deactivate connectivity monitor");
+            }
         }
+    }
+}
+
+#[derive(Debug)]
+enum StateChange {
+    NetworkConnectivity(bool),
+    Suspended(bool),
+}
+
+struct SystemState {
+    network_connectivity: bool,
+    suspended: bool,
+    daemon_channel: UnboundedSender<TunnelCommand>,
+}
+
+impl SystemState {
+    fn apply_change(&mut self, change: StateChange) {
+        let old_state = self.is_offline_currently();
+        match change {
+            StateChange::NetworkConnectivity(connectivity) => {
+                self.network_connectivity = connectivity;
+            }
+
+            StateChange::Suspended(suspended) => {
+                self.suspended = suspended;
+            }
+        };
+
+        let new_state = self.is_offline_currently();
+        if old_state != new_state {
+            if let Err(e) = self
+                .daemon_channel
+                .unbounded_send(TunnelCommand::IsOffline(new_state))
+            {
+                log::error!("Failed to send new offline state to daemon: {}", e);
+            }
+        }
+    }
+
+    fn is_offline_currently(&self) -> bool {
+        !self.network_connectivity || self.suspended
     }
 }
 
 pub type MonitorHandle = BroadcastListener;
 
 pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle, Error> {
-    let listener =
-        BroadcastListener::start(move |message: UINT, wparam: WPARAM, _lparam: LPARAM| {
-            if message == WM_POWERBROADCAST {
-                if wparam == PBT_APMSUSPEND {
-                    debug!("Machine is preparing to enter sleep mode");
-                    let _ = sender.unbounded_send(TunnelCommand::IsOffline(true));
-                } else if wparam == PBT_APMRESUMEAUTOMATIC {
-                    debug!("Machine is returning from sleep mode");
-                    let cloned_sender = sender.clone();
-                    thread::spawn(move || {
-                        // TAP will be unavailable for approximately 2 seconds on a healthy machine.
-                        thread::sleep(Duration::from_secs(5));
-                        debug!("TAP is presumed to have been re-initialized");
-                        let _ = cloned_sender.unbounded_send(TunnelCommand::IsOffline(false));
-                    });
-                }
-            }
-        })?;
+    BroadcastListener::start(sender)
+}
 
-    Ok(listener)
+fn apply_system_state_change(state: Arc<Mutex<SystemState>>, change: StateChange) {
+    let mut state = state.lock();
+    state.apply_change(change);
 }
 
 pub fn is_offline() -> bool {
-    false
+    match winnet::is_offline() {
+        Ok(state) => state,
+        Err(e) => {
+            log::error!(
+                "{}",
+                e.display_chain_with_msg("Failed to get current connectivity")
+            );
+            false
+        }
+    }
 }

--- a/windows/winnet/src/extras/loader/loader.cpp
+++ b/windows/winnet/src/extras/loader/loader.cpp
@@ -2,25 +2,39 @@
 #include "../../winnet/winnet.h"
 #include <iostream>
 
+void __stdcall ConnectivityChanged(uint8_t connected)
+{
+	std::wcout << (0 != connected? L"Connected" : L"NOT connected") << std::endl;
+}
+
 int main()
 {
-	wchar_t *alias = nullptr;
+	//wchar_t *alias = nullptr;
 
-	const auto status = WinNet_GetTapInterfaceAlias(&alias, nullptr, nullptr);
+	//const auto status = WinNet_GetTapInterfaceAlias(&alias, nullptr, nullptr);
 
-	switch (status)
-	{
-		case WINNET_GTIA_STATUS::FAILURE:
-		{
-			std::wcout << L"Could not determine alias" << std::endl;
-			break;
-		}
-		case WINNET_GTIA_STATUS::SUCCESS:
-		{
-			std::wcout << L"Interface alias: " << alias << std::endl;
-			WinNet_ReleaseString(alias);
-		}
-	};
+	//switch (status)
+	//{
+	//	case WINNET_GTIA_STATUS::FAILURE:
+	//	{
+	//		std::wcout << L"Could not determine alias" << std::endl;
+	//		break;
+	//	}
+	//	case WINNET_GTIA_STATUS::SUCCESS:
+	//	{
+	//		std::wcout << L"Interface alias: " << alias << std::endl;
+	//		WinNet_ReleaseString(alias);
+	//	}
+	//};
+
+	uint8_t currentConnectivity = 0;
+
+	const auto status = WinNet_ActivateConnectivityMonitor(ConnectivityChanged, &currentConnectivity, nullptr, nullptr);
+
+	std::wcout << L"Current connectivity: "
+		<< (0 != currentConnectivity ? L"Connected" : L"NOT connected") << std::endl;
+
+	_getwch();
 
     return 0;
 }

--- a/windows/winnet/src/winnet/netmonitor.cpp
+++ b/windows/winnet/src/winnet/netmonitor.cpp
@@ -1,0 +1,201 @@
+#include "stdafx.h"
+#include "netmonitor.h"
+#include <libcommon/error.h>
+#include <libcommon/memory.h>
+#include <libcommon/synchronization.h>
+
+namespace
+{
+
+bool ValidInterfaceType(const MIB_IF_ROW2 &iface)
+{
+	switch (iface.InterfaceLuid.Info.IfType)
+	{
+		case IF_TYPE_SOFTWARE_LOOPBACK:
+		case IF_TYPE_TUNNEL:
+		{
+			return false;
+		}
+	}
+
+	if (FALSE == iface.InterfaceAndOperStatusFlags.ConnectorPresent
+		|| FALSE != iface.InterfaceAndOperStatusFlags.EndPointInterface)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+} // anonyomus namespace
+
+NetMonitor::NetMonitor(NetMonitor::Notifier notifier, bool &currentConnectivity)
+	: m_notifier(notifier)
+	, m_connected(false)
+	, m_notificationHandle(nullptr)
+{
+	createCache();
+	updateConnectivity();
+
+	currentConnectivity = m_connected;
+
+	const auto status = NotifyIpInterfaceChange(AF_UNSPEC, callback, this, FALSE, &m_notificationHandle);
+
+	THROW_UNLESS(NO_ERROR, status, "Register interface change notification");
+}
+
+NetMonitor::~NetMonitor()
+{
+	CancelMibChangeNotify2(m_notificationHandle);
+}
+
+void NetMonitor::createCache()
+{
+	MIB_IF_TABLE2 *table;
+
+	const auto status = GetIfTable2(&table);
+
+	THROW_UNLESS(NO_ERROR, status, "Acquire network interface table");
+
+	common::memory::ScopeDestructor sd;
+
+	sd += [table]()
+	{
+		FreeMibTable(table);
+	};
+
+	for (ULONG i = 0; i < table->NumEntries; ++i)
+	{
+		addCacheEntry(table->Table[i]);
+	}
+}
+
+void NetMonitor::addCacheEntry(const MIB_IF_ROW2 &iface)
+{
+	CacheEntry e;
+
+	if (false == ValidInterfaceType(iface))
+	{
+		e.luid = iface.InterfaceLuid.Value;
+		e.valid = false;
+		e.connected = false;
+	}
+	else
+	{
+		e.luid = iface.InterfaceLuid.Value;
+		e.valid = true;
+		e.connected = (MediaConnectStateConnected == iface.MediaConnectState);
+	}
+
+	m_cache.insert(std::make_pair(e.luid, e));
+}
+
+void NetMonitor::updateConnectivity()
+{
+	for (const auto cacheEntryIter : m_cache)
+	{
+		const auto entry = cacheEntryIter.second;
+
+		if (entry.valid && entry.connected)
+		{
+			m_connected = true;
+			return;
+		}
+	}
+
+	m_connected = false;
+}
+
+//static
+void __stdcall NetMonitor::callback(void *context, MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType)
+{
+	auto thiz = reinterpret_cast<NetMonitor *>(context);
+
+	common::sync::ScopeLock<> processingLock(thiz->m_processingMutex);
+
+	switch (updateType)
+	{
+		case MibAddInstance:
+		{
+			MIB_IF_ROW2 iface = { 0 };
+			iface.InterfaceLuid = hint->InterfaceLuid;
+
+			if (NO_ERROR != GetIfEntry2(&iface))
+			{
+				// Failed to query interface.
+				return;
+			}
+
+			thiz->addCacheEntry(iface);
+
+			break;
+		}
+		case MibDeleteInstance:
+		{
+			const auto cacheEntry = thiz->m_cache.find(hint->InterfaceLuid.Value);
+
+			if (thiz->m_cache.end() != cacheEntry)
+			{
+				cacheEntry->second.connected = false;
+			}
+
+			break;
+		}
+		case MibParameterNotification:
+		{
+			auto cacheEntry = thiz->m_cache.find(hint->InterfaceLuid.Value);
+
+			if (thiz->m_cache.end() == cacheEntry)
+			{
+				//
+				// A change occurred on an interface that we're not tracking.
+				// Perhaps the MibAddInstance logic failed for some reason.
+				//
+
+				MIB_IF_ROW2 iface = { 0 };
+				iface.InterfaceLuid = hint->InterfaceLuid;
+
+				if (NO_ERROR != GetIfEntry2(&iface))
+				{
+					// Failed to query interface.
+					return;
+				}
+
+				thiz->addCacheEntry(iface);
+			}
+			else
+			{
+				//
+				// Abort processing if this is a known interface that we don't care about.
+				//
+				if (false == cacheEntry->second.valid)
+				{
+					return;
+				}
+
+				//
+				// Update cache.
+				//
+
+				MIB_IF_ROW2 iface = { 0 };
+				iface.InterfaceLuid = hint->InterfaceLuid;
+
+				const auto status = GetIfEntry2(&iface);
+
+				cacheEntry->second.connected =
+					(NO_ERROR == status ? MediaConnectStateConnected == iface.MediaConnectState : false);
+			}
+
+			break;
+		}
+	}
+
+	const auto previousConnectivity = thiz->m_connected;
+
+	thiz->updateConnectivity();
+
+	if (previousConnectivity != thiz->m_connected)
+	{
+		thiz->m_notifier(thiz->m_connected);
+	}
+}

--- a/windows/winnet/src/winnet/netmonitor.h
+++ b/windows/winnet/src/winnet/netmonitor.h
@@ -23,11 +23,9 @@ public:
 	NetMonitor(Notifier notifier, bool &currentConnectivity);
 	~NetMonitor();
 
+	static bool CheckConnectivity();
+
 private:
-
-	std::mutex m_processingMutex;
-
-	Notifier m_notifier;
 
 	struct CacheEntry
 	{
@@ -41,15 +39,20 @@ private:
 		bool connected;
 	};
 
-	std::map<uint64_t, CacheEntry> m_cache;
+	using Cache = std::map<uint64_t, CacheEntry>;
 
+	std::mutex m_processingMutex;
+	Cache m_cache;
 	bool m_connected;
+	Notifier m_notifier;
 
 	HANDLE m_notificationHandle;
 
-	void createCache();
-	void addCacheEntry(const MIB_IF_ROW2 &iface);
+	static Cache CreateCache();
+	static void AddCacheEntry(Cache &cache, const MIB_IF_ROW2 &iface);
+	static bool CheckConnectivity(const Cache &cache);
+
 	void updateConnectivity();
 
-	static void __stdcall callback(void *context, MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType);
+	static void __stdcall Callback(void *context, MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType);
 };

--- a/windows/winnet/src/winnet/netmonitor.h
+++ b/windows/winnet/src/winnet/netmonitor.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <cstdint>
+#include <mutex>
+#include <functional>
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <iphlpapi.h>
+#include <windows.h>
+
+class NetMonitor
+{
+public:
+
+	//
+	// Connectivity changed.
+	// true = connected, false = disconnected.
+	//
+	using Notifier = std::function<void(bool)>;
+
+	NetMonitor(Notifier notifier, bool &currentConnectivity);
+	~NetMonitor();
+
+private:
+
+	std::mutex m_processingMutex;
+
+	Notifier m_notifier;
+
+	struct CacheEntry
+	{
+		// Unique interface identifier.
+		uint64_t luid;
+
+		// Whether this is a physical adapter or not.
+		bool valid;
+
+		// Last known state.
+		bool connected;
+	};
+
+	std::map<uint64_t, CacheEntry> m_cache;
+
+	bool m_connected;
+
+	HANDLE m_notificationHandle;
+
+	void createCache();
+	void addCacheEntry(const MIB_IF_ROW2 &iface);
+	void updateConnectivity();
+
+	static void __stdcall callback(void *context, MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType);
+};

--- a/windows/winnet/src/winnet/winnet.def
+++ b/windows/winnet/src/winnet/winnet.def
@@ -4,3 +4,6 @@ EXPORTS
 	WinNet_GetTapInterfaceIpv6Status
 	WinNet_GetTapInterfaceAlias
 	WinNet_ReleaseString
+	WinNet_ActivateConnectivityMonitor
+	WinNet_DeactivateConnectivityMonitor
+	WinNet_CheckConnectivity

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <cstdint>
+#include <stdint.h>
+#include <stdbool.h>
 
 #ifdef WINNET_EXPORTS
 #define WINNET_LINKAGE __declspec(dllexport)
@@ -25,7 +26,7 @@ WINNET_API
 WinNet_EnsureTopMetric(
 	const wchar_t *deviceAlias,
 	WinNetErrorSink errorSink,
-	void* errorSinkContext
+	void *errorSinkContext
 );
 
 enum class WINNET_GTII_STATUS : uint32_t
@@ -41,23 +42,17 @@ WINNET_GTII_STATUS
 WINNET_API
 WinNet_GetTapInterfaceIpv6Status(
 	WinNetErrorSink errorSink,
-	void* errorSinkContext
+	void *errorSinkContext
 );
-
-enum class WINNET_GTIA_STATUS : uint32_t
-{
-	SUCCESS = 0,
-	FAILURE = 1,
-};
 
 extern "C"
 WINNET_LINKAGE
-WINNET_GTIA_STATUS
+bool
 WINNET_API
 WinNet_GetTapInterfaceAlias(
 	wchar_t **alias,
 	WinNetErrorSink errorSink,
-	void* errorSinkContext
+	void *errorSinkContext
 );
 
 //
@@ -72,23 +67,18 @@ WinNet_ReleaseString(
 	wchar_t *str
 );
 
-typedef void (WINNET_API *WinNetConnectivityMonitorCallback)(uint8_t connected);
-
-enum class WINNET_ACM_STATUS : uint32_t
-{
-	SUCCESS = 0,
-	FAILURE = 1,
-};
+typedef void (WINNET_API *WinNetConnectivityMonitorCallback)(bool connected, void *context);
 
 extern "C"
 WINNET_LINKAGE
-WINNET_ACM_STATUS
+bool
 WINNET_API
 WinNet_ActivateConnectivityMonitor(
 	WinNetConnectivityMonitorCallback callback,
-	uint8_t *currentConnectivity,
+	void *callbackContext,
+	bool *currentConnectivity,
 	WinNetErrorSink errorSink,
-	void* errorSinkContext
+	void *errorSinkContext
 );
 
 extern "C"
@@ -96,4 +86,20 @@ WINNET_LINKAGE
 void
 WINNET_API
 WinNet_DeactivateConnectivityMonitor(
+);
+
+enum class WINNET_CC_STATUS : uint32_t
+{
+	NOT_CONNECTED = 0,
+	CONNECTED = 1,
+	CONNECTIVITY_UNKNOWN = 2,
+};
+
+extern "C"
+WINNET_LINKAGE
+WINNET_CC_STATUS
+WINNET_API
+WinNet_CheckConnectivity(
+	WinNetErrorSink errorSink,
+	void *errorSinkContext
 );

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -71,3 +71,29 @@ WINNET_API
 WinNet_ReleaseString(
 	wchar_t *str
 );
+
+typedef void (WINNET_API *WinNetConnectivityMonitorCallback)(uint8_t connected);
+
+enum class WINNET_ACM_STATUS : uint32_t
+{
+	SUCCESS = 0,
+	FAILURE = 1,
+};
+
+extern "C"
+WINNET_LINKAGE
+WINNET_ACM_STATUS
+WINNET_API
+WinNet_ActivateConnectivityMonitor(
+	WinNetConnectivityMonitorCallback callback,
+	uint8_t *currentConnectivity,
+	WinNetErrorSink errorSink,
+	void* errorSinkContext
+);
+
+extern "C"
+WINNET_LINKAGE
+void
+WINNET_API
+WinNet_DeactivateConnectivityMonitor(
+);

--- a/windows/winnet/src/winnet/winnet.vcxproj
+++ b/windows/winnet/src/winnet/winnet.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="InterfacePair.cpp" />
     <ClCompile Include="interfaceutils.cpp" />
+    <ClCompile Include="netmonitor.cpp" />
     <ClCompile Include="NetworkInterfaces.cpp" />
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="winnet.cpp" />
@@ -29,6 +30,7 @@
   <ItemGroup>
     <ClInclude Include="InterfacePair.h" />
     <ClInclude Include="interfaceutils.h" />
+    <ClInclude Include="netmonitor.h" />
     <ClInclude Include="NetworkInterfaces.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />

--- a/windows/winnet/src/winnet/winnet.vcxproj.filters
+++ b/windows/winnet/src/winnet/winnet.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClCompile Include="NetworkInterfaces.cpp" />
     <ClCompile Include="InterfacePair.cpp" />
     <ClCompile Include="interfaceutils.cpp" />
+    <ClCompile Include="netmonitor.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -15,6 +16,7 @@
     <ClInclude Include="NetworkInterfaces.h" />
     <ClInclude Include="InterfacePair.h" />
     <ClInclude Include="interfaceutils.h" />
+    <ClInclude Include="netmonitor.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="winnet.def" />


### PR DESCRIPTION
@mvd-ows added code to enumerate network adapters to check if the host is connected to a network. This code is then used in the offline checking code in the daemon, in combination with the existing code that's used to detect when the host is entering sleep. This greatly improves offline detection on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/859)
<!-- Reviewable:end -->
