### PR TITLE
Respect rustflags and fix dead code

### DIFF
--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN_CHANNEL=$1
-RUSTFLAGS="--deny unused_imports --deny dead_code"
+export RUSTFLAGS="--deny unused_imports --deny dead_code"
 
 source env.sh ""
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -27,7 +27,7 @@ use talpid_types::{
     ErrorExt,
 };
 
-
+#[cfg(target_os = "android")]
 const MAX_ATTEMPTS_WITH_SAME_TUN: u32 = 5;
 const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
 


### PR DESCRIPTION
Apparently we lost our strict check of `unused_imports` and `dead_code` somewhere along the way. `export`ing the variable makes sure it's valid during the actual `cargo` runs later in the script.

Also fixes the dead code warning(now error) that made me find this :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1233)
<!-- Reviewable:end -->
