### PR TITLE
Upgrade locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,7 @@ dependencies = [
  "mullvad-paths 0.1.0",
  "mullvad-rpc 0.1.0",
  "mullvad-types 0.1.0",
+ "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
  "notify 4.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
  "os_pipe 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pfctl 0.2.1 (git+https://github.com/mullvad/pfctl-rs?rev=9f31b5ddcab941862470075eab83bb398195f3d6)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -19,23 +19,23 @@ clap = "2.25"
 err-derive = "0.1.5"
 fern = { version = "0.5", features = ["colored"] }
 futures = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-log = "0.4"
-log-panics = "2.0.0"
+ipnetwork = "0.14"
+jsonrpc-client-core = "0.5"
 jsonrpc-core = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
+jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 jsonrpc-macros = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
 jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
-jsonrpc-ipc-server = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad-fork" }
-ipnetwork = "0.14"
-uuid = { version = "0.7", features = ["v4"] }
 lazy_static = "1.0"
+log = "0.4"
+log-panics = "2.0.0"
 rand = "0.6"
+regex = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tokio-core = "0.1"
 tokio-retry = "0.2"
-jsonrpc-client-core = "0.5"
 tokio-timer = "0.1"
-regex = "1.0"
+uuid = { version = "0.7", features = ["v4"] }
 
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -28,6 +28,7 @@ jsonrpc-pubsub = { git = "https://github.com/mullvad/jsonrpc", branch = "mullvad
 lazy_static = "1.0"
 log = "0.4"
 log-panics = "2.0.0"
+parking_lot = "0.8"
 rand = "0.6"
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2.20"
 log = "0.4"
 openvpn-plugin = { git = "https://github.com/mullvad/openvpn-plugin-rs", branch = "auth-failed-event", features = ["serde"] }
 os_pipe = "0.8"
-parking_lot = "0.7"
+parking_lot = "0.8"
 regex = "1.1.0"
 shell-escape = "0.1"
 talpid-ipc = { path = "../talpid-ipc" }


### PR DESCRIPTION
While looking at something completely unrelated I saw the `self.tx.lock().unwrap()`  in our management interface code. I first thought to replace the `unwrap` with an `expect` in order to introduce better error messages. But I then realized I could just "upgrade" to `parking_lot` and get rid of poisoning altogether. We only lock this lock in a single place anyway and just call a single method on the `Sender`.

When I added the dependency anyway I made sure to change the remaining synchronization primitives in `mullvad-daemon` to use `parking_lot` as well. Simplified a few things.

Unrelated to the Mutex change, I also managed to get rid of one layer of boxing in most management interface calls. `send_command_to_daemon` boxed its return value, but most callees did some operation on the future and boxed it again. Using `-> impl Future` here got rid of the first box.

First commit just sorts the mullvad-daemon dependencies.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/969)
<!-- Reviewable:end -->
