### PR TITLE
Version check outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 - Decreased default MTU for WireGuard to 1380 to improve performance over 4G
 - WireGuard key page now shows a label explaining why buttons are disabled when in a blocked state
 - WireGuard key generation will try to replace old key if one exists.
+- Show banner about new app versions only if current platform has changes in latest release.
 
 ### Fixed
 - Fix old settings deserialization to allow migrating settings from versions older than 2019.6.

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -284,6 +284,7 @@ const tunnelStateSchema = oneOf(
 
 const appVersionInfoSchema = partialObject({
   current_is_supported: boolean,
+  current_is_outdated: boolean,
   latest_stable: string,
   latest: string,
 });

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -64,7 +64,6 @@ export interface ICurrentAppVersionInfo {
 
 export interface IAppUpgradeInfo extends IAppVersionInfo {
   nextUpgrade?: string;
-  upToDate: boolean;
 }
 
 type AccountVerification = { status: 'verified' } | { status: 'deferred'; error: Error };
@@ -134,10 +133,10 @@ class ApplicationMain {
 
   private upgradeVersion: IAppUpgradeInfo = {
     currentIsSupported: true,
+    currentIsOutdated: false,
     latestStable: '',
     latest: '',
     nextUpgrade: undefined,
-    upToDate: true,
   };
   private latestVersionInterval?: NodeJS.Timeout;
 
@@ -722,23 +721,10 @@ class ApplicationMain {
       }
     }
 
-    function checkIfLatest(current: string, latest: string, latestStable: string): boolean {
-      // perhaps -beta?
-      if (isBeta(current)) {
-        return current === latest;
-      } else {
-        // must be stable
-        return current === latestStable;
-      }
-    }
-
     const currentVersionInfo = this.currentVersion;
     const latestVersion = latestVersionInfo.latest;
     const latestStableVersion = latestVersionInfo.latestStable;
 
-    // the reason why we rely on daemon version here is because daemon obtains the version info
-    // based on its built-in version information
-    const isUpToDate = checkIfLatest(currentVersionInfo.daemon, latestVersion, latestStableVersion);
     const upgradeVersion = nextUpgrade(
       currentVersionInfo.daemon,
       latestVersion,
@@ -748,7 +734,6 @@ class ApplicationMain {
     const upgradeInfo = {
       ...latestVersionInfo,
       nextUpgrade: upgradeVersion,
-      upToDate: isUpToDate,
     };
 
     this.upgradeVersion = upgradeInfo;

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -176,7 +176,7 @@ export default class NotificationArea extends Component<IProps, State> {
           };
         }
 
-        if (!version.upToDate && version.nextUpgrade) {
+        if (version.currentIsOutdated && version.nextUpgrade) {
           return {
             visible: true,
             type: 'update-available',

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -13,7 +13,7 @@ const mapStateToProps = (state: IReduxState, props: ISharedRouteProps) => ({
   expiryLocale: props.locale,
   appVersion: state.version.current,
   consistentVersion: state.version.consistent,
-  upToDateVersion: state.version.upToDate,
+  upToDateVersion: !state.version.currentIsOutdated,
   isOffline: state.connection.isBlocked,
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch, _props: ISharedRouteProps) => {

--- a/gui/src/renderer/redux/version/actions.ts
+++ b/gui/src/renderer/redux/version/actions.ts
@@ -1,7 +1,6 @@
 import { IAppVersionInfo } from '../../../shared/daemon-rpc-types';
 
 interface IUpdateLatestActionPayload extends IAppVersionInfo {
-  upToDate: boolean;
   nextUpgrade?: string;
 }
 

--- a/gui/src/renderer/redux/version/reducers.ts
+++ b/gui/src/renderer/redux/version/reducers.ts
@@ -3,20 +3,20 @@ import { ReduxAction } from '../store';
 export interface IVersionReduxState {
   current: string;
   currentIsSupported: boolean;
+  currentIsOutdated: boolean;
   latest?: string;
   latestStable?: string;
   nextUpgrade?: string;
-  upToDate: boolean;
   consistent: boolean;
 }
 
 const initialState: IVersionReduxState = {
   current: '',
   currentIsSupported: true,
+  currentIsOutdated: false,
   latest: undefined,
   latestStable: undefined,
   nextUpgrade: undefined,
-  upToDate: true,
   consistent: true,
 };
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -280,6 +280,7 @@ export interface IShadowsocksProxySettings {
 
 export interface IAppVersionInfo {
   currentIsSupported: boolean;
+  currentIsOutdated: boolean;
   latestStable: string;
   latest: string;
 }

--- a/gui/test/components/NotificationArea.spec.tsx
+++ b/gui/test/components/NotificationArea.spec.tsx
@@ -10,7 +10,7 @@ describe('components/NotificationArea', () => {
   const defaultVersion = {
     consistent: true,
     currentIsSupported: true,
-    upToDate: true,
+    currentIsOutdated: false,
     current: '2018.2',
     latest: '2018.2-beta1',
     latestStable: '2018.2',
@@ -185,7 +185,7 @@ describe('components/NotificationArea', () => {
         version={{
           ...defaultVersion,
           currentIsSupported: false,
-          upToDate: false,
+          currentIsOutdated: true,
           current: '2018.1',
           nextUpgrade: '2018.2',
         }}
@@ -207,7 +207,7 @@ describe('components/NotificationArea', () => {
         }}
         version={{
           ...defaultVersion,
-          upToDate: false,
+          currentIsOutdated: true,
           current: '2018.2',
           latest: '2018.4-beta2',
           latestStable: '2018.3',
@@ -232,7 +232,7 @@ describe('components/NotificationArea', () => {
         }}
         version={{
           ...defaultVersion,
-          upToDate: false,
+          currentIsOutdated: true,
           current: '2018.4-beta1',
           latest: '2018.4-beta3',
           latestStable: '2018.3',

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -17,7 +17,8 @@ impl Command for Version {
         let current_version = rpc.get_current_version()?;
         println!("Current version: {}", current_version);
         let version_info = rpc.get_version_info()?;
-        println!("Supported: {}", version_info.current_is_supported);
+        println!("\tIs supported: {}", version_info.current_is_supported);
+        println!("\tIs up to date: {}", !version_info.current_is_outdated);
         if version_info.latest_stable != version_info.latest {
             println!(
                 "Latest version: {} (latest stable: {})",

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -4,8 +4,19 @@ use serde::{Deserialize, Serialize};
 /// Mullvad VPN app.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppVersionInfo {
+    /// False if Mullvad has stopped supporting the currently running version. This could mean
+    /// a number of things. For example:
+    /// * API endpoints it uses might not work any more.
+    /// * Software bundled with this version, such as OpenVPN or OpenSSL, has known security
+    ///   issues, so using it is no longer recommended.
+    /// The user should really upgrade when this is false.
     pub current_is_supported: bool,
+    /// True if there is a newer version that contains any functional differences compared to the
+    /// running version. User should upgrade if they want the latest features and bugfixes.
+    pub current_is_outdated: bool,
     pub latest_stable: AppVersion,
+    /// Equal to `latest_stable` when the newest release is a stable release. But will contain
+    /// beta versions when those are out for testing.
     pub latest: AppVersion,
 }
 


### PR DESCRIPTION
Our version check API call now contains a flag telling the app if it's outdated or not. So we let the API decide that instead of letting the app just compare it's current version with the latest version returned from the API.

This allows us to tell the app there is no relevant update for it, even if it's not running the latest. This allows us to release apps for specific platforms without annoying users on unchanged platforms.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1089)
<!-- Reviewable:end -->
