### PR TITLE
Silence the logging around relay_list downloads

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -34,7 +34,7 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 /// How often the updater should wake up to check the cache of the in-memory cache of relays.
 /// This check is very cheap. The only reason to not have it very often is because if downloading
 /// constantly fails it will try very often and fill the logs etc.
-const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 2);
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 5);
 /// How old the cached relays need to be to trigger an update
 const UPDATE_INTERVAL: Duration = Duration::from_secs(3600);
 
@@ -642,10 +642,7 @@ impl RelayListUpdater {
             if self.should_update() {
                 match self.update() {
                     Ok(()) => info!("Updated list of relays"),
-                    Err(error) => error!(
-                        "{}",
-                        error.display_chain_with_msg("Failed to update list of relays")
-                    ),
+                    Err(error) => error!("{}", error.display_chain()),
                 }
             }
         }
@@ -695,8 +692,6 @@ impl RelayListUpdater {
     }
 
     fn download_relay_list(&mut self) -> Result<RelayList, Error> {
-        info!("Downloading list of relays...");
-
         let download_future = self.rpc_client.relay_list_v2().map_err(Error::Download);
         let relay_list = Timer::default()
             .timeout(download_future, DOWNLOAD_TIMEOUT)

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -158,7 +158,7 @@ impl fmt::Display for FirewallPolicy {
                 allow_lan,
             } => write!(
                 f,
-                "Connected to {} over \"{}\" (ip: {}, v4 gw: {}, v6 gw; {:?}), {} LAN",
+                "Connected to {} over \"{}\" (ip: {}, v4 gw: {}, v6 gw: {:?}), {} LAN",
                 peer_endpoint,
                 tunnel.interface,
                 tunnel


### PR DESCRIPTION
Support complained that when the app sits idle but with no internet (for example the blocked state) it logs every two minutes that it failed to download the relay list. The best would of course be if we implemented so the relay list updater is aware of the daemon state, and just pauses while being blocked. But as a quicker solution I increased the check interval from 2 to 5 minutes (2.5x slower) and also reduced the logging around a failed download from 4 to 2 lines
Before:
```
[2019-05-26 10:47:18.360][mullvad_daemon::relays][INFO] Downloading list of relays...
[2019-05-26 10:47:18.360][mullvad_daemon::relays][ERROR] Error: Failed to update list of relays
Caused by: Failed to download the list of relays
Caused by: Unable to send the JSON-RPC 2.0 request
```
Now:
```
[2019-05-26 10:47:18.360][mullvad_daemon::relays][ERROR] Error: Failed to download the list of relays
Caused by: Unable to send the JSON-RPC 2.0 request
```

Since both a successful update and a failed one will log something I did not feel the `Downloading list of relays...` entry added any value. And since the only error the `update` method can return is failing to download, it felt overkill to add another layer of error, so I cut out one error chain layer.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/879)
<!-- Reviewable:end -->
