### PR TITLE
Fix `JniEventListener` crash after running for a while

### DIFF
--- a/mullvad-jni/src/jni_event_listener.rs
+++ b/mullvad-jni/src/jni_event_listener.rs
@@ -167,11 +167,13 @@ impl<'env> JniEventHandler<'env> {
     }
 
     fn handle_settings(&self, settings: Settings) {
+        let java_settings = self.env.auto_local(settings.into_java(&self.env));
+
         let result = self.env.call_method_unchecked(
             self.mullvad_ipc_client,
             self.notify_settings_event,
             JavaType::Primitive(Primitive::Void),
-            &[JValue::Object(settings.into_java(&self.env))],
+            &[JValue::Object(java_settings.as_obj())],
         );
 
         if let Err(error) = result {

--- a/mullvad-jni/src/jni_event_listener.rs
+++ b/mullvad-jni/src/jni_event_listener.rs
@@ -185,11 +185,13 @@ impl<'env> JniEventHandler<'env> {
     }
 
     fn handle_tunnel_event(&self, event: TunnelStateTransition) {
+        let java_tunnel_state_transition = self.env.auto_local(event.into_java(&self.env));
+
         let result = self.env.call_method_unchecked(
             self.mullvad_ipc_client,
             self.notify_tunnel_event,
             JavaType::Primitive(Primitive::Void),
-            &[JValue::Object(event.into_java(&self.env))],
+            &[JValue::Object(java_tunnel_state_transition.as_obj())],
         );
 
         if let Err(error) = result {

--- a/mullvad-jni/src/jni_event_listener.rs
+++ b/mullvad-jni/src/jni_event_listener.rs
@@ -149,11 +149,13 @@ impl<'env> JniEventHandler<'env> {
     }
 
     fn handle_relay_list_event(&self, relay_list: RelayList) {
+        let java_relay_list = self.env.auto_local(relay_list.into_java(&self.env));
+
         let result = self.env.call_method_unchecked(
             self.mullvad_ipc_client,
             self.notify_relay_list_event,
             JavaType::Primitive(Primitive::Void),
-            &[JValue::Object(relay_list.into_java(&self.env))],
+            &[JValue::Object(java_relay_list.as_obj())],
         );
 
         if let Err(error) = result {

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -33,6 +33,7 @@ const LOG_FILENAME: &str = "daemon.log";
 const CLASSES_TO_LOAD: &[&str] = &[
     "java/net/InetAddress",
     "java/util/ArrayList",
+    "java/util/List",
     "net/mullvad/mullvadvpn/model/AccountData",
     "net/mullvad/mullvadvpn/model/Constraint$Any",
     "net/mullvad/mullvadvpn/model/Constraint$Only",


### PR DESCRIPTION
This PR removes Java local reference leaks that would eventually lead to a full local reference frame, causing the thread to crash. There were basically two types of leaks:

1. Leaking of objects created and sent to the `MullvadDaemon` instance listener methods;
2. Leaking of `Class` instances when creating `jni::objects::JList`.

The first cause was fixed by wrapping the objects in an `AutoLocal` before sending them to the `MullvadDaemon` object.

The second cause is actually inside the `jni` crate, so a pull request was opened upstream ([#190](https://github.com/jni-rs/jni-rs/pull/190)). Until the fix is integrated and a new version released, this PR
works around the issue by not using `JList`.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/944)
<!-- Reviewable:end -->
