### PR TITLE
Show "Blocked connection" status message

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectionStatus.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectionStatus.kt
@@ -11,9 +11,9 @@ class ConnectionStatus(val parentView: View, val context: Context) {
     private val spinner: View = parentView.findViewById(R.id.connecting_spinner)
     private val text: TextView = parentView.findViewById(R.id.connection_status)
 
-    private val disconnectedTextColor = context.getColor(R.color.red)
+    private val unsecuredTextColor = context.getColor(R.color.red)
     private val connectingTextColor = context.getColor(R.color.white)
-    private val connectedTextColor = context.getColor(R.color.green)
+    private val securedTextColor = context.getColor(R.color.green)
 
     fun setState(state: TunnelState) {
         when (state) {
@@ -34,7 +34,7 @@ class ConnectionStatus(val parentView: View, val context: Context) {
     private fun disconnected() {
         spinner.visibility = View.GONE
 
-        text.setTextColor(disconnectedTextColor)
+        text.setTextColor(unsecuredTextColor)
         text.setText(R.string.unsecured_connection)
     }
 
@@ -48,14 +48,14 @@ class ConnectionStatus(val parentView: View, val context: Context) {
     private fun connected() {
         spinner.visibility = View.GONE
 
-        text.setTextColor(connectedTextColor)
+        text.setTextColor(securedTextColor)
         text.setText(R.string.secure_connection)
     }
 
     private fun blocked() {
         spinner.visibility = View.GONE
 
-        text.setTextColor(connectedTextColor)
+        text.setTextColor(securedTextColor)
         text.setText(R.string.blocked_connection)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectionStatus.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectionStatus.kt
@@ -27,7 +27,7 @@ class ConnectionStatus(val parentView: View, val context: Context) {
             is TunnelState.Disconnected -> disconnected()
             is TunnelState.Connecting -> connecting()
             is TunnelState.Connected -> connected()
-            is TunnelState.Blocked -> connected()
+            is TunnelState.Blocked -> blocked()
         }
     }
 
@@ -50,5 +50,12 @@ class ConnectionStatus(val parentView: View, val context: Context) {
 
         text.setTextColor(connectedTextColor)
         text.setText(R.string.secure_connection)
+    }
+
+    private fun blocked() {
+        spinner.visibility = View.GONE
+
+        text.setTextColor(connectedTextColor)
+        text.setText(R.string.blocked_connection)
     }
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="unsecured_connection">Unsecured connection</string>
     <string name="creating_secure_connection">Creating secure connection</string>
     <string name="secure_connection">Secure connection</string>
+    <string name="blocked_connection">Blocked connection</string>
     <string name="connect">Secure my connection</string>
     <string name="cancel">Cancel</string>
     <string name="disconnect">Disconnect</string>


### PR DESCRIPTION
This PR fixes the status message shown when the tunnel is blocking connections. It would previously say "secure connection", but this PR changes it so that it says "blocked connection", which is more accurate and mirrors the behavior of the desktop app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1078)
<!-- Reviewable:end -->
