### PR TITLE
Retrieve Relay List on android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Job
 import android.os.Bundle
 import android.support.v4.app.FragmentActivity
 
+import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 
 class MainActivity : FragmentActivity() {
@@ -26,7 +27,7 @@ class MainActivity : FragmentActivity() {
     val relayList: RelayList
         get() = runBlocking { asyncRelayList.await() }
 
-    var selectedRelayItemCode: String? = null
+    var selectedRelayItem: RelayItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn
 
 import net.mullvad.mullvadvpn.model.AccountData
+import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.model.Settings
 
 class MullvadDaemon {
@@ -10,6 +11,7 @@ class MullvadDaemon {
     }
 
     external fun getAccountData(accountToken: String): AccountData?
+    external fun getRelayLocations(): RelayList
     external fun getSettings(): Settings
     external fun setAccount(accountToken: String?)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 
 import net.mullvad.mullvadvpn.relaylist.RelayItemDividerDecoration
+import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.relaylist.RelayListAdapter
 
 class SelectLocationFragment : Fragment() {
@@ -32,11 +33,12 @@ class SelectLocationFragment : Fragment() {
     }
 
     private fun configureRelayList(relayList: RecyclerView) {
-        val parentActivity = activity as MainActivity?
-        val relayListAdapter = RelayListAdapter(parentActivity?.selectedRelayItemCode)
+        val parentActivity = activity as MainActivity
+        val relayListAdapter =
+            RelayListAdapter(parentActivity.relayList, parentActivity.selectedRelayItemCode)
 
         relayListAdapter.onSelect = { relayItemCode ->
-            parentActivity?.selectedRelayItemCode = relayItemCode
+            parentActivity.selectedRelayItemCode = relayItemCode
             close()
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -35,10 +35,10 @@ class SelectLocationFragment : Fragment() {
     private fun configureRelayList(relayList: RecyclerView) {
         val parentActivity = activity as MainActivity
         val relayListAdapter =
-            RelayListAdapter(parentActivity.relayList, parentActivity.selectedRelayItemCode)
+            RelayListAdapter(parentActivity.relayList, parentActivity.selectedRelayItem)
 
-        relayListAdapter.onSelect = { relayItemCode ->
-            parentActivity.selectedRelayItemCode = relayItemCode
+        relayListAdapter.onSelect = { relayItem ->
+            parentActivity.selectedRelayItem = relayItem
             close()
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
@@ -1,0 +1,4 @@
+package net.mullvad.mullvadvpn.model
+
+data class Relay(val hostname: String) {
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
@@ -1,0 +1,4 @@
+package net.mullvad.mullvadvpn.model
+
+data class RelayList(val countries: List<RelayListCountry>) {
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
@@ -1,0 +1,4 @@
+package net.mullvad.mullvadvpn.model
+
+data class RelayListCity(val name: String, val code: String, val relays: List<Relay>) {
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
@@ -1,0 +1,4 @@
+package net.mullvad.mullvadvpn.model
+
+data class RelayListCountry(val name: String, val code: String, val cities: List<RelayListCity>) {
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
@@ -47,6 +47,4 @@ class RelayCity(
     }
 
     fun getRelayCount(): Int = relays.size
-
-    fun findRelayByCode(code: String): RelayItem? = relays.find { relay -> relay.code == code }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
@@ -45,18 +45,4 @@ class RelayCountry(
     }
 
     fun getRelayCount(): Int = cities.map { city -> city.getRelayCount() }.sum()
-
-    fun findRelayItemByCode(cityCode: String, relayCode: String?): RelayItem? {
-        for (city in cities) {
-            if (city.code == cityCode) {
-                if (relayCode != null) {
-                    return city.findRelayByCode("$cityCode-$relayCode")
-                } else {
-                    return city
-                }
-            }
-        }
-
-        return null
-    }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -8,7 +8,7 @@ class RelayList {
             val cities = country.cities.map { city -> 
                 val relays = city.relays.map { relay -> Relay(relay.hostname) }
 
-                RelayCity(city.name, "${country.code}-${city.code}", false, relays)
+                RelayCity(city.name, city.code, false, relays)
             }
 
             RelayCountry(country.name, country.code, false, cities)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -1,0 +1,17 @@
+package net.mullvad.mullvadvpn.relaylist
+
+class RelayList {
+    val countries: List<RelayCountry>
+
+    constructor(model: net.mullvad.mullvadvpn.model.RelayList) {
+        countries = model.countries.map { country ->
+            val cities = country.cities.map { city -> 
+                val relays = city.relays.map { relay -> Relay(relay.hostname) }
+
+                RelayCity(city.name, "${country.code}-${city.code}", false, relays)
+            }
+
+            RelayCountry(country.name, country.code, false, cities)
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
@@ -11,17 +11,12 @@ import net.mullvad.mullvadvpn.R
 
 class RelayListAdapter(
     private val relayList: RelayList,
-    private val initialSelectedItemCode: String?
+    private var selectedItem: RelayItem?
 ) : Adapter<RelayItemHolder>() {
     private val activeIndices = LinkedList<WeakReference<RelayListAdapterPosition>>()
-    private var selectedItem: RelayItem? = null
     private var selectedItemHolder: RelayItemHolder? = null
 
-    var onSelect: ((String?) -> Unit)? = null
-
-    init {
-        initialSelectedItemCode?.let { code -> selectedItem = findRelayItemByCode(code) }
-    }
+    var onSelect: ((RelayItem?) -> Unit)? = null
 
     override fun onCreateViewHolder(parentView: ViewGroup, type: Int): RelayItemHolder {
         val inflater = LayoutInflater.from(parentView.context)
@@ -59,7 +54,7 @@ class RelayListAdapter(
         selectedItemHolder = holder
         selectedItemHolder?.apply { selected = true }
 
-        onSelect?.invoke(item?.code)
+        onSelect?.invoke(item)
     }
 
     fun expandItem(itemIndex: RelayListAdapterPosition, childCount: Int) {
@@ -104,27 +99,5 @@ class RelayListAdapter(
         } else {
             holder.selected = false
         }
-    }
-
-    private fun findRelayItemByCode(code: String): RelayItem? {
-        val codeParts = code.split('-')
-
-        for (country in relayList.countries) {
-            if (country.code == codeParts[0]) {
-                if (codeParts.size == 1) {
-                    return country
-                } else {
-                    var relayCode: String? = null
-
-                    if (codeParts.size == 3) {
-                        relayCode = codeParts[2]
-                    }
-
-                    return country.findRelayItemByCode("${codeParts[0]}-${codeParts[1]}", relayCode)
-                }
-            }
-        }
-
-        return null
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
@@ -9,8 +9,10 @@ import android.view.ViewGroup
 
 import net.mullvad.mullvadvpn.R
 
-class RelayListAdapter(private val initialSelectedItemCode: String?) : Adapter<RelayItemHolder>() {
-    private val relayList = fakeRelayList
+class RelayListAdapter(
+    private val relayList: RelayList,
+    private val initialSelectedItemCode: String?
+) : Adapter<RelayItemHolder>() {
     private val activeIndices = LinkedList<WeakReference<RelayListAdapterPosition>>()
     private var selectedItem: RelayItem? = null
     private var selectedItemHolder: RelayItemHolder? = null
@@ -34,7 +36,7 @@ class RelayListAdapter(private val initialSelectedItemCode: String?) : Adapter<R
     override fun onBindViewHolder(holder: RelayItemHolder, position: Int) {
         var remaining = position
 
-        for (country in relayList) {
+        for (country in relayList.countries) {
             val itemOrCount = country.getItem(remaining)
 
             when (itemOrCount) {
@@ -47,7 +49,8 @@ class RelayListAdapter(private val initialSelectedItemCode: String?) : Adapter<R
         }
     }
 
-    override fun getItemCount() = relayList.map { country -> country.visibleItemCount }.sum()
+    override fun getItemCount() =
+        relayList.countries.map { country -> country.visibleItemCount }.sum()
 
     fun selectItem(item: RelayItem?, holder: RelayItemHolder?) {
         selectedItemHolder?.selected = false
@@ -106,7 +109,7 @@ class RelayListAdapter(private val initialSelectedItemCode: String?) : Adapter<R
     private fun findRelayItemByCode(code: String): RelayItem? {
         val codeParts = code.split('-')
 
-        for (country in relayList) {
+        for (country in relayList.countries) {
             if (country.code == codeParts[0]) {
                 if (codeParts.size == 1) {
                     return country
@@ -125,145 +128,3 @@ class RelayListAdapter(private val initialSelectedItemCode: String?) : Adapter<R
         return null
     }
 }
-
-val fakeRelayList = listOf(
-    RelayCountry(
-        "Australia",
-        "au",
-        false,
-        listOf(
-            RelayCity(
-                "Brisbane",
-                "au-bne",
-                false,
-                listOf(Relay("au-bne-001"))
-            ),
-            RelayCity(
-                "Melbourne",
-                "au-mel",
-                false,
-                listOf(Relay("au-mel-002"), Relay("au-mel-003"), Relay("au-mel-004"))
-            ),
-            RelayCity(
-                "Perth",
-                "au-per",
-                false,
-                listOf(Relay("au-per-001"))
-            ),
-            RelayCity(
-                "Sydney",
-                "au-syd",
-                false,
-                listOf(
-                    Relay("au1-wireguard"),
-                    Relay("au-syd-001"),
-                    Relay("au-syd-002"),
-                    Relay("au-mel-003")
-                )
-            )
-        )
-    ),
-    RelayCountry(
-        "South Africa",
-        "za",
-        false,
-        listOf(
-            RelayCity(
-                "Johannesburg",
-                "za-jnb",
-                false,
-                listOf(Relay("za-jnb-001"))
-            )
-        )
-    ),
-    RelayCountry(
-        "Sweden",
-        "se",
-        false,
-        listOf(
-            RelayCity(
-                "Gothenburg",
-                "se-got",
-                false,
-                listOf(
-                    Relay("se3-wireguard"),
-                    Relay("se5-wireguard"),
-                    Relay("se-got-001"),
-                    Relay("se-got-002"),
-                    Relay("se-got-003"),
-                    Relay("se-got-004"),
-                    Relay("se-got-005"),
-                    Relay("se-got-006"),
-                    Relay("se-got-007")
-                )
-            ),
-            RelayCity(
-                "Helsingborg",
-                "se-hel",
-                false,
-                listOf(
-                    Relay("se-hel-001"),
-                    Relay("se-hel-002"),
-                    Relay("se-hel-003"),
-                    Relay("se-hel-004"),
-                    Relay("se-hel-007"),
-                    Relay("se-hel-008")
-                )
-            ),
-            RelayCity(
-                "Malmö",
-                "se-mma",
-                false,
-                listOf(
-                    Relay("se4-wireguard"),
-                    Relay("se-mma-001"),
-                    Relay("se-mma-002"),
-                    Relay("se-mma-003"),
-                    Relay("se-mma-004"),
-                    Relay("se-mma-005"),
-                    Relay("se-mma-006"),
-                    Relay("se-mma-007"),
-                    Relay("se-mma-008"),
-                    Relay("se-mma-009"),
-                    Relay("se-mma-010")
-                )
-            ),
-            RelayCity(
-                "Stockholm",
-                "se-sto",
-                false,
-                listOf(
-                    Relay("se2-wireguard"),
-                    Relay("se6-wireguard"),
-                    Relay("se7-wireguard"),
-                    Relay("se8-wireguard"),
-                    Relay("se-sto-001"),
-                    Relay("se-sto-002"),
-                    Relay("se-sto-003"),
-                    Relay("se-sto-004"),
-                    Relay("se-sto-005"),
-                    Relay("se-sto-006"),
-                    Relay("se-sto-007"),
-                    Relay("se-sto-008"),
-                    Relay("se-sto-009"),
-                    Relay("se-sto-010"),
-                    Relay("se-sto-011"),
-                    Relay("se-sto-012"),
-                    Relay("se-sto-013"),
-                    Relay("se-sto-014"),
-                    Relay("se-sto-015"),
-                    Relay("se-sto-016"),
-                    Relay("se-sto-017"),
-                    Relay("se-sto-018"),
-                    Relay("se-sto-019"),
-                    Relay("se-sto-020"),
-                    Relay("se-sto-021"),
-                    Relay("se-sto-022"),
-                    Relay("se-sto-023"),
-                    Relay("se-sto-024"),
-                    Relay("se-sto-025")
-                )
-            )
-        )
-    )
-)

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -1,6 +1,6 @@
 use futures::{sync::oneshot, Future};
 use mullvad_daemon::{DaemonCommandSender, ManagementCommand};
-use mullvad_types::{account::AccountData, settings::Settings};
+use mullvad_types::{account::AccountData, relay_list::RelayList, settings::Settings};
 
 #[derive(Debug, err_derive::Error)]
 pub enum Error {
@@ -43,6 +43,14 @@ impl DaemonInterface {
             .map_err(|_| Error::NoResponse)?
             .wait()
             .map_err(Error::RpcError)
+    }
+
+    pub fn get_relay_locations(&self) -> Result<RelayList> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::GetRelayLocations(tx))?;
+
+        Ok(rx.wait().map_err(|_| Error::NoResponse)?)
     }
 
     pub fn get_settings(&self) -> Result<Settings> {

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -4,7 +4,11 @@ use jni::{
     sys::jint,
     JNIEnv,
 };
-use mullvad_types::{account::AccountData, settings::Settings};
+use mullvad_types::{
+    account::AccountData,
+    relay_list::{Relay, RelayList, RelayListCity, RelayListCountry},
+    settings::Settings,
+};
 
 pub trait IntoJava<'env> {
     type JavaType;
@@ -75,6 +79,78 @@ impl<'env> IntoJava<'env> for AccountData {
 
         env.new_object(&class, "(Ljava/lang/String;)V", &parameters)
             .expect("Failed to create AccountData Java object")
+    }
+}
+
+impl<'env> IntoJava<'env> for RelayList {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/RelayList");
+        let relay_countries = env.auto_local(self.countries.into_java(env));
+        let parameters = [JValue::Object(relay_countries.as_obj())];
+
+        env.new_object(&class, "(Ljava/util/List;)V", &parameters)
+            .expect("Failed to create RelayList Java object")
+    }
+}
+
+impl<'env> IntoJava<'env> for RelayListCountry {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/RelayListCountry");
+        let name = env.auto_local(JObject::from(self.name.into_java(env)));
+        let code = env.auto_local(JObject::from(self.code.into_java(env)));
+        let relay_cities = env.auto_local(self.cities.into_java(env));
+        let parameters = [
+            JValue::Object(name.as_obj()),
+            JValue::Object(code.as_obj()),
+            JValue::Object(relay_cities.as_obj()),
+        ];
+
+        env.new_object(
+            &class,
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V",
+            &parameters,
+        )
+        .expect("Failed to create RelayListCountry Java object")
+    }
+}
+
+impl<'env> IntoJava<'env> for RelayListCity {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/RelayListCity");
+        let name = env.auto_local(JObject::from(self.name.into_java(env)));
+        let code = env.auto_local(JObject::from(self.code.into_java(env)));
+        let relays = env.auto_local(self.relays.into_java(env));
+        let parameters = [
+            JValue::Object(name.as_obj()),
+            JValue::Object(code.as_obj()),
+            JValue::Object(relays.as_obj()),
+        ];
+
+        env.new_object(
+            &class,
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V",
+            &parameters,
+        )
+        .expect("Failed to create RelayListCity Java object")
+    }
+}
+
+impl<'env> IntoJava<'env> for Relay {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/Relay");
+        let hostname = env.auto_local(JObject::from(self.hostname.into_java(env)));
+        let parameters = [JValue::Object(hostname.as_obj())];
+
+        env.new_object(&class, "(Ljava/lang/String;)V", &parameters)
+            .expect("Failed to create Relay Java object")
     }
 }
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -21,6 +21,10 @@ const LOG_FILENAME: &str = "daemon.log";
 const CLASSES_TO_LOAD: &[&str] = &[
     "java/util/ArrayList",
     "net/mullvad/mullvadvpn/model/AccountData",
+    "net/mullvad/mullvadvpn/model/Relay",
+    "net/mullvad/mullvadvpn/model/RelayList",
+    "net/mullvad/mullvadvpn/model/RelayListCity",
+    "net/mullvad/mullvadvpn/model/RelayListCountry",
     "net/mullvad/mullvadvpn/model/Settings",
 ];
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -19,6 +19,7 @@ use talpid_types::{tunnel::TunnelStateTransition, ErrorExt};
 const LOG_FILENAME: &str = "daemon.log";
 
 const CLASSES_TO_LOAD: &[&str] = &[
+    "java/util/ArrayList",
     "net/mullvad/mullvadvpn/model/AccountData",
     "net/mullvad/mullvadvpn/model/Settings",
 ];

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -173,6 +173,26 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getAccountData<
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getRelayLocations<'env, 'this>(
+    env: JNIEnv<'env>,
+    _: JObject<'this>,
+) -> JObject<'env> {
+    let daemon = DAEMON_INTERFACE.lock();
+
+    match daemon.get_relay_locations() {
+        Ok(relay_list) => relay_list.into_java(&env),
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to get relay locations")
+            );
+            JObject::null()
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getSettings<'env, 'this>(
     env: JNIEnv<'env>,
     _: JObject<'this>,


### PR DESCRIPTION
This PR replaces the mock relay list used in the Android app with one fetched by the daemon. It also changes how the selected relay list is stored, to avoid relying on the relay code strings.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/870)
<!-- Reviewable:end -->
