### PR TITLE
Allow CSP: unsafe-eval in development because redux-devtools use eval

### DIFF
--- a/gui/tasks/hotreload.js
+++ b/gui/tasks/hotreload.js
@@ -23,7 +23,9 @@ function startBrowserSync(done) {
 function injectBrowserSync() {
   return src('src/renderer/index.html')
     .pipe(inject.before('</body>', browserSync.getOption('snippet')))
-    .pipe(inject.after('script-src', ' ' + browserSync.getOption('urls').get('local')))
+    .pipe(
+      inject.after('script-src', " 'unsafe-eval' " + browserSync.getOption('urls').get('local')),
+    )
     .pipe(dest('build/src/renderer'));
 }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Seems like running any actions from redux-devtools requires `unsafe-eval` CSP. This PR adds the CSP permissions when in development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1132)
<!-- Reviewable:end -->
