### PR TITLE
Disable automatic wireguard key generation.

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1119,6 +1119,11 @@ where
     }
 
     fn ensure_wireguard_keys_for_current_account(&mut self) {
+        // Temporary hack to disable wireguard key generation
+        if true {
+            return;
+        }
+
         if let Some(account) = self.settings.get_account_token() {
             if self
                 .account_history


### PR DESCRIPTION
...in a somewhat hacky fashion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/967)
<!-- Reviewable:end -->
