### PR TITLE
Retry to connect when WireGuard encounters a bad file descriptor

### DIFF
--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -57,7 +57,7 @@ pub enum Error {
     /// There was an error listening for events from the Wireguard tunnel
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     #[error(display = "Failed while listening for events from the Wireguard tunnel")]
-    WirguardTunnelMonitoringError(#[error(cause)] wireguard::Error),
+    WireguardTunnelMonitoringError(#[error(cause)] wireguard::Error),
 }
 
 

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -21,7 +21,7 @@ pub struct ConnectedStateBootstrap {
     pub tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
     pub tunnel_parameters: TunnelParameters,
     pub tunnel_close_event: oneshot::Receiver<Option<BlockReason>>,
-    pub close_handle: CloseHandle,
+    pub close_handle: Option<CloseHandle>,
 }
 
 /// The tunnel is up and working.
@@ -30,7 +30,7 @@ pub struct ConnectedState {
     tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
     tunnel_parameters: TunnelParameters,
     tunnel_close_event: oneshot::Receiver<Option<BlockReason>>,
-    close_handle: CloseHandle,
+    close_handle: Option<CloseHandle>,
 }
 
 impl ConnectedState {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -35,7 +35,7 @@ pub struct ConnectingState {
     tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
     tunnel_parameters: TunnelParameters,
     tunnel_close_event: oneshot::Receiver<Option<BlockReason>>,
-    close_handle: CloseHandle,
+    close_handle: Option<CloseHandle>,
     retry_attempt: u32,
 }
 
@@ -78,7 +78,7 @@ impl ConnectingState {
             on_tunnel_event,
             tun_provider,
         )?;
-        let close_handle = monitor.close_handle();
+        let close_handle = Some(monitor.close_handle());
         let tunnel_close_event = Self::spawn_tunnel_monitor_wait_thread(monitor);
 
         Ok(ConnectingState {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -344,6 +344,18 @@ impl TunnelState for ConnectingState {
                                 TunnelStateTransition::Connecting(params.get_tunnel_endpoint()),
                             )
                         }
+                        #[cfg(not(windows))]
+                        Err(tunnel::Error::WireguardTunnelMonitoringError(
+                            tunnel::wireguard::Error::StartWireguardError { status: -2 },
+                        )) => {
+                            log::warn!(
+                                "Retrying to connect after failing to start Wireguard tunnel"
+                            );
+                            DisconnectingState::enter(
+                                shared_values,
+                                (None, None, AfterDisconnect::Reconnect(retry_attempt + 1)),
+                            )
+                        }
                         Err(error) => {
                             log::error!("Failed to start tunnel: {}", error);
                             let block_reason = match error {


### PR DESCRIPTION
This PR handles the newly introduced `-2` error code returned from `wireguard-go` by retrying to connect. In order to do so in a clean manner, it now enters the `Disconnecting` state but without providing the tunnel close handle. Therefore, this PR changed the tunnel state machine so that the `Disconnecting` state uses an optional tunnel close handle and tunnel close event receiver.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/993)
<!-- Reviewable:end -->
