### PR TITLE
Windows: Detect network disconnects quicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - More adjustments in online/offline detection logic.
+- Be quicker to notice network disconnects.
 
 
 ## [2019.8] - 2019-09-23

--- a/windows/winnet/src/winnet/netmonitor.cpp
+++ b/windows/winnet/src/winnet/netmonitor.cpp
@@ -19,7 +19,14 @@ bool ValidInterfaceType(const MIB_IF_ROW2 &iface)
 		}
 	}
 
-	if (FALSE != iface.InterfaceAndOperStatusFlags.FilterInterface
+	//
+	// (Windows 10, and possibly others.)
+	// The BT adapter is erronously not marked as representing hardware.
+	// By filtering on this we currently do not support BT tethering.
+	//
+
+	if (FALSE == iface.InterfaceAndOperStatusFlags.HardwareInterface
+		|| FALSE != iface.InterfaceAndOperStatusFlags.FilterInterface
 		|| 0 == iface.PhysicalAddressLength
 		|| FALSE != iface.InterfaceAndOperStatusFlags.EndPointInterface)
 	{


### PR DESCRIPTION
This change enables us to detect network disconnects quicker. For some reason the logic did not previously consider the `HardwareInterface` flag. That had the effect that we were waiting for the TAP adapter to disconnect before concluding that all adapters were indeed disconnected. And this could take quite some time, before OpenVPN determines that the tunnel is non-functional and terminates it.

By correcting this we lose support for BT tethering. See comment in code. This can be worked around but not supporting BT may actually be better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1176)
<!-- Reviewable:end -->
