### PR TITLE
Refactor connection panel into container

### DIFF
--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -1,10 +1,45 @@
 import * as React from 'react';
 import { Component, Styles, Text, Types, View } from 'reactxp';
 import { sprintf } from 'sprintf-js';
-import { proxyTypeToString, TunnelType, tunnelTypeToString } from '../../shared/daemon-rpc-types';
+import {
+  ProxyType,
+  proxyTypeToString,
+  RelayProtocol,
+  TunnelType,
+  tunnelTypeToString,
+} from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
-import { default as ConnectionInfoDisclosure } from './ConnectionInfoDisclosure';
-import { IBridgeData } from './TunnelControl';
+import { default as ConnectionPanelDisclosure } from '../components/ConnectionPanelDisclosure';
+
+export interface IEndpoint {
+  ip: string;
+  port: number;
+  protocol: RelayProtocol;
+}
+
+export interface IInAddress extends IEndpoint {
+  tunnelType: TunnelType;
+}
+
+export interface IBridgeData extends IEndpoint {
+  bridgeType: ProxyType;
+}
+
+export interface IOutAddress {
+  ipv4?: string;
+  ipv6?: string;
+}
+
+interface IProps {
+  isOpen: boolean;
+  hostname?: string;
+  bridgeHostname?: string;
+  inAddress?: IInAddress;
+  bridgeInfo?: IBridgeData;
+  outAddress?: IOutAddress;
+  onToggle: () => void;
+  style?: Types.ViewStyleRuleSet | Types.ViewStyleRuleSet[];
+}
 
 const styles = {
   row: Styles.createViewStyle({
@@ -32,42 +67,7 @@ const styles = {
   }),
 };
 
-interface IInAddress {
-  ip: string;
-  port: number;
-  protocol: string;
-  tunnelType: TunnelType;
-}
-
-interface IOutAddress {
-  ipv4?: string;
-  ipv6?: string;
-}
-
-interface IProps {
-  hostname?: string;
-  bridgeHostname?: string;
-  inAddress?: IInAddress;
-  bridgeInfo?: IBridgeData;
-  outAddress?: IOutAddress;
-  defaultOpen?: boolean;
-  style?: Types.ViewStyleRuleSet | Types.ViewStyleRuleSet[];
-  onToggle?: (isOpen: boolean) => void;
-}
-
-interface IState {
-  isOpen: boolean;
-}
-
-export default class ConnectionInfo extends Component<IProps, IState> {
-  constructor(props: IProps) {
-    super(props);
-
-    this.state = {
-      isOpen: props.defaultOpen === true,
-    };
-  }
-
+export default class ConnectionPanel extends Component<IProps> {
   public render() {
     const { inAddress, outAddress, bridgeInfo } = this.props;
     const entryPoint = bridgeInfo && inAddress ? bridgeInfo : inAddress;
@@ -76,13 +76,13 @@ export default class ConnectionInfo extends Component<IProps, IState> {
       <View style={this.props.style}>
         {this.props.hostname && (
           <View style={styles.header}>
-            <ConnectionInfoDisclosure defaultOpen={this.props.defaultOpen} onToggle={this.onToggle}>
+            <ConnectionPanelDisclosure pointsUp={this.props.isOpen} onToggle={this.props.onToggle}>
               {this.hostnameLine()}
-            </ConnectionInfoDisclosure>
+            </ConnectionPanelDisclosure>
           </View>
         )}
 
-        {this.state.isOpen && this.props.hostname && (
+        {this.props.isOpen && this.props.hostname && (
           <React.Fragment>
             {this.props.inAddress && (
               <View style={styles.row}>
@@ -159,15 +159,4 @@ export default class ConnectionInfo extends Component<IProps, IState> {
       return '';
     }
   }
-
-  private onToggle = (isOpen: boolean) => {
-    this.setState(
-      (state) => ({ ...state, isOpen }),
-      () => {
-        if (this.props.onToggle) {
-          this.props.onToggle(isOpen);
-        }
-      },
-    );
-  };
 }

--- a/gui/src/renderer/components/ConnectionPanelDisclosure.tsx
+++ b/gui/src/renderer/components/ConnectionPanelDisclosure.tsx
@@ -22,41 +22,39 @@ const styles = {
 };
 
 interface IProps {
-  onToggle?: (isOpen: boolean) => void;
-  defaultOpen?: boolean;
+  pointsUp: boolean;
+  onToggle?: () => void;
   children: React.ReactText;
   style?: Types.ViewStyleRuleSet | Types.ViewStyleRuleSet[];
 }
 
 interface IState {
   isHovered: boolean;
-  isOpen: boolean;
 }
 
-export default class ConnectionInfoDisclosure extends Component<IProps, IState> {
+export default class ConnectionPanelDisclosure extends Component<IProps, IState> {
   constructor(props: IProps) {
     super(props);
 
     this.state = {
       isHovered: false,
-      isOpen: props.defaultOpen === true,
     };
   }
 
   public render() {
     const tintColor = this.state.isHovered ? 'rgb(255, 255, 255)' : 'rgb(255, 255, 255, 0.4)';
     const textHoverStyle =
-      this.state.isOpen || this.state.isHovered ? styles.caption.hovered : undefined;
+      this.props.pointsUp || this.state.isHovered ? styles.caption.hovered : undefined;
 
     return (
       <View
         style={[styles.container, this.props.style]}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
-        onPress={this.onToggle}>
+        onPress={this.props.onToggle}>
         <Text style={[styles.caption.base, textHoverStyle]}>{this.props.children}</Text>
         <ImageView
-          source={this.state.isOpen ? 'icon-chevron-up' : 'icon-chevron-down'}
+          source={this.props.pointsUp ? 'icon-chevron-up' : 'icon-chevron-down'}
           width={24}
           height={24}
           tintColor={tintColor}
@@ -71,19 +69,5 @@ export default class ConnectionInfoDisclosure extends Component<IProps, IState> 
 
   private onMouseLeave = () => {
     this.setState({ isHovered: false });
-  };
-
-  private onToggle = () => {
-    this.setState(
-      (state) => ({
-        ...state,
-        isOpen: !state.isOpen,
-      }),
-      () => {
-        if (this.props.onToggle) {
-          this.props.onToggle(this.state.isOpen);
-        }
-      },
-    );
   };
 }

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -1,51 +1,20 @@
 import * as React from 'react';
 import { Component, Styles, Text, Types, View } from 'reactxp';
 import { colors } from '../../config.json';
-import {
-  ProxyType,
-  RelayProtocol,
-  TunnelStateTransition,
-  TunnelType,
-} from '../../shared/daemon-rpc-types';
+import { TunnelStateTransition } from '../../shared/daemon-rpc-types';
 import { cities, countries, messages, relayLocations } from '../../shared/gettext';
+import ConnectionPanelContainer from '../containers/ConnectionPanelContainer';
 import * as AppButton from './AppButton';
-import ConnectionInfo from './ConnectionInfo';
 import SecuredLabel, { SecuredDisplayStyle } from './SecuredLabel';
-
-export interface IEndpoint {
-  ip: string;
-  port: number;
-  protocol: RelayProtocol;
-}
-
-export interface IRelayInAddress extends IEndpoint {
-  tunnelType: TunnelType;
-}
-
-export interface IBridgeData extends IEndpoint {
-  bridgeType: ProxyType;
-}
-
-export interface IRelayOutAddress {
-  ipv4?: string;
-  ipv6?: string;
-}
 
 interface ITunnelControlProps {
   tunnelState: TunnelStateTransition;
   selectedRelayName: string;
   city?: string;
   country?: string;
-  hostname?: string;
-  defaultConnectionInfoOpen?: boolean;
-  relayInAddress?: IRelayInAddress;
-  relayOutAddress?: IRelayOutAddress;
-  bridge?: IBridgeData;
-  bridgeHostname?: string;
   onConnect: () => void;
   onDisconnect: () => void;
   onSelectLocation: () => void;
-  onToggleConnectionInfo: (value: boolean) => void;
 }
 
 const styles = {
@@ -157,18 +126,6 @@ export default class TunnelControl extends Component<ITunnelControlProps> {
       <View style={styles.footer}>{children}</View>
     );
 
-    const connectionDetails = (
-      <ConnectionInfo
-        hostname={this.props.hostname}
-        bridgeHostname={this.props.bridgeHostname}
-        inAddress={this.props.relayInAddress}
-        bridgeInfo={this.props.bridge}
-        outAddress={this.props.relayOutAddress}
-        defaultOpen={this.props.defaultConnectionInfoOpen}
-        onToggle={this.props.onToggleConnectionInfo}
-      />
-    );
-
     let state = this.props.tunnelState.state;
 
     switch (this.props.tunnelState.state) {
@@ -208,7 +165,7 @@ export default class TunnelControl extends Component<ITunnelControlProps> {
                 <City />
                 <Country />
               </Location>
-              {connectionDetails}
+              <ConnectionPanelContainer />
             </Body>
             <Footer>
               <SwitchLocation />
@@ -225,7 +182,7 @@ export default class TunnelControl extends Component<ITunnelControlProps> {
                 <City />
                 <Country />
               </Location>
-              {connectionDetails}
+              <ConnectionPanelContainer />
             </Body>
             <Footer>
               <SwitchLocation />

--- a/gui/src/renderer/containers/ConnectPage.tsx
+++ b/gui/src/renderer/containers/ConnectPage.tsx
@@ -11,12 +11,9 @@ import {
 } from '../../shared/gettext';
 import Connect from '../components/Connect';
 import AccountExpiry from '../lib/account-expiry';
-import userInterfaceActions from '../redux/userinterface/actions';
-
+import { IRelayLocationRedux, RelaySettingsRedux } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 import { ISharedRouteProps } from '../routes';
-
-import { IRelayLocationRedux, RelaySettingsRedux } from '../redux/settings/reducers';
 
 function getRelayName(
   relaySettings: RelaySettingsRedux,
@@ -79,19 +76,14 @@ const mapStateToProps = (state: IReduxState, props: ISharedRouteProps) => {
     selectedRelayName: getRelayName(state.settings.relaySettings, state.settings.relayLocations),
     connection: state.connection,
     version: state.version,
-    connectionInfoOpen: state.userInterface.connectionInfoOpen,
     blockWhenDisconnected: state.settings.blockWhenDisconnected,
   };
 };
 
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
-  const userInterface = bindActionCreators(userInterfaceActions, dispatch);
   const history = bindActionCreators({ push }, dispatch);
 
   return {
-    onToggleConnectionInfo: (isOpen: boolean) => {
-      userInterface.updateConnectionInfoOpen(isOpen);
-    },
     onSettings: () => {
       history.push('/settings');
     },

--- a/gui/src/renderer/containers/ConnectionPanelContainer.tsx
+++ b/gui/src/renderer/containers/ConnectionPanelContainer.tsx
@@ -1,0 +1,75 @@
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { ITunnelEndpoint, parseSocketAddress } from '../../shared/daemon-rpc-types';
+import ConnectionPanel, {
+  IBridgeData,
+  IInAddress,
+  IOutAddress,
+} from '../components/ConnectionPanel';
+import { IReduxState, ReduxDispatch } from '../redux/store';
+import userInterfaceActions from '../redux/userinterface/actions';
+
+function tunnelEndpointToRelayInAddress(tunnelEndpoint: ITunnelEndpoint): IInAddress {
+  const socketAddr = parseSocketAddress(tunnelEndpoint.address);
+  return {
+    ip: socketAddr.host,
+    port: socketAddr.port,
+    protocol: tunnelEndpoint.protocol,
+    tunnelType: tunnelEndpoint.tunnelType,
+  };
+}
+
+function tunnelEndpointToBridgeData(endpoint: ITunnelEndpoint): IBridgeData | undefined {
+  if (!endpoint.proxy) {
+    return undefined;
+  }
+
+  const socketAddr = parseSocketAddress(endpoint.proxy.address);
+  return {
+    ip: socketAddr.host,
+    port: socketAddr.port,
+    protocol: endpoint.proxy.protocol,
+    bridgeType: endpoint.proxy.proxyType,
+  };
+}
+
+const mapStateToProps = (state: IReduxState) => {
+  const status = state.connection.status;
+
+  const outAddress: IOutAddress = {
+    ipv4: state.connection.ipv4,
+    ipv6: state.connection.ipv6,
+  };
+
+  const inAddress: IInAddress | undefined =
+    (status.state === 'connecting' || status.state === 'connected') && status.details
+      ? tunnelEndpointToRelayInAddress(status.details)
+      : undefined;
+
+  const bridgeInfo: IBridgeData | undefined =
+    (status.state === 'connecting' || status.state === 'connected') && status.details
+      ? tunnelEndpointToBridgeData(status.details)
+      : undefined;
+
+  return {
+    isOpen: state.userInterface.connectionPanelVisible,
+    hostname: state.connection.hostname,
+    bridgeHostname: state.connection.bridgeHostname,
+    inAddress,
+    bridgeInfo,
+    outAddress,
+  };
+};
+
+const mapDispatchToProps = (dispatch: ReduxDispatch) => {
+  const userInterface = bindActionCreators(userInterfaceActions, dispatch);
+
+  return {
+    onToggle: userInterface.toggleConnectionPanel,
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ConnectionPanel);

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -4,8 +4,7 @@ export interface IUpdateWindowArrowPositionAction {
 }
 
 export interface IUpdateConnectionInfoOpenAction {
-  type: 'UPDATE_CONNECTION_INFO_OPEN';
-  isOpen: boolean;
+  type: 'TOGGLE_CONNECTION_PANEL';
 }
 
 export type UserInterfaceAction =
@@ -19,11 +18,10 @@ function updateWindowArrowPosition(arrowPosition: number): IUpdateWindowArrowPos
   };
 }
 
-function updateConnectionInfoOpen(isOpen: boolean): IUpdateConnectionInfoOpenAction {
+function toggleConnectionPanel(): IUpdateConnectionInfoOpenAction {
   return {
-    type: 'UPDATE_CONNECTION_INFO_OPEN',
-    isOpen,
+    type: 'TOGGLE_CONNECTION_PANEL',
   };
 }
 
-export default { updateWindowArrowPosition, updateConnectionInfoOpen };
+export default { updateWindowArrowPosition, toggleConnectionPanel };

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -2,11 +2,11 @@ import { ReduxAction } from '../store';
 
 export interface IUserInterfaceReduxState {
   arrowPosition?: number;
-  connectionInfoOpen: boolean;
+  connectionPanelVisible: boolean;
 }
 
 const initialState: IUserInterfaceReduxState = {
-  connectionInfoOpen: false,
+  connectionPanelVisible: false,
 };
 
 export default function(
@@ -17,8 +17,8 @@ export default function(
     case 'UPDATE_WINDOW_ARROW_POSITION':
       return { ...state, arrowPosition: action.arrowPosition };
 
-    case 'UPDATE_CONNECTION_INFO_OPEN':
-      return { ...state, connectionInfoOpen: action.isOpen };
+    case 'TOGGLE_CONNECTION_PANEL':
+      return { ...state, connectionPanelVisible: !state.connectionPanelVisible };
 
     default:
       return state;


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

A bit of tech debt was accumulated when more and more props were added to the React components. This PR refactors the `ConnectionInfo` into a container directly connected to Redux to avoid passing props all the way down from `Connect` -> `TunnelControl` -> `ConnectionInfo`. I think we should do the same with `TunnelControl` and `NotificationArea`. This would make the top level components less heavy on props.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/945)
<!-- Reviewable:end -->
