### PR TITLE
Hide the menubar window when other program captures the focus

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1336,6 +1336,13 @@ class ApplicationMain {
 
     window.on('show', () => macEventMonitor.start(eventMask, () => windowController.hide()));
     window.on('hide', () => macEventMonitor.stop());
+    window.on('blur', () => {
+      // Make sure to hide the menubar window when other program captures the focus.
+      // But avoid doing that when dev tools capture the focus to make it possible to inspect the UI
+      if (window.isVisible() && !window.webContents.isDevToolsFocused()) {
+        windowController.hide();
+      }
+    });
     tray.on('click', () => windowController.toggle());
   }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

The app window remains visible when alt-tabbing or calling any action that opens the external app to either follow the web link or view app logs. This is not intended on macOS.

This PR also makes sure that switching between the dev tools and the menubar window does not hide the app window, since we often do that when inspecting the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1054)
<!-- Reviewable:end -->
