### PR TITLE
Add offline mode grace period

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,6 +2255,7 @@ dependencies = [
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tun 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-types/src/settings/migrations/mod.rs
+++ b/mullvad-types/src/settings/migrations/mod.rs
@@ -133,7 +133,8 @@ mod test {
 
     #[test]
     fn test_deserialization_success() {
-        let _version: SettingsVersion = serde_json::from_str("2").expect("Failed to deserialize valid version");
+        let _version: SettingsVersion =
+            serde_json::from_str("2").expect("Failed to deserialize valid version");
     }
 
     #[test]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -26,6 +26,7 @@ shell-escape = "0.1"
 talpid-ipc = { path = "../talpid-ipc" }
 talpid-types = { path = "../talpid-types" }
 tokio-core = "0.1"
+tokio-timer = "0.1"
 uuid = { version = "0.7", features = ["v4"] }
 
 

--- a/talpid-core/src/offline/graceful_stream.rs
+++ b/talpid-core/src/offline/graceful_stream.rs
@@ -1,0 +1,110 @@
+use futures::{Async, Future, Poll, Stream};
+use std::time;
+use tokio_timer::Timer;
+
+/// A stream that only returns the last item that was received in a given time period.
+pub struct GracefulStream<S>
+where
+    S: Stream,
+{
+    timer: Timer,
+    timeout: time::Duration,
+    stream: Option<S>,
+    delayed_item: Option<DelayedValue<S::Item>>,
+}
+
+impl<S: Stream> GracefulStream<S> {
+    pub fn new(stream: S, timeout: time::Duration) -> Self {
+        let timer = Default::default();
+        Self {
+            timer,
+            timeout,
+            stream: Some(stream),
+            delayed_item: None,
+        }
+    }
+
+    fn poll_delay(&mut self) -> Async<Option<S::Item>> {
+        match self.delayed_item.as_mut() {
+            Some(value) => match value.poll() {
+                Ok(Async::Ready(value)) => {
+                    self.delayed_item = None;
+                    Async::Ready(Some(value))
+                }
+                Ok(Async::NotReady) => Async::NotReady,
+                Err(_) => Async::Ready(None),
+            },
+            None => Async::NotReady,
+        }
+    }
+}
+
+impl<S: Stream> Stream for GracefulStream<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Some(stream) = self.stream.as_mut() {
+            let mut next_item = None;
+            loop {
+                match stream.poll()? {
+                    Async::Ready(Some(item)) => {
+                        next_item = Some(item);
+                    }
+                    Async::Ready(None) => {
+                        // when the stream ends, the last item can be returned early
+                        self.stream = None;
+                        return Ok(Async::Ready(
+                            next_item
+                                .or_else(|| self.delayed_item.take().map(|item| item.consume())),
+                        ));
+                    }
+                    Async::NotReady => {
+                        break;
+                    }
+                }
+            }
+            if let Some(next_item) = next_item {
+                self.delayed_item =
+                    Some(DelayedValue::new(next_item, self.timer.sleep(self.timeout)));
+            }
+        };
+        Ok(self.poll_delay())
+    }
+}
+
+struct DelayedValue<I> {
+    delay: tokio_timer::Sleep,
+    value: Option<I>,
+}
+
+impl<I> DelayedValue<I> {
+    fn consume(self) -> I {
+        self.value.unwrap()
+    }
+}
+
+impl<I> Future for DelayedValue<I> {
+    type Item = I;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<I, ()> {
+        match self
+            .delay
+            .poll()
+            .map_err(|e| log::error!("Timer error: {}", e))?
+        {
+            Async::NotReady => Ok(Async::NotReady),
+            Async::Ready(_) => Ok(Async::Ready(self.value.take().unwrap())),
+        }
+    }
+}
+
+impl<I> DelayedValue<I> {
+    fn new(value: I, delay: tokio_timer::Sleep) -> Self {
+        Self {
+            value: Some(value),
+            delay,
+        }
+    }
+}

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -43,5 +43,12 @@ pub fn spawn_monitor(
             .map(|_| ()),
     );
 
-    Ok(MonitorHandle(imp::spawn_monitor(sender)?))
+    #[cfg(not(target_os = "linux"))]
+    {
+        return Ok(MonitorHandle(imp::spawn_monitor(tx)?));
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return Ok(MonitorHandle(imp::spawn_monitor(tx, handle)?));
+    }
 }


### PR DESCRIPTION
To decrease thrashing in the app between when a user is switching between different networks, thus temporarily losing internet connectivity, a grace period for sending out offline mode commands is implemented. The grace period works as follows - any new offline state event is buffered for 3 seconds, if during that time a new event is received, the timer is reset and the new event is buffered. Once the timeout runs out, if no other events have been received, the offline event will be sent out.

I also took the opportunity to spawn one less thread on Linux, by reusing a tokio handle rather than spawning a new reactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1001)
<!-- Reviewable:end -->
