### PR TITLE
Fix addObserver bug in AccountExpiryRefresh on iOS

### DIFF
--- a/ios/MullvadVPN/AccountExpiryRefresh.swift
+++ b/ios/MullvadVPN/AccountExpiryRefresh.swift
@@ -43,11 +43,13 @@ class AccountExpiryRefresh {
     /// Register observer and start updating the account expiry if hasn't started yet
     private func addObserver(_ observer: Observer) {
         lock.withCriticalScope {
-            if observers.isEmpty {
-                procedureQueue.addOperation(makePeriodicUpdateProcedure())
-            }
+            let wasEmpty = observers.isEmpty
 
             observers.append(WeakBox(observer))
+
+            if wasEmpty {
+                procedureQueue.addOperation(makePeriodicUpdateProcedure())
+            }
         }
 
     }


### PR DESCRIPTION
Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

The `RepeatProcedure` created during the call to `makePeriodicUpdateProcedure`, synchronously invokes the block given via constructor, which consults the `shouldKeepRefreshing` before producing the network request to refresh the account data. During the very first call, the `observers` list is empty, hence no network request is created. This PR simply adds the observer first before producing the periodic update procedure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1036)
<!-- Reviewable:end -->
