### PR TITLE
Show selected location on "Switch location" button

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -87,6 +87,7 @@ class ConnectFragment : Fragment() {
 
     override fun onDestroyView() {
         locationInfo.onDestroy()
+        switchLocationButton.onDestroy()
 
         waitForDaemonJob?.cancel()
         attachListenerJob?.cancel()
@@ -186,6 +187,8 @@ class ConnectFragment : Fragment() {
 
     private fun updateView(state: TunnelStateTransition) = GlobalScope.launch(Dispatchers.Main) {
         actionButton.state = state
+        switchLocationButton.state = state
+
         headerBar.setState(state)
         notificationBanner.setState(state)
         status.setState(state)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -21,6 +21,7 @@ import android.widget.Button
 import android.widget.ImageButton
 
 import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
+import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.TunnelStateTransition
 
@@ -34,6 +35,7 @@ class ConnectFragment : Fragment() {
 
     private lateinit var parentActivity: MainActivity
     private lateinit var locationInfoCache: LocationInfoCache
+    private lateinit var relayListListener: RelayListListener
 
     private var daemon = CompletableDeferred<MullvadDaemon>()
     private var vpnPermission = CompletableDeferred<Unit>()
@@ -51,6 +53,7 @@ class ConnectFragment : Fragment() {
 
         parentActivity = context as MainActivity
         locationInfoCache = parentActivity.locationInfoCache
+        relayListListener = parentActivity.relayListListener
         waitForDaemonJob = waitForDaemon(parentActivity.asyncDaemon)
     }
 
@@ -83,6 +86,20 @@ class ConnectFragment : Fragment() {
         attachListenerJob = attachListener()
 
         return view
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        relayListListener.onRelayListChange = { relayList, selectedRelayItem ->
+            switchLocationButton.location = selectedRelayItem
+        }
+    }
+
+    override fun onPause() {
+        relayListListener.onRelayListChange = null
+
+        super.onPause()
     }
 
     override fun onDestroyView() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -26,6 +26,7 @@ import net.mullvad.mullvadvpn.model.TunnelStateTransition
 
 class ConnectFragment : Fragment() {
     private lateinit var actionButton: ConnectActionButton
+    private lateinit var switchLocationButton: SwitchLocationButton
     private lateinit var headerBar: HeaderBar
     private lateinit var notificationBanner: NotificationBanner
     private lateinit var status: ConnectionStatus
@@ -64,10 +65,6 @@ class ConnectFragment : Fragment() {
             parentActivity.openSettings()
         }
 
-        view.findViewById<Button>(R.id.switch_location).setOnClickListener {
-            openSwitchLocationScreen()
-        }
-
         headerBar = HeaderBar(view, context!!)
         notificationBanner = NotificationBanner(view)
         status = ConnectionStatus(view, context!!)
@@ -79,6 +76,9 @@ class ConnectFragment : Fragment() {
             onCancel = { disconnect() }
             onDisconnect = { disconnect() }
         }
+
+        switchLocationButton = SwitchLocationButton(view)
+        switchLocationButton.onClick = { openSwitchLocationScreen() }
 
         attachListenerJob = attachListener()
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -48,10 +48,6 @@ class SelectLocationFragment : Fragment() {
 
         parentActivity = context as MainActivity
         relayListListener = parentActivity.relayListListener
-
-        relayListListener.onRelayListChange = { relayList, selectedItem ->
-            updateRelayListJob = updateRelayList(relayList, selectedItem)
-        }
     }
 
     override fun onCreateView(
@@ -69,6 +65,20 @@ class SelectLocationFragment : Fragment() {
         configureRelayList(view.findViewById<RecyclerView>(R.id.relay_list))
 
         return view
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        relayListListener.onRelayListChange = { relayList, selectedItem ->
+            updateRelayListJob = updateRelayList(relayList, selectedItem)
+        }
+    }
+
+    override fun onPause() {
+        relayListListener.onRelayListChange = null
+
+        super.onPause()
     }
 
     override fun onDestroyView() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
@@ -1,14 +1,54 @@
 package net.mullvad.mullvadvpn
 
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+
 import android.view.View
 import android.widget.Button
 
+import net.mullvad.mullvadvpn.model.TunnelStateTransition
+
 class SwitchLocationButton(val parentView: View) {
     private val button: Button = parentView.findViewById(R.id.switch_location)
+
+    private var updateJob: Job? = null
+
+    var state: TunnelStateTransition = TunnelStateTransition.Disconnected()
+        set(value) {
+            field = value
+            update()
+        }
 
     var onClick: (() -> Unit)? = null
 
     init {
         button.setOnClickListener { onClick?.invoke() }
+    }
+
+    fun onDestroy() {
+        updateJob?.cancel()
+    }
+
+    private fun update() {
+        updateJob?.cancel()
+        updateJob = GlobalScope.launch(Dispatchers.Main) {
+            when (state) {
+                is TunnelStateTransition.Disconnected -> showLocation()
+                is TunnelStateTransition.Disconnecting -> showLocation()
+                is TunnelStateTransition.Connecting -> showLabel()
+                is TunnelStateTransition.Connected -> showLabel()
+                is TunnelStateTransition.Blocked -> showLocation()
+            }
+        }
+    }
+
+    private fun showLabel() {
+        button.setText(R.string.switch_location)
+    }
+
+    private fun showLocation() {
+        showLabel()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
@@ -9,11 +9,18 @@ import android.view.View
 import android.widget.Button
 
 import net.mullvad.mullvadvpn.model.TunnelStateTransition
+import net.mullvad.mullvadvpn.relaylist.RelayItem
 
 class SwitchLocationButton(val parentView: View) {
     private val button: Button = parentView.findViewById(R.id.switch_location)
 
     private var updateJob: Job? = null
+
+    var location: RelayItem? = null
+        set(value) {
+            field = value
+            update()
+        }
 
     var state: TunnelStateTransition = TunnelStateTransition.Disconnected()
         set(value) {
@@ -49,6 +56,12 @@ class SwitchLocationButton(val parentView: View) {
     }
 
     private fun showLocation() {
-        showLabel()
+        val locationName = location?.locationName
+
+        if (locationName == null) {
+            showLabel()
+        } else {
+            button.setText(locationName)
+        }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 
+import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.Button
 
@@ -13,6 +14,7 @@ import net.mullvad.mullvadvpn.relaylist.RelayItem
 
 class SwitchLocationButton(val parentView: View) {
     private val button: Button = parentView.findViewById(R.id.switch_location)
+    private val chevron: Drawable = button.compoundDrawables[2]
 
     private var updateJob: Job? = null
 
@@ -53,6 +55,7 @@ class SwitchLocationButton(val parentView: View) {
 
     private fun showLabel() {
         button.setText(R.string.switch_location)
+        button.setCompoundDrawables(null, null, null, null)
     }
 
     private fun showLocation() {
@@ -62,6 +65,7 @@ class SwitchLocationButton(val parentView: View) {
             showLabel()
         } else {
             button.setText(locationName)
+            button.setCompoundDrawables(null, null, chevron, null)
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
@@ -1,0 +1,14 @@
+package net.mullvad.mullvadvpn
+
+import android.view.View
+import android.widget.Button
+
+class SwitchLocationButton(val parentView: View) {
+    private val button: Button = parentView.findViewById(R.id.switch_location)
+
+    var onClick: (() -> Unit)? = null
+
+    init {
+        button.setOnClickListener { onClick?.invoke() }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/Relay.kt
@@ -5,7 +5,8 @@ import net.mullvad.mullvadvpn.model.LocationConstraint
 data class Relay(
     val countryCode: String,
     val cityCode: String,
-    override val name: String
+    override val name: String,
+    val cityName: String
 ) : RelayItem {
     override val code = name
     override val type = RelayItemType.Relay
@@ -13,6 +14,8 @@ data class Relay(
     override val hasChildren = false
 
     override val visibleChildCount = 0
+
+    override val locationName = "$cityName ($name)"
 
     override var expanded
         get() = false

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItem.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItem.kt
@@ -13,5 +13,8 @@ interface RelayItem {
     val visibleItemCount: Int
         get() = visibleChildCount + 1
 
+    val locationName: String
+        get() = name
+
     var expanded: Boolean
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -13,7 +13,9 @@ class RelayList {
                     .map { city -> 
                         val relays = city.relays
                             .filter { relay -> relay.hasWireguardTunnels }
-                            .map { relay -> Relay(country.code, city.code, relay.hostname) }
+                            .map { relay ->
+                                Relay(country.code, city.code, relay.hostname, city.name)
+                            }
 
                         RelayCity(city.name, country.code, city.code, false, relays)
                     }


### PR DESCRIPTION
This PR updates the Connect screen slightly so that the "Switch location" button behaves as in the desktop app. Now, when disconnected the button will show the currently selected location, and will only show "Switch location" when connected.

In order to show the same information as the desktop app, the city name was added to the `Relay` class.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/939)
<!-- Reviewable:end -->
