### PR TITLE
Don't log args when a problem report send fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix `mullvad relay update` to trigger a relay list download even if the existing cache is new.
+- Don't include problem-report arguments in error logging. Stops user email from ending up in the
+  log file on error.
 
 #### Android
 - Show WireGuard key age in local timezone instead of UTC.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1006,8 +1006,8 @@ class ApplicationMain {
           if (error) {
             log.error(
               `Failed to collect a problem report.
-             Stdout: ${stdout.toString()}
-             Stderr: ${stderr.toString()}`,
+              Stdout: ${stdout.toString()}
+              Stderr: ${stderr.toString()}`,
             );
 
             event.sender.send('collect-logs-reply', requestId, {
@@ -1041,9 +1041,9 @@ class ApplicationMain {
         execFile(executable, args, { windowsHide: true }, (error, stdout, stderr) => {
           if (error) {
             log.error(
-              `Failed to send a problem report: ${error.message}
-           Stdout: ${stdout.toString()}
-           Stderr: ${stderr.toString()}`,
+              `Failed to send a problem report.
+              Stdout: ${stdout.toString()}
+              Stderr: ${stderr.toString()}`,
             );
 
             event.sender.send('send-problem-report-reply', requestId, {


### PR DESCRIPTION
Don't log the arguments to the problem report binary if it fails to be sent. Protects users from having their email included in the otherwise redacted logfiles.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1179)
<!-- Reviewable:end -->
