### PR TITLE
Refactor app quit procedure

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
@@ -18,11 +18,15 @@ val CHANNEL_ID = "vpn_tunnel_status"
 val FOREGROUND_NOTIFICATION_ID: Int = 1
 
 class ForegroundNotificationManager(val service: Service, val connectionProxy: ConnectionProxy) {
-    private var listenerId: Int? = null
+    private val notificationManager =
+        service.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    private val listenerId = connectionProxy.onUiStateChange.subscribe { uiState ->
+        tunnelState = uiState
+    }
+
     private var reconnecting = false
     private var showingReconnecting = false
-
-    private lateinit var notificationManager: NotificationManager
 
     private var tunnelState: TunnelState = TunnelState.Disconnected()
         set(value) {
@@ -60,14 +64,7 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
             }
         }
 
-    fun onCreate() {
-        notificationManager =
-            service.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-        listenerId = connectionProxy.onUiStateChange.subscribe { uiState ->
-            tunnelState = uiState
-        }
-
+    init {
         if (Build.VERSION.SDK_INT >= 26) {
             initChannel()
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -57,14 +57,17 @@ class MainActivity : FragmentActivity() {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
             val localBinder = binder as MullvadVpnService.LocalBinder
 
-            service.complete(localBinder)
-
             waitForDaemonJob = GlobalScope.launch(Dispatchers.Default) {
+                localBinder.resetComplete?.await()
+                service.complete(localBinder)
                 daemon.complete(localBinder.daemon.await())
             }
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
+            waitForDaemonJob?.cancel()
+            waitForDaemonJob = null
+
             service.cancel()
             daemon.cancel()
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -21,15 +21,15 @@ class MullvadVpnService : VpnService() {
     private val created = CompletableDeferred<Unit>()
     private val binder = LocalBinder()
 
+    private lateinit var notificationManager: ForegroundNotificationManager
     private lateinit var versionInfoFetcher: AppVersionInfoFetcher
 
     val daemon = startDaemon()
     val connectionProxy = ConnectionProxy(this, daemon)
-    val notificationManager = ForegroundNotificationManager(this, connectionProxy)
 
     override fun onCreate() {
         versionInfoFetcher = AppVersionInfoFetcher(daemon, this)
-        notificationManager.onCreate()
+        notificationManager = ForegroundNotificationManager(this, connectionProxy)
         created.complete(Unit)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -74,13 +74,7 @@ class MullvadVpnService : VpnService() {
             get() = this@MullvadVpnService.connectionProxy
 
         fun stop() {
-            if (daemon.isCompleted) {
-                runBlocking { daemon.await().shutdown() }
-            } else {
-                daemon.cancel()
-            }
-
-            stopSelf()
+            this@MullvadVpnService.stop()
         }
     }
 
@@ -95,6 +89,18 @@ class MullvadVpnService : VpnService() {
         created.await()
         ApiRootCaFile().extract(application)
         MullvadDaemon(this@MullvadVpnService)
+    }
+
+    private fun stop() {
+        this@MullvadVpnService.resetComplete = CompletableDeferred()
+
+        if (daemon.isCompleted) {
+            runBlocking { daemon.await().shutdown() }
+        } else {
+            daemon.cancel()
+        }
+
+        stopSelf()
     }
 
     private fun tearDown() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -18,18 +18,16 @@ import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.model.TunConfig
 
 class MullvadVpnService : VpnService() {
-    private val created = CompletableDeferred<Unit>()
     private val binder = LocalBinder()
+    private val created = CompletableDeferred<Unit>()
 
+    private lateinit var daemon: Deferred<MullvadDaemon>
+    private lateinit var connectionProxy: ConnectionProxy
     private lateinit var notificationManager: ForegroundNotificationManager
     private lateinit var versionInfoFetcher: AppVersionInfoFetcher
 
-    val daemon = startDaemon()
-    val connectionProxy = ConnectionProxy(this, daemon)
-
     override fun onCreate() {
-        versionInfoFetcher = AppVersionInfoFetcher(daemon, this)
-        notificationManager = ForegroundNotificationManager(this, connectionProxy)
+        setUp()
         created.complete(Unit)
     }
 
@@ -86,6 +84,13 @@ class MullvadVpnService : VpnService() {
 
             stopSelf()
         }
+    }
+
+    private fun setUp() {
+        daemon = startDaemon()
+        connectionProxy = ConnectionProxy(this, daemon)
+        notificationManager = ForegroundNotificationManager(this, connectionProxy)
+        versionInfoFetcher = AppVersionInfoFetcher(daemon, this)
     }
 
     private fun startDaemon() = GlobalScope.async(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -36,9 +36,7 @@ class MullvadVpnService : VpnService() {
     }
 
     override fun onDestroy() {
-        connectionProxy.onDestroy()
-        notificationManager.onDestroy()
-        versionInfoFetcher.stop()
+        tearDown()
         daemon.cancel()
         created.cancel()
     }
@@ -97,5 +95,11 @@ class MullvadVpnService : VpnService() {
         created.await()
         ApiRootCaFile().extract(application)
         MullvadDaemon(this@MullvadVpnService)
+    }
+
+    private fun tearDown() {
+        connectionProxy.onDestroy()
+        notificationManager.onDestroy()
+        versionInfoFetcher.stop()
     }
 }


### PR DESCRIPTION
This PR refactors how the Android app quits in order to become more robust. Sometimes Android may reuse the service while it's shutting down, attaching it to a new instance of the app UI. When that happened, the app would crash because the daemon thread would have been stopped. The changes in this PR makes it handle that case, by manually restarting and the daemon thread and delaying the connection to the new UI until the thread is running successfully.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1097)
<!-- Reviewable:end -->
