### PR TITLE
Stop ping monitor thread if first ping fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Make GUI WireGuard key verification resilient to failure.
 - Fix issue where daemon would try and connect with UDP when the tunnel protocol is set to OpenVPN
   and the bridge mode is set to "On".
+- Don't start ping monitor loop if first ping fails when checking WireGuard connection.
 
 #### macOS
 - Unregister the app properly from the OS when running the bundled `uninstall.sh` script.


### PR DESCRIPTION
Previously the ping monitor thread would enter the ping loop even if the first ping had failed. This could lead to a situation where there might be two ping monitor threads active at the same time for a while. This PR fixes that by only entering the loop if the first ping succeeds.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1121)
<!-- Reviewable:end -->
