### PR TITLE
Fix invalid usage of --locked

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,9 +62,11 @@ if [[ "$BUILD_MODE" == "dev" || $(git describe) != "$PRODUCT_VERSION" ]]; then
 
     echo "Disabling Apple notarization (macOs only) of installer in this dev build"
     NPM_PACK_ARGS+=" --no-apple-notarization"
+    CARGO_ARGS=""
 else
     echo "Removing old Rust build artifacts"
     cargo +stable clean
+    CARGO_ARGS="--locked"
 fi
 
 echo "Building Mullvad VPN $PRODUCT_VERSION"
@@ -92,7 +94,7 @@ if [[ "$(uname -s)" == "MINGW"* ]]; then
 fi
 
 echo "Building Rust code in release mode using $RUSTC_VERSION..."
-MULLVAD_ADD_MANIFEST="1" cargo +stable build --locked --release
+MULLVAD_ADD_MANIFEST="1" cargo +stable build $CARGO_ARGS --release
 
 ################################################################################
 # Other work to prepare the release.


### PR DESCRIPTION
I screwed up back in #1190 
Obviously the lockfile will change, we explicitly inject new versions into the crates upon build.

So we have to limit usage of `--locked` to release build.

Reason for renaming `CARGO_FLAGS` to `CARGO_ARGS` in `build-apk.sh` was that we already had variables named `_ARGS` in `build.sh` so it felt most consistent to use the same. We could of course change all of them the other way if you think `_FLAGS` make more sense. But flags are a subset of possible args, so `_ARGS` is more generic and would allow us to pass non-flag args.

The `cargo +stable clean` that I added is to become equivalent to `build.sh`. On a production build we probably want to build everything from scratch. This won't slow down things in practice since we run `build.sh` before `build-apk.sh` anyway and as such, the first script has already cleaned up for us. But we should not rely on that very implicit fact to always be true.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1191)
<!-- Reviewable:end -->
