### PR TITLE
Move around one Android changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,13 +51,11 @@ This release is for Android only.
 - Use authenticated URLs to go to wireguard key page on website.
 - WireGuard key fragment has been made more similar to its desktop counterpart.
 
-### Changed
-#### Android
-- Recreate tun device after a fixed number of connection attempts on the same tun device.
-
 ### Fixed
 - Fix bad file descriptor errors caused by sending a file descriptor between the daemon and the
   `wireguard-go` library.
+- Recreate tun device after a fixed number of connection attempts on the same tun device. Breaks
+  infinite reconnection loops on broken tun devices.
 
 
 ## [2019.9] - 2019-10-11


### PR DESCRIPTION
Correct me if I'm wrong. But I interpret this change as being mostly(only?) for fixing the infinite reconnect loop. If true, it's a bugfix. It's true that bugfixes are changes, but after all this is a changelog. Anything that does not fit into any more specific category can go in `### Changed` but this felt like it was more of a `### Fixed` thing?

The release tag is already published and all. But does not hurt to fix this after either. If we get this approved very soon, I can use the new formulation in the github release post.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1234)
<!-- Reviewable:end -->
