### PR TITLE
Show bridge info in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ sections.
     cargo build
     ```
 
-1. Copy the OpenVPN binary, and our plugin for it, to the directory we will use as resource
-   directory. If you want to use any other directory, you would need to copy even more files.
+1. Copy the OpenVPN and Shadowsocks binaries, and our plugin for it, to the directory we will
+   use as resource directory. If you want to use any other directory, you would need to copy
+   even more files.
    ```bash
-   cp dist-assets/binaries/<platform>/openvpn[.exe] dist-assets/
+   cp dist-assets/binaries/<platform>/{openvpn, sslocal}[.exe] dist-assets/
    cp target/debug/*talpid_openvpn_plugin* dist-assets/
    ```
 

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -41,6 +41,7 @@ const locationSchema = maybe(
     longitude: number,
     mullvad_exit_ip: boolean,
     hostname: maybe(string),
+    bridge_hostname: maybe(string),
   }),
 );
 

--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -12,7 +12,7 @@ import ImageView from './ImageView';
 import { Container, Header, Layout } from './Layout';
 import Map, { MarkerStyle, ZoomLevel } from './Map';
 import NotificationArea from './NotificationArea';
-import TunnelControl, { IRelayInAddress, IRelayOutAddress } from './TunnelControl';
+import TunnelControl, { IBridgeData, IRelayInAddress, IRelayOutAddress } from './TunnelControl';
 
 interface IProps {
   connection: IConnectionReduxState;
@@ -50,7 +50,7 @@ const styles = {
     paddingLeft: 24,
     paddingRight: 24,
     paddingBottom: 0,
-    marginTop: 186,
+    marginTop: 176,
   }),
   container: Styles.createViewStyle({
     flex: 1,
@@ -159,6 +159,11 @@ export default class Connect extends Component<IProps, IState> {
         ? this.tunnelEndpointToRelayInAddress(status.details)
         : undefined;
 
+    const bridgeData: IBridgeData | undefined =
+      (status.state === 'connecting' || status.state === 'connected') && status.details
+        ? this.tunnelEndpointToBridgeData(status.details)
+        : undefined;
+
     return (
       <View style={styles.connect}>
         <Map style={styles.map} {...this.getMapProps()} />
@@ -178,6 +183,8 @@ export default class Connect extends Component<IProps, IState> {
             hostname={this.props.connection.hostname}
             defaultConnectionInfoOpen={this.props.connectionInfoOpen}
             relayInAddress={relayInAddress}
+            bridge={bridgeData}
+            bridgeHostname={this.props.connection.bridgeHostname}
             relayOutAddress={relayOutAddress}
             onConnect={this.props.onConnect}
             onDisconnect={this.props.onDisconnect}
@@ -321,6 +328,21 @@ export default class Connect extends Component<IProps, IState> {
       ip: socketAddr.host,
       port: socketAddr.port,
       protocol: tunnelEndpoint.protocol,
+      tunnelType: tunnelEndpoint.tunnelType,
+    };
+  }
+
+  private tunnelEndpointToBridgeData(endpoint: ITunnelEndpoint): IBridgeData | undefined {
+    if (!endpoint.proxy) {
+      return undefined;
+    }
+
+    const socketAddr = parseSocketAddress(endpoint.proxy.address);
+    return {
+      ip: socketAddr.host,
+      port: socketAddr.port,
+      protocol: endpoint.proxy.protocol,
+      bridgeType: endpoint.proxy.proxyType,
     };
   }
 }

--- a/gui/src/renderer/components/ConnectionInfoDisclosure.tsx
+++ b/gui/src/renderer/components/ConnectionInfoDisclosure.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Component, Styles, Text, Types, View } from 'reactxp';
+import { Component, Styles, Types, View } from 'reactxp';
 import ImageView from './ImageView';
 
 const styles = {
@@ -23,7 +23,7 @@ const styles = {
 interface IProps {
   onToggle?: (isOpen: boolean) => void;
   defaultOpen?: boolean;
-  children: string;
+  children: React.ReactNode;
   style?: Types.ViewStyleRuleSet | Types.ViewStyleRuleSet[];
 }
 
@@ -51,10 +51,7 @@ export default class ConnectionInfoDisclosure extends Component<IProps, IState> 
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onPress={this.onToggle}>
-        <Text
-          style={[styles.caption.base, this.state.isHovered ? styles.caption.hovered : undefined]}>
-          {this.props.children}
-        </Text>
+        {this.props.children}
         <ImageView
           source={this.state.isOpen ? 'icon-chevron-up' : 'icon-chevron-down'}
           width={24}

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -1,16 +1,29 @@
 import * as React from 'react';
 import { Component, Styles, Text, Types, View } from 'reactxp';
 import { colors } from '../../config.json';
-import { RelayProtocol, TunnelStateTransition } from '../../shared/daemon-rpc-types';
+import {
+  ProxyType,
+  RelayProtocol,
+  TunnelStateTransition,
+  TunnelType,
+} from '../../shared/daemon-rpc-types';
 import { cities, countries, messages, relayLocations } from '../../shared/gettext';
 import * as AppButton from './AppButton';
 import ConnectionInfo from './ConnectionInfo';
 import SecuredLabel, { SecuredDisplayStyle } from './SecuredLabel';
 
-export interface IRelayInAddress {
+export interface IEndpoint {
   ip: string;
   port: number;
   protocol: RelayProtocol;
+}
+
+export interface IRelayInAddress extends IEndpoint {
+  tunnelType: TunnelType;
+}
+
+export interface IBridgeData extends IEndpoint {
+  bridgeType: ProxyType;
 }
 
 export interface IRelayOutAddress {
@@ -27,6 +40,8 @@ interface ITunnelControlProps {
   defaultConnectionInfoOpen?: boolean;
   relayInAddress?: IRelayInAddress;
   relayOutAddress?: IRelayOutAddress;
+  bridge?: IBridgeData;
+  bridgeHostname?: string;
   onConnect: () => void;
   onDisconnect: () => void;
   onSelectLocation: () => void;
@@ -39,7 +54,7 @@ const styles = {
     paddingLeft: 24,
     paddingRight: 24,
     paddingBottom: 0,
-    marginTop: 186,
+    marginTop: 176,
     flex: 1,
   }),
   footer: Styles.createViewStyle({
@@ -145,7 +160,9 @@ export default class TunnelControl extends Component<ITunnelControlProps> {
     const connectionDetails = (
       <ConnectionInfo
         hostname={this.props.hostname}
+        bridgeHostname={this.props.bridgeHostname}
         inAddress={this.props.relayInAddress}
+        bridgeInfo={this.props.bridge}
         outAddress={this.props.relayOutAddress}
         defaultOpen={this.props.defaultConnectionInfoOpen}
         onToggle={this.props.onToggleConnectionInfo}

--- a/gui/src/renderer/redux/connection/reducers.ts
+++ b/gui/src/renderer/redux/connection/reducers.ts
@@ -7,6 +7,7 @@ export interface IConnectionReduxState {
   ipv4?: Ip;
   ipv6?: Ip;
   hostname?: string;
+  bridgeHostname?: string;
   latitude?: number;
   longitude?: number;
   country?: string;
@@ -19,6 +20,7 @@ const initialState: IConnectionReduxState = {
   ipv4: undefined,
   ipv6: undefined,
   hostname: undefined,
+  bridgeHostname: undefined,
   latitude: undefined,
   longitude: undefined,
   country: undefined,

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -12,6 +12,7 @@ export interface ILocation {
   longitude: number;
   mullvadExitIp: boolean;
   hostname?: string;
+  bridgeHostname?: string;
 }
 
 export type BlockReason =

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -33,10 +33,30 @@ export type AfterDisconnect = 'nothing' | 'block' | 'reconnect';
 export type TunnelState = 'connecting' | 'connected' | 'disconnecting' | 'disconnected' | 'blocked';
 
 export type TunnelType = 'wireguard' | 'openvpn';
+export function tunnelTypeToString(tunnel: TunnelType): string {
+  switch (tunnel) {
+    case 'wireguard':
+      return 'WireGuard';
+    case 'openvpn':
+      return 'OpenVPN';
+    default:
+      return '';
+  }
+}
 
 export type RelayProtocol = 'tcp' | 'udp';
 
 export type ProxyType = 'shadowsocks' | 'custom';
+export function proxyTypeToString(proxy: ProxyType): string {
+  switch (proxy) {
+    case 'shadowsocks':
+      return 'Shadowsocks';
+    case 'custom':
+      return 'Custom';
+    default:
+      return '';
+  }
+}
 
 export interface ITunnelEndpoint {
   address: string;

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -41,14 +41,14 @@ export type ProxyType = 'shadowsocks' | 'custom';
 export interface ITunnelEndpoint {
   address: string;
   protocol: RelayProtocol;
-  tunnel: TunnelType;
+  tunnelType: TunnelType;
   proxy?: IProxyEndpoint;
 }
 
 export interface IProxyEndpoint {
   address: string;
   protocol: RelayProtocol;
-  proxy_type: ProxyType;
+  proxyType: ProxyType;
 }
 
 export type DaemonEvent =

--- a/gui/test/components/NotificationArea.spec.tsx
+++ b/gui/test/components/NotificationArea.spec.tsx
@@ -65,7 +65,7 @@ describe('components/NotificationArea', () => {
           details: {
             address: '1.2.3.4',
             protocol: 'tcp',
-            tunnel: 'openvpn',
+            tunnelType: 'openvpn',
           },
         }}
         version={defaultVersion}

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -280,7 +280,7 @@ impl RelaySelector {
         bridge_constraints: &InternalBridgeConstraints,
         location: &Location,
         retry_attempt: u32,
-    ) -> Option<ProxySettings> {
+    ) -> Option<(ProxySettings, Relay)> {
         if !self.should_use_bridge(retry_attempt) {
             return None;
         }
@@ -307,7 +307,7 @@ impl RelaySelector {
         &mut self,
         constraints: &InternalBridgeConstraints,
         location: &Location,
-    ) -> Option<ProxySettings> {
+    ) -> Option<(ProxySettings, Relay)> {
         let mut matching_relays: Vec<Relay> = self
             .lock_parsed_relays()
             .relays()
@@ -322,9 +322,11 @@ impl RelaySelector {
         matching_relays.sort_by_cached_key(|relay| {
             (relay.location.as_ref().unwrap().distance_from(&location) * 1000.0) as i64
         });
-        return matching_relays
-            .get(0)
-            .and_then(|relay| self.pick_random_bridge(&relay));
+        return matching_relays.get(0).and_then(|relay| {
+            (self
+                .pick_random_bridge(&relay)
+                .map(|bridge| (bridge, relay.clone())))
+        });
     }
 
 

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -73,6 +73,7 @@ pub struct GeoIpLocation {
     pub longitude: f64,
     pub mullvad_exit_ip: bool,
     pub hostname: Option<String>,
+    pub bridge_hostname: Option<String>,
 }
 
 impl From<AmIMullvad> for GeoIpLocation {
@@ -81,6 +82,7 @@ impl From<AmIMullvad> for GeoIpLocation {
             IpAddr::V4(v4) => (Some(v4), None),
             IpAddr::V6(v6) => (None, Some(v6)),
         };
+
         GeoIpLocation {
             ipv4,
             ipv6,
@@ -90,6 +92,7 @@ impl From<AmIMullvad> for GeoIpLocation {
             longitude: location.longitude,
             mullvad_exit_ip: location.mullvad_exit_ip,
             hostname: None,
+            bridge_hostname: None,
         }
     }
 }


### PR DESCRIPTION
I've updated the GUI to show more information about the current tunnel - it now shows the tunnel type, a bridge type if there is one, the bridge entry IP if a bridge is used, and the bridge hostname. Showing the bridge hostname required some changes in the daemon - namely sending the bridge hostname and keeping track of the previously selected bridge relay. The extra information shown requires the `TunelControl`'s top margin to be decreased to squeeze in another line to display the tunnel and bridge types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/903)
<!-- Reviewable:end -->
