### PR TITLE
Add offline-state label to WireGuard key page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Changed
 - Decreased default MTU for WireGuard to 1380 to improve performance over 4G
+- WireGuard key page now shows a label explaining why buttons are disabled when in a blocked state
 
 ### Fixed
 - Fix old settings deserialization to allow migrating settings from versions older than 2019.6.

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -41,6 +41,7 @@ export default class WireguardKeys extends Component<IProps> {
                 </HeaderTitle>
               </SettingsHeader>
 
+              <View style={styles.wgkeys__row}>{this.blockedStateLabel()}</View>
               <View style={styles.wgkeys__row}>
                 <Text style={styles.wgkeys__row_label}>
                   {messages.pgettext('wireguard-keys', 'Public key')}
@@ -164,5 +165,16 @@ export default class WireguardKeys extends Component<IProps> {
       default:
         return '';
     }
+  }
+
+  private blockedStateLabel() {
+    if (!this.props.isOffline) {
+      return undefined;
+    }
+    return (
+      <Text style={styles.wgkeys__invalid_key}>
+        {messages.pgettext('wireguard-key-view', "Can't manage keys whilst in a blocked state")}
+      </Text>
+    );
   }
 }


### PR DESCRIPTION
I've added a label to the top of the WireGuard key page in the desktop client to inform the user that keys can't be managed whilst in a blocked state.

![blocked-state-label](https://user-images.githubusercontent.com/7757572/64165933-f4638300-ce3d-11e9-8715-9a2e43322911.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1077)
<!-- Reviewable:end -->
