### PR TITLE
Problem report automatically include frontend logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add translations for the current location displayed on the main screen in the GUI.
 - Allow a subset of NDP (Router solicitation, router advertisement and redirects) in the firewall.
 - Allow setting proxy mode from UI.
+- Automatically include frontend logs in problem report when ran from CLI.
 
 #### Linux
 - Add standard window decorations to the application window.

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -199,7 +199,13 @@ fn run() -> Result<(), Error> {
         let output_path = Path::new(collect_matches.value_of_os("output").unwrap());
         collect_report(&extra_logs, output_path, redact_custom_strings)?;
 
-        println!("Problem report written to \"{}\"", output_path.display());
+        let expanded_output_path = output_path
+            .canonicalize()
+            .unwrap_or_else(|_| output_path.to_owned());
+        println!(
+            "Problem report written to {}",
+            expanded_output_path.display()
+        );
         println!("");
         println!("Send the problem report to support via the send subcommand. See:");
         println!(" $ {} send --help", env::args().next().unwrap());
@@ -426,7 +432,7 @@ impl ProblemReport {
                 },
             ));
             self.logs.push((redacted_path, content));
-            println!("Adding {} to report", expanded_path.display());
+            println!("Adding {}", expanded_path.display());
         }
     }
 

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -15,6 +15,7 @@ use std::{
     borrow::Cow,
     cmp::min,
     collections::{HashMap, HashSet},
+    env,
     ffi::OsStr,
     fs::{self, File},
     io::{self, BufWriter, Read, Seek, SeekFrom, Write},
@@ -191,7 +192,13 @@ fn run() -> Result<(), Error> {
             .map(|os_values| os_values.map(Path::new).collect())
             .unwrap_or_else(Vec::new);
         let output_path = Path::new(collect_matches.value_of_os("output").unwrap());
-        collect_report(&extra_logs, output_path, redact_custom_strings)
+        collect_report(&extra_logs, output_path, redact_custom_strings)?;
+
+        println!("Problem report written to \"{}\"", output_path.display());
+        println!("");
+        println!("Send the problem report to support via the send subcommand. See:");
+        println!(" $ {} send --help", env::args().next().unwrap());
+        Ok(())
     } else if let Some(send_matches) = matches.subcommand_matches("send") {
         let report_path = Path::new(send_matches.value_of_os("report").unwrap());
         let user_email = send_matches.value_of("email").unwrap_or("");
@@ -362,6 +369,7 @@ impl ProblemReport {
                 },
             ));
             self.logs.push((redacted_path, content));
+            println!("Adding {} to report", expanded_path.display());
         }
     }
 


### PR DESCRIPTION
If people are having frontend issues they sometimes can't send problem reports via the GUI. Then they need to either manually find all the logs, or they need to use the CLI problem report tool. The problem with the tool is that it does not include the frontend logs automatically. Since the user is having frontend issues that's usually the logs we need in that situation, so it becomes a bit useless. This PR tries to automatically find and include the frontend logs in problem reports even when ran directly from a terminal.

I also added some helpful output from `problem-report collect` to help the user understand what happens and to understand the next step they need to take.

I have so far only tested this on Linux myself.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/898)
<!-- Reviewable:end -->
