### PR TITLE
Run the routing manager in it's own thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Line wrap the file at 100 chars.                                              Th
   minutes to allow for addressing the issue.
 
 ### Fixed
+#### Linux
+- Improved stability on Linux by using the routing netlink socket in it's own thread.
+
 #### Windows
 - Detect removal of the OpenVPN TAP adapter on reconnection attempts.
 - Improve robustness in path environment variable logic in Windows installer. Handle the case

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -277,7 +277,9 @@ pub fn install_service() -> Result<(), InstallError> {
     const FIFTEEN_MINUTES_AS_SECS: u64 = 60 * 15;
 
     let failure_actions = ServiceFailureActions {
-        reset_period: ServiceFailureResetPeriod::After(Duration::from_secs(FIFTEEN_MINUTES_AS_SECS)),
+        reset_period: ServiceFailureResetPeriod::After(Duration::from_secs(
+            FIFTEEN_MINUTES_AS_SECS,
+        )),
         reboot_msg: None,
         command: None,
         actions: Some(recovery_actions),

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -97,11 +97,8 @@ impl WireguardMonitor {
             Self::get_tunnel_routes(config),
         )?);
         let iface_name = tunnel.get_interface_name();
-        let route_handle = routing::RouteManager::new(
-            Self::get_routes(iface_name, &config),
-            &mut tokio_executor::DefaultExecutor::current(),
-        )
-        .map_err(Error::SetupRoutingError)?;
+        let route_handle = routing::RouteManager::new(Self::get_routes(iface_name, &config))
+            .map_err(Error::SetupRoutingError)?;
         let event_callback = Box::new(on_event.clone());
         let (close_msg_sender, close_msg_receiver) = mpsc::channel();
         let (pinger_tx, pinger_rx) = mpsc::channel();


### PR DESCRIPTION
There are issues with deadlocking when running the routing code on the same event loop as the tunnel state machine. Thus, I've moved the routing code into it's own thread which resolves the issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1242)
<!-- Reviewable:end -->
