### PR TITLE
Automatic wireguard keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "jsonrpc-ipc-server 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
@@ -1133,6 +1134,7 @@ dependencies = [
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2406,6 +2408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3004,7 @@ dependencies = [
 "checksum tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88e1281e412013f1ff5787def044a9577a0bed059f451e835f1643201f8b777d"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
+"checksum tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
 "checksum tokio-sync 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fda385df506bf7546e70872767f71e81640f1f251bdf2fd8eb81a0eaec5fe022"

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -337,6 +337,14 @@ const daemonEventSchema = oneOf(
   object({
     relay_list: relayListSchema,
   }),
+  object({
+    wireguard_key: oneOf(
+      enumeration('too_many_keys', 'generation_failure'),
+      object({
+        new_key: string,
+      }),
+    ),
+  }),
 );
 
 export class ResponseParseError extends Error {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -486,6 +486,10 @@ class ApplicationMain {
           this.setSettings(daemonEvent.settings);
         } else if ('relayList' in daemonEvent) {
           this.setRelays(daemonEvent.relayList, this.settings.relaySettings);
+        } else if ('wireguardKey' in daemonEvent) {
+          /// TODO: handle wireguard key events properly.
+          log.info(`Received new key event`);
+          log.info(daemonEvent);
         }
       },
       (error: Error) => {

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -74,7 +74,8 @@ export interface IProxyEndpoint {
 export type DaemonEvent =
   | { stateTransition: TunnelStateTransition }
   | { settings: ISettings }
-  | { relayList: IRelayList };
+  | { relayList: IRelayList }
+  | { wireguardKey: KeygenEvent };
 
 export type TunnelStateTransition =
   | { state: 'disconnected' }
@@ -276,6 +277,12 @@ export interface ISettings {
   tunnelOptions: ITunnelOptions;
   bridgeSettings: BridgeSettings;
   bridgeState: BridgeState;
+}
+
+export type KeygenEvent = INewWireguardKey | 'too_many_keys' | 'generation_failure';
+
+export interface INewWireguardKey {
+  newKey: string;
 }
 
 export type BridgeState = 'auto' | 'on' | 'off';

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -57,6 +57,11 @@ impl Command for Status {
                             println!("New relay list: {:#?}", relay_list);
                         }
                     }
+                    DaemonEvent::WireguardKey(key_event) => {
+                        if verbose {
+                            println!("{}", key_event);
+                        }
+                    }
                 }
             }
         }

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -173,7 +173,11 @@ impl Tunnel {
 
     fn process_wireguard_key_generate() -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        rpc.generate_wireguard_key().map_err(|e| e.into())
+        let result = rpc
+            .generate_wireguard_key()
+            .map_err(|e| crate::Error::RpcClientError(e))?;
+        println!("{}", result);
+        Ok(())
     }
 
     fn handle_ipv6_cmd(matches: &clap::ArgMatches<'_>) -> Result<()> {

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -32,6 +32,8 @@ uuid = { version = "0.7", features = ["v4"] }
 lazy_static = "1.0"
 rand = "0.6"
 tokio-core = "0.1"
+tokio-retry = "0.2"
+jsonrpc-client-core = "0.5"
 tokio-timer = "0.1"
 regex = "1.0"
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -56,6 +56,8 @@ use talpid_types::{
     tunnel::{BlockReason, TunnelStateTransition},
     ErrorExt,
 };
+#[path = "wireguard.rs"]
+mod key_pusher;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -1,0 +1,234 @@
+use crate::InternalDaemonEvent;
+use futures::{future::Executor, sync::oneshot, Async, Future, Poll};
+use jsonrpc_client_core::Error as JsonRpcError;
+use mullvad_types::{account::AccountToken, wireguard::WireguardData};
+use std::{sync::mpsc, time::Duration};
+pub use talpid_types::net::wireguard::*;
+use talpid_types::ErrorExt;
+use tokio_core::reactor::Remote;
+use tokio_retry::{
+    strategy::{jitter, ExponentialBackoff},
+    RetryIf,
+};
+
+const TOO_MANY_KEYS_ERROR_CODE: i64 = -703;
+
+
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    #[error(display = "Failed to generate private key")]
+    GenerationError(#[error(cause)] rand::Error),
+    #[error(display = "Failed to spawn future")]
+    ExectuionError,
+    #[error(display = "Unexpected RPC error")]
+    RpcError(#[error(cause)] jsonrpc_client_core::Error),
+    #[error(display = "Account already has maximum number of keys")]
+    TooManyKeys,
+}
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+pub struct KeyManager {
+    daemon_tx: mpsc::Sender<InternalDaemonEvent>,
+    http_handle: mullvad_rpc::HttpHandle,
+    tokio_remote: Remote,
+    current_job: Option<CancelHandle>,
+}
+
+impl KeyManager {
+    pub(crate) fn new(
+        daemon_tx: mpsc::Sender<InternalDaemonEvent>,
+        http_handle: mullvad_rpc::HttpHandle,
+        tokio_remote: Remote,
+    ) -> Self {
+        Self {
+            daemon_tx,
+            http_handle,
+            tokio_remote,
+            current_job: None,
+        }
+    }
+
+    /// Stop current key generation
+    pub fn reset(&mut self) {
+        if let Some(job) = self.current_job.take() {
+            job.cancel()
+        }
+    }
+
+    /// Generate a new private key
+    pub fn generate_key_sync(&mut self, account: AccountToken) -> Result<WireguardData> {
+        self.reset();
+        let private_key = PrivateKey::new_from_random().map_err(Error::GenerationError)?;
+        let (tx, rx) = oneshot::channel();
+        let fut = self.push_future_generator(account, private_key)().then(|result| {
+            let _ = tx.send(result);
+            Ok(())
+        });
+        self.tokio_remote
+            .execute(fut)
+            .map_err(|_e| Error::ExectuionError)?;
+
+        rx.wait()
+            .map_err(|_| Error::ExectuionError)?
+            .map_err(Self::map_rpc_error)
+    }
+
+
+    /// Generate a new private key asyncronously. The new keys will be sent to the daemon channel.
+    pub fn generate_key_async(&mut self, account: AccountToken) -> Result<()> {
+        self.reset();
+        let private_key = PrivateKey::new_from_random().map_err(Error::GenerationError)?;
+        let future_generator = self.push_future_generator(account.clone(), private_key);
+
+        let retry_strategy = ExponentialBackoff::from_millis(300)
+            .max_delay(Duration::from_secs(60 * 60))
+            .map(jitter);
+
+        let should_retry = |err: &jsonrpc_client_core::Error| -> bool {
+            match err.kind() {
+                jsonrpc_client_core::ErrorKind::JsonRpcError(err)
+                    if err.code.code() == TOO_MANY_KEYS_ERROR_CODE =>
+                {
+                    false
+                }
+                _ => true,
+            }
+        };
+
+        let upload_future =
+            RetryIf::spawn(retry_strategy, future_generator, should_retry).map_err(move |err| {
+                match err {
+                    // This should really be unreachable, since the retry strategy is infinite.
+                    tokio_retry::Error::OperationError(e) => {
+                        log::error!(
+                            "{}",
+                            e.display_chain_with_msg("Failed to generate wireguard key:")
+                        );
+                        Self::map_rpc_error(e)
+                    }
+                    tokio_retry::Error::TimerError(timer_error) => {
+                        log::error!("Tokio timer error {}", timer_error);
+                        Error::ExectuionError
+                    }
+                }
+            });
+
+
+        let (fut, cancel_handle) = Cancellable::new(upload_future);
+        let daemon_tx = self.daemon_tx.clone();
+        let fut = fut.then(move |result| {
+            match result {
+                Ok(wireguard_data) => {
+                    let _ = daemon_tx.send(InternalDaemonEvent::WgKeyEvent((
+                        account,
+                        Ok(wireguard_data),
+                    )));
+                }
+                Err(CancelErr::Inner(e)) => {
+                    let _ = daemon_tx.send(InternalDaemonEvent::WgKeyEvent((account, Err(e))));
+                }
+                Err(CancelErr::Cancelled) => {
+                    log::error!("Key generation cancelled");
+                }
+            };
+            Ok(())
+        });
+
+        match self
+            .tokio_remote
+            .execute(fut)
+            .map_err(|_| Error::ExectuionError)
+        {
+            Ok(res) => {
+                self.current_job = Some(cancel_handle);
+                Ok(res)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+
+    fn push_future_generator(
+        &self,
+        account: AccountToken,
+        private_key: PrivateKey,
+    ) -> Box<dyn FnMut() -> Box<dyn Future<Item = WireguardData, Error = JsonRpcError> + Send> + Send>
+    {
+        let mut rpc = mullvad_rpc::WireguardKeyProxy::new(self.http_handle.clone());
+        let public_key = private_key.public_key();
+
+        let push_future =
+            move || -> Box<dyn Future<Item = WireguardData, Error = JsonRpcError> + Send> {
+                let key = private_key.clone();
+                Box::new(rpc.push_wg_key(account.clone(), public_key.clone()).map(
+                    move |addresses| WireguardData {
+                        private_key: key,
+                        addresses,
+                    },
+                ))
+            };
+        Box::new(push_future)
+    }
+
+    fn map_rpc_error(err: jsonrpc_client_core::Error) -> Error {
+        match err.kind() {
+            // TODO: Consider handling the invalid account case too.
+            jsonrpc_client_core::ErrorKind::JsonRpcError(err) if err.code.code() == -703 => {
+                Error::TooManyKeys
+            }
+            _ => Error::RpcError(err),
+        }
+    }
+}
+
+pub enum CancelErr<E> {
+    Cancelled,
+    Inner(E),
+}
+
+pub struct Cancellable<T, E, F: Future<Item = T, Error = E>> {
+    rx: oneshot::Receiver<()>,
+    f: F,
+}
+
+pub struct CancelHandle {
+    tx: oneshot::Sender<()>,
+}
+
+impl CancelHandle {
+    fn cancel(self) {
+        let _ = self.tx.send(());
+    }
+}
+
+
+impl<T, E, F> Cancellable<T, E, F>
+where
+    F: Future<Item = T, Error = E>,
+{
+    fn new(f: F) -> (Self, CancelHandle) {
+        let (tx, rx) = oneshot::channel();
+        (Self { f, rx }, CancelHandle { tx })
+    }
+}
+
+impl<T, E, F> Future for Cancellable<T, E, F>
+where
+    F: Future<Item = T, Error = E>,
+{
+    type Item = T;
+    type Error = CancelErr<E>;
+
+    fn poll(&mut self) -> Poll<T, CancelErr<E>> {
+        match self.rx.poll() {
+            Ok(Async::Ready(_)) | Err(_) => return Err(CancelErr::Cancelled),
+            Ok(Async::NotReady) => (),
+        };
+
+        match self.f.poll() {
+            Ok(v) => Ok(v),
+            Err(e) => Err(CancelErr::Inner(e)),
+        }
+    }
+}

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -159,7 +159,7 @@ impl DaemonRpcClient {
         self.call("get_settings", &NO_ARGS)
     }
 
-    pub fn generate_wireguard_key(&mut self) -> Result<()> {
+    pub fn generate_wireguard_key(&mut self) -> Result<mullvad_types::wireguard::KeygenEvent> {
         self.call("generate_wireguard_key", &NO_ARGS)
     }
 

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -2,7 +2,7 @@ use futures::{sync::oneshot, Future};
 use mullvad_daemon::{DaemonCommandSender, ManagementCommand};
 use mullvad_types::{
     account::AccountData, location::GeoIpLocation, relay_constraints::RelaySettingsUpdate,
-    relay_list::RelayList, settings::Settings, states::TargetState,
+    relay_list::RelayList, settings::Settings, states::TargetState, wireguard::KeygenEvent,
 };
 use parking_lot::Mutex;
 use talpid_types::{net::wireguard, tunnel::TunnelStateTransition};
@@ -64,14 +64,12 @@ impl DaemonInterface {
         Ok(())
     }
 
-    pub fn generate_wireguard_key(&self) -> Result<()> {
+    pub fn generate_wireguard_key(&self) -> Result<KeygenEvent> {
         let (tx, rx) = oneshot::channel();
 
         self.send_command(ManagementCommand::GenerateWireguardKey(tx))?;
 
-        rx.wait()
-            .map_err(|_| Error::NoResponse)?
-            .map_err(Error::RpcError)
+        rx.wait().map_err(|_| Error::NoResponse)
     }
 
     pub fn get_account_data(&self, account_token: String) -> Result<AccountData> {

--- a/mullvad-jni/src/jni_event_listener.rs
+++ b/mullvad-jni/src/jni_event_listener.rs
@@ -5,7 +5,7 @@ use jni::{
     AttachGuard, JNIEnv,
 };
 use mullvad_daemon::EventListener;
-use mullvad_types::{relay_list::RelayList, settings::Settings};
+use mullvad_types::{relay_list::RelayList, settings::Settings, wireguard::KeygenEvent};
 use std::{sync::mpsc, thread};
 use talpid_types::{tunnel::TunnelStateTransition, ErrorExt};
 
@@ -48,6 +48,9 @@ impl EventListener for JniEventListener {
     fn notify_relay_list(&self, relay_list: RelayList) {
         let _ = self.0.send(Event::RelayList(relay_list));
     }
+
+    // TODO: manage key events properly
+    fn notify_key_event(&self, _key_event: KeygenEvent) {}
 }
 
 struct JniEventHandler<'env> {

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -34,4 +34,7 @@ pub enum DaemonEvent {
 
     /// The daemon got an updated relay list.
     RelayList(relay_list::RelayList),
+
+    /// Key event
+    WireguardKey(wireguard::KeygenEvent),
 }

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use talpid_types::net::wireguard;
 
 /// Contains account specific wireguard data
@@ -14,4 +15,23 @@ pub struct WireguardData {
 pub struct AssociatedAddresses {
     pub ipv4_address: ipnetwork::Ipv4Network,
     pub ipv6_address: ipnetwork::Ipv6Network,
+}
+
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Event that is emitted when the daemon has finished generating a key.
+pub enum KeygenEvent {
+    NewKey(wireguard::PublicKey),
+    TooManyKeys,
+    GenerationFailure,
+}
+
+impl fmt::Display for KeygenEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            KeygenEvent::NewKey(public_key) => write!(f, "New wireguard key {}", public_key),
+            KeygenEvent::TooManyKeys => write!(f, "Account has too many keys already"),
+            KeygenEvent::GenerationFailure => write!(f, "Failed to generate new wireguard key"),
+        }
+    }
 }


### PR DESCRIPTION
This PR changes the daemon to generate wireguard keys automatically in case the currently selected account does not have a key. A key will be generated and the daemon will repeatedly attempt to publish it to our API until it fails because the account already has enough keys or it succeeds. In any case, the daemon then publishes a key event signalling whether the key generation was a success or not to all the daemon event subscribers. 
Since the API can fail in distinct ways, the CLI is also updated to display the key generation result somewhat more appropriately.
As far as the GUI goes, I've only updated the schema so that a key event wouldn't crash it. But further integration will come soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/941)
<!-- Reviewable:end -->
