### PR TITLE
Ignore error while installing rustfmt-preview

### DIFF
--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -24,9 +24,12 @@ if [ "${RUST_TOOLCHAIN_CHANNEL}" != "nightly" ]; then
 fi
 
 if [ "${RUST_TOOLCHAIN_CHANNEL}" = "nightly" ]; then
-  rustup component add rustfmt-preview;
-  rustfmt --version;
-  cargo fmt -- --check --unstable-features;
+  if rustup component add rustfmt-preview; then
+    rustfmt --version;
+    cargo fmt -- --check --unstable-features;
+  else
+    echo "There seems to not be any rustfmt for the current nighly. Skipping formatting check!"
+  fi
 fi
 
 if ! git diff-index --quiet HEAD; then


### PR DESCRIPTION
It is very annoying having the CI error out just because there is no `rustfmt-preview` available for nighly Rust. When this happens and we can't check formatting, is it better the CI becomes green so we know everything else worked? Or do we want it to keep failing, forcing us to open up the CI logs and check that the fail actually was just the formatting, or something else?

This seems a bit more sane to me. Keeping the CI alive and giving us usable results even when things we can't affect goes up and down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1173)
<!-- Reviewable:end -->
