### PR TITLE
Use UI state for action anticipation check

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -76,7 +76,7 @@ class ConnectionProxy(val parentActivity: MainActivity) {
 
     private fun anticipateConnectingState(): Boolean {
         synchronized(this) {
-            val currentState = state
+            val currentState = uiState
 
             if (currentState is TunnelState.Connecting || currentState is TunnelState.Connected) {
                 return false
@@ -89,7 +89,7 @@ class ConnectionProxy(val parentActivity: MainActivity) {
 
     private fun anticipateDisconnectingState(): Boolean {
         synchronized(this) {
-            val currentState = state
+            val currentState = uiState
 
             if (currentState is TunnelState.Disconnected) {
                 return false


### PR DESCRIPTION
This is a small fix for the "Cancel" button not working immediately after entering the "Connecting" state. This was happening because the `ConnectionProxy` class was using the state from the daemon thread to filter out repeated commands. This meant that when a `Connect` command was sent, it took a while before the daemon actually changed into the "Connecting" state, but the UI would already have shown the "Cancel" button. If it was pressed, it wouldn't work until the daemon thread entered the "Connecting" state.

The fix was to use the `uiState` instead of the daemon thread state, which then allows sending the "Disconnect" command right after the "Connect" command before the daemon actually entering the "Connecting" state.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1016)
<!-- Reviewable:end -->
