### PR TITLE
Build android on buildservers

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -58,7 +58,7 @@ for ARCHITECTURE in $ARCHITECTURES; do
             ;;
     esac
 
-    . env.sh "$TARGET"
+    source env.sh "$TARGET"
     cargo build $CARGO_FLAGS --target "$TARGET" --package mullvad-jni
 
     cp -a "$SCRIPT_DIR/dist-assets/binaries/$TARGET" "$SCRIPT_DIR/android/build/extraJni/$ABI"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -27,12 +27,9 @@ fi
 
 if [[ "$BUILD_TYPE" == "debug" || "$(git describe)" != "$PRODUCT_VERSION" ]]; then
     GIT_COMMIT="$(git rev-parse --short HEAD)"
-    APK_VERSION="${PRODUCT_VERSION}-dev-${GIT_COMMIT}"
-else
-    APK_VERSION="$PRODUCT_VERSION"
+    PRODUCT_VERSION="${PRODUCT_VERSION}-dev-${GIT_COMMIT}"
+    echo "Modifying product version to $PRODUCT_VERSION"
 fi
-
-ARCHITECTURES="aarch64 armv7 x86_64 i686"
 
 cd "$SCRIPT_DIR/android"
 ./gradlew --console plain clean
@@ -40,6 +37,7 @@ mkdir -p "${SCRIPT_DIR}/android/build/extraJni"
 
 cd "$SCRIPT_DIR"
 
+ARCHITECTURES="aarch64 armv7 x86_64 i686"
 for ARCHITECTURE in $ARCHITECTURES; do
     case "$ARCHITECTURE" in
         "x86_64")
@@ -70,7 +68,15 @@ done
 cd "$SCRIPT_DIR/android"
 ./gradlew --console plain "$GRADLE_TASK"
 
-GENERATED_APK="$SCRIPT_DIR/android/build/outputs/apk/$BUILD_TYPE/android-$BUILD_TYPE.apk"
+mkdir -p "$SCRIPT_DIR/dist"
+cp  "$SCRIPT_DIR/android/build/outputs/apk/$BUILD_TYPE/android-$BUILD_TYPE.apk" \
+    "$SCRIPT_DIR/dist/MullvadVPN-${PRODUCT_VERSION}${APK_SUFFIX}.apk"
 
-mkdir -p ../dist
-cp "$GENERATED_APK" "$SCRIPT_DIR/dist/MullvadVPN-${APK_VERSION}${APK_SUFFIX}.apk"
+echo "**********************************"
+echo ""
+echo " The build finished successfully! "
+echo " You have built:"
+echo ""
+echo " $PRODUCT_VERSION"
+echo ""
+echo "**********************************"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -58,6 +58,7 @@ for ARCHITECTURE in $ARCHITECTURES; do
             ;;
     esac
 
+    echo "Building mullvad-daemon for $TARGET"
     source env.sh "$TARGET"
     cargo build $CARGO_FLAGS --target "$TARGET" --package mullvad-jni
 

--- a/build.sh
+++ b/build.sh
@@ -59,14 +59,6 @@ else
     echo "Removing old Rust build artifacts"
     cargo +stable clean
 fi
-if [[ "${1:-""}" == "--dev-build" ]]; then
-    # Disable installer compression on *explicit* dev builds.
-    # This does not disable compression on build server builds, since they
-    # always run without --dev-buid.
-    echo "Disabling compression of installer in this dev build"
-    cp gui/electron-builder.yml gui/electron-builder.yml.bak
-    echo "compression: store" >> gui/electron-builder.yml
-fi
 
 echo "Building Mullvad VPN $PRODUCT_VERSION"
 SEMVER_VERSION=$(echo $PRODUCT_VERSION | sed -Ee 's/($|-.*)/.0\1/g')
@@ -85,6 +77,15 @@ function restore_metadata_backups() {
     popd
 }
 trap 'restore_metadata_backups' EXIT
+
+if [[ "${1:-""}" == "--dev-build" ]]; then
+    # Disable installer compression on *explicit* dev builds.
+    # This does not disable compression on build server builds, since they
+    # always run without --dev-buid.
+    echo "Disabling compression of installer in this dev build"
+    cp gui/electron-builder.yml gui/electron-builder.yml.bak
+    echo "compression: store" >> gui/electron-builder.yml
+fi
 
 sed -i.bak \
     -Ee "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" \

--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,9 @@ SEMVER_VERSION=$(echo $PRODUCT_VERSION | sed -Ee 's/($|-.*)/.0\1/g')
 
 function restore_metadata_backups() {
     pushd "$SCRIPT_DIR"
+    if [[ "${1:-""}" == "--dev-build" ]]; then
+        mv gui/electron-builder.yml.bak gui/electron-builder.yml || true
+    fi
     mv gui/package.json.bak gui/package.json || true
     mv gui/package-lock.json.bak gui/package-lock.json || true
     mv Cargo.lock.bak Cargo.lock || true
@@ -73,7 +76,6 @@ function restore_metadata_backups() {
     mv mullvad-problem-report/Cargo.toml.bak mullvad-problem-report/Cargo.toml || true
     mv talpid-openvpn-plugin/Cargo.toml.bak talpid-openvpn-plugin/Cargo.toml || true
     mv dist-assets/windows/version.h.bak dist-assets/windows/version.h || true
-    mv gui/electron-builder.yml.bak gui/electron-builder.yml || true
     popd
 }
 trap 'restore_metadata_backups' EXIT

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -66,7 +66,7 @@ sign_win() {
 
 upload() {
   current_hash=$1
-  for f in MullvadVPN-*.{deb,rpm,exe,pkg}; do
+  for f in MullvadVPN-*.{deb,rpm,exe,pkg,apk}; do
     sha256sum "$f" > "$f.sha256"
     case "$(uname -s)" in
       # Linux is both the build and upload server. Just move directly to target dir
@@ -128,6 +128,10 @@ build_ref() {
       sign_win || return 0
       echo "Packaging all PDB files..."
       find ./windows/ -iname "*.pdb" | tar -cJf $SCRIPT_DIR/pdb/$current_hash.tar.xz -T -
+      ;;
+    Linux*)
+      echo "Building Android APK"
+      ./build-apk.sh || return 0
       ;;
   esac
 

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -9,7 +9,7 @@ cd $UPLOAD_DIR
 
 while true; do
   sleep 10
-  for f_checksum in MullvadVPN-*.{deb,rpm,exe,pkg}.sha256; do
+  for f_checksum in MullvadVPN-*.{deb,rpm,exe,pkg,apk}.sha256; do
     sleep 1
     f="${f_checksum/.sha256/}"
     if ! sha256sum --quiet -c "$f_checksum"; then
@@ -17,7 +17,7 @@ while true; do
       continue
     fi
 
-    version=$(echo $f | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm)/\1/g')
+    version=$(echo $f | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm|.apk)/\1/g')
     ssh build.mullvad.net mkdir -p "app/$version" || continue
     scp -pB "$f" build.mullvad.net:app/$version/ || continue
 


### PR DESCRIPTION
Updating build server scripts to automatically build the Android APK on the Linux build machine.

Also various small improvements to the `build-apk.sh` script. Most of them just to make it work more like `build.sh` and to print more useful info while building.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1022)
<!-- Reviewable:end -->
