### PR TITLE
Use newer commit for netlink libraries

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -43,10 +43,10 @@ dbus = "0.6"
 failure = "0.1"
 notify = "4.0"
 resolv-conf = "0.6.1"
-rtnetlink = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
-netlink-proto = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
-netlink-packet = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
-netlink-sys = { git = "https://github.com/mullvad/netlink", rev = "e629e58797c2d14d7f4777c4ade0d85ee0167027" }
+rtnetlink = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
+netlink-proto = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
+netlink-packet = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
+netlink-sys = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
 nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "86b30cdc38a6d4b30a900c21f7c644857d6f7401", features = ["nftnl-1-1-0"] }
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"


### PR DESCRIPTION
I've added another commit to our changes to the netlink library to further remove kernel structs.
https://github.com/mullvad/netlink/commit/b367ac9c012e6c2a5e065e201384ec20d9708109

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/950)
<!-- Reviewable:end -->
