### PR TITLE
Add missing data in `TunConfig`

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -13,6 +13,7 @@ derive_more = "0.14"
 duct = "0.12"
 err-derive = "0.1.5"
 futures = "0.1"
+ipnetwork = "0.14"
 jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 libc = "0.2.20"
@@ -30,7 +31,6 @@ uuid = { version = "0.7", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 hex = "0.3"
-ipnetwork = "0.14"
 lazy_static = "1.0"
 nix = "0.13"
 tokio-process = "0.2"

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -139,7 +139,7 @@ pub struct TunnelMonitor {
 impl TunnelMonitor {
     /// Creates a new `TunnelMonitor` that connects to the given remote and notifies `on_event`
     /// on tunnel state changes.
-    #[cfg_attr(target_os = "android", allow(unused_variables))]
+    #[cfg_attr(any(target_os = "android", windows), allow(unused_variables))]
     pub fn start<L>(
         tunnel_parameters: &TunnelParameters,
         log_dir: &Option<PathBuf>,

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -51,12 +51,3 @@ pub struct TunConfig {
     /// IP addresses for the tunnel interface.
     pub addresses: Vec<IpAddr>,
 }
-
-impl TunConfig {
-    /// Create a new tunnel device configuration using the specified tunnel addresses.
-    pub fn new(addresses: impl IntoIterator<Item = IpAddr>) -> Self {
-        TunConfig {
-            addresses: addresses.into_iter().collect(),
-        }
-    }
-}

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -54,4 +54,7 @@ pub struct TunConfig {
 
     /// IP addresses for the DNS servers to use.
     pub dns_servers: Vec<IpAddr>,
+
+    /// Maximum Transmission Unit in the tunnel.
+    pub mtu: u16,
 }

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -51,4 +51,7 @@ pub trait TunProvider: Send + 'static {
 pub struct TunConfig {
     /// IP addresses for the tunnel interface.
     pub addresses: Vec<IpAddr>,
+
+    /// IP addresses for the DNS servers to use.
+    pub dns_servers: Vec<IpAddr>,
 }

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -1,4 +1,5 @@
 use cfg_if::cfg_if;
+use ipnetwork::IpNetwork;
 use std::net::IpAddr;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
@@ -54,6 +55,9 @@ pub struct TunConfig {
 
     /// IP addresses for the DNS servers to use.
     pub dns_servers: Vec<IpAddr>,
+
+    /// Routes to configure for the tunnel.
+    pub routes: Vec<IpNetwork>,
 
     /// Maximum Transmission Unit in the tunnel.
     pub mtu: u16,

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -47,6 +47,7 @@ pub trait TunProvider: Send + 'static {
 }
 
 /// Configuration for creating a tunnel device.
+#[derive(Clone, Debug)]
 pub struct TunConfig {
     /// IP addresses for the tunnel interface.
     pub addresses: Vec<IpAddr>,

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -17,7 +17,9 @@ impl WgGoTunnel {
         log_path: Option<&Path>,
         tun_provider: &dyn TunProvider,
     ) -> Result<Self> {
-        let tunnel_config = TunConfig::new(config.tunnel.addresses.clone());
+        let tunnel_config = TunConfig {
+            addresses: config.tunnel.addresses.clone())
+        };
         let tunnel_device = tun_provider
             .create_tun(tunnel_config)
             .map_err(Error::SetupTunnelDeviceError)?;

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -1,5 +1,6 @@
 use super::{Config, Error, Result, Tunnel};
 use crate::tunnel::tun_provider::{Tun, TunConfig, TunProvider};
+use ipnetwork::IpNetwork;
 use std::{ffi::CString, fs, net::IpAddr, os::unix::io::AsRawFd, path::Path};
 
 pub struct WgGoTunnel {
@@ -16,9 +17,10 @@ impl WgGoTunnel {
         config: &Config,
         log_path: Option<&Path>,
         tun_provider: &dyn TunProvider,
+        routes: impl Iterator<Item = IpNetwork>,
     ) -> Result<Self> {
         let tunnel_device = tun_provider
-            .create_tun(Self::create_tunnel_config(config))
+            .create_tun(Self::create_tunnel_config(config, routes))
             .map_err(Error::SetupTunnelDeviceError)?;
 
         let interface_name: String = tunnel_device.interface_name().to_string();
@@ -51,13 +53,14 @@ impl WgGoTunnel {
         })
     }
 
-    fn create_tunnel_config(config: &Config) -> TunConfig {
+    fn create_tunnel_config(config: &Config, routes: impl Iterator<Item = IpNetwork>) -> TunConfig {
         let mut dns_servers = vec![IpAddr::V4(config.ipv4_gateway)];
         dns_servers.extend(config.ipv6_gateway.clone().map(IpAddr::V6));
 
         TunConfig {
             addresses: config.tunnel.addresses.clone(),
             dns_servers,
+            routes: routes.collect(),
             mtu: config.mtu,
         }
     }

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -1,6 +1,6 @@
 use super::{Config, Error, Result, Tunnel};
 use crate::tunnel::tun_provider::{Tun, TunConfig, TunProvider};
-use std::{ffi::CString, fs, os::unix::io::AsRawFd, path::Path};
+use std::{ffi::CString, fs, net::IpAddr, os::unix::io::AsRawFd, path::Path};
 
 pub struct WgGoTunnel {
     interface_name: String,
@@ -52,8 +52,12 @@ impl WgGoTunnel {
     }
 
     fn create_tunnel_config(config: &Config) -> TunConfig {
+        let mut dns_servers = vec![IpAddr::V4(config.ipv4_gateway)];
+        dns_servers.extend(config.ipv6_gateway.clone().map(IpAddr::V6));
+
         TunConfig {
             addresses: config.tunnel.addresses.clone(),
+            dns_servers,
         }
     }
 

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -17,11 +17,8 @@ impl WgGoTunnel {
         log_path: Option<&Path>,
         tun_provider: &dyn TunProvider,
     ) -> Result<Self> {
-        let tunnel_config = TunConfig {
-            addresses: config.tunnel.addresses.clone())
-        };
         let tunnel_device = tun_provider
-            .create_tun(tunnel_config)
+            .create_tun(Self::create_tunnel_config(config))
             .map_err(Error::SetupTunnelDeviceError)?;
 
         let interface_name: String = tunnel_device.interface_name().to_string();
@@ -52,6 +49,12 @@ impl WgGoTunnel {
             _tunnel_device: tunnel_device,
             _log_file: log_file,
         })
+    }
+
+    fn create_tunnel_config(config: &Config) -> TunConfig {
+        TunConfig {
+            addresses: config.tunnel.addresses.clone(),
+        }
     }
 
     fn stop_tunnel(&mut self) -> Result<()> {

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -58,6 +58,7 @@ impl WgGoTunnel {
         TunConfig {
             addresses: config.tunnel.addresses.clone(),
             dns_servers,
+            mtu: config.mtu,
         }
     }
 


### PR DESCRIPTION
The previous PR included the `TunConfig` parameters that I used for the first test version of the app. However, some other VPN tunnel parameters were also set, but they had hard-coded values. That included the MTU (set to 1400), the DNS server (8.8.8.8) and the tunnel routes (only had `0.0.0.0/0`). 

This PR adds the missing parameters to `TunConfig` and uses them when setting up the Wireguard tunnel.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/884)
<!-- Reviewable:end -->
