### PR TITLE
Cache location info

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn
 
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
@@ -21,6 +20,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageButton
 
+import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.TunnelStateTransition
 
@@ -32,6 +32,7 @@ class ConnectFragment : Fragment() {
     private lateinit var locationInfo: LocationInfo
 
     private lateinit var parentActivity: MainActivity
+    private lateinit var locationInfoCache: LocationInfoCache
 
     private var daemon = CompletableDeferred<MullvadDaemon>()
     private var vpnPermission = CompletableDeferred<Unit>()
@@ -50,6 +51,7 @@ class ConnectFragment : Fragment() {
         super.onAttach(context)
 
         parentActivity = context as MainActivity
+        locationInfoCache = parentActivity.locationInfoCache
         waitForDaemonJob = waitForDaemon(parentActivity.asyncDaemon)
     }
 
@@ -71,7 +73,7 @@ class ConnectFragment : Fragment() {
         headerBar = HeaderBar(view, context!!)
         notificationBanner = NotificationBanner(view)
         status = ConnectionStatus(view, context!!)
-        locationInfo = LocationInfo(view, daemon)
+        locationInfo = LocationInfo(view, locationInfoCache)
 
         actionButton = ConnectActionButton(view)
         actionButton.apply {
@@ -86,11 +88,16 @@ class ConnectFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        locationInfo.onDestroy()
+
         waitForDaemonJob?.cancel()
         attachListenerJob?.cancel()
+
         detachListener()
+
         generateWireguardKeyJob.cancel()
         updateViewJob?.cancel()
+
         super.onDestroyView()
     }
 
@@ -184,7 +191,7 @@ class ConnectFragment : Fragment() {
         headerBar.setState(state)
         notificationBanner.setState(state)
         status.setState(state)
-        locationInfo.setState(state)
+        locationInfoCache.setState(state)
     }
 
     private fun openSwitchLocationScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -40,8 +40,6 @@ class ConnectFragment : Fragment() {
     private var fetchInitialStateJob = fetchInitialState()
     private var generateWireguardKeyJob = generateWireguardKey()
 
-    private var lastKnownRealLocation: GeoIpLocation? = null
-
     private var activeAction: Job? = null
     private var attachListenerJob: Job? = null
     private var updateViewJob: Job? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -17,6 +17,7 @@ import android.os.IBinder
 import android.support.v4.app.FragmentActivity
 
 import net.mullvad.mullvadvpn.dataproxy.AccountCache
+import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
@@ -34,6 +35,7 @@ class MainActivity : FragmentActivity() {
         get() = runBlocking { asyncSettings.await() }
 
     val accountCache = AccountCache(this)
+    val locationInfoCache = LocationInfoCache(asyncDaemon)
     var relayListListener = RelayListListener(this)
 
     private var waitForDaemonJob: Job? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -16,11 +16,12 @@ import android.os.Bundle
 import android.os.IBinder
 import android.support.v4.app.FragmentActivity
 
+import net.mullvad.mullvadvpn.dataproxy.AccountCache
+import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
-import net.mullvad.mullvadvpn.relaylist.RelayListListener
 
 class MainActivity : FragmentActivity() {
     var asyncDaemon = CompletableDeferred<MullvadDaemon>()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -16,6 +16,7 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.ViewSwitcher
 
+import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.LocationConstraint
 import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
@@ -23,7 +24,6 @@ import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayItemDividerDecoration
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.relaylist.RelayListAdapter
-import net.mullvad.mullvadvpn.relaylist.RelayListListener
 
 class SelectLocationFragment : Fragment() {
     private lateinit var parentActivity: MainActivity

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -1,14 +1,13 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.dataproxy
 
 import kotlinx.coroutines.async
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.DateTime
 
-import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.MainActivity
 
 val EXPIRY_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss z")
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -1,0 +1,67 @@
+package net.mullvad.mullvadvpn.dataproxy
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+
+import net.mullvad.mullvadvpn.model.GeoIpLocation
+import net.mullvad.mullvadvpn.model.TunnelStateTransition
+import net.mullvad.mullvadvpn.MullvadDaemon
+
+class LocationInfoCache(val daemon: Deferred<MullvadDaemon>) {
+    private var lastKnownRealLocation: GeoIpLocation? = null
+    private var activeFetch: Job? = null
+
+    var onNewLocation: ((String, String, String) -> Unit)? = null
+
+    var location: GeoIpLocation? = null
+        set(value) {
+            field = value
+            notifyNewLocation(value)
+        }
+
+    fun setState(state: TunnelStateTransition) {
+        activeFetch?.cancel()
+        activeFetch = null
+
+        when (state) {
+            is TunnelStateTransition.Disconnected -> activeFetch = fetchRealLocation()
+            is TunnelStateTransition.Connecting -> activeFetch = fetchRelayLocation()
+            is TunnelStateTransition.Connected -> activeFetch = fetchRelayLocation()
+            is TunnelStateTransition.Disconnecting -> location = lastKnownRealLocation
+            is TunnelStateTransition.Blocked -> location = null
+        }
+    }
+
+    fun notifyNewLocation(location: GeoIpLocation?) {
+        val country = location?.country ?: ""
+        val city = location?.city ?: ""
+        val hostname = location?.hostname ?: ""
+
+        onNewLocation?.invoke(country, city, hostname)
+    }
+
+    private fun fetchRealLocation() = GlobalScope.launch(Dispatchers.Main) {
+        var realLocation: GeoIpLocation? = null
+        var remainingAttempts = 10
+
+        while (realLocation == null && remainingAttempts > 0) {
+            realLocation = fetchLocation().await()
+            remainingAttempts -= 1
+        }
+
+        lastKnownRealLocation = realLocation
+        location = realLocation
+    }
+
+    private fun fetchRelayLocation() = GlobalScope.launch(Dispatchers.Main) {
+        location = fetchLocation().await()
+    }
+
+    private fun fetchLocation() = GlobalScope.async(Dispatchers.Default) {
+        daemon.await().getCurrentLocation()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -16,11 +16,15 @@ class LocationInfoCache(val daemon: Deferred<MullvadDaemon>) {
     private var activeFetch: Job? = null
 
     var onNewLocation: ((String, String, String) -> Unit)? = null
+        set(value) {
+            field = value
+            notifyNewLocation()
+        }
 
     var location: GeoIpLocation? = null
         set(value) {
             field = value
-            notifyNewLocation(value)
+            notifyNewLocation()
         }
 
     fun setState(state: TunnelStateTransition) {
@@ -36,7 +40,8 @@ class LocationInfoCache(val daemon: Deferred<MullvadDaemon>) {
         }
     }
 
-    fun notifyNewLocation(location: GeoIpLocation?) {
+    fun notifyNewLocation() {
+        val location = this.location
         val country = location?.country ?: ""
         val city = location?.city ?: ""
         val hostname = location?.hostname ?: ""

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.relaylist
+package net.mullvad.mullvadvpn.dataproxy
 
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CompletableDeferred
@@ -10,6 +10,8 @@ import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.LocationConstraint
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.MullvadDaemon
+import net.mullvad.mullvadvpn.relaylist.RelayList
+import net.mullvad.mullvadvpn.relaylist.RelayItem
 
 class RelayListListener(val parentActivity: MainActivity) {
     private val daemon = CompletableDeferred<MullvadDaemon>()


### PR DESCRIPTION
This PR started out as an attempt to reduce the number of fetches to get the current location information. In order to do so, I decoupled it from the Connect fragment, so that it is cached in a `LocationInfoCache` helper class while the activity is running. While doing so, I also reorganized and cleaned up some code, moving all classes that proxy data between the UI and the daemon thread to a separate `dataproxy` package.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/926)
<!-- Reviewable:end -->
