### PR TITLE
Remove proxy endpoints using UDP. So we don't select them

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -92,6 +92,17 @@ impl ParsedRelays {
                 let latitude = city.latitude;
                 let longitude = city.longitude;
                 for relay in &mut city.relays {
+                    // Filter out all UDP endpoints from relays. We currently don't support them.
+                    relay.bridges.shadowsocks = relay
+                        .bridges
+                        .shadowsocks
+                        .iter()
+                        .filter(|shadowsocks_endpoint| {
+                            shadowsocks_endpoint.protocol == TransportProtocol::Tcp
+                        })
+                        .cloned()
+                        .collect();
+
                     let mut relay_with_location = relay.clone();
                     relay_with_location.location = Some(Location {
                         country: country_name.clone(),


### PR DESCRIPTION
Apparently our daemon can pick a bridge using UDP, but then apply firewall rules as if it was a TCP endpoint. And finally try to start OpenVPN over UDP over this proxy. There are multiple issues here:

1. We should only use TCP bridges
2. The firewall rules should reflect the correct endpoint
3. OpenVPN should never use UDP when going over a proxy.

This PR is a bit of a hack. I just had to get something written down today. This removes all UDP bridge endpoints directly when they are parsed. Probably not the correct place. Better to improve the `RelaySelector` selection algorithm to pick the correct endpoints.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1108)
<!-- Reviewable:end -->
