### PR TITLE
Improve naming w.r.t. bridges in the GUI.

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -205,7 +205,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                   <Selector
                     title={
                       // TRANSLATORS: The title for the shadowsocks bridge selector section.
-                      messages.pgettext('advanced-settings-view', 'Shadowsocks bridge')
+                      messages.pgettext('advanced-settings-view', 'Bridge mode')
                     }
                     values={this.bridgeStateItems}
                     value={this.props.bridgeState}

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -52,7 +52,7 @@ export function proxyTypeToString(proxy: ProxyType): string {
     case 'shadowsocks':
       return 'Shadowsocks';
     case 'custom':
-      return 'Custom';
+      return 'custom bridge';
     default:
       return '';
   }


### PR DESCRIPTION
Richard brought up a couple of issues around naming in the GUI:
- the advanced setting _Shadowsocks bridge_ actually sets the bridge state. Calling it _Shadowsocks_ could lead the user into thinking that forcing it _on_ would imply that shadowsocks would be used, which wouldn't be the case if the user had set custom bridge settings.
- the line that informs the user about what protocols are being used in the tunnel would just say _Custom_ for the bridge part when custom bridge settings were used, .i.e. _OpenVPN via Custom_. This isn't all too clear, so it has been changed to _OpenVPN via custom bridge_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/904)
<!-- Reviewable:end -->
