### PR TITLE
Improve help text shown around "Block when disconnected"

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -170,15 +170,15 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                   <Cell.Footer>
                     {messages.pgettext(
                       'advanced-settings-view',
-                      "Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
+                      "Unless connected to Mullvad, this setting will completely block your internet, even when you've disconnected or quit the app.",
                     )}
                   </Cell.Footer>
                   {this.props.blockWhenDisconnected ? (
                     <Cell.Footer>
-                    {messages.pgettext(
-                      'advanced-settings-view',
-                      "Warning: Your internet won't work without a VPN connection, even when you've quit the app. Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
-                    )}
+                      {messages.pgettext(
+                        'advanced-settings-view',
+                        "Warning: Your internet won't work without a VPN connection, even when you've quit the app. Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
+                      )}
                     </Cell.Footer>
                   ) : (
                     undefined

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -170,7 +170,15 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                   <Cell.Footer>
                     {messages.pgettext(
                       'advanced-settings-view',
-                      "Unless connected, always block all network traffic, even when you've disconnected or quit the app.",
+                      "Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
+                    )}
+                    {this.props.blockWhenDisconnected ? (
+                      messages.pgettext(
+                        'advanced-settings-view',
+                        "\n\nWarning: Your internet won't work without a VPN connection, even when you've quit the app. Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
+                      )
+                    ) : (
+                      undefined
                     )}
                   </Cell.Footer>
 

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -172,15 +172,17 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                       'advanced-settings-view',
                       "Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
                     )}
-                    {this.props.blockWhenDisconnected ? (
-                      messages.pgettext(
-                        'advanced-settings-view',
-                        "\n\nWarning: Your internet won't work without a VPN connection, even when you've quit the app. Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
-                      )
-                    ) : (
-                      undefined
-                    )}
                   </Cell.Footer>
+                  {this.props.blockWhenDisconnected ? (
+                    <Cell.Footer>
+                    {messages.pgettext(
+                      'advanced-settings-view',
+                      "Warning: Your internet won't work without a VPN connection, even when you've quit the app. Unless connected to Mullvad, this setting will completely block your internet, even when you have quit the app.",
+                    )}
+                    </Cell.Footer>
+                  ) : (
+                    undefined
+                  )}
 
                   <View style={styles.advanced_settings__content}>
                     <Selector


### PR DESCRIPTION
Quite a few users misunderstand the "Block when disconnected" setting. They activate it and then don't understand why their internet "breaks" when they disconnect/quit Mullvad. This improved version of the text was written some time back.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/966)
<!-- Reviewable:end -->
