### PR TITLE
Fix country not being selected on first run

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -80,11 +80,15 @@ class AccountFragment : Fragment() {
         if (accountNumber != null) {
             accountNumberDisplay.setText(accountNumber)
             accountNumberContainer.visibility = View.VISIBLE
+        } else {
+            accountNumberContainer.visibility = View.INVISIBLE
         }
 
         if (accountExpiry != null) {
             accountExpiryDisplay.setText(formatExpiry(accountExpiry))
             accountExpiryContainer.visibility = View.VISIBLE
+        } else {
+            accountExpiryContainer.visibility = View.INVISIBLE
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -114,7 +114,7 @@ class AccountFragment : Fragment() {
     }
 
     private fun clearAccountNumber() = GlobalScope.launch(Dispatchers.Default) {
-        val daemon = parentActivity.asyncDaemon.await()
+        val daemon = parentActivity.daemon.await()
 
         daemon.setAccount(null)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountFragment.kt
@@ -58,25 +58,33 @@ class AccountFragment : Fragment() {
 
         accountNumberContainer.setOnClickListener { copyAccountNumberToClipboard() }
 
-        updateViewJob = updateView()
-
         return view
     }
 
-    private fun updateView() = GlobalScope.launch(Dispatchers.Main) {
-        val accountCache = parentActivity.accountCache
-        val accountNumber = accountCache.accountNumber.await()
+    override fun onResume() {
+        super.onResume()
 
+        parentActivity.accountCache.onAccountDataChange = { accountNumber, accountExpiry ->
+            updateViewJob = updateView(accountNumber, accountExpiry)
+        }
+    }
+
+    override fun onPause() {
+        parentActivity.accountCache.onAccountDataChange = null
+
+        super.onPause()
+    }
+
+    private fun updateView(accountNumber: String?, accountExpiry: DateTime?) =
+            GlobalScope.launch(Dispatchers.Main) {
         if (accountNumber != null) {
-            accountNumberDisplay.setText(accountCache.accountNumber.await())
+            accountNumberDisplay.setText(accountNumber)
             accountNumberContainer.visibility = View.VISIBLE
+        }
 
-            val accountExpiry = accountCache.accountExpiry.await()
-
-            if (accountExpiry != null) {
-                accountExpiryDisplay.setText(formatExpiry(accountExpiry))
-                accountExpiryContainer.visibility = View.VISIBLE
-            }
+        if (accountExpiry != null) {
+            accountExpiryDisplay.setText(formatExpiry(accountExpiry))
+            accountExpiryContainer.visibility = View.VISIBLE
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -54,7 +54,7 @@ class ConnectFragment : Fragment() {
         parentActivity = context as MainActivity
         locationInfoCache = parentActivity.locationInfoCache
         relayListListener = parentActivity.relayListListener
-        waitForDaemonJob = waitForDaemon(parentActivity.asyncDaemon)
+        waitForDaemonJob = waitForDaemon(parentActivity.daemon)
     }
 
     override fun onCreateView(
@@ -123,9 +123,9 @@ class ConnectFragment : Fragment() {
         }
     }
 
-    private fun waitForDaemon(asyncDaemon: Deferred<MullvadDaemon>) =
+    private fun waitForDaemon(originalDaemon: Deferred<MullvadDaemon>) =
             GlobalScope.launch(Dispatchers.Default) {
-        daemon.complete(asyncDaemon.await())
+        daemon.complete(originalDaemon.await())
     }
 
     private fun attachListener() = GlobalScope.launch(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
@@ -38,7 +38,7 @@ class LaunchFragment : Fragment() {
 
     private fun checkForAccountToken() = GlobalScope.async(Dispatchers.Default) {
         val parentActivity = activity as MainActivity
-        val daemon = parentActivity.asyncDaemon.await()
+        val daemon = parentActivity.daemon.await()
         val settings = daemon.getSettings()
 
         settings.accountToken != null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
@@ -38,7 +38,8 @@ class LaunchFragment : Fragment() {
 
     private fun checkForAccountToken() = GlobalScope.async(Dispatchers.Default) {
         val parentActivity = activity as MainActivity
-        val settings = parentActivity.asyncSettings.await()
+        val daemon = parentActivity.asyncDaemon.await()
+        val settings = daemon.getSettings()
 
         settings.accountToken != null
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
@@ -90,7 +90,6 @@ class LoginFragment : Fragment() {
 
     private suspend fun loggedIn() {
         showLoggedInMessage()
-        parentActivity.refetchSettings()
         delay(1000)
         openConnectScreen()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
@@ -70,7 +70,7 @@ class LoginFragment : Fragment() {
     private fun performLogin(accountToken: String) = GlobalScope.launch(Dispatchers.Main) {
         loginJob?.cancel()
         loginJob = GlobalScope.async(Dispatchers.Default) {
-            val daemon = parentActivity.asyncDaemon.await()
+            val daemon = parentActivity.daemon.await()
             val accountData = daemon.getAccountData(accountToken)
 
             if (accountData != null) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -38,8 +38,8 @@ class MainActivity : FragmentActivity() {
 
     val locationInfoCache = LocationInfoCache(asyncDaemon)
     val problemReport = MullvadProblemReport()
-    var relayListListener = RelayListListener(this)
     var settingsListener = SettingsListener(this)
+    var relayListListener = RelayListListener(this)
     val accountCache = AccountCache(settingsListener, asyncDaemon)
 
     private var waitForDaemonJob: Job? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -36,11 +36,11 @@ class MainActivity : FragmentActivity() {
     val settings
         get() = runBlocking { asyncSettings.await() }
 
-    val accountCache = AccountCache(this)
     val locationInfoCache = LocationInfoCache(asyncDaemon)
     val problemReport = MullvadProblemReport()
     var relayListListener = RelayListListener(this)
     var settingsListener = SettingsListener(this)
+    val accountCache = AccountCache(settingsListener, asyncDaemon)
 
     private var waitForDaemonJob: Job? = null
 
@@ -106,13 +106,6 @@ class MainActivity : FragmentActivity() {
             replace(R.id.main_fragment, SettingsFragment())
             addToBackStack(null)
             commit()
-        }
-    }
-
-    fun refetchSettings() {
-        if (asyncSettings.isCompleted) {
-            asyncSettings = fetchSettings()
-            accountCache.settings = asyncSettings
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -20,6 +20,7 @@ import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
+import net.mullvad.mullvadvpn.dataproxy.SettingsListener
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
@@ -39,6 +40,7 @@ class MainActivity : FragmentActivity() {
     val locationInfoCache = LocationInfoCache(asyncDaemon)
     val problemReport = MullvadProblemReport()
     var relayListListener = RelayListListener(this)
+    var settingsListener = SettingsListener(this)
 
     private var waitForDaemonJob: Job? = null
 
@@ -84,6 +86,7 @@ class MainActivity : FragmentActivity() {
     override fun onDestroy() {
         accountCache.onDestroy()
         relayListListener.onDestroy()
+        settingsListener.onDestroy()
 
         waitForDaemonJob?.cancel()
         asyncSettings.cancel()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -31,11 +31,6 @@ class MainActivity : FragmentActivity() {
     val daemon
         get() = runBlocking { asyncDaemon.await() }
 
-    var asyncSettings = fetchSettings()
-        private set
-    val settings
-        get() = runBlocking { asyncSettings.await() }
-
     val locationInfoCache = LocationInfoCache(asyncDaemon)
     val problemReport = MullvadProblemReport()
     var settingsListener = SettingsListener(this)
@@ -89,7 +84,6 @@ class MainActivity : FragmentActivity() {
         settingsListener.onDestroy()
 
         waitForDaemonJob?.cancel()
-        asyncSettings.cancel()
         asyncDaemon.cancel()
 
         super.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -15,6 +15,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     }
 
     var onRelayListChange: ((RelayList) -> Unit)? = null
+    var onSettingsChange: ((Settings) -> Unit)? = null
     var onTunnelStateChange: ((TunnelStateTransition) -> Unit)? = null
 
     external fun connect()
@@ -33,6 +34,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
 
     private fun notifyRelayListEvent(relayList: RelayList) {
         onRelayListChange?.invoke(relayList)
+    }
+
+    private fun notifySettingsEvent(settings: Settings) {
+        onSettingsChange?.invoke(settings)
     }
 
     private fun notifyTunnelStateEvent(event: TunnelStateTransition) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -22,9 +22,7 @@ class MullvadVpnService : VpnService() {
     private val created = CompletableDeferred<Unit>()
     private val binder = LocalBinder()
 
-    val asyncDaemon = startDaemon()
-    val daemon
-        get() = runBlocking { asyncDaemon.await() }
+    val daemon = startDaemon()
 
     override fun onCreate() {
         created.complete(Unit)
@@ -37,7 +35,7 @@ class MullvadVpnService : VpnService() {
 
     override fun onDestroy() {
         connectivityListener.unregister(this)
-        asyncDaemon.cancel()
+        daemon.cancel()
         created.cancel()
     }
 
@@ -72,8 +70,8 @@ class MullvadVpnService : VpnService() {
     }
 
     inner class LocalBinder : Binder() {
-        val asyncDaemon
-            get() = this@MullvadVpnService.asyncDaemon
+        val daemon
+            get() = this@MullvadVpnService.daemon
     }
 
     private fun startDaemon() = GlobalScope.async(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -104,7 +104,7 @@ class SelectLocationFragment : Fragment() {
         val constraint: Constraint<LocationConstraint> =
             relayItem?.run { Constraint.Only(location) } ?: Constraint.Any()
 
-        parentActivity.asyncDaemon.await().updateRelaySettings(
+        parentActivity.daemon.await().updateRelaySettings(
             RelaySettingsUpdate.RelayConstraintsUpdate(constraint)
         )
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -37,8 +37,7 @@ class SelectLocationFragment : Fragment() {
 
     init {
         relayListAdapter.onSelect = { relayItem ->
-            relayListListener.selectedRelayItem = relayItem
-            updateLocationConstraint()
+            updateLocationConstraint(relayItem)
             close()
         }
     }
@@ -100,8 +99,10 @@ class SelectLocationFragment : Fragment() {
         }
     }
 
-    private fun updateLocationConstraint() = GlobalScope.launch(Dispatchers.Default) {
-        val constraint = relayListListener.selectedRelayLocation
+    private fun updateLocationConstraint(relayItem: RelayItem?) =
+            GlobalScope.launch(Dispatchers.Default) {
+        val constraint: Constraint<LocationConstraint> =
+            relayItem?.run { Constraint.Only(location) } ?: Constraint.Any()
 
         parentActivity.asyncDaemon.await().updateRelaySettings(
             RelaySettingsUpdate.RelayConstraintsUpdate(constraint)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
@@ -51,9 +51,9 @@ class SettingsFragment : Fragment() {
         remainingTimeLabel.onResume()
     }
 
-    override fun onDestroyView() {
-        remainingTimeLabel.onDestroy()
-        super.onDestroyView()
+    override fun onPause() {
+        remainingTimeLabel.onPause()
+        super.onPause()
     }
 
     private fun openSubFragment(fragment: Fragment) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -54,7 +54,7 @@ class RelayListListener(val parentActivity: MainActivity) {
     }
 
     private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
-        daemon.complete(parentActivity.asyncDaemon.await())
+        daemon.complete(parentActivity.daemon.await())
 
         setUpListener()
         fetchInitialRelayList()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -21,21 +21,7 @@ class RelayListListener(val parentActivity: MainActivity) {
     private var relaySettings: RelaySettings? = null
 
     var selectedRelayItem: RelayItem? = null
-        set(value) {
-            field = value
-            updateRelaySettings()
-        }
-
-    val selectedRelayLocation: Constraint<LocationConstraint>
-        get() {
-            val location = selectedRelayItem?.location
-
-            if (location == null) {
-                return Constraint.Any()
-            } else {
-                return Constraint.Only(location)
-            }
-        }
+        private set
 
     var onRelayListChange: ((RelayList, RelayItem?) -> Unit)? = null
         set(value) {
@@ -50,8 +36,15 @@ class RelayListListener(val parentActivity: MainActivity) {
             }
         }
 
+    init {
+        parentActivity.settingsListener.onRelaySettingsChange = { newRelaySettings ->
+            relaySettingsChanged(newRelaySettings)
+        }
+    }
+
     fun onDestroy() {
         setUpJob.cancel()
+        parentActivity.settingsListener.onRelaySettingsChange = null
 
         if (daemon.isActive) {
             daemon.cancel()
@@ -76,11 +69,21 @@ class RelayListListener(val parentActivity: MainActivity) {
     private suspend fun fetchInitialRelayList() {
         val relayLocations = daemon.await().getRelayLocations()
 
-        relaySettings = parentActivity.asyncSettings.await().relaySettings
-
         synchronized(this) {
             if (relayList == null) {
                 relayListChanged(RelayList(relayLocations))
+            }
+        }
+    }
+
+    private fun relaySettingsChanged(newRelaySettings: RelaySettings?) {
+        synchronized(this) {
+            val relayList = this.relayList
+
+            relaySettings = newRelaySettings ?: RelaySettings.RelayConstraints(Constraint.Any())
+
+            if (relayList != null) {
+                relayListChanged(relayList)
             }
         }
     }
@@ -107,9 +110,5 @@ class RelayListListener(val parentActivity: MainActivity) {
         }
 
         return null
-    }
-
-    private fun updateRelaySettings() {
-        relaySettings = RelaySettings.RelayConstraints(selectedRelayLocation)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -41,7 +41,7 @@ class SettingsListener(val parentActivity: MainActivity) {
     }
 
     private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
-        daemon = parentActivity.asyncDaemon.await()
+        daemon = parentActivity.daemon.await()
         daemon.onSettingsChange = { settings -> handleNewSettings(settings) }
         fetchInitialSettings()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -15,6 +15,14 @@ class SettingsListener(val parentActivity: MainActivity) {
 
     private var settings: Settings? = null
 
+    var onAccountNumberChange: ((String?) -> Unit)? = null
+        set(value) {
+            synchronized(this) {
+                field = value
+                value?.invoke(settings?.accountToken)
+            }
+        }
+
     fun onDestroy() {
         setUpJob.cancel()
 
@@ -41,6 +49,10 @@ class SettingsListener(val parentActivity: MainActivity) {
 
     private fun handleNewSettings(newSettings: Settings) {
         synchronized(this) {
+            if (settings?.accountToken != newSettings.accountToken) {
+                onAccountNumberChange?.invoke(newSettings.accountToken)
+            }
+
             settings = newSettings
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 
 import net.mullvad.mullvadvpn.MainActivity
+import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.MullvadDaemon
 
@@ -20,6 +21,14 @@ class SettingsListener(val parentActivity: MainActivity) {
             synchronized(this) {
                 field = value
                 value?.invoke(settings?.accountToken)
+            }
+        }
+
+    var onRelaySettingsChange: ((RelaySettings?) -> Unit)? = null
+        set(value) {
+            synchronized(this) {
+                field = value
+                value?.invoke(settings?.relaySettings)
             }
         }
 
@@ -51,6 +60,10 @@ class SettingsListener(val parentActivity: MainActivity) {
         synchronized(this) {
             if (settings?.accountToken != newSettings.accountToken) {
                 onAccountNumberChange?.invoke(newSettings.accountToken)
+            }
+
+            if (settings?.relaySettings != newSettings.relaySettings) {
+                onRelaySettingsChange?.invoke(newSettings.relaySettings)
             }
 
             settings = newSettings

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -1,18 +1,26 @@
 package net.mullvad.mullvadvpn.dataproxy
 
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+
 import net.mullvad.mullvadvpn.MainActivity
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.MullvadDaemon
 
 class SettingsListener(val parentActivity: MainActivity) {
-    private var daemon: MullvadDaemon? = null
+    private lateinit var daemon: MullvadDaemon
+
     private val setUpJob = setUp()
 
     private var settings: Settings? = null
 
     fun onDestroy() {
         setUpJob.cancel()
-        daemon?.onSettingsChange = null
+
+        if (::daemon.isInitialized) {
+            daemon.onSettingsChange = null
+        }
     }
 
     private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
@@ -26,7 +34,7 @@ class SettingsListener(val parentActivity: MainActivity) {
 
         synchronized(this) {
             if (settings == null) {
-                settings = initialSettings
+                handleNewSettings(initialSettings)
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -1,0 +1,39 @@
+package net.mullvad.mullvadvpn.dataproxy
+
+import net.mullvad.mullvadvpn.MainActivity
+import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.MullvadDaemon
+
+class SettingsListener(val parentActivity: MainActivity) {
+    private var daemon: MullvadDaemon? = null
+    private val setUpJob = setUp()
+
+    private var settings: Settings? = null
+
+    fun onDestroy() {
+        setUpJob.cancel()
+        daemon?.onSettingsChange = null
+    }
+
+    private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
+        daemon = parentActivity.asyncDaemon.await()
+        daemon.onSettingsChange = { settings -> handleNewSettings(settings) }
+        fetchInitialSettings()
+    }
+
+    private fun fetchInitialSettings() {
+        val initialSettings = daemon!!.getSettings()
+
+        synchronized(this) {
+            if (settings == null) {
+                settings = initialSettings
+            }
+        }
+    }
+
+    private fun handleNewSettings(newSettings: Settings) {
+        synchronized(this) {
+            settings = newSettings
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a bug that was happening because of a sequence of events.

1. The first relay list fetch returned an empty list;
2. When the fetch finished, an attempt was made to find the relay item that matches the configured relay constraints;
3. Since the list was empty, the selected relay item was set to `null`;
4. The setter for that field would recalculate the relay constraints, setting it to `Any`;
5. When a non-empty relay list was received, the search for the selected relay would always be `null`, since the constraint was set to `Any`.

The fix was to simply ignore the initial fetch if it resulted in an empty relay list.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/938)
<!-- Reviewable:end -->
