### PR TITLE
Require the "mullvad relay set custom" command to have a subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Check and adjust relay and bridge constraints when they are updated, so no incompatible
   combinations are used.
+- Fix panic when running CLI "mullvad relay set custom" without any more arguments.
 
 
 ## [2019.7-beta1] - 2019-08-08

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -35,6 +35,7 @@ impl Command for Relay {
                     .subcommand(
                         clap::SubCommand::with_name("custom")
                             .about("Set a custom VPN relay")
+                            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                             .subcommand(clap::SubCommand::with_name("wireguard")
                                 .arg(
                                     clap::Arg::with_name("host")


### PR DESCRIPTION
We got a panic when running `mullvad relay set custom` without a subcommand under it. This fixes that.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1105)
<!-- Reviewable:end -->
