### PR TITLE
Actually set proxy parameters

### DIFF
--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -173,6 +173,12 @@ impl OpenVpnCommand {
         self
     }
 
+    /// Sets the proxy settings.
+    pub fn proxy_settings(&mut self, proxy_settings: net::openvpn::ProxySettings) -> &mut Self {
+        self.proxy_settings = Some(proxy_settings);
+        self
+    }
+
     /// Build a runnable expression from the current state of the command.
     pub fn build(&self) -> duct::Expression {
         log::debug!("Building expression: {}", &self);

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -463,6 +463,9 @@ impl<C: OpenVpnBuilder + 'static> OpenVpnMonitor<C> {
         cmd.tunnel_alias(Some(
             crate::winnet::get_tap_interface_alias().map_err(Error::WinnetError)?,
         ));
+        if let Some(proxy_settings) = params.proxy.clone().take() {
+            cmd.proxy_settings(proxy_settings);
+        }
         if let Some(proxy_auth_file) = proxy_auth_file {
             cmd.proxy_auth(proxy_auth_file);
         }


### PR DESCRIPTION
During debugging my woes with Shadowsocks, it became very obvious that whilst refactoring the proxy settings out of the tunnel settings, the code that would set the proxy parameters for OpenVPN got removed. This PR adds back the setter for proxy settings and sets the proxy settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/897)
<!-- Reviewable:end -->
