### PR TITLE
Move login functions to the main process

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -8,6 +8,9 @@ msgstr ""
 msgid "CREATING SECURE CONNECTION"
 msgstr ""
 
+msgid "Invalid account number"
+msgstr ""
+
 msgid "SECURE CONNECTION"
 msgstr ""
 
@@ -273,6 +276,10 @@ msgid "Failed to apply firewall rules. The device might currently be unsecured"
 msgstr ""
 
 msgctxt "in-app-notifications"
+msgid "Failed to resolve host of custom tunnel. Consider changing the settings"
+msgstr ""
+
+msgctxt "in-app-notifications"
 msgid "Failed to set system DNS server"
 msgstr ""
 
@@ -321,6 +328,10 @@ msgstr ""
 
 msgctxt "in-app-notifications"
 msgid "UPDATE AVAILABLE"
+msgstr ""
+
+msgctxt "in-app-notifications"
+msgid "WireGuard key not published to our servers. You can manage your key in Advanced settings."
 msgstr ""
 
 #. The in-app banner displayed to the user when the running app becomes unsupported.

--- a/gui/src/main/account-data-cache.ts
+++ b/gui/src/main/account-data-cache.ts
@@ -1,5 +1,5 @@
 import log from 'electron-log';
-import { AccountToken, IAccountData } from '../../shared/daemon-rpc-types';
+import { AccountToken, IAccountData } from '../shared/daemon-rpc-types';
 
 export enum AccountFetchRetryAction {
   stop,

--- a/gui/src/main/errors.ts
+++ b/gui/src/main/errors.ts
@@ -1,9 +1,3 @@
-export class NoCreditError extends Error {
-  constructor() {
-    super("Account doesn't have enough credit available for connection");
-  }
-}
-
 export class NoDaemonError extends Error {
   constructor() {
     super('Could not connect to Mullvad daemon');

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1037,7 +1037,11 @@ class ApplicationMain {
     } catch (error) {
       log.error(`Failed to login: ${error.message}`);
 
-      throw error;
+      if (error instanceof InvalidAccountError) {
+        throw Error(messages.gettext('Invalid account number'));
+      } else {
+        throw error;
+      }
     }
   }
 

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, Display, screen, Tray, WebContents } from 'electron';
+import { IpcMainEventChannel } from '../shared/ipc-event-channel';
 
 interface IPosition {
   x: number;
@@ -201,7 +202,8 @@ export default class WindowController {
 
   private notifyUpdateWindowShape() {
     const shapeParameters = this.windowPositioning.getWindowShapeParameters(this.windowValue);
-    this.windowValue.webContents.send('update-window-shape', shapeParameters);
+
+    IpcMainEventChannel.windowShape.notify(this.windowValue.webContents, shapeParameters);
   }
 
   // Installs display event handlers to update the window position on any changes in the display or

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -22,7 +22,6 @@ import userInterfaceActions from './redux/userinterface/actions';
 import versionActions from './redux/version/actions';
 
 import { IAppUpgradeInfo, ICurrentAppVersionInfo } from '../main';
-import { IWindowShapeParameters } from '../main/window-controller';
 import { cities, countries, loadTranslations, messages, relayLocations } from '../shared/gettext';
 import { IGuiSettingsState } from '../shared/gui-settings-state';
 import { IpcRendererEventChannel } from '../shared/ipc-event-channel';
@@ -84,18 +83,15 @@ export default class AppRenderer {
   constructor() {
     setupLogging(getRendererLogFile());
 
-    ipcRenderer.on(
-      'update-window-shape',
-      (_event: Electron.Event, shapeParams: IWindowShapeParameters) => {
-        if (typeof shapeParams.arrowPosition === 'number') {
-          this.reduxActions.userInterface.updateWindowArrowPosition(shapeParams.arrowPosition);
-        }
-      },
-    );
-
     ipcRenderer.on('window-shown', () => {
       if (this.connectedToDaemon) {
         this.updateAccountExpiry();
+      }
+    });
+
+    IpcRendererEventChannel.windowShape.listen((windowShapeParams) => {
+      if (typeof windowShapeParams.arrowPosition === 'number') {
+        this.reduxActions.userInterface.updateWindowArrowPosition(windowShapeParams.arrowPosition);
       }
     });
 

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -5,6 +5,7 @@ import * as uuid from 'uuid';
 import { IGuiSettingsState } from './gui-settings-state';
 
 import { IAppUpgradeInfo, ICurrentAppVersionInfo } from '../main/index';
+import { IWindowShapeParameters } from '../main/window-controller';
 import {
   AccountToken,
   BridgeState,
@@ -128,6 +129,8 @@ interface IWireguardKeyHandlers extends ISender<string | undefined> {
 
 /// Events names
 
+const WINDOW_SHAPE_CHANGED = 'window-shape-changed';
+
 const DAEMON_CONNECTED = 'daemon-connected';
 const DAEMON_DISCONNECTED = 'daemon-disconnected';
 
@@ -182,6 +185,10 @@ export class IpcRendererEventChannel {
     get(): IAppStateSnapshot {
       return ipcRenderer.sendSync(GET_APP_STATE);
     },
+  };
+
+  public static windowShape: IReceiver<IWindowShapeParameters> = {
+    listen: listen(WINDOW_SHAPE_CHANGED),
   };
 
   public static daemonConnected: IReceiver<void> = {
@@ -263,6 +270,10 @@ export class IpcMainEventChannel {
         event.returnValue = fn();
       });
     },
+  };
+
+  public static windowShape: ISender<IWindowShapeParameters> = {
+    notify: sender<IWindowShapeParameters>(WINDOW_SHAPE_CHANGED),
   };
 
   public static daemonConnected: ISenderVoid = {

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -22,6 +22,7 @@ export interface IAppStateSnapshot {
   locale: string;
   isConnected: boolean;
   autoStart: boolean;
+  accountData?: IAccountData;
   accountHistory: AccountToken[];
   tunnelState: TunnelState;
   settings: ISettings;
@@ -87,16 +88,14 @@ interface IGuiSettingsHandlers extends ISender<IGuiSettingsState> {
   handleMonochromaticIcon(fn: (monochromaticIcon: boolean) => void): void;
 }
 
-interface IAccountHandlers {
-  handleSet(fn: (token: AccountToken) => Promise<void>): void;
-  handleUnset(fn: () => Promise<void>): void;
-  handleGetData(fn: (token: AccountToken) => Promise<IAccountData>): void;
+interface IAccountHandlers extends ISender<IAccountData | undefined> {
+  handleLogin(fn: (token: AccountToken) => Promise<void>): void;
+  handleLogout(fn: () => Promise<void>): void;
 }
 
-interface IAccountMethods {
-  set(token: AccountToken): Promise<void>;
-  unset(): Promise<void>;
-  getData(token: AccountToken): Promise<IAccountData>;
+interface IAccountMethods extends IReceiver<IAccountData | undefined> {
+  login(token: AccountToken): Promise<void>;
+  logout(): Promise<void>;
 }
 
 interface IAccountHistoryHandlers extends ISender<AccountToken[]> {
@@ -162,9 +161,9 @@ const GET_APP_STATE = 'get-app-state';
 const ACCOUNT_HISTORY_CHANGED = 'account-history-changed';
 const REMOVE_ACCOUNT_HISTORY_ITEM = 'remove-account-history-item';
 
-const SET_ACCOUNT = 'set-account';
-const UNSET_ACCOUNT = 'unset-account';
-const GET_ACCOUNT_DATA = 'get-account-data';
+const DO_LOGIN = 'do-login';
+const DO_LOGOUT = 'do-logout';
+const ACCOUNT_DATA_CHANGED = 'account-data-changed';
 
 const AUTO_START_CHANGED = 'auto-start-changed';
 const SET_AUTO_START = 'set-auto-start';
@@ -245,9 +244,9 @@ export class IpcRendererEventChannel {
   };
 
   public static account: IAccountMethods = {
-    set: requestSender(SET_ACCOUNT),
-    unset: requestSender(UNSET_ACCOUNT),
-    getData: requestSender(GET_ACCOUNT_DATA),
+    listen: listen(ACCOUNT_DATA_CHANGED),
+    login: requestSender(DO_LOGIN),
+    logout: requestSender(DO_LOGOUT),
   };
 
   public static accountHistory: IAccountHistoryMethods = {
@@ -330,9 +329,9 @@ export class IpcMainEventChannel {
   };
 
   public static account: IAccountHandlers = {
-    handleSet: requestHandler(SET_ACCOUNT),
-    handleUnset: requestHandler(UNSET_ACCOUNT),
-    handleGetData: requestHandler(GET_ACCOUNT_DATA),
+    notify: sender<IAccountData | undefined>(ACCOUNT_DATA_CHANGED),
+    handleLogin: requestHandler(DO_LOGIN),
+    handleLogout: requestHandler(DO_LOGOUT),
   };
 
   public static accountHistory: IAccountHistoryHandlers = {

--- a/gui/test/account-data-cache.spec.ts
+++ b/gui/test/account-data-cache.spec.ts
@@ -1,4 +1,4 @@
-import AccountDataCache, { AccountFetchRetryAction } from '../src/renderer/lib/account-data-cache';
+import AccountDataCache, { AccountFetchRetryAction } from '../src/main/account-data-cache';
 import { IAccountData } from '../src/shared/daemon-rpc-types';
 import * as sinon from 'sinon';
 import { expect, spy } from 'chai';


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Move account verification and log in and log out functions into the main process. Expose `login` and `logout` IPC methods for the renderer process and account data events.
1. Localize "Invalid account number" error. Since the `Error` has to travel through the IPC there is no way to preserve the type, so I figured the best way is to localise it in the main process and simply throw it into the IPC. This is not exactly beautiful but given that we only have 1 error there, I guess it's reasonable.
1. Update messages.pot with missing localizations from the past PRs.
1. Wrap window-shape related events into the IPC event channel. (Used for the arrow pointer that points to the menubar item on macOS)

Worth to mention that the main process does not track the login stage, i.e if user started the account verification and subsequent login (if verification succeeds), it’s expected that the renderer process is aware that it did so… There are no events from the main process that tell when the login starts or completes, except that the caller receives the result back in response to the IPC `login()` call. 

Hence if we ever decide to completely offload the renderer process at some point, it's possible that the renderer process may go out of sync with the main process if it was offloaded during the verification process, however it should eventually catch up by receiving the settings update from the daemon. I didn't want to solve that riddle because it would only complicate everything... :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1041)
<!-- Reviewable:end -->