### PR TITLE
Fix interactions between relay and bridge settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Fixed
+- Check and adjust relay and bridge constraints when they are updated, so no incompatbile
+  combinations are used.
 
 
 ## [2019.7-beta1] - 2019-08-08

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -55,7 +55,7 @@ use talpid_core::{
     tunnel_state_machine::{self, TunnelCommand, TunnelParametersGenerator},
 };
 use talpid_types::{
-    net::{openvpn, TransportProtocol, TunnelParameters},
+    net::{openvpn, TunnelParameters},
     tunnel::{BlockReason, TunnelStateTransition},
     ErrorExt,
 };
@@ -1171,7 +1171,7 @@ where
         let constraints_update = RelayConstraintsUpdate {
             tunnel_protocol: Some(Constraint::Only(TunnelProtocol::OpenVpn)),
             openvpn_constraints: Some(OpenVpnConstraints {
-                protocol: Constraint::Only(TransportProtocol::Tcp),
+                protocol: Constraint::Any,
                 port: Constraint::Any,
             }),
             ..Default::default()

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -554,7 +554,11 @@ where
                 }
                 RelaySettings::Normal(constraints) => self
                     .relay_selector
-                    .get_tunnel_endpoint(&constraints, retry_attempt)
+                    .get_tunnel_endpoint(
+                        &constraints,
+                        self.settings.get_bridge_state(),
+                        retry_attempt,
+                    )
                     .map_err(|e| {
                         e.display_chain_with_msg(
                             "No valid relay servers match the current settings",

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -4,7 +4,7 @@ use std::{
     fmt, io,
     net::{IpAddr, SocketAddr, ToSocketAddrs},
 };
-use talpid_types::net::{openvpn, wireguard, TunnelParameters};
+use talpid_types::net::{openvpn, wireguard, Endpoint, TunnelParameters};
 
 
 #[derive(err_derive::Error, Debug)]
@@ -26,6 +26,13 @@ pub struct CustomTunnelEndpoint {
 impl CustomTunnelEndpoint {
     pub fn new(host: String, config: ConnectionConfig) -> Self {
         Self { host, config }
+    }
+
+    pub fn endpoint(&self) -> Endpoint {
+        match &self.config {
+            ConnectionConfig::OpenVpn(config) => config.endpoint,
+            ConnectionConfig::Wireguard(config) => config.get_endpoint(),
+        }
     }
 
     pub fn to_tunnel_parameters(

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -91,6 +91,31 @@ impl RelaySettings {
             }),
         }
     }
+
+    pub(crate) fn ensure_bridge_compatibility(&mut self) {
+        match self {
+            RelaySettings::Normal(ref mut constraints) => {
+                if constraints.tunnel_protocol == Constraint::Only(TunnelProtocol::Wireguard) {
+                    constraints.tunnel_protocol = Constraint::Any;
+                }
+                if constraints.openvpn_constraints.protocol
+                    == Constraint::Only(TransportProtocol::Udp)
+                {
+                    constraints.openvpn_constraints = OpenVpnConstraints {
+                        protocol: Constraint::Any,
+                        port: Constraint::Any,
+                    }
+                }
+            }
+            RelaySettings::CustomTunnelEndpoint(config) => {
+                if config.endpoint().protocol == TransportProtocol::Udp {
+                    log::warn!(
+                        "Using custom tunnel endpoint with UDP, bridges will likely not work"
+                    );
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -296,6 +296,9 @@ impl Settings {
     pub fn set_bridge_state(&mut self, bridge_state: BridgeState) -> Result<bool> {
         if self.bridge_state != bridge_state {
             self.bridge_state = bridge_state;
+            if self.bridge_state == BridgeState::On {
+                self.relay_settings.ensure_bridge_compatibility();
+            }
             self.save().map(|_| true)
         } else {
             Ok(false)

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -188,8 +188,12 @@ impl Settings {
     }
 
     pub fn update_relay_settings(&mut self, update: RelaySettingsUpdate) -> Result<bool> {
+        let update_supports_bridge = update.supports_bridge();
         let new_settings = self.relay_settings.merge(update);
         if self.relay_settings != new_settings {
+            if !update_supports_bridge && BridgeState::On == self.bridge_state {
+                self.bridge_state = BridgeState::Auto;
+            }
             debug!(
                 "changing relay settings from {} to {}",
                 self.relay_settings, new_settings


### PR DESCRIPTION
A couple of improvements w.r.t. bridge mode:
- when new relay constraints are applied, they will change the bridge state if they enforce constraints that don't support bridges
- when bridge mode is set to _On_, then relay constraints will be cleared to auto
- take bridge mode into account when determining preferred relay constraints

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1028)
<!-- Reviewable:end -->
