### PR TITLE
Add bridge status to CLI

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -240,6 +240,13 @@ const tunnelStateTransitionSchema = oneOf(
       address: string,
       protocol: enumeration('tcp', 'udp'),
       tunnel_type: enumeration('wireguard', 'openvpn'),
+      proxy: maybe(
+        partialObject({
+          address: string,
+          protocol: enumeration('tcp', 'udp'),
+          proxy_type: enumeration('shadowsocks', 'custom'),
+        }),
+      ),
     }),
   }),
   object({

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -35,10 +35,19 @@ export type TunnelType = 'wireguard' | 'openvpn';
 
 export type RelayProtocol = 'tcp' | 'udp';
 
+export type ProxyType = 'shadowsocks' | 'custom';
+
 export interface ITunnelEndpoint {
   address: string;
   protocol: RelayProtocol;
   tunnel: TunnelType;
+  proxy?: IProxyEndpoint;
+}
+
+export interface IProxyEndpoint {
+  address: string;
+  protocol: RelayProtocol;
+  proxy_type: ProxyType;
 }
 
 export type DaemonEvent =

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -69,8 +69,10 @@ fn print_state(state: &TunnelStateTransition) {
     print!("Tunnel status: ");
     match state {
         Blocked(reason) => print_blocked_reason(reason),
-        Connected(_) => println!("Connected"),
-        Connecting(_) => println!("Connecting..."),
+        Connected(details) => {
+            println!("Connected to {}", details);
+        }
+        Connecting(details) => println!("Connecting to {}...", details),
         Disconnected => println!("Disconnected"),
         Disconnecting(_) => println!("Disconnecting..."),
     }

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -454,7 +454,7 @@ impl<C: OpenVpnBuilder + 'static> OpenVpnMonitor<C> {
                 .compat()
                 .map_err(Error::IpRouteNotFound)?,
         );
-        cmd.remote(params.config.get_tunnel_endpoint().endpoint)
+        cmd.remote(params.config.endpoint)
             .user_pass(user_pass_file)
             .tunnel_options(&params.options)
             .enable_ipv6(params.generic_options.enable_ipv6)

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -61,11 +61,11 @@ impl ConnectedState {
 
     fn get_endpoint_from_params(&self) -> Endpoint {
         match self.tunnel_parameters {
-            TunnelParameters::OpenVpn(ref config) => match config.proxy {
-                Some(ref proxy_settings) => proxy_settings.get_endpoint(),
-                None => self.tunnel_parameters.get_tunnel_endpoint().endpoint,
+            TunnelParameters::OpenVpn(ref params) => match params.proxy {
+                Some(ref proxy_settings) => proxy_settings.get_endpoint().endpoint,
+                None => params.config.endpoint,
             },
-            _ => self.tunnel_parameters.get_tunnel_endpoint().endpoint,
+            TunnelParameters::Wireguard(ref params) => params.connection.get_endpoint(),
         }
     }
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -48,7 +48,7 @@ impl ConnectingState {
         let endpoint = params.get_tunnel_endpoint().endpoint;
 
         let peer_endpoint = match proxy {
-            Some(proxy_settings) => proxy_settings.get_endpoint(),
+            Some(proxy_settings) => proxy_settings.get_endpoint().endpoint,
             None => endpoint,
         };
 

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 pub mod openvpn;
+pub mod proxy;
 pub mod wireguard;
 
 /// TunnelParameters are used to encapsulate all the data needed to start a tunnel. This is enum
@@ -22,8 +23,16 @@ pub enum TunnelParameters {
 impl TunnelParameters {
     pub fn get_tunnel_endpoint(&self) -> TunnelEndpoint {
         match self {
-            TunnelParameters::OpenVpn(params) => params.config.get_tunnel_endpoint(),
-            TunnelParameters::Wireguard(params) => params.connection.get_tunnel_endpoint(),
+            TunnelParameters::OpenVpn(params) => TunnelEndpoint {
+                tunnel_type: TunnelType::OpenVpn,
+                endpoint: params.config.endpoint,
+                proxy: params.proxy.as_ref().map(|proxy| proxy.get_endpoint()),
+            },
+            TunnelParameters::Wireguard(params) => TunnelEndpoint {
+                tunnel_type: TunnelType::Wireguard,
+                endpoint: params.connection.get_endpoint(),
+                proxy: None,
+            },
         }
     }
 
@@ -75,11 +84,20 @@ pub struct TunnelEndpoint {
     pub endpoint: Endpoint,
     /// Type of the tunnel
     pub tunnel_type: TunnelType,
+    pub proxy: Option<proxy::ProxyEndpoint>,
 }
 
 impl fmt::Display for TunnelEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{} - {}", self.tunnel_type, self.endpoint,)
+        write!(f, "{} - {}", self.tunnel_type, self.endpoint)?;
+        if let Some(ref proxy) = self.proxy {
+            write!(
+                f,
+                " via {} {} over {}",
+                proxy.proxy_type, proxy.endpoint.address, proxy.endpoint.protocol
+            )?;
+        }
+        Ok(())
     }
 }
 

--- a/talpid-types/src/net/openvpn.rs
+++ b/talpid-types/src/net/openvpn.rs
@@ -1,4 +1,7 @@
-use crate::net::{Endpoint, GenericTunnelOptions, TransportProtocol, TunnelEndpoint, TunnelType};
+use crate::net::{
+    proxy::{ProxyEndpoint, ProxyType},
+    Endpoint, GenericTunnelOptions, TransportProtocol,
+};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
@@ -25,12 +28,6 @@ impl ConnectionConfig {
             password,
         }
     }
-    pub fn get_tunnel_endpoint(&self) -> TunnelEndpoint {
-        TunnelEndpoint {
-            tunnel_type: TunnelType::OpenVpn,
-            endpoint: self.endpoint,
-        }
-    }
 }
 
 /// TunnelOptions contains options for an openvpn tunnel that should be applied
@@ -54,12 +51,22 @@ pub enum ProxySettings {
     Shadowsocks(ShadowsocksProxySettings),
 }
 
+
 impl ProxySettings {
-    pub fn get_endpoint(&self) -> Endpoint {
+    pub fn get_endpoint(&self) -> ProxyEndpoint {
         match self {
-            ProxySettings::Local(settings) => settings.get_endpoint(),
-            ProxySettings::Remote(settings) => settings.get_endpoint(),
-            ProxySettings::Shadowsocks(settings) => settings.get_endpoint(),
+            ProxySettings::Local(settings) => ProxyEndpoint {
+                endpoint: settings.get_endpoint(),
+                proxy_type: ProxyType::Custom,
+            },
+            ProxySettings::Remote(settings) => ProxyEndpoint {
+                endpoint: settings.get_endpoint(),
+                proxy_type: ProxyType::Custom,
+            },
+            ProxySettings::Shadowsocks(settings) => ProxyEndpoint {
+                endpoint: settings.get_endpoint(),
+                proxy_type: ProxyType::Shadowsocks,
+            },
         }
     }
 }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -1,0 +1,32 @@
+use crate::net::Endpoint;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Types of bridges that can be used to proxy a connection to a tunnel
+#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ProxyType {
+    /// Shadowsocks
+    Shadowsocks,
+    /// Custom bridge
+    Custom,
+}
+
+impl fmt::Display for ProxyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let bridge = match self {
+            ProxyType::Shadowsocks => "Shadowsocks",
+            ProxyType::Custom => "custom bridge",
+        };
+        write!(f, "{}", bridge)
+    }
+}
+
+
+/// Bridge endpoint, broadcast as part of TunnelEndpoint
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProxyEndpoint {
+    #[serde(flatten)]
+    pub endpoint: Endpoint,
+    pub proxy_type: ProxyType,
+}

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -1,4 +1,4 @@
-use crate::net::{Endpoint, GenericTunnelOptions, TransportProtocol, TunnelEndpoint, TunnelType};
+use crate::net::{Endpoint, GenericTunnelOptions, TransportProtocol};
 use ipnetwork::IpNetwork;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -26,14 +26,10 @@ pub struct ConnectionConfig {
 }
 
 impl ConnectionConfig {
-    pub fn get_tunnel_endpoint(&self) -> TunnelEndpoint {
-        let host = self.peer.endpoint;
-        TunnelEndpoint {
-            tunnel_type: TunnelType::Wireguard,
-            endpoint: Endpoint {
-                address: host,
-                protocol: TransportProtocol::Udp,
-            },
+    pub fn get_endpoint(&self) -> Endpoint {
+        Endpoint {
+            address: self.peer.endpoint,
+            protocol: TransportProtocol::Udp,
         }
     }
 }


### PR DESCRIPTION
I've added a `bridge` field to `TunnelEndpoint` so that we can provide information about bridges to our user interfaces. I've updated the GUI schemas and I've made the CLI print the status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/900)
<!-- Reviewable:end -->
