### PR TITLE
Fix systemd-resolved resolv.conf detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Add better offline detection
 
+#### Linux
+- Fix `systemd-resolved` detection by better compraing `/etc/resolv.conf` symlinks.
+
 
 ## [2019.4] - 2019-05-08
 This release is identical to 2019.4-beta1


### PR DESCRIPTION
The way the daemon detects `systemd-resolved` has been improved. Previously, we'd only detect a single mode of operation, whereas now we detect all 3 active modes of operation. This is because we only checked for a single symlink path for `/etc/resolv.conf`, but there can be two.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/896)
<!-- Reviewable:end -->
