### PR TITLE
Disable nightly rust ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
       before_script:
         - env
       script:
-        - ./ci/travis-rust-script.sh stable
+        - ./ci/ci-rust-script.sh stable
 
     # Daemon - Linux
     - os: linux
@@ -73,7 +73,7 @@ matrix:
         - docker run -d --name mvd-build -v $(pwd):/travis -w /travis  mullvadvpn/mullvadvpn-app-build:latest tail -f /dev/null
         - docker ps
       script:
-        - docker exec -t mvd-build bash ci/travis-rust-script.sh nightly
+        - docker exec -t mvd-build bash ci/ci-rust-script.sh nightly
 
     - os: linux
       name: Daemon - beta Rust
@@ -82,7 +82,7 @@ matrix:
       services: docker
       before_script: *rust_before_script
       script:
-        - docker exec -t mvd-build bash ci/travis-rust-script.sh beta
+        - docker exec -t mvd-build bash ci/ci-rust-script.sh beta
 
     - os: linux
       name: Daemon - stable Rust
@@ -91,7 +91,7 @@ matrix:
       services: docker
       before_script: *rust_before_script
       script:
-        - docker exec -t mvd-build bash ci/travis-rust-script.sh stable
+        - docker exec -t mvd-build bash ci/ci-rust-script.sh stable
 
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,7 @@ environment:
   # overridden on a case by case basis down below
     RUST_VERSION: stable
     RUST_BACKTRACE: "1"
-    RUSTFLAGS: "--deny unused_imports --deny dead_code"
     CPP_BUILD_MODES: "Debug"
-    OPENSSL_STATIC: "1"
 
   # These are all the build jobs. Adjust as necessary. Comment out what you
   # don't need
@@ -49,10 +47,7 @@ install:
 
 # This is the "test phase", tweak it as you see fit
 test_script:
-  - ps: . .\env.ps1
-  - bash -x build_windows_modules.sh --dev-build
-  - cargo build
-  - cargo test
+  - bash -x ci/ci-rust-script.sh %RUST_VERSION%
 
 # Stops feature branches from triggering two builds (One for branch and one for PR)
 skip_branch_with_pr: true

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -1,10 +1,20 @@
+#!/usr/bin/env bash
+
 set -eu
+
 RUST_TOOLCHAIN_CHANNEL=$1
 RUSTFLAGS="--deny unused_imports --deny dead_code"
 
 source env.sh ""
+
 rustup update $RUST_TOOLCHAIN_CHANNEL
 rustup default $RUST_TOOLCHAIN_CHANNEL
+
+case "$(uname -s)" in
+  MINGW*|MSYS_NT*)
+    ./build_windows_modules.sh --dev-build
+    ;;
+esac
 
 # FIXME: Becaues of our old jsonrpc dependency our Rust code won't build
 # on latest nightly.

--- a/ci/travis-rust-script.sh
+++ b/ci/travis-rust-script.sh
@@ -6,8 +6,13 @@ source env.sh ""
 rustup update $RUST_TOOLCHAIN_CHANNEL
 rustup default $RUST_TOOLCHAIN_CHANNEL
 
-cargo build --verbose
-cargo test --verbose
+# FIXME: Becaues of our old jsonrpc dependency our Rust code won't build
+# on latest nightly.
+if [ "${RUST_TOOLCHAIN_CHANNEL}" != "nightly" ]; then
+  cargo build --verbose
+  cargo test --verbose
+fi
+
 if [ "${RUST_TOOLCHAIN_CHANNEL}" = "nightly" ]; then
   rustup component add rustfmt-preview;
   rustfmt --version;


### PR DESCRIPTION
We can't go forever with a broken CI. That will make us ignore the CI results completely after a while. And it will be very easy to miss formatting errors that would end up in the nightly test, but hidden by other errors. So since the actual fix for making it build on nightly seem a bit further away, let's just disable it for now.

And in order to not have to figure out if statements in `appveyor.yml` I decided to make both CI environments run the same script. Reduced some other duplication as a bonus and made the build more uniform across platforms.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1076)
<!-- Reviewable:end -->
