### PR TITLE
Fix nightly rust in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,9 +142,6 @@ matrix:
       install: *rust_windows_install
       script: *rust_windows_script
 
-jobs:
-  allow_failures:
-    - name: Daemon, Linux - nigtly Rust
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,11 @@ matrix:
       dist: xenial
       services: docker
       before_script: &rust_before_script
-        - docker run -d --name mvd-build -v $(pwd):/travis -w /travis  mullvadvpn/mullvadvpn-app-build:latest tail -f /dev/null
+        - docker --version
+        # --privileged is required because nightly cargo uses statx instead of stat, and that
+        # syscall is so new that it's not on the docker whitelist yet.
+        # https://github.com/rust-lang/rust/issues/65662
+        - docker run -d --privileged --name mvd-build -v $(pwd):/travis -w /travis  mullvadvpn/mullvadvpn-app-build:latest tail -f /dev/null
         - docker ps
       script:
         - docker exec -t mvd-build bash ci/ci-rust-script.sh nightly


### PR DESCRIPTION
Reverts #1214 and fixes the running of rustfmt on nightly. The core of the problem was not rustfmt related at all. It was that nightly rust/cargo recently switched syscall from `stat` to `statx` for checking files. And `statx` is so new that it's not a whitelisted syscall in the version of docker running on travis. As such it was denied, and `cargo fmt` could not find the corresponding `cargo-fmt` binary. Even if I directly used `cargo-fmt` that binary in turn could not find `Cargo.toml` because it also used `statx`. The solution here was to just add `--privileged` to docker. Usually not a good approach from a security perspective, but there is nothing that requires any security in our Travis runs anyway.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1216)
<!-- Reviewable:end -->
