### PR TITLE
Add "Create account" button to login screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
@@ -21,7 +21,16 @@ class AccountInput(val parentView: View, val context: Context) {
     private val focusedBorder = resources.getDrawable(R.drawable.account_input_border_focused, null)
     private val errorBorder = resources.getDrawable(R.drawable.account_input_border_error, null)
 
+    private var inputHasFocus = false
+        set(value) {
+            field = value
+            updateBorder()
+        }
     private var usingErrorColor = false
+        set(value) {
+            field = value
+            updateBorder()
+        }
 
     var state = LoginState.Initial
         set(value) {
@@ -46,7 +55,7 @@ class AccountInput(val parentView: View, val context: Context) {
         input.apply {
             addTextChangedListener(InputWatcher())
             onFocusChangeListener = OnFocusChangeListener { view, hasFocus ->
-                updateBorder(hasFocus && view.isEnabled())
+                inputHasFocus = hasFocus && view.isEnabled()
             }
         }
 
@@ -97,7 +106,6 @@ class AccountInput(val parentView: View, val context: Context) {
         }
 
         usingErrorColor = true
-        updateBorder(false)
     }
 
     private fun setButtonEnabled(enabled: Boolean) {
@@ -110,7 +118,7 @@ class AccountInput(val parentView: View, val context: Context) {
         }
     }
 
-    private fun updateBorder(inputHasFocus: Boolean) {
+    private fun updateBorder() {
         if (usingErrorColor) {
             container.foreground = errorBorder
         } else {
@@ -128,12 +136,12 @@ class AccountInput(val parentView: View, val context: Context) {
         override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {}
 
         override fun afterTextChanged(text: Editable) {
+            inputHasFocus = true
             setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
 
             if (usingErrorColor) {
                 input.setTextColor(enabledTextColor)
                 usingErrorColor = false
-                updateBorder(true)
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.text.Editable
+import android.text.style.MetricAffectingSpan
 import android.text.TextWatcher
 import android.widget.EditText
 import android.widget.ImageButton
@@ -137,6 +138,12 @@ class AccountInput(val parentView: View, val context: Context) {
         }
     }
 
+    private fun removeFormattingSpans(text: Editable) {
+        for (span in text.getSpans(0, text.length, MetricAffectingSpan::class.java)) {
+            text.removeSpan(span)
+        }
+    }
+
     inner class InputWatcher : TextWatcher {
         override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {}
 
@@ -144,6 +151,7 @@ class AccountInput(val parentView: View, val context: Context) {
 
         override fun afterTextChanged(text: Editable) {
             inputHasFocus = true
+            removeFormattingSpans(text)
             setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
             leaveErrorState()
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/AccountInput.kt
@@ -130,6 +130,13 @@ class AccountInput(val parentView: View, val context: Context) {
         }
     }
 
+    private fun leaveErrorState() {
+        if (usingErrorColor) {
+            input.setTextColor(enabledTextColor)
+            usingErrorColor = false
+        }
+    }
+
     inner class InputWatcher : TextWatcher {
         override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {}
 
@@ -138,11 +145,7 @@ class AccountInput(val parentView: View, val context: Context) {
         override fun afterTextChanged(text: Editable) {
             inputHasFocus = true
             setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
-
-            if (usingErrorColor) {
-                input.setTextColor(enabledTextColor)
-                usingErrorColor = false
-            }
+            leaveErrorState()
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.support.v4.app.Fragment
@@ -51,7 +53,16 @@ class LoginFragment : Fragment() {
         accountInput = AccountInput(view, parentActivity)
         accountInput.onLogin = { accountToken -> login(accountToken) }
 
+        view.findViewById<View>(R.id.create_account).setOnClickListener { createAccount() }
+
         return view
+    }
+
+    private fun createAccount() {
+        val uri = Uri.parse(parentActivity.getString(R.string.create_account_url))
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+
+        startActivity(intent)
     }
 
     private fun login(accountToken: String) {

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -132,4 +132,32 @@
                 android:layout_weight="3"
                 />
     </LinearLayout>
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:orientation="vertical"
+            android:paddingHorizontal="24dp"
+            android:paddingBottom="24dp"
+            android:paddingTop="16dp"
+            android:background="@color/darkBlue"
+            >
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:gravity="start"
+                android:textColor="@color/white80"
+                android:textSize="13sp"
+                android:text="@string/dont_have_an_account"
+                />
+        <Button android:id="@+id/create_account"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="9dp"
+                android:drawableRight="@drawable/icon_extlink"
+                android:text="@string/create_account"
+                style="@style/BlueButton"
+                />
+    </LinearLayout>
 </LinearLayout>

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -91,7 +91,7 @@
                 android:layout_weight="0"
                 android:layout_marginBottom="10dp"
                 android:gravity="start"
-                android:textColor="@color/white60"
+                android:textColor="@color/white80"
                 android:textSize="13sp"
                 android:text="@string/login_description"
                 />

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -116,5 +116,6 @@
     </string>
 
     <string name="account_url">https://mullvad.net/en/account</string>
+    <string name="create_account_url">https://mullvad.net/en/account/create</string>
     <string name="download_url">https://mullvad.net/en/download</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="logged_in_title">Login successful</string>
     <string name="login_fail_title">Login failed</string>
     <string name="login_fail_description">Invalid account number, try again</string>
+    <string name="dont_have_an_account">Don\'t have an account number?</string>
+    <string name="create_account">Create account</string>
 
     <string name="settings">Settings</string>
     <string name="settings_account">Account</string>


### PR DESCRIPTION
This PR adds a button to the login page to create a new account. When the button is pressed, the user is sent to the web page to create a new account.

If the user copies the account number from the web page to the account input field, the HTML formatting would also be pasted, and the text size would be larger than expected. Therefore, this PR also changes the account input so that it removes any formatting.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1060)
<!-- Reviewable:end -->
