### PR TITLE
Refine visual styles in Advanced Settings

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -190,10 +190,12 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     <Cell.Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
                   </Cell.Container>
                   <Cell.Footer>
-                    {messages.pgettext(
-                      'advanced-settings-view',
-                      'Enable IPv6 communication through the tunnel.',
-                    )}
+                    <Cell.FooterText>
+                      {messages.pgettext(
+                        'advanced-settings-view',
+                        'Enable IPv6 communication through the tunnel.',
+                      )}
+                    </Cell.FooterText>
                   </Cell.Footer>
 
                   <Cell.Container>
@@ -206,21 +208,23 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     />
                   </Cell.Container>
                   <Cell.Footer>
-                    {messages.pgettext(
-                      'advanced-settings-view',
-                      "Unless connected to Mullvad, this setting will completely block your internet, even when you've disconnected or quit the app.",
-                    )}
-                  </Cell.Footer>
-                  {this.props.blockWhenDisconnected ? (
-                    <Cell.Footer>
+                    <Cell.FooterText>
                       {messages.pgettext(
                         'advanced-settings-view',
-                        "Warning: Your internet won't work without a VPN connection, even when you've quit the app.",
+                        "Unless connected to Mullvad, this setting will completely block your internet, even when you've disconnected or quit the app.",
                       )}
-                    </Cell.Footer>
-                  ) : (
-                    undefined
-                  )}
+                    </Cell.FooterText>
+
+                    {this.props.blockWhenDisconnected && (
+                      <Cell.FooterBoldText
+                        style={styles.advanced_settings__cell_footer_internet_warning_label}>
+                        {messages.pgettext(
+                          'advanced-settings-view',
+                          "Warning: Your internet won't work without a VPN connection, even when you've quit the app.",
+                        )}
+                      </Cell.FooterBoldText>
+                    )}
+                  </Cell.Footer>
 
                   {process.platform !== 'win32' ? (
                     <View style={styles.advanced_settings__content}>
@@ -315,20 +319,22 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     </Cell.InputFrame>
                   </Cell.Container>
                   <Cell.Footer>
-                    {sprintf(
-                      // TRANSLATORS: The hint displayed below the Mssfix input field.
-                      // TRANSLATORS: Available placeholders:
-                      // TRANSLATORS: %(max)d - the maximum possible mssfix value
-                      // TRANSLATORS: %(min)d - the minimum possible mssfix value
-                      messages.pgettext(
-                        'advanced-settings-view',
-                        'Set OpenVPN MSS value. Valid range: %(min)d - %(max)d.',
-                      ),
-                      {
-                        min: MIN_MSSFIX_VALUE,
-                        max: MAX_MSSFIX_VALUE,
-                      },
-                    )}
+                    <Cell.FooterText>
+                      {sprintf(
+                        // TRANSLATORS: The hint displayed below the Mssfix input field.
+                        // TRANSLATORS: Available placeholders:
+                        // TRANSLATORS: %(max)d - the maximum possible mssfix value
+                        // TRANSLATORS: %(min)d - the minimum possible mssfix value
+                        messages.pgettext(
+                          'advanced-settings-view',
+                          'Set OpenVPN MSS value. Valid range: %(min)d - %(max)d.',
+                        ),
+                        {
+                          min: MIN_MSSFIX_VALUE,
+                          max: MAX_MSSFIX_VALUE,
+                        },
+                      )}
+                    </Cell.FooterText>
                   </Cell.Footer>
                   {this.wireguardKeysButton()}
                 </NavigationScrollbars>

--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -40,6 +40,9 @@ export default {
     color: colors.white,
     flex: 0,
   }),
+  advanced_settings__cell_footer_internet_warning_label: Styles.createTextStyle({
+    marginTop: 4,
+  }),
   advanced_settings__mssfix_input: Styles.createTextInputStyle({
     minWidth: 80,
   }),

--- a/gui/src/renderer/components/Cell.tsx
+++ b/gui/src/renderer/components/Cell.tsx
@@ -49,6 +49,9 @@ const styles = {
       letterSpacing: -0.2,
       color: colors.white80,
     }),
+    boldText: Styles.createTextStyle({
+      fontWeight: '900',
+    }),
   },
   label: {
     container: Styles.createViewStyle({
@@ -386,9 +389,21 @@ export const UntintedIcon = function CellIcon(props: ImageView['props']) {
 };
 
 export const Footer = function CellFooter({ children }: IContainerProps) {
+  return <View style={styles.footer.container}>{children}</View>;
+};
+
+export const FooterText = function CellFooterText(props: Text['props']) {
   return (
-    <View style={styles.footer.container}>
-      <Text style={styles.footer.text}>{children}</Text>
-    </View>
+    <Text {...props} style={[styles.footer.text, props.style]}>
+      {props.children}
+    </Text>
+  );
+};
+
+export const FooterBoldText = function CellFooterText(props: Text['props']) {
+  return (
+    <Text {...props} style={[styles.footer.text, styles.footer.boldText, props.style]}>
+      {props.children}
+    </Text>
   );
 };

--- a/gui/src/renderer/components/Preferences.tsx
+++ b/gui/src/renderer/components/Preferences.tsx
@@ -79,10 +79,12 @@ export default class Preferences extends Component<IProps> {
                       />
                     </Cell.Container>
                     <Cell.Footer>
-                      {messages.pgettext(
-                        'preferences-view',
-                        'Automatically connect to a server when the app launches.',
-                      )}
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'preferences-view',
+                          'Automatically connect to a server when the app launches.',
+                        )}
+                      </Cell.FooterText>
                     </Cell.Footer>
 
                     <Cell.Container>
@@ -92,10 +94,12 @@ export default class Preferences extends Component<IProps> {
                       <Cell.Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
                     </Cell.Container>
                     <Cell.Footer>
-                      {messages.pgettext(
-                        'preferences-view',
-                        'Allows access to other devices on the same network for sharing, printing etc.',
-                      )}
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'preferences-view',
+                          'Allows access to other devices on the same network for sharing, printing etc.',
+                        )}
+                      </Cell.FooterText>
                     </Cell.Footer>
 
                     <Cell.Container>
@@ -108,10 +112,12 @@ export default class Preferences extends Component<IProps> {
                       />
                     </Cell.Container>
                     <Cell.Footer>
-                      {messages.pgettext(
-                        'preferences-view',
-                        'Enable or disable system notifications. The critical notifications will always be displayed.',
-                      )}
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'preferences-view',
+                          'Enable or disable system notifications. The critical notifications will always be displayed.',
+                        )}
+                      </Cell.FooterText>
                     </Cell.Footer>
 
                     {this.props.enableMonochromaticIconToggle ? (
@@ -126,10 +132,12 @@ export default class Preferences extends Component<IProps> {
                           />
                         </Cell.Container>
                         <Cell.Footer>
-                          {messages.pgettext(
-                            'preferences-view',
-                            'Use a monochromatic tray icon instead of a colored one.',
-                          )}
+                          <Cell.FooterText>
+                            {messages.pgettext(
+                              'preferences-view',
+                              'Use a monochromatic tray icon instead of a colored one.',
+                            )}
+                          </Cell.FooterText>
                         </Cell.Footer>
                       </React.Fragment>
                     ) : (
@@ -148,10 +156,12 @@ export default class Preferences extends Component<IProps> {
                           />
                         </Cell.Container>
                         <Cell.Footer>
-                          {messages.pgettext(
-                            'preferences-view',
-                            'Show only the tray icon when the app starts.',
-                          )}
+                          <Cell.FooterText>
+                            {messages.pgettext(
+                              'preferences-view',
+                              'Show only the tray icon when the app starts.',
+                            )}
+                          </Cell.FooterText>
                         </Cell.Footer>
                       </React.Fragment>
                     ) : (

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -48,17 +48,30 @@ export default class WireguardKeys extends Component<IProps> {
                 </HeaderTitle>
               </SettingsHeader>
 
-              <View style={styles.wgkeys__row}>{this.blockedStateLabel()}</View>
-              <View style={styles.wgkeys__row}>
-                <Text style={styles.wgkeys__row_label}>
-                  {messages.pgettext('wireguard-keys', 'Public key')}
+              {this.props.isOffline && (
+                <Text style={[styles.wgkeys__row, styles.wgkeys__invalid_key]}>
+                  {messages.pgettext(
+                    'wireguard-key-view',
+                    "Can't manage keys whilst in a blocked state",
+                  )}
                 </Text>
+              )}
+
+              <View style={styles.wgkeys__row}>
+                <View style={styles.wgkeys__validity_row}>
+                  <Text style={styles.wgkeys__row_label}>
+                    {messages.pgettext('wireguard-keys', 'Public key')}
+                  </Text>
+                  {this.keyValidityLabel()}
+                </View>
+
                 <View style={styles.wgkeys__row_value}>{this.getKeyText()}</View>
+              </View>
+              <View style={styles.wgkeys__row}>
                 <Text style={styles.wgkeys__row_label}>
                   {messages.pgettext('wireguard-keys', 'Key generated')}
                 </Text>
                 <Text style={styles.wgkeys__row_value}>{this.ageOfKeyString()}</Text>
-                <View style={styles.wgkeys__validity_row}>{this.keyValidityLabel()}</View>
               </View>
 
               <View style={styles.wgkeys__row}>{this.getGenerateButton()}</View>
@@ -249,16 +262,5 @@ export default class WireguardKeys extends Component<IProps> {
       default:
         return failure;
     }
-  }
-
-  private blockedStateLabel() {
-    if (!this.props.isOffline) {
-      return undefined;
-    }
-    return (
-      <Text style={styles.wgkeys__invalid_key}>
-        {messages.pgettext('wireguard-key-view', "Can't manage keys whilst in a blocked state")}
-      </Text>
-    );
   }
 }

--- a/gui/src/renderer/components/WireguardKeysStyles.tsx
+++ b/gui/src/renderer/components/WireguardKeysStyles.tsx
@@ -18,15 +18,17 @@ export default {
     marginBottom: 24,
   }),
   wgkeys__row_label: Styles.createTextStyle({
+    flex: 1,
     fontFamily: 'Open Sans',
     fontSize: 13,
     fontWeight: '600',
     lineHeight: 20,
     letterSpacing: -0.2,
     color: colors.white60,
+    marginBottom: 9,
   }),
   wgkeys__validity_row: Styles.createViewStyle({
-    paddingTop: 5,
+    flexDirection: 'row',
   }),
   wgkeys__row_value: Styles.createTextStyle({
     fontFamily: 'Open Sans',
@@ -37,13 +39,14 @@ export default {
   }),
   wgkeys__invalid_key: Styles.createTextStyle({
     fontFamily: 'Open Sans',
-    fontSize: 16,
+    fontSize: 13,
     fontWeight: '800',
+    lineHeight: 20,
     color: colors.red,
   }),
   wgkeys__valid_key: Styles.createTextStyle({
     fontFamily: 'Open Sans',
-    fontSize: 16,
+    fontSize: 13,
     fontWeight: '600',
     lineHeight: 20,
     color: colors.green,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This is a tiny PR that fixes a couple of visual issues on our UI. 

1. Fix the appearance of a warning message displayed when block when disconnected is on. Maybe we should make the message in red, but I didn't want to stress much on that right now. Too much red can be depressing for eyes. 😖👁 Let me know what you think. 

<img width="319" alt="Screenshot 2019-10-04 at 18 21 23" src="https://user-images.githubusercontent.com/704044/66223470-deaedb00-e6d3-11e9-8b18-a9ef8a8cec41.png">

2. Align Wireguard view styles with the Account vew presentation, so both views have equal margins across the board. Move the key 🔑 validation result on the opposite side of the "Public Key"

<img width="366" alt="Screenshot 2019-10-04 at 18 24 10" src="https://user-images.githubusercontent.com/704044/66223637-3c432780-e6d4-11e9-92d0-417e79a231f5.png">

<img width="366" alt="Screenshot 2019-10-04 at 18 22 28" src="https://user-images.githubusercontent.com/704044/66223527-ff773080-e6d3-11e9-8f32-5bd28f4c31b4.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1170)
<!-- Reviewable:end -->
