### PR TITLE
Wireguard key generation on android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -98,6 +98,7 @@ class ConnectFragment : Fragment() {
     }
 
     private fun connect() {
+        updateViewToPreConnecting()
         activeAction?.cancel()
 
         activeAction = GlobalScope.launch(Dispatchers.Default) {
@@ -112,6 +113,17 @@ class ConnectFragment : Fragment() {
         activeAction = GlobalScope.launch(Dispatchers.Default) {
             daemon.await().disconnect()
         }
+    }
+
+    private fun updateViewToPreConnecting() {
+        val connecting = TunnelStateTransition.Connecting()
+        val disconnected = TunnelStateTransition.Disconnected()
+
+        headerBar.setState(disconnected)
+
+        actionButton.state = connecting
+        notificationBanner.setState(connecting)
+        status.setState(connecting)
     }
 
     private fun updateView(state: TunnelStateTransition) = GlobalScope.launch(Dispatchers.Main) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -97,6 +97,7 @@ class ConnectFragment : Fragment() {
     }
 
     private fun connect() = GlobalScope.launch(Dispatchers.Default) {
+        generateWireguardKeyJob.join()
         daemon.await().connect()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -28,6 +28,7 @@ class ConnectFragment : Fragment() {
 
     private var generateWireguardKeyJob = generateWireguardKey()
 
+    private var activeAction: Job? = null
     private var attachListenerJob: Job? = null
     private var updateViewJob: Job? = null
     private var waitForDaemonJob: Job? = null
@@ -96,13 +97,21 @@ class ConnectFragment : Fragment() {
         }
     }
 
-    private fun connect() = GlobalScope.launch(Dispatchers.Default) {
-        generateWireguardKeyJob.join()
-        daemon.await().connect()
+    private fun connect() {
+        activeAction?.cancel()
+
+        activeAction = GlobalScope.launch(Dispatchers.Default) {
+            generateWireguardKeyJob.join()
+            daemon.await().connect()
+        }
     }
 
-    private fun disconnect() = GlobalScope.launch(Dispatchers.Default) {
-        daemon.await().disconnect()
+    private fun disconnect() {
+        activeAction?.cancel()
+
+        activeAction = GlobalScope.launch(Dispatchers.Default) {
+            daemon.await().disconnect()
+        }
     }
 
     private fun updateView(state: TunnelStateTransition) = GlobalScope.launch(Dispatchers.Main) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn
 
 import net.mullvad.mullvadvpn.model.AccountData
+import net.mullvad.mullvadvpn.model.PublicKey
 import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
 import net.mullvad.mullvadvpn.model.Settings
@@ -19,6 +20,7 @@ class MullvadDaemon {
     external fun getAccountData(accountToken: String): AccountData?
     external fun getRelayLocations(): RelayList
     external fun getSettings(): Settings
+    external fun getWireguardKey(): PublicKey?
     external fun setAccount(accountToken: String?)
     external fun updateRelaySettings(update: RelaySettingsUpdate)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -17,6 +17,7 @@ class MullvadDaemon {
 
     external fun connect()
     external fun disconnect()
+    external fun generateWireguardKey(): Boolean
     external fun getAccountData(accountToken: String): AccountData?
     external fun getRelayLocations(): RelayList
     external fun getSettings(): Settings

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/PublicKey.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/PublicKey.kt
@@ -1,0 +1,3 @@
+package net.mullvad.mullvadvpn.model
+
+data class PublicKey(val key: ByteArray)

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -61,6 +61,16 @@ impl DaemonInterface {
         Ok(())
     }
 
+    pub fn generate_wireguard_key(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::GenerateWireguardKey(tx))?;
+
+        rx.wait()
+            .map_err(|_| Error::NoResponse)?
+            .map_err(Error::RpcError)
+    }
+
     pub fn get_account_data(&self, account_token: String) -> Result<AccountData> {
         let (tx, rx) = oneshot::channel();
 

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -4,6 +4,7 @@ use mullvad_types::{
     account::AccountData, relay_constraints::RelaySettingsUpdate, relay_list::RelayList,
     settings::Settings, states::TargetState,
 };
+use talpid_types::net::wireguard;
 
 #[derive(Debug, err_derive::Error)]
 pub enum Error {
@@ -85,6 +86,14 @@ impl DaemonInterface {
         self.send_command(ManagementCommand::GetSettings(tx))?;
 
         Ok(rx.wait().map_err(|_| Error::NoResponse)?)
+    }
+
+    pub fn get_wireguard_key(&self) -> Result<Option<wireguard::PublicKey>> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::GetWireguardKey(tx))?;
+
+        rx.wait().map_err(|_| Error::NoResponse)
     }
 
     pub fn set_account(&self, account_token: Option<String>) -> Result<()> {

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -1,7 +1,7 @@
 use crate::get_class;
 use jni::{
     objects::{JList, JObject, JString, JValue},
-    sys::jint,
+    sys::{jint, jsize},
     JNIEnv,
 };
 use mullvad_types::{
@@ -70,6 +70,24 @@ where
         }
 
         list_object
+    }
+}
+
+impl<'array, 'env> IntoJava<'env> for &'array [u8] {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let size = self.len();
+        let array = env
+            .new_byte_array(size as jsize)
+            .expect("Failed to create a Java array of bytes");
+
+        let data = unsafe { std::slice::from_raw_parts(self.as_ptr() as *const i8, size) };
+
+        env.set_byte_array_region(array, 0, data)
+            .expect("Failed to copy bytes to Java array");
+
+        JObject::from(array)
     }
 }
 

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -12,7 +12,7 @@ use mullvad_types::{
     CustomTunnelEndpoint,
 };
 use std::fmt::Debug;
-use talpid_types::tunnel::TunnelStateTransition;
+use talpid_types::{net::wireguard::PublicKey, tunnel::TunnelStateTransition};
 
 pub trait IntoJava<'env> {
     type JavaType;
@@ -88,6 +88,19 @@ impl<'array, 'env> IntoJava<'env> for &'array [u8] {
             .expect("Failed to copy bytes to Java array");
 
         JObject::from(array)
+    }
+}
+
+impl<'env> IntoJava<'env> for PublicKey {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/PublicKey");
+        let key = env.auto_local(self.as_bytes().into_java(env));
+        let parameters = [JValue::Object(key.as_obj())];
+
+        env.new_object(&class, "([B)V", &parameters)
+            .expect("Failed to create PublicKey Java object")
     }
 }
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use jni::{
     objects::{GlobalRef, JObject, JString},
+    sys::{jboolean, JNI_FALSE, JNI_TRUE},
     JNIEnv,
 };
 use lazy_static::lazy_static;
@@ -193,6 +194,26 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_disconnect(_: J
             "{}",
             error.display_chain_with_msg("Failed to request daemon to disconnect")
         );
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_generateWireguardKey(
+    _: JNIEnv,
+    _: JObject,
+) -> jboolean {
+    let daemon = DAEMON_INTERFACE.lock();
+
+    match daemon.generate_wireguard_key() {
+        Ok(()) => JNI_TRUE,
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to generate wireguard key")
+            );
+            JNI_FALSE
+        }
     }
 }
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -30,6 +30,7 @@ const CLASSES_TO_LOAD: &[&str] = &[
     "net/mullvad/mullvadvpn/model/LocationConstraint$City",
     "net/mullvad/mullvadvpn/model/LocationConstraint$Country",
     "net/mullvad/mullvadvpn/model/LocationConstraint$Hostname",
+    "net/mullvad/mullvadvpn/model/PublicKey",
     "net/mullvad/mullvadvpn/model/Relay",
     "net/mullvad/mullvadvpn/model/RelayList",
     "net/mullvad/mullvadvpn/model/RelayListCity",

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -258,6 +258,26 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getSettings<'en
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getWireguardKey<'env, 'this>(
+    env: JNIEnv<'env>,
+    _: JObject<'this>,
+) -> JObject<'env> {
+    let daemon = DAEMON_INTERFACE.lock();
+
+    match daemon.get_wireguard_key() {
+        Ok(public_key) => public_key.into_java(&env),
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to get wireguard key")
+            );
+            JObject::null()
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_setAccount(
     env: JNIEnv,
     _: JObject,


### PR DESCRIPTION
This PR implements Wireguard key generation on Android. Every time the connect screen is first shown, the app will communicate with the daemon to check if there is a Wireguard key set. If there isn't, it will request the daemon to generate one.

While the key is being created, pressing the "Connect" button will stall sending the actual connection request to the daemon until the key generation is complete. To avoid any use visible delays, the app will immediately change the UI to a "pre-connecting" state, which is identical to the "connecting" state UI except that the notification banner is red. In practice, this happens so fast that it isn't visible.

Since the connect operation can take longer now, the code has also been updated to ensure that there is never more than one request active, so that two requests don't arrive at the daemon in the wrong order. Starting a new request (connect or disconnect) will attempt to cancel the previous action. There might be cases where the cancellation fails, but I believe that would only happen if the daemon has already received a request but hasn't sent back a response. Even so, the new request will arrive afterwards, so there should be no problems AFAICT.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Android version not released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/875)
<!-- Reviewable:end -->
