### PR TITLE
Add forgotten changelog entry about upgrading Open{SSL,VPN}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add new settings page for generating and verifying wireguard keys.
 
+### Changed
+- Upgrade OpenVPN from 2.4.6 to 2.4.7.
+- Upgrade OpenSSL from 1.1.0h to 1.1.1c.
 
 ### Fixed
 - Mark CLI `bridge set state` argument as required to avoid a crash.


### PR DESCRIPTION
Err. Forgot this when updating the submodule :/
I'm aware this is not yet completely true for all platforms. But I assume we will be able to build the OpenSSL libraries for Windows before the release comes.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/974)
<!-- Reviewable:end -->
