### PR TITLE
Use notification channel for service notification

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -7,6 +7,10 @@
     <string name="secured">Secured</string>
     <string name="unsecured">Unsecured</string>
     <string name="blocking_all_connections">Blocking all connections</string>
+    <string name="foreground_notification_channel_name">VPN tunnel status</string>
+    <string name="foreground_notification_channel_description">
+        Shows current VPN tunnel status
+    </string>
 
     <string name="connecting_to_daemon">Connecting to Mullvad system service...</string>
 


### PR DESCRIPTION
This PR fixes the notification on Android Oreo (API 26) and later. On newer versions, notifications on Android must be assigned to a channel so that the user can control how groups of notifications are presented. This PR creates a channel for the VPN status messages and assigns it to the foreground notification.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes an issue on an unreleased version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1088)
<!-- Reviewable:end -->
