### PR TITLE
Show version in Settings

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -36,6 +36,8 @@ class MainActivity : FragmentActivity() {
     var daemon = CompletableDeferred<MullvadDaemon>()
         private set
 
+    var currentVersion = fetchCurrentVersion()
+
     val connectionProxy = ConnectionProxy(this)
     val keyStatusListener = KeyStatusListener(daemon)
     val problemReport = MullvadProblemReport()
@@ -148,5 +150,9 @@ class MainActivity : FragmentActivity() {
 
     private fun fetchSettings() = GlobalScope.async(Dispatchers.Default) {
         daemon.await().getSettings()
+    }
+
+    private fun fetchCurrentVersion() = GlobalScope.async(Dispatchers.Default) {
+        daemon.await().getCurrentVersion()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -25,6 +25,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     external fun generateWireguardKey(): KeygenEvent?
     external fun getAccountData(accountToken: String): AccountData?
     external fun getCurrentLocation(): GeoIpLocation?
+    external fun getCurrentVersion(): String
     external fun getRelayLocations(): RelayList
     external fun getSettings(): Settings
     external fun getState(): TunnelState

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
@@ -1,6 +1,8 @@
 package net.mullvad.mullvadvpn
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
@@ -37,6 +39,9 @@ class SettingsFragment : Fragment() {
         view.findViewById<View>(R.id.account).setOnClickListener {
             openSubFragment(AccountFragment())
         }
+        view.findViewById<View>(R.id.app_version).setOnClickListener {
+            openLink("https://mullvad.net/download/")
+        }
         view.findViewById<View>(R.id.report_a_problem).setOnClickListener {
             openSubFragment(ProblemReportFragment())
         }
@@ -68,5 +73,11 @@ class SettingsFragment : Fragment() {
             addToBackStack(null)
             commit()
         }
+    }
+
+    private fun openLink(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+
+        startActivity(intent)
     }
 }

--- a/android/src/main/res/drawable/icon_extlink.xml
+++ b/android/src/main/res/drawable/icon_extlink.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M12.5858,2L8.9908,2C8.451,2 8,1.5523 8,1C8,0.4439 8.4464,0 8.997,0L15.003,0C15.547,0 16,0.4464 16,0.997L16,7.003C16,7.547 15.5523,8 15,8C14.4439,8 14,7.5564 14,7.0092L14,3.4142L6.7071,10.7071C6.3166,11.0976 5.6834,11.0976 5.2929,10.7071C4.9024,10.3166 4.9024,9.6834 5.2929,9.2929L12.5858,2ZM8.4645,4L6.4645,6L2,6L2,14L10,14L10,9.5355L12,7.5355L12,14.9975C12,15.5512 11.5442,16 10.9975,16L1.0025,16C0.4488,16 0,15.5442 0,14.9975L0,5.0025C0,4.4488 0.4558,4 1.0025,4L8.4645,4Z"
+      android:fillColor="#FFFFFF"
+      android:fillType="evenOdd"/>
+</vector>

--- a/android/src/main/res/layout/settings.xml
+++ b/android/src/main/res/layout/settings.xml
@@ -64,6 +64,46 @@
                 android:src="@drawable/icon_chevron"
                 />
     </LinearLayout>
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:paddingHorizontal="16dp"
+            android:background="@drawable/cell_button_background"
+            android:clickable="true"
+            android:gravity="center"
+            >
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="17dp"
+                android:textColor="@color/white"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:text="@string/app_version"
+                />
+        <TextView android:id="@+id/app_version_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingHorizontal="8dp"
+                android:gravity="right"
+                android:textColor="@color/white60"
+                android:textSize="13sp"
+                android:textStyle="bold"
+                android:text=""
+                android:textAllCaps="true"
+                />
+        <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_weight="0"
+                android:alpha="0.6"
+                android:src="@drawable/icon_extlink"
+                />
+    </LinearLayout>
     <LinearLayout android:id="@+id/report_a_problem"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/android/src/main/res/layout/settings.xml
+++ b/android/src/main/res/layout/settings.xml
@@ -64,7 +64,7 @@
                 android:src="@drawable/icon_chevron"
                 />
     </LinearLayout>
-    <LinearLayout
+    <LinearLayout android:id="@+id/app_version"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="settings_account">Account</string>
     <string name="less_than_a_day_left">less than a day left</string>
     <string name="out_of_time">Out of time</string>
+    <string name="app_version">App version</string>
     <string name="report_a_problem">Report a problem</string>
     <string name="quit">Quit</string>
 

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -96,6 +96,14 @@ impl DaemonInterface {
         Ok(rx.wait().map_err(|_| Error::NoResponse)?)
     }
 
+    pub fn get_current_version(&self) -> Result<String> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::GetCurrentVersion(tx))?;
+
+        Ok(rx.wait().map_err(|_| Error::NoResponse)?)
+    }
+
     pub fn get_relay_locations(&self) -> Result<RelayList> {
         let (tx, rx) = oneshot::channel();
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -300,6 +300,24 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getCurrentLocat
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getCurrentVersion<'env, 'this>(
+    env: JNIEnv<'env>,
+    _: JObject<'this>,
+) -> JString<'env> {
+    match DAEMON_INTERFACE.get_current_version() {
+        Ok(location) => location.into_java(&env),
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to get current version")
+            );
+            String::new().into_java(&env)
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getRelayLocations<'env, 'this>(
     env: JNIEnv<'env>,
     _: JObject<'this>,


### PR DESCRIPTION
This PR adds the `App version` entry in the `Settings` screen on Android. The version is obtained from `mullvad-daemon`. When the entry is pressed, it opens the web page to download the app. This might need to be revisited in the future, maybe opening the link to the app on Google Play.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android versions yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1000)
<!-- Reviewable:end -->
