### PR TITLE
Make the amount of chars from the git hash in version string constant

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -26,7 +26,7 @@ else
 fi
 
 if [[ "$BUILD_TYPE" == "debug" || "$(git describe)" != "$PRODUCT_VERSION" ]]; then
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
+    GIT_COMMIT="$(git rev-parse HEAD | head -c 6)"
     PRODUCT_VERSION="${PRODUCT_VERSION}-dev-${GIT_COMMIT}"
     echo "Modifying product version to $PRODUCT_VERSION"
 fi

--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ else
 fi
 
 if [[ "$BUILD_MODE" == "dev" || $(git describe) != "$PRODUCT_VERSION" ]]; then
-    GIT_COMMIT=$(git rev-parse --short HEAD)
+    GIT_COMMIT=$(git rev-parse HEAD | head -c 6)
     PRODUCT_VERSION="$PRODUCT_VERSION-dev-$GIT_COMMIT"
     echo "Modifying product version to $PRODUCT_VERSION"
 else


### PR DESCRIPTION
We have a funky situation that different OSes figure out different hash lengths. Probably because they use different git versions. This is a bit messy and makes the same commit generate apps with different names. This PR locks the amount of chars from the git hash to a fixed number. Keeping the number low since it does not have to be strictly unique globally, just for the current version.

We could increase it from 6 to 8 chars if you want to. 8 is what we currently have, except for slightly older git where it sometimes chooses 9 chars.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1071)
<!-- Reviewable:end -->
