### PR TITLE
Refactor `AppVersionInfoCache` initialization to avoid crash

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -103,6 +103,8 @@ class ConnectFragment : Fragment() {
     override fun onResume() {
         super.onResume()
 
+        notificationBanner.onResume()
+
         locationInfo.isTunnelInfoExpanded = isTunnelInfoExpanded
 
         keyStatusListener.onKeyStatusChange = { keyStatus ->
@@ -125,6 +127,8 @@ class ConnectFragment : Fragment() {
         relayListListener.onRelayListChange = null
 
         isTunnelInfoExpanded = locationInfo.isTunnelInfoExpanded
+
+        notificationBanner.onPause()
 
         super.onPause()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -41,7 +41,7 @@ class MainActivity : FragmentActivity() {
 
     var currentVersion = fetchCurrentVersion()
 
-    lateinit var appVersionInfoCache: AppVersionInfoCache
+    var appVersionInfoCache = AppVersionInfoCache(this)
     val connectionProxy = ConnectionProxy(this)
     val keyStatusListener = KeyStatusListener(daemon)
     val problemReport = MullvadProblemReport()
@@ -81,7 +81,7 @@ class MainActivity : FragmentActivity() {
             addInitialFragment()
         }
 
-        appVersionInfoCache = AppVersionInfoCache(this)
+        appVersionInfoCache.onCreate()
     }
 
     override fun onStart() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -39,8 +39,6 @@ class MainActivity : FragmentActivity() {
     var service = CompletableDeferred<MullvadVpnService.LocalBinder>()
         private set
 
-    var currentVersion = fetchCurrentVersion()
-
     var appVersionInfoCache = AppVersionInfoCache(this)
     val connectionProxy = ConnectionProxy(this)
     val keyStatusListener = KeyStatusListener(daemon)
@@ -172,9 +170,5 @@ class MainActivity : FragmentActivity() {
 
     private fun fetchSettings() = GlobalScope.async(Dispatchers.Default) {
         daemon.await().getSettings()
-    }
-
-    private fun fetchCurrentVersion() = GlobalScope.async(Dispatchers.Default) {
-        daemon.await().getCurrentVersion()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
@@ -46,6 +46,14 @@ class NotificationBanner(
         banner.setOnClickListener { onClick() }
     }
 
+    fun onResume() {
+        versionInfoCache.onUpdate = { update() }
+    }
+
+    fun onPause() {
+        versionInfoCache.onUpdate = null
+    }
+
     private fun update() {
         externalLink = null
         updateBasedOnKeyState() || updateBasedOnTunnelState() || updateBasedOnVersionInfo()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
@@ -103,8 +103,8 @@ class SettingsFragment : Fragment() {
     }
 
     private fun showCurrentVersion() = GlobalScope.launch(Dispatchers.Main) {
-        val version = parentActivity.currentVersion.await()
         val versionInfoCache = parentActivity.appVersionInfoCache
+        val version = versionInfoCache.currentVersion.await()
 
         appVersionLabel.setText(version)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
@@ -17,19 +17,24 @@ import android.widget.Button
 import android.widget.ImageButton
 import android.widget.TextView
 
+import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
+
 class SettingsFragment : Fragment() {
     private lateinit var parentActivity: MainActivity
+    private lateinit var versionInfoCache: AppVersionInfoCache
+
     private lateinit var remainingTimeLabel: RemainingTimeLabel
     private lateinit var appVersionWarning: View
     private lateinit var appVersionLabel: TextView
     private lateinit var appVersionFooter: View
 
-    private var showCurrentVersionJob: Job? = null
+    private var updateVersionInfoJob: Job? = null
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
 
         parentActivity = context as MainActivity
+        versionInfoCache = parentActivity.appVersionInfoCache
     }
 
     override fun onCreateView(
@@ -62,23 +67,26 @@ class SettingsFragment : Fragment() {
         appVersionLabel = view.findViewById<TextView>(R.id.app_version_label)
         appVersionFooter = view.findViewById(R.id.app_version_footer)
 
-        showCurrentVersionJob = showCurrentVersion()
-
         return view
     }
 
     override fun onResume() {
         super.onResume()
         remainingTimeLabel.onResume()
+        versionInfoCache.onUpdate = {
+            updateVersionInfoJob?.cancel()
+            updateVersionInfoJob = updateVersionInfo()
+        }
     }
 
     override fun onPause() {
+        versionInfoCache.onUpdate = null
         remainingTimeLabel.onPause()
         super.onPause()
     }
 
     override fun onDestroyView() {
-        showCurrentVersionJob?.cancel()
+        updateVersionInfoJob?.cancel()
         super.onDestroyView()
     }
 
@@ -102,11 +110,8 @@ class SettingsFragment : Fragment() {
         startActivity(intent)
     }
 
-    private fun showCurrentVersion() = GlobalScope.launch(Dispatchers.Main) {
-        val versionInfoCache = parentActivity.appVersionInfoCache
-        val version = versionInfoCache.currentVersion.await()
-
-        appVersionLabel.setText(version)
+    private fun updateVersionInfo() = GlobalScope.launch(Dispatchers.Main) {
+        appVersionLabel.setText(versionInfoCache.version ?: "")
 
         if (versionInfoCache.isLatest && versionInfoCache.isSupported) {
             appVersionWarning.visibility = View.GONE

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -25,6 +25,12 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
 
     val currentVersion = fetchCurrentVersion()
 
+    var onUpdate: (() -> Unit)? = null
+        set(value) {
+            field = value
+            value?.invoke()
+        }
+
     var version: String? = null
         private set
     var isStable = true
@@ -93,5 +99,7 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
             isLatest = false
             upgradeVersion = target
         }
+
+        onUpdate?.invoke()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -57,7 +57,7 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
         }
     }
 
-    init {
+    fun onCreate() {
         preferences.registerOnSharedPreferenceChangeListener(listener)
 
         lastUpdated = preferences.getLong(KEY_LAST_UPDATED, 0L)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -19,8 +19,8 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
         val SHARED_PREFERENCES = "app_version_info_cache"
     }
 
-    private val preferences =
-        parentActivity.getSharedPreferences(SHARED_PREFERENCES, Context.MODE_PRIVATE)
+    private val preferences: SharedPreferences
+        get() = parentActivity.getSharedPreferences(SHARED_PREFERENCES, Context.MODE_PRIVATE)
 
     private val updateVersionJob = updateVersion()
 


### PR DESCRIPTION
A crash was reported when opening the app. While analyzing the stack trace, the cause seems to be related to the initialization sequence of the `AppVersionInfoCache`. In `MainActivity`, it is the only data proxy class that is initialized differently, by being instantiated later in the life-cycle. This led to the crash when an attempt to use the cache before it was initialized.

This PR attempts to fix the crash by refactoring the way `AppVersionInfoCache` is initialized, to be more consistent with the other classes. Now it is instantiated earlier, but an `onCreate` method is added to actually configure the shared preferences listener and to load the initial values.

As part of the refactor, the `MainActivity.currentVersion` property was removed, and in its place the `AppVersionInfoCache` now provides a listener callback interface. This also allows the improvement for the notification banner and the settings page to be updated when an update is detected. Even though the scenario is rare, previously the user could leave the app running on one of the screens and miss the update for a while.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1042)
<!-- Reviewable:end -->
