### PR TITLE
Use tunnel agnostic log message when disconnecting from the connecting state.

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -253,7 +253,7 @@ impl ConnectingState {
             )),
             Ok(_) => SameState(self),
             Err(_) => {
-                debug!("The OpenVPN tunnel event plugin disconnected");
+                debug!("The tunnel disconnected unexpectedly");
                 NewState(DisconnectingState::enter(
                     shared_values,
                     (


### PR DESCRIPTION
A small fix to a logging call to be tunnel agnostic. This has previously confused some of us whilst debugging WireGuard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1215)
<!-- Reviewable:end -->
