### PR TITLE
Retry after specific WireGuard connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Mark CLI `bridge set state` argument as required to avoid a crash.
 - The VPN service on Windows will now be restarted when it crashes.
+- Retry to connect when WireGuard tunnel fails due to a bad file descriptor.
 
 
 ## [2019.6] - 2019-07-15

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -24,9 +24,20 @@ pub enum Error {
     #[error(display = "Failed to create tunnel device")]
     SetupTunnelDeviceError(#[error(cause)] BoxedError),
 
-    /// Failed to setup wireguard tunnel.
-    #[error(display = "Failed to start wireguard tunnel - {}", status)]
-    StartWireguardError { status: i32 },
+    /// A recoverable error occurred while starting the wireguard tunnel
+    ///
+    /// This is an error returned by wireguard-go that indicates that trying to establish the
+    /// tunnel again should work normally. The error encountered is known to be sporadic.
+    #[error(display = "Recoverable error while starting wireguard tunnel")]
+    RecoverableStartWireguardError,
+
+    /// An unrecoverable error occurred while starting the wireguard tunnel
+    ///
+    /// This is an error returned by wireguard-go that indicates that trying to establish the
+    /// tunnel again will likely fail with the same error. An error was encountered during tunnel
+    /// configuration which can't be dealt with gracefully.
+    #[error(display = "Failed to start wireguard tunnel")]
+    FatalStartWireguardError,
 
     /// Failed to tear down wireguard tunnel.
     #[error(display = "Failed to stop wireguard tunnel - {}", status)]

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -45,7 +45,12 @@ impl WgGoTunnel {
         };
 
         if handle < 0 {
-            return Err(Error::StartWireguardError { status: handle });
+            // Error values returned from the wireguard-go library
+            return match handle {
+                -1 => Err(Error::FatalStartWireguardError),
+                -2 => Err(Error::RecoverableStartWireguardError),
+                _ => unreachable!("Unknown status code returned from wireguard-go"),
+            };
         }
 
         #[cfg(target_os = "android")]

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -347,7 +347,7 @@ impl TunnelState for ConnectingState {
                         #[cfg(not(windows))]
                         Err(
                             error @ tunnel::Error::WireguardTunnelMonitoringError(
-                                tunnel::wireguard::Error::StartWireguardError { status: -2 },
+                                tunnel::wireguard::Error::RecoverableStartWireguardError,
                             ),
                         ) => {
                             log::warn!(

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -345,11 +345,16 @@ impl TunnelState for ConnectingState {
                             )
                         }
                         #[cfg(not(windows))]
-                        Err(tunnel::Error::WireguardTunnelMonitoringError(
-                            tunnel::wireguard::Error::StartWireguardError { status: -2 },
-                        )) => {
+                        Err(
+                            error @ tunnel::Error::WireguardTunnelMonitoringError(
+                                tunnel::wireguard::Error::StartWireguardError { status: -2 },
+                            ),
+                        ) => {
                             log::warn!(
-                                "Retrying to connect after failing to start Wireguard tunnel"
+                                "{}",
+                                error.display_chain_with_msg(
+                                    "Retrying to connect after failing to start Wireguard tunnel"
+                                )
                             );
                             DisconnectingState::enter(
                                 shared_values,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -312,6 +312,11 @@ fn should_retry(error: &tunnel::Error) -> bool {
             tunnel::wireguard::Error::RecoverableStartWireguardError,
         ) => true,
 
+        #[cfg(target_os = "android")]
+        tunnel::Error::WireguardTunnelMonitoringError(tunnel::wireguard::Error::BypassError(_)) => {
+            true
+        }
+
         _ => false,
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -357,7 +357,10 @@ impl TunnelState for ConnectingState {
                             )
                         }
                         Err(error) => {
-                            log::error!("Failed to start tunnel: {}", error);
+                            log::error!(
+                                "{}",
+                                error.display_chain_with_msg("Failed to start tunnel")
+                            );
                             let block_reason = match error {
                                 tunnel::Error::EnableIpv6Error => BlockReason::Ipv6Unavailable,
                                 _ => BlockReason::StartTunnelError,


### PR DESCRIPTION
This PR updates the tunnel state machine to retry to connect when some known WireGuard issues occur. The two errors right now are when a bad file descriptor is provided to `wireguard-go` and when bypassing the tunnel socket on Android fails.

I added a new `StartTunnelResult` type to help with the `cfg` specific error handling in order to not have to repeat the retry code. Hopefully, this new type can implement the `Try` trait when it becomes stable, and the `ConnectingStart::start_tunnel` method can return it directly.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1012)
<!-- Reviewable:end -->
