### PR TITLE
Update Android app metadata

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "net.mullvad.mullvadvpn"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 201901
-        versionName "2019.1"
+        versionCode 1
+        versionName "2019.6"
     }
 
     if (keystorePropertiesFile.exists()) {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+            android:label="@string/app_name"
             android:icon="@mipmap/ic_launcher"
             android:roundIcon="@mipmap/ic_launcher"
             android:theme="@style/AppTheme"


### PR DESCRIPTION
This PR updates the Android application label, so that in the Android Settings app, the app name is actually `Mullvad VPN` instead of `net.mullvad.mullvadvpn`.

The version information of the app was also updated.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android versions released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/990)
<!-- Reviewable:end -->
