### PR TITLE
Only allow number digits in account input

### DIFF
--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -102,6 +102,7 @@
                 >
             <EditText
                     android:id="@+id/account_input"
+                    android:digits="0123456789"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_weight="1"


### PR DESCRIPTION
Even though the account input view was configured to only accept numbers, it could still accept number related characters, like `-`, `.` and `,` (to enter for example `-1,000.00`). This PR adds a further restriction so that the input only accepts digits (`0-9`).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/999)
<!-- Reviewable:end -->
