### PR TITLE
Fix cli panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Line wrap the file at 100 chars.                                              Th
 - Add new settings page for generating and verifying wireguard keys.
 
 
+### Fixed
+- Mark CLI `bridge set state` argument as required to avoid a crash.
+
+
 ## [2019.6] - 2019-07-15
 ### Added
 - Add simplified Chinese translations.

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -138,6 +138,7 @@ fn create_set_state_subcommand() -> clap::App<'static, 'static> {
         .arg(
             clap::Arg::with_name("state")
                 .help("Specifies whether a bridge should be used")
+                .required(true)
                 .index(1)
                 .possible_values(&["auto", "on", "off"]),
         )


### PR DESCRIPTION
The CLI command `mullvad bridge set state` caused a panic. Because the argument to this subcommand was not marked as required, but we `unwrap` it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/973)
<!-- Reviewable:end -->
