### PR TITLE
Limit Android app to Wireguard relays

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
@@ -1,4 +1,4 @@
 package net.mullvad.mullvadvpn.model
 
-data class Relay(val hostname: String) {
+data class Relay(val hostname: String, val hasWireguardTunnels: Boolean) {
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -7,17 +7,21 @@ class RelayList {
     val countries: List<RelayCountry>
 
     constructor(model: net.mullvad.mullvadvpn.model.RelayList) {
-        countries = model.countries.map { country ->
-            val cities = country.cities.map { city -> 
-                val relays = city.relays.map { relay ->
-                    Relay(country.code, city.code, relay.hostname)
-                }
+        countries = model.countries
+            .map { country ->
+                val cities = country.cities
+                    .map { city -> 
+                        val relays = city.relays
+                            .filter { relay -> relay.hasWireguardTunnels }
+                            .map { relay -> Relay(country.code, city.code, relay.hostname) }
 
-                RelayCity(city.name, country.code, city.code, false, relays)
+                        RelayCity(city.name, country.code, city.code, false, relays)
+                    }
+                    .filter { city -> city.relays.isNotEmpty() }
+
+                RelayCountry(country.name, country.code, false, cities)
             }
-
-            RelayCountry(country.name, country.code, false, cities)
-        }
+            .filter { country -> country.cities.isNotEmpty() }
     }
 
     fun findItemForLocation(

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -248,9 +248,14 @@ impl RelaySelector {
         // any constraints that are explicitly specified.
         let tunnel_constraints = match original_constraints.tunnel {
             // No constraints, we use our preferred ones.
+            #[cfg(not(target_os = "android"))]
             Constraint::Any => TunnelConstraints::OpenVpn(OpenVpnConstraints {
                 port: preferred_port,
                 protocol: Constraint::Only(preferred_protocol),
+            }),
+            #[cfg(target_os = "android")]
+            Constraint::Any => TunnelConstraints::Wireguard(WireguardConstraints {
+                port: Constraint::Any,
             }),
             Constraint::Only(TunnelConstraints::OpenVpn(ref openvpn_constraints)) => {
                 match openvpn_constraints {

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -3,7 +3,7 @@ use ipnetwork::IpNetwork;
 use jni::{
     objects::{JList, JObject, JString, JValue},
     signature::JavaType,
-    sys::{jint, jshort, jsize},
+    sys::{jboolean, jint, jshort, jsize},
     JNIEnv,
 };
 use mullvad_types::{
@@ -304,9 +304,13 @@ impl<'env> IntoJava<'env> for Relay {
     fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
         let class = get_class("net/mullvad/mullvadvpn/model/Relay");
         let hostname = env.auto_local(JObject::from(self.hostname.into_java(env)));
-        let parameters = [JValue::Object(hostname.as_obj())];
+        let has_wireguard_tunnels = (!self.tunnels.wireguard.is_empty()) as jboolean;
+        let parameters = [
+            JValue::Object(hostname.as_obj()),
+            JValue::Bool(has_wireguard_tunnels),
+        ];
 
-        env.new_object(&class, "(Ljava/lang/String;)V", &parameters)
+        env.new_object(&class, "(Ljava/lang/String;Z)V", &parameters)
             .expect("Failed to create Relay Java object")
     }
 }


### PR DESCRIPTION
Previously, the Android app would show all relays, even though it only supports Wireguard relays. This PR changes the UI to filter out non-Wireguard relays and locations and updates the relay selection code in the daemon to prefer Wireguard relays on Android.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public version of the Android app released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/919)
<!-- Reviewable:end -->
