### PR TITLE
Update bridge state when new settings are published in GUI

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -497,6 +497,7 @@ export default class AppRenderer {
     reduxSettings.updateEnableIpv6(newSettings.tunnelOptions.generic.enableIpv6);
     reduxSettings.updateBlockWhenDisconnected(newSettings.blockWhenDisconnected);
     reduxSettings.updateOpenVpnMssfix(newSettings.tunnelOptions.openvpn.mssfix);
+    reduxSettings.updateBridgeState(newSettings.bridgeState);
 
     this.setRelaySettings(newSettings.relaySettings);
 


### PR DESCRIPTION
Currently, the bridge state controls in the GUI won't be initialized or updated from the GUI settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/905)
<!-- Reviewable:end -->
