### PR TITLE
Fix gettext integration

### DIFF
--- a/gui/scripts/extract-geo-data.py
+++ b/gui/scripts/extract-geo-data.py
@@ -153,7 +153,7 @@ def extract_countries_po():
 
     if os.path.isdir(locale_dir):
       with fiona.open(input_path) as source:
-        po = POFile(encoding='UTF-8')
+        po = POFile(encoding='utf-8')
         po.metadata = {"Content-Type": "text/plain; charset=utf-8"}
         output_path = path.join(locale_out_dir, "countries.po")
 
@@ -225,7 +225,7 @@ def extract_cities_po():
     locale_out_dir = path.join(LOCALE_OUT_DIR, locale)
 
     if os.path.isdir(locale_dir):
-      po = POFile(encoding='UTF-8')
+      po = POFile(encoding='utf-8')
       po.metadata = {"Content-Type": "text/plain; charset=utf-8"}
       output_path = path.join(locale_out_dir, "cities.po")
       hits = 0
@@ -291,7 +291,7 @@ def extract_relay_translations():
 
 
 def extract_relay_locations_pot(countries):
-  pot = POFile(encoding='UTF-8')
+  pot = POFile(encoding='utf-8')
   pot.metadata = {"Content-Type": "text/plain; charset=utf-8"}
   output_path = path.join(LOCALE_OUT_DIR, "relay-locations.pot")
 
@@ -356,7 +356,7 @@ def translate_relay_locations_pot(countries):
 
 
 def translate_relay_locations(place_translator, countries, locale):
-  po = POFile(encoding='UTF-8')
+  po = POFile(encoding='utf-8')
   po.metadata = {"Content-Type": "text/plain; charset=utf-8"}
   locale_out_dir = path.join(LOCALE_OUT_DIR, locale)
   output_path = path.join(locale_out_dir, "relay-locations.po")

--- a/gui/scripts/extract-geo-data.py
+++ b/gui/scripts/extract-geo-data.py
@@ -153,7 +153,7 @@ def extract_countries_po():
 
     if os.path.isdir(locale_dir):
       with fiona.open(input_path) as source:
-        po = POFile(encoding='utf-8')
+        po = POFile(encoding='utf-8', check_for_duplicates=True)
         po.metadata = {"Content-Type": "text/plain; charset=utf-8"}
         output_path = path.join(locale_out_dir, "countries.po")
 
@@ -226,7 +226,7 @@ def extract_cities_po():
     locale_out_dir = path.join(LOCALE_OUT_DIR, locale)
 
     if os.path.isdir(locale_dir):
-      po = POFile(encoding='utf-8')
+      po = POFile(encoding='utf-8', check_for_duplicates=True)
       po.metadata = {"Content-Type": "text/plain; charset=utf-8"}
       output_path = path.join(locale_out_dir, "cities.po")
       hits = 0
@@ -259,10 +259,14 @@ def extract_cities_po():
                 )
 
             entry = POEntry(
-              msgid=props["name"],
+              msgid=props.get("name"),
               msgstr=translated_name
             )
-            po.append(entry)
+
+            try:
+              po.append(entry)
+            except ValueError as err:
+              print c.orange(u"Cannot add an entry: {}".format(err))
 
       sort_pofile_entries(po)
       po.save(output_path)
@@ -297,7 +301,7 @@ def extract_relay_translations():
 
 
 def extract_relay_locations_pot(countries):
-  pot = POFile(encoding='utf-8')
+  pot = POFile(encoding='utf-8', check_for_duplicates=True)
   pot.metadata = {"Content-Type": "text/plain; charset=utf-8"}
   output_path = path.join(LOCALE_OUT_DIR, "relay-locations.pot")
 
@@ -362,7 +366,7 @@ def translate_relay_locations_pot(countries):
 
 
 def translate_relay_locations(place_translator, countries, locale):
-  po = POFile(encoding='utf-8')
+  po = POFile(encoding='utf-8', check_for_duplicates=True)
   po.metadata = {"Content-Type": "text/plain; charset=utf-8"}
   locale_out_dir = path.join(LOCALE_OUT_DIR, locale)
   output_path = path.join(locale_out_dir, "relay-locations.po")

--- a/gui/scripts/extract-geo-data.py
+++ b/gui/scripts/extract-geo-data.py
@@ -212,6 +212,7 @@ def extract_countries_po():
             )
             po.append(entry)
 
+        sort_pofile_entries(po)
         po.save(output_path)
         print c.green("Extracted {} countries for {} to {}".format(len(po), locale, output_path))
 
@@ -263,12 +264,17 @@ def extract_cities_po():
             )
             po.append(entry)
 
+      sort_pofile_entries(po)
       po.save(output_path)
       print c.green("Extracted {} cities to {}".format(len(po), output_path))
 
       stats.append((locale, hits, misses))
 
   print_stats_table("Cities translations", stats)
+
+
+def sort_pofile_entries(pofile):
+  pofile.sort(key=lambda o: o.msgid_with_context.encode('utf-8'))
 
 
 def extract_relay_translations():

--- a/gui/scripts/prepare-rtree.ts
+++ b/gui/scripts/prepare-rtree.ts
@@ -1,6 +1,6 @@
 //
 // Script that generates r-trees for geo data.
-// run with `npx babel-node geo-data/prepare-rtree.js`
+// run with `npx ts-node geo-data/prepare-rtree.ts`
 //
 
 import * as fs from 'fs';


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Merge `relay-locations.pot` to make sure we preserve the old locations and include the new ones
1. Sort `countries.po`, `cities.po`, `relay-locations.po`, `relay-locations.pot` output to reduce amount of diffs in git

The generator behaviour for `relay-locations` was change to:

1. Generate `relay-locations.pot` from `relays.json`
1. Auto-translate the produced `relay-locations.pot` and produce `relay-locations.po` for each language
1. Merge the existing `locales/relay-locations.pot` with the generated one `out/locales/relay-locations.pot` using `msgcat`. Which basically puts together two files so that we hvae old relays + new relays to preserve all of the relays we ever witnessed.
1. Merge each `locales/*/relay-locations.po` with the corresponding generated file `out/locales/*/relay-locations.po`. I use `--use-first` flag to make sure that the first translation trumps the generated one. This way we make sure that we never replace the existing translations with the ones that are automatically generated, so that we can preserve the crowdin translations.

### Tests:

#### Test 1:
- Remove Tirana from `tr/relay-locations.po` and run integration script
- Result: added back with automatic translation
#### Test 2:
- Replace `msgstr` for `Tirana` with `RUBBER DUCK` from `tr/relay-locations.po` and run integration script
- Result: original translation was preserved: msgstr still contains `RUBER DUCK`
#### Test 3:
- Replace `msgstr` for Tirana with `""` (empty string) from `tr/relay-locations.po` and run integration script
- Result: automatic translation replaced an empty string
#### Test 4:
- Add custom entry to `tr/relay-locations.po` and run integration script:
    ```
    #. BLAH
    msgid "Blah"
    msgstr "Blah haha"
    ```
- Result: the entry is still there after running a script.

This PR does not ship the updated translations since all of them would be changed/resorted. We can do it in a follow up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1195)
<!-- Reviewable:end -->
