### PR TITLE
Implement `TunProvider` abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ name = "talpid-core"
 version = "0.1.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
  "mullvad-paths 0.1.0",
  "mullvad-types 0.1.0",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "talpid-core 0.1.0",
  "talpid-types 0.1.0",
 ]
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -45,10 +45,9 @@ use mullvad_types::{
     version::{AppVersion, AppVersionInfo},
 };
 use std::{io, mem, path::PathBuf, sync::mpsc, thread, time::Duration};
-use talpid_core::tunnel::tun_provider::StubTunProvider;
 use talpid_core::{
     mpsc::IntoSender,
-    tunnel::tun_provider::TunProvider,
+    tunnel::tun_provider::{PlatformTunProvider, TunProvider},
     tunnel_state_machine::{self, TunnelCommand, TunnelParametersGenerator},
 };
 use talpid_types::{
@@ -235,7 +234,7 @@ impl Daemon<ManagementInterfaceEventBroadcaster> {
             tx,
             rx,
             management_interface_broadcaster,
-            StubTunProvider,
+            PlatformTunProvider::default(),
             log_dir,
             resource_dir,
             cache_dir,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -48,6 +48,7 @@ use std::{io, mem, path::PathBuf, sync::mpsc, thread, time::Duration};
 use talpid_core::tunnel::tun_provider::StubTunProvider;
 use talpid_core::{
     mpsc::IntoSender,
+    tunnel::tun_provider::TunProvider,
     tunnel_state_machine::{self, TunnelCommand, TunnelParametersGenerator},
 };
 use talpid_types::{
@@ -234,6 +235,7 @@ impl Daemon<ManagementInterfaceEventBroadcaster> {
             tx,
             rx,
             management_interface_broadcaster,
+            StubTunProvider,
             log_dir,
             resource_dir,
             cache_dir,
@@ -279,8 +281,9 @@ impl<L> Daemon<L>
 where
     L: EventListener + Clone + Send + 'static,
 {
-    pub fn start_with_event_listener(
+    pub fn start_with_event_listener_and_tun_provider(
         event_listener: L,
+        tun_provider: impl TunProvider,
         log_dir: Option<PathBuf>,
         resource_dir: PathBuf,
         cache_dir: PathBuf,
@@ -292,6 +295,7 @@ where
             tx,
             rx,
             event_listener,
+            tun_provider,
             log_dir,
             resource_dir,
             cache_dir,
@@ -303,6 +307,7 @@ where
         internal_event_tx: mpsc::Sender<InternalDaemonEvent>,
         internal_event_rx: mpsc::Receiver<InternalDaemonEvent>,
         event_listener: L,
+        tun_provider: impl TunProvider,
         log_dir: Option<PathBuf>,
         resource_dir: PathBuf,
         cache_dir: PathBuf,
@@ -346,7 +351,7 @@ where
             settings.get_allow_lan(),
             settings.get_block_when_disconnected(),
             tunnel_parameters_generator,
-            StubTunProvider,
+            tun_provider,
             log_dir,
             resource_dir,
             cache_dir.clone(),

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -45,6 +45,7 @@ use mullvad_types::{
     version::{AppVersion, AppVersionInfo},
 };
 use std::{io, mem, path::PathBuf, sync::mpsc, thread, time::Duration};
+use talpid_core::tunnel::tun_provider::StubTunProvider;
 use talpid_core::{
     mpsc::IntoSender,
     tunnel_state_machine::{self, TunnelCommand, TunnelParametersGenerator},
@@ -345,6 +346,7 @@ where
             settings.get_allow_lan(),
             settings.get_block_when_disconnected(),
             tunnel_parameters_generator,
+            StubTunProvider,
             log_dir,
             resource_dir,
             cache_dir.clone(),

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -22,4 +22,5 @@ parking_lot = "0.8"
 mullvad-daemon = { path = "../mullvad-daemon" }
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-types = { path = "../mullvad-types" }
+talpid-core = { path = "../talpid-core" }
 talpid-types = { path = "../talpid-types" }

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -19,6 +19,7 @@ use lazy_static::lazy_static;
 use mullvad_daemon::{logging, version, Daemon, DaemonCommandSender};
 use parking_lot::{Mutex, RwLock};
 use std::{collections::HashMap, path::PathBuf, sync::mpsc, thread};
+use talpid_core::tunnel::tun_provider::StubTunProvider;
 use talpid_types::ErrorExt;
 
 const LOG_FILENAME: &str = "daemon.log";
@@ -152,8 +153,9 @@ fn create_daemon(
     let resource_dir = mullvad_paths::get_resource_dir();
     let cache_dir = mullvad_paths::cache_dir().map_err(Error::GetCacheDir)?;
 
-    let daemon = Daemon::start_with_event_listener(
+    let daemon = Daemon::start_with_event_listener_and_tun_provider(
         listener,
+        StubTunProvider,
         Some(log_dir),
         resource_dir,
         cache_dir,

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 atty = "0.2"
+cfg-if = "0.1"
 derive_more = "0.14"
 duct = "0.12"
 err-derive = "0.1.5"

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -19,6 +19,9 @@ pub mod openvpn;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod wireguard;
 
+/// A module for low level platform specific tunnel device management.
+pub mod tun_provider;
+
 const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
 const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";
 

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -1,3 +1,4 @@
+use self::tun_provider::TunProvider;
 use crate::logging;
 #[cfg(not(target_os = "android"))]
 use std::collections::HashMap;
@@ -144,6 +145,7 @@ impl TunnelMonitor {
         log_dir: &Option<PathBuf>,
         resource_dir: &Path,
         on_event: L,
+        tun_provider: &dyn TunProvider,
     ) -> Result<Self>
     where
         L: Fn(TunnelEvent) + Send + Clone + Sync + 'static,
@@ -158,7 +160,7 @@ impl TunnelMonitor {
             }
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             TunnelParameters::Wireguard(config) => {
-                Self::start_wireguard_tunnel(&config, log_file, on_event)
+                Self::start_wireguard_tunnel(&config, log_file, on_event, tun_provider)
             }
             #[cfg(target_os = "android")]
             TunnelParameters::OpenVpn(_) => Err(Error::UnsupportedPlatform),
@@ -172,6 +174,7 @@ impl TunnelMonitor {
         params: &wireguard_types::TunnelParameters,
         log: Option<PathBuf>,
         on_event: L,
+        tun_provider: &dyn TunProvider,
     ) -> Result<Self>
     where
         L: Fn(TunnelEvent) + Send + Sync + Clone + 'static,
@@ -181,6 +184,7 @@ impl TunnelMonitor {
             &config,
             log.as_ref().map(|p| p.as_path()),
             on_event,
+            tun_provider,
         )?;
         Ok(TunnelMonitor {
             monitor: InternalTunnelMonitor::Wireguard(monitor),

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -4,9 +4,6 @@ use std::net::IpAddr;
 use std::os::unix::io::AsRawFd;
 use talpid_types::BoxedError;
 
-mod stub;
-pub use self::stub::StubTunProvider;
-
 cfg_if! {
     if #[cfg(all(unix, not(target_os = "android")))] {
         #[path = "unix.rs"]
@@ -19,6 +16,9 @@ cfg_if! {
         /// here.
         pub type PlatformTunProvider = UnixTunProvider;
     } else {
+        mod stub;
+        pub use self::stub::StubTunProvider;
+
         /// Default stub implementation of `TunProvider` for Android and Windows.
         pub type PlatformTunProvider = StubTunProvider;
     }

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -3,6 +3,9 @@ use std::net::IpAddr;
 use std::os::unix::io::AsRawFd;
 use talpid_types::BoxedError;
 
+mod stub;
+pub use self::stub::StubTunProvider;
+
 /// Generic tunnel device.
 ///
 /// Must be associated with a platform specific file descriptor representing the device.

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use std::net::IpAddr;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
@@ -5,6 +6,14 @@ use talpid_types::BoxedError;
 
 mod stub;
 pub use self::stub::StubTunProvider;
+
+cfg_if! {
+    if #[cfg(all(unix, not(target_os = "android")))] {
+        #[path = "unix.rs"]
+        mod imp;
+        use self::imp::UnixTunProvider;
+    }
+}
 
 /// Generic tunnel device.
 ///

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -1,0 +1,41 @@
+use std::net::IpAddr;
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+use talpid_types::BoxedError;
+
+/// Generic tunnel device.
+///
+/// Must be associated with a platform specific file descriptor representing the device.
+#[cfg(unix)]
+pub trait Tun: AsRawFd + Send {
+    /// Retrieve the tunnel interface name.
+    fn interface_name(&self) -> &str;
+}
+
+/// Stub tunnel device.
+#[cfg(windows)]
+pub trait Tun: Send {
+    /// Retrieve the tunnel interface name.
+    fn interface_name(&self) -> &str;
+}
+
+/// Factory of tunnel devices.
+pub trait TunProvider: Send + 'static {
+    /// Create a tunnel device using the provided configuration.
+    fn create_tun(&self, config: TunConfig) -> Result<Box<dyn Tun>, BoxedError>;
+}
+
+/// Configuration for creating a tunnel device.
+pub struct TunConfig {
+    /// IP addresses for the tunnel interface.
+    pub addresses: Vec<IpAddr>,
+}
+
+impl TunConfig {
+    /// Create a new tunnel device configuration using the specified tunnel addresses.
+    pub fn new(addresses: impl IntoIterator<Item = IpAddr>) -> Self {
+        TunConfig {
+            addresses: addresses.into_iter().collect(),
+        }
+    }
+}

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -12,6 +12,15 @@ cfg_if! {
         #[path = "unix.rs"]
         mod imp;
         use self::imp::UnixTunProvider;
+
+        /// Default implementation of `TunProvider` for Unix based operating systems.
+        ///
+        /// Android has a different mechanism to obtain tunnel interfaces, so it is not supported
+        /// here.
+        pub type PlatformTunProvider = UnixTunProvider;
+    } else {
+        /// Default stub implementation of `TunProvider` for Android and Windows.
+        pub type PlatformTunProvider = StubTunProvider;
     }
 }
 

--- a/talpid-core/src/tunnel/tun_provider/stub.rs
+++ b/talpid-core/src/tunnel/tun_provider/stub.rs
@@ -1,0 +1,11 @@
+use super::{Tun, TunConfig, TunProvider};
+use talpid_types::BoxedError;
+
+/// Factory stub of tunnel devices.
+pub struct StubTunProvider;
+
+impl TunProvider for StubTunProvider {
+    fn create_tun(&self, _: TunConfig) -> Result<Box<dyn Tun>, BoxedError> {
+        unimplemented!();
+    }
+}

--- a/talpid-core/src/tunnel/tun_provider/stub.rs
+++ b/talpid-core/src/tunnel/tun_provider/stub.rs
@@ -4,6 +4,12 @@ use talpid_types::BoxedError;
 /// Factory stub of tunnel devices.
 pub struct StubTunProvider;
 
+impl Default for StubTunProvider {
+    fn default() -> Self {
+        StubTunProvider
+    }
+}
+
 impl TunProvider for StubTunProvider {
     fn create_tun(&self, _: TunConfig) -> Result<Box<dyn Tun>, BoxedError> {
         unimplemented!();

--- a/talpid-core/src/tunnel/tun_provider/unix.rs
+++ b/talpid-core/src/tunnel/tun_provider/unix.rs
@@ -1,0 +1,48 @@
+use super::{Tun, TunConfig, TunProvider};
+use crate::network_interface::{self, NetworkInterface, TunnelDevice};
+use std::net::IpAddr;
+use talpid_types::BoxedError;
+
+/// Errors that can occur while setting up a tunnel device.
+#[derive(Debug, err_derive::Error)]
+pub enum Error {
+    /// Failure to create a tunnel device.
+    #[error(display = "Failed to create a tunnel device")]
+    CreateTunnelDevice(#[cause] network_interface::Error),
+
+    /// Failure to set a tunnel device IP address.
+    #[error(display = "Failed to set tunnel IP address: {}", _0)]
+    SetIpAddr(IpAddr, #[cause] network_interface::Error),
+
+    /// Failure to set the tunnel device as up.
+    #[error(display = "Failed to set the tunnel device as up")]
+    SetUp(#[cause] network_interface::Error),
+}
+
+/// Factory of tunnel devices on Unix systems.
+pub struct UnixTunProvider;
+
+impl TunProvider for UnixTunProvider {
+    fn create_tun(&self, config: TunConfig) -> Result<Box<dyn Tun>, BoxedError> {
+        let mut tunnel_device = TunnelDevice::new()
+            .map_err(|cause| BoxedError::new(Error::CreateTunnelDevice(cause)))?;
+
+        for ip in config.addresses.iter() {
+            tunnel_device
+                .set_ip(*ip)
+                .map_err(|cause| BoxedError::new(Error::SetIpAddr(*ip, cause)))?;
+        }
+
+        tunnel_device
+            .set_up(true)
+            .map_err(|cause| BoxedError::new(Error::SetUp(cause)))?;
+
+        Ok(Box::new(tunnel_device))
+    }
+}
+
+impl Tun for TunnelDevice {
+    fn interface_name(&self) -> &str {
+        self.get_name()
+    }
+}

--- a/talpid-core/src/tunnel/tun_provider/unix.rs
+++ b/talpid-core/src/tunnel/tun_provider/unix.rs
@@ -22,6 +22,12 @@ pub enum Error {
 /// Factory of tunnel devices on Unix systems.
 pub struct UnixTunProvider;
 
+impl Default for UnixTunProvider {
+    fn default() -> Self {
+        UnixTunProvider
+    }
+}
+
 impl TunProvider for UnixTunProvider {
     fn create_tun(&self, config: TunConfig) -> Result<Box<dyn Tun>, BoxedError> {
         let mut tunnel_device = TunnelDevice::new()

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -4,6 +4,7 @@ use self::config::Config;
 use super::{tun_provider::TunProvider, TunnelEvent, TunnelMetadata};
 use crate::routing;
 use std::{collections::HashMap, io, path::Path, sync::mpsc};
+use talpid_types::BoxedError;
 
 pub mod config;
 mod ping_monitor;
@@ -21,7 +22,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// Failed to setup a tunnel device.
     #[error(display = "Failed to create tunnel device")]
-    SetupTunnelDeviceError(#[error(cause)] crate::network_interface::Error),
+    SetupTunnelDeviceError(#[error(cause)] BoxedError),
 
     /// Failed to setup wireguard tunnel.
     #[error(display = "Failed to start wireguard tunnel - {}", status)]
@@ -65,9 +66,9 @@ impl WireguardMonitor {
         config: &Config,
         log_path: Option<&Path>,
         on_event: F,
-        _tun_provider: &dyn TunProvider,
+        tun_provider: &dyn TunProvider,
     ) -> Result<WireguardMonitor> {
-        let tunnel = Box::new(WgGoTunnel::start_tunnel(&config, log_path)?);
+        let tunnel = Box::new(WgGoTunnel::start_tunnel(&config, log_path, tun_provider)?);
         let iface_name = tunnel.get_interface_name();
         let route_handle = routing::RouteManager::new(
             Self::get_routes(iface_name, &config),

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use self::config::Config;
-use super::{TunnelEvent, TunnelMetadata};
+use super::{tun_provider::TunProvider, TunnelEvent, TunnelMetadata};
 use crate::routing;
 use std::{collections::HashMap, io, path::Path, sync::mpsc};
 
@@ -65,6 +65,7 @@ impl WireguardMonitor {
         config: &Config,
         log_path: Option<&Path>,
         on_event: F,
+        _tun_provider: &dyn TunProvider,
     ) -> Result<WireguardMonitor> {
         let tunnel = Box::new(WgGoTunnel::start_tunnel(&config, log_path)?);
         let iface_name = tunnel.get_interface_name();

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     firewall::{Firewall, FirewallArguments},
     mpsc::IntoSender,
     offline,
+    tunnel::tun_provider::TunProvider,
 };
 use futures::{sync::mpsc, Async, Future, Poll, Stream};
 use std::{
@@ -63,6 +64,7 @@ pub fn spawn<P, T>(
     allow_lan: bool,
     block_when_disconnected: bool,
     tunnel_parameters_generator: impl TunnelParametersGenerator,
+    tun_provider: impl TunProvider,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
     cache_dir: P,
@@ -84,6 +86,7 @@ where
             block_when_disconnected,
             is_offline,
             tunnel_parameters_generator,
+            tun_provider,
             log_dir,
             resource_dir,
             cache_dir,
@@ -122,6 +125,7 @@ fn create_event_loop<T>(
     block_when_disconnected: bool,
     is_offline: bool,
     tunnel_parameters_generator: impl TunnelParametersGenerator,
+    tun_provider: impl TunProvider,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
     cache_dir: impl AsRef<Path>,
@@ -137,6 +141,7 @@ where
         block_when_disconnected,
         is_offline,
         tunnel_parameters_generator,
+        tun_provider,
         log_dir,
         resource_dir,
         cache_dir,
@@ -186,6 +191,7 @@ impl TunnelStateMachine {
         block_when_disconnected: bool,
         is_offline: bool,
         tunnel_parameters_generator: impl TunnelParametersGenerator,
+        tun_provider: impl TunProvider,
         log_dir: Option<PathBuf>,
         resource_dir: PathBuf,
         cache_dir: impl AsRef<Path>,
@@ -211,6 +217,7 @@ impl TunnelStateMachine {
             block_when_disconnected,
             is_offline,
             tunnel_parameters_generator: Box::new(tunnel_parameters_generator),
+            tun_provider: Box::new(tun_provider),
             log_dir,
             resource_dir,
         };
@@ -293,6 +300,8 @@ struct SharedTunnelStateValues {
     is_offline: bool,
     /// The generator of new `TunnelParameter`s
     tunnel_parameters_generator: Box<dyn TunnelParametersGenerator>,
+    /// The provider of tunnel devices.
+    tun_provider: Box<dyn TunProvider>,
     /// Directory to store tunnel log file.
     log_dir: Option<PathBuf>,
     /// Resource directory path.


### PR DESCRIPTION
Different platforms have different procedures for setting up tunnel interfaces. In the case of Android, the order of operations also needs to be different. To support such diversity, this PR creates a `TunProvider` trait that should be implemented for each supported platform.

Currently, it only contains a refactoring of the Unix implementation, since Windows doesn't yet have Wireguard support in the app. The Android implementation will be added as a separate PR, since it contains a reasonable amount of code. In the meantime, there is a `StubTunProvider` to keep the builds on both platforms compiling without issues.

The trait abstracts the tunnel interface creation. It can be used to create a tunnel interface from a given configuration (which currently only contains the IP addresses to be assigned to the tunnel, but will include more information in the future, such as MTU, DNS servers and routes).

The daemon by default uses the platform specific implementation of the `TunProvider` trait, available as a `PlatformTunProvider` type alias (which implements `Default` so that it can be constructed). On Android however, the implementation will require some setting up before being handed to the daemon, so this PR also includes some changes to support setting a custom `TunProvider` implementation when starting the daemon.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/880)
<!-- Reviewable:end -->
