### PR TITLE
Let Linux offline check fail into an online state

### DIFF
--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -189,11 +189,15 @@ fn monitor_event_loop(
         })
         .map_err(|_| Error::MonitorNetlinkError);
 
-    connection
+    // Under normal circumstances, this runs forever.
+    let result = connection
         .map_err(Error::NetlinkError)
         .join(monitor)
         .wait()
-        .map(|_| ())
+        .map(|_| ());
+    // But if it fails, it should fail open.
+    link_monitor.reset();
+    result
 }
 
 struct LinkMonitor {
@@ -219,5 +223,10 @@ impl LinkMonitor {
                 .sender
                 .unbounded_send(TunnelCommand::IsOffline(is_offline));
         }
+    }
+
+    /// Allow the offline check to fail open.
+    fn reset(&mut self) {
+        let _ = self.sender.unbounded_send(TunnelCommand::IsOffline(false));
     }
 }


### PR DESCRIPTION
I've changed the linux offline check so that if/when the nelink connection used to listen for changes does fail, it would fail into an online state. This way, even if we do fail, we fail open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/918)
<!-- Reviewable:end -->
