### PR TITLE
Add GUI page for managing WireGuard key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add a switch to turn off system notifications under Preferences in the GUI.
+- Add new settings page for generating and verifying wireguard keys.
 
 #### Windows
 - Add migration logic to restore lost settings after major Windows update.

--- a/gui/src/config.json
+++ b/gui/src/config.json
@@ -2,6 +2,7 @@
   "links": {
     "createAccount": "https://mullvad.net/account/create/",
     "purchase": "https://mullvad.net/account/login/",
+    "manageKeys": "https://mullvad.net/account/login/",
     "faq": "https://mullvad.net/faq/",
     "download": "https://mullvad.net/download/",
     "supportEmail": "support@mullvad.net"

--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -109,6 +109,16 @@ export default class NotificationController {
     });
   }
 
+  public notifyKeyGenerationFailed() {
+    const notification = new Notification({
+      title: this.notificationTitle,
+      body: messages.pgettext('notifications', 'Wireguard key generation failed'),
+      silent: true,
+      icon: this.notificationIcon,
+    });
+    this.scheduleNotification(notification);
+  }
+
   public cancelPendingNotifications() {
     for (const notification of this.pendingNotifications) {
       notification.close();

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -36,6 +36,7 @@ import {
   ILocation,
   IRelayList,
   ISettings,
+  KeygenEvent,
   RelaySettings,
   RelaySettingsUpdate,
   TunnelState,
@@ -152,6 +153,10 @@ export default class AppRenderer {
 
     IpcRendererEventChannel.wireguardKeys.listen((publicKey?: string) => {
       this.setWireguardPublicKey(publicKey);
+    });
+
+    IpcRendererEventChannel.wireguardKeys.listenKeygenEvents((event: KeygenEvent) => {
+      this.reduxActions.settings.setWireguardKeygenEvent(event);
     });
 
     // Request the initial state from the main process

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -41,6 +41,7 @@ interface IProps {
   setBlockWhenDisconnected: (value: boolean) => void;
   setOpenVpnMssfix: (value: number | undefined) => void;
   setRelayProtocolAndPort: (protocol?: RelayProtocol, port?: number) => void;
+  onViewWireguardKeys: () => void;
   onClose: () => void;
 }
 
@@ -255,6 +256,14 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                       },
                     )}
                   </Cell.Footer>
+                  <View>
+                    <Cell.CellButton onPress={this.props.onViewWireguardKeys}>
+                      <Cell.Label>
+                        {messages.pgettext('advanced-settings-view', 'WireGuard keys')}
+                      </Cell.Label>
+                      <Cell.Icon height={12} width={7} source="icon-chevron" />
+                    </Cell.CellButton>
+                  </View>
                 </NavigationScrollbars>
               </View>
             </NavigationContainer>

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -36,6 +36,7 @@ interface IProps {
   mssfix?: number;
   port?: number;
   bridgeState: BridgeState;
+  enableWireguardKeysPage: boolean;
   setBridgeState: (value: BridgeState) => void;
   setEnableIpv6: (value: boolean) => void;
   setBlockWhenDisconnected: (value: boolean) => void;
@@ -256,14 +257,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                       },
                     )}
                   </Cell.Footer>
-                  <View>
-                    <Cell.CellButton onPress={this.props.onViewWireguardKeys}>
-                      <Cell.Label>
-                        {messages.pgettext('advanced-settings-view', 'WireGuard keys')}
-                      </Cell.Label>
-                      <Cell.Icon height={12} width={7} source="icon-chevron" />
-                    </Cell.CellButton>
-                  </View>
+                  {this.wireguardKeysButton()}
                 </NavigationScrollbars>
               </View>
             </NavigationContainer>
@@ -271,6 +265,21 @@ export default class AdvancedSettings extends Component<IProps, IState> {
         </Container>
       </Layout>
     );
+  }
+
+  private wireguardKeysButton() {
+    if (this.props.enableWireguardKeysPage) {
+      return (
+        <View>
+          <Cell.CellButton onPress={this.props.onViewWireguardKeys}>
+            <Cell.Label>{messages.pgettext('advanced-settings-view', 'WireGuard keys')}</Cell.Label>
+            <Cell.Icon height={12} width={7} source="icon-chevron" />
+          </Cell.CellButton>
+        </View>
+      );
+    } else {
+      return null;
+    }
   }
 
   private onSelectProtocol = (protocol?: RelayProtocol) => {

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import { Component, Text, View } from 'reactxp';
+import { messages } from '../../shared/gettext';
+import { WgKeyState } from '../redux/settings/reducers';
+import * as AppButton from './AppButton';
+import ImageView from './ImageView';
+import { Container, Layout } from './Layout';
+import { BackBarItem, NavigationBar, NavigationContainer } from './NavigationBar';
+import SettingsHeader, { HeaderTitle } from './SettingsHeader';
+import styles from './WireguardKeysStyles';
+
+export interface IProps {
+  keyState: WgKeyState;
+  isOffline: boolean;
+
+  onGenerateKey: () => void;
+  onVerifyKey: (publicKey: string) => void;
+  onVisitWebsiteKey: () => void;
+  onClose: () => void;
+}
+
+export default class WireguardKeys extends Component<IProps> {
+  public render() {
+    return (
+      <Layout>
+        <Container>
+          <View>
+            <NavigationContainer>
+              <NavigationBar>
+                <BackBarItem action={this.props.onClose}>
+                  {// TRANSLATORS: Back button in navigation bar
+                  messages.pgettext('wireguard-keys-nav', 'Advanced')}
+                </BackBarItem>
+              </NavigationBar>
+            </NavigationContainer>
+
+            <View style={styles.wgkeys__container}>
+              <SettingsHeader>
+                <HeaderTitle>
+                  {messages.pgettext('wireguard-keys-nav', 'WireGuard keys')}
+                </HeaderTitle>
+              </SettingsHeader>
+
+              <View style={styles.wgkeys__row}>
+                <Text style={styles.wgkeys__row_label}>
+                  {messages.pgettext('wireguard-keys', 'Public key')}
+                </Text>
+                <View style={styles.wgkeys__row_value}>{this.getKeyRow()}</View>
+                <View style={styles.wgkeys__validity_row}>{this.keyValidityLabel()}</View>
+              </View>
+
+              <View style={styles.wgkeys__row}>{this.getActionButton()}</View>
+              <View style={styles.wgkeys__row}>
+                <AppButton.GreenButton
+                  disabled={this.props.isOffline}
+                  onPress={this.props.onVisitWebsiteKey}>
+                  <AppButton.Label>
+                    {messages.pgettext('wireguard-key-view', 'Manage keys in website')}
+                  </AppButton.Label>
+                  <AppButton.Icon source="icon-extLink" height={16} width={16} />
+                </AppButton.GreenButton>
+              </View>
+            </View>
+          </View>
+        </Container>
+      </Layout>
+    );
+  }
+
+  /// Action button can either generate or verify a key
+  private getActionButton() {
+    switch (this.props.keyState.type) {
+      case 'key-set':
+        const publicKey = this.props.keyState.publicKey;
+        // if the key is known to be invalid, allow the user to generate a new one
+        if (this.props.keyState.valid === false) {
+          break;
+        }
+
+        const verificationCallback = () => this.props.onVerifyKey(publicKey);
+
+        return (
+          <AppButton.GreenButton disabled={this.props.isOffline} onPress={verificationCallback}>
+            <AppButton.Label>
+              {messages.pgettext('wireguard-key-view', 'Verify key')}
+            </AppButton.Label>
+          </AppButton.GreenButton>
+        );
+
+      case 'being-verified':
+        return this.busyButton(messages.pgettext('wireguard-key-view', 'Verifying key'));
+      case 'being-generated':
+        return this.busyButton(messages.pgettext('wireguard-key-view', 'Generating key'));
+    }
+    return (
+      <AppButton.GreenButton disabled={this.props.isOffline} onPress={this.props.onGenerateKey}>
+        <AppButton.Label>{messages.pgettext('wireguard-key-view', 'Generate key')}</AppButton.Label>
+      </AppButton.GreenButton>
+    );
+  }
+
+  private busyButton(message: string) {
+    return (
+      <AppButton.GreenButton disabled={true}>
+        <AppButton.Label>{message}</AppButton.Label>
+        <AppButton.Icon source="icon-spinner" height={16} width={16} />
+      </AppButton.GreenButton>
+    );
+  }
+
+  private getKeyRow() {
+    switch (this.props.keyState.type) {
+      case 'being-verified':
+      case 'key-set':
+        // mimicking the truncating of the key from website
+        return (
+          <View title={this.props.keyState.publicKey}>
+            <Text style={styles.wgkeys__row_value}>
+              {this.props.keyState.publicKey.substring(0, 20) + '...'}
+            </Text>
+          </View>
+        );
+      case 'being-generated':
+        return <ImageView source="icon-spinner" height={25} width={25} />;
+      case 'too-many-keys':
+        return (
+          <Text style={styles.wgkeys__invalid_key}>
+            {messages.pgettext('wireguard-key-view', 'Account has too many keys already')}
+          </Text>
+        );
+      case 'generation-failure':
+        return (
+          <Text style={styles.wgkeys__invalid_key}>
+            {messages.pgettext('wireguard-key-view', 'Failed to generate key')}
+          </Text>
+        );
+      default:
+        return (
+          <Text style={styles.wgkeys__row_value}>
+            {messages.pgettext('wireguard-key-view', 'No key set')}
+          </Text>
+        );
+    }
+  }
+
+  private keyValidityLabel() {
+    switch (this.props.keyState.type) {
+      case 'being-verified':
+        return <ImageView source="icon-spinner" height={25} width={25} />;
+      case 'key-set':
+        if (this.props.keyState.valid === true) {
+          return (
+            <Text style={styles.wgkeys__valid_key}>
+              {messages.pgettext('account-view', 'Key is valid')}
+            </Text>
+          );
+        } else if (this.props.keyState.valid === false) {
+          return (
+            <Text style={styles.wgkeys__invalid_key}>
+              {messages.pgettext('wireguard-key-view', 'Key is invalid')}
+            </Text>
+          );
+        }
+      default:
+        return '';
+    }
+  }
+}

--- a/gui/src/renderer/components/WireguardKeysStyles.tsx
+++ b/gui/src/renderer/components/WireguardKeysStyles.tsx
@@ -1,0 +1,48 @@
+import { Styles } from 'reactxp';
+import { colors } from '../../config.json';
+
+export default {
+  wgkeys__container: Styles.createViewStyle({
+    flexDirection: 'column',
+    flex: 1,
+  }),
+  wgkeys__row: Styles.createViewStyle({
+    paddingTop: 0,
+    paddingBottom: 0,
+    paddingLeft: 24,
+    paddingRight: 24,
+    marginBottom: 24,
+  }),
+  wgkeys__row_label: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 13,
+    fontWeight: '600',
+    lineHeight: 20,
+    letterSpacing: -0.2,
+    color: colors.white60,
+    marginBottom: 9,
+  }),
+  wgkeys__validity_row: Styles.createViewStyle({
+    paddingTop: 5,
+  }),
+  wgkeys__row_value: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 16,
+    lineHeight: 19,
+    fontWeight: '800',
+    color: colors.white,
+  }),
+  wgkeys__invalid_key: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 16,
+    fontWeight: '800',
+    color: colors.red,
+  }),
+  wgkeys__valid_key: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 20,
+    color: colors.green,
+  }),
+};

--- a/gui/src/renderer/containers/AdvancedSettingsPage.tsx
+++ b/gui/src/renderer/containers/AdvancedSettingsPage.tsx
@@ -12,12 +12,14 @@ import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: IReduxState) => {
   const protocolAndPort = mapRelaySettingsToProtocolAndPort(state.settings.relaySettings);
+  const enableWireguardKeysPage = process.platform === 'linux' || process.platform === 'darwin';
 
   return {
     enableIpv6: state.settings.enableIpv6,
     blockWhenDisconnected: state.settings.blockWhenDisconnected,
     mssfix: state.settings.openVpn.mssfix,
     bridgeState: state.settings.bridgeState,
+    enableWireguardKeysPage,
     ...protocolAndPort,
   };
 };

--- a/gui/src/renderer/containers/AdvancedSettingsPage.tsx
+++ b/gui/src/renderer/containers/AdvancedSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { goBack } from 'connected-react-router';
+import { goBack, push } from 'connected-react-router';
 import log from 'electron-log';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -38,7 +38,7 @@ const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) =>
 };
 
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
-  const history = bindActionCreators({ goBack }, dispatch);
+  const history = bindActionCreators({ push, goBack }, dispatch);
   return {
     onClose: () => {
       history.goBack();
@@ -98,6 +98,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
         log.error('Failed to update mssfix value', e.message);
       }
     },
+    onViewWireguardKeys: () => history.push('/settings/advanced/wireguard-keys'),
   };
 };
 

--- a/gui/src/renderer/containers/WireguardKeysPage.tsx
+++ b/gui/src/renderer/containers/WireguardKeysPage.tsx
@@ -1,0 +1,27 @@
+import { goBack, push } from 'connected-react-router';
+import { shell } from 'electron';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { links } from '../../config.json';
+import WireguardKeys from '../components/WireguardKeys';
+import { IReduxState, ReduxDispatch } from '../redux/store';
+import { ISharedRouteProps } from '../routes';
+
+const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => ({
+  keyState: state.settings.wireguardKeyState,
+  isOffline: state.connection.isBlocked,
+});
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+  const history = bindActionCreators({ push, goBack }, dispatch);
+  return {
+    onGenerateKey: () => props.app.generateWireguardKey(),
+    onVerifyKey: (publicKey: string) => props.app.verifyWireguardKey(publicKey),
+    onVisitWebsiteKey: () => shell.openExternal(links.manageKeys),
+    onClose: () => history.goBack(),
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(WireguardKeys);

--- a/gui/src/renderer/redux/settings/actions.ts
+++ b/gui/src/renderer/redux/settings/actions.ts
@@ -1,4 +1,4 @@
-import { BridgeState } from '../../../shared/daemon-rpc-types';
+import { BridgeState, KeygenEvent } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
 import { IRelayLocationRedux, RelaySettingsRedux } from './reducers';
 
@@ -47,6 +47,31 @@ export interface IUpdateAutoStartAction {
   autoStart: boolean;
 }
 
+// Used to set wireguard key when accounts are changed.
+export interface IWireguardSetKey {
+  type: 'SET_WIREGUARD_KEY';
+  publicKey?: string;
+}
+
+export interface IWireguardGenerateKey {
+  type: 'GENERATE_WIREGUARD_KEY';
+}
+
+export interface IWireguardVerifyKey {
+  type: 'VERIFY_WIREGUARD_KEY';
+  publicKey: string;
+}
+
+export interface IWireguardKeygenEvent {
+  type: 'WIREGUARD_KEYGEN_EVENT';
+  event: KeygenEvent;
+}
+
+export interface IWireguardKeyVerifiedAction {
+  type: 'WIREGUARD_KEY_VERIFICATION_COMPLETE';
+  verified: boolean;
+}
+
 export type SettingsAction =
   | IUpdateGuiSettingsAction
   | IUpdateRelayAction
@@ -56,7 +81,12 @@ export type SettingsAction =
   | IUpdateBlockWhenDisconnectedAction
   | IUpdateBridgeStateAction
   | IUpdateOpenVpnMssfixAction
-  | IUpdateAutoStartAction;
+  | IUpdateAutoStartAction
+  | IWireguardSetKey
+  | IWireguardVerifyKey
+  | IWireguardGenerateKey
+  | IWireguardKeygenEvent
+  | IWireguardKeyVerifiedAction;
 
 function updateGuiSettings(guiSettings: IGuiSettingsState): IUpdateGuiSettingsAction {
   return {
@@ -123,6 +153,40 @@ function updateAutoStart(autoStart: boolean): IUpdateAutoStartAction {
   };
 }
 
+function setWireguardKey(publicKey?: string): IWireguardSetKey {
+  return {
+    type: 'SET_WIREGUARD_KEY',
+    publicKey,
+  };
+}
+
+function setWireguardKeygenEvent(event: KeygenEvent): IWireguardKeygenEvent {
+  return {
+    type: 'WIREGUARD_KEYGEN_EVENT',
+    event,
+  };
+}
+
+function generateWireguardKey(): IWireguardGenerateKey {
+  return {
+    type: 'GENERATE_WIREGUARD_KEY',
+  };
+}
+
+function verifyWireguardKey(publicKey: string): IWireguardVerifyKey {
+  return {
+    type: 'VERIFY_WIREGUARD_KEY',
+    publicKey,
+  };
+}
+
+function completeWireguardKeyVerification(verified: boolean): IWireguardKeyVerifiedAction {
+  return {
+    type: 'WIREGUARD_KEY_VERIFICATION_COMPLETE',
+    verified,
+  };
+}
+
 export default {
   updateGuiSettings,
   updateRelay,
@@ -133,4 +197,9 @@ export default {
   updateBridgeState,
   updateOpenVpnMssfix,
   updateAutoStart,
+  setWireguardKey,
+  setWireguardKeygenEvent,
+  generateWireguardKey,
+  verifyWireguardKey,
+  completeWireguardKeyVerification,
 };

--- a/gui/src/renderer/routes.tsx
+++ b/gui/src/renderer/routes.tsx
@@ -12,6 +12,7 @@ import PreferencesPage from './containers/PreferencesPage';
 import SelectLocationPage from './containers/SelectLocationPage';
 import SettingsPage from './containers/SettingsPage';
 import SupportPage from './containers/SupportPage';
+import WireguardKeysPage from './containers/WireguardKeysPage';
 import { getTransitionProps } from './transitions';
 
 export interface ISharedRouteProps {
@@ -89,6 +90,11 @@ class AppRoutes extends React.Component<IAppRoutesProps, IAppRoutesState> {
                 exact={true}
                 path="/settings/advanced"
                 component={AdvancedSettingsPage}
+              />
+              <CustomRoute
+                exact={true}
+                path="/settings/advanced/wireguard-keys"
+                component={WireguardKeysPage}
               />
               <CustomRoute exact={true} path="/settings/support" component={SupportPage} />
               <CustomRoute exact={true} path="/select-location" component={SelectLocationPage} />

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -114,7 +114,7 @@ interface IAutoStartHandlers extends ISender<boolean> {
   handleSet(fn: (value: boolean) => Promise<void>): void;
 }
 
-interface IWireguardKeyMethods extends IReceiver<string> {
+interface IWireguardKeyMethods extends IReceiver<string | undefined> {
   listenKeygenEvents(fn: (event: KeygenEvent) => void): void;
   generateKey(): Promise<KeygenEvent>;
   verifyKey(): Promise<boolean>;

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1173,7 +1173,9 @@ where
                     self.account_history.insert(account_entry).map_err(|e| {
                         format!("Failed to add new wireguard key to account data: {}", e)
                     })?;
-                    Ok(KeygenEvent::NewKey(public_key))
+                    let keygen_event = KeygenEvent::NewKey(public_key);
+                    self.event_listener.notify_key_event(keygen_event.clone());
+                    Ok(keygen_event)
                 }
                 Err(wireguard::Error::TooManyKeys) => Ok(KeygenEvent::TooManyKeys),
                 Err(e) => Err(format!("Failed to generate new key - {}", e)),


### PR DESCRIPTION
This PR adds a new settings page for managing WireGuard keys. This allows the user to manually generate and verify their keys with our API. The user will be able to verify if previously generated key is valid, and re-generate one if it isn't. If key generation fails because their account has too many keys already, the user will be shown a button that takes him to the website. If the app window is closed when automatic key generation fails, a notification will be shown. The notification support is a bit crude as they won't take the user to the appropriate key management screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/965)
<!-- Reviewable:end -->
