### PR TITLE
Show login errors on iOS

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		58461AD3228D622E00B72ECB /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58461AD2228D622E00B72ECB /* Account.swift */; };
 		5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */; };
 		5867A51C2248F26A005513C0 /* SegueIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5867A51B2248F26A005513C0 /* SegueIdentifier.swift */; };
+		587B08E0229433EB000E6F17 /* LoginState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587B08DF229433EB000E6F17 /* LoginState.swift */; };
+		587B08E2229460C1000E6F17 /* WebLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587B08E1229460C1000E6F17 /* WebLinks.swift */; };
 		587CBFE322807F530028DED3 /* UIColor+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587CBFE222807F530028DED3 /* UIColor+Helpers.swift */; };
 		5888AD7F2279B6BF0051EB06 /* RelayStatusIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5888AD7E2279B6BF0051EB06 /* RelayStatusIndicatorView.swift */; };
 		5888AD83227B11080051EB06 /* SelectLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5888AD82227B11080051EB06 /* SelectLocationCell.swift */; };
@@ -73,6 +75,8 @@
 		5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslucentButtonBlurView.swift; sourceTree = "<group>"; };
 		5866F39B2243B82D00168AE5 /* MullvadVPN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MullvadVPN.entitlements; sourceTree = "<group>"; };
 		5867A51B2248F26A005513C0 /* SegueIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegueIdentifier.swift; sourceTree = "<group>"; };
+		587B08DF229433EB000E6F17 /* LoginState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginState.swift; sourceTree = "<group>"; };
+		587B08E1229460C1000E6F17 /* WebLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebLinks.swift; sourceTree = "<group>"; };
 		587CBFE222807F530028DED3 /* UIColor+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Helpers.swift"; sourceTree = "<group>"; };
 		5888AD7E2279B6BF0051EB06 /* RelayStatusIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayStatusIndicatorView.swift; sourceTree = "<group>"; };
 		5888AD82227B11080051EB06 /* SelectLocationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationCell.swift; sourceTree = "<group>"; };
@@ -178,6 +182,7 @@
 				58F19E30228B2AEB00C7710B /* JSONRequestProcedure.swift */,
 				58ADDB3B227B1BD200FAFEA7 /* JsonRpc.swift */,
 				58CE5E6C224146210008646E /* LaunchScreen.storyboard */,
+				587B08DF229433EB000E6F17 /* LoginState.swift */,
 				58CE5E65224146200008646E /* LoginViewController.swift */,
 				58CE5E67224146200008646E /* Main.storyboard */,
 				58ADDB3D227B1CD900FAFEA7 /* MullvadAPI.swift */,
@@ -194,6 +199,7 @@
 				587CBFE222807F530028DED3 /* UIColor+Helpers.swift */,
 				58CCA0152242560B004F3011 /* UIColor+Palette.swift */,
 				58FFE443228C82A00036F391 /* UserDefaultsInteractor.swift */,
+				587B08E1229460C1000E6F17 /* WebLinks.swift */,
 			);
 			path = MullvadVPN;
 			sourceTree = "<group>";
@@ -407,8 +413,10 @@
 				58CCA0162242560B004F3011 /* UIColor+Palette.swift in Sources */,
 				587CBFE322807F530028DED3 /* UIColor+Helpers.swift in Sources */,
 				589AB4F9227C50D80039131E /* CustomNavigationBar.swift in Sources */,
+				587B08E2229460C1000E6F17 /* WebLinks.swift in Sources */,
 				58CCA01822426713004F3011 /* AccountViewController.swift in Sources */,
 				58ADDB3E227B1CD900FAFEA7 /* MullvadAPI.swift in Sources */,
+				587B08E0229433EB000E6F17 /* LoginState.swift in Sources */,
 				5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */,
 				5888AD83227B11080051EB06 /* SelectLocationCell.swift in Sources */,
 				58CE5E66224146200008646E /* LoginViewController.swift in Sources */,

--- a/ios/MullvadVPN/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/AccountInputGroupView.swift
@@ -12,20 +12,69 @@ import UIKit
 
     @IBOutlet var textField: UITextField!
 
+    enum Style {
+        case normal, error, authenticating
+    }
+
+    var loginState = LoginState.default {
+        didSet {
+            updateAppearance()
+            updateTextFieldEnabled()
+        }
+    }
+
     private let borderRadius = CGFloat(8)
     private let borderWidth = CGFloat(2)
+
+    private var borderColor: UIColor {
+        switch loginState {
+        case .default:
+            return textField.isEditing
+                ? UIColor.AccountTextField.NormalState.borderColor
+                : UIColor.clear
+
+        case .failure:
+            return UIColor.AccountTextField.ErrorState.borderColor
+
+        case .authenticating, .success:
+            return UIColor.AccountTextField.AuthenticatingState.borderColor
+        }
+    }
+
+    private var textColor: UIColor {
+        switch loginState {
+        case .default:
+            return UIColor.AccountTextField.NormalState.textColor
+
+        case .failure:
+            return UIColor.AccountTextField.ErrorState.textColor
+
+        case .authenticating, .success:
+            return UIColor.AccountTextField.AuthenticatingState.textColor
+        }
+    }
+
+    private var backgroundLayerColor: UIColor {
+        switch loginState {
+        case .default:
+            return UIColor.AccountTextField.NormalState.backgroundColor
+
+        case .failure:
+            return UIColor.AccountTextField.ErrorState.backgroundColor
+
+        case .authenticating, .success:
+            return UIColor.AccountTextField.AuthenticatingState.backgroundColor
+        }
+    }
 
     private let borderLayer = CAShapeLayer()
     private let backgroundLayer = CAShapeLayer()
     private let maskLayer = CALayer()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setup()
-    }
+    // MARK: - View lifecycle
 
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+    override func awakeFromNib() {
+        super.awakeFromNib()
         setup()
     }
 
@@ -55,11 +104,11 @@ import UIKit
     // MARK: - Notifications
 
     @objc func textDidBeginEditing() {
-        updateBorderStyle()
+        updateAppearance()
     }
 
     @objc func textDidEndEditing() {
-        updateBorderStyle()
+        updateAppearance()
     }
 
     // MARK: - Private
@@ -68,29 +117,46 @@ import UIKit
         backgroundColor = UIColor.clear
 
         borderLayer.lineWidth = borderWidth
-        borderLayer.strokeColor = UIColor.clear.cgColor
         borderLayer.fillColor = UIColor.clear.cgColor
-
-        backgroundLayer.backgroundColor = UIColor.white.cgColor
         backgroundLayer.mask = maskLayer
 
         layer.insertSublayer(borderLayer, at: 0)
         layer.insertSublayer(backgroundLayer, at: 0)
 
+        updateAppearance()
+        updateTextFieldEnabled()
+
         addTextFieldNotificationObservers()
     }
 
-
     private func addTextFieldNotificationObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(textDidBeginEditing), name: UITextField.textDidBeginEditingNotification, object: textField)
-        NotificationCenter.default.addObserver(self, selector: #selector(textDidEndEditing), name: UITextField.textDidEndEditingNotification, object: textField)
+        let notificationCenter = NotificationCenter.default
+
+        notificationCenter.addObserver(self,
+                                       selector: #selector(textDidBeginEditing),
+                                       name: UITextField.textDidBeginEditingNotification,
+                                       object: textField)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(textDidEndEditing),
+                                       name: UITextField.textDidEndEditingNotification,
+                                       object: textField)
     }
 
-    private func updateBorderStyle() {
-        let borderColor = textField.isEditing ? UIColor.accountTextFieldBorderColor : UIColor.clear
-
+    private func updateAppearance() {
         borderLayer.strokeColor = borderColor.cgColor
+        backgroundLayer.backgroundColor = backgroundLayerColor.cgColor
+        textField.textColor = textColor
     }
+
+    private func updateTextFieldEnabled() {
+        switch loginState {
+        case .authenticating, .success:
+            textField.isEnabled = false
+
+        default:
+            textField.isEnabled = true
+        }
+     }
 
     private func borderBezierPath(size: CGSize) -> UIBezierPath {
         let borderPath = UIBezierPath(roundedRect: CGRect(origin: .zero, size: size), cornerRadius: borderRadius)

--- a/ios/MullvadVPN/Base.lproj/Main.storyboard
+++ b/ios/MullvadVPN/Base.lproj/Main.storyboard
@@ -64,6 +64,9 @@
                                                         <nil key="textColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no" textContentType="username"/>
+                                                        <connections>
+                                                            <outlet property="delegate" destination="BYZ-38-t0r" id="jeF-vG-YXi"/>
+                                                        </connections>
                                                     </textField>
                                                 </subviews>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/MullvadVPN/Base.lproj/Main.storyboard
+++ b/ios/MullvadVPN/Base.lproj/Main.storyboard
@@ -19,6 +19,7 @@
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VIF-P4-vZU" userLabel="Header">
                                 <rect key="frame" x="0.0" y="20" width="375" height="74"/>
+                                <color key="backgroundColor" red="0.16078431369999999" green="0.30196078430000001" blue="0.45098039220000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="74" id="ohH-N4-eN7"/>
                                 </constraints>
@@ -37,6 +38,9 @@
                                             <constraint firstAttribute="width" constant="48" id="ohE-fk-mg9"/>
                                         </constraints>
                                     </view>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.0" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="IconSuccess" translatesAutoresizingMaskIntoConstraints="NO" id="7ux-Tb-Fzq">
+                                        <rect key="frame" x="157.5" y="119.5" width="60" height="60"/>
+                                    </imageView>
                                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="V3j-Lb-fSQ" userLabel="Form">
                                         <rect key="frame" x="0.0" y="203.5" width="375" height="126"/>
                                         <subviews>
@@ -92,8 +96,10 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
+                                    <constraint firstItem="7ux-Tb-Fzq" firstAttribute="centerX" secondItem="pID-oa-Rrg" secondAttribute="centerX" id="0pe-6n-wrA"/>
                                     <constraint firstItem="V3j-Lb-fSQ" firstAttribute="top" secondItem="pID-oa-Rrg" secondAttribute="bottom" constant="30" id="2Sy-bS-AZZ"/>
                                     <constraint firstItem="V3j-Lb-fSQ" firstAttribute="centerY" secondItem="0ZY-Kh-JiM" secondAttribute="centerY" constant="-20" id="3Uk-YZ-4C3"/>
+                                    <constraint firstItem="7ux-Tb-Fzq" firstAttribute="centerY" secondItem="pID-oa-Rrg" secondAttribute="centerY" id="BRH-Bd-Pe8"/>
                                     <constraint firstAttribute="trailing" secondItem="V3j-Lb-fSQ" secondAttribute="trailing" id="EHy-Cx-cGj"/>
                                     <constraint firstItem="pID-oa-Rrg" firstAttribute="centerX" secondItem="0ZY-Kh-JiM" secondAttribute="centerX" id="Ojm-D5-HnO"/>
                                     <constraint firstItem="V3j-Lb-fSQ" firstAttribute="leading" secondItem="0ZY-Kh-JiM" secondAttribute="leading" id="alr-G1-L4w"/>
@@ -115,6 +121,9 @@
                                         <state key="normal" title="Create account" backgroundImage="DefaultButton">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </state>
+                                        <connections>
+                                            <action selector="openCreateAccount" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ejr-wN-rdN"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" red="0.098039215686274508" green="0.1803921568627451" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -147,11 +156,15 @@
                         <viewLayoutGuide key="safeArea" id="RSb-dJ-fKl"/>
                     </view>
                     <connections>
+                        <outlet property="accountInputGroup" destination="VmT-ya-ufe" id="ku3-qa-yfV"/>
                         <outlet property="accountTextField" destination="XOB-ct-yLU" id="mXd-SV-E16"/>
                         <outlet property="activityIndicator" destination="pID-oa-Rrg" id="GG2-Hv-FWl"/>
                         <outlet property="keyboardToolbar" destination="waX-JF-VTG" id="kav-5t-mkA"/>
+                        <outlet property="keyboardToolbarLoginButton" destination="0VH-wf-oEs" id="fsM-6o-9nL"/>
                         <outlet property="loginForm" destination="V3j-Lb-fSQ" id="tYu-S8-ylm"/>
                         <outlet property="loginFormWrapperBottomConstraint" destination="09L-EV-qfI" id="fYF-OK-trh"/>
+                        <outlet property="messageLabel" destination="XSV-Lk-dj4" id="8bd-TU-yhD"/>
+                        <outlet property="statusImageView" destination="7ux-Tb-Fzq" id="UhU-kS-PKR"/>
                         <segue destination="Ki6-Mt-b6R" kind="presentation" identifier="ShowConnect" animates="NO" id="ccw-Nc-l0Q"/>
                         <segue destination="Kqv-qu-mfF" kind="presentation" identifier="ShowSettings" id="RjC-Wk-Enk"/>
                     </connections>
@@ -404,6 +417,9 @@
                         <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                         <viewLayoutGuide key="safeArea" id="oeE-aF-UYv"/>
                     </view>
+                    <connections>
+                        <outlet property="settingsButton" destination="uXv-Tf-PET" id="MuL-Bu-ZRF"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Kbx-AI-gkv" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -532,6 +548,7 @@
         <image name="IconChevronDown" width="24" height="24"/>
         <image name="IconClose" width="24" height="24"/>
         <image name="IconSettings" width="24" height="24"/>
+        <image name="IconSuccess" width="60" height="60"/>
         <image name="IconTick" width="24" height="24"/>
         <image name="LogoIcon" width="49" height="50"/>
         <image name="MapBackground" width="637" height="982"/>

--- a/ios/MullvadVPN/Base.lproj/Main.storyboard
+++ b/ios/MullvadVPN/Base.lproj/Main.storyboard
@@ -168,6 +168,7 @@
                         <outlet property="loginFormWrapperBottomConstraint" destination="09L-EV-qfI" id="fYF-OK-trh"/>
                         <outlet property="messageLabel" destination="XSV-Lk-dj4" id="8bd-TU-yhD"/>
                         <outlet property="statusImageView" destination="7ux-Tb-Fzq" id="UhU-kS-PKR"/>
+                        <outlet property="titleLabel" destination="Nxn-Fc-EGe" id="lOm-uS-4Ff"/>
                         <segue destination="Ki6-Mt-b6R" kind="presentation" identifier="ShowConnect" animates="NO" id="ccw-Nc-l0Q"/>
                         <segue destination="Kqv-qu-mfF" kind="presentation" identifier="ShowSettings" id="RjC-Wk-Enk"/>
                     </connections>
@@ -211,7 +212,7 @@
                                 </connections>
                             </containerView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MapBackground" translatesAutoresizingMaskIntoConstraints="NO" id="3Ck-JT-ogd">
-                                <rect key="frame" x="0.0" y="94" width="375" height="573"/>
+                                <rect key="frame" x="0.0" y="94" width="375" height="573.00000000000023"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="shY-Lj-oYx">
                                 <rect key="frame" x="24" y="533" width="327" height="110"/>
@@ -390,17 +391,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoIcon" translatesAutoresizingMaskIntoConstraints="NO" id="cKg-hE-JsS">
-                                <rect key="frame" x="11" y="29" width="16" height="16"/>
+                                <rect key="frame" x="11" y="12" width="49.000000000000014" height="50"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uXv-Tf-PET">
-                                <rect key="frame" x="343" y="26" width="16" height="22"/>
+                                <rect key="frame" x="335" y="25" width="24" height="24"/>
                                 <state key="normal" image="IconSettings"/>
                                 <connections>
                                     <action selector="handleSettingsButton" destination="rCI-6x-aLd" eventType="touchUpInside" id="TaM-cZ-TvJ"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MULLVAD VPN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dqy-A0-TdV">
-                                <rect key="frame" x="35" y="22" width="168" height="30"/>
+                                <rect key="frame" x="68" y="22" width="168" height="30"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <color key="textColor" white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>

--- a/ios/MullvadVPN/Base.lproj/Main.storyboard
+++ b/ios/MullvadVPN/Base.lproj/Main.storyboard
@@ -212,7 +212,7 @@
                                 </connections>
                             </containerView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MapBackground" translatesAutoresizingMaskIntoConstraints="NO" id="3Ck-JT-ogd">
-                                <rect key="frame" x="0.0" y="94" width="375" height="573.00000000000023"/>
+                                <rect key="frame" x="0.0" y="94" width="375" height="573"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="shY-Lj-oYx">
                                 <rect key="frame" x="24" y="533" width="327" height="110"/>
@@ -391,17 +391,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoIcon" translatesAutoresizingMaskIntoConstraints="NO" id="cKg-hE-JsS">
-                                <rect key="frame" x="11" y="12" width="49.000000000000014" height="50"/>
+                                <rect key="frame" x="11" y="29" width="16" height="16"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uXv-Tf-PET">
-                                <rect key="frame" x="335" y="25" width="24" height="24"/>
+                                <rect key="frame" x="343" y="26" width="16" height="22"/>
                                 <state key="normal" image="IconSettings"/>
                                 <connections>
                                     <action selector="handleSettingsButton" destination="rCI-6x-aLd" eventType="touchUpInside" id="TaM-cZ-TvJ"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MULLVAD VPN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dqy-A0-TdV">
-                                <rect key="frame" x="68" y="22" width="168" height="30"/>
+                                <rect key="frame" x="35" y="22" width="168" height="30"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <color key="textColor" white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>

--- a/ios/MullvadVPN/BasicTableViewCell.swift
+++ b/ios/MullvadVPN/BasicTableViewCell.swift
@@ -14,10 +14,10 @@ class BasicTableViewCell: UITableViewCell {
         super.awakeFromNib()
 
         let backgroundView = UIView()
-        backgroundView.backgroundColor = UIColor.cellBackgroundColor
+        backgroundView.backgroundColor = UIColor.Cell.backgroundColor
 
         let selectedBackgroundView = UIView()
-        selectedBackgroundView.backgroundColor = UIColor.cellSelectedBackgroundColor
+        selectedBackgroundView.backgroundColor = UIColor.Cell.selectedBackgroundColor
 
         self.backgroundView = backgroundView
         self.selectedBackgroundView = selectedBackgroundView

--- a/ios/MullvadVPN/HeaderBarViewController.swift
+++ b/ios/MullvadVPN/HeaderBarViewController.swift
@@ -15,6 +15,8 @@ protocol HeaderBarViewControllerDelegate: class {
 class HeaderBarViewController: UIViewController {
     weak var delegate: HeaderBarViewControllerDelegate?
 
+    @IBOutlet var settingsButton: UIButton!
+
     @IBAction func handleSettingsButton() {
         delegate?.headerBarViewControllerShouldOpenSettings(self)
     }

--- a/ios/MullvadVPN/LoginState.swift
+++ b/ios/MullvadVPN/LoginState.swift
@@ -1,0 +1,16 @@
+//
+//  LoginState.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 21/05/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+
+enum LoginState {
+    case `default`
+    case authenticating
+    case failure(Error)
+    case success
+}

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -183,12 +183,23 @@ class LoginViewController: UIViewController, HeaderBarViewControllerDelegate, UI
     private func loginStateDidChange() {
         accountInputGroup.loginState = loginState
 
-        if case .authenticating = loginState {
+        // Keep the settings button disabled to prevent user from going to settings while
+        // authentication or during the delay after the successful login and transition to the main
+        // controller.
+        switch loginState {
+        case .authenticating:
             activityIndicator.isAnimating = true
+
+            // Fallthrough to make sure that the settings button is disabled
+            // in .authenticating and .success cases.
+            fallthrough
+
+        case .success:
             headerBarController?.settingsButton.isEnabled = false
-        } else {
-            activityIndicator.isAnimating = false
+
+        default:
             headerBarController?.settingsButton.isEnabled = true
+            activityIndicator.isAnimating = false
         }
 
         updateDisplayedMessage()

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -19,6 +19,7 @@ class LoginViewController: UIViewController, HeaderBarViewControllerDelegate, UI
     @IBOutlet var keyboardToolbarLoginButton: UIBarButtonItem!
     @IBOutlet var accountInputGroup: AccountInputGroupView!
     @IBOutlet var accountTextField: UITextField!
+    @IBOutlet var titleLabel: UILabel!
     @IBOutlet var messageLabel: UILabel!
     @IBOutlet var loginForm: UIView!
     @IBOutlet var loginFormWrapperBottomConstraint: NSLayoutConstraint!
@@ -237,7 +238,8 @@ class LoginViewController: UIViewController, HeaderBarViewControllerDelegate, UI
     }
 
     private func updateDisplayedMessage() {
-        messageLabel.text = loginState.localizedDescription
+        titleLabel.text = loginState.localizedTitle
+        messageLabel.text = loginState.localizedMessage
     }
 
     private func updateKeyboardToolbar() {
@@ -258,7 +260,23 @@ class LoginViewController: UIViewController, HeaderBarViewControllerDelegate, UI
 
 /// Private extension that brings localizable messages displayed in the Login view controller
 private extension LoginState {
-    var localizedDescription: String {
+    var localizedTitle: String {
+        switch self {
+        case .default:
+            return NSLocalizedString("Login", tableName: "Login", comment: "")
+
+        case .authenticating:
+            return NSLocalizedString("Logging in...", tableName: "Login", comment: "")
+
+        case .failure:
+            return NSLocalizedString("Login failed", tableName: "Login", comment: "")
+
+        case .success:
+            return NSLocalizedString("Logged in", tableName: "Login", comment: "")
+        }
+    }
+
+    var localizedMessage: String {
         switch self {
         case .default:
             return NSLocalizedString("Enter your account number", tableName: "Login", comment: "")

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -11,8 +11,9 @@ import ProcedureKit
 import os.log
 
 private let kMinimumAccountTokenLength = 10
+private let kValidAccountTokenCharacterSet = CharacterSet(charactersIn: "01234567890")
 
-class LoginViewController: UIViewController, HeaderBarViewControllerDelegate {
+class LoginViewController: UIViewController, HeaderBarViewControllerDelegate, UITextFieldDelegate {
 
     @IBOutlet var keyboardToolbar: UIToolbar!
     @IBOutlet var keyboardToolbarLoginButton: UIBarButtonItem!
@@ -127,6 +128,13 @@ class LoginViewController: UIViewController, HeaderBarViewControllerDelegate {
 
         // Enable the log in button in the keyboard toolbar
         updateKeyboardToolbar()
+    }
+
+    // MARK: - UITextFieldDelegate
+
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        // prevent the change if the replacement string contains disallowed characters
+        return string.unicodeScalars.allSatisfy { kValidAccountTokenCharacterSet.contains($0) }
     }
 
     // MARK: - IBActions

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -197,7 +197,7 @@ class LoginViewController: UIViewController, HeaderBarViewControllerDelegate, UI
         case .success:
             headerBarController?.settingsButton.isEnabled = false
 
-        default:
+        case .default, .failure:
             headerBarController?.settingsButton.isEnabled = true
             activityIndicator.isAnimating = false
         }
@@ -217,7 +217,7 @@ class LoginViewController: UIViewController, HeaderBarViewControllerDelegate, UI
             statusImageView.image = UIImage(imageLiteralResourceName: "IconSuccess")
             animateStatusImage(to: 1)
 
-        default:
+        case .default, .authenticating:
             animateStatusImage(to: 0)
         }
     }

--- a/ios/MullvadVPN/RelayStatusIndicatorView.swift
+++ b/ios/MullvadVPN/RelayStatusIndicatorView.swift
@@ -49,8 +49,8 @@ import UIKit
 
     private func updateCircleLayerColor() {
         let baseColor = isActive
-            ? UIColor.relayStatusIndicatorActiveColor
-            : UIColor.relayStatusIndicatorInactiveColor
+            ? UIColor.RelayStatusIndicator.activeColor
+            : UIColor.RelayStatusIndicator.inactiveColor
 
         let circleColor = isHighlighted
             ? baseColor.darkened(by: 0.2) ?? baseColor

--- a/ios/MullvadVPN/SelectLocationCell.swift
+++ b/ios/MullvadVPN/SelectLocationCell.swift
@@ -91,11 +91,11 @@ class SelectLocationCell: BasicTableViewCell {
     private func colorForIdentationLevel() -> UIColor {
         switch indentationLevel {
         case 1:
-            return UIColor.subCellBackgroundColor
+            return UIColor.Cell.subCellBackgroundColor
         case 2:
-            return UIColor.subSubCellBackgroundColor
+            return UIColor.Cell.subSubCellBackgroundColor
         default:
-            return UIColor.cellBackgroundColor
+            return UIColor.Cell.backgroundColor
         }
     }
 

--- a/ios/MullvadVPN/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UIColor+Palette.swift
@@ -9,8 +9,26 @@
 import UIKit
 
 extension UIColor {
-    // Account text field
-    static let accountTextFieldBorderColor = UIColor(red: 0.10, green: 0.18, blue: 0.27, alpha: 1.0)
+
+    struct AccountTextField {
+        struct NormalState {
+            static let borderColor = UIColor(red: 0.10, green: 0.18, blue: 0.27, alpha: 1.0)
+            static let textColor = UIColor(red: 0.16, green: 0.30, blue: 0.45, alpha: 1.0)
+            static let backgroundColor = UIColor.white
+        }
+
+        struct ErrorState {
+            static let borderColor = UIColor(red: 0.82, green: 0.01, blue: 0.11, alpha: 0.4)
+            static let textColor = UIColor(red: 0.82, green: 0.01, blue: 0.11, alpha: 1.0)
+            static let backgroundColor = UIColor.white
+        }
+
+        struct AuthenticatingState {
+            static let borderColor = UIColor.clear
+            static let textColor = UIColor.white
+            static let backgroundColor = UIColor.white.withAlphaComponent(0.2)
+        }
+    }
 
     // Relay availability indicator view
     static let relayStatusIndicatorActiveColor = UIColor(red: 0.27, green: 0.68, blue: 0.30, alpha: 0.9)

--- a/ios/MullvadVPN/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UIColor+Palette.swift
@@ -31,13 +31,16 @@ extension UIColor {
     }
 
     // Relay availability indicator view
-    static let relayStatusIndicatorActiveColor = UIColor(red: 0.27, green: 0.68, blue: 0.30, alpha: 0.9)
-    static let relayStatusIndicatorInactiveColor = UIColor(red: 0.82, green: 0.01, blue: 0.11, alpha: 0.95)
+    struct RelayStatusIndicator {
+        static let activeColor = UIColor(red: 0.27, green: 0.68, blue: 0.30, alpha: 0.9)
+        static let inactiveColor = UIColor(red: 0.82, green: 0.01, blue: 0.11, alpha: 0.95)
+    }
 
     // Cells
-    static let cellBackgroundColor = UIColor(red: 0.16, green: 0.30, blue: 0.45, alpha: 1.0)
-    static let subCellBackgroundColor = UIColor(red:0.15, green:0.23, blue:0.33, alpha:1.0)
-    static let subSubCellBackgroundColor = UIColor(red:0.13, green:0.20, blue:0.30, alpha:1.0)
-
-    static let cellSelectedBackgroundColor = UIColor(red: 0.27, green: 0.68, blue: 0.30, alpha: 1.0)
+    struct Cell {
+        static let backgroundColor = UIColor(red: 0.16, green: 0.30, blue: 0.45, alpha: 1.0)
+        static let selectedBackgroundColor = UIColor(red: 0.27, green: 0.68, blue: 0.30, alpha: 1.0)
+        static let subCellBackgroundColor = UIColor(red:0.15, green:0.23, blue:0.33, alpha:1.0)
+        static let subSubCellBackgroundColor = UIColor(red:0.13, green:0.20, blue:0.30, alpha:1.0)
+    }
 }

--- a/ios/MullvadVPN/WebLinks.swift
+++ b/ios/MullvadVPN/WebLinks.swift
@@ -1,0 +1,17 @@
+//
+//  WebLinks.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 21/05/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+
+struct WebLinks {
+
+    static let createAccountURL = URL(string: "https://mullvad.net/account/create/")!
+    static let purchaseURL = URL(string: "https://mullvad.net/account/login/")!
+    static let faqURL = URL(string: "https://mullvad.net/faq/")!
+
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Disable the log in button until ten digits entered in the account input field
2. Only allow entering or pasting digits in the account input field
3. Show the checkmark or cross icon in the login view
4. Style the account input view
5. Display error messages in the login view
6. Disable the settings button while logging in
7. Wire up the "Create account" button to open the web browser with the corresponding URL to create the account number.
8. Restructure the `UIColor` extension that holds the color palette.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/865)
<!-- Reviewable:end -->
