### PR TITLE
Revert "Activate LTO and size optimization"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,3 @@ members = [
     "talpid-ipc",
 ]
 exclude = ["dist-assets/binaries/shadowsocks-rust"]
-
-
-[profile.release]
-lto = true
-opt-level = 'z'


### PR DESCRIPTION
Enabling LTO optimizations break builds on Windows. For now, reverting the LTO optimizations is the easiest fix. I suspect that the underlying issue is the fact that we don't compile `openssl` with LTO flags, or maybe some other statically linked dependency is not compiled appropriately. But it's somewhat telling that the daemon seemingly fails during around the time it would try to load TLS certs for HTTPS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/902)
<!-- Reviewable:end -->
