### PR TITLE
Add newlines+tabs to relay settings change log entry

### DIFF
--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -196,7 +196,7 @@ impl Settings {
                 self.bridge_state = BridgeState::Auto;
             }
             debug!(
-                "changing relay settings from {} to {}",
+                "Changing relay settings:\n\tfrom: {}\n\tto: {}",
                 self.relay_settings, new_settings
             );
 


### PR DESCRIPTION
The relay settings struct `Display` impl can be very very long. Which makes two in a row just reparated by " to " hard to see clearly. Adding newlines and other formatting to make it clearer how things change.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1224)
<!-- Reviewable:end -->
