### PR TITLE
Remove unused hex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,6 @@ version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 ipnetwork = "0.14"
 base64 = "0.10"
-hex = "0.3"
 x25519-dalek = { version = "0.4.5", features = [ "std", "u64_backend" ], default-features = false }
 rand = "0.7"
 err-derive = "0.1.5"


### PR DESCRIPTION
I saw the `cargo-udeps` tool mentioned in this week in rust. It finds unused dependencies. So I ran it on our code. Sadly the tool only works on nightly rust, due to the way it integrates with the compiler. And most of our code can't build on nightly Rust at the moment. So catch 22 :man_shrugging: . But I was able to run it on some of our smaller crates and found one tiiiiny unused dep at least.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1084)
<!-- Reviewable:end -->
