### PR TITLE
Less duplicated translations

### DIFF
--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -31,7 +31,7 @@ export default class Account extends Component<IProps> {
               <NavigationItems>
                 <BackBarItem action={this.props.onClose}>
                   {// TRANSLATORS: Back button in navigation bar
-                  messages.pgettext('account-nav', 'Settings')}
+                  messages.pgettext('navigation-bar', 'Settings')}
                 </BackBarItem>
               </NavigationItems>
             </NavigationBar>

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -166,7 +166,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                 <NavigationItems>
                   <BackBarItem action={this.props.onClose}>
                     {// TRANSLATORS: Back button in navigation bar
-                    messages.pgettext('advanced-settings-nav', 'Settings')}
+                    messages.pgettext('navigation-bar', 'Settings')}
                   </BackBarItem>
                   <TitleBarItem>
                     {// TRANSLATORS: Title label in navigation bar

--- a/gui/src/renderer/components/ErrorBoundary.tsx
+++ b/gui/src/renderer/components/ErrorBoundary.tsx
@@ -78,7 +78,7 @@ export default class ErrorBoundary extends Component<IProps, IState> {
               <View style={styles.container}>
                 <ImageView height={120} width={120} source="logo-icon" style={styles.logo} />
                 <Text style={styles.title}>
-                  {messages.pgettext('error-boundary-view', 'MULLVAD VPN')}
+                  {messages.pgettext('generic', 'MULLVAD VPN')}
                 </Text>
                 <Text style={styles.subtitle}>{reachBackMessage}</Text>
               </View>

--- a/gui/src/renderer/components/ErrorBoundary.tsx
+++ b/gui/src/renderer/components/ErrorBoundary.tsx
@@ -77,9 +77,7 @@ export default class ErrorBoundary extends Component<IProps, IState> {
             <Container>
               <View style={styles.container}>
                 <ImageView height={120} width={120} source="logo-icon" style={styles.logo} />
-                <Text style={styles.title}>
-                  {messages.pgettext('generic', 'MULLVAD VPN')}
-                </Text>
+                <Text style={styles.title}>{messages.pgettext('generic', 'MULLVAD VPN')}</Text>
                 <Text style={styles.subtitle}>{reachBackMessage}</Text>
               </View>
             </Container>

--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -94,7 +94,7 @@ export class Brand extends Component {
     return (
       <View style={brandStyles.container}>
         <ImageView width={50} height={50} source="logo-icon" />
-        <Text style={brandStyles.title}>{messages.pgettext('headerbar', 'MULLVAD VPN')}</Text>
+        <Text style={brandStyles.title}>{messages.pgettext('generic', 'MULLVAD VPN')}</Text>
       </View>
     );
   }

--- a/gui/src/renderer/components/Launch.tsx
+++ b/gui/src/renderer/components/Launch.tsx
@@ -48,7 +48,7 @@ export default class Launch extends Component<IProps> {
         <Container>
           <View style={styles.container}>
             <ImageView height={120} width={120} source="logo-icon" style={styles.logo} />
-            <Text style={styles.title}>{messages.pgettext('launch-view', 'MULLVAD VPN')}</Text>
+            <Text style={styles.title}>{messages.pgettext('generic', 'MULLVAD VPN')}</Text>
             <Text style={styles.subtitle}>
               {messages.pgettext('launch-view', 'Connecting to Mullvad system service...')}
             </Text>

--- a/gui/src/renderer/components/Preferences.tsx
+++ b/gui/src/renderer/components/Preferences.tsx
@@ -43,7 +43,7 @@ export default class Preferences extends Component<IProps> {
                 <NavigationItems>
                   <BackBarItem action={this.props.onClose}>
                     {// TRANSLATORS: Back button in navigation bar
-                    messages.pgettext('preferences-nav', 'Settings')}
+                    messages.pgettext('navigation-bar', 'Settings')}
                   </BackBarItem>
                   <TitleBarItem>
                     {// TRANSLATORS: Title label in navigation bar

--- a/gui/src/renderer/components/SelectLanguage.tsx
+++ b/gui/src/renderer/components/SelectLanguage.tsx
@@ -72,7 +72,7 @@ export default class SelectLanguage extends Component<IProps, IState> {
                 <NavigationItems>
                   <BackBarItem action={this.props.onClose}>
                     {// TRANSLATORS: Back button in navigation bar
-                    messages.pgettext('select-language-nav', 'Settings')}
+                    messages.pgettext('navigation-bar', 'Settings')}
                   </BackBarItem>
                   <TitleBarItem>
                     {// TRANSLATORS: Title label in navigation bar

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -52,7 +52,7 @@ export default class Settings extends Component<IProps> {
                   <CloseBarItem action={this.props.onClose} />
                   <TitleBarItem>
                     {// TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('settings-view-nav', 'Settings')}
+                    messages.pgettext('navigation-bar', 'Settings')}
                   </TitleBarItem>
                 </NavigationItems>
               </NavigationBar>
@@ -62,7 +62,7 @@ export default class Settings extends Component<IProps> {
                   <View style={styles.content}>
                     {showLargeTitle && (
                       <SettingsHeader>
-                        <HeaderTitle>{messages.pgettext('settings-view', 'Settings')}</HeaderTitle>
+                        <HeaderTitle>{messages.pgettext('navigation-bar', 'Settings')}</HeaderTitle>
                       </SettingsHeader>
                     )}
                     <View>

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -112,7 +112,10 @@ export default class Settings extends Component<IProps> {
       <View>
         <View>
           <Cell.CellButton onPress={this.props.onViewAccount}>
-            <Cell.Label>{messages.pgettext('settings-view', 'Account')}</Cell.Label>
+            <Cell.Label>
+              {// TRANSLATORS: Navigation button to the 'Account' view
+              messages.pgettext('settings-view', 'Account')}
+            </Cell.Label>
             <Cell.SubText style={isOutOfTime ? styles.accountPaidUntilErrorLabel : undefined}>
               {isOutOfTime ? outOfTimeMessage : formattedExpiry}
             </Cell.SubText>
@@ -121,12 +124,18 @@ export default class Settings extends Component<IProps> {
         </View>
 
         <Cell.CellButton onPress={this.props.onViewPreferences}>
-          <Cell.Label>{messages.pgettext('settings-view', 'Preferences')}</Cell.Label>
+          <Cell.Label>
+            {// TRANSLATORS: Navigation button to the 'Preferences' view
+            messages.pgettext('settings-view', 'Preferences')}
+          </Cell.Label>
           <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
 
         <Cell.CellButton onPress={this.props.onViewAdvancedSettings}>
-          <Cell.Label>{messages.pgettext('settings-view', 'Advanced')}</Cell.Label>
+          <Cell.Label>
+            {// TRANSLATORS: Navigation button to the 'Advanced' settings view
+            messages.pgettext('settings-view', 'Advanced')}
+          </Cell.Label>
           <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
         <View style={styles.cellSpacer} />
@@ -179,18 +188,27 @@ export default class Settings extends Component<IProps> {
     return (
       <View>
         <Cell.CellButton onPress={this.props.onViewSupport}>
-          <Cell.Label>{messages.pgettext('settings-view', 'Report a problem')}</Cell.Label>
+          <Cell.Label>
+            {// TRANSLATORS: Navigation button to the 'Report a problem' help view
+            messages.pgettext('settings-view', 'Report a problem')}
+          </Cell.Label>
           <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
 
         <Cell.CellButton disabled={this.props.isOffline} onPress={this.openFaqLink}>
-          <Cell.Label>{messages.pgettext('settings-view', 'FAQs & Guides')}</Cell.Label>
+          <Cell.Label>
+            {// TRANSLATORS: Link to the webpage
+            messages.pgettext('settings-view', 'FAQs & Guides')}
+          </Cell.Label>
           <Cell.Icon height={16} width={16} source="icon-extLink" />
         </Cell.CellButton>
 
         <Cell.CellButton onPress={this.props.onViewSelectLanguage}>
           <Cell.UntintedIcon width={24} height={24} source="icon-language" />
-          <Cell.Label>{messages.pgettext('settings-view', 'Language')}</Cell.Label>
+          <Cell.Label>
+            {// TRANSLATORS: Navigation button to the 'Language' settings view
+            messages.pgettext('settings-view', 'Language')}
+          </Cell.Label>
           <Cell.SubText>{this.props.preferredLocaleDisplayName}</Cell.SubText>
           <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -142,7 +142,7 @@ export default class Support extends Component<ISupportProps, ISupportState> {
                   <NavigationItems>
                     <BackBarItem action={this.props.onClose}>
                       {// TRANSLATORS: Back button in navigation bar
-                      messages.pgettext('support-nav', 'Settings')}
+                      messages.pgettext('navigation-bar', 'Settings')}
                     </BackBarItem>
                   </NavigationItems>
                 </NavigationBar>


### PR DESCRIPTION
PR on what I brought up on Slack a while back. Reducing translating the same string multiple times when there is virtually zero chance any language would actually want them to be different in different places, because the context is the same in all locations.

All `'Settings'` strings are moved to the new `'navigation-bar'` context. There is one instance of this string per page that can navigate back to the settings view, plus the header on the actual settings view (when you are logged out)

All `'MULLVAD VPN'` strings are moved to the new `'generic'` context. This is the name of our product, and I doubt it should be translated at all actually. I could not find any of our existing languages actually changing it to anything else currently. So maybe we could move it out of gettext altogether? Not sure, to at least keep it translated I at least moved all three instances to the same gettext context.

Added some translator help comments.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1194)
<!-- Reviewable:end -->
