### PR TITLE
Handle wireguard log file inside `wireguard-go`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Line wrap the file at 100 chars.                                              Th
 - Recreate tun device after a fixed number of connection attempts on the same tun device.
 
 ### Fixed
+- Fix bad file descriptor errors caused by sending a file descriptor between the daemon and the
+  `wireguard-go` library.
+
 #### Windows
 - Detect removal of the OpenVPN TAP adapter on reconnection attempts.
 - Improve robustness in path environment variable logic in Windows installer. Handle the case

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -221,13 +221,14 @@ impl TunnelMonitor {
         log_dir: &Option<PathBuf>,
     ) -> Result<Option<PathBuf>> {
         if let Some(ref log_dir) = log_dir {
-            let filename = match parameters {
-                TunnelParameters::OpenVpn(_) => OPENVPN_LOG_FILENAME,
-                TunnelParameters::Wireguard(_) => WIREGUARD_LOG_FILENAME,
-            };
-            let tunnel_log = log_dir.join(filename);
-            logging::rotate_log(&tunnel_log)?;
-            Ok(Some(tunnel_log))
+            match parameters {
+                TunnelParameters::OpenVpn(_) => {
+                    let tunnel_log = log_dir.join(OPENVPN_LOG_FILENAME);
+                    logging::rotate_log(&tunnel_log)?;
+                    Ok(Some(tunnel_log))
+                }
+                TunnelParameters::Wireguard(_) => Ok(Some(log_dir.join(WIREGUARD_LOG_FILENAME))),
+            }
         } else {
             Ok(None)
         }


### PR DESCRIPTION
Previously, the `wireguard-go` glue library would use as log output a file descriptor received through FFI. This led to some weird issues, where sometimes the process would run into EBADF errors in different places.

This PR changes the logging setup to use an updated version of the `wireguard-go` glue library. The new version doesn't receive a file descriptor anymore, but a file path instead and the file is handled inside the Go library.

The code in `talpid-core` is updated in this PR to only send the file path, and to not handle the log file anymore.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1230)
<!-- Reviewable:end -->
