### PR TITLE
Fix android outdated check

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
@@ -109,7 +109,7 @@ class NotificationBanner(
     }
 
     private fun updateBasedOnVersionInfo(): Boolean {
-        if (versionInfoCache.isLatest) {
+        if (!versionInfoCache.isOutdated && versionInfoCache.isSupported) {
             hide()
         } else {
             val title: Int

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/SettingsFragment.kt
@@ -116,7 +116,7 @@ class SettingsFragment : Fragment() {
     private fun updateVersionInfo() = GlobalScope.launch(Dispatchers.Main) {
         appVersionLabel.setText(versionInfoCache.version ?: "")
 
-        if (versionInfoCache.isLatest && versionInfoCache.isSupported) {
+        if (!versionInfoCache.isOutdated && versionInfoCache.isSupported) {
             appVersionWarning.visibility = View.GONE
             appVersionFooter.visibility = View.GONE
         } else {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -13,6 +13,7 @@ import net.mullvad.mullvadvpn.MainActivity
 class AppVersionInfoCache(val parentActivity: MainActivity) {
     companion object {
         val KEY_CURRENT_IS_SUPPORTED = "current_is_supported"
+        val KEY_CURRENT_IS_OUTDATED = "current_is_outdated"
         val KEY_LAST_UPDATED = "last_updated"
         val KEY_LATEST_STABLE = "latest_stable"
         val KEY_LATEST = "latest"
@@ -39,13 +40,13 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
         private set
     var isSupported = true
         private set
+    var isOutdated = false
+        private set
     var latestStable: String? = null
         private set
     var latest: String? = null
         private set
 
-    var isLatest = true
-        private set
     var upgradeVersion: String? = null
         private set
 
@@ -53,6 +54,7 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
         override fun onSharedPreferenceChanged(preferences: SharedPreferences, key: String) {
             when (key) {
                 KEY_CURRENT_IS_SUPPORTED -> isSupported = preferences.getBoolean(key, isSupported)
+                KEY_CURRENT_IS_OUTDATED -> isOutdated = preferences.getBoolean(key, isOutdated)
                 KEY_LAST_UPDATED -> lastUpdated = preferences.getLong(key, lastUpdated)
                 KEY_LATEST_STABLE -> latestStable = preferences.getString(key, latestStable)
                 KEY_LATEST -> latest = preferences.getString(key, latest)
@@ -68,6 +70,7 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
 
         lastUpdated = preferences.getLong(KEY_LAST_UPDATED, 0L)
         isSupported = preferences.getBoolean(KEY_CURRENT_IS_SUPPORTED, true)
+        isOutdated = preferences.getBoolean(KEY_CURRENT_IS_OUTDATED, false)
         latestStable = preferences.getString(KEY_LATEST_STABLE, null)
         latest = preferences.getString(KEY_LATEST, null)
     }
@@ -90,13 +93,12 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
         val target = if (isStable) latestStable else latest
 
         if (target == version || target == null) {
-            isLatest = true
             upgradeVersion = null
         } else {
-            isLatest = false
             upgradeVersion = target
         }
 
         onUpdate?.invoke()
     }
+
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoFetcher.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoFetcher.kt
@@ -61,6 +61,7 @@ class AppVersionInfoFetcher(val daemon: Deferred<MullvadDaemon>, val context: Co
                 with(AppVersionInfoCache) {
                     putLong(KEY_LAST_UPDATED, now)
                     putBoolean(KEY_CURRENT_IS_SUPPORTED, versionInfo.currentIsSupported)
+                    putBoolean(KEY_CURRENT_IS_OUTDATED, versionInfo.currentIsOutdated)
                     putString(KEY_LATEST_STABLE, versionInfo.latestStable)
                     putString(KEY_LATEST, versionInfo.latest)
                     commit()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.model
 
 data class AppVersionInfo(
     val currentIsSupported: Boolean,
+    val currentIsOutdated: Boolean,
     val latestStable: String,
     val latest: String
 )

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -232,10 +232,12 @@ impl<'env> IntoJava<'env> for AppVersionInfo {
     fn into_java(self, env: &JNIEnv<'env>) -> Self::JavaType {
         let class = get_class("net/mullvad/mullvadvpn/model/AppVersionInfo");
         let current_is_supported = self.current_is_supported as jboolean;
+        let current_is_outdated = self.current_is_outdated as jboolean;
         let latest_stable = env.auto_local(*self.latest_stable.into_java(env));
         let latest = env.auto_local(*self.latest.into_java(env));
         let parameters = [
             JValue::Bool(current_is_supported),
+            JValue::Bool(current_is_outdated),
             JValue::Object(latest_stable.as_obj()),
             JValue::Object(latest.as_obj()),
         ];

--- a/mullvad-jni/src/into_java.rs
+++ b/mullvad-jni/src/into_java.rs
@@ -244,7 +244,7 @@ impl<'env> IntoJava<'env> for AppVersionInfo {
 
         env.new_object(
             &class,
-            "(ZLjava/lang/String;Ljava/lang/String;)V",
+            "(ZZLjava/lang/String;Ljava/lang/String;)V",
             &parameters,
         )
         .expect("Failed to create AppVersionInfo Java object")


### PR DESCRIPTION
Making sure Android respects the new `current_is_outdated` flag in the version check. Should making notifying users about upgrades more correct. 

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1125)
<!-- Reviewable:end -->
