### PR TITLE
Listen for relay list updates

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -14,6 +14,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         initialize(vpnService)
     }
 
+    var onRelayListChange: ((RelayList) -> Unit)? = null
     var onTunnelStateChange: ((TunnelStateTransition) -> Unit)? = null
 
     external fun connect()
@@ -29,6 +30,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     external fun updateRelaySettings(update: RelaySettingsUpdate)
 
     private external fun initialize(vpnService: MullvadVpnService)
+
+    private fun notifyRelayListEvent(relayList: RelayList) {
+        onRelayListChange?.invoke(relayList)
+    }
 
     private fun notifyTunnelStateEvent(event: TunnelStateTransition) {
         onTunnelStateChange?.invoke(event)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -14,6 +14,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import android.widget.ViewSwitcher
 
 import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.LocationConstraint
@@ -27,6 +28,8 @@ import net.mullvad.mullvadvpn.relaylist.RelayListListener
 class SelectLocationFragment : Fragment() {
     private lateinit var parentActivity: MainActivity
     private lateinit var relayListListener: RelayListListener
+
+    private lateinit var relayListContainer: ViewSwitcher
 
     private val relayListAdapter = RelayListAdapter()
 
@@ -59,6 +62,9 @@ class SelectLocationFragment : Fragment() {
         val view = inflater.inflate(R.layout.select_location, container, false)
 
         view.findViewById<ImageButton>(R.id.close).setOnClickListener { close() }
+
+        relayListContainer = view.findViewById<ViewSwitcher>(R.id.relay_list_container)
+        relayListContainer.showNext()
 
         configureRelayList(view.findViewById<RecyclerView>(R.id.relay_list))
 
@@ -95,5 +101,11 @@ class SelectLocationFragment : Fragment() {
     private fun updateRelayList(relayList: RelayList, selectedItem: RelayItem?) =
             GlobalScope.launch(Dispatchers.Main) {
         relayListAdapter.onRelayListChange(relayList, selectedItem)
+
+        if (relayList.countries.isEmpty()) {
+            relayListContainer.showPrevious()
+        } else if (relayListContainer.displayedChild == 0) {
+            relayListContainer.showNext()
+        }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
@@ -9,10 +9,9 @@ import android.view.ViewGroup
 
 import net.mullvad.mullvadvpn.R
 
-class RelayListAdapter(
-    private val relayList: RelayList,
-    private var selectedItem: RelayItem?
-) : Adapter<RelayItemHolder>() {
+class RelayListAdapter : Adapter<RelayItemHolder>() {
+    private var relayList: RelayList? = null
+    private var selectedItem: RelayItem? = null
     private val activeIndices = LinkedList<WeakReference<RelayListAdapterPosition>>()
     private var selectedItemHolder: RelayItemHolder? = null
 
@@ -29,23 +28,34 @@ class RelayListAdapter(
     }
 
     override fun onBindViewHolder(holder: RelayItemHolder, position: Int) {
-        var remaining = position
+        val relayList = this.relayList
 
-        for (country in relayList.countries) {
-            val itemOrCount = country.getItem(remaining)
+        if (relayList != null) {
+            var remaining = position
 
-            when (itemOrCount) {
-                is GetItemResult.Item -> {
-                    bindHolderToItem(holder, itemOrCount.item, position)
-                    return
+            for (country in relayList.countries) {
+                val itemOrCount = country.getItem(remaining)
+
+                when (itemOrCount) {
+                    is GetItemResult.Item -> {
+                        bindHolderToItem(holder, itemOrCount.item, position)
+                        return
+                    }
+                    is GetItemResult.Count -> remaining -= itemOrCount.count
                 }
-                is GetItemResult.Count -> remaining -= itemOrCount.count
             }
         }
     }
 
     override fun getItemCount() =
-        relayList.countries.map { country -> country.visibleItemCount }.sum()
+        relayList?.countries?.map { country -> country.visibleItemCount }?.sum() ?: 0
+
+    fun onRelayListChange(relayList: RelayList, selectedItem: RelayItem?) {
+        this.relayList = relayList
+        this.selectedItem = selectedItem
+
+        notifyDataSetChanged()
+    }
 
     fun selectItem(item: RelayItem?, holder: RelayItemHolder?) {
         selectedItemHolder?.selected = false

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListListener.kt
@@ -1,0 +1,113 @@
+package net.mullvad.mullvadvpn.relaylist
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+
+import net.mullvad.mullvadvpn.MainActivity
+import net.mullvad.mullvadvpn.model.Constraint
+import net.mullvad.mullvadvpn.model.LocationConstraint
+import net.mullvad.mullvadvpn.model.RelaySettings
+import net.mullvad.mullvadvpn.MullvadDaemon
+
+class RelayListListener(val parentActivity: MainActivity) {
+    private val daemon = CompletableDeferred<MullvadDaemon>()
+    private val setUpJob = setUp()
+
+    private var relayList: RelayList? = null
+    private var relaySettings: RelaySettings? = null
+
+    var selectedRelayItem: RelayItem? = null
+        set(value) {
+            field = value
+            updateRelaySettings()
+        }
+
+    val selectedRelayLocation: Constraint<LocationConstraint>
+        get() {
+            val location = selectedRelayItem?.location
+
+            if (location == null) {
+                return Constraint.Any()
+            } else {
+                return Constraint.Only(location)
+            }
+        }
+
+    var onRelayListChange: ((RelayList, RelayItem?) -> Unit)? = null
+        set(value) {
+            field = value
+
+            synchronized(this) {
+                val relayList = this.relayList
+
+                if (relayList != null) {
+                    value?.invoke(relayList, selectedRelayItem)
+                }
+            }
+        }
+
+    fun onDestroy() {
+        setUpJob.cancel()
+
+        if (daemon.isActive) {
+            daemon.cancel()
+        } else {
+            daemon.getCompleted().onRelayListChange = null
+        }
+    }
+
+    private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
+        daemon.complete(parentActivity.asyncDaemon.await())
+
+        setUpListener()
+        fetchInitialRelayList()
+    }
+
+    private suspend fun setUpListener() {
+        daemon.await().onRelayListChange = { relayLocations ->
+            relayListChanged(RelayList(relayLocations))
+        }
+    }
+
+    private suspend fun fetchInitialRelayList() {
+        val relayLocations = daemon.await().getRelayLocations()
+
+        relaySettings = parentActivity.asyncSettings.await().relaySettings
+
+        synchronized(this) {
+            if (relayList == null) {
+                relayListChanged(RelayList(relayLocations))
+            }
+        }
+    }
+
+    private fun relayListChanged(newRelayList: RelayList) {
+        synchronized(this) {
+            relayList = newRelayList
+            selectedRelayItem = findSelectedRelayItem()
+
+            onRelayListChange?.invoke(newRelayList, selectedRelayItem)
+        }
+    }
+
+    private fun findSelectedRelayItem(): RelayItem? {
+        val relaySettings = this.relaySettings
+
+        when (relaySettings) {
+            is RelaySettings.CustomTunnelEndpoint -> return null
+            is RelaySettings.RelayConstraints -> {
+                val location = relaySettings.location
+
+                return relayList?.findItemForLocation(location, true)
+            }
+        }
+
+        return null
+    }
+
+    private fun updateRelaySettings() {
+        relaySettings = RelaySettings.RelayConstraints(selectedRelayLocation)
+    }
+}

--- a/android/src/main/res/anim/fade_in.xml
+++ b/android/src/main/res/anim/fade_in.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+            android:fromAlpha="0.0"
+            android:toAlpha="1.0"
+            android:duration="450"
+            />
+</set>

--- a/android/src/main/res/anim/fade_out.xml
+++ b/android/src/main/res/anim/fade_out.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+            android:fromAlpha="1.0"
+            android:toAlpha="0.0"
+            android:duration="450"
+            />
+</set>

--- a/android/src/main/res/layout/select_location.xml
+++ b/android/src/main/res/layout/select_location.xml
@@ -41,6 +41,8 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:inAnimation="@anim/fade_in"
+            android:outAnimation="@anim/fade_out"
             >
         <ProgressBar
                 android:layout_width="60dp"

--- a/android/src/main/res/layout/select_location.xml
+++ b/android/src/main/res/layout/select_location.xml
@@ -37,10 +37,25 @@
             android:textSize="13sp"
             android:text="@string/select_location_description"
             />
-    <android.support.v7.widget.RecyclerView android:id="@+id/relay_list"
+    <ViewSwitcher android:id="@+id/relay_list_container"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:scrollbars="vertical"
-            />
+            >
+        <ProgressBar
+                android:layout_width="60dp"
+                android:layout_height="60dp"
+                android:layout_gravity="center"
+                android:indeterminate="true"
+                android:indeterminateOnly="true"
+                android:indeterminateDuration="600"
+                android:indeterminateDrawable="@drawable/icon_spinner"
+                android:visibility="invisible"
+                />
+        <android.support.v7.widget.RecyclerView android:id="@+id/relay_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scrollbars="vertical"
+                />
+    </ViewSwitcher>
 </LinearLayout>

--- a/mullvad-jni/src/jni_event_listener.rs
+++ b/mullvad-jni/src/jni_event_listener.rs
@@ -21,8 +21,13 @@ pub enum Error {
     GetJvmInstance(#[error(cause)] jni::errors::Error),
 }
 
+enum Event {
+    RelayList(RelayList),
+    Tunnel(TunnelStateTransition),
+}
+
 #[derive(Clone, Debug)]
-pub struct JniEventListener(mpsc::Sender<TunnelStateTransition>);
+pub struct JniEventListener(mpsc::Sender<Event>);
 
 impl JniEventListener {
     pub fn spawn(env: &JNIEnv, mullvad_daemon: &JObject) -> Result<Self, Error> {
@@ -32,18 +37,22 @@ impl JniEventListener {
 
 impl EventListener for JniEventListener {
     fn notify_new_state(&self, state: TunnelStateTransition) {
-        let _ = self.0.send(state);
+        let _ = self.0.send(Event::Tunnel(state));
     }
 
     fn notify_settings(&self, _: Settings) {}
-    fn notify_relay_list(&self, _: RelayList) {}
+
+    fn notify_relay_list(&self, relay_list: RelayList) {
+        let _ = self.0.send(Event::RelayList(relay_list));
+    }
 }
 
 struct JniEventHandler<'env> {
     env: AttachGuard<'env>,
     mullvad_ipc_client: JObject<'env>,
+    notify_relay_list_event: JMethodID<'env>,
     notify_tunnel_event: JMethodID<'env>,
-    events: mpsc::Receiver<TunnelStateTransition>,
+    events: mpsc::Receiver<Event>,
 }
 
 impl JniEventHandler<'_> {
@@ -80,9 +89,15 @@ impl<'env> JniEventHandler<'env> {
     fn new(
         env: AttachGuard<'env>,
         mullvad_ipc_client: JObject<'env>,
-        events: mpsc::Receiver<TunnelStateTransition>,
+        events: mpsc::Receiver<Event>,
     ) -> Result<Self, Error> {
         let class = get_class("net/mullvad/mullvadvpn/MullvadDaemon");
+        let notify_relay_list_event = Self::get_method_id(
+            &env,
+            &class,
+            "notifyRelayListEvent",
+            "(Lnet/mullvad/mullvadvpn/model/RelayList;)V",
+        )?;
         let notify_tunnel_event = Self::get_method_id(
             &env,
             &class,
@@ -93,6 +108,7 @@ impl<'env> JniEventHandler<'env> {
         Ok(JniEventHandler {
             env,
             mullvad_ipc_client,
+            notify_relay_list_event,
             notify_tunnel_event,
             events,
         })
@@ -110,7 +126,26 @@ impl<'env> JniEventHandler<'env> {
 
     fn run(&mut self) {
         while let Ok(event) = self.events.recv() {
-            self.handle_tunnel_event(event);
+            match event {
+                Event::RelayList(relay_list) => self.handle_relay_list_event(relay_list),
+                Event::Tunnel(tunnel_event) => self.handle_tunnel_event(tunnel_event),
+            }
+        }
+    }
+
+    fn handle_relay_list_event(&self, relay_list: RelayList) {
+        let result = self.env.call_method_unchecked(
+            self.mullvad_ipc_client,
+            self.notify_relay_list_event,
+            JavaType::Primitive(Primitive::Void),
+            &[JValue::Object(relay_list.into_java(&self.env))],
+        );
+
+        if let Err(error) = result {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to call MullvadDaemon.notifyRelayListEvent")
+            );
         }
     }
 


### PR DESCRIPTION
This PR introduces a `RelayListListener` helper class that listens for relay list update events from the daemon. It is used for providing the relay list information to the `RelayListAdapter`. The adapter was changed to start empty and support relay list updates. The Select Location screen can then use these changes to show a spinner when the relay list is empty (i.e., while it hasn't been downloaded yet), and show the relay list as soon as it becomes available.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/925)
<!-- Reviewable:end -->
