### PR TITLE
Ensure that only TCP relays are used when using a bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix old settings deserialization to allow migrating settings from versions older than 2019.6.
 - Fix various small issues in GUI<->daemon communication.
 - Make GUI WireGuard key verification resilient to failure.
+- Fix issue where daemon would try and connect with UDP when the tunnel protocol is set to OpenVPN
+  and the bridge mode is set to "On".
 
 #### macOS
 - Unregister the app properly from the OS when running the bundled `uninstall.sh` script.

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -55,7 +55,7 @@ use talpid_core::{
     tunnel_state_machine::{self, TunnelCommand, TunnelParametersGenerator},
 };
 use talpid_types::{
-    net::{openvpn, TunnelParameters},
+    net::{openvpn, TransportProtocol, TunnelParameters},
     tunnel::{BlockReason, ParameterGenerationError, TunnelStateTransition},
     ErrorExt,
 };
@@ -618,7 +618,8 @@ where
                     BridgeSettings::Normal(settings) => {
                         let bridge_constraints = InternalBridgeConstraints {
                             location: settings.location.clone(),
-                            transport_protocol: Constraint::Only(endpoint.protocol),
+                            // FIXME: This is temporary while talpid-core only supports TCP proxies
+                            transport_protocol: Constraint::Only(TransportProtocol::Tcp),
                         };
                         match self.settings.get_bridge_state() {
                             BridgeState::On => {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -273,6 +273,13 @@ impl RelaySelector {
             }
             Constraint::Only(TunnelProtocol::OpenVpn) => {
                 relay_constraints.openvpn_constraints = original_constraints.openvpn_constraints;
+                if *bridge_state == BridgeState::On
+                    && relay_constraints.openvpn_constraints.protocol.is_any()
+                {
+                    // FIXME: This is temporary while talpid-core only supports TCP proxies
+                    relay_constraints.openvpn_constraints.protocol =
+                        Constraint::Only(TransportProtocol::Tcp);
+                }
             }
             Constraint::Only(TunnelProtocol::Wireguard) => {
                 relay_constraints.wireguard_constraints =


### PR DESCRIPTION
When constructing relay parameters, there were cases where the daemon wouldn't enforce TCP tunnels and would also allow for using UDP bridges. I've added changes so that TCP is used whenever a bridge is forced if the transport protocol is not constrained to any specific protocol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1115)
<!-- Reviewable:end -->
