### PR TITLE
Fix local reference leak of `TunConfig`

### DIFF
--- a/mullvad-jni/src/vpn_service_tun_provider.rs
+++ b/mullvad-jni/src/vpn_service_tun_provider.rs
@@ -103,12 +103,13 @@ impl VpnServiceTunProvider {
                 )
                 .map_err(|cause| Error::FindMethod("createTun", cause))?;
 
+            let java_config = env.auto_local(config.clone().into_java(&env));
             let result = env
                 .call_method_unchecked(
                     self.object.as_obj(),
                     create_tun_method,
                     JavaType::Primitive(Primitive::Int),
-                    &[JValue::Object(config.clone().into_java(&env))],
+                    &[JValue::Object(java_config.as_obj())],
                 )
                 .map_err(|cause| Error::CallMethod("createTun", cause))?;
 


### PR DESCRIPTION
I left the device running a test version to see if it still ran into the bad file descriptor error, but it crashed after about an hour due to a filled local reference buffer. Apparently, we were leaking the `TunConfig`s we created to send to the Java side. This PR just wraps it in an `AutoLocal` so that it is freed after we've finished using it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes bug in an unreleased version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1137)
<!-- Reviewable:end -->
