### PR TITLE
Add `ktlint` to lint Kotlin code in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
         - sudo unzip -q -d /opt/android/ /tmp/ndk.zip
         - sudo /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm64 --install-dir=/opt/android/toolchains/android21-aarch64
         - |
+            curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.34.2/ktlint &&
+            chmod a+x ktlint &&
+            sudo mv ktlint /usr/local/bin/
+        - |
             cat >> $HOME/.cargo/config << EOF
             [target.aarch64-linux-android]
             ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
@@ -53,6 +57,8 @@ matrix:
         - cargo build --target aarch64-linux-android --verbose
         - cd android
         - ./gradlew --console plain assembleDebug
+        # Run ktlint with extra andorid rules
+        - ktlint -a
 
     # Daemon - macOS
     - language: rust

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ApiRootCaFile.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ApiRootCaFile.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn
 
 import java.io.File
 import java.io.FileOutputStream
-import java.io.InputStream
 
 import android.content.Context
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConfirmNoEmailDialogFragment.kt
@@ -13,8 +13,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 
-import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
-
 class ConfirmNoEmailDialogFragment : DialogFragment() {
     private var confirmNoEmail: CompletableDeferred<Boolean>? = null
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectActionButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectActionButton.kt
@@ -4,7 +4,6 @@ import android.view.View
 import android.widget.Button
 
 import net.mullvad.mullvadvpn.model.ActionAfterDisconnect
-import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.TunnelState
 
 class ConnectActionButton(val parentView: View) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ConnectFragment.kt
@@ -160,8 +160,7 @@ class ConnectFragment : Fragment() {
     }
 
     private fun updateTunnelState(uiState: TunnelState, realState: TunnelState) =
-        GlobalScope.launch(Dispatchers.Main)
-    {
+        GlobalScope.launch(Dispatchers.Main) {
         notificationBanner.tunnelState = realState
         locationInfoCache.state = realState
         locationInfo.state = realState

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
@@ -38,9 +38,9 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
             field = value
 
             reconnecting =
-                (value is TunnelState.Disconnecting
-                    && value.actionAfterDisconnect is ActionAfterDisconnect.Reconnect)
-                || (value is TunnelState.Connecting && reconnecting)
+                (value is TunnelState.Disconnecting &&
+                    value.actionAfterDisconnect is ActionAfterDisconnect.Reconnect) ||
+                (value is TunnelState.Connecting && reconnecting)
 
             updateNotification()
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LaunchFragment.kt
@@ -11,7 +11,6 @@ import android.content.Context
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 
 class LaunchFragment : Fragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LoginFragment.kt
@@ -6,13 +6,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
 
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.os.Handler
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -2,9 +2,7 @@ package net.mullvad.mullvadvpn
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -24,10 +22,6 @@ import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.dataproxy.SettingsListener
-import net.mullvad.mullvadvpn.model.RelaySettings
-import net.mullvad.mullvadvpn.model.Settings
-import net.mullvad.mullvadvpn.relaylist.RelayItem
-import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.util.SmartDeferred
 
 class MainActivity : FragmentActivity() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -1,7 +1,5 @@
 package net.mullvad.mullvadvpn
 
-import java.net.InetAddress
-
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.CompletableDeferred
@@ -105,7 +103,7 @@ class MullvadVpnService : VpnService() {
     private fun startDaemon() = GlobalScope.async(Dispatchers.Default) {
         created.await()
         ApiRootCaFile().extract(application)
-        MullvadDaemon(this@MullvadVpnService).apply { 
+        MullvadDaemon(this@MullvadVpnService).apply {
             onSettingsChange.subscribe { settings ->
                 notificationManager.loggedIn = settings?.accountToken != null
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
@@ -150,9 +150,11 @@ class NotificationBanner(
             is BlockReason.ParameterGeneration -> {
                 when (reason.error) {
                     is ParameterGenerationError.NoMatchingRelay -> R.string.no_matching_relay
-                    is ParameterGenerationError.NoMatchingBridgeRelay -> R.string.no_matching_bridge_relay
+                    is ParameterGenerationError.NoMatchingBridgeRelay ->
+                        R.string.no_matching_bridge_relay
                     is ParameterGenerationError.NoWireguardKey -> R.string.no_wireguard_key
-                    is ParameterGenerationError.CustomTunnelHostResultionError -> R.string.custom_tunnel_host_resolution_error
+                    is ParameterGenerationError.CustomTunnelHostResultionError ->
+                        R.string.custom_tunnel_host_resolution_error
                 }
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ProblemReportFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ProblemReportFragment.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn
 
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/RemainingTimeLabel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/RemainingTimeLabel.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 
-import org.joda.time.format.DateTimeFormat
 import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.joda.time.PeriodType

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -82,7 +82,8 @@ class WireguardKeyFragment : Fragment() {
 
         visitWebsiteView.visibility = View.VISIBLE
         visitWebsiteView.setOnClickListener {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(parentActivity.getString(R.string.account_url)))
+            val intent = Intent(Intent.ACTION_VIEW,
+                                Uri.parse(parentActivity.getString(R.string.account_url)))
             startActivity(intent)
         }
 
@@ -249,7 +250,9 @@ class WireguardKeyFragment : Fragment() {
             when (val state = keyStatusListener.keyStatus) {
                 is KeygenEvent.NewKey -> {
                     if (state.verified == null) {
-                        Toast.makeText(parentActivity, R.string.wireguard_key_verification_failure, Toast.LENGTH_SHORT).show()
+                        Toast.makeText(parentActivity,
+                            R.string.wireguard_key_verification_failure,
+                            Toast.LENGTH_SHORT).show()
                     }
                 }
             }
@@ -294,6 +297,8 @@ class WireguardKeyFragment : Fragment() {
     }
 
     private fun formatKeyDateCreated(rfc3339: String): String {
-        return parentActivity.getString(R.string.wireguard_key_age) + " " + KEY_AGE_FORMAT.print(DateTime.parse(rfc3339, RFC3339_FORMAT))
+        return (parentActivity.getString(R.string.wireguard_key_age) +
+                    " " +
+                    KEY_AGE_FORMAT.print(DateTime.parse(rfc3339, RFC3339_FORMAT)))
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -100,5 +100,4 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
 
         onUpdate?.invoke()
     }
-
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/KeyStatusListener.kt
@@ -49,7 +49,9 @@ class KeyStatusListener(val asyncDaemon: Deferred<MullvadDaemon>) {
             val oldStatus = keyStatus
             val newStatus = daemon?.generateWireguardKey()
             if (oldStatus is KeygenEvent.NewKey && newStatus is KeygenEvent.Failure) {
-                keyStatus = KeygenEvent.NewKey(oldStatus.publicKey, oldStatus.verified, newStatus.failure)
+                keyStatus = KeygenEvent.NewKey(oldStatus.publicKey,
+                                oldStatus.verified,
+                                newStatus.failure)
             } else {
                 keyStatus = newStatus
             }
@@ -61,7 +63,9 @@ class KeyStatusListener(val asyncDaemon: Deferred<MullvadDaemon>) {
             // Only update verification status if the key is actually there
             when (val state = keyStatus) {
                 is KeygenEvent.NewKey -> {
-                    keyStatus = KeygenEvent.NewKey(state.publicKey, verified, state.replacementFailure)
+                    keyStatus = KeygenEvent.NewKey(state.publicKey,
+                                    verified,
+                                    state.replacementFailure)
                 }
             }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.GlobalScope
 
 import net.mullvad.mullvadvpn.MainActivity
 import net.mullvad.mullvadvpn.model.Constraint
-import net.mullvad.mullvadvpn.model.LocationConstraint
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.relaylist.RelayList

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -1,7 +1,11 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class KeygenEvent {
-    class NewKey(val publicKey: PublicKey, val verified: Boolean?, val replacementFailure: KeygenFailure?) : KeygenEvent()
+    class NewKey(
+        val publicKey: PublicKey,
+        val verified: Boolean?,
+        val replacementFailure: KeygenFailure?
+    ) : KeygenEvent()
     class Failure(val failure: KeygenFailure) : KeygenEvent()
 }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
@@ -1,4 +1,3 @@
 package net.mullvad.mullvadvpn.model
 
-data class Relay(val hostname: String, val hasWireguardTunnels: Boolean, val active: Boolean) {
-}
+data class Relay(val hostname: String, val hasWireguardTunnels: Boolean, val active: Boolean)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
@@ -1,4 +1,3 @@
 package net.mullvad.mullvadvpn.model
 
-data class RelayList(val countries: List<RelayListCountry>) {
-}
+data class RelayList(val countries: List<RelayListCountry>)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
@@ -1,4 +1,3 @@
 package net.mullvad.mullvadvpn.model
 
-data class RelayListCity(val name: String, val code: String, val relays: List<Relay>) {
-}
+data class RelayListCity(val name: String, val code: String, val relays: List<Relay>)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
@@ -1,4 +1,3 @@
 package net.mullvad.mullvadvpn.model
 
-data class RelayListCountry(val name: String, val code: String, val cities: List<RelayListCity>) {
-}
+data class RelayListCountry(val name: String, val code: String, val cities: List<RelayListCity>)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
@@ -2,5 +2,6 @@ package net.mullvad.mullvadvpn.model
 
 sealed class RelaySettingsUpdate {
     class CustomTunnelEndpoint() : RelaySettingsUpdate()
-    class RelayConstraintsUpdate(var location: Constraint<LocationConstraint>?) : RelaySettingsUpdate()
+    class RelayConstraintsUpdate(var location: Constraint<LocationConstraint>?)
+        : RelaySettingsUpdate()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
@@ -1,4 +1,3 @@
 package net.mullvad.mullvadvpn.model
 
-data class Settings(var accountToken: String?, var relaySettings: RelaySettings) {
-}
+data class Settings(var accountToken: String?, var relaySettings: RelaySettings)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SmartDeferred.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SmartDeferred.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
 
 class SmartDeferred<T>(private val deferred: Deferred<T>) {
     private val jobTracker = JobTracker()


### PR DESCRIPTION
This is the PR for the long awaited linter for Kotlin - `ktlint`. It's nothing special, it can be `curl`'ed during the setup of the CI, it checks against very simple rules outlined [here, on it's github page](https://github.com/pinterest/ktlint#standard-rules) + `-a` argument implies Android specific rules.
We could also be using `gradle` to invoke the linter and to do the formatting, but I'm currently making do with invoking `ktlint -aF` to format it myself, and [Ale](https://github.com/dense-analysis/ale) invokes the linter and displays it in Vim. 

Seems like the first commit with it enabled did spew quite a lot of [linter errors](https://travis-ci.org/mullvad/mullvadvpn-app/jobs/591591951#L2067). All of those are resolved in the next commit, most of the issues where fixed by `ktlint` itself.

Do check out the rules to see if you disagree with any of them - we can commit the rules to the repo (possibly by setting `ktlint` up with gradle) and maintain our own ruleset. I've only eyeballed them, but the changes introduced seem sane, so I've got no bones to pick just yet. The most labor-intensive constraint is the 100 character width limit imposed by the android specific rule-set, but it's not one I disagree with.