### PR TITLE
Lower default MTU to increase quality of life on 4G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Decreased default MTU for WireGuard to 1380 to improve performance over 4G
+
 ### Fixed
 - Fix old settings deserialization to allow migrating settings from versions older than 2019.6.
 

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
 }
 
 /// Smallest MTU that supports IPv6
-const SMALLEST_IPV6_MTU: u16 = 1420;
+const SMALLEST_IPV6_MTU: u16 = 1380;
 const DEFAULT_MTU: u16 = SMALLEST_IPV6_MTU;
 
 #[derive(err_derive::Error, Debug)]


### PR DESCRIPTION
Current default MTU is too high for 4G networks, which essentially ruins the Android app. I've lowered it so that we can send a wireguard packet in a single _physical_ network packet on 4G. Long term, we should allow users to set their MTU from the Android app and also try and do MTU detection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1050)
<!-- Reviewable:end -->
