### PR TITLE
Don't talk to API by default in `mullvad status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
 - WireGuard key page now shows a label explaining why buttons are disabled when in a blocked state
 - WireGuard key generation will try to replace old key if one exists.
 - Show banner about new app versions only if current platform has changes in latest release.
+- Don't make a GeoIP lookup by default in CLI status command. Add --location flag for enabling it.
 
 ### Fixed
 - Fix old settings deserialization to allow migrating settings from versions older than 2019.6.


### PR DESCRIPTION
Fixes #617 

Would be nice to be able to query the daemon state without relying on a working internet connection. So I removed the mandatory GeoIP lookup in `mullvad status`. Makes it way easier to use this command in scripts and some other scenarios.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1091)
<!-- Reviewable:end -->
