### PR TITLE
Sort locations naturally in daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 - WireGuard key generation will try to replace old key if one exists.
 - Show banner about new app versions only if current platform has changes in latest release.
 - Don't make a GeoIP lookup by default in CLI status command. Add --location flag for enabling it.
+- Sort relay locations and hostnames with natural sorting. Meaning `se10` will show up after `se2`.
 
 ### Fixed
 - Fix old settings deserialization to allow migrating settings from versions older than 2019.6.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ dependencies = [
  "mullvad-ipc-client 0.1.0",
  "mullvad-paths 0.1.0",
  "mullvad-types 0.1.0",
+ "natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
@@ -1373,6 +1374,11 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-types 0.1.0",
 ]
+
+[[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "net2"
@@ -3113,6 +3119,7 @@ dependencies = [
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mnl 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
 "checksum mnl-sys 0.1.0 (git+https://github.com/mullvad/mnl-rs?rev=f0d19501b9b85be9a1ffaec8317a378bcbdf4fa6)" = "<none>"
+"checksum natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum netlink-packet 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)" = "<none>"
 "checksum netlink-proto 0.1.1 (git+https://github.com/mullvad/netlink?rev=f768adfcc8c6b064ef7ae3c792c4c21d0d96d0b5)" = "<none>"

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -566,13 +566,9 @@ export default class AppRenderer {
               relayA.hostname.localeCompare(relayB.hostname, this.locale, { numeric: true }),
             ),
           }))
-          .sort((cityA, cityB) =>
-            cityA.name.localeCompare(cityB.name, this.locale, { numeric: true }),
-          ),
+          .sort((cityA, cityB) => cityA.name.localeCompare(cityB.name, this.locale)),
       }))
-      .sort((countryA, countryB) =>
-        countryA.name.localeCompare(countryB.name, this.locale, { numeric: true }),
-      );
+      .sort((countryA, countryB) => countryA.name.localeCompare(countryB.name, this.locale));
   }
 
   private setRelays(relayList: IRelayList) {

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -563,12 +563,16 @@ export default class AppRenderer {
             longitude: city.longitude,
             hasActiveRelays: city.relays.some((relay) => relay.active),
             relays: city.relays.sort((relayA, relayB) =>
-              relayA.hostname.localeCompare(relayB.hostname),
+              relayA.hostname.localeCompare(relayB.hostname, this.locale, { numeric: true }),
             ),
           }))
-          .sort((cityA, cityB) => cityA.name.localeCompare(cityB.name)),
+          .sort((cityA, cityB) =>
+            cityA.name.localeCompare(cityB.name, this.locale, { numeric: true }),
+          ),
       }))
-      .sort((countryA, countryB) => countryA.name.localeCompare(countryB.name));
+      .sort((countryA, countryB) =>
+        countryA.name.localeCompare(countryB.name, this.locale, { numeric: true }),
+      );
   }
 
   private setRelays(relayList: IRelayList) {

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -18,13 +18,14 @@ name = "mullvad"
 path = "src/main.rs"
 
 [dependencies]
+base64 = "0.10"
+chrono = { version = "0.4", features = ["serde"] }
 clap = "2.32"
 err-derive = "0.1.5"
 env_logger = "0.6"
-serde = "1.0"
 futures = "0.1"
-base64 = "0.10"
-chrono = { version = "0.4", features = ["serde"] }
+natord = "1.0.9"
+serde = "1.0"
 
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-types = { path = "../mullvad-types" }

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -342,15 +342,15 @@ impl Bridge {
 
         locations
             .countries
-            .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
+            .sort_by(|c1, c2| natord::compare_ignore_case(&c1.name, &c2.name));
         for mut country in locations.countries {
             country
                 .cities
-                .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
+                .sort_by(|c1, c2| natord::compare_ignore_case(&c1.name, &c2.name));
             println!("{} ({})", country.name, country.code);
             for mut city in country.cities {
                 city.relays
-                    .sort_by(|r1, r2| r1.hostname.to_lowercase().cmp(&r2.hostname.to_lowercase()));
+                    .sort_by(|r1, r2| natord::compare_ignore_case(&r1.hostname, &r2.hostname));
                 println!(
                     "\t{} ({}) @ {:.5}°N, {:.5}°W",
                     city.name, city.code, city.latitude, city.longitude

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -344,15 +344,15 @@ impl Relay {
 
         locations
             .countries
-            .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
+            .sort_by(|c1, c2| natord::compare_ignore_case(&c1.name, &c2.name));
         for mut country in locations.countries {
             country
                 .cities
-                .sort_by(|c1, c2| c1.name.to_lowercase().cmp(&c2.name.to_lowercase()));
+                .sort_by(|c1, c2| natord::compare_ignore_case(&c1.name, &c2.name));
             println!("{} ({})", country.name, country.code);
             for mut city in country.cities {
                 city.relays
-                    .sort_by(|r1, r2| r1.hostname.to_lowercase().cmp(&r2.hostname.to_lowercase()));
+                    .sort_by(|r1, r2| natord::compare_ignore_case(&r1.hostname, &r2.hostname));
                 println!(
                     "\t{} ({}) @ {:.5}°N, {:.5}°W",
                     city.name, city.code, city.latitude, city.longitude


### PR DESCRIPTION
Sorting of relays was brought up a while back. And we implemented sorting in our frontends. One problem that remained was the classical problem of just sorting strings alphabetically when they contain numbers. Ending up with an order like `["se1", "se10", "se2"]`. This PR removes sorting from the frontends and instead sorts using a natural sorting algorithm directly in the daemon. Meaning all frontends get this benefit without having to pull is such a sorting library in all frontends. Now relays should show up as `["se1", "se2", "se10"]`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1114)
<!-- Reviewable:end -->
