### PR TITLE
Add get_www_auth_token RPC in daemon

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -742,6 +742,7 @@ where
             GetState(tx) => self.on_get_state(tx),
             GetCurrentLocation(tx) => self.on_get_current_location(tx),
             GetAccountData(tx, account_token) => self.on_get_account_data(tx, account_token),
+            GetWwwAuthToken(tx) => self.on_get_www_auth_token(tx),
             GetRelayLocations(tx) => self.on_get_relay_locations(tx),
             UpdateRelayLocations => self.on_update_relay_locations(),
             SetAccount(tx, account_token) => self.on_set_account(tx, account_token),
@@ -926,6 +927,17 @@ where
             .map(|expiry| AccountData { expiry });
         Self::oneshot_send(tx, Box::new(rpc_call), "account data")
     }
+
+    fn on_get_www_auth_token(
+        &mut self,
+        tx: oneshot::Sender<BoxFuture<String, mullvad_rpc::Error>>,
+    ) {
+        if let Some(account_token) = self.settings.get_account_token() {
+            let rpc_call = self.accounts_proxy.get_www_auth_token(account_token);
+            Self::oneshot_send(tx, Box::new(rpc_call), "get_www_auth_token response")
+        }
+    }
+
 
     fn on_get_relay_locations(&mut self, tx: oneshot::Sender<RelayList>) {
         Self::oneshot_send(tx, self.relay_selector.get_locations(), "relay locations");

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -105,6 +105,7 @@ impl MullvadRpcFactory {
 
 jsonrpc_client!(pub struct AccountsProxy {
     pub fn get_expiry(&mut self, account_token: AccountToken) -> RpcRequest<DateTime<Utc>>;
+    pub fn get_www_auth_token(&mut self, account_token: AccountToken) -> RpcRequest<String>;
 });
 
 jsonrpc_client!(pub struct ProblemReportProxy {


### PR DESCRIPTION
This PR adds an RPC to the daemon that creates WWW auth tokens so that the GUI can create URLs to log users in directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1159)
<!-- Reviewable:end -->
