### PR TITLE
Enable Wireguard on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,7 @@ android {
 
         variant.ndkCompileProvider.configure {
             dependsOn copyMullvadJni
+            dependsOn copyWireguardGo
         }
     }
 }
@@ -96,6 +97,12 @@ lint.dependsOn lintKotlin
 task copyMullvadJni(type: Copy) {
     from "$repoRootPath/target/aarch64-linux-android/debug"
     include 'libmullvad_jni.so'
+    into "$extraJniDirectory/arm64-v8a"
+}
+
+task copyWireguardGo(type: Copy) {
+    from "$repoRootPath/dist-assets/binaries/android"
+    include 'libwg.so'
     into "$extraJniDirectory/arm64-v8a"
 }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -66,7 +66,7 @@ class MullvadVpnService(val context: Context) {
             }
 
             for (route in config.routes) {
-                addRoute(route.address, route.prefixLength as Int)
+                addRoute(route.address, route.prefixLength.toInt())
             }
 
             setMtu(config.mtu)

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -196,10 +196,22 @@ impl<'env> IntoJava<'env> for TunConfig {
     fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
         let class = get_class("net/mullvad/mullvadvpn/model/TunConfig");
         let addresses = env.auto_local(self.addresses.into_java(env));
-        let parameters = [JValue::Object(addresses.as_obj())];
+        let dns_servers = env.auto_local(self.dns_servers.into_java(env));
+        let routes = env.auto_local(self.routes.into_java(env));
+        let mtu = self.mtu as jint;
+        let parameters = [
+            JValue::Object(addresses.as_obj()),
+            JValue::Object(dns_servers.as_obj()),
+            JValue::Object(routes.as_obj()),
+            JValue::Int(mtu),
+        ];
 
-        env.new_object(&class, "(Ljava/util/List;)V", &parameters)
-            .expect("Failed to create TunConfig Java object")
+        env.new_object(
+            &class,
+            "(Ljava/util/List;Ljava/util/List;Ljava/util/List;I)V",
+            &parameters,
+        )
+        .expect("Failed to create TunConfig Java object")
     }
 }
 

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -57,13 +57,20 @@ fn main() {
 
 #[cfg(not(windows))]
 fn main() {
-    let lib_dir = if cfg!(target_os = "macos") {
-        manifest_dir().join("../dist-assets/binaries/macos")
-    } else {
-        manifest_dir().join("../dist-assets/binaries/linux")
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+
+    let link_type = match target_os.as_str() {
+        "android" => "",
+        "linux" | "macos" => "=static",
+        _ => panic!("Unsupported platform: {}", target_os),
     };
-    println!("cargo:rustc-link-search={}", &lib_dir.display());
-    println!("cargo:rustc-link-lib=static=wg");
+
+    let lib_dir = manifest_dir()
+        .join("../dist-assets/binaries")
+        .join(target_os);
+
+    println!("cargo:rustc-link-search={}", lib_dir.display());
+    println!("cargo:rustc-link-lib{}=wg", link_type);
 }
 
 fn manifest_dir() -> PathBuf {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -9,7 +9,7 @@ use std::{
 };
 #[cfg(not(target_os = "android"))]
 use talpid_types::net::openvpn as openvpn_types;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use talpid_types::net::wireguard as wireguard_types;
 use talpid_types::net::{GenericTunnelOptions, TunnelParameters};
 
@@ -17,7 +17,7 @@ use talpid_types::net::{GenericTunnelOptions, TunnelParameters};
 #[cfg(not(target_os = "android"))]
 pub mod openvpn;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 pub mod wireguard;
 
 /// A module for low level platform specific tunnel device management.
@@ -45,7 +45,7 @@ pub enum Error {
     RotateLogError(#[error(cause)] crate::logging::RotateLogError),
 
     /// Failure to build Wireguard configuration.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     #[error(display = "Failed to configure Wireguard with the given parameters")]
     WireguardConfigError(#[error(cause)] self::wireguard::config::Error),
 
@@ -55,7 +55,7 @@ pub enum Error {
     OpenVpnTunnelMonitoringError(#[error(cause)] openvpn::Error),
 
     /// There was an error listening for events from the Wireguard tunnel
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     #[error(display = "Failed while listening for events from the Wireguard tunnel")]
     WirguardTunnelMonitoringError(#[error(cause)] wireguard::Error),
 }
@@ -158,18 +158,19 @@ impl TunnelMonitor {
             TunnelParameters::OpenVpn(config) => {
                 Self::start_openvpn_tunnel(&config, log_file, resource_dir, on_event)
             }
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            #[cfg(target_os = "android")]
+            TunnelParameters::OpenVpn(_) => Err(Error::UnsupportedPlatform),
+
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             TunnelParameters::Wireguard(config) => {
                 Self::start_wireguard_tunnel(&config, log_file, on_event, tun_provider)
             }
-            #[cfg(target_os = "android")]
-            TunnelParameters::OpenVpn(_) => Err(Error::UnsupportedPlatform),
-            #[cfg(any(windows, target_os = "android"))]
+            #[cfg(windows)]
             TunnelParameters::Wireguard(_) => Err(Error::UnsupportedPlatform),
         }
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     fn start_wireguard_tunnel<L>(
         params: &wireguard_types::TunnelParameters,
         log: Option<PathBuf>,
@@ -252,7 +253,7 @@ pub enum CloseHandle {
     #[cfg(not(target_os = "android"))]
     /// OpenVpn close handle
     OpenVpn(openvpn::OpenVpnCloseHandle),
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     /// Wireguard close handle
     Wireguard(wireguard::CloseHandle),
 }
@@ -260,13 +261,10 @@ pub enum CloseHandle {
 impl CloseHandle {
     /// Closes the underlying tunnel, making the `TunnelMonitor::wait` method return.
     pub fn close(self) -> io::Result<()> {
-        #[cfg(target_os = "android")]
-        unimplemented!();
-
-        #[cfg(not(target_os = "android"))]
         match self {
+            #[cfg(not(target_os = "android"))]
             CloseHandle::OpenVpn(handle) => handle.close(),
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             CloseHandle::Wireguard(mut handle) => {
                 handle.close();
                 Ok(())
@@ -278,28 +276,25 @@ impl CloseHandle {
 enum InternalTunnelMonitor {
     #[cfg(not(target_os = "android"))]
     OpenVpn(openvpn::OpenVpnMonitor),
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     Wireguard(wireguard::WireguardMonitor),
 }
 
 impl InternalTunnelMonitor {
     fn close_handle(&self) -> CloseHandle {
-        #[cfg(not(target_os = "android"))]
         match self {
+            #[cfg(not(target_os = "android"))]
             InternalTunnelMonitor::OpenVpn(tun) => CloseHandle::OpenVpn(tun.close_handle()),
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             InternalTunnelMonitor::Wireguard(tun) => CloseHandle::Wireguard(tun.close_handle()),
         }
-
-        #[cfg(target_os = "android")]
-        unimplemented!();
     }
 
     fn wait(self) -> Result<()> {
-        #[cfg(not(target_os = "android"))]
         match self {
+            #[cfg(not(target_os = "android"))]
             InternalTunnelMonitor::OpenVpn(tun) => tun.wait()?,
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             InternalTunnelMonitor::Wireguard(tun) => tun.wait()?,
         }
 

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -44,6 +44,11 @@ pub enum Error {
     #[error(display = "Invalid tunnel interface name")]
     InterfaceNameError(#[error(cause)] std::ffi::NulError),
 
+    /// Failed to configure Wireguard sockets to bypass the tunnel.
+    #[cfg(target_os = "android")]
+    #[error(display = "Failed to configure Wireguard sockets to bypass the tunnel")]
+    BypassError(#[error(cause)] BoxedError),
+
     /// Pinging timed out.
     #[error(display = "Ping timed out")]
     PingTimeoutError,

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -108,7 +108,8 @@ type WgLogLevel = i32;
 // wireguard-go supports log levels 0 through 3 with 3 being the most verbose
 const WG_GO_LOG_DEBUG: WgLogLevel = 3;
 
-#[link(name = "wg", kind = "static")]
+#[cfg_attr(target_os = "android", link(name = "wg", kind = "dylib"))]
+#[cfg_attr(not(target_os = "android"), link(name = "wg", kind = "static"))]
 extern "C" {
     // Creates a new wireguard tunnel, uses the specific interface name, MTU and file descriptors
     // for the tunnel device and logging.
@@ -123,6 +124,15 @@ extern "C" {
         log_fd: Fd,
         logLevel: WgLogLevel,
     ) -> i32;
+
     // Pass a handle that was created by wgTurnOnWithFd to stop a wireguard tunnel.
     fn wgTurnOff(handle: i32) -> i32;
+
+    // Returns the file descriptor of the tunnel IPv4 socket.
+    #[cfg(target_os = "android")]
+    fn wgGetSocketV4(handle: i32) -> Fd;
+
+    // Returns the file descriptor of the tunnel IPv6 socket.
+    #[cfg(target_os = "android")]
+    fn wgGetSocketV6(handle: i32) -> Fd;
 }

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -32,9 +32,9 @@ impl WgGoTunnel {
 
         let handle = unsafe {
             wgTurnOnWithFd(
-                iface_name.as_ptr(),
+                iface_name.as_ptr() as *const i8,
                 config.mtu as i64,
-                wg_config_str.as_ptr(),
+                wg_config_str.as_ptr() as *const i8,
                 tunnel_device.as_raw_fd(),
                 log_file.as_raw_fd(),
                 WG_GO_LOG_DEBUG,


### PR DESCRIPTION
This PR implements Wireguard support on Android. To do so, it uses the binaries that have been recently uploaded to `mullvadvpn-app-binaries`, and also retrieves the underlying sockets so that their packets can bypass the tunnel set-up by Android. The `ping_monitor` was also updated so it could be executed on Android.

The first two commits of this PR include fixes that were supposed to be included in previous PRs.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public version of Android app released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/899)
<!-- Reviewable:end -->
