### PR TITLE
Add app context

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -11,6 +11,7 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import ErrorBoundary from './components/ErrorBoundary';
+import { AppContext } from './context';
 import AppRoutes from './routes';
 
 import accountActions from './redux/account/actions';
@@ -212,13 +213,15 @@ export default class AppRenderer {
 
   public renderView() {
     return (
-      <Provider store={this.reduxStore}>
-        <ConnectedRouter history={this.memoryHistory}>
-          <ErrorBoundary>
-            <AppRoutes sharedProps={{ app: this }} />
-          </ErrorBoundary>
-        </ConnectedRouter>
-      </Provider>
+      <AppContext.Provider value={{ app: this }}>
+        <Provider store={this.reduxStore}>
+          <ConnectedRouter history={this.memoryHistory}>
+            <ErrorBoundary>
+              <AppRoutes />
+            </ErrorBoundary>
+          </ConnectedRouter>
+        </Provider>
+      </AppContext.Provider>
     );
   }
 

--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Component, Styles, View } from 'reactxp';
 import { links } from '../../config.json';
+import NotificationAreaContainer from '../containers/NotificationAreaContainer';
 import AccountExpiry from '../lib/account-expiry';
 import { AuthFailureKind, parseAuthFailure } from '../lib/auth-failure';
 import { IConnectionReduxState } from '../redux/connection/reducers';
@@ -10,7 +11,6 @@ import { Brand, HeaderBarStyle, SettingsBarButton } from './HeaderBar';
 import ImageView from './ImageView';
 import { Container, Header, Layout } from './Layout';
 import Map, { MarkerStyle, ZoomLevel } from './Map';
-import NotificationAreaContainer from '../containers/NotificationAreaContainer';
 import TunnelControl from './TunnelControl';
 
 interface IProps {

--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -10,7 +10,7 @@ import { Brand, HeaderBarStyle, SettingsBarButton } from './HeaderBar';
 import ImageView from './ImageView';
 import { Container, Header, Layout } from './Layout';
 import Map, { MarkerStyle, ZoomLevel } from './Map';
-import NotificationArea from './NotificationArea';
+import NotificationAreaContainer from '../containers/NotificationAreaContainer';
 import TunnelControl from './TunnelControl';
 
 interface IProps {
@@ -166,14 +166,7 @@ export default class Connect extends Component<IProps, IState> {
             onSelectLocation={this.props.onSelectLocation}
           />
 
-          <NotificationArea
-            style={styles.notificationArea}
-            tunnelState={this.props.connection.status}
-            version={this.props.version}
-            accountExpiry={this.props.accountExpiry}
-            openExternalLink={this.props.onExternalLink}
-            blockWhenDisconnected={this.props.blockWhenDisconnected}
-          />
+          <NotificationAreaContainer style={styles.notificationArea} />
         </View>
       </View>
     );

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -2,7 +2,6 @@ import moment from 'moment';
 import * as React from 'react';
 import { Component, Types } from 'reactxp';
 import { sprintf } from 'sprintf-js';
-import { links } from '../../config.json';
 import { messages } from '../../shared/gettext';
 import {
   NotificationActions,
@@ -24,8 +23,9 @@ interface IProps {
   accountExpiry?: AccountExpiry;
   tunnelState: TunnelState;
   version: IVersionReduxState;
-  openExternalLink: (url: string) => void;
   blockWhenDisconnected: boolean;
+  onOpenDownloadLink: () => void;
+  onOpenBuyMoreLink: () => void;
 }
 
 type NotificationAreaPresentation =
@@ -277,7 +277,7 @@ export default class NotificationArea extends Component<IProps, State> {
               </NotificationSubtitle>
             </NotificationContent>
             <NotificationActions>
-              <NotificationOpenLinkAction onPress={this.handleOpenDownloadLink} />
+              <NotificationOpenLinkAction onPress={this.props.onOpenDownloadLink} />
             </NotificationActions>
           </React.Fragment>
         )}
@@ -303,7 +303,7 @@ export default class NotificationArea extends Component<IProps, State> {
               </NotificationSubtitle>
             </NotificationContent>
             <NotificationActions>
-              <NotificationOpenLinkAction onPress={this.handleOpenDownloadLink} />
+              <NotificationOpenLinkAction onPress={this.props.onOpenDownloadLink} />
             </NotificationActions>
           </React.Fragment>
         )}
@@ -318,19 +318,11 @@ export default class NotificationArea extends Component<IProps, State> {
               <NotificationSubtitle>{this.state.timeLeft}</NotificationSubtitle>
             </NotificationContent>
             <NotificationActions>
-              <NotificationOpenLinkAction onPress={this.handleOpenBuyMoreLink} />
+              <NotificationOpenLinkAction onPress={this.props.onOpenBuyMoreLink} />
             </NotificationActions>
           </React.Fragment>
         )}
       </NotificationBanner>
     );
   }
-
-  private handleOpenDownloadLink = () => {
-    this.props.openExternalLink(links.download);
-  };
-
-  private handleOpenBuyMoreLink = () => {
-    this.props.openExternalLink(links.purchase);
-  };
 }

--- a/gui/src/renderer/containers/AccountPage.tsx
+++ b/gui/src/renderer/containers/AccountPage.tsx
@@ -5,16 +5,16 @@ import { bindActionCreators } from 'redux';
 import { links } from '../../config.json';
 import Account from '../components/Account';
 
+import withAppContext, { IAppContext } from '../context';
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
-const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => ({
+const mapStateToProps = (state: IReduxState) => ({
   accountToken: state.account.accountToken,
   accountExpiry: state.account.expiry,
   expiryLocale: state.userInterface.locale,
   isOffline: state.connection.isBlocked,
 });
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ goBack }, dispatch);
   return {
     onLogout: () => {
@@ -27,7 +27,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Account);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(Account),
+);

--- a/gui/src/renderer/containers/AdvancedSettingsPage.tsx
+++ b/gui/src/renderer/containers/AdvancedSettingsPage.tsx
@@ -6,9 +6,9 @@ import { BridgeState, RelayProtocol, TunnelProtocol } from '../../shared/daemon-
 import RelaySettingsBuilder from '../../shared/relay-settings-builder';
 import AdvancedSettings from '../components/AdvancedSettings';
 
+import withAppContext, { IAppContext } from '../context';
 import { RelaySettingsRedux } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: IReduxState) => {
   const protocolAndPort = mapRelaySettingsToProtocolAndPort(state.settings.relaySettings);
@@ -51,7 +51,7 @@ const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) =>
   }
 };
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ push, goBack }, dispatch);
   return {
     onClose: () => {
@@ -150,7 +150,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(AdvancedSettings);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(AdvancedSettings),
+);

--- a/gui/src/renderer/containers/ConnectPage.tsx
+++ b/gui/src/renderer/containers/ConnectPage.tsx
@@ -6,10 +6,10 @@ import { bindActionCreators } from 'redux';
 import { sprintf } from 'sprintf-js';
 import { messages } from '../../shared/gettext';
 import Connect from '../components/Connect';
+import withAppContext, { IAppContext } from '../context';
 import AccountExpiry from '../lib/account-expiry';
 import { IRelayLocationRedux, RelaySettingsRedux } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
 function getRelayName(
   relaySettings: RelaySettingsRedux,
@@ -64,7 +64,7 @@ function getRelayName(
   }
 }
 
-const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => {
+const mapStateToProps = (state: IReduxState) => {
   return {
     accountExpiry: state.account.expiry
       ? new AccountExpiry(state.account.expiry, state.userInterface.locale)
@@ -76,7 +76,7 @@ const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => {
   };
 };
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ push }, dispatch);
 
   return {
@@ -104,7 +104,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Connect);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(Connect),
+);

--- a/gui/src/renderer/containers/LaunchPage.tsx
+++ b/gui/src/renderer/containers/LaunchPage.tsx
@@ -2,15 +2,13 @@ import { push } from 'connected-react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Launch from '../components/Launch';
-
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (_state: IReduxState) => ({});
-const mapDispatchToProps = (dispatch: ReduxDispatch, _props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch) => {
   const history = bindActionCreators({ push }, dispatch);
   return {
-    openSettings: () => {
+    openSettings() {
       history.push('/settings');
     },
   };

--- a/gui/src/renderer/containers/LoginPage.tsx
+++ b/gui/src/renderer/containers/LoginPage.tsx
@@ -3,10 +3,9 @@ import { shell } from 'electron';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Login from '../components/Login';
+import withAppContext, { IAppContext } from '../context';
 import accountActions from '../redux/account/actions';
-
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: IReduxState) => {
   const { accountToken, accountHistory, error, status } = state.account;
@@ -17,7 +16,7 @@ const mapStateToProps = (state: IReduxState) => {
     loginState: status,
   };
 };
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ push }, dispatch);
   const { resetLoginError, updateAccountToken } = bindActionCreators(accountActions, dispatch);
   return {
@@ -36,7 +35,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Login);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(Login),
+);

--- a/gui/src/renderer/containers/NotificationAreaContainer.tsx
+++ b/gui/src/renderer/containers/NotificationAreaContainer.tsx
@@ -1,12 +1,13 @@
-import { shell } from 'electron';
 import { connect } from 'react-redux';
-import NotificationArea from '../components/NotificationArea';
-import { links } from '../../config.json';
-import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
-import AccountExpiry from '../lib/account-expiry';
 
-const mapStateToProps = (state: IReduxState) => ({
+import { shell } from 'electron';
+import { links } from '../../config.json';
+import NotificationArea from '../components/NotificationArea';
+import withAppContext, { IAppContext } from '../context';
+import AccountExpiry from '../lib/account-expiry';
+import { IReduxState, ReduxDispatch } from '../redux/store';
+
+const mapStateToProps = (state: IReduxState, _props: IAppContext) => ({
   accountExpiry: state.account.expiry
     ? new AccountExpiry(state.account.expiry, state.userInterface.locale)
     : undefined,
@@ -15,7 +16,7 @@ const mapStateToProps = (state: IReduxState) => ({
   blockWhenDisconnected: state.settings.blockWhenDisconnected,
 });
 
-const mapDispatchToProps = (_dispatch: ReduxDispatch, _props: ISharedRouteProps) => {
+const mapDispatchToProps = (_dispatch: ReduxDispatch, _props: IAppContext) => {
   return {
     onOpenDownloadLink() {
       shell.openExternal(links.download);
@@ -26,7 +27,9 @@ const mapDispatchToProps = (_dispatch: ReduxDispatch, _props: ISharedRouteProps)
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(NotificationArea);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(NotificationArea),
+);

--- a/gui/src/renderer/containers/NotificationAreaContainer.tsx
+++ b/gui/src/renderer/containers/NotificationAreaContainer.tsx
@@ -1,0 +1,32 @@
+import { shell } from 'electron';
+import { connect } from 'react-redux';
+import NotificationArea from '../components/NotificationArea';
+import { links } from '../../config.json';
+import { IReduxState, ReduxDispatch } from '../redux/store';
+import { ISharedRouteProps } from '../routes';
+import AccountExpiry from '../lib/account-expiry';
+
+const mapStateToProps = (state: IReduxState) => ({
+  accountExpiry: state.account.expiry
+    ? new AccountExpiry(state.account.expiry, state.userInterface.locale)
+    : undefined,
+  tunnelState: state.connection.status,
+  version: state.version,
+  blockWhenDisconnected: state.settings.blockWhenDisconnected,
+});
+
+const mapDispatchToProps = (_dispatch: ReduxDispatch, _props: ISharedRouteProps) => {
+  return {
+    onOpenDownloadLink() {
+      shell.openExternal(links.download);
+    },
+    onOpenBuyMoreLink() {
+      shell.openExternal(links.purchase);
+    },
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(NotificationArea);

--- a/gui/src/renderer/containers/PreferencesPage.tsx
+++ b/gui/src/renderer/containers/PreferencesPage.tsx
@@ -3,9 +3,8 @@ import log from 'electron-log';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Preferences from '../components/Preferences';
-
+import withAppContext, { IAppContext } from '../context';
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: IReduxState) => ({
   autoStart: state.settings.autoStart,
@@ -16,7 +15,7 @@ const mapStateToProps = (state: IReduxState) => ({
   startMinimized: state.settings.guiSettings.startMinimized,
 });
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ goBack }, dispatch);
   return {
     onClose: () => {
@@ -49,7 +48,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Preferences);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(Preferences),
+);

--- a/gui/src/renderer/containers/SelectLanguagePage.tsx
+++ b/gui/src/renderer/containers/SelectLanguagePage.tsx
@@ -2,15 +2,14 @@ import { goBack } from 'connected-react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import SelectLanguage from '../components/SelectLanguage';
-
+import withAppContext, { IAppContext } from '../context';
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: IReduxState) => ({
   preferredLocale: state.settings.guiSettings.preferredLocale,
 });
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ goBack }, dispatch);
 
   return {
@@ -25,7 +24,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SelectLanguage);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(SelectLanguage),
+);

--- a/gui/src/renderer/containers/SelectLocationPage.tsx
+++ b/gui/src/renderer/containers/SelectLocationPage.tsx
@@ -6,10 +6,10 @@ import BridgeSettingsBuilder from '../../shared/bridge-settings-builder';
 import { LiftedConstraint, RelayLocation } from '../../shared/daemon-rpc-types';
 import RelaySettingsBuilder from '../../shared/relay-settings-builder';
 import SelectLocation from '../components/SelectLocation';
+import withAppContext, { IAppContext } from '../context';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 import userInterfaceActions from '../redux/userinterface/actions';
 import { LocationScope } from '../redux/userinterface/reducers';
-import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: IReduxState) => {
   let selectedExitLocation: RelayLocation | undefined;
@@ -40,7 +40,7 @@ const mapStateToProps = (state: IReduxState) => {
     allowBridgeSelection,
   };
 };
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ goBack }, dispatch);
   const userInterface = bindActionCreators(userInterfaceActions, dispatch);
 
@@ -89,7 +89,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SelectLocation);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(SelectLocation),
+);

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -3,11 +3,9 @@ import { remote, shell } from 'electron';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Settings from '../components/Settings';
-
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
-const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => ({
+const mapStateToProps = (state: IReduxState) => ({
   preferredLocaleDisplayName: state.userInterface.preferredLocaleName,
   loginState: state.account.status,
   accountExpiry: state.account.expiry,
@@ -17,7 +15,7 @@ const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => ({
   upToDateVersion: !state.version.currentIsOutdated,
   isOffline: state.connection.isBlocked,
 });
-const mapDispatchToProps = (dispatch: ReduxDispatch, _props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch) => {
   const history = bindActionCreators({ push, goBack }, dispatch);
   return {
     onQuit: () => remote.app.quit(),

--- a/gui/src/renderer/containers/SupportPage.tsx
+++ b/gui/src/renderer/containers/SupportPage.tsx
@@ -4,10 +4,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Support from '../components/Support';
 import { collectProblemReport, sendProblemReport } from '../lib/problem-report';
-
 import { IReduxState, ReduxDispatch } from '../redux/store';
 import supportActions from '../redux/support/actions';
-import { ISharedRouteProps } from '../routes';
 
 const mapStateToProps = (state: IReduxState) => ({
   defaultEmail: state.support.email,
@@ -16,15 +14,17 @@ const mapStateToProps = (state: IReduxState) => ({
   isOffline: state.connection.isBlocked,
 });
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, _props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch) => {
   const { saveReportForm, clearReportForm } = bindActionCreators(supportActions, dispatch);
   const history = bindActionCreators({ goBack }, dispatch);
 
   return {
-    onClose: () => {
+    onClose() {
       history.goBack();
     },
-    viewLog: (path: string) => shell.openItem(path),
+    viewLog(path: string) {
+      shell.openItem(path);
+    },
     saveReportForm,
     clearReportForm,
     collectProblemReport,

--- a/gui/src/renderer/containers/WireguardKeysPage.tsx
+++ b/gui/src/renderer/containers/WireguardKeysPage.tsx
@@ -4,16 +4,16 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { links } from '../../config.json';
 import WireguardKeys from '../components/WireguardKeys';
+import withAppContext, { IAppContext } from '../context';
 import { IWgKey } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import { ISharedRouteProps } from '../routes';
 
-const mapStateToProps = (state: IReduxState, _props: ISharedRouteProps) => ({
+const mapStateToProps = (state: IReduxState) => ({
   keyState: state.settings.wireguardKeyState,
   isOffline: state.connection.isBlocked,
   locale: state.userInterface.locale,
 });
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ push, goBack }, dispatch);
   return {
     onClose: () => history.goBack(),
@@ -24,7 +24,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: ISharedRouteProps) =
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(WireguardKeys);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(WireguardKeys),
+);

--- a/gui/src/renderer/context.tsx
+++ b/gui/src/renderer/context.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import App from './app';
+
+export interface IAppContext {
+  app: App;
+}
+
+export const AppContext = React.createContext<IAppContext | undefined>(undefined);
+if (process.env.NODE_ENV === 'development') {
+  AppContext.displayName = 'AppContext';
+}
+
+export default function withAppContext<Props>(BaseComponent: React.ComponentClass<Props>) {
+  // Exclude the IAppContext from props since those are injected props
+  const wrappedComponent = (props: Omit<Props, keyof IAppContext>) => {
+    return (
+      <AppContext.Consumer>
+        {(context) => {
+          if (context) {
+            // Enforce type because Typescript does not recognize that
+            // (Props ~ IAppContext & IAppContext) is identical to Props.
+            const mergedProps = ({ ...props, ...context } as unknown) as Props;
+
+            return <BaseComponent {...mergedProps} />;
+          } else {
+            throw new Error(
+              'The context value is empty. Make sure to wrap the component in AppContext.Provider.',
+            );
+          }
+        }}
+      </AppContext.Consumer>
+    );
+  };
+
+  if (process.env.NODE_ENV === 'development') {
+    wrappedComponent.displayName =
+      'withAppContext(' + (BaseComponent.displayName || BaseComponent.name) + ')';
+  }
+
+  return wrappedComponent;
+}

--- a/gui/src/renderer/routes.tsx
+++ b/gui/src/renderer/routes.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Route, RouteComponentProps, RouteProps, Switch, withRouter } from 'react-router';
-import App from './app';
+import { Route, RouteComponentProps, Switch, withRouter } from 'react-router';
 import TransitionContainer, { TransitionView } from './components/TransitionContainer';
 import AccountPage from './containers/AccountPage';
 import AdvancedSettingsPage from './containers/AdvancedSettingsPage';
@@ -16,27 +15,15 @@ import SupportPage from './containers/SupportPage';
 import WireguardKeysPage from './containers/WireguardKeysPage';
 import { getTransitionProps } from './transitions';
 
-export interface ISharedRouteProps {
-  app: App;
-}
-
-type CustomRouteProps = {
-  component: React.ComponentClass<ISharedRouteProps>;
-} & RouteProps;
-
-interface IAppRoutesProps extends RouteComponentProps {
-  sharedProps: ISharedRouteProps;
-}
-
 interface IAppRoutesState {
-  previousLocation?: IAppRoutesProps['location'];
-  currentLocation: IAppRoutesProps['location'];
+  previousLocation?: RouteComponentProps['location'];
+  currentLocation: RouteComponentProps['location'];
 }
 
-class AppRoutes extends React.Component<IAppRoutesProps, IAppRoutesState> {
+class AppRoutes extends React.Component<RouteComponentProps, IAppRoutesState> {
   private unobserveHistory?: () => void;
 
-  constructor(props: IAppRoutesProps) {
+  constructor(props: RouteComponentProps) {
     super(props);
 
     this.state = {
@@ -68,37 +55,26 @@ class AppRoutes extends React.Component<IAppRoutesProps, IAppRoutesState> {
       location.pathname,
     );
 
-    // Renders a route extended with shared props
-    const CustomRoute = ({ component: ComponentClass, ...routeProps }: CustomRouteProps) => {
-      const renderOverride = () => <ComponentClass {...this.props.sharedProps} />;
-
-      return <Route {...routeProps} render={renderOverride} />;
-    };
-
     return (
       <PlatformWindowContainer>
         <TransitionContainer {...transitionProps}>
           <TransitionView viewId={location.key || ''}>
             <Switch key={location.key} location={location}>
-              <CustomRoute exact={true} path="/" component={LaunchPage} />
-              <CustomRoute exact={true} path="/login" component={LoginPage} />
-              <CustomRoute exact={true} path="/connect" component={ConnectPage} />
-              <CustomRoute exact={true} path="/settings" component={SettingsPage} />
-              <CustomRoute exact={true} path="/settings/language" component={SelectLanguagePage} />
-              <CustomRoute exact={true} path="/settings/account" component={AccountPage} />
-              <CustomRoute exact={true} path="/settings/preferences" component={PreferencesPage} />
-              <CustomRoute
-                exact={true}
-                path="/settings/advanced"
-                component={AdvancedSettingsPage}
-              />
-              <CustomRoute
+              <Route exact={true} path="/" component={LaunchPage} />
+              <Route exact={true} path="/login" component={LoginPage} />
+              <Route exact={true} path="/connect" component={ConnectPage} />
+              <Route exact={true} path="/settings" component={SettingsPage} />
+              <Route exact={true} path="/settings/language" component={SelectLanguagePage} />
+              <Route exact={true} path="/settings/account" component={AccountPage} />
+              <Route exact={true} path="/settings/preferences" component={PreferencesPage} />
+              <Route exact={true} path="/settings/advanced" component={AdvancedSettingsPage} />
+              <Route
                 exact={true}
                 path="/settings/advanced/wireguard-keys"
                 component={WireguardKeysPage}
               />
-              <CustomRoute exact={true} path="/settings/support" component={SupportPage} />
-              <CustomRoute exact={true} path="/select-location" component={SelectLocationPage} />
+              <Route exact={true} path="/settings/support" component={SupportPage} />
+              <Route exact={true} path="/select-location" component={SelectLocationPage} />
             </Switch>
           </TransitionView>
         </TransitionContainer>


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

So as you know all containers use `connect()` from `react-redux` in order to subscribe to the redux store. This drives the render cycle of all of our top level react components as changes settle in the redux store.

All this time we used to pass the reference to the `AppRenderer` using the `CustomRoute` (`routes.ts`) which basically appended an extra prop called `app` which we later received in `mapStateToProps` and such.

This worked very well until I've added a container for `NotificationArea` which is rendered inside of the `Connect` view and is not a direct descendant of the `CustomRoute`, hence there is no parent that can share an `app` with it which we'll eventually need given that @pinkisemils is working on integrating WWW auth tokens which involves talking to the RPC and so on.

The idea behind is that since the complexity grows, we'd like more and more parts of the app to be self-contained and talk to the redux store and `app` directly. And then at the higher level we would only compose other components together, for example instead of having a 1000 LOC long view that handles 10 props we would have a 5 liner that would put together different sub-components that on their own talk to the store and update their presentation, i.e:

```tsx
function MainView() {
return <View>
  <NotificationArea />
  <Map />
  <TunnelControls />
</View>
}
```

Notice no `props` in this example because `NotificatonArea` and `TunnelControls` and even the `Map` could potentially implement the props mapping themselves and even perform some actions without the parent view acting as a delegate.

Apart from the benefits of having less `props` being passed from parent to child, the other benefit is that individual components will be able to re-render without the whole sub-tree update because the parent components will have very little data flowing through them.

So this PR achieves the following:

1. Wraps the `react-redux` `Provider` into `AppContext.Provider` which propagates the instance of the `AppRenderer`
1. Adds a `withAppContext ` helper to pass the `AppContext` value through to the connected component (`connect()`). All in all it's the same principle we had with `CustomRoute` except that now it expands to the entire variety of containers and not only `Route`s.

ps: the original idea was to call `connect()` behind the scenes inside of `withAppContext` but it turned out to be really difficult to implement because `connect()` is heavily generic with a dozen variations of provided parameters and type-wise, it's just madness to type the `withAppContext`, so it was easier to just chain two calls together and TypeScript infers the rest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1171)
<!-- Reviewable:end -->
