### PR TITLE
Fix a bug in the notifications configuration loading

### DIFF
--- a/gui/src/main/gui-settings.ts
+++ b/gui/src/main/gui-settings.ts
@@ -60,7 +60,7 @@ export default class GuiSettings {
       this.stateValue.autoConnect =
         typeof settings.autoConnect === 'boolean' ? settings.autoConnect : true;
       this.stateValue.enableSystemNotifications =
-        settings.enableSystemNotifications === 'boolean'
+        typeof settings.enableSystemNotifications === 'boolean'
           ? settings.enableSystemNotifications
           : true;
       this.stateValue.monochromaticIcon = settings.monochromaticIcon || false;


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Seems like I've omitted the `typeof` keyword which caused the notification setting being reset on each launch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/954)
<!-- Reviewable:end -->
