### PR TITLE
Fix icons for notification action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Show WireGuard key age in local timezone instead of UTC.
+- Fix notification button icons.
 
 
 ## [2019.8] - 2019-09-23

--- a/android/src/main/res/drawable/icon_notification_connect.xml
+++ b/android/src/main/res/drawable/icon_notification_connect.xml
@@ -1,33 +1,40 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0"
+        android:width="32dp"
+        android:height="32dp"
+        android:viewportWidth="32.0"
+        android:viewportHeight="32.0"
         android:tint="?attr/colorControlNormal">
-    <path
-            android:fillColor="#000000"
-            android:fillType="evenOdd"
-            android:pathData="
-                M -4,-1
-                v -6
-                a 1,1 0 0,1 1,-1
-                h 6
-                a 1,1 0 0,1 1,1
-                v 6
-                h 1
-                a 1,1 0 0,1 1,1
-                v 7
-                a 1,1 0 0,1 -1,1
-                h -10
-                a 1,1 0 0,1 -1,-1
-                v -7
-                a 1,1 0 0,1 1,-1
-                z
-                M -2,-1
-                v -5
-                h 4
-                v 5
-                z
-            "
-            />
+    <group
+            android:translateX="16.0"
+            android:translateY="16.0"
+            android:scaleX="1.25"
+            android:scaleY="1.25"
+            >
+        <path
+                android:fillColor="#000000"
+                android:fillType="evenOdd"
+                android:pathData="
+                    M -4,-1
+                    v -6
+                    a 1,1 0 0,1 1,-1
+                    h 6
+                    a 1,1 0 0,1 1,1
+                    v 6
+                    h 1
+                    a 1,1 0 0,1 1,1
+                    v 7
+                    a 1,1 0 0,1 -1,1
+                    h -10
+                    a 1,1 0 0,1 -1,-1
+                    v -7
+                    a 1,1 0 0,1 1,-1
+                    z
+                    M -2,-1
+                    v -5
+                    h 4
+                    v 5
+                    z
+                "
+                />
+    </group>
 </vector>

--- a/android/src/main/res/drawable/icon_notification_disconnect.xml
+++ b/android/src/main/res/drawable/icon_notification_disconnect.xml
@@ -1,31 +1,38 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0"
+        android:width="32dp"
+        android:height="32dp"
+        android:viewportWidth="32.0"
+        android:viewportHeight="32.0"
         android:tint="?attr/colorControlNormal">
-    <path
-            android:fillColor="#000000"
-            android:pathData="
-                M 0,-1
-                v -6
-                a 1,1 0 0,1 1,-1
-                h 6
-                a 1,1 0 0,1 1,1
-                v 6
-                a 1,1 0 0,1 -2,0
-                v -5
-                h -4
-                v 5
-                h 1
-                a 1,1 0 0,1 1,1
-                v 7
-                a 1,1 0 0,1 -1,1
-                h -10
-                a 1,1 0 0,1 -1,-1
-                v -7
-                a 1,1 0 0,1 1,-1
-                z
-            "
-            />
+    <group
+            android:translateX="16.0"
+            android:translateY="16.0"
+            android:scaleX="1.25"
+            android:scaleY="1.25"
+            >
+        <path
+                android:fillColor="#000000"
+                android:pathData="
+                    M 0,-1
+                    v -6
+                    a 1,1 0 0,1 1,-1
+                    h 6
+                    a 1,1 0 0,1 1,1
+                    v 6
+                    a 1,1 0 0,1 -2,0
+                    v -5
+                    h -4
+                    v 5
+                    h 1
+                    a 1,1 0 0,1 1,1
+                    v 7
+                    a 1,1 0 0,1 -1,1
+                    h -10
+                    a 1,1 0 0,1 -1,-1
+                    v -7
+                    a 1,1 0 0,1 1,-1
+                    z
+                "
+                />
+    </group>
 </vector>


### PR DESCRIPTION
Android requires icons to be set in order to create notification action buttons. However, on recent Android versions the icons aren't shown. Therefore, the images that were included for the icons weren't actually tested as being displayed on a notification. On older versions of Android, where the icons are showed, they appeared to be incorrect.

This PR fixes the icons, by making sure the sizes are correct and by translating the image to the center of the viewport.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1156)
<!-- Reviewable:end -->
