### PR TITLE
Rename problem report binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@
 /dist-assets/mullvad.exe
 /dist-assets/mullvad-daemon
 /dist-assets/mullvad-daemon.exe
-/dist-assets/problem-report
-/dist-assets/problem-report.exe
+/dist-assets/mullvad-problem-report
+/dist-assets/mullvad-problem-report.exe
 /dist-assets/libtalpid_openvpn_plugin.dylib
 /dist-assets/libtalpid_openvpn_plugin.so
 /dist-assets/talpid_openvpn_plugin.dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,20 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add ability to submit vouchers from the CLI.
 
+#### Linux
+- Add a symlink for `mullvad-problem-report` directly in `/usr/bin`. So the tool is available.
+
+### Changed
+#### Windows
+- Rename the `problem-report` tool to `mullvad-problem-report`.
+
 ### Fixed
 - Fix Norwegian (Bokmal) language detection.
 - Fix missing localizations when formatting date and time in Norwegian (Bokmal).
 - Use authenticated URL to go to account page from expired account view.
+
+#### macOS
+- Remove `mullvad` and `mullvad-problem-report` symlinks from `/usr/local/bin` on uninstall.
 
 
 ## [2019.9-beta1] - 2019-10-08

--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ to do that before starting the GUI.
 
 ### Supported environment variables
 
-1. `MULLVAD_PATH` - Allows changing the path to the folder with the `problem-report` tool when
-    running in development mode. Defaults to: `<repo>/target/debug/`.
+1. `MULLVAD_PATH` - Allows changing the path to the folder with the `mullvad-problem-report` tool
+    when running in development mode. Defaults to: `<repo>/target/debug/`.
 
 
 ## Building the Android app

--- a/build.sh
+++ b/build.sh
@@ -104,21 +104,21 @@ if [[ ("$(uname -s)" == "Darwin") ]]; then
     binaries=(
         mullvad-daemon
         mullvad
-        problem-report
+        mullvad-problem-report
         libtalpid_openvpn_plugin.dylib
     )
 elif [[ ("$(uname -s)" == "Linux") ]]; then
     binaries=(
         mullvad-daemon
         mullvad
-        problem-report
+        mullvad-problem-report
         libtalpid_openvpn_plugin.so
     )
 elif [[ ("$(uname -s)" == "MINGW"*) ]]; then
     binaries=(
         mullvad-daemon.exe
         mullvad.exe
-        problem-report.exe
+        mullvad-problem-report.exe
         talpid_openvpn_plugin.dll
     )
 fi

--- a/dist-assets/linux/after-install.sh
+++ b/dist-assets/linux/after-install.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
+ln -sf "/opt/Mullvad VPN/resources/mullvad-problem-report" /usr/bin/mullvad-problem-report
+
 if which systemctl &> /dev/null; then
     systemctl enable "/opt/Mullvad VPN/resources/mullvad-daemon.service"
     systemctl start mullvad-daemon.service

--- a/dist-assets/linux/before-remove.sh
+++ b/dist-assets/linux/before-remove.sh
@@ -9,6 +9,8 @@ if [[ "$1" =~ $is_number_re ]] && [ $1 -gt 0 ]; then
     exit 0;
 fi
 
+rm -f /usr/bin/mullvad-problem-report
+
 if which systemctl &> /dev/null; then
     # the user might've disabled or stopped the service themselves already
     systemctl stop mullvad-daemon.service || true

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -56,4 +56,4 @@ launchctl load -w $DAEMON_PLIST_PATH
 
 mkdir -p /usr/local/bin
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad" /usr/local/bin/mullvad
-ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/problem-report" /usr/local/bin/mullvad-problem-report
+ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-problem-report" /usr/local/bin/mullvad-problem-report

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -22,6 +22,9 @@ echo "Removing app from /Applications ..."
 sudo rm -rf /Applications/Mullvad\ VPN.app
 sudo pkgutil --forget net.mullvad.vpn || true
 
+echo "Removing CLI symlinks from /usr/local/bin/ ..."
+sudo rm -f /usr/local/bin/mullvad /usr/local/bin/mullvad-problem-report
+
 read -p "Do you want to delete the log and cache files the app has created? (y/n) "
 if [[ "$REPLY" =~ [Yy]$ ]]; then
     sudo rm -rf /var/log/mullvad-vpn /var/root/Library/Caches/mullvad-vpn

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -996,7 +996,7 @@ class ApplicationMain {
       'collect-logs',
       (event: Electron.IpcMainEvent, requestId: string, toRedact: string[]) => {
         const reportPath = path.join(app.getPath('temp'), uuid.v4() + '.log');
-        const executable = resolveBin('problem-report');
+        const executable = resolveBin('mullvad-problem-report');
         const args = ['collect', '--output', reportPath];
         if (toRedact.length > 0) {
           args.push('--redact', ...toRedact);
@@ -1035,7 +1035,7 @@ class ApplicationMain {
         message: string,
         savedReport: string,
       ) => {
-        const executable = resolveBin('problem-report');
+        const executable = resolveBin('mullvad-problem-report');
         const args = ['send', '--email', email, '--message', message, '--report', savedReport];
 
         execFile(executable, args, { windowsHide: true }, (error, stdout, stderr) => {

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -46,7 +46,7 @@ const config = {
     },
     extraResources: [
       { from: distAssets('mullvad'), to: '.' },
-      { from: distAssets('problem-report'), to: '.' },
+      { from: distAssets('mullvad-problem-report'), to: '.' },
       { from: distAssets('mullvad-daemon'), to: '.' },
       { from: distAssets('libtalpid_openvpn_plugin.dylib'), to: '.' },
       { from: distAssets('binaries/x86_64-apple-darwin/openvpn'), to: '.' },
@@ -84,7 +84,7 @@ const config = {
     signDlls: true,
     extraResources: [
       { from: distAssets('mullvad.exe'), to: '.' },
-      { from: distAssets('problem-report.exe'), to: '.' },
+      { from: distAssets('mullvad-problem-report.exe'), to: '.' },
       { from: distAssets('mullvad-daemon.exe'), to: '.' },
       { from: distAssets('talpid_openvpn_plugin.dll'), to: '.' },
       { from: root('windows/winfw/bin/x64-Release/winfw.dll'), to: '.' },
@@ -102,7 +102,7 @@ const config = {
     category: 'Network',
     extraFiles: [{ from: distAssets('linux/mullvad-gui-launcher.sh'), to: '.' }],
     extraResources: [
-      { from: distAssets('problem-report'), to: '.' },
+      { from: distAssets('mullvad-problem-report'), to: '.' },
       { from: distAssets('mullvad-daemon'), to: '.' },
       { from: distAssets('libtalpid_openvpn_plugin.so'), to: '.' },
       { from: distAssets('binaries/x86_64-unknown-linux-gnu/openvpn'), to: '.' },

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -13,10 +13,6 @@ description = "Collect Mullvad VPN logs into a report and send it to support"
 license = "GPL-3.0"
 edition = "2018"
 
-[[bin]]
-name = "problem-report"
-path = "src/main.rs"
-
 [dependencies]
 clap = "2.25"
 dirs = "2.0"
@@ -50,4 +46,4 @@ ProductName = "Mullvad VPN"
 CompanyName = "Amagicom AB"
 LegalCopyright = "(c) 2018 Amagicom AB"
 InternalName = "mullvad-problem-report"
-OriginalFilename = "problem-report.exe"
+OriginalFilename = "mullvad-problem-report.exe"

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -8,7 +8,7 @@
 
 #![deny(rust_2018_idioms)]
 
-use clap::crate_authors;
+use clap::{crate_authors, crate_name};
 use mullvad_problem_report::{collect_report, metadata, send_problem_report, Error};
 use std::{env, path::Path, process};
 use talpid_types::ErrorExt;
@@ -26,7 +26,7 @@ fn main() {
 
 fn run() -> Result<(), Error> {
     env_logger::init();
-    let app = clap::App::new("problem-report")
+    let app = clap::App::new(crate_name!())
         .version(metadata::PRODUCT_VERSION)
         .author(crate_authors!())
         .about("Mullvad VPN problem report tool. Collects logs and sends them to Mullvad support.")


### PR DESCRIPTION
Thanks to #1160 we now finally have the CLI tools on the PATH. Meaning they are easy to find for users. Downside is that the problem report tool is named just `problem-report`. A very generic name that can't be connected to us.

Also, on Linux we still did not have the problem report tool in the PATH, still making it hard to find there as well.

This PR goes ahead and renames the problem report tool so it's always and everywhere called `mullvad-problem-report`. Then it makes sure it's going to be available under exactly that name on the terminal for all OSes where this was not already true.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1192)
<!-- Reviewable:end -->
