### PR TITLE
Simplify unimported std usage

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -250,7 +250,7 @@ impl Relay {
     fn validate_wireguard_key(key_str: &str) -> [u8; 32] {
         let key_bytes = base64::decode(key_str.trim()).unwrap_or_else(|e| {
             eprintln!("Failed to decode wireguard key: {}", e);
-            ::std::process::exit(1);
+            std::process::exit(1);
         });
 
         let mut key = [0u8; 32];
@@ -259,7 +259,7 @@ impl Relay {
                 "Expected key length to be 32 bytes, got {}",
                 key_bytes.len()
             );
-            ::std::process::exit(1);
+            std::process::exit(1);
         }
 
         key.copy_from_slice(&key_bytes);

--- a/mullvad-cli/src/location.rs
+++ b/mullvad-cli/src/location.rs
@@ -52,7 +52,7 @@ pub fn get_constraint(matches: &clap::ArgMatches<'_>) -> Constraint<LocationCons
     }
 }
 
-fn country_code_validator(code: String) -> ::std::result::Result<(), String> {
+fn country_code_validator(code: String) -> std::result::Result<(), String> {
     if code.len() == 2 || code == "any" {
         Ok(())
     } else {
@@ -60,7 +60,7 @@ fn country_code_validator(code: String) -> ::std::result::Result<(), String> {
     }
 }
 
-fn city_code_validator(code: String) -> ::std::result::Result<(), String> {
+fn city_code_validator(code: String) -> std::result::Result<(), String> {
     if code.len() == 3 {
         Ok(())
     } else {

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -88,7 +88,7 @@ fn commit_date() -> String {
         .args(&["log", "-1", "--date=short", "--pretty=format:%cd"])
         .output()
         .expect("Unable to get git commit date");
-    ::std::str::from_utf8(&output.stdout)
+    std::str::from_utf8(&output.stdout)
         .unwrap()
         .trim()
         .to_owned()

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -147,7 +147,7 @@ pub(crate) enum InternalDaemonEvent {
     WgKeyEvent(
         (
             AccountToken,
-            ::std::result::Result<mullvad_types::wireguard::WireguardData, wireguard::Error>,
+            std::result::Result<mullvad_types::wireguard::WireguardData, wireguard::Error>,
         ),
     ),
 }
@@ -777,7 +777,7 @@ where
         &mut self,
         event: (
             AccountToken,
-            ::std::result::Result<mullvad_types::wireguard::WireguardData, wireguard::Error>,
+            std::result::Result<mullvad_types::wireguard::WireguardData, wireguard::Error>,
         ),
     ) {
         let (account, result) = event;
@@ -839,7 +839,7 @@ where
 
     fn on_set_target_state(
         &mut self,
-        tx: oneshot::Sender<::std::result::Result<(), ()>>,
+        tx: oneshot::Sender<std::result::Result<(), ()>>,
         new_target_state: TargetState,
     ) {
         if self.state.is_running() {
@@ -1123,7 +1123,7 @@ where
 
     fn on_set_bridge_settings(
         &mut self,
-        tx: oneshot::Sender<::std::result::Result<(), settings::Error>>,
+        tx: oneshot::Sender<std::result::Result<(), settings::Error>>,
         new_settings: BridgeSettings,
     ) {
         match self.settings.set_bridge_settings(new_settings) {
@@ -1147,7 +1147,7 @@ where
 
     fn on_set_bridge_state(
         &mut self,
-        tx: oneshot::Sender<::std::result::Result<(), settings::Error>>,
+        tx: oneshot::Sender<std::result::Result<(), settings::Error>>,
         bridge_state: BridgeState,
     ) {
         let result = match self.settings.set_bridge_state(bridge_state.clone()) {
@@ -1231,7 +1231,7 @@ where
     }
 
     fn on_generate_wireguard_key(&mut self, tx: oneshot::Sender<KeygenEvent>) {
-        let mut result = || -> ::std::result::Result<KeygenEvent, String> {
+        let mut result = || -> std::result::Result<KeygenEvent, String> {
             let account_token = self
                 .settings
                 .get_account_token()

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -26,7 +26,7 @@ pub enum Error {
     TooManyKeys,
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 pub struct KeyManager {
     daemon_tx: mpsc::Sender<InternalDaemonEvent>,

--- a/mullvad-rpc/src/cached_dns_resolver.rs
+++ b/mullvad-rpc/src/cached_dns_resolver.rs
@@ -296,7 +296,7 @@ mod tests {
 
         let mut cache = create_cached_dns_resolver(mock_resolver, &cache_dir, None);
 
-        ::std::mem::drop(temp_dir);
+        std::mem::drop(temp_dir);
 
         assert_eq!(cache.resolve(), mock_address);
     }

--- a/mullvad-rpc/src/event_loop.rs
+++ b/mullvad-rpc/src/event_loop.rs
@@ -9,7 +9,7 @@ where
     F: FnOnce(&mut Core) -> T + Send + 'static,
     T: Send + 'static,
 {
-    let (tx, rx) = ::std::sync::mpsc::channel();
+    let (tx, rx) = std::sync::mpsc::channel();
     thread::spawn(move || match create_core(init) {
         Err(e) => tx.send(Err(e)).unwrap(),
         Ok((mut core, out)) => {

--- a/mullvad-tests/src/lib.rs
+++ b/mullvad-tests/src/lib.rs
@@ -24,7 +24,7 @@ pub use notify::op::{self as watch_event, Op as WatchEvent};
 
 pub mod mock_openvpn;
 
-type Result<T> = ::std::result::Result<T, String>;
+type Result<T> = std::result::Result<T, String>;
 
 pub const ASSETS_DIR: &str = "../dist-assets";
 

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -49,8 +49,8 @@ impl<'a> From<&'a str> for AuthFailed {
     }
 }
 
-impl ::std::fmt::Display for AuthFailed {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl std::fmt::Display for AuthFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use self::AuthFailedInner::*;
         match self.reason {
             InvalidAccount => write!(f, "{}", INVALID_ACCOUNT_MSG),

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use regex::Regex;
+use std::fmt;
 
 #[derive(Debug)]
 pub struct AuthFailed {
@@ -49,8 +50,8 @@ impl<'a> From<&'a str> for AuthFailed {
     }
 }
 
-impl std::fmt::Display for AuthFailed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for AuthFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::AuthFailedInner::*;
         match self.reason {
             InvalidAccount => write!(f, "{}", INVALID_ACCOUNT_MSG),

--- a/mullvad-types/src/settings/migrations/mod.rs
+++ b/mullvad-types/src/settings/migrations/mod.rs
@@ -10,41 +10,18 @@ pub enum SettingsVersion {
     V2 = 2,
 }
 
-impl SettingsVersion {
-    pub fn as_u32(&self) -> u32 {
-        unsafe { std::mem::transmute(*self) }
-    }
-
-    pub fn max_version() -> Self {
-        SettingsVersion::V2
-    }
-
-    pub fn min_version() -> Self {
-        SettingsVersion::V2
-    }
-}
-
 impl<'de> Deserialize<'de> for SettingsVersion {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let version = <u32>::deserialize(deserializer)?;
-        if version < SettingsVersion::min_version().as_u32() {
-            return Err(serde::de::Error::custom(format!(
-                "Version number {} too small",
-                version
-            )));
+        match <u32>::deserialize(deserializer)? {
+            v if v == SettingsVersion::V2 as u32 => Ok(SettingsVersion::V2),
+            v => Err(serde::de::Error::custom(format!(
+                "{} is not a valid SettingsVersion",
+                v
+            ))),
         }
-
-        if version > SettingsVersion::max_version().as_u32() {
-            return Err(serde::de::Error::custom(format!(
-                "Version number {} too large",
-                version
-            )));
-        }
-
-        unsafe { Ok(std::mem::transmute(version)) }
     }
 }
 
@@ -53,7 +30,7 @@ impl Serialize for SettingsVersion {
     where
         S: Serializer,
     {
-        serializer.serialize_u32(self.as_u32())
+        serializer.serialize_u32(*self as u32)
     }
 }
 

--- a/mullvad-types/src/settings/migrations/mod.rs
+++ b/mullvad-types/src/settings/migrations/mod.rs
@@ -12,7 +12,7 @@ pub enum SettingsVersion {
 
 impl SettingsVersion {
     pub fn as_u32(&self) -> u32 {
-        unsafe { ::std::mem::transmute(*self) }
+        unsafe { std::mem::transmute(*self) }
     }
 
     pub fn max_version() -> Self {
@@ -44,7 +44,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             )));
         }
 
-        unsafe { Ok(::std::mem::transmute(version)) }
+        unsafe { Ok(std::mem::transmute(version)) }
     }
 }
 

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -52,7 +52,7 @@ impl DnsMonitor {
 }
 
 trait DnsMonitorT: Sized {
-    type Error: ::std::error::Error;
+    type Error: std::error::Error;
 
     fn new(cache_dir: impl AsRef<Path>) -> Result<Self, Self::Error>;
 

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -144,7 +144,7 @@ impl Firewall {
             .send(&get_tables_msg)
             .map_err(Error::NetlinkSendError)?;
 
-        let mut table_set = ::std::collections::HashSet::new();
+        let mut table_set = std::collections::HashSet::new();
         let mut msg_buffer = vec![0; nftnl::nft_nlmsg_maxsize() as usize];
 
         while let Some(message) = Self::socket_recv(&socket, &mut msg_buffer)? {

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -9,7 +9,7 @@ use talpid_types::net;
 
 pub use pfctl::Error;
 
-type Result<T> = ::std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 /// TODO(linus): This crate is not supposed to be Mullvad-aware. So at some point this should be
 /// replaced by allowing the anchor name to be configured from the public API of this crate.

--- a/talpid-core/src/routing/linux/change_listener.rs
+++ b/talpid-core/src/routing/linux/change_listener.rs
@@ -35,7 +35,7 @@ pub enum Error {
     NetlinkConnectionClosed,
 }
 
-type Result<T> = ::std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 pub(super) struct RouteChangeListener {
     connection: rtnetlink::Connection,

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -401,13 +401,13 @@ pub struct ChangeListener {
 }
 
 impl ChangeListener {
-    pub fn new() -> ::std::io::Result<Self> {
+    pub fn new() -> std::io::Result<Self> {
         let mut cmd = Command::new("route");
         cmd.arg("-vn").arg("monitor").stdout(Stdio::piped());
 
         let mut process = cmd.spawn_async()?;
 
-        let reader = ::std::io::BufReader::new(process.stdout().take().unwrap());
+        let reader = std::io::BufReader::new(process.stdout().take().unwrap());
         let lines = tokio_io::io::lines(reader);
 
         Ok(Self { process, lines })
@@ -416,9 +416,9 @@ impl ChangeListener {
 
 impl Future for ChangeListener {
     type Item = ();
-    type Error = ::std::io::Error;
+    type Error = std::io::Error;
 
-    fn poll(&mut self) -> ::std::io::Result<Async<Self::Item>> {
+    fn poll(&mut self) -> std::io::Result<Async<Self::Item>> {
         match self.process.poll() {
             Ok(Async::NotReady) => (),
             Ok(Async::Ready(status)) => {

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -380,7 +380,7 @@ impl<C: OpenVpnBuilder + 'static> OpenVpnMonitor<C> {
 
     fn create_proxy_auth_file(
         proxy_settings: &Option<openvpn::ProxySettings>,
-    ) -> ::std::result::Result<Option<mktemp::TempFile>, io::Error> {
+    ) -> std::result::Result<Option<mktemp::TempFile>, io::Error> {
         if let Some(openvpn::ProxySettings::Remote(ref remote_proxy)) = proxy_settings {
             if let Some(ref proxy_auth) = remote_proxy.auth {
                 return Ok(Some(Self::create_credentials_file(

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -111,7 +111,7 @@ impl WireguardMonitor {
         let gateway = config.ipv4_gateway.into();
         let close_sender = monitor.close_msg_sender.clone();
 
-        ::std::thread::spawn(move || {
+        std::thread::spawn(move || {
             match ping_monitor::ping(gateway, PING_TIMEOUT, &iface_name, true) {
                 Ok(()) => {
                     (on_event)(TunnelEvent::Up(metadata));

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -140,7 +140,7 @@ pub enum TransportProtocol {
 impl FromStr for TransportProtocol {
     type Err = TransportProtocolParseError;
 
-    fn from_str(s: &str) -> ::std::result::Result<TransportProtocol, Self::Err> {
+    fn from_str(s: &str) -> std::result::Result<TransportProtocol, Self::Err> {
         match s {
             "udp" => Ok(TransportProtocol::Udp),
             "tcp" => Ok(TransportProtocol::Tcp),


### PR DESCRIPTION
Since we mentioned `::std` vs just `std` in another PR I went ahead and checked if we used this older way in more places. Turned out we did. So I replaced them. When checking the diff I also saw two other potential improvements that I choose to include here.

One is replacing an `unsafe` `mem::transmute` with much safer conversion to and from integers for an enum with a given `repr`. This type of conversion is what we use in [windows-service](https://github.com/mullvad/windows-service-rs/blob/master/src/service.rs#L89). Ultimately I would like to replace this with some third party proc macro that does this automatically. Eliminating further risk of making an error and reduces a lot of boilerplate.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1031)
<!-- Reviewable:end -->
