### PR TITLE
Verify if dnsmasq is running and misconfigured when using resolvconf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,12 @@ Line wrap the file at 100 chars.                                              Th
 - Upgrade libsodium from 1.0.17 to 1.0.18.
 - Upgrade NDIS 6 TAP driver from 9.21.2 to 9.24.2.
 
+
 ### Fixed
 #### Linux
 - Improved stability on Linux by using the routing netlink socket in it's own thread.
+- When trying to use `resolvconf` for managing DNS, the daemon will check if
+ `dnsmasq` is running and misconfigured.
 
 #### Windows
 - Detect removal of the OpenVPN TAP adapter on reconnection attempts.


### PR DESCRIPTION
`dnsmasq` can be configured to ignore any externally configured DNS servers, which breaks `resolvconf` integration with it. Since there's no way to externally verify this (`resolvconf -l` will return the list of DNS servers that _should be set_), when using `resolvconf`, the daemon will verify if `dnsmasq` is running and whether it's configured to ignore external configurations. In case it is misconfigured and running, the daemon will not use `resolvconf` to manage DNS and will fall back to managing DNS by just manipulating `/etc/resolv.conf` manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1255)
<!-- Reviewable:end -->
