### PR TITLE
Deny unused mut

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
             ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
             linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
       before_script:
-        - export RUSTFLAGS="--deny unused_imports --deny dead_code"
+        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut"
         - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar
         - export CC_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang
         - source env.sh aarch64-linux-android

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN_CHANNEL=$1
-export RUSTFLAGS="--deny unused_imports --deny dead_code"
+export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut"
 
 source env.sh ""
 

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -82,12 +82,12 @@ impl RouteManager {
 
     /// Sets a callback that is called whenever the default route changes.
     #[cfg(target_os = "windows")]
-    pub fn set_default_route_callback<T: 'static>(
+    pub fn add_default_route_callback<T: 'static>(
         &mut self,
         callback: Option<winnet::DefaultRouteChangedCallback>,
         context: T,
     ) {
-        match winnet::set_default_route_change_callback(callback, context) {
+        match winnet::add_default_route_change_callback(callback, context) {
             Err(_e) => {
                 // not sure if this should panic
                 log::error!("Failed to add callback!");

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -102,6 +102,7 @@ impl WireguardMonitor {
             Self::get_tunnel_routes(config),
         )?);
         let iface_name = tunnel.get_interface_name();
+        #[cfg_attr(not(windows), allow(unused_mut))]
         let mut route_handle = routing::RouteManager::new(Self::get_routes(iface_name, &config))
             .map_err(Error::SetupRoutingError)?;
 

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -107,7 +107,7 @@ impl WireguardMonitor {
 
         #[cfg(target_os = "windows")]
         route_handle
-            .set_default_route_callback(Some(WgGoTunnel::default_route_changed_callback), ());
+            .add_default_route_callback(Some(WgGoTunnel::default_route_changed_callback), ());
 
         let event_callback = Box::new(on_event.clone());
         let (close_msg_sender, close_msg_receiver) = mpsc::channel();

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -338,7 +338,7 @@ pub type DefaultRouteChangedCallback = unsafe extern "system" fn(
 #[error(display = "Failed to set callback for default route")]
 pub struct DefaultRouteCallbackError;
 
-pub fn set_default_route_change_callback<T: 'static>(
+pub fn add_default_route_change_callback<T: 'static>(
     callback: Option<DefaultRouteChangedCallback>,
     context: T,
 ) -> std::result::Result<WinNetCallbackHandle, DefaultRouteCallbackError> {
@@ -350,7 +350,6 @@ pub fn set_default_route_change_callback<T: 'static>(
         {
             return Err(DefaultRouteCallbackError);
         }
-
 
         Ok(WinNetCallbackHandle {
             handle: handle_ptr,


### PR DESCRIPTION
We got a warning about unused `mut` on non-Windows platforms. Because we only need mutable access to the `route_handle` on Windows. I first added a stricter check for this in the CI. Then I fixed this particular instance.

Since it does indeed look correct that we need to mutate the instance on Windows I went with the simplest solution. Simply marking the warning/error as acceptable on non-Windows platforms. I wanted to make it as specific as possible, so if we ever stop mutating it on Windows we will get the warning back and thus be able to remove the `mut` altogether.

I also renamed `set_default` to `add_default` since it does look like one can add an arbitrary amount of callbacks, not just set one. Please tell me if this is wrong :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1262)
<!-- Reviewable:end -->
