### PR TITLE
Display public key case sensatively on Android

### DIFF
--- a/android/src/main/res/layout/wireguard_key.xml
+++ b/android/src/main/res/layout/wireguard_key.xml
@@ -70,7 +70,7 @@
             android:layout_weight="1"
             android:gravity="center"
             android:paddingTop="3dp"
-            android:textAllCaps="true"
+            android:textAllCaps="false"
             android:textColor="@color/white60"
             android:textSize="14sp"
             android:textStyle="bold" />


### PR DESCRIPTION
Previously, the public key was displayed in all caps, even though the key would be different depending on the case. This changes it so that the key is displayed case sensitively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1063)
<!-- Reviewable:end -->
