### PR TITLE
Make prepare_release.sh sync the version in package-lock.json

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -7228,18 +7228,18 @@
       "integrity": "sha512-8Gr8WHInZt5oU1q2N7ANqLSZ/TJn6bYlkqkwJJoGowFc5l81DRORgtHH9eJUpJGJsGJgYyWeVfKGVtUdTu4TEQ=="
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.9.tgz",
+      "integrity": "sha512-xisFa7Q2i3HOgfn+nmnWLGHD6Tm23hxjkx6wwGmgxkJFr6wxwXnJOdJYcZjL453PSdF0+bemO03+flAzkIdLBQ==",
       "optional": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       }
     },
     "temp-file": {

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -42,9 +42,12 @@ echo "Syncing Cargo.lock with new version numbers"
 source env.sh ""
 cargo build
 
+(cd gui/ && npm install) || exit 1
+
 echo "Commiting metadata changes to git..."
 git commit -S -m "Updating version in package files" \
     gui/package.json \
+    gui/package-lock.json \
     mullvad-daemon/Cargo.toml \
     mullvad-cli/Cargo.toml \
     mullvad-problem-report/Cargo.toml \


### PR DESCRIPTION
Run `npm install` after updating the version in `package.json` in order to make npm sync the version in `package-lock.json`. Does this have any downside? I see on master `npm install` also changes some other stuff, but I'm not sure if that's because the master lockfile is out of sync or if `npm install` usually upgrade dependencies.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/889)
<!-- Reviewable:end -->
