### PR TITLE
Update netlink dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "netlink-packet"
 version = "0.1.1"
-source = "git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109#b367ac9c012e6c2a5e065e201384ec20d9708109"
+source = "git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5#f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1343,28 +1343,28 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
+ "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
 ]
 
 [[package]]
 name = "netlink-proto"
 version = "0.1.1"
-source = "git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109#b367ac9c012e6c2a5e065e201384ec20d9708109"
+source = "git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5#f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
- "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
+ "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
+ "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "netlink-sys"
 version = "0.1.0"
-source = "git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109#b367ac9c012e6c2a5e065e201384ec20d9708109"
+source = "git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5#f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1949,14 +1949,14 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.1.1"
-source = "git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109#b367ac9c012e6c2a5e065e201384ec20d9708109"
+source = "git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5#f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
- "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
+ "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
+ "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
 ]
 
 [[package]]
@@ -2233,9 +2233,9 @@ dependencies = [
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)",
- "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
- "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
- "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
+ "netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
+ "netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
+ "netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
  "nftnl 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2245,7 +2245,7 @@ dependencies = [
  "pfctl 0.2.1 (git+https://github.com/mullvad/pfctl-rs?rev=9f31b5ddcab941862470075eab83bb398195f3d6)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)",
+ "rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "system-configuration 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
@@ -3053,9 +3053,9 @@ dependencies = [
 "checksum mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
 "checksum mnl-sys 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)" = "<none>"
-"checksum netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)" = "<none>"
-"checksum netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)" = "<none>"
+"checksum netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)" = "<none>"
+"checksum netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)" = "<none>"
+"checksum netlink-sys 0.1.0 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)" = "<none>"
 "checksum nftnl 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)" = "<none>"
 "checksum nftnl-sys 0.2.0 (git+https://github.com/mullvad/nftnl-rs?rev=86b30cdc38a6d4b30a900c21f7c644857d6f7401)" = "<none>"
 "checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
@@ -3117,7 +3117,7 @@ dependencies = [
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "4f089652ca87f5a82a62935ec6172a534066c7b97be003cc8f702ee9a7a59c92"
 "checksum rs-release 0.1.7 (git+https://github.com/mullvad/rs-release?branch=snailquote-unescape)" = "<none>"
-"checksum rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?rev=b367ac9c012e6c2a5e065e201384ec20d9708109)" = "<none>"
+"checksum rtnetlink 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)" = "<none>"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -43,10 +43,10 @@ dbus = "0.6"
 failure = "0.1"
 notify = "4.0"
 resolv-conf = "0.6.1"
-rtnetlink = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
-netlink-proto = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
-netlink-packet = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
-netlink-sys = { git = "https://github.com/mullvad/netlink", rev = "b367ac9c012e6c2a5e065e201384ec20d9708109" }
+rtnetlink = { git = "https://github.com/mullvad/netlink", rev = "f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5" }
+netlink-proto = { git = "https://github.com/mullvad/netlink", rev = "f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5" }
+netlink-packet = { git = "https://github.com/mullvad/netlink", rev = "f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5" }
+netlink-sys = { git = "https://github.com/mullvad/netlink", rev = "f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5" }
 nftnl = { git = "https://github.com/mullvad/nftnl-rs", rev = "86b30cdc38a6d4b30a900c21f7c644857d6f7401", features = ["nftnl-1-1-0"] }
 mnl = { git = "https://github.com/mullvad/mnl-rs", rev = "f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6", features = ["mnl-1-0-4"] }
 which = "2.0"


### PR DESCRIPTION
Bumping our netlink dependencies to include the changes [here](https://github.com/mullvad/netlink/compare/b367ac9c012e6c2a5e065e201384ec20d9708109...mullvad:remove-dependence-on-kernel-structures) - more kernel structs have been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1064)
<!-- Reviewable:end -->
