### PR TITLE
Remove "without errors" log message

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -109,10 +109,7 @@ impl ConnectingState {
 
     fn wait_for_tunnel_monitor(tunnel_monitor: TunnelMonitor) -> Option<BlockReason> {
         match tunnel_monitor.wait() {
-            Ok(_) => {
-                debug!("Tunnel has finished without errors");
-                None
-            }
+            Ok(_) => None,
             Err(error) => match error {
                 #[cfg(windows)]
                 error @ tunnel::Error::OpenVpnTunnelMonitoringError(


### PR DESCRIPTION
Remove the log message in the case where the tunnel monitor exits successfully. It said "Tunnel has finished without errors" and it made it really annoying to search for "error" in the logs, since daemons that had had completely successful runs still had the word "error" in them a lot.

We still log the exit code of OpenVPN etc, so I don't think this log entry was crucial for figuring out what the daemon was doing anyway.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/878)
<!-- Reviewable:end -->
