### PR TITLE
Reset state if anticipated state doesn't arrive

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -32,7 +32,7 @@ class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>)
     private val initialState: TunnelState = TunnelState.Disconnected()
 
     var state = initialState
-        set(value) {
+        private set(value) {
             field = value
             resetAnticipatedStateJob?.cancel()
             onStateChange.notify(value)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.VpnService
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
@@ -17,10 +18,13 @@ import net.mullvad.mullvadvpn.model.ActionAfterDisconnect
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.util.EventNotifier
 
+val ANTICIPATED_STATE_TIMEOUT_MS = 1500L
+
 class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>) {
     var mainActivity: MainActivity? = null
 
     private var activeAction: Job? = null
+    private var resetAnticipatedStateJob: Job? = null
 
     private val attachListenerJob = attachListener()
     private val fetchInitialStateJob = fetchInitialState()
@@ -30,6 +34,7 @@ class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>)
     var state = initialState
         set(value) {
             field = value
+            resetAnticipatedStateJob?.cancel()
             onStateChange.notify(value)
             uiState = value
         }
@@ -87,6 +92,7 @@ class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>)
             if (currentState is TunnelState.Connecting || currentState is TunnelState.Connected) {
                 return false
             } else {
+                scheduleToResetAnticipatedState()
                 uiState = TunnelState.Connecting(null, null)
                 return true
             }
@@ -100,10 +106,30 @@ class ConnectionProxy(val context: Context, val daemon: Deferred<MullvadDaemon>)
             if (currentState is TunnelState.Disconnected) {
                 return false
             } else {
+                scheduleToResetAnticipatedState()
                 uiState = TunnelState.Disconnecting(ActionAfterDisconnect.Nothing())
                 return true
             }
         }
+    }
+
+    private fun scheduleToResetAnticipatedState() {
+        resetAnticipatedStateJob?.cancel()
+
+        var currentJob: Job? = null
+
+        val newJob = GlobalScope.launch(Dispatchers.Default) {
+            delay(ANTICIPATED_STATE_TIMEOUT_MS)
+
+            synchronized(this@ConnectionProxy) {
+                if (!currentJob!!.isCancelled) {
+                    uiState = state
+                }
+            }
+        }
+
+        currentJob = newJob
+        resetAnticipatedStateJob = newJob
     }
 
     private fun requestVpnPermission() {


### PR DESCRIPTION
The UI will anticipate certain tunnel states (Connecting and Disconnecting) when certain UI actions are performed in order to provide feedback as fast as possible. However, if any issue occurs when sending the command or when the daemon is handling the command, the anticipated state will never arrive. Therefore, this PR adds a timeout after setting the UI state to an anticipated state. If the time expires without receiving a tunnel state event from the daemon, the UI state is restored to the previous known tunnel state.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1106)
<!-- Reviewable:end -->
