### PR TITLE
Add --locked to all cargo build invocations

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -70,7 +70,7 @@ for ARCHITECTURE in $ARCHITECTURES; do
 
     echo "Building mullvad-daemon for $TARGET"
     source env.sh "$TARGET"
-    cargo build $CARGO_FLAGS --target "$TARGET" --package mullvad-jni
+    cargo +stable build --locked $CARGO_FLAGS --target "$TARGET" --package mullvad-jni
 
     cp -a "$SCRIPT_DIR/dist-assets/binaries/$TARGET" "$SCRIPT_DIR/android/build/extraJni/$ABI"
     cp "$SCRIPT_DIR/target/$TARGET/$BUILD_TYPE/libmullvad_jni.so" "$SCRIPT_DIR/android/build/extraJni/$ABI/"

--- a/build.sh
+++ b/build.sh
@@ -92,7 +92,7 @@ if [[ "$(uname -s)" == "MINGW"* ]]; then
 fi
 
 echo "Building Rust code in release mode using $RUSTC_VERSION..."
-MULLVAD_ADD_MANIFEST="1" cargo +stable build --release
+MULLVAD_ADD_MANIFEST="1" cargo +stable build --locked --release
 
 ################################################################################
 # Other work to prepare the release.

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -19,8 +19,8 @@ esac
 # FIXME: Becaues of our old jsonrpc dependency our Rust code won't build
 # on latest nightly.
 if [ "${RUST_TOOLCHAIN_CHANNEL}" != "nightly" ]; then
-  cargo build --verbose
-  cargo test --verbose
+  cargo build --locked --verbose
+  cargo test --locked --verbose
 fi
 
 if [ "${RUST_TOOLCHAIN_CHANNEL}" = "nightly" ]; then

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -28,7 +28,7 @@ echo "Updating version in metadata files..."
 
 echo "Syncing Cargo.lock with new version numbers"
 source env.sh ""
-cargo +stable build
+cargo +stable --locked build
 
 echo "Commiting metadata changes to git..."
 git commit -S -m "Updating version in package files" \


### PR DESCRIPTION
Inspired by #1183 

Making sure distribution builds are built frozen. Meaning the lockfile in the repo has to be up to date. Doing the same in CI. If we change something and we don't commit the corresponding lockfile change to the repo we should fail.

Also adding `+stable` to the `build-apk.sh` script. Since that's what we use in `build.sh`. To better ensure we use the same toolchain.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1190)
<!-- Reviewable:end -->
