### PR TITLE
Add elaborate tunnel params error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,12 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add more details to the block reason shown in GUI when the daemon fails to generate tunnel
+  parameters.
+
 ### Fixed
-- Check and adjust relay and bridge constraints when they are updated, so no incompatbile
+- Check and adjust relay and bridge constraints when they are updated, so no incompatible
   combinations are used.
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ name = "talpid-types"
 version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -256,7 +256,6 @@ const tunnelStateSchema = oneOf(
           'set_firewall_policy_error',
           'set_dns_error',
           'start_tunnel_error',
-          'no_matching_relay',
           'is_offline',
           'tap_adapter_problem',
         ),
@@ -264,6 +263,15 @@ const tunnelStateSchema = oneOf(
       object({
         reason: enumeration('auth_failed'),
         details: maybe(string),
+      }),
+      object({
+        reason: enumeration('tunnel_parameter_error'),
+        details: enumeration(
+          'no_matching_relay',
+          'no_matching_bridge_relay',
+          'no_wireguard_key',
+          'custom_tunnel_host_resultion_error',
+        ),
       }),
     ),
   }),

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -14,7 +14,7 @@ import {
   NotificationTitle,
 } from './NotificationBanner';
 
-import { BlockReason, TunnelState } from '../../shared/daemon-rpc-types';
+import { BlockReason, TunnelParameterError, TunnelState } from '../../shared/daemon-rpc-types';
 import AccountExpiry from '../lib/account-expiry';
 import { parseAuthFailure } from '../lib/auth-failure';
 import { IVersionReduxState } from '../redux/version/reducers';
@@ -39,6 +39,29 @@ type NotificationAreaPresentation =
 type State = NotificationAreaPresentation & {
   visible: boolean;
 };
+
+function getTunnelParameterMessage(err: TunnelParameterError): string {
+  switch (err) {
+    /// TODO: once bridge constraints can be set, add a more descriptive error message
+    case 'no_matching_bridge_relay':
+    case 'no_matching_relay':
+      return messages.pgettext(
+        'in-app-notifications',
+        'No relay server matches the current settings. You can try changing the location or the relay settings.',
+      );
+    case 'no_wireguard_key':
+      return messages.pgettext(
+        'in-app-notifications',
+        'WireGuard key not set. You can generate one manually in the advanced settings.',
+      );
+      break;
+    case 'custom_tunnel_host_resultion_error':
+      return messages.pgettext(
+        'in-app-notifications',
+        'Failed to resolve host of custom tunnel. Consider changing the settings',
+      );
+  }
+}
 
 function getBlockReasonMessage(blockReason: BlockReason): string {
   switch (blockReason.reason) {
@@ -70,11 +93,8 @@ function getBlockReasonMessage(blockReason: BlockReason): string {
       return messages.pgettext('in-app-notifications', 'Failed to set system DNS server');
     case 'start_tunnel_error':
       return messages.pgettext('in-app-notifications', 'Failed to start tunnel connection');
-    case 'no_matching_relay':
-      return messages.pgettext(
-        'in-app-notifications',
-        'No relay server matches the current settings. You can try changing the location or the relay settings.',
-      );
+    case 'tunnel_parameter_error':
+      return getTunnelParameterMessage(blockReason.details);
     case 'is_offline':
       return messages.pgettext(
         'in-app-notifications',

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -52,7 +52,7 @@ function getTunnelParameterMessage(err: TunnelParameterError): string {
     case 'no_wireguard_key':
       return messages.pgettext(
         'in-app-notifications',
-        'WireGuard key not set. You can generate one manually in the advanced settings.',
+        'WireGuard key not published to our servers. You can manage your key in Advanced settings.',
       );
       break;
     case 'custom_tunnel_host_resultion_error':

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -15,6 +15,12 @@ export interface ILocation {
   bridgeHostname?: string;
 }
 
+export type TunnelParameterError =
+  | 'no_matching_relay'
+  | 'no_matching_bridge_relay'
+  | 'no_wireguard_key'
+  | 'custom_tunnel_host_resultion_error';
+
 export type BlockReason =
   | {
       reason:
@@ -22,10 +28,10 @@ export type BlockReason =
         | 'set_firewall_policy_error'
         | 'set_dns_error'
         | 'start_tunnel_error'
-        | 'no_matching_relay'
         | 'is_offline'
         | 'tap_adapter_problem';
     }
+  | { reason: 'tunnel_parameter_error'; details: TunnelParameterError }
   | { reason: 'auth_failed'; details?: string };
 
 export type AfterDisconnect = 'nothing' | 'block' | 'reconnect';

--- a/gui/test/components/NotificationArea.spec.tsx
+++ b/gui/test/components/NotificationArea.spec.tsx
@@ -141,7 +141,8 @@ describe('components/NotificationArea', () => {
         tunnelState={{
           state: 'blocked',
           details: {
-            reason: 'no_matching_relay',
+            reason: 'tunnel_parameter_error',
+            details: 'no_matching_relay',
           },
         }}
         version={defaultVersion}

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -648,7 +648,8 @@ impl<'env> IntoJava<'env> for BlockReason {
             BlockReason::SetFirewallPolicyError => "SetFirewallPolicyError",
             BlockReason::SetDnsError => "SetDnsError",
             BlockReason::StartTunnelError => "StartTunnelError",
-            BlockReason::NoMatchingRelay => "NoMatchingRelay",
+            // TODO(emilsp): Fix Android code to handle new TunnelParameterError block reason
+            BlockReason::TunnelParameterError(_) => "NoMatchingRelay",
             BlockReason::IsOffline => "IsOffline",
             BlockReason::TapAdapterProblem => "TapAdapterProblem",
         };

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -50,7 +50,6 @@ netlink-sys = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6
 nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "86b30cdc38a6d4b30a900c21f7c644857d6f7401", features = ["nftnl-1-1-0"] }
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"
-err-derive = "0.1.5"
 tun = "0.4.3"
 
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -335,8 +335,8 @@ impl TunnelState for ConnectingState {
             .tunnel_parameters_generator
             .generate(retry_attempt)
         {
-            None => BlockedState::enter(shared_values, BlockReason::NoMatchingRelay),
-            Some(tunnel_parameters) => {
+            Err(err) => BlockedState::enter(shared_values, BlockReason::TunnelParameterError(err)),
+            Ok(tunnel_parameters) => {
                 if let Err(error) = Self::set_firewall_policy(shared_values, &tunnel_parameters) {
                     error!(
                         "{}",

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -30,7 +30,7 @@ use std::{
 };
 use talpid_types::{
     net::TunnelParameters,
-    tunnel::{BlockReason, TunnelStateTransition},
+    tunnel::{BlockReason, ParameterGenerationError, TunnelStateTransition},
     ErrorExt,
 };
 use tokio_core::reactor::Core;
@@ -280,12 +280,16 @@ impl<T: TunnelState> From<EventConsequence<T>> for TunnelStateMachineAction {
     }
 }
 
+
 /// Trait for any type that can provide a stream of `TunnelParameters` to the `TunnelStateMachine`.
 pub trait TunnelParametersGenerator: Send + 'static {
     /// Given the number of consecutive failed retry attempts, it should yield a `TunnelParameters`
     /// to establish a tunnel with.
     /// If this returns `None` then the state machine goes into the `Blocked` state.
-    fn generate(&mut self, retry_attempt: u32) -> Option<TunnelParameters>;
+    fn generate(
+        &mut self,
+        retry_attempt: u32,
+    ) -> Result<TunnelParameters, ParameterGenerationError>;
 }
 
 /// Values that are common to all tunnel states.

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -13,3 +13,4 @@ base64 = "0.10"
 hex = "0.3"
 x25519-dalek = { version = "0.4.5", features = [ "std", "u64_backend" ], default-features = false }
 rand = "0.7"
+err-derive = "0.1.5"


### PR DESCRIPTION
I've changed the block-reason struct in `talpid-types` and added an error type for tunnel parameter generation failures to pass on more information to the user when tunnel parameter generation fails. The extra cases are:
- no wireguard key
- hostname resolution failure in case of custom tunnel endpoints
- failure to select a matching bridge relay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1030)
<!-- Reviewable:end -->
