### PR TITLE
Implement manual key rotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,19 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add ability to replace the WireGuard key with a new one. Allows manual key rotation.
+- Show age of currently set WireGuard key.
+
 ### Changed
 - Decreased default MTU for WireGuard to 1380 to improve performance over 4G
 - WireGuard key page now shows a label explaining why buttons are disabled when in a blocked state
+- WireGuard key generation will try to replace old key if one exists.
 
 ### Fixed
 - Fix old settings deserialization to allow migrating settings from versions older than 2019.6.
 - Fix various small issues in GUI<->daemon communication.
+- Make GUI WireGuard key verification resilient to failure.
 
 #### macOS
 - Unregister the app properly from the OS when running the bundled `uninstall.sh` script.

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -8,6 +8,7 @@ import {
   ILocation,
   IRelayList,
   ISettings,
+  IWireguardPublicKey,
   KeygenEvent,
   RelaySettingsUpdate,
   TunnelState,
@@ -337,10 +338,18 @@ const settingsSchema = partialObject({
   tunnel_options: tunnelOptionsSchema,
 });
 
+const wireguardPublicKey = object({
+  key: string,
+  created: string,
+});
+
 const keygenEventSchema = oneOf(
   enumeration('too_many_keys', 'generation_failure'),
   object({
-    new_key: string,
+    new_key: object({
+      key: string,
+      created: string,
+    }),
   }),
 );
 
@@ -567,10 +576,10 @@ export class DaemonRpc {
     }
   }
 
-  public async getWireguardKey(): Promise<string | undefined> {
+  public async getWireguardKey(): Promise<IWireguardPublicKey | undefined> {
     const response = await this.transport.send('get_wireguard_key');
     try {
-      return validate(maybe(string), response) || undefined;
+      return validate(maybe(wireguardPublicKey), response) || undefined;
     } catch (error) {
       throw new ResponseParseError('Invalid response from get_wireguard_key');
     }

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -14,6 +14,7 @@ import {
   IRelayList,
   IRelayListHostname,
   ISettings,
+  IWireguardPublicKey,
   KeygenEvent,
   RelaySettings,
   RelaySettingsUpdate,
@@ -143,7 +144,7 @@ class ApplicationMain {
   // The UI locale which is set once from onReady handler
   private locale = 'en';
 
-  private wireguardPublicKey?: string;
+  private wireguardPublicKey?: IWireguardPublicKey;
 
   private accountDataCache = new AccountDataCache(
     (accountToken) => {
@@ -560,7 +561,7 @@ class ApplicationMain {
     }
   }
 
-  private setWireguardKey(wireguardKey?: string) {
+  private setWireguardKey(wireguardKey?: IWireguardPublicKey) {
     this.wireguardPublicKey = wireguardKey;
     if (this.windowController) {
       IpcMainEventChannel.wireguardKeys.notify(this.windowController.webContents, wireguardKey);

--- a/gui/src/renderer/components/WireguardKeysStyles.tsx
+++ b/gui/src/renderer/components/WireguardKeysStyles.tsx
@@ -24,7 +24,6 @@ export default {
     lineHeight: 20,
     letterSpacing: -0.2,
     color: colors.white60,
-    marginBottom: 9,
   }),
   wgkeys__validity_row: Styles.createViewStyle({
     paddingTop: 5,

--- a/gui/src/renderer/containers/WireguardKeysPage.tsx
+++ b/gui/src/renderer/containers/WireguardKeysPage.tsx
@@ -4,20 +4,23 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { links } from '../../config.json';
 import WireguardKeys from '../components/WireguardKeys';
+import { IWgKey } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 import { ISharedRouteProps } from '../routes';
 
-const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => ({
+const mapStateToProps = (state: IReduxState, props: ISharedRouteProps) => ({
   keyState: state.settings.wireguardKeyState,
   isOffline: state.connection.isBlocked,
+  locale: props.locale,
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
   const history = bindActionCreators({ push, goBack }, dispatch);
   return {
-    onGenerateKey: () => props.app.generateWireguardKey(),
-    onVerifyKey: (publicKey: string) => props.app.verifyWireguardKey(publicKey),
-    onVisitWebsiteKey: () => shell.openExternal(links.manageKeys),
     onClose: () => history.goBack(),
+    onGenerateKey: () => props.app.generateWireguardKey(),
+    onReplaceKey: (oldKey: IWgKey) => props.app.replaceWireguardKey(oldKey),
+    onVerifyKey: (publicKey: IWgKey) => props.app.verifyWireguardKey(publicKey),
+    onVisitWebsiteKey: () => shell.openExternal(links.manageKeys),
   };
 };
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -295,10 +295,16 @@ export interface ISettings {
   bridgeState: BridgeState;
 }
 
-export type KeygenEvent = INewWireguardKey | 'too_many_keys' | 'generation_failure';
+export type KeygenEvent = INewWireguardKey | KeygenFailure;
+export type KeygenFailure = 'too_many_keys' | 'generation_failure';
 
 export interface INewWireguardKey {
-  newKey: string;
+  newKey: IWireguardPublicKey;
+}
+
+export interface IWireguardPublicKey {
+  key: string;
+  created: string;
 }
 
 export type BridgeState = 'auto' | 'on' | 'off';

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -13,6 +13,7 @@ import {
   ILocation,
   IRelayList,
   ISettings,
+  IWireguardPublicKey,
   KeygenEvent,
   RelaySettingsUpdate,
   TunnelState,
@@ -31,7 +32,7 @@ export interface IAppStateSnapshot {
   currentVersion: ICurrentAppVersionInfo;
   upgradeVersion: IAppUpgradeInfo;
   guiSettings: IGuiSettingsState;
-  wireguardPublicKey?: string;
+  wireguardPublicKey?: IWireguardPublicKey;
 }
 
 interface ISender<T> {
@@ -114,13 +115,13 @@ interface IAutoStartHandlers extends ISender<boolean> {
   handleSet(fn: (value: boolean) => Promise<void>): void;
 }
 
-interface IWireguardKeyMethods extends IReceiver<string | undefined> {
+interface IWireguardKeyMethods extends IReceiver<IWireguardPublicKey | undefined> {
   listenKeygenEvents(fn: (event: KeygenEvent) => void): void;
   generateKey(): Promise<KeygenEvent>;
   verifyKey(): Promise<boolean>;
 }
 
-interface IWireguardKeyHandlers extends ISender<string | undefined> {
+interface IWireguardKeyHandlers extends ISender<IWireguardPublicKey | undefined> {
   notifyKeygenEvent(webContents: WebContents, event: KeygenEvent): void;
   handleGenerateKey(fn: () => Promise<KeygenEvent>): void;
   handleVerifyKey(fn: () => Promise<boolean>): void;
@@ -340,7 +341,7 @@ export class IpcMainEventChannel {
   };
 
   public static wireguardKeys: IWireguardKeyHandlers = {
-    notify: sender<string | undefined>(WIREGUARD_KEY_SET),
+    notify: sender<IWireguardPublicKey | undefined>(WIREGUARD_KEY_SET),
     notifyKeygenEvent: sender<KeygenEvent>(WIREGUARD_KEYGEN_EVENT),
     handleGenerateKey: requestHandler(GENERATE_WIREGUARD_KEY),
     handleVerifyKey: requestHandler(VERIFY_WIREGUARD_KEY),

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -72,7 +72,11 @@ impl AccountHistory {
             Ok(accounts) => accounts,
         };
         let file = io::BufWriter::new(reader.into_inner());
-        Ok(AccountHistory { file, accounts })
+        let mut history = AccountHistory { file, accounts };
+        if let Err(e) = history.save_to_disk() {
+            log::error!("Failed to save account cache after opening it: {}", e);
+        }
+        Ok(history)
     }
 
     fn try_old_format(reader: &mut io::BufReader<fs::File>) -> Result<Vec<AccountToken>> {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1251,10 +1251,16 @@ where
                     })
                 })?;
 
-            match self
-                .wireguard_key_manager
-                .generate_key_sync(account_token.clone())
-            {
+            let gen_result = match &account_entry.wireguard {
+                Some(wireguard_data) => self
+                    .wireguard_key_manager
+                    .replace_key(account_token.clone(), wireguard_data.get_public_key()),
+                None => self
+                    .wireguard_key_manager
+                    .generate_key_sync(account_token.clone()),
+            };
+
+            match gen_result {
                 Ok(new_data) => {
                     let public_key = new_data.get_public_key();
                     account_entry.wireguard = Some(new_data.clone());

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -795,7 +795,7 @@ where
 
         match result {
             Ok(data) => {
-                let public_key = data.private_key.public_key();
+                let public_key = data.get_public_key();
                 let mut account_entry = self
                     .account_history
                     .get(&account)
@@ -1256,7 +1256,7 @@ where
                 .generate_key_sync(account_token.clone())
             {
                 Ok(new_data) => {
-                    let public_key = new_data.private_key.public_key();
+                    let public_key = new_data.get_public_key();
                     account_entry.wireguard = Some(new_data.clone());
                     self.account_history.insert(account_entry).map_err(|e| {
                         format!("Failed to add new wireguard key to account data: {}", e)
@@ -1285,11 +1285,7 @@ where
             .settings
             .get_account_token()
             .and_then(|account| self.account_history.get(&account).ok()?)
-            .and_then(|account_entry| {
-                account_entry
-                    .wireguard
-                    .map(|wg| wg.private_key.public_key())
-            });
+            .and_then(|account_entry| account_entry.wireguard.map(|wg| wg.get_public_key()));
 
         Self::oneshot_send(tx, key, "get_wireguard_key response");
     }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -19,7 +19,7 @@ use mullvad_types::{
     relay_list::RelayList,
     settings::{self, Settings},
     states::{TargetState, TunnelState},
-    version, DaemonEvent,
+    version, wireguard, DaemonEvent,
 };
 use parking_lot::{Mutex, RwLock};
 use std::{
@@ -28,7 +28,7 @@ use std::{
 };
 use talpid_core::mpsc::IntoSender;
 use talpid_ipc;
-use talpid_types::{net::wireguard, ErrorExt};
+use talpid_types::ErrorExt;
 use uuid;
 
 /// FIXME(linus): This is here just because the futures crate has deprecated it and jsonrpc_core
@@ -133,7 +133,7 @@ build_rpc_trait! {
 
         /// Generates new wireguard key for current account
         #[rpc(meta, name = "generate_wireguard_key")]
-        fn generate_wireguard_key(&self, Self::Metadata) -> BoxFuture<mullvad_types::wireguard::KeygenEvent, Error>;
+        fn generate_wireguard_key(&self, Self::Metadata) -> BoxFuture<wireguard::KeygenEvent, Error>;
 
         /// Retrieve a public key for current account if the account has one.
         #[rpc(meta, name = "get_wireguard_key")]
@@ -217,7 +217,7 @@ pub enum ManagementCommand {
     /// Get the daemon settings
     GetSettings(OneshotSender<Settings>),
     /// Generate new wireguard key
-    GenerateWireguardKey(OneshotSender<mullvad_types::wireguard::KeygenEvent>),
+    GenerateWireguardKey(OneshotSender<wireguard::KeygenEvent>),
     /// Return a public key of the currently set wireguard private key, if there is one
     GetWireguardKey(OneshotSender<Option<wireguard::PublicKey>>),
     /// Verify if the currently set wireguard key is valid.

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -8,10 +8,9 @@ use mullvad_types::{
     settings::Settings,
     states::{TargetState, TunnelState},
     version::AppVersionInfo,
-    wireguard::KeygenEvent,
+    wireguard::{self, KeygenEvent},
 };
 use parking_lot::Mutex;
-use talpid_types::net::wireguard;
 
 #[derive(Debug, err_derive::Error)]
 pub enum Error {

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -546,7 +546,7 @@ impl<'env> IntoJava<'env> for KeygenEvent {
         match self {
             KeygenEvent::NewKey(public_key) => {
                 let class = get_class("net/mullvad/mullvadvpn/model/KeygenEvent$NewKey");
-                let java_public_key = env.auto_local(public_key.into_java(env));
+                let java_public_key = env.auto_local(public_key.key.into_java(env));
 
                 let parameters = [
                     JValue::Object(java_public_key.as_obj()),

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -428,7 +428,7 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getWireguardKey
     _: JObject<'this>,
 ) -> JObject<'env> {
     match DAEMON_INTERFACE.get_wireguard_key() {
-        Ok(public_key) => public_key.into_java(&env),
+        Ok(key) => key.map(|k| k.key).into_java(&env),
         Err(error) => {
             log::error!(
                 "{}",

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -131,6 +131,12 @@ jsonrpc_client!(pub struct WireguardKeyProxy {
         account_token: AccountToken,
         public_key: wireguard::PublicKey
     ) -> RpcRequest<mullvad_types::wireguard::AssociatedAddresses>;
+    pub fn replace_wg_key(
+        &mut self,
+        account_token: AccountToken,
+        old_key: wireguard::PublicKey,
+        new_key: wireguard::PublicKey
+    ) -> RpcRequest<mullvad_types::wireguard::AssociatedAddresses>;
     pub fn check_wg_key(
         &mut self,
         account_token: AccountToken,


### PR DESCRIPTION
This PR enhances the functionality of the wireguard key page in the GUI  in two ways  - 
- show the currently set key's creation date
- allow user to regenerate a key.

To allow users to regenerate a key, a new RPC is introduced to allow the daemon to replace an old public key with a new one. This master RPC will be used whenever a key generation takes place. An extra button is shown in the wireguard key page in the GUI that allows the user to regenerate a key. The button is only enabled when a key is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1075)
<!-- Reviewable:end -->
