### PR TITLE
Detect removal of TAP adapter when daemon reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Use a larger icon in notifications on Windows 10.
 
+### Fixed
+#### Windows
+- Detect removal of the OpenVPN TAP adapter on reconnection attempts.
+
 
 ## [2019.9] - 2019-10-11
 ### Added

--- a/windows/winnet/src/winnet/interfaceutils.cpp
+++ b/windows/winnet/src/winnet/interfaceutils.cpp
@@ -11,9 +11,6 @@
 #include <windows.h>
 
 //static
-std::wstring InterfaceUtils::m_alias;
-
-//static
 std::mutex InterfaceUtils::m_mutex;
 
 //static
@@ -77,11 +74,6 @@ std::wstring InterfaceUtils::GetTapInterfaceAlias()
 {
 	common::sync::ScopeLock<> cacheLock(m_mutex);
 
-	if (false == m_alias.empty())
-	{
-		return m_alias;
-	}
-
 	//
 	// Look for TAP adapter with alias "Mullvad".
 	//
@@ -102,7 +94,7 @@ std::wstring InterfaceUtils::GetTapInterfaceAlias()
 
 	if (findByAlias(adapters, baseAlias))
 	{
-		return m_alias = baseAlias;
+		return baseAlias;
 	}
 
 	//
@@ -119,7 +111,7 @@ std::wstring InterfaceUtils::GetTapInterfaceAlias()
 
 		if (findByAlias(adapters, alias))
 		{
-			return m_alias = alias;
+			return alias;
 		}
 	}
 

--- a/windows/winnet/src/winnet/interfaceutils.cpp
+++ b/windows/winnet/src/winnet/interfaceutils.cpp
@@ -2,7 +2,6 @@
 #include "interfaceutils.h"
 #include "libcommon/error.h"
 #include "libcommon/string.h"
-#include "libcommon/synchronization.h"
 #include <vector>
 #include <cstdint>
 #include <algorithm>
@@ -10,8 +9,6 @@
 #include <iphlpapi.h>
 #include <windows.h>
 
-//static
-std::mutex InterfaceUtils::m_mutex;
 
 //static
 std::set<InterfaceUtils::NetworkAdapter> InterfaceUtils::GetAllAdapters()
@@ -72,8 +69,6 @@ InterfaceUtils::GetTapAdapters(const std::set<InterfaceUtils::NetworkAdapter> &a
 //static
 std::wstring InterfaceUtils::GetTapInterfaceAlias()
 {
-	common::sync::ScopeLock<> cacheLock(m_mutex);
-
 	//
 	// Look for TAP adapter with alias "Mullvad".
 	//

--- a/windows/winnet/src/winnet/interfaceutils.h
+++ b/windows/winnet/src/winnet/interfaceutils.h
@@ -2,13 +2,10 @@
 
 #include <string>
 #include <set>
-#include <mutex>
 
 class InterfaceUtils
 {
 	InterfaceUtils() = delete;
-
-	static std::mutex m_mutex;
 
 public:
 

--- a/windows/winnet/src/winnet/interfaceutils.h
+++ b/windows/winnet/src/winnet/interfaceutils.h
@@ -8,7 +8,6 @@ class InterfaceUtils
 {
 	InterfaceUtils() = delete;
 
-	static std::wstring m_alias;
 	static std::mutex m_mutex;
 
 public:


### PR DESCRIPTION
winnet would cache the name of the TAP adapter and only report an error if it wasn't found the first time it was looked up, resulting in perpetual reconnection attempts if it were removed or renamed. Easily fixed by not caching the lookup.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1218)
<!-- Reviewable:end -->
