### PR TITLE
Fix crash on 32-bit platforms when opening Wireguard tunnel

### DIFF
--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -36,7 +36,7 @@ impl WgGoTunnel {
         let handle = unsafe {
             wgTurnOnWithFd(
                 iface_name.as_ptr() as *const i8,
-                config.mtu as i64,
+                config.mtu as isize,
                 wg_config_str.as_ptr() as *const i8,
                 tunnel_device.as_raw_fd(),
                 log_file.as_raw_fd(),
@@ -139,7 +139,7 @@ extern "C" {
     #[cfg_attr(target_os = "android", link_name = "wgTurnOnWithFdAndroid")]
     fn wgTurnOnWithFd(
         iface_name: *const i8,
-        mtu: i64,
+        mtu: isize,
         settings: *const i8,
         fd: Fd,
         log_fd: Fd,


### PR DESCRIPTION
This PR is a simple fix for a memory alignment issue on 32-bit platforms. It replaces a cast to `i64` with a cast to `isize`, which maps correctly to the expected `int` Go type in `wireguard-go`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Doesn't affect any supported platforms yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/989)
<!-- Reviewable:end -->
