### PR TITLE
Fixed a typo in relay get command response

### DIFF
--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -161,7 +161,7 @@ impl fmt::Display for RelayConstraints {
         match self.tunnel_protocol {
             Constraint::Any => write!(
                 f,
-                "Any tunnel protcol with OpenVPN through {} and WireGuard through {}",
+                "Any tunnel protocol with OpenVPN through {} and WireGuard through {}",
                 &self.openvpn_constraints, &self.wireguard_constraints,
             )?,
             Constraint::Only(ref tunnel_protocol) => {


### PR DESCRIPTION
This corrects a typo (protcol >> protocol) in the output of the "relay get" command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1143)
<!-- Reviewable:end -->
