### PR TITLE
Allow "Switch location" button to grow taller

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -86,7 +86,7 @@ class ConnectFragment : Fragment() {
             onDisconnect = { connectionProxy.disconnect() }
         }
 
-        switchLocationButton = SwitchLocationButton(view)
+        switchLocationButton = SwitchLocationButton(view, resources)
         switchLocationButton.onClick = { openSwitchLocationScreen() }
 
         updateKeyStatusJob = updateKeyStatus(keyStatusListener.keyStatus)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SwitchLocationButton.kt
@@ -5,18 +5,26 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 
+import android.content.res.Resources
 import android.graphics.drawable.Drawable
+import android.text.TextUtils.TruncateAt
 import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.Button
 
 import net.mullvad.mullvadvpn.model.ActionAfterDisconnect
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 
-class SwitchLocationButton(val parentView: View) {
+class SwitchLocationButton(val parentView: View, val resources: Resources) {
     private val button: Button = parentView.findViewById(R.id.switch_location)
     private val chevron: Drawable = button.compoundDrawables[2]
 
+    private val normalButtonHeight = resources.getDimensionPixelSize(R.dimen.normal_button_height)
+    private val tallButtonHeight = resources.getDimensionPixelSize(R.dimen.tall_button_height)
+    private val topMargin = tallButtonHeight - normalButtonHeight
+
+    private var tall = false
     private var updateJob: Job? = null
 
     var location: RelayItem? = null
@@ -35,6 +43,7 @@ class SwitchLocationButton(val parentView: View) {
 
     init {
         button.setOnClickListener { onClick?.invoke() }
+        button.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> resizeIfNecessary() }
     }
 
     fun onDestroy() {
@@ -65,6 +74,7 @@ class SwitchLocationButton(val parentView: View) {
     private fun showLabel() {
         button.setText(R.string.switch_location)
         button.setCompoundDrawables(null, null, null, null)
+        resizeIfNecessary()
     }
 
     private fun showLocation() {
@@ -75,6 +85,35 @@ class SwitchLocationButton(val parentView: View) {
         } else {
             button.setText(locationName)
             button.setCompoundDrawables(null, null, chevron, null)
+            resizeIfNecessary()
+        }
+    }
+
+    private fun resizeIfNecessary() {
+        val layoutParams = button.layoutParams
+
+        if (button.lineCount > 1 && !tall) {
+            tall = true
+
+            if (layoutParams is MarginLayoutParams) {
+                layoutParams.height = tallButtonHeight
+                layoutParams.topMargin = 0
+            }
+
+            button.maxLines = 2
+            button.ellipsize = TruncateAt.END
+            button.requestLayout()
+        } else if (button.lineCount <= 1 && tall) {
+            tall = false
+
+            if (layoutParams is MarginLayoutParams) {
+                layoutParams.height = normalButtonHeight
+                layoutParams.topMargin = topMargin
+            }
+
+            button.maxLines = -1
+            button.ellipsize = null
+            button.requestLayout()
         }
     }
 }

--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -234,7 +234,9 @@
             android:padding="24dp"
             >
         <Button android:id="@+id/switch_location"
+                android:layout_marginTop="20dp"
                 android:layout_marginBottom="16dp"
+                android:paddingHorizontal="8dp"
                 android:text="@string/switch_location"
                 android:drawableRight="@drawable/icon_chevron"
                 android:paddingRight="8dp"

--- a/android/src/main/res/values/dimensions.xml
+++ b/android/src/main/res/values/dimensions.xml
@@ -4,4 +4,6 @@
     <dimen name="relay_row_padding">60dp</dimen>
     <dimen name="relay_list_divider">1dp</dimen>
     <dimen name="account_input_corner_radius">4dp</dimen>
+    <dimen name="normal_button_height">44dp</dimen>
+    <dimen name="tall_button_height">64dp</dimen>
 </resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
     </style>
 
     <style name="Button" parent="Widget.AppCompat.Button.Borderless">
-        <item name="android:layout_height">44dp</item>
+        <item name="android:layout_height">@dimen/normal_button_height</item>
         <item name="android:layout_width">match_parent</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">@color/white</item>


### PR DESCRIPTION
This PR changes the "Switch location" button to detect when the text it contains doesn't fit. It will then attempt to expand the button to fit two lines. If a third line is necessary, the text will be ellipsized.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1017)
<!-- Reviewable:end -->
