### PR TITLE
Add "Confirm no email" dialog

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
@@ -1,0 +1,24 @@
+package net.mullvad.mullvadvpn
+
+import android.app.Dialog
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.LayoutInflater
+import android.view.ViewGroup
+
+class ConfirmNoEmailDialogFragment : DialogFragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ) = inflater.inflate(R.layout.confirm_no_email, container, false)
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+
+        dialog.window.setBackgroundDrawable(ColorDrawable(android.R.color.transparent))
+
+        return dialog
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
@@ -5,14 +5,24 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.support.v4.app.DialogFragment
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 
 class ConfirmNoEmailDialogFragment : DialogFragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ) = inflater.inflate(R.layout.confirm_no_email, container, false)
+    ): View {
+        val view = inflater.inflate(R.layout.confirm_no_email, container, false)
+
+        view.findViewById<Button>(R.id.back_button).setOnClickListener {
+            activity?.onBackPressed()
+        }
+
+        return view
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
@@ -1,6 +1,10 @@
 package net.mullvad.mullvadvpn
 
+import kotlinx.coroutines.CompletableDeferred
+
 import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.support.v4.app.DialogFragment
@@ -9,7 +13,19 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 
+import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
+
 class ConfirmNoEmailDialogFragment : DialogFragment() {
+    private var confirmNoEmail: CompletableDeferred<Boolean>? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        val parentActivity = context as MainActivity
+
+        confirmNoEmail = parentActivity.problemReport.confirmNoEmail
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -21,6 +37,12 @@ class ConfirmNoEmailDialogFragment : DialogFragment() {
             activity?.onBackPressed()
         }
 
+        view.findViewById<Button>(R.id.send_button).setOnClickListener {
+            confirmNoEmail?.complete(true)
+            confirmNoEmail = null
+            dismiss()
+        }
+
         return view
     }
 
@@ -30,5 +52,9 @@ class ConfirmNoEmailDialogFragment : DialogFragment() {
         dialog.window.setBackgroundDrawable(ColorDrawable(android.R.color.transparent))
 
         return dialog
+    }
+
+    override fun onDismiss(dialogInterface: DialogInterface) {
+        confirmNoEmail?.complete(false)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.dataproxy
 import java.io.File
 
 import kotlinx.coroutines.async
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -12,6 +13,8 @@ const val PROBLEM_REPORT_PATH = "/data/data/net.mullvad.mullvadvpn/problem_repor
 class MullvadProblemReport {
     private var collectJob: Deferred<Boolean>? = null
     private var sendJob: Deferred<Boolean>? = null
+
+    var confirmNoEmail: CompletableDeferred<Boolean>? = null
 
     var userEmail = ""
     var userMessage = ""

--- a/android/src/main/res/drawable/dialog_background.xml
+++ b/android/src/main/res/drawable/dialog_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="rectangle"
+        >
+    <corners android:radius="11dp"/>
+    <solid android:color="@color/darkBlue"/>
+</shape>

--- a/android/src/main/res/layout/confirm_no_email.xml
+++ b/android/src/main/res/layout/confirm_no_email.xml
@@ -1,0 +1,29 @@
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:background="@drawable/dialog_background"
+        android:orientation="vertical"
+        android:gravity="left"
+        android:elevation="2dp"
+        >
+    <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:layout_marginBottom="12dp"
+            android:textColor="@color/white80"
+            android:textSize="16sp"
+            android:text="@string/confirm_no_email"
+            />
+    <Button android:id="@+id/send_button"
+            android:text="@string/send_anyway"
+            style="@style/GreenButton"
+            />
+    <Button android:id="@+id/back_button"
+            android:layout_marginTop="16dp"
+            android:text="@string/back"
+            style="@style/RedButton"
+            />
+</LinearLayout>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -36,6 +36,12 @@
     <string name="sending">Sending...</string>
     <string name="sent">Sent</string>
     <string name="failed_to_send">Failed to send</string>
+    <string name="confirm_no_email">
+        You are about to send the problem report without a way for us to get back to you. If you
+        want an answer to your report you will have to enter an email address.
+    </string>
+    <string name="send_anyway">Send anyway</string>
+    <string name="back">Back</string>
     <string name="sent_thanks">Thanks! We will look into this.</string>
     <string name="sent_contact">If needed we will contact you on</string>
     <string name="failed_to_send_details">


### PR DESCRIPTION
This PR extends the Problem report screen so that when the user tries to send a report with no email to reply to, a confirmation dialog is shown. The `MullvadProblemReport` class is used to hold a `confirmNoEmail` field used by the dialog to notify the user's selection back to the `ProblemReportFragment`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/937)
<!-- Reviewable:end -->
