### PR TITLE
Implement notification action buttons

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,9 +3,14 @@
         xmlns:tools="http://schemas.android.com/tools"
         package="net.mullvad.mullvadvpn"
         >
+    <permission android:name="net.mullvad.mullvadvpn.permission.TUNNEL_ACTION"
+            android:protectionLevel="signature"
+            />
+
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="net.mullvad.mullvadvpn.permission.TUNNEL_ACTION" />
 
     <application
             android:label="@string/app_name"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -98,7 +98,7 @@ class MullvadVpnService : VpnService() {
     private fun setUp() {
         daemon = startDaemon()
         connectionProxy = ConnectionProxy(this, daemon)
-        notificationManager = ForegroundNotificationManager(this, connectionProxy)
+        notificationManager = startNotificationManager()
         versionInfoFetcher = AppVersionInfoFetcher(daemon, this)
     }
 
@@ -106,6 +106,13 @@ class MullvadVpnService : VpnService() {
         created.await()
         ApiRootCaFile().extract(application)
         MullvadDaemon(this@MullvadVpnService)
+    }
+
+    private fun startNotificationManager(): ForegroundNotificationManager {
+        return ForegroundNotificationManager(this, connectionProxy).apply {
+            onConnect = { connectionProxy.connect() }
+            onDisconnect = { connectionProxy.disconnect() }
+        }
     }
 
     private fun stop() {

--- a/android/src/main/res/drawable/icon_notification_connect.xml
+++ b/android/src/main/res/drawable/icon_notification_connect.xml
@@ -1,0 +1,33 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0"
+        android:tint="?attr/colorControlNormal">
+    <path
+            android:fillColor="#000000"
+            android:fillType="evenOdd"
+            android:pathData="
+                M -4,-1
+                v -6
+                a 1,1 0 0,1 1,-1
+                h 6
+                a 1,1 0 0,1 1,1
+                v 6
+                h 1
+                a 1,1 0 0,1 1,1
+                v 7
+                a 1,1 0 0,1 -1,1
+                h -10
+                a 1,1 0 0,1 -1,-1
+                v -7
+                a 1,1 0 0,1 1,-1
+                z
+                M -2,-1
+                v -5
+                h 4
+                v 5
+                z
+            "
+            />
+</vector>

--- a/android/src/main/res/drawable/icon_notification_disconnect.xml
+++ b/android/src/main/res/drawable/icon_notification_disconnect.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0"
+        android:tint="?attr/colorControlNormal">
+    <path
+            android:fillColor="#000000"
+            android:pathData="
+                M 0,-1
+                v -6
+                a 1,1 0 0,1 1,-1
+                h 6
+                a 1,1 0 0,1 1,1
+                v 6
+                a 1,1 0 0,1 -2,0
+                v -5
+                h -4
+                v 5
+                h 1
+                a 1,1 0 0,1 1,1
+                v 7
+                a 1,1 0 0,1 -1,1
+                h -10
+                a 1,1 0 0,1 -1,-1
+                v -7
+                a 1,1 0 0,1 1,-1
+                z
+            "
+            />
+</vector>


### PR DESCRIPTION
This PR updates the Mullvad notification to include two action buttons that are shown when the notification is expanded (i.e., dragged down with two fingers). One button allows the user to quickly quit the app. The other button contains the "tunnel action", which reproduces the behavior of the "action button" in the Connect screen. Depending on the tunnel state, the tunnel action may be to connect or disconnect the tunnel or cancel a connection attempt.

In order to implement quiting from the notification, the app shutdown code was refactored. A consequence of this is that the quit behavior should become more robust.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1094)
<!-- Reviewable:end -->
