### PR TITLE
Add RPC to create accounts in daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add ability to change the desktop GUI language from within Settings.
+- Add ability to create new accounts form the CLI
 
 #### Windows
 - Add CLI tools (the resource/ directory) to the system PATH.

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -30,6 +30,10 @@ impl Command for Account {
                 clap::SubCommand::with_name("unset")
                     .about("Removes the account number from the settings"),
             )
+            .subcommand(
+                clap::SubCommand::with_name("create")
+                    .about("Creates a new account and sets it as the active one"),
+            )
     }
 
     fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
@@ -40,6 +44,8 @@ impl Command for Account {
             self.set(None)
         } else if let Some(_matches) = matches.subcommand_matches("get") {
             self.get()
+        } else if let Some(_matches) = matches.subcommand_matches("create") {
+            self.create()
         } else {
             unreachable!("No account command given");
         }
@@ -69,5 +75,12 @@ impl Account {
             println!("No account configured");
         }
         Ok(())
+    }
+
+    fn create(&self) -> Result<()> {
+        let mut rpc = new_rpc_client()?;
+        rpc.create_new_account()?;
+        println!("New account created!");
+        self.get()
     }
 }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -99,6 +99,10 @@ impl DaemonRpcClient {
         self.call("disconnect", &NO_ARGS)
     }
 
+    pub fn create_new_account(&mut self) -> Result<()> {
+        self.call("create_new_account", &NO_ARGS)
+    }
+
     pub fn get_account(&mut self) -> Result<Option<AccountToken>> {
         self.call("get_account", &NO_ARGS)
     }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -104,6 +104,7 @@ impl MullvadRpcFactory {
 }
 
 jsonrpc_client!(pub struct AccountsProxy {
+    pub fn create_account(&mut self) -> RpcRequest<AccountToken>;
     pub fn get_expiry(&mut self, account_token: AccountToken) -> RpcRequest<DateTime<Utc>>;
     pub fn get_www_auth_token(&mut self, account_token: AccountToken) -> RpcRequest<String>;
 });


### PR DESCRIPTION
To allow users to create a new account from the GUI, firstly the daemon has to support this. This PR adds a new RPC to the daemon that will call the `create_account` RPC on the API to create a new account. I have also added a new subcommand to the CLI to allow creating accounts with it.

Since after creating an account, there's no _money_ on it, I've made it so that whilst the new account is set, the daemon will not try to connect as it would fail, and then the user wouldn't be able to pay for time on the account without unblocking anyway. Maybe this should be changed so that we fail shut anyway, as it would be the more secure thing to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1163)
<!-- Reviewable:end -->
