### PR TITLE
Show current location in the Connect screen on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -38,6 +38,8 @@ class ConnectFragment : Fragment() {
     private var fetchInitialStateJob = fetchInitialState()
     private var generateWireguardKeyJob = generateWireguardKey()
 
+    private var lastKnownRealLocation: GeoIpLocation? = null
+
     private var activeAction: Job? = null
     private var attachListenerJob: Job? = null
     private var updateViewJob: Job? = null
@@ -64,7 +66,7 @@ class ConnectFragment : Fragment() {
         headerBar = HeaderBar(view, context!!)
         notificationBanner = NotificationBanner(view)
         status = ConnectionStatus(view, context!!)
-        locationInfo = LocationInfo(view)
+        locationInfo = LocationInfo(view, daemon)
 
         actionButton = ConnectActionButton(view)
         actionButton.apply {
@@ -154,7 +156,6 @@ class ConnectFragment : Fragment() {
 
     private fun disconnect() {
         activeAction?.cancel()
-        clearLocation()
 
         activeAction = GlobalScope.launch(Dispatchers.Default) {
             daemon.await().disconnect()
@@ -177,16 +178,7 @@ class ConnectFragment : Fragment() {
         headerBar.setState(state)
         notificationBanner.setState(state)
         status.setState(state)
-
-        locationInfo.location = fetchLocation().await()
-    }
-
-    private fun fetchLocation() = GlobalScope.async(Dispatchers.Default) {
-        daemon.await().getCurrentLocation()
-    }
-
-    private fun clearLocation() = GlobalScope.launch(Dispatchers.Main) {
-        locationInfo.location = null
+        locationInfo.setState(state)
     }
 
     private fun openSwitchLocationScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -154,6 +154,7 @@ class ConnectFragment : Fragment() {
 
     private fun disconnect() {
         activeAction?.cancel()
+        clearLocation()
 
         activeAction = GlobalScope.launch(Dispatchers.Default) {
             daemon.await().disconnect()
@@ -182,6 +183,10 @@ class ConnectFragment : Fragment() {
 
     private fun fetchLocation() = GlobalScope.async(Dispatchers.Default) {
         daemon.await().getCurrentLocation()
+    }
+
+    private fun clearLocation() = GlobalScope.launch(Dispatchers.Main) {
+        locationInfo.location = null
     }
 
     private fun openSwitchLocationScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn
 
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
@@ -19,6 +20,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 
+import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.TunnelStateTransition
 
 class ConnectFragment : Fragment() {
@@ -26,6 +28,7 @@ class ConnectFragment : Fragment() {
     private lateinit var headerBar: HeaderBar
     private lateinit var notificationBanner: NotificationBanner
     private lateinit var status: ConnectionStatus
+    private lateinit var locationInfo: LocationInfo
 
     private lateinit var parentActivity: MainActivity
 
@@ -61,6 +64,7 @@ class ConnectFragment : Fragment() {
         headerBar = HeaderBar(view, context!!)
         notificationBanner = NotificationBanner(view)
         status = ConnectionStatus(view, context!!)
+        locationInfo = LocationInfo(view)
 
         actionButton = ConnectActionButton(view)
         actionButton.apply {
@@ -172,6 +176,12 @@ class ConnectFragment : Fragment() {
         headerBar.setState(state)
         notificationBanner.setState(state)
         status.setState(state)
+
+        locationInfo.location = fetchLocation().await()
+    }
+
+    private fun fetchLocation() = GlobalScope.async(Dispatchers.Default) {
+        daemon.await().getCurrentLocation()
     }
 
     private fun openSwitchLocationScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -155,6 +155,7 @@ class ConnectFragment : Fragment() {
     }
 
     private fun disconnect() {
+        updateView(TunnelStateTransition.Disconnecting())
         activeAction?.cancel()
 
         activeAction = GlobalScope.launch(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
@@ -1,14 +1,23 @@
 package net.mullvad.mullvadvpn
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+
 import android.view.View
 import android.widget.TextView
 
 import net.mullvad.mullvadvpn.model.GeoIpLocation
+import net.mullvad.mullvadvpn.model.TunnelStateTransition
 
-class LocationInfo(val parentView: View) {
+class LocationInfo(val parentView: View, val daemon: Deferred<MullvadDaemon>) {
     private val country: TextView = parentView.findViewById(R.id.country)
     private val city: TextView = parentView.findViewById(R.id.city)
     private val hostname: TextView = parentView.findViewById(R.id.hostname)
+
+    private var lastKnownRealLocation: GeoIpLocation? = null
 
     var location: GeoIpLocation? = null
         set(value) {
@@ -16,9 +25,34 @@ class LocationInfo(val parentView: View) {
             updateViews(value)
         }
 
+    fun setState(state: TunnelStateTransition) {
+        when (state) {
+            is TunnelStateTransition.Disconnected -> fetchRealLocation()
+            is TunnelStateTransition.Connecting -> fetchRelayLocation()
+            is TunnelStateTransition.Connected -> fetchRelayLocation()
+            is TunnelStateTransition.Disconnecting -> location = lastKnownRealLocation
+            is TunnelStateTransition.Blocked -> location = null
+        }
+    }
+
     fun updateViews(location: GeoIpLocation?) {
         country.text = location?.country ?: ""
         city.text = location?.city ?: ""
         hostname.text = location?.hostname ?: ""
+    }
+
+    private fun fetchRealLocation() = GlobalScope.launch(Dispatchers.Main) {
+        val realLocation = fetchLocation().await()
+
+        lastKnownRealLocation = realLocation
+        location = realLocation
+    }
+
+    private fun fetchRelayLocation() = GlobalScope.launch(Dispatchers.Main) {
+        location = fetchLocation().await()
+    }
+
+    private fun fetchLocation() = GlobalScope.async(Dispatchers.Default) {
+        daemon.await().getCurrentLocation()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
@@ -1,0 +1,24 @@
+package net.mullvad.mullvadvpn
+
+import android.view.View
+import android.widget.TextView
+
+import net.mullvad.mullvadvpn.model.GeoIpLocation
+
+class LocationInfo(val parentView: View) {
+    private val country: TextView = parentView.findViewById(R.id.country)
+    private val city: TextView = parentView.findViewById(R.id.city)
+    private val hostname: TextView = parentView.findViewById(R.id.hostname)
+
+    var location: GeoIpLocation? = null
+        set(value) {
+            field = value
+            updateViews(value)
+        }
+
+    fun updateViews(location: GeoIpLocation?) {
+        country.text = location?.country ?: ""
+        city.text = location?.city ?: ""
+        hostname.text = location?.hostname ?: ""
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn
 
 import net.mullvad.mullvadvpn.model.AccountData
+import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.PublicKey
 import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
@@ -19,6 +20,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     external fun disconnect()
     external fun generateWireguardKey(): Boolean
     external fun getAccountData(accountToken: String): AccountData?
+    external fun getCurrentLocation(): GeoIpLocation?
     external fun getRelayLocations(): RelayList
     external fun getSettings(): Settings
     external fun getState(): TunnelStateTransition

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GeoIpLocation.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GeoIpLocation.kt
@@ -1,0 +1,3 @@
+package net.mullvad.mullvadvpn.model
+
+data class GeoIpLocation(val country: String, val city: String?, val hostname: String?)

--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -96,31 +96,29 @@
                 android:text="@string/unsecured_connection"
                 android:textAllCaps="true"
                 />
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/white"
-                android:textSize="34sp"
-                android:textStyle="bold"
-                android:text="@string/country"
-                />
-        <TextView
+        <TextView android:id="@+id/country"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/white"
                 android:textSize="34sp"
                 android:textStyle="bold"
                 android:text=""
-                android:visibility="invisible"
                 />
-        <TextView
+        <TextView android:id="@+id/city"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/white"
+                android:textSize="34sp"
+                android:textStyle="bold"
+                android:text=""
+                />
+        <TextView android:id="@+id/hostname"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/white"
                 android:textSize="16sp"
                 android:textStyle="bold"
                 android:text=""
-                android:visibility="invisible"
                 />
     </LinearLayout>
 

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -16,7 +16,6 @@
     <string name="creating_secure_connection">Creating secure connection</string>
     <string name="secure_connection">Secure connection</string>
     <string name="blocking_internet">Blocking internet</string>
-    <string name="country">Country</string>
     <string name="connect">Secure my connection</string>
     <string name="cancel">Cancel</string>
     <string name="disconnect">Disconnect</string>

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -1,8 +1,8 @@
 use futures::{sync::oneshot, Future};
 use mullvad_daemon::{DaemonCommandSender, ManagementCommand};
 use mullvad_types::{
-    account::AccountData, relay_constraints::RelaySettingsUpdate, relay_list::RelayList,
-    settings::Settings, states::TargetState,
+    account::AccountData, location::GeoIpLocation, relay_constraints::RelaySettingsUpdate,
+    relay_list::RelayList, settings::Settings, states::TargetState,
 };
 use talpid_types::{net::wireguard, tunnel::TunnelStateTransition};
 
@@ -80,6 +80,14 @@ impl DaemonInterface {
             .map_err(|_| Error::NoResponse)?
             .wait()
             .map_err(Error::RpcError)
+    }
+
+    pub fn get_current_location(&self) -> Result<Option<GeoIpLocation>> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::GetCurrentLocation(tx))?;
+
+        Ok(rx.wait().map_err(|_| Error::NoResponse)?)
     }
 
     pub fn get_relay_locations(&self) -> Result<RelayList> {

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -8,6 +8,7 @@ use jni::{
 };
 use mullvad_types::{
     account::AccountData,
+    location::GeoIpLocation,
     relay_constraints::{Constraint, LocationConstraint, RelayConstraints, RelaySettings},
     relay_list::{Relay, RelayList, RelayListCity, RelayListCountry},
     settings::Settings,
@@ -212,6 +213,29 @@ impl<'env> IntoJava<'env> for TunConfig {
             &parameters,
         )
         .expect("Failed to create TunConfig Java object")
+    }
+}
+
+impl<'env> IntoJava<'env> for GeoIpLocation {
+    type JavaType = JObject<'env>;
+
+    fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
+        let class = get_class("net/mullvad/mullvadvpn/model/GeoIpLocation");
+        let country = env.auto_local(JObject::from(self.country.into_java(env)));
+        let city = env.auto_local(JObject::from(self.city.into_java(env)));
+        let hostname = env.auto_local(JObject::from(self.hostname.into_java(env)));
+        let parameters = [
+            JValue::Object(country.as_obj()),
+            JValue::Object(city.as_obj()),
+            JValue::Object(hostname.as_obj()),
+        ];
+
+        env.new_object(
+            &class,
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+            &parameters,
+        )
+        .expect("Failed to create GeoIpLocation Java object")
     }
 }
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -30,6 +30,7 @@ const CLASSES_TO_LOAD: &[&str] = &[
     "net/mullvad/mullvadvpn/model/AccountData",
     "net/mullvad/mullvadvpn/model/Constraint$Any",
     "net/mullvad/mullvadvpn/model/Constraint$Only",
+    "net/mullvad/mullvadvpn/model/GeoIpLocation",
     "net/mullvad/mullvadvpn/model/InetNetwork",
     "net/mullvad/mullvadvpn/model/LocationConstraint$City",
     "net/mullvad/mullvadvpn/model/LocationConstraint$Country",

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -264,6 +264,26 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getAccountData<
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getCurrentLocation<'env, 'this>(
+    env: JNIEnv<'env>,
+    _: JObject<'this>,
+) -> JObject<'env> {
+    let daemon = DAEMON_INTERFACE.lock();
+
+    match daemon.get_current_location() {
+        Ok(location) => location.into_java(&env),
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to get current location")
+            );
+            JObject::null()
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getRelayLocations<'env, 'this>(
     env: JNIEnv<'env>,
     _: JObject<'this>,


### PR DESCRIPTION
This PR implements showing the current location in the Connect screen on Android. To prevent lag, now the connect screen anticipates changing to the disconnecting tunnel state. Because when disconnecting the connection is blocked (well, actually it's more that there's an offline period while the tunnel is being teared down), the real location is cached when possible to prevent querying the API for a location when we know it will take a while or fail.

A `LocationInfo` helper class is responsible for fetching, caching and updating the UI when appropriate.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/911)
<!-- Reviewable:end -->
