### PR TITLE
Disable Rust nightly temporarily until rustfmt issues are resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,9 @@ matrix:
       install: *rust_windows_install
       script: *rust_windows_script
 
+jobs:
+  allow_failures:
+    - name: Daemon, Linux - nigtly Rust
 
 notifications:
   email:


### PR DESCRIPTION
The rustfmt checks on Travis has failed for about a week now. Very annoying. I tried fixing it yesterday with no success. To make the CI not fully red all the time I opted to disable the nightly builds for now. Will look into fixing the formatting check later again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1214)
<!-- Reviewable:end -->
