### PR TITLE
Fix initial version fetch race condition

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -83,7 +83,7 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
     private fun updateUpgradeVersion() {
         val target = if (isStable) latestStable else latest
 
-        if (target == version) {
+        if (target == version || target == null) {
             isLatest = true
             upgradeVersion = null
         } else {


### PR DESCRIPTION
This is a minor bug-fix for a race condition where the current version is known before the next update version. When that happens, the `target` variable would be `null`, which is always different than the current version, and the new version banner would appear. This happens only on the first run after installation.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1015)
<!-- Reviewable:end -->
