### PR TITLE
Fix tunnel out IP address disappears after collapsing tunnel information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Show WireGuard key age in local timezone instead of UTC.
 - Fix notification button icons.
+- Fix collapsing tunnel information causing tunnel out IP address information to be lost.
 
 
 ## [2019.8] - 2019-09-23

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/LocationInfo.kt
@@ -24,6 +24,8 @@ class LocationInfo(val parentView: View, val context: Context) {
 
     var location: GeoIpLocation? = null
         set(value) {
+            field = value
+
             country.text = value?.country ?: ""
             city.text = value?.city ?: ""
             hostname.text = value?.hostname ?: ""


### PR DESCRIPTION
Previously, collapsing the tunnel information box and expanding it again would reveal the tunnel information without the out IP address that was previously shown. This was caused because the location information that was fetched wasn't stored in the class for future use, so it would only be shown right after the information is received.

This PR fixes the issue by storing the value in the correct field in the class.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1162)
<!-- Reviewable:end -->
