### PR TITLE
Translate city on switch location button

### DIFF
--- a/gui/src/renderer/containers/ConnectPage.tsx
+++ b/gui/src/renderer/containers/ConnectPage.tsx
@@ -52,7 +52,7 @@ function getRelayName(
             // TRANSLATORS: %(hostname)s - a hostname
             messages.pgettext('connect-container', '%(city)s (%(hostname)s)'),
             {
-              city: city.name,
+              city: relayLocationsLocalization.gettext(city.name),
               hostname,
             },
           );


### PR DESCRIPTION
We properly translated the "switch location" button in all cases except when a specific hostname was selected as the location constraint. Then we forgot to translate the city. This PR fixes that.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/979)
<!-- Reviewable:end -->
