### PR TITLE
Include Android version and ABI list in report

### DIFF
--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -112,16 +112,21 @@ mod os {
 #[cfg(target_os = "android")]
 mod os {
     pub fn version() -> String {
+        let version = get_prop("ro.build.version.release").unwrap_or_else(String::new);
+        let api_level = get_prop("ro.build.version.sdk")
+            .map(|api| format!(" (API level: {})", api))
+            .unwrap_or_else(String::new);
+        let abi_list = get_prop("ro.product.cpu.abilist")
+            .map(|abis| format!(" (ABI list: {})", abis))
+            .unwrap_or_else(String::new);
+
         let manufacturer = get_prop("ro.product.manufacturer").unwrap_or_else(String::new);
         let product = get_prop("ro.product.model").unwrap_or_else(String::new);
         let build = get_prop("ro.build.display.id").unwrap_or_else(String::new);
-        let api_level = get_prop("ro.build.version.sdk")
-            .map(|api| format!("(API level: {})", api))
-            .unwrap_or_else(String::new);
 
         format!(
-            "Android {} {} {} {}",
-            manufacturer, product, build, api_level
+            "Android {}{}{} - {} {} {}",
+            version, api_level, abi_list, manufacturer, product, build
         )
     }
 


### PR DESCRIPTION
This PR changes slightly the Android system information present in the problem report. The idea is to make it clearer what version of Android it is and what ABI it's running on.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1018)
<!-- Reviewable:end -->
