### PR TITLE
Allow copying account number to clipboard

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -17,6 +17,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.Toast
 
 import org.joda.time.DateTime
 
@@ -99,6 +100,9 @@ class AccountFragment : Fragment() {
         val clipData = ClipData.newPlainText(clipLabel, accountNumberDisplay.text)
 
         clipboard.primaryClip = clipData
+
+        Toast.makeText(parentActivity, R.string.copied_mullvad_account_number, Toast.LENGTH_SHORT)
+            .show()
     }
 
     private fun clearAccountNumber() = GlobalScope.launch(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 
 import android.content.Context
+import android.content.ClipboardManager
+import android.content.ClipData
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
@@ -53,6 +55,8 @@ class AccountFragment : Fragment() {
         accountExpiryDisplay = view.findViewById<TextView>(R.id.account_expiry_display)
         accountNumberDisplay = view.findViewById<TextView>(R.id.account_number_display)
 
+        accountNumberContainer.setOnClickListener { copyAccountNumberToClipboard() }
+
         updateViewJob = updateView()
 
         return view
@@ -86,6 +90,15 @@ class AccountFragment : Fragment() {
         clearAccountNumber()
         clearBackStack()
         goToLoginScreen()
+    }
+
+    private fun copyAccountNumberToClipboard() {
+        val clipboard =
+            parentActivity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clipLabel = parentActivity.resources.getString(R.string.mullvad_account_number)
+        val clipData = ClipData.newPlainText(clipLabel, accountNumberDisplay.text)
+
+        clipboard.primaryClip = clipData
     }
 
     private fun clearAccountNumber() = GlobalScope.launch(Dispatchers.Default) {

--- a/android/src/main/res/layout/account.xml
+++ b/android/src/main/res/layout/account.xml
@@ -34,7 +34,6 @@
     <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginHorizontal="24dp"
             android:layout_marginTop="4dp"
             android:layout_marginBottom="24dp"
             android:orientation="vertical"
@@ -42,7 +41,8 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="24dp"
+                android:layout_marginBottom="12dp"
+                android:layout_marginHorizontal="24dp"
                 android:textColor="@color/white"
                 android:textSize="32sp"
                 android:textStyle="bold"
@@ -51,9 +51,12 @@
         <LinearLayout android:id="@+id/account_number_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="24dp"
+                android:paddingHorizontal="24dp"
+                android:paddingVertical="12dp"
                 android:orientation="vertical"
                 android:visibility="invisible"
+                android:background="?android:attr/selectableItemBackground"
+                android:clickable="true"
                 >
             <TextView
                     android:layout_width="wrap_content"
@@ -76,7 +79,8 @@
         <LinearLayout android:id="@+id/account_expiry_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="24dp"
+                android:paddingHorizontal="24dp"
+                android:paddingVertical="12dp"
                 android:orientation="vertical"
                 android:visibility="invisible"
                 >
@@ -99,6 +103,8 @@
                     />
         </LinearLayout>
         <Button android:id="@+id/logout"
+                android:layout_marginTop="12dp"
+                android:layout_marginHorizontal="24dp"
                 android:text="@string/log_out"
                 style="@style/RedButton"
                 />

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="quit">Quit</string>
 
     <string name="account_number">Account number</string>
+    <string name="mullvad_account_number">Mullvad account number</string>
     <string name="paid_until">Paid until</string>
     <string name="log_out">Log out</string>
 

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
 
     <string name="account_number">Account number</string>
     <string name="mullvad_account_number">Mullvad account number</string>
+    <string name="copied_mullvad_account_number">Copied Mullvad account number</string>
     <string name="paid_until">Paid until</string>
     <string name="log_out">Log out</string>
 


### PR DESCRIPTION
This PR makes the account number row clickable in the Account screen. When it is clicked, the account number is copied to the clipboard, and a toast message is shown.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/931)
<!-- Reviewable:end -->
