### PR TITLE
Connect when selecting location

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -16,6 +16,7 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.ViewSwitcher
 
+import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.LocationConstraint
@@ -27,6 +28,7 @@ import net.mullvad.mullvadvpn.relaylist.RelayListAdapter
 
 class SelectLocationFragment : Fragment() {
     private lateinit var parentActivity: MainActivity
+    private lateinit var connectionProxy: ConnectionProxy
     private lateinit var relayListListener: RelayListListener
 
     private lateinit var relayListContainer: ViewSwitcher
@@ -38,6 +40,7 @@ class SelectLocationFragment : Fragment() {
     init {
         relayListAdapter.onSelect = { relayItem ->
             updateLocationConstraint(relayItem)
+            connectionProxy.connect()
             close()
         }
     }
@@ -46,6 +49,7 @@ class SelectLocationFragment : Fragment() {
         super.onAttach(context)
 
         parentActivity = context as MainActivity
+        connectionProxy = parentActivity.connectionProxy
         relayListListener = parentActivity.relayListListener
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -1,0 +1,93 @@
+package net.mullvad.mullvadvpn.dataproxy
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+
+import net.mullvad.mullvadvpn.MainActivity
+import net.mullvad.mullvadvpn.model.TunnelStateTransition
+
+class ConnectionProxy(val parentActivity: MainActivity) {
+    val daemon = parentActivity.daemon
+
+    private var activeAction: Job? = null
+
+    private val attachListenerJob = attachListener()
+    private val fetchInitialStateJob = fetchInitialState()
+
+    private var realState: TunnelStateTransition? = null
+        set(value) {
+            field = value
+            uiState = value ?: TunnelStateTransition.Disconnected()
+        }
+
+    val state: TunnelStateTransition
+        get() {
+            return realState ?: TunnelStateTransition.Disconnected()
+        }
+
+    var uiState: TunnelStateTransition = TunnelStateTransition.Disconnected()
+        private set(value) {
+            field = value
+            onUiStateChange?.invoke(value)
+        }
+
+    var onUiStateChange: ((TunnelStateTransition) -> Unit)? = null
+
+    fun connect() {
+        uiState = TunnelStateTransition.Connecting()
+
+        cancelActiveAction()
+
+        val vpnPermission = parentActivity.requestVpnPermission()
+
+        activeAction = GlobalScope.launch(Dispatchers.Default) {
+            if (vpnPermission.await()) {
+                daemon.await().connect()
+            }
+        }
+    }
+
+    fun disconnect() {
+        uiState = TunnelStateTransition.Disconnecting()
+
+        cancelActiveAction()
+        activeAction = GlobalScope.launch(Dispatchers.Default) {
+            daemon.await().disconnect()
+        }
+    }
+
+    fun cancelActiveAction() {
+        activeAction?.cancel()
+    }
+
+    fun onDestroy() {
+        attachListenerJob.cancel()
+        detachListener()
+        fetchInitialStateJob.cancel()
+        cancelActiveAction()
+    }
+
+    private fun fetchInitialState() = GlobalScope.launch(Dispatchers.Default) {
+        val initialState = daemon.await().getState()
+
+        synchronized(this) {
+            if (realState == null) {
+                realState = initialState
+            }
+        }
+    }
+
+    private fun attachListener() = GlobalScope.launch(Dispatchers.Default) {
+        daemon.await().onTunnelStateChange = { newState ->
+            synchronized(this) {
+                realState = newState
+            }
+        }
+    }
+
+    private fun detachListener() = GlobalScope.launch(Dispatchers.Default) {
+        daemon.await().onTunnelStateChange = null
+    }
+}


### PR DESCRIPTION
This PR moves the connection handling code to a new `ConnectionProxy` helper class, so that it's not specific to the `ConnectFragment`. This is then used to allow the `SelectLocationFragment` to request a connection when a location is selected.

When moving around the code to change the UI before an actual state is received, it became hard to do it the same way, so the state had to be split in two. There's the "real state" that comes from the daemon, and the "UI state" that anticipates the real state based on the requests started from the UI.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/940)
<!-- Reviewable:end -->
