### PR TITLE
Create build script for Android release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@
 /dist-assets/openvpn
 /dist-assets/openvpn.exe
 /windows/**/bin/
+/android/local.properties
 **/.vs/
 *.bak

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /dist-assets/openvpn
 /dist-assets/openvpn.exe
 /windows/**/bin/
+/android/keystore.properties
 /android/local.properties
 **/.vs/
 *.bak

--- a/README.md
+++ b/README.md
@@ -96,12 +96,30 @@ unzip android-ndk-r20-linux-x86_64.zip
   --platform=android-21 \
   --arch=arm64 \
   --install-dir=$PWD/toolchains/android21-aarch64
+./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
+  --platform=android-21 \
+  --arch=arm \
+  --install-dir=$PWD/toolchains/android21-armv7
+./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
+  --platform=android-21 \
+  --arch=x86_64 \
+  --install-dir=$PWD/toolchains/android21-x86_64
+./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
+  --platform=android-21 \
+  --arch=x86 \
+  --install-dir=$PWD/toolchains/android21-i686
 ```
 
 Set up the required environment variables:
 ```
 export AR_aarch64_linux_android="$PWD/toolchains/android21-aarch64/bin/aarch64-linux-android-ar"
+export AR_armv7_linux_androideabi="$PWD/toolchains/android21-armv7/bin/arm-linux-androideabi-ar"
+export AR_x86_64_linux_android="$PWD/toolchains/android21-x86_64/bin/x86_64-linux-android-ar"
+export AR_i686_linux_android="$PWD/toolchains/android21-i686/bin/i686-linux-android-ar"
 export CC_aarch64_linux_android="$PWD/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang"
+export CC_armv7_linux_androideabi="$PWD/toolchains/android21-armv7/bin/armv7a-linux-androideabi21-clang"
+export CC_x86_64_linux_android="$PWD/toolchains/android21-x86_64/bin/x86_64-linux-android21-clang"
+export CC_i686_linux_android="$PWD/toolchains/android21-i686/bin/i686-linux-android21-clang"
 export ANDROID_HOME="$PWD"
 ```
 
@@ -111,7 +129,7 @@ These steps has to be done **after** you have installed Rust in the section belo
 
 ##### Install the Rust Android target
 ```bash
-rustup target add aarch64-linux-android
+rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 ```
 
 ##### Set up cargo to use the correct linker and archiver
@@ -123,7 +141,19 @@ Add to `~/.cargo/config`:
 ```
 [target.aarch64-linux-android]
 ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
-linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
+linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+
+[target.armv7-linux-androideabi]
+ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar"
+linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang"
+
+[target.x86_64-linux-android]
+ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar"
+linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang"
+
+[target.i686-linux-android]
+ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"
+linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang"
 ```
 
 ### All platforms
@@ -250,16 +280,11 @@ to do that before starting the GUI.
 
 ## Building the Android app
 
-Build the Rust daemon with:
+Running the `build-apk.sh` script will build the necessary Rust daemon for all supported ABIs and
+build the final APK. You may pass a `--dev-build` to build the Rust daemon and the UI in debug mode
+and sign the APK with automatically generated debug keys.
 ```bash
-. env.sh "aarch64-linux-android"
-cargo build --target aarch64-linux-android --release
-```
-
-Packaging the APK:
-```bash
-cd android/
-./gradlew assembleRelease
+./build-apk.sh
 ```
 
 If the above fails with an error related to compression, try allowing more memory to the JVM:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i68
 linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang"
 ```
 
+#### Signing the release APK
+
+In order to build release APKs, they need to be signed. First, a signing key must be generated and
+stored in a keystore file. In the example below, the keystore file will be
+`/home/user/app-keys.jks` and will contain a key called `release`.
+
+```
+keytool -genkey -v -keystore /home/user/app-keys.jks -alias release -keyalg RSA -keysize 4096 -validity 10000
+```
+
+Fill in the requested information to generate the key and the keystore file. Suppose the file was
+protected by a password `keystore-password` and the key with a password `key-password`. This
+information should then be added to the `android/keystore.properties` file:
+
+```
+keyAlias = release
+keyPassword = key-password
+storeFile = /home/user/app-keys.jks
+storePassword = keystore-password
+```
+
 ### All platforms
 
 1. Get the latest **stable** Rust toolchain via [rustup.rs](https://rustup.rs/).

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ cd android/
 If the above fails with an error related to compression, try allowing more memory to the JVM:
 ```bash
 echo "org.gradle.jvmargs=-Xmx4608M" >> ~/.gradle/gradle.properties
-./gradlew --stop
+./android/gradlew --stop
 ```
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,11 +62,6 @@ android {
         variant.mergeAssetsProvider.configure {
             dependsOn copyApiRootCertificate
         }
-
-        variant.ndkCompileProvider.configure {
-            dependsOn copyMullvadJni
-            dependsOn copyWireguardGo
-        }
     }
 }
 
@@ -113,18 +108,6 @@ task format(type: FormatTask, group: 'formatting') {
 }
 
 lint.dependsOn lintKotlin
-
-task copyMullvadJni(type: Copy) {
-    from "$repoRootPath/target/aarch64-linux-android/debug"
-    include 'libmullvad_jni.so'
-    into "$extraJniDirectory/arm64-v8a"
-}
-
-task copyWireguardGo(type: Copy) {
-    from "$repoRootPath/dist-assets/binaries/aarch64-linux-android"
-    include 'libwg.so'
-    into "$extraJniDirectory/arm64-v8a"
-}
 
 task copyApiRootCertificate(type: Copy) {
     from "$repoRootPath/dist-assets"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,13 @@ def repoRootPath = projectDir.absoluteFile.parentFile.absolutePath
 def extraAssetsDirectory = "$project.buildDir/extraAssets"
 def extraJniDirectory = "$project.buildDir/extraJni"
 
+def keystorePropertiesFile = file('keystore.properties')
+def keystoreProperties = new Properties()
+
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
@@ -20,10 +27,22 @@ android {
         versionName "2019.1"
     }
 
-    buildTypes {
-        release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+    if (keystorePropertiesFile.exists()) {
+        signingConfigs {
+            release {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
+        }
+
+        buildTypes {
+            release {
+                minifyEnabled true
+                proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+                signingConfig signingConfigs.release
+            }
         }
     }
 

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,1 +1,5 @@
 -dontwarn org.joda.convert.**
+
+-keep class net.mullvad.mullvadvpn.model.** { *; }
+-keep class net.mullvad.mullvadvpn.MullvadDaemon { *; }
+-keep class net.mullvad.mullvadvpn.MullvadVpnService { *; }

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+PRODUCT_VERSION="$(node -p "require('$SCRIPT_DIR/gui/package.json').version" | sed -Ee 's/\.0//g')"
+
+if [[ "${1:-""}" == "--dev-build" ]]; then
+    BUILD_TYPE="debug"
+    GRADLE_TASK="assembleDebug"
+    APK_SUFFIX="-debug"
+    CARGO_FLAGS=""
+else
+    BUILD_TYPE="release"
+    GRADLE_TASK="assembleRelease"
+    APK_SUFFIX=""
+    CARGO_FLAGS="--release"
+
+    if [ ! -f "$SCRIPT_DIR/android/keystore.properties" ]; then
+        echo "ERROR: No keystore.properties file found" >&2
+        echo "       Please configure the signing keys as described in the README" >&2
+        exit 1
+    fi
+fi
+
+if [[ "$BUILD_TYPE" == "debug" || "$(git describe)" != "$PRODUCT_VERSION" ]]; then
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+    APK_VERSION="${PRODUCT_VERSION}-dev-${GIT_COMMIT}"
+else
+    APK_VERSION="$PRODUCT_VERSION"
+fi
+
+ARCHITECTURES="aarch64 armv7 x86_64 i686"
+
+cd "$SCRIPT_DIR/android"
+./gradlew --console plain clean
+mkdir -p "${SCRIPT_DIR}/android/build/extraJni"
+
+cd "$SCRIPT_DIR"
+
+for ARCHITECTURE in $ARCHITECTURES; do
+    case "$ARCHITECTURE" in
+        "x86_64")
+            TARGET="x86_64-linux-android"
+            ABI="x86_64"
+            ;;
+        "i686")
+            TARGET="i686-linux-android"
+            ABI="x86"
+            ;;
+        "aarch64")
+            TARGET="aarch64-linux-android"
+            ABI="arm64-v8a"
+            ;;
+        "armv7")
+            TARGET="armv7-linux-androideabi"
+            ABI="armeabi-v7a"
+            ;;
+    esac
+
+    . env.sh "$TARGET"
+    cargo build $CARGO_FLAGS --target "$TARGET" --package mullvad-jni
+
+    cp -a "$SCRIPT_DIR/dist-assets/binaries/$TARGET" "$SCRIPT_DIR/android/build/extraJni/$ABI"
+    cp "$SCRIPT_DIR/target/$TARGET/$BUILD_TYPE/libmullvad_jni.so" "$SCRIPT_DIR/android/build/extraJni/$ABI/"
+done
+
+cd "$SCRIPT_DIR/android"
+./gradlew --console plain "$GRADLE_TASK"
+
+GENERATED_APK="$SCRIPT_DIR/android/build/outputs/apk/$BUILD_TYPE/android-$BUILD_TYPE.apk"
+
+mkdir -p ../dist
+cp "$GENERATED_APK" "$SCRIPT_DIR/dist/MullvadVPN-${APK_VERSION}${APK_SUFFIX}.apk"


### PR DESCRIPTION
This PR creates a script to help build the Android APKs. The script will automatically build `mullvad-jni` for all supported ABIs, and copy the resulting shared library along with `libwg.so` to a directory where Gradle can pack them into the APK. The final APK is then copied to the `dist` directory with the version name.

The `README` was updated to describe how to set-up the environment for all supported ABIs and to use the script.

The script supports building development builds using `--dev-build`. These are built faster and are automatically signed with a debug key, making the development process simpler. The generated APKs have a `-debug` suffix.

In order to build a "release" APK, it has to be signed. This is done automatically, as long as the signing keys are configured according to the README.

The PR also includes some ProGuard rules to not obfuscate classes that `mullvad-jni` uses, so that in release builds they can still be found.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user-visible changes included.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/981)
<!-- Reviewable:end -->
