### PR TITLE
Win log offline

### DIFF
--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -55,7 +55,7 @@ impl FirewallT for Firewall {
                 WinFw_InitializeBlocked(
                     WINFW_TIMEOUT_SECONDS,
                     &cfg,
-                    Some(winnet::error_sink),
+                    Some(winnet::log_sink),
                     ptr::null_mut(),
                 )
                 .into_result()?
@@ -64,7 +64,7 @@ impl FirewallT for Firewall {
             unsafe {
                 WinFw_Initialize(
                     WINFW_TIMEOUT_SECONDS,
-                    Some(winnet::error_sink),
+                    Some(winnet::log_sink),
                     ptr::null_mut(),
                 )
                 .into_result()?
@@ -253,7 +253,7 @@ mod winfw {
         #[link_name = "WinFw_Initialize"]
         pub fn WinFw_Initialize(
             timeout: libc::c_uint,
-            sink: Option<winnet::ErrorSink>,
+            sink: Option<winnet::LogSink>,
             sink_context: *mut libc::c_void,
         ) -> InitializationResult;
 
@@ -261,7 +261,7 @@ mod winfw {
         pub fn WinFw_InitializeBlocked(
             timeout: libc::c_uint,
             settings: &WinFwSettings,
-            sink: Option<winnet::ErrorSink>,
+            sink: Option<winnet::LogSink>,
             sink_context: *mut libc::c_void,
         ) -> InitializationResult;
 

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -201,7 +201,7 @@ impl BroadcastListener {
             Some(Self::connectivity_callback),
             callback_context,
             &mut current_connectivity as *mut _,
-            Some(winnet::error_sink),
+            Some(winnet::log_sink),
             ptr::null_mut(),
         ) {
             return Err(Error::ConnectivityMonitorError);

--- a/windows/shared/logsink.h
+++ b/windows/shared/logsink.h
@@ -1,0 +1,26 @@
+#pragma once
+
+//
+// This file is shared between DLL modules to help define their public interface.
+// It should always be C-compatible.
+//
+
+enum MULLVAD_LOG_SINK_SEVERITY
+{
+	MULLVAD_LOG_SINK_SEVERITY_ERROR = 0,
+	MULLVAD_LOG_SINK_SEVERITY_WARNING,
+	MULLVAD_LOG_SINK_SEVERITY_INFO,
+	MULLVAD_LOG_SINK_SEVERITY_TRACE
+};
+
+//
+// The log sink is registered with a DLL during e.g. initialization.
+// It may later be activated as a direct or indirect result of calling into the DLL.
+//
+// The parameters are:
+//
+// `MULLVAD_LOG_SINK_SEVERITY` - Severity of the message.
+// `const char *` - The message itself.
+// `void *` - The sink context that was registered along with the sink.
+//
+typedef void (__stdcall *MullvadLogSink)(MULLVAD_LOG_SINK_SEVERITY, const char *, void *);

--- a/windows/shared/logsinkadapter.h
+++ b/windows/shared/logsinkadapter.h
@@ -1,0 +1,52 @@
+#include "logsink.h"
+#include <libcommon/logging/logsink.h>
+
+namespace shared
+{
+
+//
+// Adapt common::logging::LogSink C++ world to
+// MullvadLogSink C world.
+//
+class LogSinkAdapter : public common::logging::LogSink
+{
+public:
+
+	LogSinkAdapter(MullvadLogSink target, void *context)
+		: LogSink(MakeAdapter(target, context))
+	{
+	}
+
+private:
+
+	static common::logging::LogTarget MakeAdapter(MullvadLogSink target, void *context)
+	{
+		return [target, context](common::logging::Severity s, const char *msg)
+		{
+			if (nullptr == target)
+			{
+				return;
+			}
+
+			const MULLVAD_LOG_SINK_SEVERITY severity = [s]()
+			{
+				switch (s)
+				{
+					case common::logging::Severity::Warning:
+						return MULLVAD_LOG_SINK_SEVERITY_WARNING;
+					case common::logging::Severity::Info:
+						return MULLVAD_LOG_SINK_SEVERITY_INFO;
+					case common::logging::Severity::Trace:
+						return MULLVAD_LOG_SINK_SEVERITY_TRACE;
+					case common::logging::Severity::Error:
+					default:
+						return MULLVAD_LOG_SINK_SEVERITY_ERROR;
+				}
+			}();
+
+			target(severity, msg, context);
+		};
+	}
+};
+
+}

--- a/windows/winnet/src/winnet/netmonitor.cpp
+++ b/windows/winnet/src/winnet/netmonitor.cpp
@@ -2,7 +2,8 @@
 #include "netmonitor.h"
 #include <libcommon/error.h>
 #include <libcommon/memory.h>
-#include <libcommon/synchronization.h>
+#include <libcommon/string.h>
+#include <sstream>
 
 namespace
 {
@@ -28,11 +29,17 @@ bool ValidInterfaceType(const MIB_IF_ROW2 &iface)
 	return true;
 }
 
-} // anonyomus namespace
+} // anonymous namespace
 
-NetMonitor::NetMonitor(NetMonitor::Notifier notifier, bool &currentConnectivity)
-	: m_connected(false)
+NetMonitor::NetMonitor
+(
+	std::shared_ptr<common::logging::ILogSink> logSink,
+	NetMonitor::Notifier notifier,
+	bool &currentConnectivity
+)
+	: m_logSink(logSink)
 	, m_notifier(notifier)
+	, m_connected(false)
 	, m_notificationHandle(nullptr)
 {
 	m_cache = CreateCache();
@@ -43,6 +50,11 @@ NetMonitor::NetMonitor(NetMonitor::Notifier notifier, bool &currentConnectivity)
 	const auto status = NotifyIpInterfaceChange(AF_UNSPEC, Callback, this, FALSE, &m_notificationHandle);
 
 	THROW_UNLESS(NO_ERROR, status, "Register interface change notification");
+
+	if (false == m_connected)
+	{
+		LogOfflineState(m_logSink);
+	}
 }
 
 NetMonitor::~NetMonitor()
@@ -51,9 +63,23 @@ NetMonitor::~NetMonitor()
 }
 
 // static
-bool NetMonitor::CheckConnectivity()
+bool NetMonitor::CheckConnectivity(std::shared_ptr<common::logging::ILogSink> logSink)
 {
-	return CheckConnectivity(CreateCache());
+	static bool loggedOffline = false;
+
+	const auto connected = CheckConnectivity(CreateCache());
+
+	if (connected)
+	{
+		loggedOffline = false;
+	}
+	else if (false == loggedOffline)
+	{
+		LogOfflineState(logSink);
+		loggedOffline = true;
+	}
+
+	return connected;
 }
 
 // static
@@ -78,6 +104,7 @@ NetMonitor::Cache NetMonitor::CreateCache()
 	{
 		AddCacheEntry(cache, table->Table[i]);
 	}
+
 	return cache;
 }
 
@@ -126,9 +153,12 @@ void NetMonitor::updateConnectivity()
 //static
 void __stdcall NetMonitor::Callback(void *context, MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType)
 {
-	auto thiz = reinterpret_cast<NetMonitor *>(context);
+	reinterpret_cast<NetMonitor *>(context)->callback(hint, updateType);
+}
 
-	common::sync::ScopeLock<> processingLock(thiz->m_processingMutex);
+void NetMonitor::callback(MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType)
+{
+	std::scoped_lock<std::mutex> processingLock(m_processingMutex);
 
 	switch (updateType)
 	{
@@ -143,15 +173,15 @@ void __stdcall NetMonitor::Callback(void *context, MIB_IPINTERFACE_ROW *hint, MI
 				return;
 			}
 
-			thiz->AddCacheEntry(thiz->m_cache, iface);
+			AddCacheEntry(m_cache, iface);
 
 			break;
 		}
 		case MibDeleteInstance:
 		{
-			const auto cacheEntry = thiz->m_cache.find(hint->InterfaceLuid.Value);
+			const auto cacheEntry = m_cache.find(hint->InterfaceLuid.Value);
 
-			if (thiz->m_cache.end() != cacheEntry)
+			if (m_cache.end() != cacheEntry)
 			{
 				cacheEntry->second.connected = false;
 			}
@@ -160,9 +190,9 @@ void __stdcall NetMonitor::Callback(void *context, MIB_IPINTERFACE_ROW *hint, MI
 		}
 		case MibParameterNotification:
 		{
-			auto cacheEntry = thiz->m_cache.find(hint->InterfaceLuid.Value);
+			auto cacheEntry = m_cache.find(hint->InterfaceLuid.Value);
 
-			if (thiz->m_cache.end() == cacheEntry)
+			if (m_cache.end() == cacheEntry)
 			{
 				//
 				// A change occurred on an interface that we're not tracking.
@@ -178,7 +208,7 @@ void __stdcall NetMonitor::Callback(void *context, MIB_IPINTERFACE_ROW *hint, MI
 					return;
 				}
 
-				thiz->AddCacheEntry(thiz->m_cache, iface);
+				AddCacheEntry(m_cache, iface);
 			}
 			else
 			{
@@ -207,12 +237,134 @@ void __stdcall NetMonitor::Callback(void *context, MIB_IPINTERFACE_ROW *hint, MI
 		}
 	}
 
-	const auto previousConnectivity = thiz->m_connected;
+	const auto previousConnectivity = m_connected;
 
-	thiz->updateConnectivity();
+	updateConnectivity();
 
-	if (previousConnectivity != thiz->m_connected)
+	if (previousConnectivity != m_connected)
 	{
-		thiz->m_notifier(thiz->m_connected);
+		m_notifier(m_connected);
+
+		if (false == m_connected)
+		{
+			LogOfflineState(m_logSink);
+		}
 	}
+}
+
+//static
+void NetMonitor::LogOfflineState(std::shared_ptr<common::logging::ILogSink> logSink)
+{
+	//
+	// There is a race condition here because logging is not done using the
+	// same data set that the online/offline logic processes.
+	//
+	// Not much of a problem really, this is temporary logging.
+	//
+
+	logSink->info("Machine is offline");
+
+	MIB_IF_TABLE2 *table;
+
+	const auto status = GetIfTable2(&table);
+
+	if (NO_ERROR != status)
+	{
+		logSink->error("Failed to acquire list of network interfaces. Aborting detailed logging");
+		return;
+	}
+
+	common::memory::ScopeDestructor sd;
+
+	sd += [table]()
+	{
+		FreeMibTable(table);
+	};
+
+	logSink->info("Begin detailed listing of network interfaces");
+
+	for (ULONG i = 0; i < table->NumEntries; ++i)
+	{
+		const auto &iface = table->Table[i];
+
+		std::stringstream ss;
+
+		ss << "Detailed interface logging" << std::endl;
+		ss << "Interface ordinal " << i << std::endl;
+
+		//
+		// Don't flood the log with garbage.
+		//
+		const auto blacklist = std::vector<std::wstring>
+		{
+			L"WFP Native MAC Layer LightWeight Filter",
+			L"QoS Packet Scheduler",
+			L"WFP 802.3 MAC Layer LightWeight Filter",
+			L"Microsoft Kernel Debug Network Adapter",
+			L"Software Loopback Interface",
+			L"Microsoft Teredo Tunneling Adapter",
+			L"Microsoft IP-HTTPS Platform Adapter",
+			L"Microsoft 6to4 Adapter",
+		};
+
+		bool blacklisted = false;
+
+		for (const auto &black : blacklist)
+		{
+			if (nullptr != wcsstr(iface.Description, black.c_str()))
+			{
+				blacklisted = true;
+				break;
+			}
+		}
+
+		if (blacklisted)
+		{
+			ss << "  filtered out to avoid flooding log";
+			logSink->info(ss.str().c_str());
+
+			continue;
+		}
+
+		{
+			const auto s = std::wstring(L"  Alias: ").append(iface.Alias);
+			ss << common::string::ToAnsi(s) << std::endl;
+		}
+
+		{
+			const auto s = std::wstring(L"  \"Description\": ").append(iface.Description);
+			ss << common::string::ToAnsi(s) << std::endl;
+		}
+
+		ss << "  PhysicalAddressLength: " << iface.PhysicalAddressLength << std::endl;
+		ss << "  Type: " << iface.Type << std::endl;
+		ss << "  MediaType: " << iface.MediaType << std::endl;
+		ss << "  PhysicalMediumType: " << iface.PhysicalMediumType << std::endl;
+		ss << "  AccessType: " << iface.AccessType << std::endl;
+
+		//
+		// Bool cast prevents idiot stream from inserting literal 0/1.
+		//
+
+		ss << "  InterfaceAndOperStatusFlags.HardwareInterface: " << (bool)iface.InterfaceAndOperStatusFlags.HardwareInterface << std::endl;
+		ss << "  InterfaceAndOperStatusFlags.FilterInterface: " << (bool)iface.InterfaceAndOperStatusFlags.FilterInterface << std::endl;
+		ss << "  InterfaceAndOperStatusFlags.ConnectorPresent: " << (bool)iface.InterfaceAndOperStatusFlags.ConnectorPresent << std::endl;
+		ss << "  InterfaceAndOperStatusFlags.NotAuthenticated: " << (bool)iface.InterfaceAndOperStatusFlags.NotAuthenticated << std::endl;
+		ss << "  InterfaceAndOperStatusFlags.NotMediaConnected: " << (bool)iface.InterfaceAndOperStatusFlags.NotMediaConnected << std::endl;
+		ss << "  InterfaceAndOperStatusFlags.Paused: " << (bool)iface.InterfaceAndOperStatusFlags.Paused << std::endl;
+		ss << "  InterfaceAndOperStatusFlags.LowPower: " << (bool)iface.InterfaceAndOperStatusFlags.LowPower << std::endl;
+		ss << "  InterfaceAndOperStatusFlags.EndPointInterface: " << (bool)iface.InterfaceAndOperStatusFlags.EndPointInterface << std::endl;
+
+		ss << "  OperStatus: " << iface.OperStatus << std::endl;
+		ss << "  AdminStatus: " << iface.AdminStatus << std::endl;
+		ss << "  MediaConnectState: " << iface.MediaConnectState << std::endl;
+		ss << "  TransmitLinkSpeed: " << iface.TransmitLinkSpeed << std::endl;
+
+		ss << "  ReceiveLinkSpeed: " << iface.ReceiveLinkSpeed << std::endl;
+		ss << "  InUcastPkts:" << iface.InUcastPkts;
+
+		logSink->info(ss.str().c_str());
+	}
+
+	logSink->info("End detailed listing of network interfaces");
 }

--- a/windows/winnet/src/winnet/netmonitor.h
+++ b/windows/winnet/src/winnet/netmonitor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <libcommon/logging/ilogsink.h>
+#include <memory>
 #include <map>
 #include <string>
 #include <cstdint>
@@ -20,12 +22,15 @@ public:
 	//
 	using Notifier = std::function<void(bool)>;
 
-	NetMonitor(Notifier notifier, bool &currentConnectivity);
+	NetMonitor(std::shared_ptr<common::logging::ILogSink> logSink, Notifier notifier, bool &currentConnectivity);
 	~NetMonitor();
 
-	static bool CheckConnectivity();
+	static bool CheckConnectivity(std::shared_ptr<common::logging::ILogSink> logSink);
 
 private:
+
+	std::shared_ptr<common::logging::ILogSink> m_logSink;
+	Notifier m_notifier;
 
 	struct CacheEntry
 	{
@@ -44,7 +49,6 @@ private:
 	std::mutex m_processingMutex;
 	Cache m_cache;
 	bool m_connected;
-	Notifier m_notifier;
 
 	HANDLE m_notificationHandle;
 
@@ -55,4 +59,7 @@ private:
 	void updateConnectivity();
 
 	static void __stdcall Callback(void *context, MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType);
+	void callback(MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType);
+
+	static void LogOfflineState(std::shared_ptr<common::logging::ILogSink> logSink);
 };

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <stdint.h>
+
+#include "../../shared/logsink.h"
 #include <stdbool.h>
 
 #ifdef WINNET_EXPORTS
@@ -10,13 +11,11 @@
 
 #define WINNET_API __stdcall
 
-typedef void (WINNET_API *WinNetErrorSink)(const char *errorMessage, void *context);
-
-enum class WINNET_ETM_STATUS : uint32_t
+enum WINNET_ETM_STATUS
 {
-	METRIC_NO_CHANGE = 0,
-	METRIC_SET = 1,
-	FAILURE = 2,
+	WINNET_ETM_STATUS_METRIC_NO_CHANGE = 0,
+	WINNET_ETM_STATUS_METRIC_SET = 1,
+	WINNET_ETM_STATUS_FAILURE = 2,
 };
 
 extern "C"
@@ -25,15 +24,15 @@ WINNET_ETM_STATUS
 WINNET_API
 WinNet_EnsureTopMetric(
 	const wchar_t *deviceAlias,
-	WinNetErrorSink errorSink,
-	void *errorSinkContext
+	MullvadLogSink logSink,
+	void *logSinkContext
 );
 
-enum class WINNET_GTII_STATUS : uint32_t
+enum WINNET_GTII_STATUS
 {
-	ENABLED = 0,
-	DISABLED = 1,
-	FAILURE = 2,
+	WINNET_GTII_STATUS_ENABLED = 0,
+	WINNET_GTII_STATUS_DISABLED = 1,
+	WINNET_GTII_STATUS_FAILURE = 2,
 };
 
 extern "C"
@@ -41,8 +40,8 @@ WINNET_LINKAGE
 WINNET_GTII_STATUS
 WINNET_API
 WinNet_GetTapInterfaceIpv6Status(
-	WinNetErrorSink errorSink,
-	void *errorSinkContext
+	MullvadLogSink logSink,
+	void *logSinkContext
 );
 
 extern "C"
@@ -51,8 +50,8 @@ bool
 WINNET_API
 WinNet_GetTapInterfaceAlias(
 	wchar_t **alias,
-	WinNetErrorSink errorSink,
-	void *errorSinkContext
+	MullvadLogSink logSink,
+	void *logSinkContext
 );
 
 //
@@ -77,8 +76,8 @@ WinNet_ActivateConnectivityMonitor(
 	WinNetConnectivityMonitorCallback callback,
 	void *callbackContext,
 	bool *currentConnectivity,
-	WinNetErrorSink errorSink,
-	void *errorSinkContext
+	MullvadLogSink logSink,
+	void *logSinkContext
 );
 
 extern "C"
@@ -88,11 +87,11 @@ WINNET_API
 WinNet_DeactivateConnectivityMonitor(
 );
 
-enum class WINNET_CC_STATUS : uint32_t
+enum WINNET_CC_STATUS
 {
-	NOT_CONNECTED = 0,
-	CONNECTED = 1,
-	CONNECTIVITY_UNKNOWN = 2,
+	WINNET_CC_STATUS_NOT_CONNECTED = 0,
+	WINNET_CC_STATUS_CONNECTED = 1,
+	WINNET_CC_STATUS_CONNECTIVITY_UNKNOWN = 2,
 };
 
 extern "C"
@@ -100,6 +99,6 @@ WINNET_LINKAGE
 WINNET_CC_STATUS
 WINNET_API
 WinNet_CheckConnectivity(
-	WinNetErrorSink errorSink,
-	void *errorSinkContext
+	MullvadLogSink logSink,
+	void *logSinkContext
 );


### PR DESCRIPTION
Formalize logging types and structure files for reuse between DLLs.
Minimize global namespace pollution.
Add logging of network adapters whenever the logic decides the machine is offline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1092)
<!-- Reviewable:end -->
