### PR TITLE
Make symlinks in /usr/local/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Add migration logic to restore lost settings after major Windows update.
 
+#### macOS
+- Add the Mullvad CLI frontend and problem report CLI tool to the PATH, so it can be
+  run directly from a terminal.
+
 ### Fixed
 
 #### Windows

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -53,3 +53,7 @@ sleep 1
 launchctl unload -w $DAEMON_PLIST_PATH
 echo "$DAEMON_PLIST" > $DAEMON_PLIST_PATH
 launchctl load -w $DAEMON_PLIST_PATH
+
+mkdir -p /usr/local/bin
+ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad" /usr/local/bin/mullvad
+ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/problem-report" /usr/local/bin/mullvad-problem-report


### PR DESCRIPTION
Support asked if we can make the CLI easier to find. So not every guide have to start with how to find/run it. This PR solves that for macOS specifically. We create a symlink to our two CLI tools in `/usr/local/bin`. From what I have gathered online this path should be in all users default `PATH` *but* the directory itself might not exist. So we should hopefully be good if we try to create it and then add the symlinks.

I'll make sure to test this on an untouched macOS computer before merging. But can have it reviewed now.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/964)
<!-- Reviewable:end -->
