### PR TITLE
Make margins around the account label clickable

### DIFF
--- a/gui/src/renderer/components/LoginStyles.tsx
+++ b/gui/src/renderer/components/LoginStyles.tsx
@@ -99,9 +99,11 @@ export default {
     color: colors.blue,
   }),
   account_dropdown__label_container: Styles.createViewStyle({
-    marginLeft: 12,
-    marginTop: 11,
-    marginBottom: 11,
+    paddingLeft: 12,
+    paddingTop: 11,
+    paddingBottom: 11,
+    marginHorizontal: 0,
+    marginVertical: 0,
   }),
 
   login_footer__prompt: Styles.createTextStyle({


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR extends the clickable area of the the account token labels in the account history dropdown on Login view. The new hot area also includes the margins surrounding the label with the account token making it easier to select the item. Previously clicking anywhere around the small text label would be a no-op..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1040)
<!-- Reviewable:end -->
