### PR TITLE
Use authentication tokens for account and wireguard keys pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for Android Lollipop.
 - Allow logging in without connectivity.
 
+### Changed
+- Account and WireGuard keys links in the App will now log the user in automatically.
+- Update FAQ URL to `https://mullvad.net/help/tag/mullvad-app/`
+
 ### Removed
 - Remove support for `MULLVAD_LOCALE` environment variable.
 

--- a/gui/src/config.json
+++ b/gui/src/config.json
@@ -1,8 +1,8 @@
 {
   "links": {
     "createAccount": "https://mullvad.net/account/create/",
-    "purchase": "https://mullvad.net/account/login/",
-    "manageKeys": "https://mullvad.net/account/login/",
+    "purchase": "https://mullvad.net/account/",
+    "manageKeys": "https://mullvad.net/account/ports/",
     "faq": "https://mullvad.net/faq/",
     "download": "https://mullvad.net/download/",
     "supportEmail": "support@mullvad.net"

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -428,6 +428,15 @@ export class DaemonRpc {
     }
   }
 
+  public async getWwwAuthToken(): Promise<string> {
+    const response = await this.transport.send('get_www_auth_token');
+    try {
+      return validate(string, response);
+    } catch (error) {
+      throw new ResponseParseError('Invalid response from get_www_auth_token', error);
+    }
+  }
+
   public async getRelayLocations(): Promise<IRelayList> {
     const response = await this.transport.send('get_relay_locations');
     try {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -991,6 +991,7 @@ class ApplicationMain {
 
     IpcMainEventChannel.account.handleLogin((token: AccountToken) => this.login(token));
     IpcMainEventChannel.account.handleLogout(() => this.logout());
+    IpcMainEventChannel.account.handleWwwAuthToken(() => this.daemonRpc.getWwwAuthToken());
 
     IpcMainEventChannel.accountHistory.handleRemoveItem(async (token: AccountToken) => {
       await this.daemonRpc.removeAccountFromHistory(token);

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -3,7 +3,7 @@ import {
   push as pushHistory,
   replace as replaceHistory,
 } from 'connected-react-router';
-import { ipcRenderer, webFrame } from 'electron';
+import { ipcRenderer, shell, webFrame } from 'electron';
 import log from 'electron-log';
 import { createMemoryHistory } from 'history';
 import * as React from 'react';
@@ -286,6 +286,16 @@ export default class AppRenderer {
 
   public async removeAccountFromHistory(accountToken: AccountToken): Promise<void> {
     return IpcRendererEventChannel.accountHistory.removeItem(accountToken);
+  }
+
+  public async openLinkWithAuth(link: string) {
+    let token;
+    try {
+      token = await IpcRendererEventChannel.account.getWwwAuthToken();
+    } catch (e) {
+      token = '';
+    }
+    shell.openExternal(`${link}?token=${token}`);
   }
 
   public async setAllowLan(allowLan: boolean) {

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -288,12 +288,12 @@ export default class AppRenderer {
     return IpcRendererEventChannel.accountHistory.removeItem(accountToken);
   }
 
-  public async openLinkWithAuth(link: string) {
-    let token;
+  public async openLinkWithAuth(link: string): Promise<void> {
+    let token = '';
     try {
       token = await IpcRendererEventChannel.account.getWwwAuthToken();
     } catch (e) {
-      token = '';
+      log.error(`Failed to get the WWW auth token: ${e.message}`);
     }
     shell.openExternal(`${link}?token=${token}`);
   }

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -18,7 +18,7 @@ interface IProps {
   isOffline: boolean;
   onLogout: () => void;
   onClose: () => void;
-  onBuyMore: () => void;
+  onBuyMore: () => Promise<void>;
 }
 
 export default class Account extends Component<IProps> {
@@ -65,15 +65,16 @@ export default class Account extends Component<IProps> {
                   </View>
 
                   <View style={styles.account__footer}>
-                    <AppButton.GreenButton
-                      style={styles.account__buy_button}
+                    <AppButton.BlockingButton
                       disabled={this.props.isOffline}
                       onPress={this.props.onBuyMore}>
-                      <AppButton.Label>
-                        {messages.pgettext('account-view', 'Buy more credit')}
-                      </AppButton.Label>
-                      <AppButton.Icon source="icon-extLink" height={16} width={16} />
-                    </AppButton.GreenButton>
+                      <AppButton.GreenButton style={styles.account__buy_button}>
+                        <AppButton.Label>
+                          {messages.pgettext('account-view', 'Buy more credit')}
+                        </AppButton.Label>
+                        <AppButton.Icon source="icon-extLink" height={16} width={16} />
+                      </AppButton.GreenButton>
+                    </AppButton.BlockingButton>
                     <AppButton.RedButton onPress={this.props.onLogout}>
                       {messages.pgettext('account-view', 'Log out')}
                     </AppButton.RedButton>

--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -23,7 +23,8 @@ interface IProps {
   onSelectLocation: () => void;
   onConnect: () => void;
   onDisconnect: () => void;
-  onExternalLink: (url: string) => void;
+  onExternalLink: (url: string) => Promise<void>;
+  onExternalLinkWithAuth: (url: string) => Promise<void>;
 }
 
 type MarkerOrSpinner = 'marker' | 'spinner';

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -24,8 +24,8 @@ interface IProps {
   tunnelState: TunnelState;
   version: IVersionReduxState;
   blockWhenDisconnected: boolean;
-  onOpenDownloadLink: () => void;
-  onOpenBuyMoreLink: () => void;
+  onOpenDownloadLink: () => Promise<void>;
+  onOpenBuyMoreLink: () => Promise<void>;
 }
 
 type NotificationAreaPresentation =

--- a/gui/src/renderer/components/NotificationBanner.tsx
+++ b/gui/src/renderer/components/NotificationBanner.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Animated, Button, Component, Styles, Text, Types, UserInterface, View } from 'reactxp';
 import { colors } from '../../config.json';
+import { BlockingButton } from './AppButton';
 import ImageView from './ImageView';
 
 const styles = {
@@ -83,25 +84,26 @@ export class NotificationSubtitle extends Component {
   }
 }
 
-export class NotificationOpenLinkAction extends Component<{ onPress: () => void }> {
+export class NotificationOpenLinkAction extends Component<{ onPress: () => Promise<void> }> {
   public state = {
     hovered: false,
   };
 
   public render() {
     return (
-      <Button
-        style={styles.actionButton}
-        onPress={this.props.onPress}
-        onHoverStart={this.onHoverStart}
-        onHoverEnd={this.onHoverEnd}>
-        <ImageView
-          height={12}
-          width={12}
-          tintColor={this.state.hovered ? colors.white80 : colors.white60}
-          source="icon-extLink"
-        />
-      </Button>
+      <BlockingButton onPress={this.props.onPress}>
+        <Button
+          style={styles.actionButton}
+          onHoverStart={this.onHoverStart}
+          onHoverEnd={this.onHoverEnd}>
+          <ImageView
+            height={12}
+            width={12}
+            tintColor={this.state.hovered ? colors.white80 : colors.white60}
+            source="icon-extLink"
+          />
+        </Button>
+      </BlockingButton>
     );
   }
 

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -21,7 +21,7 @@ export interface IProps {
   onGenerateKey: () => void;
   onReplaceKey: (old: IWgKey) => void;
   onVerifyKey: (publicKey: IWgKey) => void;
-  onVisitWebsiteKey: () => void;
+  onVisitWebsiteKey: () => Promise<void>;
 }
 
 export default class WireguardKeys extends Component<IProps> {
@@ -85,14 +85,16 @@ export default class WireguardKeys extends Component<IProps> {
                 </AppButton.GreenButton>
               </View>
               <View style={styles.wgkeys__row}>
-                <AppButton.GreenButton
+                <AppButton.BlockingButton
                   disabled={this.props.isOffline}
                   onPress={this.props.onVisitWebsiteKey}>
-                  <AppButton.Label>
-                    {messages.pgettext('wireguard-key-view', 'Manage keys')}
-                  </AppButton.Label>
-                  <AppButton.Icon source="icon-extLink" height={16} width={16} />
-                </AppButton.GreenButton>
+                  <AppButton.GreenButton>
+                    <AppButton.Label>
+                      {messages.pgettext('wireguard-key-view', 'Manage keys')}
+                    </AppButton.Label>
+                    <AppButton.Icon source="icon-extLink" height={16} width={16} />
+                  </AppButton.GreenButton>
+                </AppButton.BlockingButton>
               </View>
             </View>
           </View>

--- a/gui/src/renderer/containers/AccountPage.tsx
+++ b/gui/src/renderer/containers/AccountPage.tsx
@@ -1,5 +1,4 @@
 import { goBack } from 'connected-react-router';
-import { shell } from 'electron';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { links } from '../../config.json';
@@ -23,7 +22,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
     onClose: () => {
       history.goBack();
     },
-    onBuyMore: () => shell.openExternal(links.purchase),
+    onBuyMore: () => props.app.openLinkWithAuth(links.purchase),
   };
 };
 

--- a/gui/src/renderer/containers/ConnectPage.tsx
+++ b/gui/src/renderer/containers/ConnectPage.tsx
@@ -101,6 +101,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
       }
     },
     onExternalLink: (url: string) => shell.openExternal(url),
+    onExternalLinkWithAuth: (url: string) => props.app.openLinkWithAuth(url),
   };
 };
 

--- a/gui/src/renderer/containers/NotificationAreaContainer.tsx
+++ b/gui/src/renderer/containers/NotificationAreaContainer.tsx
@@ -16,13 +16,13 @@ const mapStateToProps = (state: IReduxState, _props: IAppContext) => ({
   blockWhenDisconnected: state.settings.blockWhenDisconnected,
 });
 
-const mapDispatchToProps = (_dispatch: ReduxDispatch, _props: IAppContext) => {
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: IAppContext) => {
   return {
-    onOpenDownloadLink() {
-      shell.openExternal(links.download);
+    onOpenDownloadLink(): Promise<void> {
+      return shell.openExternal(links.download);
     },
-    onOpenBuyMoreLink() {
-      shell.openExternal(links.purchase);
+    onOpenBuyMoreLink(): Promise<void> {
+      return props.app.openLinkWithAuth(links.purchase);
     },
   };
 };

--- a/gui/src/renderer/containers/WireguardKeysPage.tsx
+++ b/gui/src/renderer/containers/WireguardKeysPage.tsx
@@ -1,5 +1,4 @@
 import { goBack, push } from 'connected-react-router';
-import { shell } from 'electron';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { links } from '../../config.json';
@@ -20,7 +19,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
     onGenerateKey: () => props.app.generateWireguardKey(),
     onReplaceKey: (oldKey: IWgKey) => props.app.replaceWireguardKey(oldKey),
     onVerifyKey: (publicKey: IWgKey) => props.app.verifyWireguardKey(publicKey),
-    onVisitWebsiteKey: () => shell.openExternal(links.manageKeys),
+    onVisitWebsiteKey: () => props.app.openLinkWithAuth(links.manageKeys),
   };
 };
 

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -102,11 +102,13 @@ interface IGuiSettingsHandlers extends ISender<IGuiSettingsState> {
 interface IAccountHandlers extends ISender<IAccountData | undefined> {
   handleLogin(fn: (token: AccountToken) => Promise<void>): void;
   handleLogout(fn: () => Promise<void>): void;
+  handleWwwAuthToken(fn: () => Promise<string>): void;
 }
 
 interface IAccountMethods extends IReceiver<IAccountData | undefined> {
   login(token: AccountToken): Promise<void>;
   logout(): Promise<void>;
+  getWwwAuthToken(): Promise<string>;
 }
 
 interface IAccountHistoryHandlers extends ISender<AccountToken[]> {
@@ -177,6 +179,7 @@ const REMOVE_ACCOUNT_HISTORY_ITEM = 'remove-account-history-item';
 
 const DO_LOGIN = 'do-login';
 const DO_LOGOUT = 'do-logout';
+const DO_GET_WWW_AUTH_TOKEN = 'do-get-www-auth-token';
 const ACCOUNT_DATA_CHANGED = 'account-data-changed';
 
 const AUTO_START_CHANGED = 'auto-start-changed';
@@ -267,6 +270,7 @@ export class IpcRendererEventChannel {
     listen: listen(ACCOUNT_DATA_CHANGED),
     login: requestSender(DO_LOGIN),
     logout: requestSender(DO_LOGOUT),
+    getWwwAuthToken: requestSender(DO_GET_WWW_AUTH_TOKEN),
   };
 
   public static accountHistory: IAccountHistoryMethods = {
@@ -358,6 +362,7 @@ export class IpcMainEventChannel {
     notify: sender<IAccountData | undefined>(ACCOUNT_DATA_CHANGED),
     handleLogin: requestHandler(DO_LOGIN),
     handleLogout: requestHandler(DO_LOGOUT),
+    handleWwwAuthToken: requestHandler(DO_GET_WWW_AUTH_TOKEN),
   };
 
   public static accountHistory: IAccountHistoryHandlers = {

--- a/gui/test/components/NotificationArea.spec.tsx
+++ b/gui/test/components/NotificationArea.spec.tsx
@@ -33,7 +33,8 @@ describe('components/NotificationArea', () => {
           }}
           version={defaultVersion}
           accountExpiry={defaultExpiry}
-          openExternalLink={() => {}}
+          onOpenDownloadLink={async () => {}}
+          onOpenBuyMoreLink={async () => {}}
           blockWhenDisconnected={false}
         />,
       );
@@ -50,7 +51,8 @@ describe('components/NotificationArea', () => {
         }}
         version={defaultVersion}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -78,7 +80,8 @@ describe('components/NotificationArea', () => {
         }}
         version={defaultVersion}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -94,7 +97,8 @@ describe('components/NotificationArea', () => {
         }}
         version={defaultVersion}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -110,7 +114,8 @@ describe('components/NotificationArea', () => {
         }}
         version={defaultVersion}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={true}
       />,
     );
@@ -126,7 +131,8 @@ describe('components/NotificationArea', () => {
         }}
         version={defaultVersion}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -147,7 +153,8 @@ describe('components/NotificationArea', () => {
         }}
         version={defaultVersion}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -167,7 +174,8 @@ describe('components/NotificationArea', () => {
           consistent: false,
         }}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -190,7 +198,8 @@ describe('components/NotificationArea', () => {
           nextUpgrade: '2018.2',
         }}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -214,7 +223,8 @@ describe('components/NotificationArea', () => {
           nextUpgrade: '2018.3',
         }}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -239,7 +249,8 @@ describe('components/NotificationArea', () => {
           nextUpgrade: '2018.4-beta3',
         }}
         accountExpiry={defaultExpiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );
@@ -263,7 +274,8 @@ describe('components/NotificationArea', () => {
         }}
         version={defaultVersion}
         accountExpiry={expiry}
-        openExternalLink={() => {}}
+        onOpenDownloadLink={async () => {}}
+        onOpenBuyMoreLink={async () => {}}
         blockWhenDisconnected={false}
       />,
     );


### PR DESCRIPTION
This PR changes the GUI so that the URLs for the account and wireguard keys pages will be opened with the `token` URL parameter populated with a token received from the daemon. The net result is that the user will already be logged in when they will open these links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1161)
<!-- Reviewable:end -->
