### PR TITLE
Unregister uninstalled pkg from the system

### DIFF
--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -20,6 +20,7 @@ sudo rm -f "$DAEMON_PLIST_PATH"
 
 echo "Removing app from /Applications ..."
 sudo rm -rf /Applications/Mullvad\ VPN.app
+sudo pkgutil --forget net.mullvad.vpn || true
 
 read -p "Do you want to delete the log and cache files the app has created? (y/n) "
 if [[ "$REPLY" =~ [Yy]$ ]]; then


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

The existing uninstaller for macOS does not unregister the PKG file from the system after wiping the files.

```
$ /Applications/Mullvad\ VPN.app/Contents/Resources/uninstall.sh 
Are you sure you want to stop and uninstall Mullvad VPN? (y/n) y
Uninstalling Mullvad VPN ...
Stopping GUI process ...
No GUI process found
Stopping and unloading mullvad-daemon system daemon ...
Removing app from /Applications ...
Do you want to delete the log and cache files the app has created? (y/n) n
Do you want to delete the Mullvad VPN settings? (y/n) n
$ pkgutil --pkgs | grep net.mullvad.vpn                         
net.mullvad.vpn
```

This PR makes sure that the package is cleaned up from the system registry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1072)
<!-- Reviewable:end -->
