### PR TITLE
Fix installer/updater regression

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -286,8 +286,8 @@
 			log::LogWithDetails $R0 $1
 		${EndIf}
 	${EndIf}
-	
-	IntCmp $0 ${EB_NO_TAP_ADAPTERS_PRESENT} InstallDriver_install_driver
+
+	IntCmp $InstallDriver_BaselineStatus ${EB_NO_TAP_ADAPTERS_PRESENT} InstallDriver_install_driver
 
 	#
 	# Driver is already installed and there are one or several virtual adapters present.


### PR DESCRIPTION
The TAP driver would sometimes attempt to call `update` instead of `install`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1249)
<!-- Reviewable:end -->
