### PR TITLE
Automatically retry key generation when Android app resumes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -87,6 +87,11 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        keyStatusListener.onResume()
+    }
+
     override fun onStop() {
         unbindService(serviceConnection)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -22,7 +22,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
 
     external fun connect()
     external fun disconnect()
-    external fun generateWireguardKey(): Boolean
+    external fun generateWireguardKey(): KeygenEvent?
     external fun getAccountData(accountToken: String): AccountData?
     external fun getCurrentLocation(): GeoIpLocation?
     external fun getRelayLocations(): RelayList


### PR DESCRIPTION
This PR is a minor UX improvement. If the user has too many keys registered to his account, he currently has to go to the web-site to revoke some keys. After doing so, when he returns the app it would previously still think there are too many keys, so the user would have to log out and log in again for the changes to take effect.

This PR implements automatic retries to generate the WireGuard key if it had previously failed because there were too many keys. The retries occur every time the app is resumed, so this aligns with the user returning to the app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/991)
<!-- Reviewable:end -->
