### PR TITLE
Update how the UI responds to predicted and real tunnel state changes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -162,14 +162,14 @@ class ConnectFragment : Fragment() {
     private fun updateTunnelState(uiState: TunnelState, realState: TunnelState) =
         GlobalScope.launch(Dispatchers.Main)
     {
+        notificationBanner.tunnelState = realState
         locationInfoCache.state = realState
         locationInfo.state = realState
         headerBar.setState(realState)
+        status.setState(realState)
 
         actionButton.tunnelState = uiState
         switchLocationButton.state = uiState
-        notificationBanner.tunnelState = uiState
-        status.setState(uiState)
     }
 
     private fun updateKeyStatus(keyStatus: KeygenEvent?) = GlobalScope.launch(Dispatchers.Main) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
@@ -26,8 +26,8 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
     private val notificationManager =
         service.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    private val listenerId = connectionProxy.onUiStateChange.subscribe { uiState ->
-        tunnelState = uiState
+    private val listenerId = connectionProxy.onStateChange.subscribe { state ->
+        tunnelState = state
     }
 
     private var reconnecting = false
@@ -147,7 +147,7 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
 
     fun onDestroy() {
         listenerId?.let { listener ->
-            connectionProxy.onUiStateChange.unsubscribe(listener)
+            connectionProxy.onStateChange.unsubscribe(listener)
         }
 
         service.apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -30,6 +30,7 @@ class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>)
     var state = initialState
         set(value) {
             field = value
+            onStateChange.notify(value)
             uiState = value
         }
 
@@ -40,6 +41,7 @@ class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>)
         }
 
     var onUiStateChange = EventNotifier(uiState)
+    var onStateChange = EventNotifier(state)
     var vpnPermission = CompletableDeferred<Boolean>()
 
     fun connect() {
@@ -71,6 +73,7 @@ class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>)
 
     fun onDestroy() {
         onUiStateChange.unsubscribeAll()
+        onStateChange.unsubscribeAll()
         attachListenerJob.cancel()
         detachListener()
         fetchInitialStateJob.cancel()


### PR DESCRIPTION
This PR changes which parts of the UI change on predicted tunnel state changes, and which parts change on real tunnel state change events. A quick summary is:

1. Predicted tunnel state
- Action button
- Switch location button text

2. Real tunnel state
- Notification banner (showing "Blocking connections" when in Connecting state)
- Location information
- In/Out IP address
- Connection status message
- Header bar color
- Notification (both button and text)

As part of this PR, the race condition prevention code was slightly refactored. The code exists so that fetching the tunnel state for the first time doesn't overwrite any tunnel state that was received by an event from the daemon. Previously the real state would be set to `null` until an event changed it or the initial fetch successfully set it. Now, it's set to a fixed object reference representing an initial disconnected state, and while the `state` properties references the same initial object (compared using the `===` operator) it's considered as not initially set. Any change to this state sets it to a new object received externally, so the reference equality will fail after the state is set.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1104)
<!-- Reviewable:end -->
