### PR TITLE
Move things under 2019.9 that is not yet released to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+#### Windows
+- Install Wintun driver that provides the WireGuard TUN adapter.
+- Remove Mullvad TAP adapter on uninstall. Also remove the TAP driver if there are no other TAP
+  adapters in the system.
+
+#### Android
+- Use authenticated URLs to go to wireguard key page on website.
+
 ### Changed
 - Notifications shown when connecting to a server include its location.
 
@@ -34,17 +43,12 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add ability to submit vouchers from the CLI.
 
-#### Android
-- Use authenticated URLs to go to wireguard key page on website.
-
 #### Linux
 - Add a symlink for `mullvad-problem-report` directly in `/usr/bin`. So the tool is available.
 
 #### Windows
 - Install the OpenVPN certificate to avoid the TAP adapter driver installation warning on
   Windows 8 and newer.
-- Remove Mullvad TAP adapter on uninstall. Also remove the TAP driver if there are no other TAP adapters in the system.
-- Install Wintun driver that provides the WireGuard TUN adapter.
 
 ### Changed
 #### Windows


### PR DESCRIPTION
David L had sharp eyes and spotted three places where we had merged things adding changelog entries for 2019.9 *after* that was released. These should all be under `[Unreleased]`.

Not sure exactly how we best mitigate this in the future.

Also did a formatting fix, one line was longer than 100 chars.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1219)
<!-- Reviewable:end -->
