### PR TITLE
Include logcat in collected problem report logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ version = "2019.5.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -32,6 +32,10 @@ mullvad-rpc = { path = "../mullvad-rpc" }
 talpid-types = { path = "../talpid-types" }
 
 
+[target.'cfg(target_os = "android")'.dependencies]
+duct = "0.12"
+
+
 [target.'cfg(target_os = "linux")'.dependencies]
 rs-release = { git = "https://github.com/mullvad/rs-release", branch = "snailquote-unescape" }
 


### PR DESCRIPTION
On Android, the GUI logs messages to Android's default "logcat" (a syslog equivalent). A `logcat` command can be used to access it. Running it without special privileges limits access to the logs of the current process, so this should keep out any sensitive data from other processes.

This PR changes `mullvad-problem-report` so that on Android it runs the `logcat` command to generate a file with the log contents and include it in the problem report.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/935)
<!-- Reviewable:end -->
