### PR TITLE
Make relay location parameter in tunnel state broadcast optional

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.model
 sealed class TunnelState() {
     class Disconnected() : TunnelState()
     class Connecting(val location: GeoIpLocation?) : TunnelState()
-    class Connected(val location: GeoIpLocation) : TunnelState()
+    class Connected(val location: GeoIpLocation?) : TunnelState()
     class Disconnecting() : TunnelState()
     class Blocked() : TunnelState()
 }

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -250,7 +250,7 @@ const tunnelStateSchema = oneOf(
           }),
         ),
       }),
-      location: locationSchema,
+      location: maybe(locationSchema),
     }),
   }),
   object({

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -729,7 +729,7 @@ class ApplicationMain {
     if (tunnelState.state === 'connected' || tunnelState.state === 'connecting') {
       // Location was broadcasted with the tunnel state, but it doesn't contain the relay out IP
       // address, so it will have to be fetched afterwards
-      if (tunnelState.details) {
+      if (tunnelState.details && tunnelState.details.location) {
         this.setLocation(tunnelState.details.location);
       }
     } else if (tunnelState.state === 'disconnected') {

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -77,7 +77,7 @@ export type DaemonEvent =
 
 export interface ITunnelStateRelayInfo {
   endpoint: ITunnelEndpoint;
-  location: ILocation;
+  location?: ILocation;
 }
 
 export type TunnelState =

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -790,11 +790,7 @@ where
             match &self.tunnel_state {
                 Disconnected => Box::new(self.get_geo_location().map(Some)),
                 Connecting { location, .. } => Box::new(future::result(Ok(location.clone()))),
-                Disconnecting(..) => match self.build_location_from_relay() {
-                    Some(relay_location) => Box::new(future::result(Ok(Some(relay_location)))),
-                    // Custom relay is set, no location is known
-                    None => Box::new(future::result(Ok(None))),
-                },
+                Disconnecting(..) => Box::new(future::result(Ok(self.build_location_from_relay()))),
                 Connected { location, .. } => {
                     let relay_location = location.clone();
                     Box::new(

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -23,11 +23,11 @@ pub enum TunnelState {
     Disconnected,
     Connecting {
         endpoint: TunnelEndpoint,
-        location: GeoIpLocation,
+        location: Option<GeoIpLocation>,
     },
     Connected {
         endpoint: TunnelEndpoint,
-        location: GeoIpLocation,
+        location: Option<GeoIpLocation>,
     },
     Disconnecting(ActionAfterDisconnect),
     Blocked(BlockReason),


### PR DESCRIPTION
This PR fixes a bug introduced in a recent PR, where using custom tunnels would cause the daemon to crash when broadcasting tunnel state changes. The daemon was assuming that there would always be a relay location set when reaching the `connecting` or `connected` states, but that's not true for custom tunnels.

The fix was to allow the relay location to be wrapped in an `Option` type, so that it may or may not be present. The code for the GUI was updated to handle the change.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/957)
<!-- Reviewable:end -->
