### PR TITLE
Limit OpenVPN to use TLS >=1.2 and limit 1.3 ciphers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ Line wrap the file at 100 chars.                                              Th
   string.
 - Fix suspend and resume issues with OpenVPN by upgrading the TAP driver.
 
+### Security
+- Force OpenVPN to use TLS 1.2 or newer. And limit the TLS 1.3 ciphers to only the strongest ones.
+  The Mullvad servers have never allowed any insecure ciphers, so this was not really a problem.
+  Just one extra safety precaution.
+
 
 ## [2019.10-beta1] - 2019-11-06
 This release is for Android only.


### PR DESCRIPTION
We already specify only secure ciphers for TLS <=1.2. But since layers upon layers of security is our usual method I felt we could just as well specify `--tls-version-min` as well. Later when more servers are upgraded we can even set it to 1.3.

The `--tls-client` argument should force the control channel to use TLS. It already did that from before given the combination of server+client options anyway, but this makes it more explicit, and it tells it to act as the client half of said TLS handshake from the start.

There are not really any insecure ciphers allowed in TLS 1.3 by default. But specifying the two strongest ones rules out the 128 bit AES one. Mostly because why not. The servers currently support that 128 bit AES cipher, but they plan on setting the same `tls-ciphersuites` as us soon.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1250)
<!-- Reviewable:end -->
