### PR TITLE
Fix auto relay selection

### DIFF
--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -134,7 +134,11 @@ impl RelayConstraints {
 impl fmt::Display for RelayConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.tunnel_protocol {
-            Constraint::Any => write!(f, "any tunnel protocol")?,
+            Constraint::Any => write!(
+                f,
+                "Any tunnel protcol with OpenVPN through {} and WireGuard through {}",
+                &self.openvpn_constraints, &self.wireguard_constraints,
+            )?,
             Constraint::Only(ref tunnel_protocol) => {
                 tunnel_protocol.fmt(f)?;
                 match tunnel_protocol {


### PR DESCRIPTION
The extra tunnel protocol constraint I introduced a couple of weeks ago was not implemented as far as relay selection goes. The couple of subtle bugs that I did introduce are rectified with this PR.
The underlying issue was that the relay filtering code assumed that if any tunnel protocol was ok, then no tunnel constraints were to be applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1023)
<!-- Reviewable:end -->
