### PR TITLE
Compute android version code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,10 +91,9 @@ if [[ "$BUILD_MODE" == "dev" ]]; then
     echo "compression: store" >> gui/electron-builder.yml
 fi
 
-sed -i.bak \
-    -Ee "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" \
-    gui/package.json
 cp gui/package-lock.json gui/package-lock.json.bak
+sed -i.bak -Ee "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" \
+    gui/package.json
 
 cp Cargo.lock Cargo.lock.bak
 sed -i.bak \

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -12,11 +12,21 @@ if [[ "$#" != "1" ]]; then
 fi
 VERSION=$1
 
-if [[ $(echo $VERSION | egrep '^[0-9]{4}\.[0-9]+(-(beta|alpha)[0-9]+)?$') == "" ]]; then
+# Regex that only matches valid Mullvad VPN versions. It also captures
+# relevant values into capture groups, read out via BASH_REMATCH[x]
+VERSION_REGEX="^20([0-9]{2})\.([0-9]+)(-beta([0-9]+))?$"
+if [[ ! $VERSION =~ $VERSION_REGEX ]]; then
     echo "Invalid version format. Please specify version as:"
-    echo "<YEAR>.<NUMBER>[-(beta|alpha)<NUMBER>]"
+    echo "<YEAR>.<NUMBER>[-beta<NUMBER>]"
     exit 1
 fi
+VERSION_YEAR=$(printf "%02d" ${BASH_REMATCH[1]})
+VERSION_NUMBER=$(printf "%02d" ${BASH_REMATCH[2]})
+VERSION_PATCH="00"
+VERSION_BETA=$(printf "%02d" ${BASH_REMATCH[4]:-99})
+ANDROID_VERSION_CODE=${VERSION_YEAR}${VERSION_NUMBER}${VERSION_PATCH}${VERSION_BETA}
+
+SEMVER_VERSION=$(echo $VERSION | sed -Ee 's/($|-.*)/.0\1/g')
 
 if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
     echo "Dirty working directory! Will not accept that for an official release."
@@ -30,13 +40,18 @@ if [[ $(grep $VERSION CHANGELOG.md) == "" ]]; then
 fi
 
 echo "Updating version in metadata files..."
-SEMVER_VERSION=`echo $VERSION | sed -Ee 's/($|-.*)/.0\1/g'`
 sed -i.bak -Ee "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" \
     gui/package.json
 sed -i.bak -Ee "s/^version = \"[^\"]+\"\$/version = \"$SEMVER_VERSION\"/g" \
     mullvad-daemon/Cargo.toml \
     mullvad-cli/Cargo.toml \
     mullvad-problem-report/Cargo.toml
+
+sed -i.bak -Ee "s/versionCode [0-9]+/versionCode $ANDROID_VERSION_CODE/g" \
+    android/build.gradle
+sed -i.bak -Ee "s/versionName \"[^\"]+\"/versionName \"$VERSION\"/g" \
+    android/build.gradle
+
 
 echo "Syncing Cargo.lock with new version numbers"
 source env.sh ""

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -14,7 +14,7 @@ VERSION=$1
 
 # Regex that only matches valid Mullvad VPN versions. It also captures
 # relevant values into capture groups, read out via BASH_REMATCH[x]
-VERSION_REGEX="^20([0-9]{2})\.([0-9]+)(-beta([0-9]+))?$"
+VERSION_REGEX="^20([0-9]{2})\.([1-9][0-9]?)(-beta([1-9][0-9]?))?$"
 if [[ ! $VERSION =~ $VERSION_REGEX ]]; then
     echo "Invalid version format. Please specify version as:"
     echo "<YEAR>.<NUMBER>[-beta<NUMBER>]"


### PR DESCRIPTION
This PR changes `prepare_release.sh` so it computes the correct Android version numbers/codes and inserts them into `build.gradle`.

I made the version matching regex stricter than before. Making sure the year starts with `20`, and only accepts the range `[1,99]` for release and beta numbers.

I also removed the possibility of doing `alpha` releases. We have so far never used them, have no plan on using them, and they would cause collisions with how we compute the code anyway.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1066)
<!-- Reviewable:end -->
