### PR TITLE
Fix usage of `stopForeground`

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
@@ -160,7 +160,7 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
             unregisterReceiver(connectReceiver)
             unregisterReceiver(disconnectReceiver)
 
-            stopForeground(FOREGROUND_NOTIFICATION_ID)
+            stopForeground(true)
         }
     }
 


### PR DESCRIPTION
The `stopForeground` method was being passed the notification ID, but it's parameter required a flags argument instead. Luckily, this hadn't appeared as a bug before because the hard-coded notification ID (`1`) was the value required for the flags.

However, on Android Lollipop there's only one overload of `stopForeground`, which receives a `boolean` as parameter instead of an `int`. So this issue ended up appearing as a crash while stopping the service.

This PR fixes the issue by using the overload present on Lollipop (which is also available on later versions).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Issue didn't manifest to users on released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1158)
<!-- Reviewable:end -->
