### PR TITLE
Recreate tun when stuck in reconnect loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Use a larger icon in notifications on Windows 10.
 
+#### Android
+- Recreate tun device after a fixed number of connection attempts on the same tun device.
+
 ### Fixed
 #### Windows
 - Detect removal of the OpenVPN TAP adapter on reconnection attempts.

--- a/talpid-core/src/tunnel/tun_provider/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/mod.rs
@@ -53,6 +53,14 @@ pub trait TunProvider: Send + 'static {
     fn get_tun(&mut self, config: TunConfig) -> Result<Box<dyn Tun>, BoxedError>;
 
     /// Open a tunnel device using the previous or the default configuration.
+    ///
+    /// Will open a new tunnel if there is already an active tunnel. The previous tunnel will be
+    /// closed.
+    #[cfg(target_os = "android")]
+    fn create_tun(&mut self) -> Result<(), BoxedError>;
+
+    /// Open a tunnel device using the previous or the default configuration if there is no
+    /// currently active tunnel.
     #[cfg(target_os = "android")]
     fn create_tun_if_closed(&mut self) -> Result<(), BoxedError>;
 

--- a/talpid-core/src/tunnel/tun_provider/stub.rs
+++ b/talpid-core/src/tunnel/tun_provider/stub.rs
@@ -16,6 +16,11 @@ impl TunProvider for StubTunProvider {
     }
 
     #[cfg(target_os = "android")]
+    fn create_tun(&mut self) -> Result<(), BoxedError> {
+        unimplemented!();
+    }
+
+    #[cfg(target_os = "android")]
     fn create_tun_if_closed(&mut self) -> Result<(), BoxedError> {
         unimplemented!();
     }


### PR DESCRIPTION
Sometimes, the `tun` that is opened and used for the connection attempts seems to simply discard all packets. When this happens, the app would previously get stuck in an endless reconnecting loop.

This PR implements a workaround to the issue, by closing and opening the `tun` device after a specified number of reconnection attempts. This number is currently hard-coded in the code.

The `TunProvider` already had a `create_tun_if_closed` method that's specific to Android. This PR adds a new `create_tun` method that opens a new tunnel whether or not there already is an open tunnel. The common code was moved to a new `open_tun` private helper method.

When the tunnel state machine's `ConnectingState` detects it has tried to connect with the same tunnel as many times as the maximum number, it will call the new `create_tun` method to create a new `tun` device. If that fails, things proceed normally, since the code that follows will try to create the tunnel if it doesn't already exist, and either that succeeds and things continue as normal, or it will fail again and move to the blocked state.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1229)
<!-- Reviewable:end -->
