### PR TITLE
Remove cached relay list during installation

### DIFF
--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -7,3 +7,5 @@ if which systemctl &> /dev/null; then
         systemctl disable mullvad-daemon.service
     fi
 fi
+
+rm -f /var/cache/mullvad-vpn/relays.json || true

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -75,3 +75,5 @@ if [ -d "$OLD_CACHE_DIR" ]; then
     mv "$OLD_CACHE_DIR"/* "$NEW_CACHE_DIR/" || echo "Unable to migrate cache. No cache files?"
     rm -rf "$OLD_CACHE_DIR"
 fi
+
+rm -f "$NEW_CACHE_DIR/relays.json" || true

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -37,6 +37,10 @@
 !define PTI_GENERAL_ERROR 0
 !define PTI_SUCCESS 1
 
+# Return codes from cleanup::RemoveRelayCache
+!define RRC_GENERAL_ERROR 0
+!define RRC_SUCCESS 1
+
 # Windows error codes
 !define ERROR_SERVICE_DEPENDENCY_DELETED 1075
 
@@ -416,6 +420,40 @@
 !define RemoveSettings '!insertmacro "RemoveSettings"'
 
 #
+# RemoveRelayCache
+#
+# Call into helper DLL instructing it to remove all relay cache.
+# Currently, errors are only logged and not propagated.
+#
+!macro RemoveRelayCache
+
+	log::Log "RemoveRelayCache()"
+	
+	Push $0
+	Push $1
+
+	cleanup::RemoveRelayCache
+	
+	Pop $0
+	Pop $1
+	
+	${If} $0 != ${RRC_SUCCESS}
+		log::Log "Failed to remove relay cache: $1"
+		Goto RemoveRelayCache_return
+	${EndIf}
+
+	log::Log "RemoveRelayCache() completed successfully"
+	
+	RemoveRelayCache_return:
+
+	Pop $1
+	Pop $0
+
+!macroend
+
+!define RemoveRelayCache '!insertmacro "RemoveRelayCache"'
+
+#
 # customInit
 #
 # This macro is activated right when the installer first starts up.
@@ -471,6 +509,8 @@
 	SetShellVarContext current
 	RMDir /r "$APPDATA\${PRODUCT_NAME}"
 
+	${RemoveRelayCache}
+	
 	${ExtractDriver}
 	${InstallDriver}
 

--- a/windows/nsis-plugins/src/cleanup/cleaningops.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleaningops.cpp
@@ -272,4 +272,18 @@ void RemoveSettingsServiceUser()
 	RemoveDirectoryW(std::wstring(L"\\\\?\\").append(mullvadAppData).c_str());
 }
 
+void RemoveRelayCacheServiceUser()
+{
+	const auto localAppData = GetSystemUserLocalAppData();
+	const auto mullvadAppData = std::experimental::filesystem::path(localAppData).append(L"Mullvad VPN");
+
+	common::fs::ScopedNativeFileSystem nativeFileSystem;
+
+	common::security::AddAdminToObjectDacl(mullvadAppData, SE_FILE_OBJECT);
+
+	const auto cacheFile = std::experimental::filesystem::path(mullvadAppData).append(L"relays.json");
+
+	std::experimental::filesystem::remove(cacheFile);
+}
+
 }

--- a/windows/nsis-plugins/src/cleanup/cleaningops.h
+++ b/windows/nsis-plugins/src/cleanup/cleaningops.h
@@ -7,7 +7,10 @@ void RemoveLogsCacheCurrentUser();
 void RemoveLogsCacheOtherUsers();
 void RemoveLogsServiceUser();
 void RemoveCacheServiceUser();
-
 void RemoveSettingsServiceUser();
+
+// Remove only the relay cache, leaving other cache files untouched.
+// This is useful when updating the app.
+void RemoveRelayCacheServiceUser();
 
 }

--- a/windows/nsis-plugins/src/cleanup/cleanup.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleanup.cpp
@@ -1,5 +1,6 @@
 #include <stdafx.h>
 #include "cleaningops.h"
+#include <libcommon/string.h>
 #include <windows.h>
 #include <nsis/pluginapi.h>
 #include <functional>
@@ -77,5 +78,42 @@ void __declspec(dllexport) NSISCALL RemoveSettings
 	catch (...)
 	{
 		pushint(RemoveSettingsStatus::GENERAL_ERROR);
+	}
+}
+
+enum class RemoveRelayCacheStatus
+{
+	GENERAL_ERROR = 0,
+	SUCCESS
+};
+
+void __declspec(dllexport) NSISCALL RemoveRelayCache
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	try
+	{
+		cleaningops::RemoveRelayCacheServiceUser();
+
+		pushstring(L"");
+		pushint(RemoveRelayCacheStatus::SUCCESS);
+	}
+	catch (const std::exception &err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(RemoveRelayCacheStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(RemoveRelayCacheStatus::GENERAL_ERROR);
 	}
 }

--- a/windows/nsis-plugins/src/cleanup/cleanup.def
+++ b/windows/nsis-plugins/src/cleanup/cleanup.def
@@ -4,3 +4,4 @@ EXPORTS
 
 RemoveLogsAndCache
 RemoveSettings
+RemoveRelayCache


### PR DESCRIPTION
Me and @mvd-ows have updated the installers to remove the cached relay list when the app is being installed on Linux, MacOS and Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/912)
<!-- Reviewable:end -->
