### PR TITLE
Add SIGINT and SIGTERM handlers to properly clean up the watch script

### DIFF
--- a/gui/scripts/serve.js
+++ b/gui/scripts/serve.js
@@ -81,3 +81,15 @@ watch.start(...prepareWatchArguments(path.resolve(__dirname, '..')));
 watch.on('first_success', () => {
   startBrowserSync();
 });
+
+process.on('exit', () => {
+  watch.kill();
+});
+
+process.on('SIGINT', () => {
+  process.exit();
+});
+
+process.on('SIGTERM', () => {
+  process.exit();
+});


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR makes sure that aborting the `npm run develop` using `SIGTERM`, `SIGINT` or by closing the Electron app, properly terminates the `tsc-watch` which supposedly creates a `node` subprocess, that used to hang in the system until it hit the error in attempt to talk to the parent process in response to source code changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1044)
<!-- Reviewable:end -->
