### PR TITLE
Update wireguard-go to  v0.0.20190518

### DIFF
--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -136,6 +136,7 @@ extern "C" {
     //
     // Positive return values are tunnel handles for this specific wireguard tunnel instance.
     // Negative return values signify errors. All error codes are opaque.
+    #[cfg_attr(target_os = "android", link_name = "wgTurnOnWithFdAndroid")]
     fn wgTurnOnWithFd(
         iface_name: *const i8,
         mtu: i64,


### PR DESCRIPTION
Updating wireguard-go to `v0.0.20190518` and adjusting `talpid-core` to link a different function for Android.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/951)
<!-- Reviewable:end -->
