### PR TITLE
Don't force version label to be capitalized

### DIFF
--- a/android/src/main/res/layout/settings.xml
+++ b/android/src/main/res/layout/settings.xml
@@ -101,7 +101,6 @@
                 android:textSize="13sp"
                 android:textStyle="bold"
                 android:text=""
-                android:textAllCaps="true"
                 />
         <ImageView
                 android:layout_width="16dp"


### PR DESCRIPTION
This is a tiny UI fix so that the app version isn't capitalized. It's okay for something like `2019.6`, but it fails when it's `2019.7-BETA1`, which should actually be `2019.7-beta1`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1043)
<!-- Reviewable:end -->
