### PR TITLE
Fix: Bump next_update_time correctly every time

### DIFF
--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -146,9 +146,9 @@ impl<F: Fn(&AppVersionInfo) + Send + 'static> Future for VersionUpdater<F> {
                         VersionUpdaterState::Sleeping(Self::create_sleep_future())
                     }
                     Ok(Async::Ready(app_version_info)) => {
+                        log::debug!("Got new version check: {:?}", app_version_info);
+                        self.next_update_time = Instant::now() + UPDATE_INTERVAL;
                         if app_version_info != self.last_app_version_info {
-                            self.next_update_time = Instant::now() + UPDATE_INTERVAL;
-                            log::debug!("Got new version check: {:?}", app_version_info);
                             (self.on_version_update)(&app_version_info);
                             self.last_app_version_info = app_version_info;
                             if let Err(e) = self.write_cache() {


### PR DESCRIPTION
Fixing what I screwed up in #1167 

I only bumped `self.next_update_time` if the newly downloaded `app_version_info` was different from the cached one. Meaning as long as it did not change server side, we did one version check every 5 minutes instead of every 24 hours.

Also making sure we log every time we actually download it. So we can see in logs when it's actually downloaded and not just when we broadcast it to frontends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1196)
<!-- Reviewable:end -->
