### PR TITLE
Handle EBADF on Linux and Android

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -60,9 +60,9 @@ pub enum Error {
     #[error(display = "Failed to configure Wireguard sockets to bypass the tunnel")]
     BypassError(#[error(cause)] BoxedError),
 
-    /// Failed to duplicate file descriptors for logging on wireguard-go
+    /// Failed to duplicate tunnel file descriptor for wireguard-go
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
-    #[error(display = "Failed to configure Wireguard sockets to bypass the tunnel")]
+    #[error(display = "Failed to duplicate tunnel file descriptor for wireguard-go")]
     FdDuplicationError(#[error(cause)] nix::Error),
 
     /// Pinging timed out.


### PR DESCRIPTION
On Android, sometimes attempting to connect would lead to a start tunnel error due to an `EBADF` error when calling `dup`. This PR changes the code around `dup` to not assume `EBADF` is macOS specific, so either `EBADFD` or `EBADF` can occur on Linux and Android too.

As part of the PR, the error message was reworded as well to avoid confusion.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes an issue that isn't present on any released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1145)
<!-- Reviewable:end -->
