### PR TITLE
Use pointer-events instead of z-index to fix the hover state

### DIFF
--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -36,9 +36,9 @@ const styles = {
   transitionView: Styles.createViewStyle({
     flex: 1,
   }),
-  userInteractionBlocker: Styles.createViewStyle({
+  blockUserInteraction: Styles.createViewStyle({
     // @ts-ignore
-    zIndex: 2,
+    pointerEvents: 'none',
   }),
   transitionContainer: Styles.createViewStyle({
     flex: 1,
@@ -150,7 +150,12 @@ export default class TransitionContainer extends Component<IProps, IState> {
       this.state.itemQueue.length > 0 || this.state.nextItem ? true : false;
 
     return (
-      <View style={styles.transitionContainer} onLayout={this.onLayout}>
+      <View
+        style={[
+          styles.transitionContainer,
+          disableUserInteraction ? styles.blockUserInteraction : undefined,
+        ]}
+        onLayout={this.onLayout}>
         {this.state.currentItem && (
           <Animated.View
             key={this.state.currentItem.view.props.viewId}
@@ -165,10 +170,6 @@ export default class TransitionContainer extends Component<IProps, IState> {
             style={[styles.animatedContainer, this.state.nextItemStyle]}>
             {this.state.nextItem.view}
           </Animated.View>
-        )}
-
-        {disableUserInteraction && (
-          <View style={[styles.animatedContainer, styles.userInteractionBlocker]} />
         )}
       </View>
     );


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

When transitioning between views in Settings. If the mouse position coincides with the hoverable element, such as cell, the hover is not activated at the end of transition. Even moving mouse does not fix this unless the mouse goes outside of the element underneath the mouse. I've spotted this only happens when using `z-index` to block the transition container interactions during transitions. However, using `pointer-events` works just fine and hovered cell re-activates successfully at the end of transition. I should add that in the newer versions of ReactXP this is implemented as a part of `blockPointerEvents` prop for the web platform, however there was no stable release yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1128)
<!-- Reviewable:end -->
