### PR TITLE
Fix local reference leaks

### DIFF
--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -680,7 +680,8 @@ impl<'env> IntoJava<'env> for BlockReason {
             BlockReason::TunnelParameterError(reason) => {
                 let class =
                     get_class("net/mullvad/mullvadvpn/model/BlockReason$ParameterGeneration");
-                let parameters = [JValue::Object(reason.into_java(env))];
+                let reason = env.auto_local(JObject::from(reason.into_java(env)));
+                let parameters = [JValue::Object(reason.as_obj())];
                 return env
                     .new_object(
                         &class,

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -133,7 +133,7 @@ fn ipvx_addr_into_java<'env>(original_octets: &[u8], env: &JNIEnv<'env>) -> JObj
     let octets = env.auto_local(JObject::from(octets_array));
     let result = env
         .call_static_method_unchecked(
-            "java/net/InetAddress",
+            class.as_obj(),
             constructor,
             JavaType::Object("java/net/InetAddress".to_owned()),
             &[JValue::Object(octets.as_obj())],


### PR DESCRIPTION
The app would previously crash after being left running in a connect/disconnect loop overnight. The cause was that the local reference buffer would get filled with references to `Class<InetAddress>` objects. The cause was that `JNIEnv::call_static_method_unchecked` would create a local reference if provided with a class name instead of a class reference. This PR changes the call to use a class reference.

As part of the investigation, I also noticed that there was a situation that could also leak a local reference, so the PR also wraps up a parameter conversion with an `AutoLocal` to make sure it's freed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1109)
<!-- Reviewable:end -->
