### PR TITLE
Fix UI delay when disconnecting too quickly

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
@@ -1,10 +1,5 @@
 package net.mullvad.mullvadvpn
 
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-
 import android.view.View
 import android.widget.TextView
 
@@ -15,22 +10,17 @@ class LocationInfo(val parentView: View, val locationInfoCache: LocationInfoCach
     private val cityLabel: TextView = parentView.findViewById(R.id.city)
     private val hostnameLabel: TextView = parentView.findViewById(R.id.hostname)
 
-    private var updateJob: Job? = null
-
     init {
         locationInfoCache.onNewLocation = { country, city, hostname ->
-            updateJob?.cancel()
-            updateJob = updateViews(country, city, hostname)
+            updateViews(country, city, hostname)
         }
     }
 
     fun onDestroy() {
-        updateJob?.cancel()
         locationInfoCache.onNewLocation = null
     }
 
-    fun updateViews(country: String, city: String, hostname: String) =
-            GlobalScope.launch(Dispatchers.Main) {
+    fun updateViews(country: String, city: String, hostname: String) {
         countryLabel.text = country
         cityLabel.text = city
         hostnameLabel.text = hostname

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -39,7 +39,10 @@ class LocationInfoCache(
             field = value
 
             when (value) {
-                is TunnelState.Disconnected -> fetchLocation()
+                is TunnelState.Disconnected -> {
+                    location = lastKnownRealLocation
+                    fetchLocation()
+                }
                 is TunnelState.Connecting -> location = value.location
                 is TunnelState.Connected -> {
                     location = value.location


### PR DESCRIPTION
With the crash in `wireguard-go` mitigated and the `ConnectivityListener` removed, disconnection happens a lot faster. Sometimes, it happens in less than a single UI frame (less than 16 ms). In these cases, the UI would skip handling the `Disconnecting` state and skip directly to the `Disconnected` state.

The problem is that the `LocationInfoCache` was relying on the `Disconnecting` state to update the UI to show the last known real location. So when disconnection happens too quickly the location isn't updated, and the UI keeps showing the tunnel location for a few seconds until the RPC call to get the real location finishes.

This PR removes the delay by setting the UI location to the last known real location also when entering the `Disconnected` state.

Also in this PR is a slight cleanup of `LocationInfo`. The UI thread scheduling code was removed since all methods are only called from the UI thread anyway.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/998)
<!-- Reviewable:end -->
