### PR TITLE
Fetch the current tunnel state when Connect activity resumes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -21,6 +21,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     external fun getAccountData(accountToken: String): AccountData?
     external fun getRelayLocations(): RelayList
     external fun getSettings(): Settings
+    external fun getState(): TunnelStateTransition
     external fun getWireguardKey(): PublicKey?
     external fun setAccount(accountToken: String?)
     external fun updateRelaySettings(update: RelaySettingsUpdate)

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -4,7 +4,7 @@ use mullvad_types::{
     account::AccountData, relay_constraints::RelaySettingsUpdate, relay_list::RelayList,
     settings::Settings, states::TargetState,
 };
-use talpid_types::net::wireguard;
+use talpid_types::{net::wireguard, tunnel::TunnelStateTransition};
 
 #[derive(Debug, err_derive::Error)]
 pub enum Error {
@@ -94,6 +94,14 @@ impl DaemonInterface {
         let (tx, rx) = oneshot::channel();
 
         self.send_command(ManagementCommand::GetSettings(tx))?;
+
+        Ok(rx.wait().map_err(|_| Error::NoResponse)?)
+    }
+
+    pub fn get_state(&self) -> Result<TunnelStateTransition> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::GetState(tx))?;
 
         Ok(rx.wait().map_err(|_| Error::NoResponse)?)
     }

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -300,6 +300,23 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getSettings<'en
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getState<'env, 'this>(
+    env: JNIEnv<'env>,
+    _: JObject<'this>,
+) -> JObject<'env> {
+    let daemon = DAEMON_INTERFACE.lock();
+
+    match daemon.get_state() {
+        Ok(state) => state.into_java(&env),
+        Err(error) => {
+            log::error!("{}", error.display_chain_with_msg("Failed to get state"));
+            JObject::null()
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getWireguardKey<'env, 'this>(
     env: JNIEnv<'env>,
     _: JObject<'this>,


### PR DESCRIPTION
Previously, the Connect screen would always start showing the "Disconnected" state and only change when the daemon sends a tunnel state change event. However, that meant that if the user is connected and left the app and then returned to it, it would incorrectly show the current state as "Disconnected".

This PR changes that so that every time the Connect screen is created it fetches the current tunnel state. Priority is still given to tunnel state change events, so if a state transition event is received at the same time the fetch initial state job is scheduling to update the screen, the operations are synchronized so that either the view is updated to the event state (and the fetch job doesn't schedule a view update) or the view is updated to the fetched state first but then updated again to the event state right after.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/909)
<!-- Reviewable:end -->
