### PR TITLE
Simpler code for converting ExceptionCode to a string

### DIFF
--- a/mullvad-daemon/src/windows_exception_logging.rs
+++ b/mullvad-daemon/src/windows_exception_logging.rs
@@ -25,75 +25,44 @@ pub fn enable() {
 }
 
 fn exception_code_to_string(value: &EXCEPTION_RECORD) -> Option<Cow<'_, str>> {
-    match value.ExceptionCode {
-        winapi::um::minwinbase::EXCEPTION_ACCESS_VIOLATION
-        | winapi::um::minwinbase::EXCEPTION_IN_PAGE_ERROR => {
-            let operation_type = match value.ExceptionInformation[0] {
-                0 => "read from inaccessible address",
-                1 => "wrote to inaccessible address",
-                8 => "user-mode data execution prevention (DEP) violation",
-                _ => "unknown error",
-            };
-            let name =
-                if let winapi::um::minwinbase::EXCEPTION_ACCESS_VIOLATION = value.ExceptionCode {
-                    "EXCEPTION_ACCESS_VIOLATION"
-                } else {
-                    "EXCEPTION_IN_PAGE_ERROR"
-                };
-            Some(Cow::Owned(format!(
-                "{} ({}, VA {:#x?})",
-                name, operation_type, value.ExceptionInformation[1]
-            )))
-        }
-        winapi::um::minwinbase::EXCEPTION_ARRAY_BOUNDS_EXCEEDED => {
-            Some(Cow::Borrowed("EXCEPTION_ARRAY_BOUNDS_EXCEEDED"))
-        }
-        winapi::um::minwinbase::EXCEPTION_DATATYPE_MISALIGNMENT => {
-            Some(Cow::Borrowed("EXCEPTION_DATATYPE_MISALIGNMENT"))
-        }
-        winapi::um::minwinbase::EXCEPTION_FLT_DENORMAL_OPERAND => {
-            Some(Cow::Borrowed("EXCEPTION_FLT_DENORMAL_OPERAND"))
-        }
-        winapi::um::minwinbase::EXCEPTION_FLT_DIVIDE_BY_ZERO => {
-            Some(Cow::Borrowed("EXCEPTION_FLT_DIVIDE_BY_ZERO"))
-        }
-        winapi::um::minwinbase::EXCEPTION_FLT_INEXACT_RESULT => {
-            Some(Cow::Borrowed("EXCEPTION_FLT_INEXACT_RESULT"))
-        }
-        winapi::um::minwinbase::EXCEPTION_FLT_INVALID_OPERATION => {
-            Some(Cow::Borrowed("EXCEPTION_FLT_INVALID_OPERATION"))
-        }
-        winapi::um::minwinbase::EXCEPTION_FLT_STACK_CHECK => {
-            Some(Cow::Borrowed("EXCEPTION_FLT_STACK_CHECK"))
-        }
-        winapi::um::minwinbase::EXCEPTION_FLT_UNDERFLOW => {
-            Some(Cow::Borrowed("EXCEPTION_FLT_UNDERFLOW"))
-        }
-        winapi::um::minwinbase::EXCEPTION_ILLEGAL_INSTRUCTION => {
-            Some(Cow::Borrowed("EXCEPTION_ILLEGAL_INSTRUCTION"))
-        }
-        winapi::um::minwinbase::EXCEPTION_INT_DIVIDE_BY_ZERO => {
-            Some(Cow::Borrowed("EXCEPTION_INT_DIVIDE_BY_ZERO"))
-        }
-        winapi::um::minwinbase::EXCEPTION_INT_OVERFLOW => {
-            Some(Cow::Borrowed("EXCEPTION_INT_OVERFLOW"))
-        }
-        winapi::um::minwinbase::EXCEPTION_INVALID_DISPOSITION => {
-            Some(Cow::Borrowed("EXCEPTION_INVALID_DISPOSITION"))
-        }
-        winapi::um::minwinbase::EXCEPTION_NONCONTINUABLE_EXCEPTION => {
-            Some(Cow::Borrowed("EXCEPTION_NONCONTINUABLE_EXCEPTION"))
-        }
-        winapi::um::minwinbase::EXCEPTION_PRIV_INSTRUCTION => {
-            Some(Cow::Borrowed("EXCEPTION_PRIV_INSTRUCTION"))
-        }
-        winapi::um::minwinbase::EXCEPTION_SINGLE_STEP => {
-            Some(Cow::Borrowed("EXCEPTION_SINGLE_STEP"))
-        }
-        winapi::um::minwinbase::EXCEPTION_STACK_OVERFLOW => {
-            Some(Cow::Borrowed("EXCEPTION_STACK_OVERFLOW"))
-        }
-        _ => None,
+    use winapi::um::minwinbase::*;
+    let name = match value.ExceptionCode {
+        EXCEPTION_ACCESS_VIOLATION => "EXCEPTION_ACCESS_VIOLATION",
+        EXCEPTION_IN_PAGE_ERROR => "EXCEPTION_IN_PAGE_ERROR",
+        EXCEPTION_ARRAY_BOUNDS_EXCEEDED => "EXCEPTION_ARRAY_BOUNDS_EXCEEDED",
+        EXCEPTION_DATATYPE_MISALIGNMENT => "EXCEPTION_DATATYPE_MISALIGNMENT",
+        EXCEPTION_FLT_DENORMAL_OPERAND => "EXCEPTION_FLT_DENORMAL_OPERAND",
+        EXCEPTION_FLT_DIVIDE_BY_ZERO => "EXCEPTION_FLT_DIVIDE_BY_ZERO",
+        EXCEPTION_FLT_INEXACT_RESULT => "EXCEPTION_FLT_INEXACT_RESULT",
+        EXCEPTION_FLT_INVALID_OPERATION => "EXCEPTION_FLT_INVALID_OPERATION",
+        EXCEPTION_FLT_STACK_CHECK => "EXCEPTION_FLT_STACK_CHECK",
+        EXCEPTION_FLT_UNDERFLOW => "EXCEPTION_FLT_UNDERFLOW",
+        EXCEPTION_ILLEGAL_INSTRUCTION => "EXCEPTION_ILLEGAL_INSTRUCTION",
+        EXCEPTION_INT_DIVIDE_BY_ZERO => "EXCEPTION_INT_DIVIDE_BY_ZERO",
+        EXCEPTION_INT_OVERFLOW => "EXCEPTION_INT_OVERFLOW",
+        EXCEPTION_INVALID_DISPOSITION => "EXCEPTION_INVALID_DISPOSITION",
+        EXCEPTION_NONCONTINUABLE_EXCEPTION => "EXCEPTION_NONCONTINUABLE_EXCEPTION",
+        EXCEPTION_PRIV_INSTRUCTION => "EXCEPTION_PRIV_INSTRUCTION",
+        EXCEPTION_SINGLE_STEP => "EXCEPTION_SINGLE_STEP",
+        EXCEPTION_STACK_OVERFLOW => "EXCEPTION_STACK_OVERFLOW",
+        _ => return None,
+    };
+
+    if value.ExceptionCode == EXCEPTION_ACCESS_VIOLATION
+        || value.ExceptionCode == EXCEPTION_IN_PAGE_ERROR
+    {
+        let operation_type = match value.ExceptionInformation[0] {
+            0 => "read from inaccessible address",
+            1 => "wrote to inaccessible address",
+            8 => "user-mode data execution prevention (DEP) violation",
+            _ => "unknown error",
+        };
+        Some(Cow::Owned(format!(
+            "{} ({}, VA {:#x?})",
+            name, operation_type, value.ExceptionInformation[1]
+        )))
+    } else {
+        Some(Cow::Borrowed(name))
     }
 }
 


### PR DESCRIPTION
I didn't want to comment on this in your original PR. Because your code worked and it was nothing wrong with it. But I felt I wanted to experiment a bit with the matching and see if I could do it a bit less verbose. See if you like it or not and feel free to ask questions or come with feedback :)

My main goal here was to reduce duplication of `Some(Cow::Borrowed(`. But I also employed the wildcard import trick I mentioned in your PR. These things together allows all match arms to be a single line.

The early return in the match allows us to abort on invalid code and make the type of `name` a `&'static str`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1257)
<!-- Reviewable:end -->
