### PR TITLE
Use new relay_list_v3 to properly know relay types and which cities have what type of relays

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
@@ -1,4 +1,4 @@
 package net.mullvad.mullvadvpn.model
 
-data class Relay(val hostname: String, val hasWireguardTunnels: Boolean) {
+data class Relay(val hostname: String, val hasWireguardTunnels: Boolean, val active: Boolean) {
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/Relay.kt
@@ -2,7 +2,11 @@ package net.mullvad.mullvadvpn.relaylist
 
 import net.mullvad.mullvadvpn.model.LocationConstraint
 
-data class Relay(val city: RelayCity, override val name: String) : RelayItem {
+data class Relay(
+    val city: RelayCity,
+    override val name: String,
+    override val active: Boolean
+) : RelayItem {
     override val code = name
     override val type = RelayItemType.Relay
     override val location = LocationConstraint.Hostname(city.country.code, city.code, name)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
@@ -12,6 +12,9 @@ class RelayCity(
     override val type = RelayItemType.City
     override val location = LocationConstraint.City(country.code, code)
 
+    override val active
+        get() = relays.any { relay -> relay.active }
+
     override val hasChildren
         get() = relays.size > 1
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
@@ -11,6 +11,9 @@ class RelayCountry(
     override val type = RelayItemType.Country
     override val location = LocationConstraint.Country(code)
 
+    override val active
+        get() = cities.any { city -> city.active }
+
     override val hasChildren
         get() = getRelayCount() > 1
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItem.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItem.kt
@@ -7,6 +7,7 @@ interface RelayItem {
     val name: String
     val code: String
     val location: LocationConstraint
+    val active: Boolean
     val hasChildren: Boolean
     val visibleChildCount: Int
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
@@ -64,6 +64,8 @@ class RelayItemHolder(
                 }
             }
 
+            view.setEnabled(item.active)
+
             when (item.type) {
                 RelayItemType.Country -> setViewStyle(countryColor, countryPadding)
                 RelayItemType.City -> setViewStyle(cityColor, cityPadding)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
@@ -50,6 +50,12 @@ class RelayItemHolder(
         if (item != null) {
             name.text = item.name
 
+            if (item.active) {
+                name.alpha = 1.0F
+            } else {
+                name.alpha = 0.5F
+            }
+
             if (selected) {
                 relayActive.visibility = View.INVISIBLE
                 selectedIcon.visibility = View.VISIBLE

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.relaylist
 import android.support.v7.widget.RecyclerView.ViewHolder
 import android.view.View
 import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.TextView
 
 import net.mullvad.mullvadvpn.R
@@ -14,7 +15,7 @@ class RelayItemHolder(
 ) : ViewHolder(view) {
     private val name: TextView = view.findViewById(R.id.name)
     private val chevron: ImageButton = view.findViewById(R.id.chevron)
-    private val relayActive: View = view.findViewById(R.id.relay_active)
+    private val relayActive: ImageView = view.findViewById(R.id.relay_active)
     private val selectedIcon: View = view.findViewById(R.id.selected)
 
     private val countryColor = view.context.getColor(R.color.blue)
@@ -55,6 +56,12 @@ class RelayItemHolder(
             } else {
                 relayActive.visibility = View.VISIBLE
                 selectedIcon.visibility = View.INVISIBLE
+
+                if (item.active) {
+                    relayActive.setImageResource(R.drawable.icon_relay_active)
+                } else {
+                    relayActive.setImageResource(R.drawable.icon_relay_inactive)
+                }
             }
 
             when (item.type) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -19,7 +19,7 @@ class RelayList {
                     val validCityRelays = city.relays.filter { relay -> relay.hasWireguardTunnels }
 
                     for (relay in validCityRelays) {
-                        relays.add(Relay(relayCity, relay.hostname))
+                        relays.add(Relay(relayCity, relay.hostname, relay.active))
                     }
 
                     if (relays.isNotEmpty()) {

--- a/android/src/main/res/drawable/icon_relay_inactive.xml
+++ b/android/src/main/res/drawable/icon_relay_inactive.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="oval"
+        >
+    <solid android:color="@color/red"/>
+    <size android:width="16dp" android:height="16dp"/>
+</shape>

--- a/build.sh
+++ b/build.sh
@@ -148,7 +148,7 @@ set -e
 JSONRPC_RESPONSE="$(curl -X POST \
     --fail \
      -H "Content-Type: application/json" \
-     -d '{"jsonrpc": "2.0", "id": "0", "method": "relay_list_v2"}' \
+     -d '{"jsonrpc": "2.0", "id": "0", "method": "relay_list_v3"}' \
      https://api.mullvad.net/rpc/)"
 echo $JSONRPC_RESPONSE | node -e "$JSONRPC_CODE" >  dist-assets/relays.json
 

--- a/gui/scripts/extract-geo-data.py
+++ b/gui/scripts/extract-geo-data.py
@@ -519,7 +519,7 @@ def map_locale(locale_ident):
 
 
 def request_relays():
-  data = json.dumps({"jsonrpc": "2.0", "id": "0", "method": "relay_list_v2"})
+  data = json.dumps({"jsonrpc": "2.0", "id": "0", "method": "relay_list_v3"})
   headers = {"Content-Type": "application/json"}
   request = urllib2.Request("https://api.mullvad.net/rpc/", data, headers)
   return json.load(urllib2.urlopen(request))

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -137,6 +137,7 @@ const relayListSchema = partialObject({
               hostname: string,
               ipv4_addr_in: string,
               include_in_country: boolean,
+              active: boolean,
               weight: number,
               bridges: maybe(
                 partialObject({

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -555,14 +555,14 @@ export default class AppRenderer {
       .map((country) => ({
         name: country.name,
         code: country.code,
-        hasActiveRelays: country.cities.some((city) => city.relays.length > 0),
+        hasActiveRelays: country.cities.some((city) => city.relays.some((relay) => relay.active)),
         cities: country.cities
           .map((city) => ({
             name: city.name,
             code: city.code,
             latitude: city.latitude,
             longitude: city.longitude,
-            hasActiveRelays: city.relays.length > 0,
+            hasActiveRelays: city.relays.some((relay) => relay.active),
             relays: city.relays,
           }))
           .sort((cityA, cityB) => cityA.name.localeCompare(cityB.name)),

--- a/gui/src/renderer/components/LocationList.tsx
+++ b/gui/src/renderer/components/LocationList.tsx
@@ -84,6 +84,7 @@ export default class LocationList extends Component<IProps, IState> {
                       return (
                         <RelayRow
                           key={getLocationKey(relayLocation)}
+                          active={relay.active}
                           hostname={relay.hostname}
                           onSelect={this.handleSelection}
                           {...this.getCommonCellProps(relayLocation)}

--- a/gui/src/renderer/components/RelayRow.tsx
+++ b/gui/src/renderer/components/RelayRow.tsx
@@ -7,6 +7,7 @@ import RelayStatusIndicator from './RelayStatusIndicator';
 
 interface IProps {
   location: RelayLocation;
+  active: boolean;
   hostname: string;
   selected: boolean;
   onSelect?: (location: RelayLocation) => void;
@@ -30,6 +31,7 @@ export default class RelayRow extends Component<IProps> {
     return (
       oldProps.hostname === nextProps.hostname &&
       oldProps.selected === nextProps.selected &&
+      oldProps.active === nextProps.active &&
       compareRelayLocation(oldProps.location, nextProps.location)
     );
   }
@@ -43,8 +45,9 @@ export default class RelayRow extends Component<IProps> {
       <Cell.CellButton
         onPress={this.handlePress}
         cellHoverStyle={this.props.selected ? styles.selected : undefined}
+        disabled={!this.props.active}
         style={[styles.base, this.props.selected ? styles.selected : undefined]}>
-        <RelayStatusIndicator isActive={true} isSelected={this.props.selected} />
+        <RelayStatusIndicator isActive={this.props.active} isSelected={this.props.selected} />
 
         <Cell.Label>{this.props.hostname}</Cell.Label>
       </Cell.CellButton>

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -47,6 +47,7 @@ export interface IRelayLocationRelayRedux {
   hostname: string;
   ipv4AddrIn: string;
   includeInCountry: boolean;
+  active: boolean;
   weight: number;
 }
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -198,6 +198,7 @@ export interface IRelayListHostname {
   hostname: string;
   ipv4AddrIn: string;
   includeInCountry: boolean;
+  active: boolean;
   weight: number;
   tunnels?: IRelayTunnels;
   bridges?: IRelayBridges;

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -323,7 +323,8 @@ impl Bridge {
                     .cities
                     .into_iter()
                     .filter_map(|mut city| {
-                        city.relays.retain(|relay| relay.active && !relay.bridges.is_empty());
+                        city.relays
+                            .retain(|relay| relay.active && !relay.bridges.is_empty());
                         if !city.relays.is_empty() {
                             Some(city)
                         } else {
@@ -339,9 +340,13 @@ impl Bridge {
             })
             .collect();
 
-        locations.countries.sort_by(|c1, c2| c1.name.cmp(&c2.name));
+        locations
+            .countries
+            .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
         for mut country in locations.countries {
-            country.cities.sort_by(|c1, c2| c1.name.cmp(&c2.name));
+            country
+                .cities
+                .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
             println!("{} ({})", country.name, country.code);
             for city in &country.cities {
                 println!(

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -323,7 +323,7 @@ impl Bridge {
                     .cities
                     .into_iter()
                     .filter_map(|mut city| {
-                        city.relays.retain(|relay| !relay.bridges.is_empty());
+                        city.relays.retain(|relay| relay.active && !relay.bridges.is_empty());
                         if !city.relays.is_empty() {
                             Some(city)
                         } else {
@@ -339,6 +339,7 @@ impl Bridge {
             })
             .collect();
 
+        locations.countries.sort_by(|c1, c2| c1.name.cmp(&c2.name));
         for mut country in locations.countries {
             country.cities.sort_by(|c1, c2| c1.name.cmp(&c2.name));
             println!("{} ({})", country.name, country.code);

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -353,6 +353,9 @@ impl Bridge {
                     "\t{} ({}) @ {:.5}°N, {:.5}°W",
                     city.name, city.code, city.latitude, city.longitude
                 );
+                for relay in &city.relays {
+                    println!("\t\t{} ({})", relay.hostname, relay.ipv4_addr_in);
+                }
             }
             println!();
         }

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -348,7 +348,9 @@ impl Bridge {
                 .cities
                 .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
             println!("{} ({})", country.name, country.code);
-            for city in &country.cities {
+            for mut city in country.cities {
+                city.relays
+                    .sort_by(|r1, r2| r1.hostname.to_lowercase().cmp(&r2.hostname.to_lowercase()));
                 println!(
                     "\t{} ({}) @ {:.5}°N, {:.5}°W",
                     city.name, city.code, city.latitude, city.longitude

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -324,7 +324,8 @@ impl Relay {
                     .cities
                     .into_iter()
                     .filter_map(|mut city| {
-                        city.relays.retain(|relay| relay.active && !relay.tunnels.is_empty());
+                        city.relays
+                            .retain(|relay| relay.active && !relay.tunnels.is_empty());
                         if !city.relays.is_empty() {
                             Some(city)
                         } else {
@@ -340,9 +341,13 @@ impl Relay {
             })
             .collect();
 
-        locations.countries.sort_by(|c1, c2| c1.name.cmp(&c2.name));
+        locations
+            .countries
+            .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
         for mut country in locations.countries {
-            country.cities.sort_by(|c1, c2| c1.name.cmp(&c2.name));
+            country
+                .cities
+                .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
             println!("{} ({})", country.name, country.code);
             for city in &country.cities {
                 println!(

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -354,6 +354,20 @@ impl Relay {
                     "\t{} ({}) @ {:.5}°N, {:.5}°W",
                     city.name, city.code, city.latitude, city.longitude
                 );
+                for relay in &city.relays {
+                    let supports_openvpn = !relay.tunnels.openvpn.is_empty();
+                    let supports_wireguard = !relay.tunnels.wireguard.is_empty();
+                    let support_msg = match (supports_openvpn, supports_wireguard) {
+                        (true, true) => "OpenVPN and WireGuard",
+                        (true, false) => "OpenVPN",
+                        (false, true) => "WireGuard",
+                        _ => unreachable!("Bug in relay filtering earlier on"),
+                    };
+                    println!(
+                        "\t\t{} ({}) - {}",
+                        relay.hostname, relay.ipv4_addr_in, support_msg
+                    );
+                }
             }
             println!();
         }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -349,7 +349,9 @@ impl Relay {
                 .cities
                 .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
             println!("{} ({})", country.name, country.code);
-            for city in &country.cities {
+            for mut city in country.cities {
+                city.relays
+                    .sort_by(|r1, r2| r1.hostname.to_lowercase().cmp(&r2.hostname.to_lowercase()));
                 println!(
                     "\t{} ({}) @ {:.5}°N, {:.5}°W",
                     city.name, city.code, city.latitude, city.longitude

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -530,7 +530,18 @@ impl RelaySelector {
             .bridges
             .shadowsocks
             .choose(&mut self.rng)
-            .map(|data| data.clone().to_proxy_settings(relay.ipv4_addr_in.into()))
+            .map(|shadowsocks_endpoint| {
+                info!(
+                    "Selected Shadowsocks bridge {} at {}:{}/{}",
+                    relay.hostname,
+                    relay.ipv4_addr_in,
+                    shadowsocks_endpoint.port,
+                    shadowsocks_endpoint.protocol
+                );
+                shadowsocks_endpoint
+                    .clone()
+                    .to_proxy_settings(relay.ipv4_addr_in.into())
+            })
     }
 
     fn get_random_tunnel(

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -762,7 +762,7 @@ impl RelayListUpdater {
     }
 
     fn download_relay_list(&mut self) -> Result<RelayList, Error> {
-        let download_future = self.rpc_client.relay_list_v2().map_err(Error::Download);
+        let download_future = self.rpc_client.relay_list_v3().map_err(Error::Download);
         let relay_list = Timer::default()
             .timeout(download_future, DOWNLOAD_TIMEOUT)
             .wait()?;

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -321,6 +321,7 @@ impl RelaySelector {
             .lock()
             .relays()
             .iter()
+            .filter(|relay| relay.active)
             .filter_map(|relay| Self::matching_bridge_relay(relay, constraints))
             .collect();
 
@@ -349,6 +350,7 @@ impl RelaySelector {
             .lock()
             .relays()
             .iter()
+            .filter(|relay| relay.active)
             .filter_map(|relay| Self::matching_relay(relay, constraints))
             .collect();
 
@@ -495,6 +497,7 @@ impl RelaySelector {
             .cloned()
             .collect()
     }
+
     /// Pick a random relay from the given slice. Will return `None` if the given slice is empty
     /// or all relays in it has zero weight.
     fn pick_random_relay<'a>(&mut self, relays: &'a [Relay]) -> Option<&'a Relay> {

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -436,9 +436,10 @@ impl<'env> IntoJava<'env> for Relay {
         let parameters = [
             JValue::Object(hostname.as_obj()),
             JValue::Bool(has_wireguard_tunnels),
+            JValue::Bool(self.active as jboolean),
         ];
 
-        env.new_object(&class, "(Ljava/lang/String;Z)V", &parameters)
+        env.new_object(&class, "(Ljava/lang/String;ZZ)V", &parameters)
             .expect("Failed to create Relay Java object")
     }
 }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -118,7 +118,7 @@ jsonrpc_client!(pub struct ProblemReportProxy {
 });
 
 jsonrpc_client!(pub struct RelayListProxy {
-    pub fn relay_list_v2(&mut self) -> RpcRequest<RelayList>;
+    pub fn relay_list_v3(&mut self) -> RpcRequest<RelayList>;
 });
 
 jsonrpc_client!(pub struct AppVersionProxy {

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -48,6 +48,7 @@ pub struct Relay {
     pub hostname: String,
     pub ipv4_addr_in: Ipv4Addr,
     pub include_in_country: bool,
+    pub active: bool,
     pub weight: u64,
     #[serde(skip_serializing_if = "RelayTunnels::is_empty", default)]
     pub tunnels: RelayTunnels,


### PR DESCRIPTION
Update the daemon/build scripts to use new `relay_list_v3` that will always include all relays, even the inactive ones in maintenance mode. But with the extra `active` flag on the relays. This allows us to properly know which servers should exist and what types they are. So we can show inactive cities under the correct relay type (OpenVPN, WireGuard or a Bridge)

DONT merge until `relay_list_v3` is actually deployed, which it is not at the time of writing this. Also remove the TMP commit disabling daemon downloading of the relay list.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1096)
<!-- Reviewable:end -->
