### PR TITLE
Log after forcefully killing OpenVPN

### DIFF
--- a/talpid-core/src/process/stoppable_process.rs
+++ b/talpid-core/src/process/stoppable_process.rs
@@ -1,4 +1,4 @@
-use log::{debug, trace, warn};
+use log::{debug, info, trace, warn};
 use std::{
     io, thread,
     time::{Duration, Instant},
@@ -28,11 +28,12 @@ where
         self.stop();
         if wait_timeout(self, timeout)? {
             debug!("Child process terminated gracefully");
-            Ok(())
         } else {
             warn!("Child process did not terminate gracefully within timeout, forcing termination");
-            self.kill()
+            self.kill()?;
+            info!("Child process killed");
         }
+        Ok(())
     }
 }
 /// Wait for a process to die for a maximum of `timeout`. Returns true if the process died within


### PR DESCRIPTION
The daemon can get stuck sometimes when disconnecting. We are not sure exactly what it is, but we suspect it's a bug in the subprocess handling. Maybe related to our other filedescriptor issues.

To easier detect if it's the killing of OpenVPN that is stuck or not I add this logging. We still can't reliably reproduce this error. But if we get this merged, then maybe we can get some slightly more helpful logs about this sometime in the future.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1221)
<!-- Reviewable:end -->
