### PR TITLE
Implement Android specific `VpnServiceTunProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ version = "0.1.0"
 dependencies = [
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -22,5 +22,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+                android:name=".MullvadVpnService$InnerVpnService"
+                android:permission="android.permission.BIND_VPN_SERVICE"
+                >
+            <intent-filter>
+                <action android:name="android.net.VpnService" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : FragmentActivity() {
     private fun startDaemon() = GlobalScope.async(Dispatchers.Default) {
         activityCreated.await()
         ApiRootCaFile().extract(this@MainActivity)
-        MullvadDaemon()
+        MullvadDaemon(MullvadVpnService(this@MainActivity))
     }
 
     private fun fetchRelayList() = GlobalScope.async(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -7,10 +7,10 @@ import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.model.TunnelStateTransition
 
-class MullvadDaemon {
+class MullvadDaemon(val vpnService: MullvadVpnService) {
     init {
         System.loadLibrary("mullvad_jni")
-        initialize()
+        initialize(vpnService)
     }
 
     var onTunnelStateChange: ((TunnelStateTransition) -> Unit)? = null
@@ -25,7 +25,7 @@ class MullvadDaemon {
     external fun setAccount(accountToken: String?)
     external fun updateRelaySettings(update: RelaySettingsUpdate)
 
-    private external fun initialize()
+    private external fun initialize(vpnService: MullvadVpnService)
 
     private fun notifyTunnelStateEvent(event: TunnelStateTransition) {
         onTunnelStateChange?.invoke(event)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -1,0 +1,79 @@
+package net.mullvad.mullvadvpn
+
+import java.net.InetAddress
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CompletableDeferred
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.VpnService
+
+import net.mullvad.mullvadvpn.model.TunConfig
+
+var INNER_VPN_SERVICE = CompletableDeferred<MullvadVpnService.InnerVpnService>()
+var SERVICE_NOT_RUNNING = true
+
+class MullvadVpnService(val context: Context) {
+    class InnerVpnService : VpnService() {
+        override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+            INNER_VPN_SERVICE.complete(this)
+
+            return super.onStartCommand(intent, flags, startId)
+        }
+
+        override fun onDestroy() {
+            INNER_VPN_SERVICE = CompletableDeferred<MullvadVpnService.InnerVpnService>()
+            SERVICE_NOT_RUNNING = true
+            super.onDestroy()
+        }
+
+        fun builder(): Builder {
+            return Builder()
+        }
+    }
+
+    fun createTun(config: TunConfig): Int {
+        return createTun(config, startService())
+    }
+
+    fun bypass(socket: Int): Boolean {
+        return startService().protect(socket)
+    }
+
+    private fun startService(): InnerVpnService {
+        lateinit var service: InnerVpnService
+
+        if (SERVICE_NOT_RUNNING) {
+            SERVICE_NOT_RUNNING = false
+            context.startService(Intent(context, InnerVpnService::class.java))
+        }
+
+        runBlocking { service = INNER_VPN_SERVICE.await() }
+
+        return service
+    }
+
+    private fun createTun(config: TunConfig, service: InnerVpnService): Int {
+        val builder = service.builder().apply {
+            for (address in config.addresses) {
+                addAddress(address, 32)
+            }
+
+            for (dnsServer in config.dnsServers) {
+                addDnsServer(dnsServer)
+            }
+
+            for (route in config.routes) {
+                addRoute(route.address, route.prefixLength as Int)
+            }
+
+            setMtu(config.mtu)
+        }
+
+        val vpnInterface = builder.establish()
+
+        return vpnInterface.detachFd()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/InetNetwork.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/InetNetwork.kt
@@ -1,0 +1,5 @@
+package net.mullvad.mullvadvpn.model
+
+import java.net.InetAddress
+
+data class InetNetwork(val address: InetAddress, val prefixLength: Short)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunConfig.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunConfig.kt
@@ -1,0 +1,10 @@
+package net.mullvad.mullvadvpn.model
+
+import java.net.InetAddress
+
+data class TunConfig(
+    val addresses: List<InetAddress>,
+    val dnsServers: List<InetAddress>,
+    val routes: List<InetNetwork>,
+    val mtu: Int
+)

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -12,6 +12,7 @@ crate_type = ["cdylib"]
 [dependencies]
 err-derive = "0.1.5"
 futures = "0.1"
+ipnetwork = "0.14"
 jni = "0.12"
 jsonrpc-client-core = "0.5"
 lazy_static = "1"

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -1,8 +1,9 @@
 use crate::get_class;
+use ipnetwork::IpNetwork;
 use jni::{
     objects::{JList, JObject, JString, JValue},
     signature::JavaType,
-    sys::{jint, jsize},
+    sys::{jint, jshort, jsize},
     JNIEnv,
 };
 use mullvad_types::{
@@ -142,6 +143,23 @@ impl<'env> IntoJava<'env> for IpAddr {
                 );
             }
         }
+    }
+}
+
+impl<'env> IntoJava<'env> for IpNetwork {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/InetNetwork");
+        let address = env.auto_local(self.ip().into_java(env));
+        let prefix_length = self.prefix() as jshort;
+        let parameters = [
+            JValue::Object(address.as_obj()),
+            JValue::Short(prefix_length),
+        ];
+
+        env.new_object(&class, "(Ljava/net/InetAddress;S)V", &parameters)
+            .expect("Failed to create InetNetwork Java object")
     }
 }
 

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -14,6 +14,7 @@ use mullvad_types::{
     CustomTunnelEndpoint,
 };
 use std::{fmt::Debug, net::IpAddr};
+use talpid_core::tunnel::tun_provider::TunConfig;
 use talpid_types::{net::wireguard::PublicKey, tunnel::TunnelStateTransition};
 
 pub trait IntoJava<'env> {
@@ -186,6 +187,19 @@ impl<'env> IntoJava<'env> for AccountData {
 
         env.new_object(&class, "(Ljava/lang/String;)V", &parameters)
             .expect("Failed to create AccountData Java object")
+    }
+}
+
+impl<'env> IntoJava<'env> for TunConfig {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/TunConfig");
+        let addresses = env.auto_local(self.addresses.into_java(env));
+        let parameters = [JValue::Object(addresses.as_obj())];
+
+        env.new_object(&class, "(Ljava/util/List;)V", &parameters)
+            .expect("Failed to create TunConfig Java object")
     }
 }
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -73,6 +73,7 @@ pub enum Error {
 pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_initialize(
     env: JNIEnv,
     this: JObject,
+    _vpnService: JObject,
 ) {
     let log_dir = start_logging();
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -25,6 +25,7 @@ use talpid_types::ErrorExt;
 const LOG_FILENAME: &str = "daemon.log";
 
 const CLASSES_TO_LOAD: &[&str] = &[
+    "java/net/InetAddress",
     "java/util/ArrayList",
     "net/mullvad/mullvadvpn/model/AccountData",
     "net/mullvad/mullvadvpn/model/Constraint$Any",

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -5,6 +5,7 @@ mod from_java;
 mod into_java;
 mod is_null;
 mod jni_event_listener;
+mod vpn_service_tun_provider;
 
 use crate::{
     daemon_interface::DaemonInterface, from_java::FromJava, into_java::IntoJava,

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -30,6 +30,7 @@ const CLASSES_TO_LOAD: &[&str] = &[
     "net/mullvad/mullvadvpn/model/AccountData",
     "net/mullvad/mullvadvpn/model/Constraint$Any",
     "net/mullvad/mullvadvpn/model/Constraint$Only",
+    "net/mullvad/mullvadvpn/model/InetNetwork",
     "net/mullvad/mullvadvpn/model/LocationConstraint$City",
     "net/mullvad/mullvadvpn/model/LocationConstraint$Country",
     "net/mullvad/mullvadvpn/model/LocationConstraint$Hostname",

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -44,6 +44,7 @@ const CLASSES_TO_LOAD: &[&str] = &[
     "net/mullvad/mullvadvpn/model/RelaySettingsUpdate$CustomTunnelEndpoint",
     "net/mullvad/mullvadvpn/model/RelaySettingsUpdate$RelayConstraintsUpdate",
     "net/mullvad/mullvadvpn/model/Settings",
+    "net/mullvad/mullvadvpn/model/TunConfig",
     "net/mullvad/mullvadvpn/model/TunnelStateTransition$Blocked",
     "net/mullvad/mullvadvpn/model/TunnelStateTransition$Connected",
     "net/mullvad/mullvadvpn/model/TunnelStateTransition$Connecting",

--- a/mullvad-jni/src/vpn_service_tun_provider.rs
+++ b/mullvad-jni/src/vpn_service_tun_provider.rs
@@ -1,0 +1,150 @@
+use crate::{get_class, into_java::IntoJava};
+use jni::{
+    objects::{GlobalRef, JObject, JValue},
+    signature::{JavaType, Primitive},
+    JNIEnv, JavaVM,
+};
+use std::os::unix::io::{AsRawFd, RawFd};
+use talpid_core::tunnel::tun_provider::{Tun, TunConfig, TunProvider};
+use talpid_types::BoxedError;
+
+/// Errors that occur while setting up VpnService tunnel.
+#[derive(Debug, err_derive::Error)]
+#[error(display = "Failed to set up the VpnService")]
+pub enum Error {
+    #[error(display = "Failed to attach Java VM to tunnel thread")]
+    AttachJvmToThread(#[error(cause)] jni::errors::Error),
+
+    #[error(display = "Failed to allow socket to bypass tunnel")]
+    Bypass,
+
+    #[error(display = "Failed to call Java method {}", _0)]
+    CallMethod(&'static str, #[error(cause)] jni::errors::Error),
+
+    #[error(display = "Failed to create global reference to MullvadVpnService instance")]
+    CreateGlobalReference(#[error(cause)] jni::errors::Error),
+
+    #[error(display = "Failed to find {} method", _0)]
+    FindMethod(&'static str, #[error(cause)] jni::errors::Error),
+
+    #[error(display = "Failed to get Java VM instance")]
+    GetJvmInstance(#[error(cause)] jni::errors::Error),
+
+    #[error(display = "Received an invalid result from {}: {}", _0, _1)]
+    InvalidMethodResult(&'static str, String),
+}
+
+/// Factory of tunnel devices on Android.
+pub struct VpnServiceTunProvider {
+    jvm: JavaVM,
+    class: GlobalRef,
+    object: GlobalRef,
+}
+
+impl VpnServiceTunProvider {
+    /// Create a new VpnServiceTunProvider interfacing with Android's VpnService.
+    pub fn new(env: &JNIEnv, mullvad_vpn_service: &JObject) -> Result<Self, Error> {
+        let jvm = env.get_java_vm().map_err(Error::GetJvmInstance)?;
+        let class = get_class("net/mullvad/mullvadvpn/MullvadVpnService");
+        let object = env
+            .new_global_ref(*mullvad_vpn_service)
+            .map_err(Error::CreateGlobalReference)?;
+
+        Ok(VpnServiceTunProvider { jvm, class, object })
+    }
+}
+
+impl TunProvider for VpnServiceTunProvider {
+    fn create_tun(&self, config: TunConfig) -> Result<Box<dyn Tun>, BoxedError> {
+        let env = self
+            .jvm
+            .attach_current_thread()
+            .map_err(|cause| BoxedError::new(Error::AttachJvmToThread(cause)))?;
+        let create_tun_method = env
+            .get_method_id(
+                &self.class,
+                "createTun",
+                "(Lnet/mullvad/mullvadvpn/model/TunConfig;)I",
+            )
+            .map_err(|cause| {
+                BoxedError::new(Error::FindMethod("MullvadVpnService.createTun", cause))
+            })?;
+
+        let result = env
+            .call_method_unchecked(
+                self.object.as_obj(),
+                create_tun_method,
+                JavaType::Primitive(Primitive::Int),
+                &[JValue::Object(config.into_java(&env))],
+            )
+            .map_err(|cause| {
+                BoxedError::new(Error::CallMethod("MullvadVpnService.createTun", cause))
+            })?;
+
+        match result {
+            JValue::Int(fd) => Ok(Box::new(VpnServiceTun {
+                tunnel: fd,
+                jvm: env
+                    .get_java_vm()
+                    .map_err(|cause| BoxedError::new(Error::GetJvmInstance(cause)))?,
+                class: self.class.clone(),
+                object: self.object.clone(),
+            })),
+            value => Err(BoxedError::new(Error::InvalidMethodResult(
+                "MullvadVpnService.createTun",
+                format!("{:?}", value),
+            ))),
+        }
+    }
+}
+
+struct VpnServiceTun {
+    tunnel: RawFd,
+    jvm: JavaVM,
+    class: GlobalRef,
+    object: GlobalRef,
+}
+
+impl AsRawFd for VpnServiceTun {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tunnel
+    }
+}
+
+impl Tun for VpnServiceTun {
+    fn interface_name(&self) -> &str {
+        "tun"
+    }
+
+    fn bypass(&mut self, socket: RawFd) -> Result<(), BoxedError> {
+        let env = self
+            .jvm
+            .attach_current_thread()
+            .map_err(|cause| BoxedError::new(Error::AttachJvmToThread(cause)))?;
+        let create_tun_method =
+            env.get_method_id(&self.class, "bypass", "(I)Z")
+                .map_err(|cause| {
+                    BoxedError::new(Error::FindMethod("MullvadVpnService.bypass", cause))
+                })?;
+
+        let result = env
+            .call_method_unchecked(
+                self.object.as_obj(),
+                create_tun_method,
+                JavaType::Primitive(Primitive::Boolean),
+                &[JValue::Int(socket)],
+            )
+            .map_err(|cause| {
+                BoxedError::new(Error::CallMethod("MullvadVpnService.bypass", cause))
+            })?;
+
+        match result {
+            JValue::Bool(0) => Err(BoxedError::new(Error::Bypass)),
+            JValue::Bool(_) => Ok(()),
+            value => Err(BoxedError::new(Error::InvalidMethodResult(
+                "MullvadVpnService.bypass",
+                format!("{:?}", value),
+            ))),
+        }
+    }
+}

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -20,7 +20,7 @@ cfg_if! {
         pub type PlatformTunProvider = UnixTunProvider;
     } else {
         mod stub;
-        pub use self::stub::StubTunProvider;
+        use self::stub::StubTunProvider;
 
         /// Default stub implementation of `TunProvider` for Android and Windows.
         pub type PlatformTunProvider = StubTunProvider;

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -3,6 +3,8 @@ use ipnetwork::IpNetwork;
 use std::net::IpAddr;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(target_os = "android")]
+use std::os::unix::io::RawFd;
 use talpid_types::BoxedError;
 
 cfg_if! {
@@ -32,6 +34,10 @@ cfg_if! {
 pub trait Tun: AsRawFd + Send {
     /// Retrieve the tunnel interface name.
     fn interface_name(&self) -> &str;
+
+    /// Allow a socket to bypass the tunnel.
+    #[cfg(target_os = "android")]
+    fn bypass(&mut self, socket: RawFd) -> Result<(), BoxedError>;
 }
 
 /// Stub tunnel device.


### PR DESCRIPTION
This PR leverages the `TunProvider` defined in the previous PR to implement the interface between Android's `VpnService` Java API and the `talpid-core` Rust crate.

An Android service that derives from `VpnService` is implemented. It can be used to create tunnel interfaces, when the necessary parameters are specified.

The `VpnServiceTunProvider` implements the `TunProvider` trait to convert the `TunConfig` into a Java object that is then sent to the `MullvadVpnService` to create a tunnel interface. Because the provider needs an instance to the service, it is created when the JNI interface is initalized, and then passed on to the daemon thread.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Android version not released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/890)
<!-- Reviewable:end -->
