### PR TITLE
Change text/visibility on elements in WireGuard key view

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -110,7 +110,7 @@ class WireguardKeyFragment : Fragment() {
                 publicKey.visibility = View.VISIBLE
                 publicKey.setText(publicKeyString)
 
-                setValidateButton()
+                setVerifyButton()
 
                 if (keyState.verified != null) {
                     if (keyState.verified) {
@@ -148,7 +148,7 @@ class WireguardKeyFragment : Fragment() {
         }
     }
 
-    private fun setValidateButton() {
+    private fun setVerifyButton() {
         if (validatingKey) {
             showActionSpinner()
             return

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -70,6 +70,12 @@ class WireguardKeyFragment : Fragment() {
         actionButton = view.findViewById<Button>(R.id.wg_key_button)
         actionSpinner = view.findViewById<ProgressBar>(R.id.wg_action_spinner)
 
+        visitWebsiteView.visibility = View.VISIBLE
+        visitWebsiteView.setOnClickListener {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(parentActivity.getString(R.string.account_url)))
+            startActivity(intent)
+        }
+
         updateViews()
 
         return view
@@ -82,7 +88,6 @@ class WireguardKeyFragment : Fragment() {
 
     private fun updateViews() {
         clearErrorMessage()
-        visitWebsiteView.visibility = View.GONE
 
         actionButton.setClickable(true)
 
@@ -92,11 +97,6 @@ class WireguardKeyFragment : Fragment() {
                 setGenerateButton()
             }
             is KeygenEvent.TooManyKeys -> {
-                visitWebsiteView.visibility = View.VISIBLE
-                visitWebsiteView.setOnClickListener {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(parentActivity.getString(R.string.account_url)))
-                    startActivity(intent)
-                }
 
                 setStatusMessage(R.string.too_many_keys, R.color.red)
                 setGenerateButton()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -65,7 +65,7 @@ class WireguardKeyFragment : Fragment() {
 
 
         statusMessage = view.findViewById<TextView>(R.id.wireguard_key_status)
-        visitWebsiteView = view.findViewById<View>(R.id.wireguard_key_visit_website)
+        visitWebsiteView = view.findViewById<View>(R.id.wireguard_manage_keys)
         publicKey = view.findViewById<TextView>(R.id.wireguard_public_key)
         actionButton = view.findViewById<Button>(R.id.wg_key_button)
         actionSpinner = view.findViewById<ProgressBar>(R.id.wg_action_spinner)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -155,7 +155,7 @@ class WireguardKeyFragment : Fragment() {
         }
         actionSpinner.visibility = View.GONE
         actionButton.visibility = View.VISIBLE
-        actionButton.setText(R.string.wireguard_validate_key)
+        actionButton.setText(R.string.wireguard_verify_key)
         actionButton.setOnClickListener {
             onValidateKeyPress()
         }

--- a/android/src/main/res/layout/wireguard_key.xml
+++ b/android/src/main/res/layout/wireguard_key.xml
@@ -87,7 +87,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/wireguard_key_visit_website"
+        android:id="@+id/wireguard_manage_keys"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
@@ -102,7 +102,7 @@
             android:layout_height="wrap_content"
             android:paddingHorizontal="8dp"
             android:paddingVertical="17dp"
-            android:text="@string/wireguard_key_visit_website"
+            android:text="@string/wireguard_manage_keys"
             android:textColor="@color/white"
             android:textSize="20sp"
             android:textStyle="bold" />

--- a/android/src/main/res/layout/wireguard_key.xml
+++ b/android/src/main/res/layout/wireguard_key.xml
@@ -87,34 +87,6 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/wireguard_manage_keys"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:background="@drawable/cell_button_background"
-        android:clickable="true"
-        android:gravity="center"
-        android:paddingHorizontal="16dp"
-        android:visibility="gone">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingHorizontal="8dp"
-            android:paddingVertical="17dp"
-            android:text="@string/wireguard_manage_keys"
-            android:textColor="@color/white"
-            android:textSize="20sp"
-            android:textStyle="bold" />
-
-        <ImageView
-            android:layout_width="16dp"
-            android:layout_height="16dp"
-            android:alpha="0.6"
-            android:src="@drawable/icon_extlink" />
-    </LinearLayout>
-
-    <LinearLayout
         android:id="@+id/wireguard_button_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -148,6 +120,34 @@
                 android:indeterminateOnly="true"
                 android:visibility="gone" />
         </RelativeLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/wireguard_manage_keys"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:background="@drawable/cell_button_background"
+        android:clickable="true"
+        android:gravity="center"
+        android:paddingHorizontal="16dp"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="17dp"
+            android:text="@string/wireguard_manage_keys"
+            android:textColor="@color/white"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:alpha="0.6"
+            android:src="@drawable/icon_extlink" />
     </LinearLayout>
 
 </LinearLayout>

--- a/android/src/main/res/layout/wireguard_key.xml
+++ b/android/src/main/res/layout/wireguard_key.xml
@@ -136,7 +136,7 @@
                 style="@style/Button"
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
-                android:text="@string/wireguard_validate_key"/>
+                android:text="@string/wireguard_verify_key"/>
 
             <ProgressBar
                 android:id="@+id/wg_action_spinner"

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -108,7 +108,7 @@
     <string name="wireguard_public_key">Public key</string>
     <string name="wireguard_validate_key">Validate key</string>
     <string name="wireguard_generate_key">Generate key</string>
-    <string name="wireguard_key_visit_website">Manage your keys on website</string>
+    <string name="wireguard_manage_keys">Manage keys</string>
     <string name="wireguard_key_connectivity">
         Connectivity required to manage your key.
     </string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -106,7 +106,7 @@
     </string>
     <string name="wireguard_key">WireGuard key</string>
     <string name="wireguard_public_key">Public key</string>
-    <string name="wireguard_validate_key">Validate key</string>
+    <string name="wireguard_verify_key">Verify key</string>
     <string name="wireguard_generate_key">Generate key</string>
     <string name="wireguard_manage_keys">Manage keys</string>
     <string name="wireguard_key_connectivity">

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -342,7 +342,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
       return (
         <View style={styles.advanced_settings__wgkeys_cell}>
           <Cell.CellButton onPress={this.props.onViewWireguardKeys}>
-            <Cell.Label>{messages.pgettext('advanced-settings-view', 'WireGuard keys')}</Cell.Label>
+            <Cell.Label>{messages.pgettext('advanced-settings-view', 'WireGuard key')}</Cell.Label>
             <Cell.Icon height={12} width={7} source="icon-chevron" />
           </Cell.CellButton>
         </View>

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -37,7 +37,7 @@ export default class WireguardKeys extends Component<IProps> {
             <View style={styles.wgkeys__container}>
               <SettingsHeader>
                 <HeaderTitle>
-                  {messages.pgettext('wireguard-keys-nav', 'WireGuard keys')}
+                  {messages.pgettext('wireguard-keys-nav', 'WireGuard key')}
                 </HeaderTitle>
               </SettingsHeader>
 

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -52,7 +52,7 @@ fn create_wireguard_mtu_subcommand() -> clap::App<'static, 'static> {
 
 fn create_wireguard_keys_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("key")
-        .about("Manage your wireguard keys")
+        .about("Manage your wireguard key")
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::SubCommand::with_name("check"))
         .subcommand(clap::SubCommand::with_name("generate"))


### PR DESCRIPTION
After comparing the WireGuard key view on desktop and mobile I found a few differences. We should keep the look/content as consistent as possible at least three reasons:
* Familiarity to users/consistency - It just looks better if the apps are the same.
* Guides - We can't say "click the verify key button" if it's not called that on all platforms.
* Localization - If we use even the slightest different strings, we will end up having to double translate everything, which will be more painful than it has to be.

Whenever adding or changing any GUI element, please make sure it's consistent across platforms.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1070)
<!-- Reviewable:end -->
