### PR TITLE
Rerun build scripts if binary artifacts have changed

### DIFF
--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -70,6 +70,7 @@ fn main() {
         .join("../dist-assets/binaries")
         .join(target_triplet);
 
+    println!("cargo:rerun-if-changed={}", lib_dir.display());
     println!("cargo:rustc-link-search={}", lib_dir.display());
     println!("cargo:rustc-link-lib{}=wg", link_type);
 }


### PR DESCRIPTION
To elude a rather heavy handed `cargo clean` when trying out different changes in any of the binary artifacts we link against, I've added a small change to `build.rs` of `talpid-core` to rebuild the library any time any of the binary artifacts for the target platform change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1256)
<!-- Reviewable:end -->
