### PR TITLE
Fix error message for block reason

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
     - language: node_js
       node_js: '8'
       cache: npm
+      services:
+        - xvfb
       install:
         - cd gui
         - npm install
-      before_script:
-        - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
       script:
         - npm run check-format
         - npm run lint

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,6 +1,6 @@
 use crate::net::TunnelEndpoint;
 use serde::{Deserialize, Serialize};
-use std::{error::Error, fmt};
+use std::fmt;
 
 /// Event resulting from a transition to a new tunnel state.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -97,11 +97,7 @@ impl fmt::Display for BlockReason {
             SetDnsError => "Failed to set system DNS server",
             StartTunnelError => "Failed to start connection to remote server",
             TunnelParameterError(ref err) => {
-                return write!(
-                    f,
-                    "Failure to generate tunnel parameters: {}",
-                    err.description(),
-                );
+                return write!(f, "Failure to generate tunnel parameters: {}", err);
             }
             IsOffline => "This device is offline, no tunnels can be established",
             TapAdapterProblem => "A problem with the TAP adapter has been detected",


### PR DESCRIPTION
The recently extended block reason for tunnel parameter generation error used a deprecated way of printing the inner error, these changes fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1039)
<!-- Reviewable:end -->
