### PR TITLE
Fix relay update CLI command to always trigger download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Removed
 - Remove support for `MULLVAD_LOCALE` environment variable.
 
+### Fixed
+- Fix `mullvad relay update` to trigger a relay list download even if the existing cache is new.
+
 
 ## [2019.8] - 2019-09-23
 This release is identical to 2019.8-beta1


### PR DESCRIPTION
We had a bug so when running `mullvad relay update` it would just trigger a check of the cache age. And if the cache was newer than the set limit, it would not actually download anything. The point of the command is to trigger a list update even when the cache is new.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1144)
<!-- Reviewable:end -->
