### PR TITLE
Fix driver error handling in Windows installer

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -262,14 +262,14 @@
 	Pop $0
 	Pop $1
 
+	Push $0
+	Pop $InstallDriver_BaselineStatus
+
 	${If} $0 == ${EB_GENERAL_ERROR}
 		StrCpy $R0 "Failed to enumerate network adapters: $1"
 		log::Log $R0
 		Goto InstallDriver_return
 	${EndIf}
-
-	Push $0
-	Pop $InstallDriver_BaselineStatus
 
 	${IfNot} ${AtLeastWin10}
 		#
@@ -300,6 +300,7 @@
 	Pop $1
 
 	${If} $0 != 0
+	${AndIf} $0 != 1
 		StrCpy $R0 "Failed to update TAP driver: error $0"
 		log::LogWithDetails $R0 $1
 		Goto InstallDriver_return
@@ -337,6 +338,7 @@
 	Pop $1
 
 	${If} $0 != 0
+	${AndIf} $0 != 1
 		StrCpy $R0 "Failed to create virtual adapter: error $0"
 		log::LogWithDetails $R0 $1
 		Goto InstallDriver_return

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -50,6 +50,12 @@
 !define PE_GENERAL_ERROR 0
 !define PE_SUCCESS 1
 
+# Return codes from tapinstall
+!define DEVCON_EXIT_OK 0
+!define DEVCON_EXIT_REBOOT 1
+!define DEVCON_EXIT_FAIL 2
+!define DEVCON_EXIT_USAGE 3
+
 # Log targets
 !define LOG_FILE 0
 !define LOG_VOID 1
@@ -299,8 +305,8 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != 0
-	${AndIf} $0 != 1
+	${If} $0 != ${DEVCON_EXIT_OK}
+	${AndIf} $0 != ${DEVCON_EXIT_REBOOT}
 		StrCpy $R0 "Failed to update TAP driver: error $0"
 		log::LogWithDetails $R0 $1
 		Goto InstallDriver_return
@@ -337,8 +343,8 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != 0
-	${AndIf} $0 != 1
+	${If} $0 != ${DEVCON_EXIT_OK}
+	${AndIf} $0 != ${DEVCON_EXIT_REBOOT}
 		StrCpy $R0 "Failed to create virtual adapter: error $0"
 		log::LogWithDetails $R0 $1
 		Goto InstallDriver_return

--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -81,7 +81,8 @@ std::set<Context::NetworkAdapter> GetTapAdapters(const std::set<Context::Network
 	return tapAdapters;
 }
 
-void LogAdapters(const std::wstring &description, const std::set<Context::NetworkAdapter> &adapters)
+template<typename T>
+void LogAdapters(const std::wstring &description, const T &adapters)
 {
 	//
 	// Flatten the information so we can log it more easily.
@@ -239,6 +240,7 @@ Context::NetworkAdapter Context::getNewAdapter()
 	if (added.size() != 1)
 	{
 		LogAdapters(L"Enumerable network adapters", m_currentState);
+		LogAdapters(L"Added TAP adapters", added);
 
 		throw std::runtime_error("Unable to identify recently added TAP adapter");
 	}


### PR DESCRIPTION
Some return values were incorrectly treated as errors. Also, log more information when TAP identification fails.

There may be an additional problem here left related to identifying the new adapter. Hopefully the logs will be more informative if it appears again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1261)
<!-- Reviewable:end -->
