### PR TITLE
Improve Linux specific message about firewall errors

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -212,6 +212,10 @@ msgid "Failed to apply firewall rules. The device might currently be unsecured"
 msgstr ""
 
 msgctxt "in-app-notifications"
+msgid "Your kernel may be outdated"
+msgstr ""
+
+msgctxt "in-app-notifications"
 msgid "Failed to set system DNS server"
 msgstr ""
 

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -50,10 +50,14 @@ function getBlockReasonMessage(blockReason: BlockReason): string {
         'Could not configure IPv6, please enable it on your system or disable it in the app',
       );
     case 'set_firewall_policy_error':
-      return messages.pgettext(
+      return `${messages.pgettext(
         'in-app-notifications',
         'Failed to apply firewall rules. The device might currently be unsecured',
-      );
+      )}${
+        process.platform === 'linux'
+          ? '. ' + messages.pgettext('in-app-notifications', 'Your kernel may be outdated')
+          : ''
+      }`;
     case 'set_dns_error':
       return messages.pgettext('in-app-notifications', 'Failed to set system DNS server');
     case 'start_tunnel_error':

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -87,6 +87,11 @@ fn print_blocked_reason(reason: &BlockReason) {
                 .unwrap_or("Account authentication failed");
             println!("Blocked: {}", AuthFailed::from(auth_failure_str));
         }
+        #[cfg(target_os = "linux")]
+        BlockReason::SetFirewallPolicyError => {
+            println!("Blocked: {}", BlockReason::SetFirewallPolicyError);
+            println!("Your kernel might be terribly out of date or missing nftables");
+        }
         other => println!("Blocked: {}", other),
     }
 }


### PR DESCRIPTION
I've added an appendix to the message that's shown to the user when the daemon enters the blocked state due to a failure to set firewall rules to inform Linux users that their kernel might be terribly outdated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/916)
<!-- Reviewable:end -->
