### PR TITLE
No action button when logged out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Removed
 - Remove support for `MULLVAD_LOCALE` environment variable.
 
+#### Android
+- Remove connect action button in notification when logged out.
+
 ### Fixed
 - Fix `mullvad relay update` to trigger a relay list download even if the existing cache is new.
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
@@ -128,6 +128,11 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
 
     var onConnect: (() -> Unit)? = null
     var onDisconnect: (() -> Unit)? = null
+    var loggedIn = false
+        set(value) {
+            field = value
+            updateNotification()
+        }
 
     init {
         if (Build.VERSION.SDK_INT >= 26) {
@@ -183,13 +188,17 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
         val pendingIntent =
             PendingIntent.getActivity(service, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
-        return NotificationCompat.Builder(service, CHANNEL_ID)
+        val builder = NotificationCompat.Builder(service, CHANNEL_ID)
             .setSmallIcon(R.drawable.notification)
             .setColor(service.getColor(R.color.colorPrimary))
             .setContentTitle(service.getString(notificationText))
             .setContentIntent(pendingIntent)
-            .addAction(buildTunnelAction())
-            .build()
+
+        if (loggedIn) {
+            builder.addAction(buildTunnelAction())
+        }
+
+        return builder.build()
     }
 
     private fun buildTunnelAction(): NotificationCompat.Action {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -9,6 +9,7 @@ import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.util.EventNotifier
 
 class MullvadDaemon(val vpnService: MullvadVpnService) {
     init {
@@ -16,9 +17,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         initialize(vpnService)
     }
 
+    val onSettingsChange = EventNotifier<Settings?>(null)
+
     var onKeygenEvent: ((KeygenEvent) -> Unit)? = null
     var onRelayListChange: ((RelayList) -> Unit)? = null
-    var onSettingsChange: ((Settings) -> Unit)? = null
     var onTunnelStateChange: ((TunnelState) -> Unit)? = null
 
     external fun connect()
@@ -48,7 +50,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     }
 
     private fun notifySettingsEvent(settings: Settings) {
-        onSettingsChange?.invoke(settings)
+        onSettingsChange.notify(settings)
     }
 
     private fun notifyTunnelStateEvent(event: TunnelState) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -12,16 +12,18 @@ import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.util.EventNotifier
 
 class MullvadDaemon(val vpnService: MullvadVpnService) {
-    init {
-        System.loadLibrary("mullvad_jni")
-        initialize(vpnService)
-    }
-
     val onSettingsChange = EventNotifier<Settings?>(null)
 
     var onKeygenEvent: ((KeygenEvent) -> Unit)? = null
     var onRelayListChange: ((RelayList) -> Unit)? = null
     var onTunnelStateChange: ((TunnelState) -> Unit)? = null
+
+    init {
+        System.loadLibrary("mullvad_jni")
+        initialize(vpnService)
+
+        onSettingsChange.notify(getSettings())
+    }
 
     external fun connect()
     external fun disconnect()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -105,7 +105,11 @@ class MullvadVpnService : VpnService() {
     private fun startDaemon() = GlobalScope.async(Dispatchers.Default) {
         created.await()
         ApiRootCaFile().extract(application)
-        MullvadDaemon(this@MullvadVpnService)
+        MullvadDaemon(this@MullvadVpnService).apply { 
+            onSettingsChange.subscribe { settings ->
+                notificationManager.loggedIn = settings?.accountToken != null
+            }
+        }
     }
 
     private fun startNotificationManager(): ForegroundNotificationManager {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -47,18 +47,6 @@ class SettingsListener(val parentActivity: MainActivity) {
         listenerId = daemon.onSettingsChange.subscribe { maybeSettings ->
             maybeSettings?.let { settings -> handleNewSettings(settings) }
         }
-
-        fetchInitialSettings()
-    }
-
-    private fun fetchInitialSettings() {
-        val initialSettings = daemon!!.getSettings()
-
-        synchronized(this) {
-            if (settings == null) {
-                handleNewSettings(initialSettings)
-            }
-        }
     }
 
     private fun handleNewSettings(newSettings: Settings) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -14,6 +14,7 @@ class SettingsListener(val parentActivity: MainActivity) {
 
     private val setUpJob = setUp()
 
+    private var listenerId = -1
     private var settings: Settings? = null
 
     var onAccountNumberChange: ((String?) -> Unit)? = null
@@ -35,14 +36,18 @@ class SettingsListener(val parentActivity: MainActivity) {
     fun onDestroy() {
         setUpJob.cancel()
 
-        if (::daemon.isInitialized) {
-            daemon.onSettingsChange = null
+        if (listenerId != -1) {
+            daemon.onSettingsChange.unsubscribe(listenerId)
         }
     }
 
     private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
         daemon = parentActivity.daemon.await()
-        daemon.onSettingsChange = { settings -> handleNewSettings(settings) }
+
+        listenerId = daemon.onSettingsChange.subscribe { maybeSettings ->
+            maybeSettings?.let { settings -> handleNewSettings(settings) }
+        }
+
         fetchInitialSettings()
     }
 


### PR DESCRIPTION
Previously the Android notification would always show an action button that allows the user to connect or disconnect the tunnel, even if the app had no account set. This PR changes that so that the button is only shown if the user is logged in.

The solution implemented here isn't the ideal one. It would be best to not touch `MullvadDaemon` and move the `AccountCache` to `MullvadVpnService`. However, that would require a lot of changes, and I think it would be best to refactor this later on anyway. For an initial stable release this should be fine, but afterwards we should refactor parts of the code to have a better solution.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1147)
<!-- Reviewable:end -->
