### PR TITLE
Update Android build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,15 @@ matrix:
         - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
         - source $HOME/.cargo/env
         - rustup target add aarch64-linux-android
-        - curl -sf -L -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip
+        - curl -sf -L -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
         - sudo mkdir /opt/android
         - sudo unzip -q -d /opt/android/ /tmp/ndk.zip
-        - sudo /opt/android/android-ndk-r19b/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm64 --install-dir=/opt/android/toolchains/android21-aarch64
+        - sudo /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm64 --install-dir=/opt/android/toolchains/android21-aarch64
         - |
             cat >> $HOME/.cargo/config << EOF
             [target.aarch64-linux-android]
-            ar = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
-            linker = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+            ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+            linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
       before_script:
         - export RUSTFLAGS="--deny unused_imports --deny dead_code"
         - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,16 +37,16 @@ matrix:
         - curl -sf -L -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip
         - sudo mkdir /opt/android
         - sudo unzip -q -d /opt/android/ /tmp/ndk.zip
-        - sudo /opt/android/android-ndk-r19b/build/tools/make-standalone-toolchain.sh --platform=android-28 --arch=arm64 --install-dir=/opt/android/toolchains/android28-aarch64
+        - sudo /opt/android/android-ndk-r19b/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm64 --install-dir=/opt/android/toolchains/android21-aarch64
         - |
             cat >> $HOME/.cargo/config << EOF
             [target.aarch64-linux-android]
             ar = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
-            linker = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
+            linker = "/opt/android/android-ndk-r19b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
       before_script:
         - export RUSTFLAGS="--deny unused_imports --deny dead_code"
-        - export AR_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android-ar
-        - export CC_aarch64_linux_android=/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android28-clang
+        - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar
+        - export CC_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang
         - source env.sh aarch64-linux-android
         - env
       script:

--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ unzip sdk-tools-linux-4333796.zip
 wget https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
 unzip android-ndk-r20-linux-x86_64.zip
 ./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
-  --platform=android-28 \
+  --platform=android-21 \
   --arch=arm64 \
-  --install-dir=$PWD/toolchains/android28-aarch64
+  --install-dir=$PWD/toolchains/android21-aarch64
 ```
 
 Set up the required environment variables:
 ```
-export AR_aarch64_linux_android="$PWD/toolchains/android28-aarch64/bin/aarch64-linux-android-ar"
-export CC_aarch64_linux_android="$PWD/toolchains/android28-aarch64/bin/aarch64-linux-android28-clang"
+export AR_aarch64_linux_android="$PWD/toolchains/android21-aarch64/bin/aarch64-linux-android-ar"
+export CC_aarch64_linux_android="$PWD/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang"
 export ANDROID_HOME="$PWD"
 ```
 


### PR DESCRIPTION
This PR tweaks the Android build in Travis CI so that it matches the steps outlined in the README. The steps also have been updated so that the API target is downgraded in order to support more devices.

More specifically, the NDK version used was bumped from `r19b` to `r20`, and the target platform to build the binaries from API version 28 to API version 21.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No included changes are user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/980)
<!-- Reviewable:end -->
