### PR TITLE
Make build.sh disable compression on --dev-build builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,14 @@ else
     echo "Removing old Rust build artifacts"
     cargo +stable clean
 fi
+if [[ "${1:-""}" == "--dev-build" ]]; then
+    # Disable installer compression on *explicit* dev builds.
+    # This does not disable compression on build server builds, since they
+    # always run without --dev-buid.
+    echo "Disabling compression of installer in this dev build"
+    cp gui/electron-builder.yml gui/electron-builder.yml.bak
+    echo "compression: store" >> gui/electron-builder.yml
+fi
 
 echo "Building Mullvad VPN $PRODUCT_VERSION"
 SEMVER_VERSION=$(echo $PRODUCT_VERSION | sed -Ee 's/($|-.*)/.0\1/g')
@@ -73,6 +81,7 @@ function restore_metadata_backups() {
     mv mullvad-problem-report/Cargo.toml.bak mullvad-problem-report/Cargo.toml || true
     mv talpid-openvpn-plugin/Cargo.toml.bak talpid-openvpn-plugin/Cargo.toml || true
     mv dist-assets/windows/version.h.bak dist-assets/windows/version.h || true
+    mv gui/electron-builder.yml.bak gui/electron-builder.yml || true
     popd
 }
 trap 'restore_metadata_backups' EXIT


### PR DESCRIPTION
Building the app installers takes a long time. A pretty large part of that time is spent compressing the installers. Especially on Linux. For dev builds we don't really need compression, and can shave something like 40% off of the deb/rpm compression time without it.

I enable this only when the build script is invoked with an explicit `--dev-build`. This so all non-release builds on the build servers will still have full compression. We don't need/want them to produce larger installers. They have plenty of spare time. It's mostly for improving local dev-test iteration speed.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/977)
<!-- Reviewable:end -->
