### PR TITLE
Fix settings migration from versions older than 2019.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Fixed
+- Fix old settings deserialization to allow migrating settings from versions older than 2019.6.
 
 
 ## [2019.7] - 2019-08-12

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -222,6 +222,49 @@ mod test {
 }
 "#;
 
+    const SETTINGS_2019V3: &str = r#"
+{
+  "account_token": "1234",
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "country": "se"
+        }
+      },
+      "tunnel": {
+        "only": {
+          "openvpn": {
+            "port": {
+              "only": 53
+            },
+            "protocol": {
+              "only": "udp"
+            }
+          }
+        }
+      }
+    }
+  },
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null,
+      "proxy": null
+    },
+    "wireguard": {
+      "mtu": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    }
+  }
+}
+
+"#;
+
     #[test]
     fn test_migration() {
         let m = super::Migration;
@@ -239,5 +282,18 @@ mod test {
         let m = super::Migration;
         m.read(&mut NEW_SETTINGS.as_bytes())
             .expect("Failed to deserialize old format");
+    }
+
+    #[test]
+    fn test_2019v3_migration() {
+        let m = super::Migration;
+        let old_settings = m
+            .read(&mut SETTINGS_2019V3.as_bytes())
+            .expect("Failed to deserialize old format");
+
+        let new_settings = serde_json::from_str(&NEW_SETTINGS).unwrap();
+
+
+        assert_eq!(&m.migrate(old_settings).unwrap(), &new_settings);
     }
 }

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -2,8 +2,9 @@ use super::{Error, Result, VersionedSettings};
 use crate::{
     custom_tunnel::CustomTunnelEndpoint,
     relay_constraints::{
-        BridgeSettings, BridgeState, Constraint, LocationConstraint, OpenVpnConstraints,
-        RelaySettings as NewRelaySettings, TunnelProtocol, WireguardConstraints,
+        BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
+        OpenVpnConstraints, RelaySettings as NewRelaySettings, TunnelProtocol,
+        WireguardConstraints,
     },
     settings::TunnelOptions,
 };
@@ -13,6 +14,7 @@ use std::io::Read;
 
 /// Mullvad daemon settings.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct Settings {
     account_token: Option<String>,
     relay_settings: RelaySettings,
@@ -28,6 +30,26 @@ pub struct Settings {
     /// Options that should be applied to tunnels of a specific type regardless of where the relays
     /// might be located.
     tunnel_options: TunnelOptions,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            account_token: None,
+            relay_settings: RelaySettings::Normal(RelayConstraints {
+                location: Constraint::Only(LocationConstraint::Country("se".to_owned())),
+                tunnel: Constraint::Any,
+            }),
+            bridge_settings: BridgeSettings::Normal(BridgeConstraints {
+                location: Constraint::Any,
+            }),
+            bridge_state: BridgeState::Auto,
+            allow_lan: false,
+            block_when_disconnected: false,
+            auto_connect: false,
+            tunnel_options: TunnelOptions::default(),
+        }
+    }
 }
 
 pub(super) struct Migration;


### PR DESCRIPTION
Since the migration struct wasn't defined exactly the same as it was in `2019.6`, it was missing some serde attributes and it did not have a `Default` implementation. As such, older versions of the settings with missing fields that were defined only in the `2019.6` wouldn't deserialize. This PR fixes that. I've also added a test to verify that we can deserialize from at least `2019.3`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1033)
<!-- Reviewable:end -->
