### PR TITLE
Persistent tunnel constraints

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -101,21 +101,14 @@ const relaySettingsSchema = oneOf(
   object({
     normal: partialObject({
       location: locationConstraintSchema,
-      tunnel: constraint(
-        oneOf(
-          object({
-            openvpn: partialObject({
-              port: constraint(number),
-              protocol: constraint(enumeration('udp', 'tcp')),
-            }),
-          }),
-          object({
-            wireguard: partialObject({
-              port: constraint(number),
-            }),
-          }),
-        ),
-      ),
+      tunnel_protocol: constraint(enumeration('wireguard', 'openvpn')),
+      wireguard_constraints: partialObject({
+        port: constraint(number),
+      }),
+      openvpn_constraints: partialObject({
+        port: constraint(number),
+        protocol: constraint(enumeration('udp', 'tcp')),
+      }),
     }),
   }),
   object({

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -83,7 +83,14 @@ class ApplicationMain {
     relaySettings: {
       normal: {
         location: 'any',
-        tunnel: 'any',
+        tunnelProtocol: 'any',
+        openvpnConstraints: {
+          port: 'any',
+          protocol: 'any',
+        },
+        wireguardConstraints: {
+          port: 'any',
+        },
       },
     },
     bridgeSettings: {
@@ -611,8 +618,8 @@ class ApplicationMain {
     let fnHasWantedTunnels = hasOpenVpnTunnels;
 
     if ('normal' in relaySettings) {
-      const tunnelConstraints = relaySettings.normal.tunnel;
-      if (tunnelConstraints !== 'any' && 'wireguard' in tunnelConstraints.only) {
+      const tunnelConstraints = relaySettings.normal.tunnelProtocol;
+      if (tunnelConstraints !== 'any' && 'wireguard' === tunnelConstraints.only) {
         fnHasWantedTunnels = hasWireguardTunnels;
       }
     }

--- a/gui/src/renderer/lib/relay-settings-builder.ts
+++ b/gui/src/renderer/lib/relay-settings-builder.ts
@@ -80,19 +80,13 @@ class NormalRelaySettingsBuilder {
 
   get tunnel(): ITunnelBuilder {
     const updateOpenvpn = (next: Partial<IOpenVpnConstraints>) => {
-      const tunnel = this.payload.tunnel;
-      if (typeof tunnel === 'string' || typeof tunnel === 'undefined') {
-        this.payload.tunnel = {
-          only: {
-            openvpn: next,
-          },
-        };
-      } else if (typeof tunnel === 'object') {
-        const prev = tunnel.only && 'openvpn' in tunnel.only ? tunnel.only.openvpn : {};
-        this.payload.tunnel = {
-          only: {
-            openvpn: { ...prev, ...next },
-          },
+      if (this.payload.openvpnConstraints === undefined) {
+        this.payload.openvpnConstraints = next;
+      } else {
+        const prev = this.payload.openvpnConstraints;
+        this.payload.openvpnConstraints = {
+          ...prev,
+          ...next,
         };
       }
     };
@@ -127,7 +121,7 @@ class NormalRelaySettingsBuilder {
         return this;
       },
       any: () => {
-        this.payload.tunnel = 'any';
+        this.payload.tunnelProtocol = 'any';
         return this;
       },
     };

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -4,6 +4,7 @@ import {
   KeygenEvent,
   RelayLocation,
   RelayProtocol,
+  TunnelProtocol,
 } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
 import { ReduxAction } from '../store';
@@ -11,6 +12,7 @@ import { ReduxAction } from '../store';
 export type RelaySettingsRedux =
   | {
       normal: {
+        tunnelProtocol: 'any' | TunnelProtocol;
         location: 'any' | RelayLocation;
         port: 'any' | number;
         protocol: 'any' | RelayProtocol;
@@ -108,6 +110,7 @@ const initialState: ISettingsReduxState = {
   relaySettings: {
     normal: {
       location: 'any',
+      tunnelProtocol: 'any',
       port: 'any',
       protocol: 'any',
     },

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -44,6 +44,13 @@ export function tunnelTypeToString(tunnel: TunnelType): string {
 
 export type RelayProtocol = 'tcp' | 'udp';
 
+export function liftConstraint<T>(constraint: 'any' | { only: T }): 'any' | T {
+  if (constraint === 'any') {
+    return 'any';
+  }
+  return constraint.only;
+}
+
 export type ProxyType = 'shadowsocks' | 'custom';
 export function proxyTypeToString(proxy: ProxyType): string {
   switch (proxy) {
@@ -101,19 +108,21 @@ export interface IWireguardConstraints {
   port: 'any' | { only: number };
 }
 
-type TunnelConstraints<OpenVpn, Wireguard> = { wireguard: Wireguard } | { openvpn: OpenVpn };
+export type TunnelProtocol = 'wireguard' | 'openvpn';
 
-interface IRelaySettingsNormal<TTunnelConstraints> {
+interface IRelaySettingsNormal<OpenVpn, Wireguard> {
   location:
     | 'any'
     | {
         only: RelayLocation;
       };
-  tunnel:
+  tunnelProtocol:
     | 'any'
     | {
-        only: TTunnelConstraints;
+        only: TunnelProtocol;
       };
+  openvpnConstraints: OpenVpn;
+  wireguardConstraints: Wireguard;
 }
 
 export type ConnectionConfig =
@@ -150,7 +159,7 @@ export interface IRelaySettingsCustom {
 }
 export type RelaySettings =
   | {
-      normal: IRelaySettingsNormal<TunnelConstraints<IOpenVpnConstraints, IWireguardConstraints>>;
+      normal: IRelaySettingsNormal<IOpenVpnConstraints, IWireguardConstraints>;
     }
   | {
       customTunnelEndpoint: IRelaySettingsCustom;
@@ -158,9 +167,7 @@ export type RelaySettings =
 
 // types describing the partial update of RelaySettings
 export type RelaySettingsNormalUpdate = Partial<
-  IRelaySettingsNormal<
-    TunnelConstraints<Partial<IOpenVpnConstraints>, Partial<IWireguardConstraints>>
-  >
+  IRelaySettingsNormal<Partial<IOpenVpnConstraints>, Partial<IWireguardConstraints>>
 >;
 
 export type RelaySettingsUpdate =

--- a/gui/test/relay-settings-builder.spec.ts
+++ b/gui/test/relay-settings-builder.spec.ts
@@ -54,13 +54,9 @@ describe('Relay settings builder', () => {
         .build(),
     ).to.deep.equal({
       normal: {
-        tunnel: {
-          only: {
-            openvpn: {
-              port: 'any',
-              protocol: 'any',
-            },
-          },
+        openvpnConstraints: {
+          port: 'any',
+          protocol: 'any',
         },
       },
     });
@@ -75,13 +71,9 @@ describe('Relay settings builder', () => {
         .build(),
     ).to.deep.equal({
       normal: {
-        tunnel: {
-          only: {
-            openvpn: {
-              port: { only: 80 },
-              protocol: { only: 'tcp' },
-            },
-          },
+        openvpnConstraints: {
+          port: { only: 80 },
+          protocol: { only: 'tcp' },
         },
       },
     });

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -9,7 +9,7 @@ use std::{
 use mullvad_types::{
     relay_constraints::{
         Constraint, OpenVpnConstraints, RelayConstraintsUpdate, RelaySettingsUpdate,
-        TunnelConstraints, WireguardConstraints,
+        TunnelProtocol, WireguardConstraints,
     },
     ConnectionConfig, CustomTunnelEndpoint,
 };
@@ -271,7 +271,7 @@ impl Relay {
 
         self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
             location: Some(location_constraint),
-            tunnel: None,
+            ..Default::default()
         }))
     }
 
@@ -287,17 +287,17 @@ impl Relay {
                 }
                 self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
                     location: None,
-                    tunnel: Some(Constraint::Only(TunnelConstraints::Wireguard(
-                        WireguardConstraints { port },
-                    ))),
+                    tunnel_protocol: Some(Constraint::Only(TunnelProtocol::Wireguard)),
+                    wireguard_constraints: Some(WireguardConstraints { port }),
+                    ..Default::default()
                 }))
             }
             "openvpn" => {
                 self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
                     location: None,
-                    tunnel: Some(Constraint::Only(TunnelConstraints::OpenVpn(
-                        OpenVpnConstraints { port, protocol },
-                    ))),
+                    tunnel_protocol: Some(Constraint::Any),
+                    openvpn_constraints: Some(OpenVpnConstraints { port, protocol }),
+                    ..Default::default()
                 }))
             }
             _ => unreachable!(),

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -38,7 +38,7 @@ use mullvad_types::{
     location::GeoIpLocation,
     relay_constraints::{
         BridgeSettings, BridgeState, Constraint, InternalBridgeConstraints, OpenVpnConstraints,
-        RelayConstraintsUpdate, RelaySettings, RelaySettingsUpdate, TunnelConstraints,
+        RelayConstraintsUpdate, RelaySettings, RelaySettingsUpdate, TunnelProtocol,
     },
     relay_list::{Relay, RelayList},
     states::{TargetState, TunnelState},
@@ -1164,16 +1164,13 @@ where
 
     // Set the OpenVPN tunnel to use TCP.
     fn apply_proxy_constraints(&mut self) -> settings::Result<bool> {
-        let openvpn_constraints = OpenVpnConstraints {
-            port: Constraint::Any,
-            protocol: Constraint::Only(TransportProtocol::Tcp),
-        };
-
-        let tunnel_constraints = TunnelConstraints::OpenVpn(openvpn_constraints);
-
         let constraints_update = RelayConstraintsUpdate {
-            location: None,
-            tunnel: Some(Constraint::Only(tunnel_constraints)),
+            tunnel_protocol: Some(Constraint::Only(TunnelProtocol::OpenVpn)),
+            openvpn_constraints: Some(OpenVpnConstraints {
+                protocol: Constraint::Only(TransportProtocol::Tcp),
+                port: Constraint::Any,
+            }),
+            ..Default::default()
         };
 
         let settings_update = RelaySettingsUpdate::Normal(constraints_update);

--- a/mullvad-jni/src/from_java.rs
+++ b/mullvad-jni/src/from_java.rs
@@ -110,7 +110,9 @@ impl<'env> FromJava<'env> for RelayConstraintsUpdate {
 
         RelayConstraintsUpdate {
             location: FromJava::from_java(env, location),
-            tunnel: None,
+            tunnel_protocol: None,
+            openvpn_constraints: None,
+            wireguard_constraints: None,
         }
     }
 }

--- a/mullvad-types/src/settings/migrations/mod.rs
+++ b/mullvad-types/src/settings/migrations/mod.rs
@@ -1,0 +1,145 @@
+use super::{Error, Result, Settings};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::io::Read;
+mod v1;
+
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(u32)]
+pub enum SettingsVersion {
+    V2 = 2,
+}
+
+impl SettingsVersion {
+    pub fn as_u32(&self) -> u32 {
+        unsafe { ::std::mem::transmute(*self) }
+    }
+
+    pub fn max_version() -> Self {
+        SettingsVersion::V2
+    }
+
+    pub fn min_version() -> Self {
+        SettingsVersion::V2
+    }
+}
+
+impl<'de> Deserialize<'de> for SettingsVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let version = <u32>::deserialize(deserializer)?;
+        if version < SettingsVersion::min_version().as_u32() {
+            return Err(serde::de::Error::custom(format!(
+                "Version number {} too small",
+                version
+            )));
+        }
+
+        if version > SettingsVersion::max_version().as_u32() {
+            return Err(serde::de::Error::custom(format!(
+                "Version number {} too large",
+                version
+            )));
+        }
+
+        unsafe { Ok(::std::mem::transmute(version)) }
+    }
+}
+
+impl Serialize for SettingsVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u32(self.as_u32())
+    }
+}
+
+
+#[derive(Debug)]
+enum VersionedSettings {
+    V1(v1::Settings),
+    V2(crate::settings::Settings),
+}
+
+impl VersionedSettings {
+    /// Unrwaps the latest version of settings or panics.
+    fn unwrap(self) -> Settings {
+        match self {
+            VersionedSettings::V2(settings) => settings,
+            lower => {
+                panic!("Unexpected settings version - {:?}", lower);
+            }
+        }
+    }
+}
+
+
+trait SettingsMigration {
+    fn read(&self, reader: &mut dyn Read) -> Result<VersionedSettings>;
+    fn migrate(&self, settings: VersionedSettings) -> VersionedSettings;
+}
+
+fn migrations() -> Vec<Box<dyn SettingsMigration>> {
+    vec![Box::new(v1::Migration)]
+}
+
+pub fn try_migrate_settings(mut settings_file: &[u8]) -> Result<crate::settings::Settings> {
+    let mut migrations_to_apply = vec![];
+    let mut valid_settings = None;
+
+    let migrations = migrations();
+    for migration in migrations.iter() {
+        match migration.read(&mut settings_file) {
+            Ok(settings) => {
+                valid_settings = Some(migration.migrate(settings));
+                break;
+            }
+            Err(_e) => {
+                migrations_to_apply.push(migration);
+            }
+        };
+    }
+
+    if let Some(settings) = valid_settings {
+        let upgraded_settings = migrations_to_apply
+            .iter()
+            .rev()
+            .fold(settings, |old_settings, migration| {
+                migration.migrate(old_settings)
+            });
+        return Ok(upgraded_settings.unwrap());
+    }
+    return Err(Error::NoMatchingVersion);
+}
+
+#[cfg(test)]
+mod test {
+    use super::SettingsVersion;
+
+    #[test]
+    #[should_panic]
+    fn test_deserialization_failure_version_too_small() {
+        let _version: SettingsVersion = serde_json::from_str("1").expect("Version too small");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_deserialization_failure_version_too_big() {
+        let _version: SettingsVersion = serde_json::from_str("3").expect("Version too big");
+    }
+
+    #[test]
+    fn test_deserialization_success() {
+        let _version: SettingsVersion = serde_json::from_str("2").expect("Failed to deserialize valid version");
+    }
+
+    #[test]
+    fn test_serialization_success() {
+        let version = SettingsVersion::V2;
+        let s = serde_json::to_string(&version).expect("Failed to serialize");
+        assert_eq!(s, "2");
+    }
+}

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -1,0 +1,102 @@
+use super::{Error, Result, VersionedSettings};
+use crate::{
+    custom_tunnel::CustomTunnelEndpoint,
+    relay_constraints::{
+        BridgeSettings, BridgeState, Constraint, LocationConstraint, OpenVpnConstraints,
+        RelaySettings as NewRelaySettings, TunnelProtocol, WireguardConstraints,
+    },
+    settings::TunnelOptions,
+};
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+
+
+/// Mullvad daemon settings.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Settings {
+    account_token: Option<String>,
+    relay_settings: RelaySettings,
+    bridge_settings: BridgeSettings,
+    bridge_state: BridgeState,
+    /// If the daemon should allow communication with private (LAN) networks.
+    allow_lan: bool,
+    /// Extra level of kill switch. When this setting is on, the disconnected state will block
+    /// the firewall to not allow any traffic in or out.
+    block_when_disconnected: bool,
+    /// If the daemon should connect the VPN tunnel directly on start or not.
+    auto_connect: bool,
+    /// Options that should be applied to tunnels of a specific type regardless of where the relays
+    /// might be located.
+    tunnel_options: TunnelOptions,
+}
+
+pub(super) struct Migration;
+impl super::SettingsMigration for Migration {
+    fn read(&self, mut reader: &mut dyn Read) -> Result<VersionedSettings> {
+        serde_json::from_reader(&mut reader)
+            .map(VersionedSettings::V1)
+            .map_err(Error::ParseError)
+    }
+    fn migrate(&self, old: VersionedSettings) -> VersionedSettings {
+        match old {
+            VersionedSettings::V1(old) => VersionedSettings::V2(crate::settings::Settings {
+                account_token: old.account_token,
+                relay_settings: migrate_relay_settings(old.relay_settings),
+                bridge_settings: old.bridge_settings,
+                bridge_state: old.bridge_state,
+                allow_lan: old.allow_lan,
+                block_when_disconnected: old.block_when_disconnected,
+                auto_connect: old.auto_connect,
+                tunnel_options: old.tunnel_options,
+                settings_version: super::SettingsVersion::V2,
+            }),
+            VersionedSettings::V2(new) => VersionedSettings::V2(new),
+        }
+    }
+}
+
+fn migrate_relay_settings(relay_settings: RelaySettings) -> NewRelaySettings {
+    match relay_settings {
+        RelaySettings::CustomTunnelEndpoint(endpoint) => {
+            crate::relay_constraints::RelaySettings::CustomTunnelEndpoint(endpoint)
+        }
+        RelaySettings::Normal(old_constraints) => {
+            let mut new_constraints = crate::relay_constraints::RelayConstraints {
+                location: old_constraints.location,
+                ..Default::default()
+            };
+            match old_constraints.tunnel {
+                Constraint::Any => (),
+                Constraint::Only(TunnelConstraints::OpenVpn(constraints)) => {
+                    new_constraints.openvpn_constraints = constraints;
+                }
+                Constraint::Only(TunnelConstraints::Wireguard(constraints)) => {
+                    new_constraints.wireguard_constraints = constraints;
+                    new_constraints.tunnel_protocol = Constraint::Only(TunnelProtocol::Wireguard);
+                }
+            };
+            crate::relay_constraints::RelaySettings::Normal(new_constraints)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RelaySettings {
+    CustomTunnelEndpoint(CustomTunnelEndpoint),
+    Normal(RelayConstraints),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct RelayConstraints {
+    pub location: Constraint<LocationConstraint>,
+    pub tunnel: Constraint<TunnelConstraints>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub enum TunnelConstraints {
+    #[serde(rename = "openvpn")]
+    OpenVpn(OpenVpnConstraints),
+    #[serde(rename = "wireguard")]
+    Wireguard(WireguardConstraints),
+}

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -50,7 +50,7 @@ static SETTINGS_FILE: &str = "settings.json";
 
 
 /// Mullvad daemon settings.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct Settings {
     account_token: Option<String>,

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::{
     fs::{self, File},
-    io,
+    io::{self, Read},
     path::PathBuf,
 };
 use talpid_types::{
@@ -15,6 +15,7 @@ use talpid_types::{
     ErrorExt,
 };
 
+mod migrations;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -40,6 +41,9 @@ pub enum Error {
 
     #[error(display = "Invalid OpenVPN proxy configuration: {}", _0)]
     InvalidProxyData(String),
+
+    #[error(display = "Unable to read any version of the settings")]
+    NoMatchingVersion,
 }
 
 static SETTINGS_FILE: &str = "settings.json";
@@ -63,6 +67,8 @@ pub struct Settings {
     /// Options that should be applied to tunnels of a specific type regardless of where the relays
     /// might be located.
     tunnel_options: TunnelOptions,
+    /// Specifies settings schema version
+    settings_version: migrations::SettingsVersion,
 }
 
 impl Default for Settings {
@@ -71,7 +77,7 @@ impl Default for Settings {
             account_token: None,
             relay_settings: RelaySettings::Normal(RelayConstraints {
                 location: Constraint::Only(LocationConstraint::Country("se".to_owned())),
-                tunnel: Constraint::Any,
+                ..Default::default()
             }),
             bridge_settings: BridgeSettings::Normal(BridgeConstraints {
                 location: Constraint::Any,
@@ -81,6 +87,7 @@ impl Default for Settings {
             block_when_disconnected: false,
             auto_connect: false,
             tunnel_options: TunnelOptions::default(),
+            settings_version: migrations::SettingsVersion::V2,
         }
     }
 }
@@ -92,7 +99,21 @@ impl Settings {
         match File::open(&path) {
             Ok(file) => {
                 info!("Loading settings from {}", path.display());
-                Self::read_settings(&mut io::BufReader::new(file))
+                let mut settings_bytes = vec![];
+                io::BufReader::new(file)
+                    .read_to_end(&mut settings_bytes)
+                    .map_err(|e| Error::ReadError("Failed to read settings file".to_owned(), e))?;
+                Self::parse_settings(&mut settings_bytes).or_else(|e| {
+                    log::error!(
+                        "{}",
+                        e.display_chain_with_msg("Failed to parse settings file")
+                    );
+                    let settings = migrations::try_migrate_settings(&settings_bytes)?;
+                    if let Err(e) = settings.save() {
+                        log::error!("Failed to save settings after migration: {}", e);
+                    }
+                    Ok(settings)
+                })
             }
             Err(e) => Err(Error::ReadError(path.display().to_string(), e)),
         }
@@ -132,8 +153,8 @@ impl Settings {
         Ok(dir.join(SETTINGS_FILE))
     }
 
-    fn read_settings<T: io::Read>(file: &mut T) -> Result<Settings> {
-        serde_json::from_reader(file).map_err(Error::ParseError)
+    fn parse_settings(bytes: &[u8]) -> Result<Settings> {
+        serde_json::from_slice(bytes).map_err(Error::ParseError)
     }
 
     pub fn get_account_token(&self) -> Option<String> {


### PR DESCRIPTION
To better support different tunnel protocols, the daemon should be capable of storing the tunnel specific constraints in a persistent fashion. This PR achieves that with a non-backwards-compatible settings file format change. As such, this PR also implements a simple migration from the old format to the new one.

Whilst the settings schema has changed, none of the user facing tools are aware, they will be updated in the following PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/982)
<!-- Reviewable:end -->
