### PR TITLE
Use relay location included in tunnel state broadcast on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -36,7 +36,7 @@ class ConnectionProxy(val parentActivity: MainActivity) {
     var onUiStateChange: ((TunnelState) -> Unit)? = null
 
     fun connect() {
-        uiState = TunnelState.Connecting()
+        uiState = TunnelState.Connecting(null)
 
         cancelActiveAction()
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -33,8 +33,11 @@ class LocationInfoCache(val daemon: Deferred<MullvadDaemon>) {
 
             when (value) {
                 is TunnelState.Disconnected -> fetchLocation()
-                is TunnelState.Connecting -> fetchLocation()
-                is TunnelState.Connected -> fetchLocation()
+                is TunnelState.Connecting -> location = value.location
+                is TunnelState.Connected -> {
+                    location = value.location
+                    fetchLocation()
+                }
                 is TunnelState.Disconnecting -> location = lastKnownRealLocation
                 is TunnelState.Blocked -> location = null
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
@@ -2,8 +2,8 @@ package net.mullvad.mullvadvpn.model
 
 sealed class TunnelState() {
     class Disconnected() : TunnelState()
-    class Connecting() : TunnelState()
-    class Connected() : TunnelState()
+    class Connecting(val location: GeoIpLocation?) : TunnelState()
+    class Connected(val location: GeoIpLocation) : TunnelState()
     class Disconnecting() : TunnelState()
     class Blocked() : TunnelState()
 }


### PR DESCRIPTION
This PR changes the `LocationInfoCache` to use the relay location that's included in the tunnel state change event when possible. This removes the location fetch when the app is in the `connecting` state, and anticipates the location when in the `connected` state. However, in the `connected` state the relay out address isn't available, so the fetch has to be kept.

The `TunnelState.Connecting` class representation allows the location to be `null`. This is similar to the desktop UI, because when anticipating a state change without waiting for the appropriate event to arrive, there is no relay information yet.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/953)
<!-- Reviewable:end -->
