### PR TITLE
Filter out the repeating calls to onDaemonConnected

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -358,6 +358,12 @@ export default class AppRenderer {
   }
 
   private async onDaemonConnected() {
+    // Filter out the calls coming from IPC events arriving right after the constructor finished
+    // execution.
+    if (this.connectedToDaemon) {
+      return;
+    }
+
     this.connectedToDaemon = true;
 
     if (this.settings.accountToken) {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

I've noticed that `Skip autoconnect in development` appears twice in logs. I ran tests and found that the `daemon-connected` IPC event can still be dispatched even after the constructor finished execution. 

Since we call the same function (`onDaemonConnected`) from both the IPC event handler and from the constructor (when `initialState.isConnected == true`), it's basically possible that we execute the same logic twice, which is not desired, but probably has insignificant side effects. 

This PR makes sure we don't execute the logic inside of `daemonConnected` if the renderer process has already registered that the app is connected to the daemon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1056)
<!-- Reviewable:end -->
