### PR TITLE
Change lifetime limitation workaround

### DIFF
--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -133,7 +133,7 @@ fn ipvx_addr_into_java<'env>(original_octets: &[u8], env: &JNIEnv<'env>) -> JObj
     let octets = env.auto_local(JObject::from(octets_array));
     let result = env
         .call_static_method_unchecked(
-            class.as_obj(),
+            &class,
             constructor,
             JavaType::Object("java/net/InetAddress".to_owned()),
             &[JValue::Object(octets.as_obj())],
@@ -141,7 +141,7 @@ fn ipvx_addr_into_java<'env>(original_octets: &[u8], env: &JNIEnv<'env>) -> JObj
         .expect("Failed to create InetAddress Java object");
 
     match result {
-        JValue::Object(object) => object,
+        JValue::Object(object) => JObject::from(object.into_inner()),
         value => {
             panic!(
                 "InetAddress.getByAddress returned an invalid value: {:?}",


### PR DESCRIPTION
The previous PR led to a situation where the JNI code would crash because it would try get the class of a `Class` object instead of using it directly. This PR changes the code so that it uses a different work-around in order to bypass the strict lifetime limitation.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1110)
<!-- Reviewable:end -->
