### PR TITLE
Add shadowsocks toggle to UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add missing GUI translations for Czech Republic, USA and UK in the select location view.
 - Add translations for the current location displayed on the main screen in the GUI.
 - Allow a subset of NDP (Router solicitation, router advertisement and redirects) in the firewall.
+- Allow setting proxy mode from UI.
 
 #### Linux
 - Add standard window decorations to the application window.

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -1,5 +1,6 @@
 import {
   AccountToken,
+  BridgeState,
   DaemonEvent,
   IAccountData,
   IAppVersionInfo,
@@ -415,6 +416,10 @@ export class DaemonRpc {
 
   public async setBlockWhenDisconnected(blockWhenDisconnected: boolean): Promise<void> {
     await this.transport.send('set_block_when_disconnected', [blockWhenDisconnected]);
+  }
+
+  public async setBridgeState(bridgeState: BridgeState): Promise<void> {
+    await this.transport.send('set_bridge_state', [bridgeState]);
   }
 
   public async setOpenVpnMssfix(mssfix?: number): Promise<void> {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as uuid from 'uuid';
 import {
   AccountToken,
+  BridgeState,
   DaemonEvent,
   IAppVersionInfo,
   ILocation,
@@ -812,6 +813,9 @@ class ApplicationMain {
     );
     IpcMainEventChannel.settings.handleBlockWhenDisconnected((blockWhenDisconnected: boolean) =>
       this.daemonRpc.setBlockWhenDisconnected(blockWhenDisconnected),
+    );
+    IpcMainEventChannel.settings.handleBridgeState((bridgeState: BridgeState) =>
+      this.daemonRpc.setBridgeState(bridgeState),
     );
     IpcMainEventChannel.settings.handleOpenVpnMssfix((mssfix?: number) =>
       this.daemonRpc.setOpenVpnMssfix(mssfix),

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -32,6 +32,7 @@ import AccountExpiry from './lib/account-expiry';
 
 import {
   AccountToken,
+  BridgeState,
   ILocation,
   IRelayList,
   ISettings,
@@ -303,6 +304,12 @@ export default class AppRenderer {
     const actions = this.reduxActions;
     await IpcRendererEventChannel.settings.setEnableIpv6(enableIpv6);
     actions.settings.updateEnableIpv6(enableIpv6);
+  }
+
+  public async setBridgeState(bridgeState: BridgeState) {
+    const actions = this.reduxActions;
+    await IpcRendererEventChannel.settings.setBridgeState(bridgeState);
+    actions.settings.updateBridgeState(bridgeState);
   }
 
   public async setBlockWhenDisconnected(blockWhenDisconnected: boolean) {

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Component, View } from 'reactxp';
 import { sprintf } from 'sprintf-js';
 import { colors } from '../../config.json';
-import { RelayProtocol } from '../../shared/daemon-rpc-types';
+import { BridgeState, RelayProtocol } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import styles from './AdvancedSettingsStyles';
 import * as Cell from './Cell';
@@ -36,12 +36,27 @@ function mapPortToSelectorItem(value: number): ISelectorItem<number> {
   return { label: value.toString(), value };
 }
 
+function makeBridgeItems(): Array<ISelectorItem<BridgeState>> {
+  return [
+    {
+      label: messages.pgettext('advanced-settings-view', 'On'),
+      value: 'on',
+    },
+    {
+      label: messages.pgettext('advanced-settings-view', 'Off'),
+      value: 'off',
+    },
+  ];
+}
+
 interface IProps {
   enableIpv6: boolean;
   blockWhenDisconnected: boolean;
   protocol?: RelayProtocol;
   mssfix?: number;
   port?: number;
+  bridgeState?: BridgeState;
+  setBridgeState: (value: BridgeState) => void;
   setEnableIpv6: (value: boolean) => void;
   setBlockWhenDisconnected: (value: boolean) => void;
   setOpenVpnMssfix: (value: number | undefined) => void;
@@ -56,6 +71,8 @@ interface IState {
 }
 
 export default class AdvancedSettings extends Component<IProps, IState> {
+  private bridgeSelectorItems = makeBridgeItems();
+
   constructor(props: IProps) {
     super(props);
 
@@ -163,6 +180,16 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     )}
                   </View>
 
+                  <Selector
+                    title={
+                      // TRANSLATORS: The title for the shadowsocks bridge selector section.
+                      messages.pgettext('advanced-settings-view', 'Shadowsocks bridge')
+                    }
+                    values={this.bridgeSelectorItems}
+                    value={this.props.bridgeState}
+                    onSelect={this.onSelectBridgeState}
+                  />
+
                   <Cell.Container>
                     <Cell.Label>{messages.pgettext('advanced-settings-view', 'Mssfix')}</Cell.Label>
                     <Cell.InputFrame style={styles.advanced_settings__mssfix_frame}>
@@ -211,6 +238,14 @@ export default class AdvancedSettings extends Component<IProps, IState> {
 
   private onSelectPort = (port?: number) => {
     this.props.setRelayProtocolAndPort(this.props.protocol, port);
+  };
+
+  private onSelectBridgeState = (bridgeState?: BridgeState) => {
+    if (bridgeState) {
+      this.props.setBridgeState(bridgeState);
+    } else {
+      this.props.setBridgeState('auto');
+    }
   };
 
   private onMssfixChange = (mssfixString: string) => {

--- a/gui/src/renderer/containers/AdvancedSettingsPage.tsx
+++ b/gui/src/renderer/containers/AdvancedSettingsPage.tsx
@@ -2,7 +2,7 @@ import { goBack } from 'connected-react-router';
 import log from 'electron-log';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { RelayProtocol } from '../../shared/daemon-rpc-types';
+import { BridgeState, RelayProtocol } from '../../shared/daemon-rpc-types';
 import AdvancedSettings from '../components/AdvancedSettings';
 import RelaySettingsBuilder from '../lib/relay-settings-builder';
 
@@ -17,6 +17,7 @@ const mapStateToProps = (state: IReduxState) => {
     enableIpv6: state.settings.enableIpv6,
     blockWhenDisconnected: state.settings.blockWhenDisconnected,
     mssfix: state.settings.openVpn.mssfix,
+    bridgeState: state.settings.bridgeState,
     ...protocolAndPort,
   };
 };
@@ -79,6 +80,14 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
         await props.app.setBlockWhenDisconnected(blockWhenDisconnected);
       } catch (e) {
         log.error('Failed to update block when disconnected', e.message);
+      }
+    },
+
+    setBridgeState: async (bridgeState: BridgeState) => {
+      try {
+        await props.app.setBridgeState(bridgeState);
+      } catch (e) {
+        log.error(`Failed to update bridge state: ${e.message}`);
       }
     },
 

--- a/gui/src/renderer/redux/settings/actions.ts
+++ b/gui/src/renderer/redux/settings/actions.ts
@@ -1,3 +1,4 @@
+import { BridgeState } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
 import { IRelayLocationRedux, RelaySettingsRedux } from './reducers';
 
@@ -31,6 +32,11 @@ export interface IUpdateBlockWhenDisconnectedAction {
   blockWhenDisconnected: boolean;
 }
 
+export interface IUpdateBridgeStateAction {
+  type: 'UPDATE_BRIDGE_STATE';
+  bridgeState: BridgeState;
+}
+
 export interface IUpdateOpenVpnMssfixAction {
   type: 'UPDATE_OPENVPN_MSSFIX';
   mssfix?: number;
@@ -48,6 +54,7 @@ export type SettingsAction =
   | IUpdateAllowLanAction
   | IUpdateEnableIpv6Action
   | IUpdateBlockWhenDisconnectedAction
+  | IUpdateBridgeStateAction
   | IUpdateOpenVpnMssfixAction
   | IUpdateAutoStartAction;
 
@@ -95,6 +102,13 @@ function updateBlockWhenDisconnected(
   };
 }
 
+function updateBridgeState(bridgeState: BridgeState): IUpdateBridgeStateAction {
+  return {
+    type: 'UPDATE_BRIDGE_STATE',
+    bridgeState,
+  };
+}
+
 function updateOpenVpnMssfix(mssfix?: number): IUpdateOpenVpnMssfixAction {
   return {
     type: 'UPDATE_OPENVPN_MSSFIX',
@@ -116,6 +130,7 @@ export default {
   updateAllowLan,
   updateEnableIpv6,
   updateBlockWhenDisconnected,
+  updateBridgeState,
   updateOpenVpnMssfix,
   updateAutoStart,
 };

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -48,7 +48,7 @@ export interface ISettingsReduxState {
   relayLocations: IRelayLocationRedux[];
   allowLan: boolean;
   enableIpv6: boolean;
-  bridgeState?: BridgeState;
+  bridgeState: BridgeState;
   blockWhenDisconnected: boolean;
   openVpn: {
     mssfix?: number;
@@ -72,7 +72,7 @@ const initialState: ISettingsReduxState = {
   relayLocations: [],
   allowLan: false,
   enableIpv6: true,
-  bridgeState: undefined,
+  bridgeState: 'auto',
   blockWhenDisconnected: false,
   openVpn: {},
 };
@@ -136,7 +136,7 @@ export default function(
     case 'UPDATE_BRIDGE_STATE':
       return {
         ...state,
-        bridgeState: action.bridgeState === 'auto' ? undefined : action.bridgeState,
+        bridgeState: action.bridgeState,
       };
 
     default:

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -1,4 +1,4 @@
-import { RelayLocation, RelayProtocol } from '../../../shared/daemon-rpc-types';
+import { BridgeState, RelayLocation, RelayProtocol } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
 import { ReduxAction } from '../store';
 
@@ -48,6 +48,7 @@ export interface ISettingsReduxState {
   relayLocations: IRelayLocationRedux[];
   allowLan: boolean;
   enableIpv6: boolean;
+  bridgeState?: BridgeState;
   blockWhenDisconnected: boolean;
   openVpn: {
     mssfix?: number;
@@ -71,6 +72,7 @@ const initialState: ISettingsReduxState = {
   relayLocations: [],
   allowLan: false,
   enableIpv6: true,
+  bridgeState: undefined,
   blockWhenDisconnected: false,
   openVpn: {},
 };
@@ -129,6 +131,12 @@ export default function(
       return {
         ...state,
         autoStart: action.autoStart,
+      };
+
+    case 'UPDATE_BRIDGE_STATE':
+      return {
+        ...state,
+        bridgeState: action.bridgeState === 'auto' ? undefined : action.bridgeState,
       };
 
     default:

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -7,6 +7,7 @@ import { IGuiSettingsState } from './gui-settings-state';
 import { IAppUpgradeInfo, ICurrentAppVersionInfo } from '../main/index';
 import {
   AccountToken,
+  BridgeState,
   IAccountData,
   ILocation,
   IRelayList,
@@ -55,6 +56,7 @@ interface ISettingsMethods extends IReceiver<ISettings> {
   setAllowLan(allowLan: boolean): Promise<void>;
   setEnableIpv6(enableIpv6: boolean): Promise<void>;
   setBlockWhenDisconnected(block: boolean): Promise<void>;
+  setBridgeState(state: BridgeState): Promise<void>;
   setOpenVpnMssfix(mssfix?: number): Promise<void>;
   updateRelaySettings(update: RelaySettingsUpdate): Promise<void>;
 }
@@ -63,6 +65,7 @@ interface ISettingsHandlers extends ISender<ISettings> {
   handleAllowLan(fn: (allowLan: boolean) => Promise<void>): void;
   handleEnableIpv6(fn: (enableIpv6: boolean) => Promise<void>): void;
   handleBlockWhenDisconnected(fn: (block: boolean) => Promise<void>): void;
+  handleBridgeState(fn: (state: BridgeState) => Promise<void>): void;
   handleOpenVpnMssfix(fn: (mssfix?: number) => Promise<void>): void;
   handleUpdateRelaySettings(fn: (update: RelaySettingsUpdate) => Promise<void>): void;
 }
@@ -120,6 +123,7 @@ const SETTINGS_CHANGED = 'settings-changed';
 const SET_ALLOW_LAN = 'set-allow-lan';
 const SET_ENABLE_IPV6 = 'set-enable-ipv6';
 const SET_BLOCK_WHEN_DISCONNECTED = 'set-block-when-disconnected';
+const SET_BRIDGE_STATE = 'set-bridge-state';
 const SET_OPENVPN_MSSFIX = 'set-openvpn-mssfix';
 const UPDATE_RELAY_SETTINGS = 'update-relay-settings';
 
@@ -177,6 +181,7 @@ export class IpcRendererEventChannel {
     setAllowLan: requestSender(SET_ALLOW_LAN),
     setEnableIpv6: requestSender(SET_ENABLE_IPV6),
     setBlockWhenDisconnected: requestSender(SET_BLOCK_WHEN_DISCONNECTED),
+    setBridgeState: requestSender(SET_BRIDGE_STATE),
     setOpenVpnMssfix: requestSender(SET_OPENVPN_MSSFIX),
     updateRelaySettings: requestSender(UPDATE_RELAY_SETTINGS),
   };
@@ -253,6 +258,7 @@ export class IpcMainEventChannel {
     handleAllowLan: requestHandler(SET_ALLOW_LAN),
     handleEnableIpv6: requestHandler(SET_ENABLE_IPV6),
     handleBlockWhenDisconnected: requestHandler(SET_BLOCK_WHEN_DISCONNECTED),
+    handleBridgeState: requestHandler(SET_BRIDGE_STATE),
     handleOpenVpnMssfix: requestHandler(SET_OPENVPN_MSSFIX),
     handleUpdateRelaySettings: requestHandler(UPDATE_RELAY_SETTINGS),
   };


### PR DESCRIPTION
I've added the RPC calls from the GUI to the Daemon to set the bridge state from the UI, and fleshed out the UI work that was already started for this feature. This allows the user to change the bridge mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/891)
<!-- Reviewable:end -->
