### PR TITLE
Load initial location constraint when Android app starts

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
@@ -38,8 +38,7 @@ class LaunchFragment : Fragment() {
 
     private fun checkForAccountToken() = GlobalScope.async(Dispatchers.Default) {
         val parentActivity = activity as MainActivity
-        val daemon = parentActivity.asyncDaemon.await()
-        val settings = daemon.getSettings()
+        val settings = parentActivity.asyncSettings.await()
 
         settings.accountToken != null
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : FragmentActivity() {
                 val location = relaySettings.location
                 val relayList = asyncRelayList.await()
 
-                selectedRelayItem = relayList.findItemForLocation(location)
+                selectedRelayItem = relayList.findItemForLocation(location, true)
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Job
 import android.os.Bundle
 import android.support.v4.app.FragmentActivity
 
+import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 
@@ -27,6 +28,11 @@ class MainActivity : FragmentActivity() {
     val relayList: RelayList
         get() = runBlocking { asyncRelayList.await() }
 
+    var asyncSettings = fetchSettings()
+        private set
+    val settings
+        get() = runBlocking { asyncSettings.await() }
+
     var selectedRelayItem: RelayItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,6 +47,7 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onDestroy() {
+        asyncSettings.cancel()
         asyncRelayList.cancel()
         asyncDaemon.cancel()
 
@@ -62,5 +69,9 @@ class MainActivity : FragmentActivity() {
 
     private fun fetchRelayList() = GlobalScope.async(Dispatchers.Default) {
         RelayList(asyncDaemon.await().getRelayLocations())
+    }
+
+    private fun fetchSettings() = GlobalScope.async(Dispatchers.Default) {
+        asyncDaemon.await().getSettings()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
@@ -1,0 +1,6 @@
+package net.mullvad.mullvadvpn.model
+
+sealed class RelaySettings {
+    class CustomTunnelEndpoint() : RelaySettings()
+    class RelayConstraints(var location: Constraint<LocationConstraint>) : RelaySettings()
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
@@ -1,4 +1,4 @@
 package net.mullvad.mullvadvpn.model
 
-data class Settings(var accountToken: String?) {
+data class Settings(var accountToken: String?, var relaySettings: RelaySettings) {
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
@@ -65,6 +65,12 @@ class RelayItemHolder(
 
             if (item.hasChildren) {
                 chevron.visibility = View.VISIBLE
+
+                if (item.expanded) {
+                    chevron.rotation = 180.0F
+                } else {
+                    chevron.rotation = 0.0F
+                }
             } else {
                 chevron.visibility = View.GONE
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -20,7 +20,10 @@ class RelayList {
         }
     }
 
-    fun findItemForLocation(constraint: Constraint<LocationConstraint>): RelayItem? {
+    fun findItemForLocation(
+        constraint: Constraint<LocationConstraint>,
+        expand: Boolean = false
+    ): RelayItem? {
         when (constraint) {
             is Constraint.Any -> return null
             is Constraint.Only -> {
@@ -35,6 +38,10 @@ class RelayList {
                             country.code == location.countryCode
                         }
 
+                        if (expand) {
+                            country?.expanded = true
+                        }
+
                         return country?.cities?.find { city -> city.code == location.cityCode }
                     }
                     is LocationConstraint.Hostname -> {
@@ -43,6 +50,11 @@ class RelayList {
                         }
 
                         val city = country?.cities?.find { city -> city.code == location.cityCode }
+
+                        if (expand) {
+                            country?.expanded = true
+                            city?.expanded = true
+                        }
 
                         return city?.relays?.find { relay -> relay.name == location.hostname }
                     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -1,5 +1,8 @@
 package net.mullvad.mullvadvpn.relaylist
 
+import net.mullvad.mullvadvpn.model.Constraint
+import net.mullvad.mullvadvpn.model.LocationConstraint
+
 class RelayList {
     val countries: List<RelayCountry>
 
@@ -14,6 +17,37 @@ class RelayList {
             }
 
             RelayCountry(country.name, country.code, false, cities)
+        }
+    }
+
+    fun findItemForLocation(constraint: Constraint<LocationConstraint>): RelayItem? {
+        when (constraint) {
+            is Constraint.Any -> return null
+            is Constraint.Only -> {
+                val location = constraint.value
+
+                when (location) {
+                    is LocationConstraint.Country -> {
+                        return countries.find { country -> country.code == location.countryCode }
+                    }
+                    is LocationConstraint.City -> {
+                        val country = countries.find { country ->
+                            country.code == location.countryCode
+                        }
+
+                        return country?.cities?.find { city -> city.code == location.cityCode }
+                    }
+                    is LocationConstraint.Hostname -> {
+                        val country = countries.find { country ->
+                            country.code == location.countryCode
+                        }
+
+                        val city = country?.cities?.find { city -> city.code == location.cityCode }
+
+                        return city?.relays?.find { relay -> relay.name == location.hostname }
+                    }
+                }
+            }
         }
     }
 }

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -6,6 +6,7 @@ use jni::{
 };
 use mullvad_types::{
     account::AccountData,
+    relay_constraints::LocationConstraint,
     relay_list::{Relay, RelayList, RelayListCity, RelayListCountry},
     settings::Settings,
 };
@@ -151,6 +152,57 @@ impl<'env> IntoJava<'env> for Relay {
 
         env.new_object(&class, "(Ljava/lang/String;)V", &parameters)
             .expect("Failed to create Relay Java object")
+    }
+}
+
+impl<'env> IntoJava<'env> for LocationConstraint {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        match self {
+            LocationConstraint::Country(country_code) => {
+                let class = get_class("net/mullvad/mullvadvpn/model/LocationConstraint$Country");
+                let country = env.auto_local(JObject::from(country_code.into_java(env)));
+                let parameters = [JValue::Object(country.as_obj())];
+
+                env.new_object(&class, "(Ljava/lang/String;)V", &parameters)
+                    .expect("Failed to create LocationConstraint.Country Java object")
+            }
+            LocationConstraint::City(country_code, city_code) => {
+                let class = get_class("net/mullvad/mullvadvpn/model/LocationConstraint$City");
+                let country = env.auto_local(JObject::from(country_code.into_java(env)));
+                let city = env.auto_local(JObject::from(city_code.into_java(env)));
+                let parameters = [
+                    JValue::Object(country.as_obj()),
+                    JValue::Object(city.as_obj()),
+                ];
+
+                env.new_object(
+                    &class,
+                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                    &parameters,
+                )
+                .expect("Failed to create LocationConstraint.City Java object")
+            }
+            LocationConstraint::Hostname(country_code, city_code, hostname) => {
+                let class = get_class("net/mullvad/mullvadvpn/model/LocationConstraint$Hostname");
+                let country = env.auto_local(JObject::from(country_code.into_java(env)));
+                let city = env.auto_local(JObject::from(city_code.into_java(env)));
+                let hostname = env.auto_local(JObject::from(hostname.into_java(env)));
+                let parameters = [
+                    JValue::Object(country.as_obj()),
+                    JValue::Object(city.as_obj()),
+                    JValue::Object(hostname.as_obj()),
+                ];
+
+                env.new_object(
+                    &class,
+                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                    &parameters,
+                )
+                .expect("Failed to create LocationConstraint.Hostname Java object")
+            }
+        }
     }
 }
 

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -280,9 +280,17 @@ impl<'env> IntoJava<'env> for Settings {
     fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
         let class = get_class("net/mullvad/mullvadvpn/model/Settings");
         let account_token = env.auto_local(JObject::from(self.get_account_token().into_java(env)));
-        let parameters = [JValue::Object(account_token.as_obj())];
+        let relay_settings = env.auto_local(self.get_relay_settings().into_java(env));
+        let parameters = [
+            JValue::Object(account_token.as_obj()),
+            JValue::Object(relay_settings.as_obj()),
+        ];
 
-        env.new_object(&class, "(Ljava/lang/String;)V", &parameters)
-            .expect("Failed to create Settings Java object")
+        env.new_object(
+            &class,
+            "(Ljava/lang/String;Lnet/mullvad/mullvadvpn/model/RelaySettings;)V",
+            &parameters,
+        )
+        .expect("Failed to create Settings Java object")
     }
 }

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -31,6 +31,8 @@ const CLASSES_TO_LOAD: &[&str] = &[
     "net/mullvad/mullvadvpn/model/RelayList",
     "net/mullvad/mullvadvpn/model/RelayListCity",
     "net/mullvad/mullvadvpn/model/RelayListCountry",
+    "net/mullvad/mullvadvpn/model/RelaySettings$CustomTunnelEndpoint",
+    "net/mullvad/mullvadvpn/model/RelaySettings$RelayConstraints",
     "net/mullvad/mullvadvpn/model/RelaySettingsUpdate$CustomTunnelEndpoint",
     "net/mullvad/mullvadvpn/model/RelaySettingsUpdate$RelayConstraintsUpdate",
     "net/mullvad/mullvadvpn/model/Settings",


### PR DESCRIPTION
This PR changes the Android UI to load the settings when it starts, and immediately set the selected relay item based on the relay settings.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Android version not released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/872)
<!-- Reviewable:end -->
