### PR TITLE
Show OpenVPN tunnel constraints options all of the time

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -232,43 +232,36 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     undefined
                   )}
 
-                  {this.props.tunnelProtocol === 'openvpn' ||
-                  this.props.tunnelProtocol === undefined ||
-                  process.platform === 'win32' ? (
-                    <View style={styles.advanced_settings__content}>
-                      <Selector
-                        title={messages.pgettext(
-                          'advanced-settings-view',
-                          'OpenVPN transport protocols',
-                        )}
-                        values={this.protocolItems}
-                        value={this.props.openvpn.protocol}
-                        onSelect={this.onSelectOpenvpnProtocol}
-                      />
-
-                      {this.props.openvpn.protocol ? (
-                        <Selector
-                          title={sprintf(
-                            // TRANSLATORS: The title for the port selector section.
-                            // TRANSLATORS: Available placeholders:
-                            // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
-                            messages.pgettext('advanced-settings-view', '%(portType)s port'),
-                            {
-                              portType: this.props.openvpn.protocol.toUpperCase(),
-                            },
-                          )}
-                          values={this.portItems[this.props.openvpn.protocol]}
-                          value={this.props.openvpn.port}
-                          onSelect={this.onSelectOpenVpnPort}
-                        />
-                      ) : (
-                        undefined
+                  <View style={styles.advanced_settings__content}>
+                    <Selector
+                      title={messages.pgettext(
+                        'advanced-settings-view',
+                        'OpenVPN transport protocols',
                       )}
-                    </View>
-                  ) : (
-                    undefined
-                  )}
+                      values={this.protocolItems}
+                      value={this.props.openvpn.protocol}
+                      onSelect={this.onSelectOpenvpnProtocol}
+                    />
 
+                    {this.props.openvpn.protocol ? (
+                      <Selector
+                        title={sprintf(
+                          // TRANSLATORS: The title for the port selector section.
+                          // TRANSLATORS: Available placeholders:
+                          // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
+                          messages.pgettext('advanced-settings-view', '%(portType)s port'),
+                          {
+                            portType: this.props.openvpn.protocol.toUpperCase(),
+                          },
+                        )}
+                        values={this.portItems[this.props.openvpn.protocol]}
+                        value={this.props.openvpn.port}
+                        onSelect={this.onSelectOpenVpnPort}
+                      />
+                    ) : (
+                      undefined
+                    )}
+                  </View>
                   {this.props.tunnelProtocol === 'wireguard' && process.platform !== 'win32' ? (
                     <View style={styles.advanced_settings__content}>
                       <Selector


### PR DESCRIPTION
Since OpenVPN tunnel constraints will be taken into account even when using automatic relay selection, they should always be shown in the settings, so this PR enables this behavior. Once we start selecting WireGuard relays with automatic relay selection, then we should show those settings all of the time as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1010)
<!-- Reviewable:end -->
