### PR TITLE
Add transition rule for wireguard-keys page

### DIFF
--- a/gui/src/renderer/transitions.ts
+++ b/gui/src/renderer/transitions.ts
@@ -43,6 +43,7 @@ const transitionRules = [
   r('/settings', '/settings/account', transitions.push),
   r('/settings', '/settings/preferences', transitions.push),
   r('/settings', '/settings/advanced', transitions.push),
+  r('/settings/advanced', '/settings/advanced/wireguard-keys', transitions.push),
   r('/settings', '/settings/support', transitions.push),
   r(null, '/settings', transitions.slide),
   r(null, '/select-location', transitions.slide),


### PR DESCRIPTION
Add transition rules for wireguard keys page so that the transition to said page is animated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/972)
<!-- Reviewable:end -->
