### PR TITLE
Replace "daemon" with "system service"

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Mullvad VPN</string>
 
-    <string name="connecting_to_daemon">Connecting to daemon...</string>
+    <string name="connecting_to_daemon">Connecting to Mullvad system service...</string>
 
     <string name="login_title">Login</string>
     <string name="login_description">Enter your account number</string>

--- a/gui/src/renderer/components/Launch.tsx
+++ b/gui/src/renderer/components/Launch.tsx
@@ -50,7 +50,7 @@ export default class Launch extends Component<IProps> {
             <ImageView height={120} width={120} source="logo-icon" style={styles.logo} />
             <Text style={styles.title}>{messages.pgettext('launch-view', 'MULLVAD VPN')}</Text>
             <Text style={styles.subtitle}>
-              {messages.pgettext('launch-view', 'Connecting to daemon...')}
+              {messages.pgettext('launch-view', 'Connecting to Mullvad system service...')}
             </Text>
           </View>
         </Container>


### PR DESCRIPTION
The word "daemon" has been confusing to users since the very start. It's not very familiar except to some Linux, and maybe pro macOS, users basically. I think "system service" is a broader parent term that still encapsulates "daemons" but also includes Windows better and is easier for non techies.

@jvff Is this the correct place to update to make it have effect on Android?

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/885)
<!-- Reviewable:end -->
