### PR TITLE
Preserve mtime and other metadata when uploading installers

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -19,11 +19,11 @@ while true; do
 
     version=$(echo $f | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm)/\1/g')
     ssh build.mullvad.net mkdir -p "app/$version" || continue
-    scp -B "$f" build.mullvad.net:app/$version/ || continue
+    scp -pB "$f" build.mullvad.net:app/$version/ || continue
 
     rm -f "$f.asc"
     gpg -u A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF --pinentry-mode loopback --sign --armor --detach-sign "$f"
-    scp -B "$f.asc" build.mullvad.net:app/$version/ || true
+    scp -pB "$f.asc" build.mullvad.net:app/$version/ || true
     yes | rm "$f" "$f_checksum" "$f.asc"
   done
 done


### PR DESCRIPTION
When I was gone the upload script failed. All builds still worked, but they were not uploaded. Now when I started it all installers got the mtime of when they were uploaded. I found we can simply add `-p` to `scp` to make it persist them, making the metadata about the installers slightly better.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1021)
<!-- Reviewable:end -->
