### PR TITLE
Refactor version injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "talpid-openvpn-plugin"
-version = "0.1.0"
+version = "2019.7.0"
 dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "net.mullvad.mullvadvpn"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 1
-        versionName "2019.6"
+        versionCode 19070099
+        versionName "2019.7"
     }
 
     if (keystorePropertiesFile.exists()) {

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -39,10 +39,12 @@ popd
 function restore_metadata_backups() {
     pushd "$SCRIPT_DIR"
     ./version_metadata.sh restore-backup
+    mv Cargo.lock.bak Cargo.lock || true
     popd
 }
 trap 'restore_metadata_backups' EXIT
 
+cp Cargo.lock Cargo.lock.bak
 ./version_metadata.sh inject $PRODUCT_VERSION
 
 ARCHITECTURES="aarch64 armv7 x86_64 i686"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -31,11 +31,19 @@ if [[ "$BUILD_TYPE" == "debug" || "$(git describe)" != "$PRODUCT_VERSION" ]]; th
     echo "Modifying product version to $PRODUCT_VERSION"
 fi
 
-cd "$SCRIPT_DIR/android"
+pushd "$SCRIPT_DIR/android"
 ./gradlew --console plain clean
-mkdir -p "${SCRIPT_DIR}/android/build/extraJni"
+mkdir -p "build/extraJni"
+popd
 
-cd "$SCRIPT_DIR"
+function restore_metadata_backups() {
+    pushd "$SCRIPT_DIR"
+    ./version_metadata.sh restore-backup
+    popd
+}
+trap 'restore_metadata_backups' EXIT
+
+./version_metadata.sh inject $PRODUCT_VERSION
 
 ARCHITECTURES="aarch64 armv7 x86_64 i686"
 for ARCHITECTURE in $ARCHITECTURES; do

--- a/dist-assets/windows/version.h
+++ b/dist-assets/windows/version.h
@@ -1,4 +1,4 @@
-#define MAJOR_VERSION 1
-#define MINOR_VERSION 2
-#define PATCH_VERSION 3
-#define PRODUCT_VERSION "1.2.3-internal"
+#define MAJOR_VERSION 2019
+#define MINOR_VERSION 7
+#define PATCH_VERSION 0
+#define PRODUCT_VERSION "2019.7"

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -10,52 +10,25 @@ if [[ "$#" != "1" ]]; then
     echo "For example: '2018.1-beta3' for a beta release, or '2018.6' for a stable one."
     exit 1
 fi
-VERSION=$1
-
-# Regex that only matches valid Mullvad VPN versions. It also captures
-# relevant values into capture groups, read out via BASH_REMATCH[x]
-VERSION_REGEX="^20([0-9]{2})\.([1-9][0-9]?)(-beta([1-9][0-9]?))?$"
-if [[ ! $VERSION =~ $VERSION_REGEX ]]; then
-    echo "Invalid version format. Please specify version as:"
-    echo "<YEAR>.<NUMBER>[-beta<NUMBER>]"
-    exit 1
-fi
-VERSION_YEAR=$(printf "%02d" ${BASH_REMATCH[1]})
-VERSION_NUMBER=$(printf "%02d" ${BASH_REMATCH[2]})
-VERSION_PATCH="00"
-VERSION_BETA=$(printf "%02d" ${BASH_REMATCH[4]:-99})
-ANDROID_VERSION_CODE=${VERSION_YEAR}${VERSION_NUMBER}${VERSION_PATCH}${VERSION_BETA}
-
-SEMVER_VERSION=$(echo $VERSION | sed -Ee 's/($|-.*)/.0\1/g')
+PRODUCT_VERSION=$1
 
 if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
     echo "Dirty working directory! Will not accept that for an official release."
     exit 1
 fi
 
-if [[ $(grep $VERSION CHANGELOG.md) == "" ]]; then
-    echo "It looks like you did not add $VERSION to the changelog?"
+if [[ $(grep $PRODUCT_VERSION CHANGELOG.md) == "" ]]; then
+    echo "It looks like you did not add $PRODUCT_VERSION to the changelog?"
     echo "Please make sure the changelog is up to date and correct before you proceed."
     exit 1
 fi
 
 echo "Updating version in metadata files..."
-sed -i.bak -Ee "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" \
-    gui/package.json
-sed -i.bak -Ee "s/^version = \"[^\"]+\"\$/version = \"$SEMVER_VERSION\"/g" \
-    mullvad-daemon/Cargo.toml \
-    mullvad-cli/Cargo.toml \
-    mullvad-problem-report/Cargo.toml
-
-sed -i.bak -Ee "s/versionCode [0-9]+/versionCode $ANDROID_VERSION_CODE/g" \
-    android/build.gradle
-sed -i.bak -Ee "s/versionName \"[^\"]+\"/versionName \"$VERSION\"/g" \
-    android/build.gradle
-
+./version_metadata.sh inject $PRODUCT_VERSION
 
 echo "Syncing Cargo.lock with new version numbers"
 source env.sh ""
-cargo build
+cargo +stable build
 
 (cd gui/ && npm install) || exit 1
 
@@ -66,21 +39,25 @@ git commit -S -m "Updating version in package files" \
     mullvad-daemon/Cargo.toml \
     mullvad-cli/Cargo.toml \
     mullvad-problem-report/Cargo.toml \
-    Cargo.lock
+    talpid-openvpn-plugin/Cargo.toml \
+    Cargo.lock \
+    android/build.gradle \
+    dist-assets/windows/version.h
 
-echo "Tagging current git commit with release tag $VERSION..."
-git tag -s $VERSION -m $VERSION
+echo "Tagging current git commit with release tag $PRODUCT_VERSION..."
+git tag -s $PRODUCT_VERSION -m $PRODUCT_VERSION
 
+./version_metadata.sh delete-backup
 
 echo "==================================================="
 echo "DONE preparing for a release! Now do the following:"
 echo " 1. Push the commit and tag created by this script"
 echo "    after you have verified they are correct"
 echo "     $ git push"
-echo "     $ git push origin $VERSION"
+echo "     $ git push origin $PRODUCT_VERSION"
 echo " 2. On each platform where you want to create a"
 echo "    release artifact, check out the tag and build:"
 echo "     $ git fetch"
-echo "     $ git checkout $VERSION"
+echo "     $ git checkout $PRODUCT_VERSION"
 echo "     $ ./build.sh"
 echo "==================================================="

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talpid-openvpn-plugin"
-version = "0.1.0"
+version = "2019.7.0"
 authors = [
     "Mullvad VPN <admin@mullvad.net>",
     "Andrej Mihajlov <and@mullvad.net>",

--- a/version_metadata.sh
+++ b/version_metadata.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Can inject correctly formatted version strings/numbers in all the various
+# project metadata files. Can also back them up and restore them.
+
+set -eu
+
+# Regex that only matches valid Mullvad VPN versions. It also captures
+# relevant values into capture groups, read out via BASH_REMATCH[x].
+VERSION_REGEX="^20([0-9]{2})\.([1-9][0-9]?)(-beta([1-9][0-9]?))?(-dev-[0-9a-f]+)?$"
+
+case "$1" in
+    "inject")
+        PRODUCT_VERSION=$2
+        if [[ ! $PRODUCT_VERSION =~ $VERSION_REGEX ]]; then
+            echo "Invalid version format. Please specify version as:"
+            echo "<YEAR>.<NUMBER>[-beta<NUMBER>]"
+            exit 1
+        fi
+
+        VERSION_YEAR=$(printf "%02d" ${BASH_REMATCH[1]})
+        VERSION_NUMBER=$(printf "%02d" ${BASH_REMATCH[2]})
+        VERSION_PATCH="00" # Not used for now.
+        VERSION_BETA=$(printf "%02d" ${BASH_REMATCH[4]:-99})
+        ANDROID_VERSION_CODE=${VERSION_YEAR}${VERSION_NUMBER}${VERSION_PATCH}${VERSION_BETA}
+
+        SEMVER_VERSION=$(echo $PRODUCT_VERSION | sed -Ee 's/($|-.*)/.0\1/g')
+        SEMVER_MAJOR="20${BASH_REMATCH[1]}"
+        SEMVER_MINOR=${BASH_REMATCH[2]}
+        SEMVER_PATCH="0"
+
+        # Electron GUI
+        sed -i.bak -Ee "s/\"version\": \"[^\"]+\",/\"version\": \"$SEMVER_VERSION\",/g" \
+            gui/package.json
+
+        # Rust crates
+        sed -i.bak -Ee "s/^version = \"[^\"]+\"\$/version = \"$SEMVER_VERSION\"/g" \
+            mullvad-daemon/Cargo.toml \
+            mullvad-cli/Cargo.toml \
+            mullvad-problem-report/Cargo.toml \
+            talpid-openvpn-plugin/Cargo.toml
+
+        # Windows C++
+        cp dist-assets/windows/version.h dist-assets/windows/version.h.bak
+        cat <<EOF > dist-assets/windows/version.h
+#define MAJOR_VERSION $SEMVER_MAJOR
+#define MINOR_VERSION $SEMVER_MINOR
+#define PATCH_VERSION $SEMVER_PATCH
+#define PRODUCT_VERSION "$PRODUCT_VERSION"
+EOF
+
+        # Android
+        cp android/build.gradle android/build.gradle.bak
+        sed -i -Ee "s/versionCode [0-9]+/versionCode $ANDROID_VERSION_CODE/g" \
+            android/build.gradle
+        sed -i -Ee "s/versionName \"[^\"]+\"/versionName \"$PRODUCT_VERSION\"/g" \
+            android/build.gradle
+        ;;
+    "restore-backup")
+        # Electron GUI
+        mv gui/package.json.bak gui/package.json || true
+        # Rust crates
+        mv mullvad-daemon/Cargo.toml.bak mullvad-daemon/Cargo.toml || true
+        mv mullvad-cli/Cargo.toml.bak mullvad-cli/Cargo.toml || true
+        mv mullvad-problem-report/Cargo.toml.bak mullvad-problem-report/Cargo.toml || true
+        mv talpid-openvpn-plugin/Cargo.toml.bak talpid-openvpn-plugin/Cargo.toml || true
+        # Windows C++
+        mv dist-assets/windows/version.h.bak dist-assets/windows/version.h || true
+        # Android
+        mv android/build.gradle.bak android/build.gradle || true
+        ;;
+    "delete-backup")
+        # Electron GUI
+        rm gui/package.json.bak || true
+        # Rust crates
+        rm mullvad-daemon/Cargo.toml.bak || true
+        rm mullvad-cli/Cargo.toml.bak || true
+        rm mullvad-problem-report/Cargo.toml.bak || true
+        rm talpid-openvpn-plugin/Cargo.toml.bak || true
+        # Windows C++
+        rm dist-assets/windows/version.h.bak || true
+        # Android
+        rm android/build.gradle.bak || true
+        ;;
+    *)
+        echo "Invalid command. Use inject or restore"
+        exit 1
+        ;;
+esac

--- a/version_metadata.sh
+++ b/version_metadata.sh
@@ -83,7 +83,7 @@ EOF
         rm android/build.gradle.bak || true
         ;;
     *)
-        echo "Invalid command. Use inject or restore"
+        echo "Invalid command"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Finally refactoring the injecting of versions into various project metadata files. Moving all such code into `version_metadata.sh` that allows injecting a version as well as restoring backups.

Also committing the changes that the script did to a few of our metadata files that just had dummy values up until now.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1068)
<!-- Reviewable:end -->
