### PR TITLE
Verify if changes made with resolvconf were actually applied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Line wrap the file at 100 chars.                                              Th
 - Upgrade libsodium from 1.0.17 to 1.0.18.
 - Upgrade NDIS 6 TAP driver from 9.21.2 to 9.24.2.
 
+#### Linux
+- Add extra verification steps when managing DNS with `resolvconf` on Linux.
+
 ### Fixed
 #### Linux
 - Improved stability on Linux by using the routing netlink socket in it's own thread.


### PR DESCRIPTION
I've added extra verification to check if `resolvconf` has worked successfully by checking 3 things:
1. Check if our servers are in output of `systemd-resolved --status`
1. Check if our servers are in the output of `resolvconf -l`.
1. Check if our servers are in `/etc/resolv.conf`.
If our servers don't appear in any of the above, then the daemon will assume that it failed to apply DNS settings, giving a _slightly_ better error to our users. Additionally, maybe we need to change the error we show to the users on Linux to encourage them to explain their exotic setups to us.

I've tested this on various configs with 16.04, 18.04 and 19.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1251)
<!-- Reviewable:end -->
