### PR TITLE
Linux - improve static file DNS management resiliency against DHCP clients.

### DIFF
--- a/mullvad-types/src/settings/migrations/mod.rs
+++ b/mullvad-types/src/settings/migrations/mod.rs
@@ -133,7 +133,8 @@ mod test {
 
     #[test]
     fn test_deserialization_success() {
-        let _version: SettingsVersion = serde_json::from_str("2").expect("Failed to deserialize valid version");
+        let _version: SettingsVersion =
+            serde_json::from_str("2").expect("Failed to deserialize valid version");
     }
 
     #[test]


### PR DESCRIPTION
There's an issue on barebones Debian installs where our DNS config doesn't last a lot longer than a day. I suspected this was because of DHCP clients overwriting `/etc/resolv.conf` occasionally. Whilst the daemon was checking for tools that would edit the file directly, the daemon wasn't checking for the file being swapped in place `mv /etc/resolv.conf.staging /etc/resolv.conf`, which is what `dhclient` does on Debian. I've improved changed the code to listen for all the changes in `/etc/` and only react to changes that affect `/etc/resolv.conf`, which does allow us to catch more filesystem events.

And I've also included a small formatting fix for `mullvad-types`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1008)
<!-- Reviewable:end -->
