### PR TITLE
Add all the stuff generated as geoip metadata to gitiginore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /target/
 /gui/node_modules
 /gui/build
+/gui/scripts/ne_10m_populated_places/
+/gui/scripts/ne_50m_admin_0_countries/
+/gui/scripts/ne_50m_admin_1_states_provinces_lines/
+/gui/scripts/ne_50m_populated_places/
+/gui/scripts/out/
 /dist
 .DS_Store
 *.log


### PR DESCRIPTION
Do you agree it would be nice to get rid of these from `git status`? As soon as one starts working with the geoIP stuff the git status becomes very dirty. As far as I know we don't do and don't want to version them anyway, so they should be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1185)
<!-- Reviewable:end -->
