### PR TITLE
Fix "Quit" button not stopping the background service

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -50,6 +50,7 @@ class MainActivity : FragmentActivity() {
     val locationInfoCache = LocationInfoCache(daemon, relayListListener)
     val accountCache = AccountCache(settingsListener, daemon)
 
+    private var shouldStopService = false
     private var waitForDaemonJob: Job? = null
 
     private val serviceConnection = object : ServiceConnection {
@@ -106,6 +107,10 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onStop() {
+        if (shouldStopService) {
+            runBlocking { service.await().stop() }
+        }
+
         unbindService(serviceConnection)
 
         super.onStop()
@@ -151,6 +156,11 @@ class MainActivity : FragmentActivity() {
         }
 
         return request
+    }
+
+    fun quit()  {
+        shouldStopService = true
+        finishAndRemoveTask()
     }
 
     private fun addInitialFragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -33,6 +33,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     external fun getVersionInfo(): AppVersionInfo?
     external fun getWireguardKey(): PublicKey?
     external fun setAccount(accountToken: String?)
+    external fun shutdown()
     external fun updateRelaySettings(update: RelaySettingsUpdate)
 
     private external fun initialize(vpnService: MullvadVpnService)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -70,6 +70,16 @@ class MullvadVpnService : VpnService() {
     inner class LocalBinder : Binder() {
         val daemon
             get() = this@MullvadVpnService.daemon
+
+        fun stop() {
+            if (daemon.isCompleted) {
+                runBlocking { daemon.await().shutdown() }
+            } else {
+                daemon.cancel()
+            }
+
+            stopSelf()
+        }
     }
 
     private fun startDaemon() = GlobalScope.async(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
@@ -44,7 +44,7 @@ class SettingsFragment : Fragment() {
         }
 
         view.findViewById<Button>(R.id.quit_button).setOnClickListener {
-            activity?.finishAndRemoveTask()
+            parentActivity.quit()
         }
 
         view.findViewById<View>(R.id.account).setOnClickListener {

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -156,6 +156,10 @@ impl DaemonInterface {
         rx.wait().map_err(|_| Error::NoResponse)
     }
 
+    pub fn shutdown(&self) -> Result<()> {
+        self.send_command(ManagementCommand::Shutdown)
+    }
+
     pub fn update_relay_settings(&self, update: RelaySettingsUpdate) -> Result<()> {
         let (tx, rx) = oneshot::channel();
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -425,6 +425,17 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_setAccount(
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_shutdown(_: JNIEnv, _: JObject) {
+    if let Err(error) = DAEMON_INTERFACE.shutdown() {
+        log::error!(
+            "{}",
+            error.display_chain_with_msg("Failed to shutdown daemon thread")
+        );
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_updateRelaySettings(
     env: JNIEnv,
     _: JObject,


### PR DESCRIPTION
This PR implements the behavior that pressing the "Quit" button will also request the background service (running the daemon thread) to stop. Previously the service would continue running indefinitely.

Due to some weird Android behavior related to services, the service only stops after the daemon thread has finished. Therefore, this fix required implementing a way for the UI to notify the service that it should stop (and shutdown the daemon thread). Otherwise, just calling `context.stopService(...)` wouldn't actually do anything.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1007)
<!-- Reviewable:end -->
