### PR TITLE
Windows TAP uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Install the OpenVPN certificate to avoid the TAP adapter driver installation warning on
   Windows 8 and newer.
+- Remove Mullvad TAP adapter on uninstall. Also remove the TAP driver if there are no other TAP adapters in the system.
 
 ### Changed
 #### Windows

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -592,8 +592,6 @@
 #
 !macro RemoveCLIFromEnvironPath
 
-	log::Log "RemoveCLIFromEnvironPath()"
-
 	Push $0
 	Push $1
 
@@ -603,11 +601,9 @@
 	Pop $1
 
 	${If} $0 != ${PE_SUCCESS}
-		log::Log "RemoveCLIFromEnvironPath() failed: $0 $1"
+		MessageBox MB_OK "Error removing app from PATH: $1"
 		Goto RemovePath_return
 	${EndIf}
-
-	log::Log "RemoveCLIFromEnvironPath() completed successfully"
 
 	RemovePath_return:
 
@@ -744,11 +740,9 @@
 
 	Sleep 1000
 
-	SetShellVarContext current
-	${RemoveRelayCache}
+	log::Pin
 
-	# Original removal functionality provided by Electron-builder
-    RMDir /r $INSTDIR
+	${RemoveCLIFromEnvironPath}
 
 	# Check command line arguments
 	${GetParameters} $0
@@ -760,13 +754,17 @@
 		${ExtractDriver}
 		${RemoveTap}
 
+		# Original removal functionality provided by Electron-builder
+		RMDir /r $INSTDIR
+
 		${RemoveLogsAndCache}
 		MessageBox MB_ICONQUESTION|MB_YESNO "Would you like to remove settings files as well?" IDNO customRemoveFiles_after_remove_settings
 		${RemoveSettings}
 		customRemoveFiles_after_remove_settings:
+	${Else}
+		# Original removal functionality provided by Electron-builder
+		RMDir /r $INSTDIR
 	${EndIf}
-
-	${RemoveCLIFromEnvironPath}
 
 	Pop $1
 	Pop $0

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -347,7 +347,7 @@
 		${EndIf}
 	${EndIf}
 
-	registry::WriteString "HKLM\SOFTWARE\Mullvad VPN" "AdapterGuid" "$InstallDriver_TapGuid"
+	registry::WriteString "HKLM\SOFTWARE\Mullvad VPN" "TapAdapterGuid" "$InstallDriver_TapGuid"
 
 	InstallDriver_return_success:
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -741,12 +741,6 @@
 
 	Sleep 1000
 
-	# Remove the TAP adapter
-	SetShellVarContext current
-	${RemoveRelayCache}
-	${ExtractDriver}
-	${RemoveTAP}
-
 	# Original removal functionality provided by Electron-builder
     RMDir /r $INSTDIR
 
@@ -756,6 +750,12 @@
 
 	# If not ran silently
 	${If} ${Errors}
+		# Remove the TAP adapter
+		SetShellVarContext current
+		${RemoveRelayCache}
+		${ExtractDriver}
+		${RemoveTAP}
+
 		${RemoveLogsAndCache}
 		MessageBox MB_ICONQUESTION|MB_YESNO "Would you like to remove settings files as well?" IDNO customRemoveFiles_after_remove_settings
 		${RemoveSettings}

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -175,6 +175,7 @@
 
 	Var /GLOBAL InstallDriver_BaselineStatus
 	Var /GLOBAL InstallDriver_TapName
+	Var /GLOBAL InstallDriver_TapGuid
 
 	log::Log "InstallDriver()"
 	
@@ -267,6 +268,7 @@
 	driverlogic::IdentifyNewAdapter
 	
 	Pop $0
+	Pop $2
 	Pop $1
 
 	${If} $0 != ${INA_SUCCESS}
@@ -276,6 +278,7 @@
 	${EndIf}
 
 	StrCpy $InstallDriver_TapName $1
+	StrCpy $InstallDriver_TapGuid $2
 	
 	log::Log "New virtual adapter is named $\"$1$\""
 	log::Log "Renaming adapter to $\"Mullvad$\""
@@ -296,12 +299,18 @@
 		${EndIf}
 	${EndIf}
 
+	registry::WriteString "HKLM\SOFTWARE\Mullvad VPN" "AdapterGuid" "$InstallDriver_TapGuid"
+
 	InstallDriver_return_success:
 
 	log::Log "InstallDriver() completed successfully"
 	
 	Push 0
 	Pop $R0
+
+	# Discard return value
+	Pop $0
+	Pop $1
 	
 	InstallDriver_return:
 
@@ -309,7 +318,7 @@
 	
 	Pop $0
 	Pop $1
-	
+
 	${If} $0 != ${DRIVERLOGIC_SUCCESS}
 		# Do not update $R0
 		log::Log "Failed to deinitialize plugin 'driverlogic': $1"

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -222,7 +222,6 @@
 
 	Var /GLOBAL InstallDriver_BaselineStatus
 	Var /GLOBAL InstallDriver_TapName
-	Var /GLOBAL InstallDriver_TapGuid
 
 	log::Log "InstallDriver()"
 	
@@ -277,19 +276,6 @@
 	${If} $InstallDriver_BaselineStatus == ${EB_MULLVAD_ADAPTER_PRESENT}
 		log::Log "Virtual adapter with custom name already present on system"
 
-		driverlogic::FindMullvadTapGuid
-
-		Pop $0
-		Pop $1
-
-		${If} $0 != 1
-			StrCpy $R0 "Failed to identify TAP adapter: error $0"
-			log::LogWithDetails $R0 $1
-			Goto InstallDriver_return
-		${EndIf}
-
-		StrCpy $InstallDriver_TapGuid $1
-
 		Goto InstallDriver_return_success
 	${EndIf}
 
@@ -340,7 +326,6 @@
 	${EndIf}
 
 	StrCpy $InstallDriver_TapName $1
-	StrCpy $InstallDriver_TapGuid $2
 	
 	log::Log "New virtual adapter is named $\"$1$\""
 	log::Log "Renaming adapter to $\"Mullvad$\""
@@ -362,8 +347,6 @@
 	${EndIf}
 
 	InstallDriver_return_success:
-
-	registry::WriteString "HKLM\SOFTWARE\Mullvad VPN" "TapAdapterGuid" "$InstallDriver_TapGuid"
 
 	Pop $0
 	Pop $1

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -151,6 +151,20 @@
 !define ForceRenameAdapter '!insertmacro "ForceRenameAdapter"'
 
 #
+# RemoveTAP
+#
+# Remove Mullvad TAP adapter
+#
+!macro RemoveTAP
+	nsExec::ExecToStack '"$TEMP\driver\tapinstall.exe" remove ${TAP_HARDWARE_ID}'
+
+	Pop $0
+	Pop $1
+!macroend
+
+!define RemoveTAP '!insertmacro "RemoveTAP"'
+
+#
 # InstallDriver
 #
 # Install tunnel driver or update it if already present on the system
@@ -682,6 +696,10 @@
 		MessageBox MB_ICONQUESTION|MB_YESNO "Would you like to remove settings files as well?" IDNO customRemoveFiles_after_remove_settings
 		${RemoveSettings}
 		customRemoveFiles_after_remove_settings:
+
+		# Remove the TAP adapter
+		${ExtractDriver}
+		${RemoveTAP}
 	${EndIf}
 
 	${RemoveCLIFromEnvironPath}

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -276,6 +276,20 @@
 
 	${If} $InstallDriver_BaselineStatus == ${EB_MULLVAD_ADAPTER_PRESENT}
 		log::Log "Virtual adapter with custom name already present on system"
+
+		driverlogic::FindMullvadTapGuid
+
+		Pop $0
+		Pop $1
+
+		${If} $0 != 1
+			StrCpy $R0 "Failed to identify TAP adapter: error $0"
+			log::LogWithDetails $R0 $1
+			Goto InstallDriver_return
+		${EndIf}
+
+		StrCpy $InstallDriver_TapGuid $1
+
 		Goto InstallDriver_return_success
 	${EndIf}
 
@@ -347,9 +361,12 @@
 		${EndIf}
 	${EndIf}
 
+	InstallDriver_return_success:
+
 	registry::WriteString "HKLM\SOFTWARE\Mullvad VPN" "TapAdapterGuid" "$InstallDriver_TapGuid"
 
-	InstallDriver_return_success:
+	Pop $0
+	Pop $1
 
 	log::Log "InstallDriver() completed successfully"
 	

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -170,6 +170,8 @@
 	Pop $1
 
 	${If} $0 != ${DRIVERLOGIC_SUCCESS}
+		StrCpy $R0 "Failed to initialize plugin 'driverlogic': $1"
+		MessageBox MB_OK $R0
 		Goto RemoveTap_return_only
 	${EndIf}
 
@@ -179,6 +181,7 @@
 	Pop $1
 
 	${If} $0 != ${TAC_SUCCESS}
+		MessageBox MB_OK $1
 		Goto RemoveTap_return
 	${EndIf}
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -170,8 +170,6 @@
 	Pop $1
 
 	${If} $0 != ${DRIVERLOGIC_SUCCESS}
-		StrCpy $R0 "Failed to initialize plugin 'driverlogic': $1"
-		MessageBox MB_OK $R0
 		Goto RemoveTap_return_only
 	${EndIf}
 
@@ -181,7 +179,6 @@
 	Pop $1
 
 	${If} $0 != ${TAC_SUCCESS}
-		MessageBox MB_OK $1
 		Goto RemoveTap_return
 	${EndIf}
 
@@ -601,7 +598,6 @@
 	Pop $1
 
 	${If} $0 != ${PE_SUCCESS}
-		MessageBox MB_OK "Error removing app from PATH: $1"
 		Goto RemovePath_return
 	${EndIf}
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -155,12 +155,12 @@
 !define ForceRenameAdapter '!insertmacro "ForceRenameAdapter"'
 
 #
-# RemoveTAP
+# RemoveTap
 #
 # Try to remove the Mullvad TAP adapter
 # and driver if there are no other TAPs available.
 #
-!macro RemoveTAP
+!macro RemoveTap
 	Push $0
 	Push $1
 
@@ -170,7 +170,7 @@
 	Pop $1
 
 	${If} $0 != ${DRIVERLOGIC_SUCCESS}
-		Goto RemoveTAP_return_only
+		Goto RemoveTap_return_only
 	${EndIf}
 
 	driverlogic::TAPAdapterCount
@@ -179,7 +179,7 @@
 	Pop $1
 
 	${If} $0 != ${TAC_SUCCESS}
-		Goto RemoveTAP_return
+		Goto RemoveTap_return
 	${EndIf}
 
 	${If} $1 == 1
@@ -195,21 +195,21 @@
 		Pop $1
 	${EndIf}
 	
-	RemoveTAP_return:
+	RemoveTap_return:
 
 	driverlogic::Deinitialize
 	
 	Pop $0
 	Pop $1
 
-	RemoveTAP_return_only:
+	RemoveTap_return_only:
 
 	Pop $1
 	Pop $0
 
 !macroend
 
-!define RemoveTAP '!insertmacro "RemoveTAP"'
+!define RemoveTap '!insertmacro "RemoveTap"'
 
 #
 # InstallDriver
@@ -755,7 +755,7 @@
 	${If} ${Errors}
 		# Remove the TAP adapter
 		${ExtractDriver}
-		${RemoveTAP}
+		${RemoveTap}
 
 		${RemoveLogsAndCache}
 		MessageBox MB_ICONQUESTION|MB_YESNO "Would you like to remove settings files as well?" IDNO customRemoveFiles_after_remove_settings

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -741,6 +741,9 @@
 
 	Sleep 1000
 
+	SetShellVarContext current
+	${RemoveRelayCache}
+
 	# Original removal functionality provided by Electron-builder
     RMDir /r $INSTDIR
 
@@ -751,8 +754,6 @@
 	# If not ran silently
 	${If} ${Errors}
 		# Remove the TAP adapter
-		SetShellVarContext current
-		${RemoveRelayCache}
 		${ExtractDriver}
 		${RemoveTAP}
 

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -25,7 +25,6 @@ namespace
 {
 
 const wchar_t TAP_HARDWARE_ID[] = L"tap0901";
-const wchar_t TAP_REGISTRY_VALUE_NAME[] = L"TapAdapterGuid";
 
 std::set<Context::NetworkAdapter> GetAllAdapters()
 {

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -101,8 +101,6 @@ void LogAdapters(const std::wstring &description, const std::set<Context::Networ
 
 std::wstring GetNetCfgInstanceId(HDEVINFO devInfo, const SP_DEVINFO_DATA &devInfoData)
 {
-	std::vector<wchar_t> instanceId(MAX_PATH + sizeof(L'\0'));
-	DWORD strSize = instanceId.size() * sizeof(wchar_t);
 	HKEY hNet = SetupDiOpenDevRegKey(
 		devInfo,
 		const_cast<SP_DEVINFO_DATA *>(&devInfoData),
@@ -116,6 +114,9 @@ std::wstring GetNetCfgInstanceId(HDEVINFO devInfo, const SP_DEVINFO_DATA &devInf
 	{
 		throw std::runtime_error("SetupDiOpenDevRegKey Failed");
 	}
+
+	std::vector<wchar_t> instanceId(MAX_PATH + sizeof(L'\0'));
+	DWORD strSize = instanceId.size() * sizeof(wchar_t);
 
 	const auto status = RegGetValueW(
 		hNet,

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -255,7 +255,7 @@ void Context::DeleteMullvadAdapter()
 		SetupDiDestroyDeviceInfoList(devInfo);
 	};
 
-	SP_DEVINFO_DATA devInfoData;
+	SP_DEVINFO_DATA devInfoData = { 0 };
 	devInfoData.cbSize = sizeof(devInfoData);
 
 	std::vector<wchar_t> buffer;

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -145,20 +145,6 @@ std::wstring GetNetCfgInstanceId(HDEVINFO devInfo, const SP_DEVINFO_DATA &devInf
 
 std::wstring Context::findMullvadGuid() const
 {
-	try
-	{
-		const auto regKey = common::registry::Registry::OpenKey(
-			HKEY_LOCAL_MACHINE,
-			L"SOFTWARE\\Mullvad VPN",
-			false,
-			common::registry::RegistryView::Force64
-		);
-		return regKey->readString(TAP_REGISTRY_VALUE_NAME);
-	}
-	catch (const std::exception&)
-	{
-	}
-
 	//
 	// If reading from the registry fails (eg because value does not exist),
 	// check all network adapters.
@@ -305,16 +291,9 @@ Context::NetworkAdapter Context::getNewAdapter()
 	return *added.begin();
 }
 
-//static
-void Context::DeleteMullvadAdapter()
+void Context::deleteMullvadAdapter() const
 {
-	const auto regkey = common::registry::Registry::OpenKey(
-		HKEY_LOCAL_MACHINE,
-		L"SOFTWARE\\Mullvad VPN",
-		false,
-		common::registry::RegistryView::Force64
-	);
-	const auto mullvadGuid = regkey->readString(TAP_REGISTRY_VALUE_NAME);
+	const auto mullvadGuid = findMullvadGuid();
 
 	HDEVINFO devInfo = SetupDiGetClassDevs(
 		&GUID_DEVCLASS_NET,

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -91,6 +91,11 @@ void LogAdapters(const std::wstring &description, const std::set<Context::Networ
 
 } // anonymous namespace
 
+std::set<Context::NetworkAdapter> Context::getTapAdapters()
+{
+	return GetTapAdapters(m_currentState);
+}
+
 Context::BaselineStatus Context::establishBaseline()
 {
 	m_baseline = GetAllAdapters();

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -145,11 +145,6 @@ std::wstring GetNetCfgInstanceId(HDEVINFO devInfo, const SP_DEVINFO_DATA &devInf
 //static
 std::wstring Context::FindMullvadGuid()
 {
-	//
-	// If reading from the registry fails (eg because value does not exist),
-	// check all network adapters.
-	//
-	
 	auto tapAdapters = GetTapAdapters(GetAllAdapters());
 
 	if (tapAdapters.empty())

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -2,6 +2,7 @@
 #include "context.h"
 #include <libcommon/string.h>
 #include <libcommon/error.h>
+#include <libcommon/memory.h>
 #include <log/log.h>
 #include <winsock2.h>
 #include <ws2ipdef.h>
@@ -12,9 +13,18 @@
 #include <stdexcept>
 #include <sstream>
 #include <algorithm>
+#include <iostream>
+#include <setupapi.h>
+#include <devguid.h>
+#include <combaseapi.h>
+#include <initguid.h>
+#include <devpkey.h>
+#include <libcommon/registry/registry.h>
 
 namespace
 {
+
+const wchar_t TAP_HARDWARE_ID[] = L"tap0901";
 
 std::set<Context::NetworkAdapter> GetAllAdapters()
 {
@@ -87,6 +97,46 @@ void LogAdapters(const std::wstring &description, const std::set<Context::Networ
 	}
 
 	PluginLogWithDetails(description, details);
+}
+
+std::wstring GetNetCfgInstanceId(HDEVINFO devInfo, const SP_DEVINFO_DATA &devInfoData)
+{
+	std::vector<wchar_t> instanceId(MAX_PATH + sizeof(L'\0'));
+	DWORD strSize = instanceId.size() * sizeof(wchar_t);
+	HKEY hNet = SetupDiOpenDevRegKey(
+		devInfo,
+		const_cast<SP_DEVINFO_DATA *>(&devInfoData),
+		DICS_FLAG_GLOBAL,
+		0,
+		DIREG_DRV,
+		KEY_READ
+	);
+
+	if (hNet == INVALID_HANDLE_VALUE)
+	{
+		throw std::runtime_error("SetupDiOpenDevRegKey Failed");
+	}
+
+	const auto status = RegGetValueW(
+		hNet,
+		nullptr,
+		L"NetCfgInstanceId",
+		RRF_RT_REG_SZ,
+		nullptr,
+		instanceId.data(),
+		&strSize
+	);
+
+	RegCloseKey(hNet);
+
+	if (ERROR_SUCCESS != status)
+	{
+		throw std::runtime_error("RegGetValue for NetCfgInstanceId failed");
+	}
+
+	instanceId[strSize / sizeof(wchar_t)] = L'\0';
+
+	return instanceId.data();
 }
 
 } // anonymous namespace
@@ -177,4 +227,98 @@ Context::NetworkAdapter Context::getNewAdapter()
 	}
 
 	return *added.begin();
+}
+
+//static
+void Context::DeleteMullvadAdapter()
+{
+	const auto regkey = common::registry::Registry::OpenKey(
+		HKEY_LOCAL_MACHINE,
+		L"SOFTWARE\\Mullvad VPN",
+		false,
+		common::registry::RegistryView::Force64
+	);
+	const auto mullvadGuid = regkey->readString(L"AdapterGuid");
+
+	HDEVINFO devInfo = SetupDiGetClassDevs(
+		&GUID_DEVCLASS_NET,
+		nullptr,
+		nullptr,
+		DIGCF_PRESENT
+	);
+
+	THROW_GLE_IF(INVALID_HANDLE_VALUE, devInfo, "SetupDiGetClassDevs() failed");
+
+	common::memory::ScopeDestructor cleanupDevList;
+	cleanupDevList += [&devInfo]()
+	{
+		SetupDiDestroyDeviceInfoList(devInfo);
+	};
+
+	SP_DEVINFO_DATA devInfoData;
+	devInfoData.cbSize = sizeof(devInfoData);
+
+	std::vector<wchar_t> buffer;
+	DWORD nameLen;
+
+	for (int memberIndex = 0; ; memberIndex++)
+	{
+		if (FALSE == SetupDiEnumDeviceInfo(devInfo, memberIndex, &devInfoData))
+		{
+			if (GetLastError() == ERROR_NO_MORE_ITEMS)
+			{
+				/* done */
+				break;
+			}
+			else
+			{
+				THROW_GLE("Error enumerating network adapters");
+			}
+		}
+
+		if (FALSE == SetupDiGetDeviceRegistryProperty(
+			devInfo,
+			&devInfoData,
+			SPDRP_HARDWAREID,
+			nullptr,
+			nullptr,
+			0,
+			&nameLen
+		))
+		{
+			THROW_GLE("Error obtaining network adapter hardware ID");
+		}
+
+		buffer.resize(nameLen);
+
+		if (FALSE == SetupDiGetDeviceRegistryProperty(
+			devInfo,
+			&devInfoData,
+			SPDRP_HARDWAREID,
+			nullptr,
+			reinterpret_cast<PBYTE>(buffer.data()),
+			buffer.size(),
+			nullptr
+		))
+		{
+			THROW_GLE("Error obtaining network adapter hardware ID");
+		}
+
+		if (wcscmp(TAP_HARDWARE_ID, buffer.data()) == 0)
+		{
+			std::wstring netCfgInstanceId = GetNetCfgInstanceId(devInfo, devInfoData);
+			if (netCfgInstanceId.compare(mullvadGuid) != 0)
+			{
+				continue;
+			}
+
+			if (FALSE == SetupDiRemoveDevice(
+				devInfo,
+				&devInfoData
+			))
+			{
+				THROW_GLE("Error removing Mullvad TAP device");
+			}
+		}
+	}
 }

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -238,7 +238,7 @@ void Context::DeleteMullvadAdapter()
 		false,
 		common::registry::RegistryView::Force64
 	);
-	const auto mullvadGuid = regkey->readString(L"AdapterGuid");
+	const auto mullvadGuid = regkey->readString(L"TapAdapterGuid");
 
 	HDEVINFO devInfo = SetupDiGetClassDevs(
 		&GUID_DEVCLASS_NET,

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -142,7 +142,8 @@ std::wstring GetNetCfgInstanceId(HDEVINFO devInfo, const SP_DEVINFO_DATA &devInf
 
 } // anonymous namespace
 
-std::wstring Context::findMullvadGuid() const
+//static
+std::wstring Context::FindMullvadGuid()
 {
 	//
 	// If reading from the registry fails (eg because value does not exist),
@@ -290,9 +291,10 @@ Context::NetworkAdapter Context::getNewAdapter()
 	return *added.begin();
 }
 
-void Context::deleteMullvadAdapter() const
+//static
+void Context::DeleteMullvadAdapter()
 {
-	const auto mullvadGuid = findMullvadGuid();
+	const auto mullvadGuid = FindMullvadGuid();
 
 	HDEVINFO devInfo = SetupDiGetClassDevs(
 		&GUID_DEVCLASS_NET,

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -47,6 +47,8 @@ public:
 	NetworkAdapter getNewAdapter();
 
 	std::set<NetworkAdapter> getTapAdapters();
+
+	static void DeleteMullvadAdapter();
 private:
 
 	std::set<NetworkAdapter> m_baseline;

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -48,8 +48,8 @@ public:
 
 	std::set<NetworkAdapter> getTapAdapters();
 
-	std::wstring findMullvadGuid() const;
-	void deleteMullvadAdapter() const;
+	static std::wstring FindMullvadGuid();
+	static void DeleteMullvadAdapter();
 private:
 
 	std::set<NetworkAdapter> m_baseline;

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -49,7 +49,7 @@ public:
 	std::set<NetworkAdapter> getTapAdapters();
 
 	std::wstring findMullvadGuid() const;
-	static void DeleteMullvadAdapter();
+	void deleteMullvadAdapter() const;
 private:
 
 	std::set<NetworkAdapter> m_baseline;

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -46,6 +46,7 @@ public:
 	//
 	NetworkAdapter getNewAdapter();
 
+	std::set<NetworkAdapter> getTapAdapters();
 private:
 
 	std::set<NetworkAdapter> m_baseline;

--- a/windows/nsis-plugins/src/driverlogic/context.h
+++ b/windows/nsis-plugins/src/driverlogic/context.h
@@ -48,6 +48,7 @@ public:
 
 	std::set<NetworkAdapter> getTapAdapters();
 
+	std::wstring findMullvadGuid() const;
 	static void DeleteMullvadAdapter();
 private:
 

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -195,16 +195,19 @@ void __declspec(dllexport) NSISCALL IdentifyNewAdapter
 		auto adapter = g_context->getNewAdapter();
 
 		pushstring(adapter.alias.c_str());
+		pushstring(adapter.guid.c_str());
 		pushint(IdentifyNewAdapterStatus::SUCCESS);
 	}
 	catch (std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
+		pushstring(L"");
 		pushint(IdentifyNewAdapterStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
+		pushstring(L"");
 		pushint(IdentifyNewAdapterStatus::GENERAL_ERROR);
 	}
 }

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -157,6 +157,57 @@ void __declspec(dllexport) NSISCALL EstablishBaseline
 }
 
 //
+// TapAdapterCount
+//
+// Return the number of TAP adapters present.
+//
+enum class TapAdapterCountStatus
+{
+	GENERAL_ERROR = 0,
+	SUCCESS
+};
+
+void __declspec(dllexport) NSISCALL TapAdapterCount
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	if (nullptr == g_context)
+	{
+		pushstring(L"Initialize() function was not called or was not successful");
+		pushint(EstablishBaselineStatus::GENERAL_ERROR);
+	}
+
+	try
+	{
+		g_context->recordCurrentState();
+
+		auto adapters = g_context->getTapAdapters();
+
+		pushint(adapters.size());
+		pushint(TapAdapterCountStatus::SUCCESS);
+	}
+	catch (std::exception &err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(TapAdapterCountStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(TapAdapterCountStatus::GENERAL_ERROR);
+	}
+}
+
+
+//
 // IdentifyNewAdapter
 //
 // Call this function after installing a TAP adapter.

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -157,6 +157,49 @@ void __declspec(dllexport) NSISCALL EstablishBaseline
 }
 
 //
+// RemoveMullvadTap
+//
+// Deletes the Mullvad TAP adapter.
+//
+//
+enum class RemoveMullvadTapStatus
+{
+	GENERAL_ERROR = 0,
+	SUCCESS
+};
+
+void __declspec(dllexport) NSISCALL RemoveMullvadTap
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	try
+	{
+		Context::DeleteMullvadAdapter();
+
+		pushstring(L"");
+		pushint(RemoveMullvadTapStatus::SUCCESS);
+	}
+	catch (std::exception &err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(RemoveMullvadTapStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(RemoveMullvadTapStatus::GENERAL_ERROR);
+	}
+}
+
+//
 // TapAdapterCount
 //
 // Return the number of TAP adapters present.

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -182,15 +182,9 @@ void __declspec(dllexport) NSISCALL FindMullvadTapGuid
 {
 	EXDLL_INIT();
 
-	if (nullptr == g_context)
-	{
-		pushstring(L"Initialize() function was not called or was not successful");
-		pushint(EstablishBaselineStatus::GENERAL_ERROR);
-	}
-
 	try
 	{
-		const auto guid = g_context->findMullvadGuid();
+		const auto guid = Context::FindMullvadGuid();
 		pushstring(guid.c_str());
 		pushint(FindMullvadTapGuidStatus::SUCCESS);
 	}
@@ -230,15 +224,9 @@ void __declspec(dllexport) NSISCALL RemoveMullvadTap
 {
 	EXDLL_INIT();
 
-	if (nullptr == g_context)
-	{
-		pushstring(L"Initialize() function was not called or was not successful");
-		pushint(EstablishBaselineStatus::GENERAL_ERROR);
-	}
-
 	try
 	{
-		g_context->deleteMullvadAdapter();
+		Context::DeleteMullvadAdapter();
 		pushstring(L"");
 		pushint(RemoveMullvadTapStatus::SUCCESS);
 	}

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -159,9 +159,8 @@ void __declspec(dllexport) NSISCALL EstablishBaseline
 //
 // FindMullvadTapGuid
 //
-// Tries to identify an existing TAP adapter using its name,
-// first using the registry. If that fails, network adapters
-// are enumerated.
+// Tries to identify an the Mullvad TAP adapter GUID
+// using its name.
 //
 //
 enum class FindMullvadTapGuidStatus

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -230,10 +230,15 @@ void __declspec(dllexport) NSISCALL RemoveMullvadTap
 {
 	EXDLL_INIT();
 
+	if (nullptr == g_context)
+	{
+		pushstring(L"Initialize() function was not called or was not successful");
+		pushint(EstablishBaselineStatus::GENERAL_ERROR);
+	}
+
 	try
 	{
-		Context::DeleteMullvadAdapter();
-
+		g_context->deleteMullvadAdapter();
 		pushstring(L"");
 		pushint(RemoveMullvadTapStatus::SUCCESS);
 	}

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -157,6 +157,56 @@ void __declspec(dllexport) NSISCALL EstablishBaseline
 }
 
 //
+// FindMullvadTapGuid
+//
+// Tries to identify an existing TAP adapter using its name,
+// first using the registry. If that fails, network adapters
+// are enumerated.
+//
+//
+enum class FindMullvadTapGuidStatus
+{
+	GENERAL_ERROR = 0,
+	SUCCESS
+};
+
+void __declspec(dllexport) NSISCALL FindMullvadTapGuid
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	if (nullptr == g_context)
+	{
+		pushstring(L"Initialize() function was not called or was not successful");
+		pushint(EstablishBaselineStatus::GENERAL_ERROR);
+	}
+
+	try
+	{
+		const auto guid = g_context->findMullvadGuid();
+		pushstring(guid.c_str());
+		pushint(FindMullvadTapGuidStatus::SUCCESS);
+	}
+	catch (std::exception &err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(FindMullvadTapGuidStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(FindMullvadTapGuidStatus::GENERAL_ERROR);
+	}
+}
+
+//
 // RemoveMullvadTap
 //
 // Deletes the Mullvad TAP adapter.

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.def
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.def
@@ -5,4 +5,5 @@ EXPORTS
 Initialize
 EstablishBaseline
 IdentifyNewAdapter
+TapAdapterCount
 Deinitialize

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.def
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.def
@@ -6,5 +6,6 @@ Initialize
 EstablishBaseline
 IdentifyNewAdapter
 TapAdapterCount
+FindMullvadTapGuid
 RemoveMullvadTap
 Deinitialize

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.def
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.def
@@ -6,4 +6,5 @@ Initialize
 EstablishBaseline
 IdentifyNewAdapter
 TapAdapterCount
+RemoveMullvadTap
 Deinitialize

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.vcxproj
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.vcxproj
@@ -70,7 +70,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <AdditionalLibraryDirectories>$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>iphlpapi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>setupapi.lib;iphlpapi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>driverlogic.def</ModuleDefinitionFile>
     </Link>
@@ -96,7 +96,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <AdditionalLibraryDirectories>$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>iphlpapi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>setupapi.lib;iphlpapi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>driverlogic.def</ModuleDefinitionFile>
     </Link>

--- a/windows/nsis-plugins/src/log/log.cpp
+++ b/windows/nsis-plugins/src/log/log.cpp
@@ -168,6 +168,25 @@ std::wstring GetWindowsVersion()
 } // anonymous namespace
 
 //
+// Pin
+//
+// Loads the DLL.
+//
+void __declspec(dllexport) NSISCALL Pin
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+	PinDll();
+}
+
+//
 // Initialize
 //
 // Opens and maintains an open handle to the log file.

--- a/windows/nsis-plugins/src/log/log.def
+++ b/windows/nsis-plugins/src/log/log.def
@@ -2,6 +2,7 @@ LIBRARY log
 
 EXPORTS
 
+Pin
 Initialize
 Log
 LogWithDetails

--- a/windows/nsis-plugins/src/registry/registry.def
+++ b/windows/nsis-plugins/src/registry/registry.def
@@ -3,3 +3,4 @@ LIBRARY registry
 EXPORTS
 
 MoveKey=?MoveKey@@YAXPAUHWND__@@HPA_WPAPAU_stack_t@@PAUextra_parameters@@ZZ
+WriteString


### PR DESCRIPTION
* Remove the Mullvad TAP adapter if there are multiple adapters. Also delete the driver if it's not being used by any other adapter.
* Add `registry::WriteString` (to nsis plugin).
* Add `TapAdapterCount` and `RemoveMullvadTap` to driverlogic plugin.


Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

* [x] Rebase commits

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1201)
<!-- Reviewable:end -->
