### PR TITLE
Trim user email address for problem report

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ProblemReportFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ProblemReportFragment.kt
@@ -114,7 +114,7 @@ class ProblemReportFragment : Fragment() {
     }
 
     private fun sendReport(shouldConfirmNoEmail: Boolean) = GlobalScope.launch(Dispatchers.Main) {
-        val userEmail = userEmailInput.text.toString()
+        val userEmail = userEmailInput.text.trim().toString()
 
         problemReport.userEmail = userEmail
         problemReport.userMessage = userMessageInput.text.toString()


### PR DESCRIPTION
The email input in the problem report screen allows entering spaces. The spaces are then forwarded to email used in the problem report. That causes the server to not detect the email correctly. This situation is more common on mobile since auto-complete can add a space after completing the email address.

This PR mitigates the issue by trimming leading and trailing whitespace from the email address before it is used in the problem report.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1046)
<!-- Reviewable:end -->
