### PR TITLE
Retry to create tunnel on bad file descriptor

### DIFF
--- a/mullvad-jni/src/vpn_service_tun_provider.rs
+++ b/mullvad-jni/src/vpn_service_tun_provider.rs
@@ -14,6 +14,8 @@ use std::{
 use talpid_core::tunnel::tun_provider::{Tun, TunConfig, TunProvider};
 use talpid_types::BoxedError;
 
+const MAX_PREPARE_TUN_ATTEMPTS: usize = 4;
+
 /// Errors that occur while setting up VpnService tunnel.
 #[derive(Debug, err_derive::Error)]
 #[error(display = "Failed to set up the VpnService")]
@@ -92,13 +94,35 @@ impl VpnServiceTunProvider {
         })
     }
 
-    fn duplicate_tun(tun: &File) -> Result<RawFd, Error> {
+    fn get_tun_fd(&mut self, config: TunConfig) -> Result<RawFd, Error> {
+        for _ in 0..MAX_PREPARE_TUN_ATTEMPTS {
+            let tun = self.prepare_tun(config.clone())?;
+
+            match Self::duplicate_tun(tun) {
+                Ok(fd) => return Ok(fd),
+                Err(error) => match error.raw_os_error() {
+                    Some(libc::EBADF) => {
+                        self.active_tun = None;
+
+                        log::warn!("VpnService returned a bad file descriptor, retrying");
+                    }
+                    _ => return Err(Error::DuplicateTunFd(error)),
+                },
+            }
+        }
+
+        Err(Error::DuplicateTunFd(io::Error::from_raw_os_error(
+            libc::EBADF,
+        )))
+    }
+
+    fn duplicate_tun(tun: &File) -> Result<RawFd, io::Error> {
         let tun_fd = unsafe { libc::dup(tun.as_raw_fd()) };
 
         if tun_fd >= 0 {
             Ok(tun_fd)
         } else {
-            Err(Error::DuplicateTunFd(io::Error::last_os_error()))
+            Err(io::Error::last_os_error())
         }
     }
 
@@ -150,8 +174,7 @@ impl VpnServiceTunProvider {
 
 impl TunProvider for VpnServiceTunProvider {
     fn get_tun(&mut self, config: TunConfig) -> Result<Box<dyn Tun>, BoxedError> {
-        let tun = self.prepare_tun(config).map_err(BoxedError::new)?;
-        let tun_fd = Self::duplicate_tun(tun).map_err(BoxedError::new)?;
+        let tun_fd = self.get_tun_fd(config).map_err(BoxedError::new)?;
 
         let jvm = unsafe { JavaVM::from_raw(self.jvm.get_java_vm_pointer()) }
             .map_err(|cause| BoxedError::new(Error::CloneJavaVm(cause)))?;


### PR DESCRIPTION
The Android `VpnService` sometimes provides a tun device with a bad file descriptor. This was previously handled correctly in `wireguard-go`, where a special error code was returned and the tunnel state machine's `ConnectingState` would automatically retry to connect.

When the Android blocking state was implemented, the tun file descriptor is duplicated in order to keep the tunnel open. However, calling `dup` on a bad file descriptor leads to an error and the connection fails, entering the blocked state.

Unfortunately, since the tunnel creation code is handled by a trait object (`&mut dyn TunProvider`), only a `BoxedError` instance can be returned to the `ConnectingState`. Therefore, returning a special error code to indicate that the connection should be reattempted would require changing the error type returned by `TunProvider::create_tun`.

A different solution was used for this PR. The `VpnServiceTunProvider` was updated to try to create the tun device for a specified number of attempts before failing. This means that opening a tun device for either a new tunnel connection or for entering the blocking state should tolerate occasional bad tun device file descriptors provided, and simply return an actual working file descriptor to a tun device or fail after the specified number of attempts.

The number of attempts is initially set to `4`, which should be safe enough for the error to appear only under extremely rare scenarios.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1102)
<!-- Reviewable:end -->
