### PR TITLE
Display age of creation for WireGuard key in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ name = "mullvad-cli"
 version = "2019.7.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -24,6 +24,7 @@ env_logger = "0.6"
 serde = "1.0"
 futures = "0.1"
 base64 = "0.10"
+chrono = { version = "0.4", features = ["serde"] }
 
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-types = { path = "../mullvad-types" }

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -158,7 +158,11 @@ impl Tunnel {
         let mut rpc = new_rpc_client()?;
         match rpc.get_wireguard_key()? {
             Some(key) => {
-                println!("Current key: {}", key);
+                println!("Current key    : {}", &key.key);
+                println!(
+                    "Key created on : {}",
+                    &key.created.with_timezone(&chrono::offset::Local)
+                );
             }
             None => {
                 println!("No key is set");

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -11,11 +11,10 @@ use mullvad_types::{
     settings::{Settings, TunnelOptions},
     states::TunnelState,
     version::AppVersionInfo,
-    DaemonEvent,
+    wireguard, DaemonEvent,
 };
 use serde::{Deserialize, Serialize};
 use std::{io, path::Path, thread};
-use talpid_types::net::wireguard;
 
 static NO_ARGS: [u8; 0] = [];
 
@@ -160,7 +159,7 @@ impl DaemonRpcClient {
         self.call("get_settings", &NO_ARGS)
     }
 
-    pub fn generate_wireguard_key(&mut self) -> Result<mullvad_types::wireguard::KeygenEvent> {
+    pub fn generate_wireguard_key(&mut self) -> Result<wireguard::KeygenEvent> {
         self.call("generate_wireguard_key", &NO_ARGS)
     }
 


### PR DESCRIPTION
The currently unreleased changes to the WireGuard key handling did not propagate to the CLI, as such the `mullvad tunnel wireguard key check` command failed since the response from the daemon would fail to deserialize. This PR updates the IPC client code to expect and deserialize the new structure properly and changes the CLI to print the date of creation of a the currently set key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1111)
<!-- Reviewable:end -->
