### PR TITLE
Unsubscribe from daemon events on exit

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1328,7 +1328,6 @@ class ApplicationMain {
   // setup NSEvent monitor to fix inconsistent window.blur on macOS
   // see https://github.com/electron/electron/issues/8689
   private installMacOsMenubarAppWindowHandlers(tray: Tray, windowController: WindowController) {
-    // $FlowFixMe: this module is only available on macOS
     const { NSEventMonitor, NSEventMask } = require('nseventmonitor');
     const macEventMonitor = new NSEventMonitor();
     // tslint:disable-next-line

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -361,13 +361,21 @@ function set<T>(event: string): (value: T) => void {
 
 function sender<T>(event: string): (webContents: WebContents, value: T) => void {
   return (webContents: WebContents, value: T) => {
-    webContents.send(event, value);
+    if (webContents.isDestroyed()) {
+      log.error(`sender(${event}): webContents is already destroyed!`);
+    } else {
+      webContents.send(event, value);
+    }
   };
 }
 
 function senderVoid(event: string): (webContents: WebContents) => void {
   return (webContents: WebContents) => {
-    webContents.send(event);
+    if (webContents.isDestroyed()) {
+      log.error(`senderVoid(${event}): webContents is already destroyed!`);
+    } else {
+      webContents.send(event);
+    }
   };
 }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR makes sure that we unsubscribe from the daemon events when the app is about to terminate, right after we tell the daemon to disconnect the tunnel. Since the app is one step away from being terminated, it does not make any sense to keep handling the daemon events, besides any of the events that may be received during the shutdown may cause the app to attempt to talk to the renderer process via IPC which can be long gone by then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1052)
<!-- Reviewable:end -->
