### PR TITLE
More debug logging around openvpn handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,12 +450,12 @@ dependencies = [
 
 [[package]]
 name = "duct"
-version = "0.12.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "os_pipe 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_pipe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_child 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1324,7 +1324,7 @@ version = "2019.9.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "duct 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1365,7 +1365,7 @@ dependencies = [
 name = "mullvad-tests"
 version = "0.1.0"
 dependencies = [
- "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "duct 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",
  "jsonrpc-client-ipc 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)",
@@ -1558,6 +1558,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "openssl"
 version = "0.10.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1603,15 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "os_pipe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2388,7 +2402,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "duct 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3161,7 +3175,7 @@ dependencies = [
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
-"checksum duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3640af123c78bedc20c1d3928e43cc0621e57011899d1ef917900c12fdb7a1ee"
+"checksum duct 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5db881d9db1674cb1e40cb225319e3a149ef85b50fd99e09fd75d26bf766de59"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -3258,10 +3272,12 @@ dependencies = [
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
 "checksum openssl-sys 0.9.51 (registry+https://github.com/rust-lang/crates.io-index)" = "ba24190c8f0805d3bd2ce028f439fe5af1d55882bbe6261bed1dbc93b50dd6b1"
 "checksum openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)" = "<none>"
 "checksum os_pipe 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "81e8dfa4c69d7bde595e9a940fcf1d7f60966d3fce8a8c4cad67c60e35ea2a11"
+"checksum os_pipe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "db4d06355a7090ce852965b2d08e11426c315438462638c6d721448d0b47aa22"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parity-tokio-ipc 0.2.0 (git+https://github.com/nikvolf/parity-tokio-ipc)" = "<none>"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -308,7 +308,6 @@ pub struct ManagementInterfaceEventBroadcaster {
 impl EventListener for ManagementInterfaceEventBroadcaster {
     /// Sends a new state update to all `new_state` subscribers of the management interface.
     fn notify_new_state(&self, new_state: TunnelState) {
-        log::debug!("Broadcasting new state: {:?}", new_state);
         self.notify(DaemonEvent::TunnelState(new_state));
     }
 

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -29,7 +29,7 @@ talpid-types = { path = "../talpid-types" }
 
 
 [target.'cfg(target_os = "android")'.dependencies]
-duct = "0.12"
+duct = "0.13"
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 integration-tests = []
 
 [dependencies]
-duct = "0.12"
+duct = "0.13"
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-types = { path = "../mullvad-types" }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 atty = "0.2"
 cfg-if = "0.1"
-duct = "0.12"
+duct = "0.13"
 err-derive = "0.2.1"
 futures = "0.1"
 ipnetwork = "0.15"

--- a/talpid-core/src/dns/linux/resolvconf.rs
+++ b/talpid-core/src/dns/linux/resolvconf.rs
@@ -63,7 +63,7 @@ impl Resolvconf {
         }
 
         let output = duct::cmd!(&self.resolvconf, "-a", &record_name)
-            .input(record_contents)
+            .stdin_bytes(record_contents)
             .stderr_capture()
             .unchecked()
             .run()

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -374,7 +374,7 @@ impl OpenVpnProcHandle {
         }
 
         let (reader, writer) = pipe()?;
-        let proc_handle = cmd.stdin_handle(reader).start()?;
+        let proc_handle = cmd.stdin_file(reader).start()?;
 
         Ok(Self {
             inner: proc_handle,

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -388,7 +388,9 @@ impl StoppableProcess for OpenVpnProcHandle {
     fn stop(&self) {
         // Dropping our stdin handle so that it is closed once. Closing the handle should
         // gracefully stop our openvpn child process.
-        let _ = self.stdin.lock().take();
+        if self.stdin.lock().take().is_none() {
+            log::warn!("Tried to close OpenVPN stdin handle twice, this is a bug");
+        }
     }
 
     fn kill(&self) -> io::Result<()> {

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -394,7 +394,10 @@ impl StoppableProcess for OpenVpnProcHandle {
     }
 
     fn kill(&self) -> io::Result<()> {
-        self.inner.kill()
+        log::warn!("Killing OpenVPN process");
+        self.inner.kill()?;
+        log::debug!("OpenVPN forcefully killed");
+        Ok(())
     }
 
     fn has_stopped(&self) -> io::Result<bool> {

--- a/talpid-core/src/process/stoppable_process.rs
+++ b/talpid-core/src/process/stoppable_process.rs
@@ -1,4 +1,3 @@
-use log::{debug, info, trace, warn};
 use std::{
     io, thread,
     time::{Duration, Instant},
@@ -24,14 +23,15 @@ where
     /// Attempts to stop a process gracefully in the given time period, otherwise kills the
     /// process.
     fn nice_kill(&self, timeout: Duration) -> io::Result<()> {
-        trace!("Trying to stop child process gracefully");
+        log::debug!("Trying to stop child process gracefully");
         self.stop();
         if wait_timeout(self, timeout)? {
-            debug!("Child process terminated gracefully");
+            log::debug!("Child process terminated gracefully");
         } else {
-            warn!("Child process did not terminate gracefully within timeout, forcing termination");
+            log::warn!(
+                "Child process did not terminate gracefully within timeout, forcing termination"
+            );
             self.kill()?;
-            info!("Child process killed");
         }
         Ok(())
     }

--- a/talpid-core/src/proxy/shadowsocks.rs
+++ b/talpid-core/src/proxy/shadowsocks.rs
@@ -151,7 +151,7 @@ impl ShadowsocksProxyMonitor {
         logging::rotate_log(&logfile)
             .map_err(|_| Error::new(ErrorKind::Other, "Failed to rotate log file"))?;
 
-        cmd = cmd.stdin_null().stderr_to_stdout().stdout(&logfile);
+        cmd = cmd.stdin_null().stderr_to_stdout().stdout_path(&logfile);
 
         let subproc = cmd.start()?;
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -99,6 +99,10 @@ impl ConnectingState {
             let start = Instant::now();
 
             let block_reason = Self::wait_for_tunnel_monitor(tunnel_monitor);
+            debug!(
+                "Tunnel monitor exited with block reason: {:?}",
+                block_reason
+            );
 
             if block_reason.is_none() {
                 if let Some(remaining_time) = MIN_TUNNEL_ALIVE_TIME.checked_sub(start.elapsed()) {


### PR DESCRIPTION
We have rare but reoccurring deadlocks that we think are related to subprocesses. We suspect the bug might be in `duct`, but it can just as well be our own fault. This PR mainly aims to add more logging around the calls we think deadlock. But it also upgrades duct to the latest version

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
