### PR TITLE
Idiomatic duration constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=f518cd53a842985eea08c236a6ebd072ee5d88ac)",
+ "windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=48d755b0afbf259ba547d4defc3e9340d1436cf6)",
  "winres 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "windows-service"
 version = "0.2.0"
-source = "git+https://github.com/mullvad/windows-service-rs.git?rev=f518cd53a842985eea08c236a6ebd072ee5d88ac#f518cd53a842985eea08c236a6ebd072ee5d88ac"
+source = "git+https://github.com/mullvad/windows-service-rs.git?rev=48d755b0afbf259ba547d4defc3e9340d1436cf6#48d755b0afbf259ba547d4defc3e9340d1436cf6"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3428,7 +3428,7 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"
-"checksum windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=f518cd53a842985eea08c236a6ebd072ee5d88ac)" = "<none>"
+"checksum windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=48d755b0afbf259ba547d4defc3e9340d1436cf6)" = "<none>"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum winres 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4fb510bbfe5b8992ff15f77a2e6fe6cf062878f0eda00c0f44963a807ca5dc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -55,7 +55,7 @@ simple-signal = "1.1"
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"
-windows-service = { git = "https://github.com/mullvad/windows-service-rs.git", rev = "f518cd53a842985eea08c236a6ebd072ee5d88ac" }
+windows-service = { git = "https://github.com/mullvad/windows-service-rs.git", rev = "48d755b0afbf259ba547d4defc3e9340d1436cf6" }
 winapi = "0.3"
 
 [target.'cfg(windows)'.build-dependencies]


### PR DESCRIPTION
This fixes the formatting error on https://travis-ci.com/mullvad/mullvadvpn-app/jobs/258138656#L230

And it also tries to be a bit more idiomatic on storing times as structured types instead of integers. That way the variable name can reflect what the time is supposed to represent, instead of the time unit and how long time it is. I'm not sure if the current names are perfect. Because I did not know exactly what they represented, which is exactly the problem I'm trying to address here :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1247)
<!-- Reviewable:end -->
