### PR TITLE
Android improve keygen fragment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Use authenticated URLs to go to wireguard key page on website.
+- WireGuard key fragment has been made more similar to it's desktop counterpart.
 
 ### Changed
 - Notifications shown when connecting to a server include its location.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -138,7 +138,7 @@ class WireguardKeyFragment : Fragment() {
                 val key = keyState.publicKey
                 val publicKeyString = Base64.encodeToString(key.key, Base64.NO_WRAP)
                 publicKey.visibility = View.VISIBLE
-                publicKey.setText(publicKeyString)
+                publicKey.setText(publicKeyString.substring(0, 20) + "...")
 
                 publicKey.setOnClickListener {
                     val label = parentActivity.getString(R.string.wireguard_key_copied_to_clibpoard)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/WireguardKeyFragment.kt
@@ -1,5 +1,7 @@
 package net.mullvad.mullvadvpn
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -137,6 +139,17 @@ class WireguardKeyFragment : Fragment() {
                 val publicKeyString = Base64.encodeToString(key.key, Base64.NO_WRAP)
                 publicKey.visibility = View.VISIBLE
                 publicKey.setText(publicKeyString)
+
+                publicKey.setOnClickListener {
+                    val label = parentActivity.getString(R.string.wireguard_key_copied_to_clibpoard)
+                    val clipboard = parentActivity
+                        .getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText(label, publicKeyString))
+
+                    Toast.makeText(parentActivity, label, Toast.LENGTH_SHORT)
+                        .show()
+                }
+
                 publicKeyAge.setText(formatKeyDateCreated(key.dateCreated))
 
                 if (keyState.verified != null) {

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
         selected region
     </string>
     <string name="wireguard_key">WireGuard key</string>
+    <string name="wireguard_key_copied_to_clibpoard">Key copied to clipboard</string>
     <string name="wireguard_public_key">Public key</string>
     <string name="wireguard_verify_key">Verify key</string>
     <string name="wireguard_generate_key">Generate key</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -116,7 +116,7 @@
     <string name="wireguard_public_key">Public key</string>
     <string name="wireguard_verify_key">Verify key</string>
     <string name="wireguard_generate_key">Generate key</string>
-    <string name="wireguard_replace_key">Replace key</string>
+    <string name="wireguard_replace_key">Regenerate key</string>
     <string name="wireguard_manage_keys">Manage keys</string>
     <string name="wireguard_key_age">Key generated on</string>
     <string name="wireguard_key_connectivity">


### PR DESCRIPTION
I've addressed some small inconsistencies with the WireGuard key fragment in the Android app:
- Only 20 characters of the public key are shown
- The public key is copied to the clipboard when clicked
- Use the term _regenerate_ instead of _repalce_ to generate a new key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1220)
<!-- Reviewable:end -->
