### PR TITLE
Reuse UI drawables

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectActionButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectActionButton.kt
@@ -10,6 +10,11 @@ import net.mullvad.mullvadvpn.model.TunnelState
 class ConnectActionButton(val parentView: View) {
     private val button: Button = parentView.findViewById(R.id.action_button)
 
+    private val resources = parentView.context.resources
+    private val greenBackground = resources.getDrawable(R.drawable.green_button_background, null)
+    private val transparentRedBackground =
+        resources.getDrawable(R.drawable.transparent_red_button_background, null)
+
     var tunnelState: TunnelState = TunnelState.Disconnected()
         set(value) {
             when (value) {
@@ -48,17 +53,17 @@ class ConnectActionButton(val parentView: View) {
     }
 
     private fun disconnected() {
-        button.setBackgroundResource(R.drawable.green_button_background)
+        button.background = greenBackground
         button.setText(R.string.connect)
     }
 
     private fun connecting() {
-        button.setBackgroundResource(R.drawable.transparent_red_button_background)
+        button.background = transparentRedBackground
         button.setText(R.string.cancel)
     }
 
     private fun connected() {
-        button.setBackgroundResource(R.drawable.transparent_red_button_background)
+        button.background = transparentRedBackground
         button.setText(R.string.disconnect)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.widget.ImageView
 import android.widget.TextView
@@ -20,8 +21,13 @@ class NotificationBanner(
     val context: Context,
     val versionInfoCache: AppVersionInfoCache
 ) {
+    private val resources = context.resources
+
     private val accountUrl = Uri.parse(context.getString(R.string.account_url))
     private val downloadUrl = Uri.parse(context.getString(R.string.download_url))
+
+    private val errorImage = resources.getDrawable(R.drawable.icon_notification_error, null)
+    private val warningImage = resources.getDrawable(R.drawable.icon_notification_warning, null)
 
     private val banner: View = parentView.findViewById(R.id.notification_banner)
     private val status: ImageView = parentView.findViewById(R.id.notification_status)
@@ -107,17 +113,17 @@ class NotificationBanner(
             hide()
         } else {
             val title: Int
-            val statusImage: Int
+            val statusImage: Drawable
             val template: Int
 
             if (versionInfoCache.isSupported) {
                 title = R.string.update_available
                 template = R.string.update_available_description
-                statusImage = R.drawable.icon_notification_warning
+                statusImage = warningImage
             } else {
                 title = R.string.unsupported_version
                 template = R.string.unsupported_version_description
-                statusImage = R.drawable.icon_notification_error
+                statusImage = errorImage
             }
 
             val parameter = versionInfoCache.upgradeVersion
@@ -158,10 +164,10 @@ class NotificationBanner(
     }
 
     private fun showError(titleText: Int, messageText: String?) {
-        show(R.drawable.icon_notification_error, titleText, messageText)
+        show(errorImage, titleText, messageText)
     }
 
-    private fun show(statusImage: Int, titleText: Int, messageText: String?) {
+    private fun show(statusImage: Drawable, titleText: Int, messageText: String?) {
         if (!visible) {
             visible = true
             banner.visibility = View.VISIBLE
@@ -169,7 +175,7 @@ class NotificationBanner(
             banner.animate().translationY(0.0F).setDuration(350).start()
         }
 
-        status.setImageResource(statusImage)
+        status.setImageDrawable(statusImage)
         title.setText(titleText)
 
         if (messageText == null) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SelectLocationFragment.kt
@@ -35,17 +35,9 @@ class SelectLocationFragment : Fragment() {
 
     private lateinit var relayListContainer: ViewSwitcher
 
-    private val relayListAdapter = RelayListAdapter()
+    private lateinit var relayListAdapter: RelayListAdapter
 
     private var updateRelayListJob: Job? = null
-
-    init {
-        relayListAdapter.onSelect = { relayItem ->
-            updateLocationConstraint(relayItem)
-            maybeConnect()
-            close()
-        }
-    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -53,6 +45,14 @@ class SelectLocationFragment : Fragment() {
         parentActivity = context as MainActivity
         connectionProxy = parentActivity.connectionProxy
         relayListListener = parentActivity.relayListListener
+
+        relayListAdapter = RelayListAdapter(context.resources).apply {
+            onSelect = { relayItem ->
+                updateLocationConstraint(relayItem)
+                maybeConnect()
+                close()
+            }
+        }
     }
 
     override fun onCreateView(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayItemHolder.kt
@@ -64,9 +64,9 @@ class RelayItemHolder(
                 selectedIcon.visibility = View.INVISIBLE
 
                 if (item.active) {
-                    relayActive.setImageResource(R.drawable.icon_relay_active)
+                    relayActive.setImageDrawable(adapter.activeRelayIcon)
                 } else {
-                    relayActive.setImageResource(R.drawable.icon_relay_inactive)
+                    relayActive.setImageDrawable(adapter.inactiveRelayIcon)
                 }
             }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayListAdapter.kt
@@ -3,17 +3,21 @@ package net.mullvad.mullvadvpn.relaylist
 import java.lang.ref.WeakReference
 import java.util.LinkedList
 
+import android.content.res.Resources
 import android.support.v7.widget.RecyclerView.Adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 
 import net.mullvad.mullvadvpn.R
 
-class RelayListAdapter : Adapter<RelayItemHolder>() {
+class RelayListAdapter(private val resources: Resources) : Adapter<RelayItemHolder>() {
     private var relayList: RelayList? = null
     private var selectedItem: RelayItem? = null
     private val activeIndices = LinkedList<WeakReference<RelayListAdapterPosition>>()
     private var selectedItemHolder: RelayItemHolder? = null
+
+    val activeRelayIcon = resources.getDrawable(R.drawable.icon_relay_active, null)
+    val inactiveRelayIcon = resources.getDrawable(R.drawable.icon_relay_inactive, null)
 
     var onSelect: ((RelayItem?) -> Unit)? = null
 


### PR DESCRIPTION
This PR is an attempt to fix the error where the UI would lock up after some reconnection attempts. The number of reconnections varies, but it is a large number (smallest I've seen was around 80).

UI views will now cache the drawables they use instead of specifying drawable IDs and letting Android allocate them. This should prevent using too much GPU memory, which is a probably cause to the issue. As a consequence, this PR also has the advantage that UI should be more responsive due to the removal of allocations in the UI thread.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No public Android version released yet.**
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1116)
<!-- Reviewable:end -->
