### PR TITLE
Activate LTO and size optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ members = [
     "talpid-ipc",
 ]
 exclude = ["dist-assets/binaries/shadowsocks-rust"]
+
+
+[profile.release]
+lto = true
+opt-level = 'z'


### PR DESCRIPTION
We should check what effects this has on build time and size of the result on macOS and Windows as well before we go ahead with anything like this. But some (very statistically unsecure) numbers point to strict improvements for Linux.

My numbers on current master branch doing `./build.sh --dev-build` after a `cargo clean`:
```
68M	dist/MullvadVPN-2019.4-dev-3e9d2fcf_amd64.deb
69M	dist/MullvadVPN-2019.4-dev-3e9d2fcf_x86_64.rpm
4.5M	dist-assets/mullvad
17M	dist-assets/mullvad-daemon
6.5M	dist-assets/problem-report

real	16m49.443s
user	27m20.172s
sys	0m31.170s
```

Same test as above, but with this LTO + opt-level change:
```
66M	dist/MullvadVPN-2019.4-dev-3e9d2fcf_amd64.deb
68M	dist/MullvadVPN-2019.4-dev-3e9d2fcf_x86_64.rpm
2.7M	dist-assets/mullvad
13M	dist-assets/mullvad-daemon
5.2M	dist-assets/problem-report

real	15m54.787s
user	24m9.212s
sys	0m31.842s
```

You can see the three Rust binaries became quite a lot smaller. However the resulting installers lost much less weight. I guess the `xz` compression was able to get rid of most of the extra binary weight in the first place as well? However, my build is also *faster* with the changes applied. Not sure if the opt-level set to `z` made the compile faster, or if the more incompressible binaries made the final `xz` compression faster. I did not measure Rust building and electron packaging individually.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/892)
<!-- Reviewable:end -->
