### PR TITLE
Improve connectivity

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
         xmlns:tools="http://schemas.android.com/tools"
         package="net.mullvad.mullvadvpn"
         >
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectivityListener.kt
@@ -1,0 +1,59 @@
+package net.mullvad.mullvadvpn
+
+import kotlinx.coroutines.CompletableDeferred
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+import android.net.NetworkInfo.DetailedState
+
+class ConnectivityListener : BroadcastReceiver() {
+    var vpnDisconnected = CompletableDeferred<Unit>()
+        private set
+
+    fun register(context: Context) {
+        val intentFilter = IntentFilter()
+
+        intentFilter.addAction(ConnectivityManager.CONNECTIVITY_ACTION)
+        context.registerReceiver(this, intentFilter)
+
+        checkInitialState(context)
+    }
+
+    fun unregister(context: Context) {
+        context.unregisterReceiver(this)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val networkInfo =
+            intent.getParcelableExtra<NetworkInfo>(ConnectivityManager.EXTRA_NETWORK_INFO)
+
+        if (networkInfo.type == ConnectivityManager.TYPE_VPN) {
+            if (networkInfo.detailedState == DetailedState.DISCONNECTED) {
+                vpnDisconnected.complete(Unit)
+            } else if (networkInfo.detailedState == DetailedState.CONNECTED) {
+                vpnDisconnected.cancel()
+                vpnDisconnected = CompletableDeferred<Unit>()
+            }
+        }
+    }
+
+    private fun checkInitialState(context: Context) {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+        val isVpnConnected = connectivityManager.allNetworks
+            .map({ network -> connectivityManager.getNetworkInfo(network) })
+            .any({ networkInfo ->
+                networkInfo.type == ConnectivityManager.TYPE_VPN
+                    && networkInfo.detailedState == DetailedState.CONNECTED
+            })
+
+        if (!isVpnConnected) {
+            vpnDisconnected.complete(Unit)
+        }
+    }
+}


### PR DESCRIPTION
Previously, the app would crash if connecting right after a disconnect. It would only do so without crashing if the user waited about 4-5 seconds between attempts. This happens because it is taking some time for the VPN tunnel to be disabled by Android. The cause of this issue is not yet known, but this PR implements a mitigation.

A new `ConnectivityListener` helper class was created to listen for connectivity status changes. A `vpnDisconnected` `Deferred` job is used to notify when the VPN tunnel is finally disconnected. An external class can then simply do `vpnDisconnected.await()` to block while the VPN tunnel is connected.

`MullvadVpnService` then uses the `ConnectivityListener`, and blocks creating a new tunnel until the previous VPN tunnel is disconnected.

Two other changes are also included:

- The lock used for the daemon interface in `mullvad-jni` changed so that more requests can be made simultaneously (the daemon has its own synchronization);
- The tunnel file descriptor is set to be "blocking". I don't know how this affects things, but I followed how it's done in Wireguard-Android.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/928)
<!-- Reviewable:end -->
