### PR TITLE
Add metadata parse test

### DIFF
--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -583,7 +583,7 @@ mod tests {
     }
 
     #[test]
-    fn test_does_not_redact_time() {
+    fn does_not_redact_time() {
         assert_does_not_redact("09:47:59");
     }
 
@@ -591,5 +591,36 @@ mod tests {
         let report = ProblemReport::new(vec![]);
         let res = report.redact(input);
         assert_eq!(input, res);
+    }
+
+    #[test]
+    fn parse_metadata() {
+        let report = ProblemReport::new(Vec::new());
+        let mut report_data = Vec::new();
+        report
+            .write_to(&mut report_data)
+            .expect("Unable to write report to vector");
+
+        let report_string = std::str::from_utf8(&report_data).expect("Report is not correct UTF-8");
+
+        let parsed_metadata = ProblemReport::parse_metadata(report_string)
+            .expect("Unable to parse metadata from report");
+        let expected_metadata = metadata::collect();
+
+        assert_eq!(parsed_metadata.len(), expected_metadata.len());
+        for (key, value) in &expected_metadata {
+            let parsed_value = parsed_metadata
+                .get(key)
+                .expect("Parsed metadata and new one don't match");
+            if key == "id" {
+                assert_ne!(parsed_value, value, "id not supposed to match");
+            } else {
+                assert_eq!(
+                    parsed_value, value,
+                    "value for key '{}' does not match",
+                    key
+                );
+            }
+        }
     }
 }

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 use std::{
     borrow::Cow,
     cmp::min,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     ffi::OsStr,
     fs::{self, File},
     io::{self, BufWriter, Read, Seek, SeekFrom, Write},
@@ -285,7 +285,7 @@ fn write_problem_report(path: &Path, problem_report: &ProblemReport) -> io::Resu
 
 #[derive(Debug)]
 struct ProblemReport {
-    metadata: HashMap<String, String>,
+    metadata: BTreeMap<String, String>,
     logs: Vec<(String, String)>,
     log_paths: HashSet<PathBuf>,
     redact_custom_strings: Vec<String>,
@@ -409,14 +409,14 @@ impl ProblemReport {
 
     /// Tries to parse out the metadata map from a string that is supposed to be a report written by
     /// this struct.
-    pub fn parse_metadata(report: &str) -> Option<HashMap<String, String>> {
+    pub fn parse_metadata(report: &str) -> Option<BTreeMap<String, String>> {
         // IMPORTANT: Make sure this implementation stays in sync with `write_to` above.
         const PATTERN: &str = ": ";
         let mut lines = report.lines();
         if lines.next() != Some("System information:") {
             return None;
         }
-        let mut metadata = HashMap::new();
+        let mut metadata = BTreeMap::new();
         for line in lines {
             // Abort on first empty line, as this is the separator between the metadata and the
             // first log

--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, process::Command};
+use std::{collections::BTreeMap, process::Command};
 
 
 pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 
-pub fn collect() -> HashMap<String, String> {
-    let mut metadata = HashMap::new();
+pub fn collect() -> BTreeMap<String, String> {
+    let mut metadata = BTreeMap::new();
     metadata.insert("id".to_owned(), uuid::Uuid::new_v4().to_string());
     metadata.insert(
         "mullvad-product-version".to_owned(),

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -13,7 +13,7 @@ use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_client_http::{header::Host, HttpTransport, HttpTransportBuilder};
 use mullvad_types::{account::AccountToken, relay_list::RelayList, version};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     net::{IpAddr, Ipv4Addr},
     path::{Path, PathBuf},
     time::Duration,
@@ -113,7 +113,7 @@ jsonrpc_client!(pub struct ProblemReportProxy {
         email: &str,
         message: &str,
         log: &str,
-        metadata: &HashMap<String, String>)
+        metadata: &BTreeMap<String, String>)
         -> RpcRequest<()>;
 });
 


### PR DESCRIPTION
Follow up to #960 from yesterday. Now adding a test making sure the parsing code works on a newly serialized version. And that the metadata collection seems idempotent, except for the `id` field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/961)
<!-- Reviewable:end -->
