### PR TITLE
Add workaround for failure on PATH value having an incorrect type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 #### Windows
 - Detect removal of the OpenVPN TAP adapter on reconnection attempts.
+- Improve robustness in path environment variable logic in Windows installer. Handle the case
+  where the registry value type is incorrectly set to be a regular string rather than an expandable
+  string.
 
 
 ## [2019.9] - 2019-10-11


### PR DESCRIPTION
We decided to abort the installation when the type of the PATH value in registry was not set to REG_EXPAND_SZ (#1160). It turns out that some applications are not as careful and will overwrite this with a value of type REG_SZ, so I've added this as fallback in case it fails.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1228)
<!-- Reviewable:end -->
