### PR TITLE
Disable wireguard key generation on Windows

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1208,7 +1208,12 @@ where
         }
     }
 
+    #[cfg_attr(target_os = "windows", allow(unreachable_code))]
     fn ensure_wireguard_keys_for_current_account(&mut self) {
+        #[cfg(target_os = "windows")]
+        {
+            return;
+        }
         if let Some(account) = self.settings.get_account_token() {
             if self
                 .account_history


### PR DESCRIPTION
I'm disabling wireguard key generation on Windows as currently there is no use for wireguard keys on Windows. The `unreachable_code` warnings are disabled for this function since I think it'd be more pragmatic to disable this lint once for Windows rather than to compile all the fields and modules that are involved with the automatic key generation conditionally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1024)
<!-- Reviewable:end -->
