### PR TITLE
Show key age in local timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix `mullvad relay update` to trigger a relay list download even if the existing cache is new.
 
+#### Android
+- Show WireGuard key age in local timezone instead of UTC.
+
 
 ## [2019.8] - 2019-09-23
 This release is identical to 2019.8-beta1

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -19,7 +19,10 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 
+import java.util.TimeZone
+
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
@@ -294,6 +297,10 @@ class WireguardKeyFragment : Fragment() {
     }
 
     private fun formatKeyDateCreated(rfc3339: String): String {
-        return parentActivity.getString(R.string.wireguard_key_age) + " " + KEY_AGE_FORMAT.print(DateTime.parse(rfc3339, RFC3339_FORMAT))
+        val dateCreated = DateTime.parse(rfc3339, RFC3339_FORMAT).withZone(DateTimeZone.UTC)
+        val localTimezone = DateTimeZone.forTimeZone(TimeZone.getDefault())
+        return parentActivity.getString(R.string.wireguard_key_age) +
+            " " +
+            KEY_AGE_FORMAT.print(dateCreated.withZone(localTimezone))
     }
 }


### PR DESCRIPTION
Previously, the WireGuard key's age was displayed in UTC, which is suboptimal. This PR changes is so that the device's configured timezone will be used to display the age of the key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1152)
<!-- Reviewable:end -->
