### PR TITLE
Fix default relay constraints on Android

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -248,7 +248,6 @@ impl RelaySelector {
         // any constraints that are explicitly specified.
         match original_constraints.tunnel_protocol {
             // If no tunnel protocol is selected, use preferred constraints
-            #[cfg(not(target_os = "android"))]
             Constraint::Any => {
                 if original_constraints.openvpn_constraints.port.is_any()
                     && original_constraints.openvpn_constraints.protocol.is_any()
@@ -264,17 +263,10 @@ impl RelaySelector {
                     };
                 }
             }
-            #[cfg(not(target_os = "android"))]
             Constraint::Only(TunnelProtocol::OpenVpn) => {
                 relay_constraints.openvpn_constraints = original_constraints.openvpn_constraints;
             }
-            #[cfg(not(target_os = "android"))]
             Constraint::Only(TunnelProtocol::Wireguard) => {
-                relay_constraints.wireguard_constraints =
-                    original_constraints.wireguard_constraints;
-            }
-            #[cfg(target_os = "android")]
-            _ => {
                 relay_constraints.wireguard_constraints =
                     original_constraints.wireguard_constraints;
             }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -93,12 +93,25 @@ impl RelaySettings {
     }
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(not(target_os = "android"), derive(Default))]
 pub struct RelayConstraints {
     pub location: Constraint<LocationConstraint>,
     pub tunnel_protocol: Constraint<TunnelProtocol>,
     pub wireguard_constraints: WireguardConstraints,
     pub openvpn_constraints: OpenVpnConstraints,
+}
+
+#[cfg(target_os = "android")]
+impl Default for RelayConstraints {
+    fn default() -> Self {
+        RelayConstraints {
+            location: Constraint::Any,
+            tunnel_protocol: Constraint::Only(TunnelProtocol::Wireguard),
+            wireguard_constraints: WireguardConstraints::default(),
+            openvpn_constraints: OpenVpnConstraints::default(),
+        }
+    }
 }
 
 impl RelayConstraints {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -60,7 +60,6 @@ impl ConnectingState {
         shared_values.firewall.apply_policy(policy)
     }
 
-    #[cfg_attr(target_os = "android", allow(unused_variables))]
     fn start_tunnel(
         parameters: TunnelParameters,
         log_dir: &Option<PathBuf>,


### PR DESCRIPTION
This PR changes the `Default` implementation of `RelayConstraints` on Android so that the `tunnel_protocol` is configured to only support Wireguard. This fixes the issue where the app tried to connect to OpenVPN relays.

This PR also removes some `cfg` attributes that aren't necessary anymore.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public version of Android released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/992)
<!-- Reviewable:end -->
