### PR TITLE
Log out button on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Job
 import android.content.Context
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -83,6 +84,7 @@ class AccountFragment : Fragment() {
 
     private fun logout() {
         clearAccountNumber()
+        clearBackStack()
         goToLoginScreen()
     }
 
@@ -90,6 +92,14 @@ class AccountFragment : Fragment() {
         val daemon = parentActivity.asyncDaemon.await()
 
         daemon.setAccount(null)
+    }
+
+    private fun clearBackStack() {
+        fragmentManager?.apply {
+            val firstEntry = getBackStackEntryAt(0)
+
+            popBackStack(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        }
     }
 
     private fun goToLoginScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -104,6 +104,12 @@ class AccountFragment : Fragment() {
 
     private fun goToLoginScreen() {
         fragmentManager?.beginTransaction()?.apply {
+            setCustomAnimations(
+                R.anim.do_nothing,
+                R.anim.fragment_exit_to_bottom,
+                R.anim.do_nothing,
+                R.anim.do_nothing
+            )
             replace(R.id.main_fragment, LoginFragment())
             commit()
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -44,6 +44,8 @@ class AccountFragment : Fragment() {
             parentActivity.onBackPressed()
         }
 
+        view.findViewById<View>(R.id.logout).setOnClickListener { logout() }
+
         accountExpiryContainer = view.findViewById<View>(R.id.account_expiry_container)
         accountNumberContainer = view.findViewById<View>(R.id.account_number_container)
 
@@ -77,5 +79,16 @@ class AccountFragment : Fragment() {
         val formatter = DateFormat.getDateTimeInstance()
 
         return formatter.format(expiryInstant)
+    }
+
+    private fun logout() {
+        goToLoginScreen()
+    }
+
+    private fun goToLoginScreen() {
+        fragmentManager?.beginTransaction()?.apply {
+            replace(R.id.main_fragment, LoginFragment())
+            commit()
+        }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -82,7 +82,14 @@ class AccountFragment : Fragment() {
     }
 
     private fun logout() {
+        clearAccountNumber()
         goToLoginScreen()
+    }
+
+    private fun clearAccountNumber() = GlobalScope.launch(Dispatchers.Default) {
+        val daemon = parentActivity.asyncDaemon.await()
+
+        daemon.setAccount(null)
     }
 
     private fun goToLoginScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
@@ -1,12 +1,14 @@
 package net.mullvad.mullvadvpn
 
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 
+import android.content.Context
 import android.os.Bundle
 import android.os.Handler
 import android.support.v4.app.Fragment
@@ -16,6 +18,8 @@ import android.view.ViewGroup
 import android.widget.TextView
 
 class LoginFragment : Fragment() {
+    private lateinit var parentActivity: MainActivity
+
     private lateinit var title: TextView
     private lateinit var subtitle: TextView
     private lateinit var loggingInStatus: View
@@ -24,6 +28,12 @@ class LoginFragment : Fragment() {
     private lateinit var accountInput: AccountInput
 
     private var loginJob: Deferred<Boolean>? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        parentActivity = context as MainActivity
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,7 +48,7 @@ class LoginFragment : Fragment() {
         loggedInStatus = view.findViewById(R.id.logged_in_status)
         loginFailStatus = view.findViewById(R.id.login_fail_status)
 
-        accountInput = AccountInput(view, context!!)
+        accountInput = AccountInput(view, parentActivity)
         accountInput.onLogin = { accountToken -> login(accountToken) }
 
         return view
@@ -60,7 +70,6 @@ class LoginFragment : Fragment() {
     private fun performLogin(accountToken: String) = GlobalScope.launch(Dispatchers.Main) {
         loginJob?.cancel()
         loginJob = GlobalScope.async(Dispatchers.Default) {
-            val parentActivity = activity as MainActivity
             val daemon = parentActivity.asyncDaemon.await()
             val accountData = daemon.getAccountData(accountToken)
 
@@ -79,7 +88,14 @@ class LoginFragment : Fragment() {
         }
     }
 
-    private fun loggedIn() {
+    private suspend fun loggedIn() {
+        showLoggedInMessage()
+        parentActivity.refetchSettings()
+        delay(1000)
+        openConnectScreen()
+    }
+
+    private fun showLoggedInMessage() {
         title.setText(R.string.logged_in_title)
         subtitle.setText("")
 
@@ -88,8 +104,6 @@ class LoginFragment : Fragment() {
         loggedInStatus.visibility = View.VISIBLE
 
         accountInput.state = LoginState.Success
-
-        Handler().postDelayed(Runnable { openConnectScreen() }, 1000)
     }
 
     private fun openConnectScreen() {

--- a/android/src/main/res/layout/account.xml
+++ b/android/src/main/res/layout/account.xml
@@ -98,5 +98,9 @@
                     android:text=""
                     />
         </LinearLayout>
+        <Button android:id="@+id/logout"
+                android:text="@string/log_out"
+                style="@style/RedButton"
+                />
     </LinearLayout>
 </LinearLayout>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
 
     <string name="account_number">Account number</string>
     <string name="paid_until">Paid until</string>
+    <string name="log_out">Log out</string>
 
     <string name="unsecured_connection">Unsecured connection</string>
     <string name="creating_secure_connection">Creating secure connection</string>


### PR DESCRIPTION
This PR adds a logout button to the Account settings screen. The button clears the account number configured in the daemon, and returns to the login screen while clearing the back stack.

The login screen was also updated to refetch the settings from the daemon so that it includes the new account number.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/923)
<!-- Reviewable:end -->
