### PR TITLE
Perform installation of Rust in one place

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,11 +127,6 @@ matrix:
       name: Daemon, Windows - stable Rust
       env: RUST_VERSION=stable
       language: bash
-      install: &rust_windows_install
-        - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-        - ./rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain $RUST_VERSION --profile minimal
-        - export PATH="$HOME/.cargo/bin/:$PATH"
-        - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/amd64/:$PATH"
       script: &rust_windows_script
         - ./ci/ci-rust-script.sh $RUST_VERSION
 
@@ -139,7 +134,6 @@ matrix:
       name: Daemon, Windows - beta Rust
       env: RUST_VERSION=beta
       language: bash
-      install: *rust_windows_install
       script: *rust_windows_script
 
 

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -7,7 +7,6 @@ RUSTFLAGS="--deny unused_imports --deny dead_code"
 
 source env.sh ""
 
-RUST_TARGET_ARG=""
 case "$(uname -s)" in
   Linux*|Darwin*)
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
@@ -16,14 +15,15 @@ case "$(uname -s)" in
   MINGW*|MSYS_NT*)
     curl -sSf -o rustup-init.exe https://win.rustup.rs/
     ./rustup-init.exe -y --default-toolchain none --profile minimal --default-host x86_64-pc-windows-msvc
-    RUST_TARGET_ARG="--target x86_64-pc-windows-msvc"
+    # See https://github.com/rust-lang/rustup.rs/issues/2082
+    RUST_TOOLCHAIN_CHANNEL="$RUST_TOOLCHAIN_CHANNEL-x86_64-pc-windows-msvc"
     ;;
 esac
 export PATH="$HOME/.cargo/bin/:$PATH"
 
 # Install the toolchain together with rustfmt. Here -c backtracks to last version where
 # the component was available.
-time rustup toolchain install $RUST_TOOLCHAIN_CHANNEL --no-self-update -c rustfmt $RUST_TARGET_ARG
+time rustup toolchain install $RUST_TOOLCHAIN_CHANNEL --no-self-update -c rustfmt
 
 case "$(uname -s)" in
   MINGW*|MSYS_NT*)
@@ -35,8 +35,8 @@ esac
 # FIXME: Becaues of our old jsonrpc dependency our Rust code won't build
 # on latest nightly.
 if [ "${RUST_TOOLCHAIN_CHANNEL}" != "nightly" ]; then
-  time cargo build --locked --verbose $RUST_TARGET_ARG
-  time cargo test --locked --verbose $RUST_TARGET_ARG
+  time cargo build --locked --verbose
+  time cargo test --locked --verbose
 fi
 
 if [[ "${RUST_TOOLCHAIN_CHANNEL}" == "nightly" && "$(uname -s)" == "Linux" ]]; then

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -1,26 +1,33 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 RUST_TOOLCHAIN_CHANNEL=$1
 RUSTFLAGS="--deny unused_imports --deny dead_code"
 
 source env.sh ""
 
-RUST_EXTRA_COMPONENTS=""
-if [ "${RUST_TOOLCHAIN_CHANNEL}" = "nightly" ]; then
-  RUST_EXTRA_COMPONENTS+=" -c rustfmt-preview"
-fi
+RUST_TARGET_ARG=""
+case "$(uname -s)" in
+  Linux*|Darwin*)
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+      -y --default-toolchain none --profile minimal
+    ;;
+  MINGW*|MSYS_NT*)
+    curl -sSf -o rustup-init.exe https://win.rustup.rs/
+    ./rustup-init.exe -y --default-toolchain none --profile minimal --default-host x86_64-pc-windows-msvc
+    RUST_TARGET_ARG="--target x86_64-pc-windows-msvc"
+    ;;
+esac
+export PATH="$HOME/.cargo/bin/:$PATH"
 
-# Install Rust if on Linux or macOS
-if [[ "$(uname -s)" == "Linux" || "$(uname -s)" == "Darwin" ]]; then
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-    -y --default-toolchain $RUST_TOOLCHAIN_CHANNEL --profile minimal $RUST_EXTRA_COMPONENTS
-  source $HOME/.cargo/env
-fi
+# Install the toolchain together with rustfmt. Here -c backtracks to last version where
+# the component was available.
+time rustup toolchain install $RUST_TOOLCHAIN_CHANNEL --no-self-update -c rustfmt $RUST_TARGET_ARG
 
 case "$(uname -s)" in
   MINGW*|MSYS_NT*)
+    export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/amd64/:$PATH"
     time ./build_windows_modules.sh --dev-build
     ;;
 esac
@@ -28,8 +35,8 @@ esac
 # FIXME: Becaues of our old jsonrpc dependency our Rust code won't build
 # on latest nightly.
 if [ "${RUST_TOOLCHAIN_CHANNEL}" != "nightly" ]; then
-  time cargo build --locked --verbose
-  time cargo test --locked --verbose
+  time cargo build --locked --verbose $RUST_TARGET_ARG
+  time cargo test --locked --verbose $RUST_TARGET_ARG
 fi
 
 if [[ "${RUST_TOOLCHAIN_CHANNEL}" == "nightly" && "$(uname -s)" == "Linux" ]]; then

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -333,9 +333,7 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_getWwwAuthToken
     _: JObject<'this>,
 ) -> JString<'env> {
     match DAEMON_INTERFACE.get_www_auth_token() {
-        Ok(token) => {
-            token.into_java(&env)
-        },
+        Ok(token) => token.into_java(&env),
         Err(err) => {
             log::error!(
                 "{}",


### PR DESCRIPTION
While I was tinkering with #1216 I also thought it was quite inconsistent to install rustup so far from each other depending on platform. When we did it directly in `.travis.yml` for Windows that was still going to be done in a git bash shell, so it could just as well be moved to our CI script to make things more even.

The `-c rustfmt` part is moved from the rustup install to the `rustup toolchain install` step. Apparently this is where the flag can automatically backtrack to last known good toolchain with said component. It did not do that if provided directly to the rustup install script I learned from some IRC conversations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1217)
<!-- Reviewable:end -->
