### PR TITLE
Automatically print help when no subcommand given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Relax the allow local network rules slightly. only checking either source or destination IP field
   instead of both. They are still unroutable
+- CLI commands that are just intermediate commands, and require another level of subcommands, will
+  automatically print the available subcommands, instead of an error if none is given.
+
+### Removed
+- The `help` subcommand in the CLI. Instead get help with the `--help` long flag.
 
 ### Fixed
 - Stop allowing the wrong IPv6 net fe02::/16 in the firewall when allow local network was enabled.

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -12,7 +12,7 @@ impl Command for Account {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Control and display information about your Mullvad account")
-            .setting(clap::AppSettings::SubcommandRequired)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 clap::SubCommand::with_name("set")
                     .about("Change account")

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -11,7 +11,7 @@ impl Command for AutoConnect {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Control the daemon auto-connect setting")
-            .setting(clap::AppSettings::SubcommandRequired)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 clap::SubCommand::with_name("set")
                     .about("Change auto-connect setting")

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -11,7 +11,7 @@ impl Command for BlockWhenDisconnected {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Control if the system service should block network access when disconnected from VPN")
-            .setting(clap::AppSettings::SubcommandRequired)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 clap::SubCommand::with_name("set")
                     .about("Change the block when disconnected setting")

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -11,7 +11,7 @@ impl Command for Lan {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Control the allow local network sharing setting")
-            .setting(clap::AppSettings::SubcommandRequired)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 clap::SubCommand::with_name("set")
                     .about("Change allow LAN setting")

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -25,13 +25,13 @@ impl Command for Relay {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Manage relay and tunnel constraints")
-            .setting(clap::AppSettings::SubcommandRequired)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 clap::SubCommand::with_name("set")
                     .about(
                         "Set relay server selection parameters. Such as location and port/protocol",
                     )
-                    .setting(clap::AppSettings::SubcommandRequired)
+                    .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                     .subcommand(
                         clap::SubCommand::with_name("custom")
                             .about("Set a custom VPN relay")

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -16,7 +16,7 @@ impl Command for Tunnel {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Manage tunnel specific options")
-            .setting(clap::AppSettings::SubcommandRequired)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(create_openvpn_subcommand())
             .subcommand(create_wireguard_subcommand())
             .subcommand(create_ipv6_subcommand())
@@ -37,7 +37,7 @@ impl Command for Tunnel {
 fn create_wireguard_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("wireguard")
         .about("Manage options for Wireguard tunnels")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(create_wireguard_mtu_subcommand())
         .subcommand(create_wireguard_keys_subcommand())
 }
@@ -45,7 +45,7 @@ fn create_wireguard_subcommand() -> clap::App<'static, 'static> {
 fn create_wireguard_mtu_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("mtu")
         .about("Configure the MTU of the wireguard tunnel")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::SubCommand::with_name("get"))
         .subcommand(clap::SubCommand::with_name("unset"))
         .subcommand(
@@ -56,7 +56,7 @@ fn create_wireguard_mtu_subcommand() -> clap::App<'static, 'static> {
 fn create_wireguard_keys_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("key")
         .about("Manage your wireguard keys")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::SubCommand::with_name("check"))
         .subcommand(clap::SubCommand::with_name("generate"))
 }
@@ -65,7 +65,7 @@ fn create_wireguard_keys_subcommand() -> clap::App<'static, 'static> {
 fn create_openvpn_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("openvpn")
         .about("Manage options for OpenVPN tunnels")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(create_openvpn_mssfix_subcommand())
         .subcommand(create_openvpn_proxy_subcommand())
 }
@@ -73,7 +73,7 @@ fn create_openvpn_subcommand() -> clap::App<'static, 'static> {
 fn create_openvpn_mssfix_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("mssfix")
         .about("Configure the optional mssfix parameter")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::SubCommand::with_name("get"))
         .subcommand(clap::SubCommand::with_name("unset"))
         .subcommand(
@@ -84,12 +84,12 @@ fn create_openvpn_mssfix_subcommand() -> clap::App<'static, 'static> {
 fn create_openvpn_proxy_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("proxy")
         .about("Configure a SOCKS5 proxy")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::SubCommand::with_name("get"))
         .subcommand(clap::SubCommand::with_name("unset"))
         .subcommand(
             clap::SubCommand::with_name("set")
-                .setting(clap::AppSettings::SubcommandRequired)
+                .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     clap::SubCommand::with_name("local")
                         .about("Registers a local SOCKS5 proxy")
@@ -174,7 +174,7 @@ fn create_openvpn_proxy_subcommand() -> clap::App<'static, 'static> {
 
 fn create_ipv6_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("ipv6")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::SubCommand::with_name("get"))
         .subcommand(
             clap::SubCommand::with_name("set").arg(

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -68,7 +68,11 @@ fn run() -> Result<()> {
         .version(PRODUCT_VERSION)
         .author(crate_authors!())
         .about(crate_description!())
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .global_settings(&[
+            clap::AppSettings::DisableHelpSubcommand,
+            clap::AppSettings::VersionlessSubcommands,
+        ])
         .subcommands(commands.values().map(|cmd| cmd.clap_subcommand()));
 
     let app_matches = app.get_matches();

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -117,7 +117,11 @@ fn run() -> Result<(), Error> {
         .version(metadata::PRODUCT_VERSION)
         .author(crate_authors!())
         .about("Mullvad VPN problem report tool. Collects logs and sends them to Mullvad support.")
-        .setting(clap::AppSettings::SubcommandRequired)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .global_settings(&[
+            clap::AppSettings::DisableHelpSubcommand,
+            clap::AppSettings::VersionlessSubcommands,
+        ])
         .subcommand(
             clap::SubCommand::with_name("collect")
                 .about("Collect problem report")


### PR DESCRIPTION
I randomly stumbled upon the `AppSettings::SubcommandRequiredElseHelp` setting in `clap`. I realized this would fix one of the most annoying things about the CLI in my opinion: The fact that when I try to explore it (since it's quite a deep nest of subcommands) I have to append and then delete `--help` for each level I explore:
```bash
mullvad tunnel
# dammit!
mullvad tunnel --help
mullvad tunnel wireguard
# Dammit!
mullvad tunnel wireguard --help
mullvad tunnel wireguard key
...
```

With this change, the help info is automatically printed when running a command that has subcommands but none were given. It just replaces the useless "you need to specify a subcommand" error with the actual list of available subcommands.

Also disable the --version flag on all subcommands. By default `clap` for some reason allows `--version` on all subcommands. It's not like we have different versions on different commands, so I just disable that for all commands except the top level app.

I also felt it was a bit inconsistent where you could do `mullvad foo help` vs `mullvad foo --help`. Most commands had **both** available, but some only `--help`. That combined with the fact that the `help` subcommand would get mixed in with the actual subcommands in the help for a command I decided to disable the `help` subcommand and consistently go with having to use `--help`. Does this seems reasonable?

Adding two reviewers since it's a UX change and I want you to be aware/agree. And I guess you are the two most prominent CLI users.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/877)
<!-- Reviewable:end -->
