### PR TITLE
Allow setting TunnelProtocol constraint from GUI

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -380,27 +380,19 @@ export default class AppRenderer {
       const location = normal.location;
       const relayLocation = location === 'any' ? 'any' : location.only;
 
-      if (tunnelProtocol === 'any' || tunnelProtocol.only === 'openvpn') {
-        const { port, protocol } = normal.openvpnConstraints;
-        actions.settings.updateRelay({
-          normal: {
-            location: relayLocation,
+      const { port, protocol } = normal.openvpnConstraints;
+      const wireguardPort = normal.wireguardConstraints.port;
+      actions.settings.updateRelay({
+        normal: {
+          location: relayLocation,
+          openvpn: {
             port: port === 'any' ? port : port.only,
             protocol: protocol === 'any' ? protocol : protocol.only,
-            tunnelProtocol: liftConstraint(tunnelProtocol),
           },
-        });
-      } else {
-        const { port } = normal.wireguardConstraints;
-        actions.settings.updateRelay({
-          normal: {
-            tunnelProtocol: liftConstraint(tunnelProtocol),
-            location: relayLocation,
-            port: port === 'any' ? port : port.only,
-            protocol: 'udp',
-          },
-        });
-      }
+          wireguard: { port: wireguardPort === 'any' ? wireguardPort : wireguardPort.only },
+          tunnelProtocol: liftConstraint(tunnelProtocol),
+        },
+      });
     } else if ('customTunnelEndpoint' in relaySettings) {
       const customTunnelEndpoint = relaySettings.customTunnelEndpoint;
       const config = customTunnelEndpoint.config;

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -233,7 +233,8 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                   )}
 
                   {this.props.tunnelProtocol === 'openvpn' ||
-                  this.props.tunnelProtocol === undefined ? (
+                  this.props.tunnelProtocol === undefined ||
+                  process.platform === 'win32' ? (
                     <View style={styles.advanced_settings__content}>
                       <Selector
                         title={messages.pgettext(
@@ -268,7 +269,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     undefined
                   )}
 
-                  {this.props.tunnelProtocol === 'wireguard' ? (
+                  {this.props.tunnelProtocol === 'wireguard' && process.platform !== 'win32' ? (
                     <View style={styles.advanced_settings__content}>
                       <Selector
                         // TRANSLATORS: The title for the shadowsocks bridge selector section.

--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -19,6 +19,9 @@ export default {
   advanced_settings__selector_section: Styles.createViewStyle({
     marginBottom: 24,
   }),
+  advanced_settings__wgkeys_cell: Styles.createViewStyle({
+    marginBottom: 24,
+  }),
   advanced_settings__cell_hover: Styles.createButtonStyle({
     backgroundColor: colors.blue80,
   }),

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -24,7 +24,7 @@ export default class WireguardKeys extends Component<IProps> {
     return (
       <Layout>
         <Container>
-          <View>
+          <View style={styles.wgkeys}>
             <NavigationContainer>
               <NavigationBar>
                 <BackBarItem action={this.props.onClose}>

--- a/gui/src/renderer/components/WireguardKeysStyles.tsx
+++ b/gui/src/renderer/components/WireguardKeysStyles.tsx
@@ -2,6 +2,10 @@ import { Styles } from 'reactxp';
 import { colors } from '../../config.json';
 
 export default {
+  wgkeys: Styles.createViewStyle({
+    backgroundColor: colors.darkBlue,
+    flex: 1,
+  }),
   wgkeys__container: Styles.createViewStyle({
     flexDirection: 'column',
     flex: 1,

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -14,8 +14,13 @@ export type RelaySettingsRedux =
       normal: {
         tunnelProtocol: 'any' | TunnelProtocol;
         location: 'any' | RelayLocation;
-        port: 'any' | number;
-        protocol: 'any' | RelayProtocol;
+        openvpn: {
+          port: 'any' | number;
+          protocol: 'any' | RelayProtocol;
+        };
+        wireguard: {
+          port: 'any' | number;
+        };
       };
     }
   | {
@@ -111,8 +116,11 @@ const initialState: ISettingsReduxState = {
     normal: {
       location: 'any',
       tunnelProtocol: 'any',
-      port: 'any',
-      protocol: 'any',
+      wireguard: { port: 'any' },
+      openvpn: {
+        port: 'any',
+        protocol: 'any',
+      },
     },
   },
   relayLocations: [],


### PR DESCRIPTION
This PR updates the GUI to allow the user to specify a tunnel protocol constraint on MacOS and Linux. Depending on the selected tunnel protocol constraint, different tunnel constraint options are shown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/997)
<!-- Reviewable:end -->
