### PR TITLE
Android version formatting and included data

### DIFF
--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -116,13 +116,12 @@ mod os {
         let api_level = get_prop("ro.build.version.sdk").unwrap_or("N/A");
         let abi_list = get_prop("ro.product.cpu.abilist").unwrap_or("N/A");
 
-        let manufacturer = get_prop("ro.product.manufacturer").unwrap_or_default();
-        let product = get_prop("ro.product.model").unwrap_or_default();
-        let build = get_prop("ro.build.display.id").unwrap_or_default();
+        let manufacturer = get_prop("ro.product.manufacturer").unwrap_or("Unknown brand");
+        let product = get_prop("ro.product.model").unwrap_or("Unknown model");
 
         format!(
-            "Android {} (API level: {}) (ABI list: {}) - {} {} {}",
-            version, api_level, abi_list, manufacturer, product, build
+            "Android {} (API: {}) - {} {}",
+            version, api_level, manufacturer, product
         )
     }
 

--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -120,9 +120,9 @@ mod os {
             .map(|abis| format!(" (ABI list: {})", abis))
             .unwrap_or_else(String::new);
 
-        let manufacturer = get_prop("ro.product.manufacturer").unwrap_or_else(String::new);
-        let product = get_prop("ro.product.model").unwrap_or_else(String::new);
-        let build = get_prop("ro.build.display.id").unwrap_or_else(String::new);
+        let manufacturer = get_prop("ro.product.manufacturer").unwrap_or_default();
+        let product = get_prop("ro.product.model").unwrap_or_default();
+        let build = get_prop("ro.build.display.id").unwrap_or_default();
 
         format!(
             "Android {}{}{} - {} {} {}",

--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -133,11 +133,12 @@ mod os {
     use std::collections::HashMap;
 
     pub fn version() -> String {
-        let version = get_prop("ro.build.version.release").unwrap_or("N/A");
-        let api_level = get_prop("ro.build.version.sdk").unwrap_or("N/A");
+        let version = get_prop("ro.build.version.release").unwrap_or_else(|| "N/A".to_owned());
+        let api_level = get_prop("ro.build.version.sdk").unwrap_or_else(|| "N/A".to_owned());
 
-        let manufacturer = get_prop("ro.product.manufacturer").unwrap_or("Unknown brand");
-        let product = get_prop("ro.product.model").unwrap_or("Unknown model");
+        let manufacturer =
+            get_prop("ro.product.manufacturer").unwrap_or_else(|| "Unknown brand".to_owned());
+        let product = get_prop("ro.product.model").unwrap_or_else(|| "Unknown model".to_owned());
 
         format!(
             "Android {} (API: {}) - {} {}",
@@ -149,7 +150,7 @@ mod os {
         let mut metadata = HashMap::new();
         metadata.insert(
             "abi".to_owned(),
-            get_prop("ro.product.cpu.abilist").unwrap_or("N/A"),
+            get_prop("ro.product.cpu.abilist").unwrap_or_else(|| "N/A".to_owned()),
         );
         metadata
     }

--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -17,8 +17,6 @@ pub fn collect() -> BTreeMap<String, String> {
 
 #[cfg(target_os = "linux")]
 mod os {
-    use std::collections::HashMap;
-
     pub fn version() -> String {
         // The OS version information is obtained first from the os-release file. If that
         // information is incomplete or unavailable, an attempt is made to obtain the
@@ -71,15 +69,13 @@ mod os {
         })
     }
 
-    pub fn extra_metadata() -> HashMap<String, String> {
-        HashMap::new()
+    pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
+        std::iter::empty()
     }
 }
 
 #[cfg(target_os = "macos")]
 mod os {
-    use std::collections::HashMap;
-
     pub fn version() -> String {
         format!(
             "macOS {}",
@@ -88,15 +84,13 @@ mod os {
         )
     }
 
-    pub fn extra_metadata() -> HashMap<String, String> {
-        HashMap::new()
+    pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
+        std::iter::empty()
     }
 }
 
 #[cfg(windows)]
 mod os {
-    use std::collections::HashMap;
-
     pub fn version() -> String {
         let system_info =
             super::command_stdout_lossy("systeminfo", &["/FO", "LIST"]).unwrap_or_else(String::new);
@@ -123,8 +117,8 @@ mod os {
         format!("Windows {} ({})", version, full_version)
     }
 
-    pub fn extra_metadata() -> HashMap<String, String> {
-        HashMap::new()
+    pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
+        std::iter::empty()
     }
 }
 

--- a/mullvad-problem-report/src/metadata.rs
+++ b/mullvad-problem-report/src/metadata.rs
@@ -112,20 +112,16 @@ mod os {
 #[cfg(target_os = "android")]
 mod os {
     pub fn version() -> String {
-        let version = get_prop("ro.build.version.release").unwrap_or_else(String::new);
-        let api_level = get_prop("ro.build.version.sdk")
-            .map(|api| format!(" (API level: {})", api))
-            .unwrap_or_else(String::new);
-        let abi_list = get_prop("ro.product.cpu.abilist")
-            .map(|abis| format!(" (ABI list: {})", abis))
-            .unwrap_or_else(String::new);
+        let version = get_prop("ro.build.version.release").unwrap_or("N/A");
+        let api_level = get_prop("ro.build.version.sdk").unwrap_or("N/A");
+        let abi_list = get_prop("ro.product.cpu.abilist").unwrap_or("N/A");
 
         let manufacturer = get_prop("ro.product.manufacturer").unwrap_or_default();
         let product = get_prop("ro.product.model").unwrap_or_default();
         let build = get_prop("ro.build.display.id").unwrap_or_default();
 
         format!(
-            "Android {}{}{} - {} {} {}",
+            "Android {} (API level: {}) (ABI list: {}) - {} {} {}",
             version, api_level, abi_list, manufacturer, product, build
         )
     }


### PR DESCRIPTION
This PR came about in multiple steps.
* First I saw `unwrap_or_else(String::new)` and thought that it would be more idiomatic with `unwrap_or_default()`.
* I then saw `format!("Android {}{}{} - {} {} {}", ...)` - I usually think a formatting string with multiple `{}` next to each other is an indication that formatting is done somewhere else than the formatting string. From this formatting string it's hard to see what the final text will actually look like. And I felt having `"API: N/A"` would be more clear than just a missing API. Then it's more obvious that we failed to get the API level.

Then I saw a final produced problem report and realized both that the email topic was very very long (the generated problem report has the full `os` metadata content in the topic), and that it contained quite detailed information about my phone. So I brought it up with support. Discussed what info they thought they would need along with how annoying it would potentially be with long topics.

Support thought the long final build number would not be useful to them. If you need it for debugging @jvff, say so and we can discuss it. Regarding the ABI it can probably be useful, but it's very long and probably not needed in the topic. So I moved it to a separate metadata entry.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1020)
<!-- Reviewable:end -->
