### PR TITLE
Simplify protocol constraint selection

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -232,36 +232,44 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     undefined
                   )}
 
-                  <View style={styles.advanced_settings__content}>
-                    <Selector
-                      title={messages.pgettext(
-                        'advanced-settings-view',
-                        'OpenVPN transport protocol',
-                      )}
-                      values={this.protocolItems}
-                      value={this.props.openvpn.protocol}
-                      onSelect={this.onSelectOpenvpnProtocol}
-                    />
-
-                    {this.props.openvpn.protocol ? (
+                  {this.props.tunnelProtocol !== 'wireguard' ? (
+                    <View style={styles.advanced_settings__content}>
                       <Selector
-                        title={sprintf(
-                          // TRANSLATORS: The title for the port selector section.
-                          // TRANSLATORS: Available placeholders:
-                          // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
-                          messages.pgettext('advanced-settings-view', 'OpenVPN %(portType)s port'),
-                          {
-                            portType: this.props.openvpn.protocol.toUpperCase(),
-                          },
+                        title={messages.pgettext(
+                          'advanced-settings-view',
+                          'OpenVPN transport protocol',
                         )}
-                        values={this.portItems[this.props.openvpn.protocol]}
-                        value={this.props.openvpn.port}
-                        onSelect={this.onSelectOpenVpnPort}
+                        values={this.protocolItems}
+                        value={this.props.openvpn.protocol}
+                        onSelect={this.onSelectOpenvpnProtocol}
                       />
-                    ) : (
-                      undefined
-                    )}
-                  </View>
+
+                      {this.props.openvpn.protocol ? (
+                        <Selector
+                          title={sprintf(
+                            // TRANSLATORS: The title for the port selector section.
+                            // TRANSLATORS: Available placeholders:
+                            // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
+                            messages.pgettext(
+                              'advanced-settings-view',
+                              'OpenVPN %(portType)s port',
+                            ),
+                            {
+                              portType: this.props.openvpn.protocol.toUpperCase(),
+                            },
+                          )}
+                          values={this.portItems[this.props.openvpn.protocol]}
+                          value={this.props.openvpn.port}
+                          onSelect={this.onSelectOpenVpnPort}
+                        />
+                      ) : (
+                        undefined
+                      )}
+                    </View>
+                  ) : (
+                    undefined
+                  )}
+
                   {this.props.tunnelProtocol === 'wireguard' && process.platform !== 'win32' ? (
                     <View style={styles.advanced_settings__content}>
                       <Selector

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -222,7 +222,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                   {process.platform !== 'win32' ? (
                     <View style={styles.advanced_settings__content}>
                       <Selector
-                        title={messages.pgettext('advanced-settings-view', 'Tunnel protocols')}
+                        title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
                         values={this.tunnelProtocolItems}
                         value={this.props.tunnelProtocol}
                         onSelect={this.onSelectTunnelProtocol}
@@ -236,7 +236,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     <Selector
                       title={messages.pgettext(
                         'advanced-settings-view',
-                        'OpenVPN transport protocols',
+                        'OpenVPN transport protocol',
                       )}
                       values={this.protocolItems}
                       value={this.props.openvpn.protocol}
@@ -249,7 +249,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                           // TRANSLATORS: The title for the port selector section.
                           // TRANSLATORS: Available placeholders:
                           // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
-                          messages.pgettext('advanced-settings-view', '%(portType)s port'),
+                          messages.pgettext('advanced-settings-view', 'OpenVPN %(portType)s port'),
                           {
                             portType: this.props.openvpn.protocol.toUpperCase(),
                           },

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -55,7 +55,7 @@ export default class WireguardKeys extends Component<IProps> {
                   disabled={this.props.isOffline}
                   onPress={this.props.onVisitWebsiteKey}>
                   <AppButton.Label>
-                    {messages.pgettext('wireguard-key-view', 'Manage keys in website')}
+                    {messages.pgettext('wireguard-key-view', 'Manage keys')}
                   </AppButton.Label>
                   <AppButton.Icon source="icon-extLink" height={16} width={16} />
                 </AppButton.GreenButton>


### PR DESCRIPTION
The "WireGuard port" setting is only visible when the VPN protocol is explicitly set to WireGuard. But the OpenVPN settings are shown no matter what. This felt inconsistent. And also, there is no need to configure the OpenVPN transport protocol or port when Wireguard is exclusively going to be used.

Also changed "protocols" into "protocol" to make it consistent with the other settings.

Also added "OpenVPN" in front of "UDP port" and "TCP port" to make it clear, and also consistent with "WireGuard port" and the other protocol specific settings.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1026)
<!-- Reviewable:end -->
