### PR TITLE
Use patched netlink libraries to be more kernel agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "netlink-packet"
 version = "0.1.1"
-source = "git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat#448fcbe49e666d773b345e84ed2ab7748eb2aaf6"
+source = "git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027#e629e58797c2d14d7f4777c4ade0d85ee0167027"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1291,37 +1291,28 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
+ "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
 ]
 
 [[package]]
 name = "netlink-proto"
 version = "0.1.1"
-source = "git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat#448fcbe49e666d773b345e84ed2ab7748eb2aaf6"
+source = "git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027#e629e58797c2d14d7f4777c4ade0d85ee0167027"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
- "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
+ "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
+ "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "netlink-socket"
-version = "0.0.2"
-source = "git+https://github.com/mullvad/netlink?branch=ignore-hw-address#670b33f535107497ae5c32d02c92de62c5e800ba"
-dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "netlink-sys"
 version = "0.1.0"
-source = "git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat#448fcbe49e666d773b345e84ed2ab7748eb2aaf6"
+source = "git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027#e629e58797c2d14d7f4777c4ade0d85ee0167027"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1841,14 +1832,14 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.1.1"
-source = "git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat#448fcbe49e666d773b345e84ed2ab7748eb2aaf6"
+source = "git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027#e629e58797c2d14d7f4777c4ade0d85ee0167027"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
- "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
+ "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
+ "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
 ]
 
 [[package]]
@@ -2111,10 +2102,9 @@ dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)",
- "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
- "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
- "netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)",
- "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
+ "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
+ "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
+ "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
  "nftnl 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)",
  "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2124,7 +2114,7 @@ dependencies = [
  "pfctl 0.2.1 (git+https://github.com/mullvad/pfctl-rs?rev=9f31b5ddcab941862470075eab83bb398195f3d6)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)",
+ "rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "system-configuration 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
@@ -2891,10 +2881,9 @@ dependencies = [
 "checksum mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
 "checksum mnl-sys 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)" = "<none>"
-"checksum netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)" = "<none>"
-"checksum netlink-socket 0.0.2 (git+https://github.com/mullvad/netlink?branch=ignore-hw-address)" = "<none>"
-"checksum netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)" = "<none>"
+"checksum netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)" = "<none>"
+"checksum netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)" = "<none>"
+"checksum netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)" = "<none>"
 "checksum nftnl 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)" = "<none>"
 "checksum nftnl-sys 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)" = "<none>"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
@@ -2948,7 +2937,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rs-release 0.1.7 (git+https://github.com/mullvad/rs-release?branch=snailquote-unescape)" = "<none>"
-"checksum rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?branch=hack-older-kernel-compat)" = "<none>"
+"checksum rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?rev=e629e58797c2d14d7f4777c4ade0d85ee0167027)" = "<none>"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -41,13 +41,12 @@ tokio-io = "0.1"
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.6"
 failure = "0.1"
-netlink-socket = { git = "https://github.com/mullvad/netlink", branch = "ignore-hw-address" }
 notify = "4.0"
 resolv-conf = "0.6.1"
-rtnetlink = { git = "https://github.com/mullvad/netlink", branch = "hack-older-kernel-compat" }
-netlink-proto = { git = "https://github.com/mullvad/netlink", branch = "hack-older-kernel-compat" }
-netlink-packet = { git = "https://github.com/mullvad/netlink", branch = "hack-older-kernel-compat" }
-netlink-sys = { git = "https://github.com/mullvad/netlink", branch = "hack-older-kernel-compat" }
+rtnetlink = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
+netlink-proto = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
+netlink-packet = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
+netlink-sys = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
 nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "86b30cdc38a6d4b30a900c21f7c644857d6f7401", features = ["nftnl-1-1-0"] }
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -154,6 +154,7 @@ fn link_provides_connectivity(link: &LinkMessage) -> bool {
     // Some tunnels have the link layer type set to None
     link.header.link_layer_type != LinkLayerType::Loopback
         && link.header.link_layer_type != LinkLayerType::None
+        && link.header.link_layer_type != LinkLayerType::Irda
         && link.header.flags.is_running()
         && !is_virtual_interface(link)
 }


### PR DESCRIPTION
Bumps the netlink dependency to use another branch which has been freshly forked off of the master. The changes made to the `netlink-packet` crate make it so that it no longer expects kernel defined data structures of a certain length inside netlink messages. This is expected to greatly increase stability of the daemon, as we should panic less often when running on kernels the library wasn't built for.
The changes can be seen [here](https://github.com/little-dude/netlink/compare/master...mullvad:remove-dependence-on-kernel-structures).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/917)
<!-- Reviewable:end -->
