### PR TITLE
Improve no-matching-relay error message in GUI

### DIFF
--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -65,7 +65,7 @@ function getBlockReasonMessage(blockReason: BlockReason): string {
     case 'no_matching_relay':
       return messages.pgettext(
         'in-app-notifications',
-        'No relay server matches the current settings',
+        'No relay server matches the current settings. You can try changing the location or the relay settings.',
       );
     case 'is_offline':
       return messages.pgettext(


### PR DESCRIPTION
A slight improvement to the no-matching-relay error message in the GUI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1025)
<!-- Reviewable:end -->
