### PR TITLE
Close tunnel thread when the daemon exits

### DIFF
--- a/talpid-core/src/offline/dummy.rs
+++ b/talpid-core/src/offline/dummy.rs
@@ -1,5 +1,6 @@
 use crate::tunnel_state_machine::TunnelCommand;
 use futures::sync::mpsc::UnboundedSender;
+use std::sync::Weak;
 
 #[derive(err_derive::Error, Debug)]
 #[error(display = "Dummy offline check error")]
@@ -13,6 +14,8 @@ impl MonitorHandle {
     }
 }
 
-pub fn spawn_monitor(_sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle, Error> {
+pub fn spawn_monitor(
+    _sender: Weak<UnboundedSender<TunnelCommand>>,
+) -> Result<MonitorHandle, Error> {
     Ok(MonitorHandle)
 }

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,5 +1,6 @@
 use crate::tunnel_state_machine::TunnelCommand;
 use futures::sync::mpsc::UnboundedSender;
+use std::sync::Weak;
 
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]
@@ -27,6 +28,6 @@ impl MonitorHandle {
     }
 }
 
-pub fn spawn_monitor(sender: UnboundedSender<TunnelCommand>) -> Result<MonitorHandle, Error> {
+pub fn spawn_monitor(sender: Weak<UnboundedSender<TunnelCommand>>) -> Result<MonitorHandle, Error> {
     Ok(MonitorHandle(imp::spawn_monitor(sender)?))
 }

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -223,9 +223,7 @@ impl Drop for BroadcastListener {
             PostThreadMessageW(self.thread_id, REQUEST_THREAD_SHUTDOWN, 0, 0);
             WaitForSingleObject(self.thread_handle, INFINITE);
             CloseHandle(self.thread_handle);
-            if !winnet::WinNet_DeactivateConnectivityMonitor() {
-                log::error!("Failed to deactivate connectivity monitor");
-            }
+            winnet::WinNet_DeactivateConnectivityMonitor();
         }
     }
 }

--- a/talpid-core/src/routing/windows.rs
+++ b/talpid-core/src/routing/windows.rs
@@ -47,9 +47,7 @@ impl RouteManagerImpl {
 
 impl Drop for RouteManagerImpl {
     fn drop(&mut self) {
-        if !winnet::deactivate_routing_manager() {
-            log::error!("Failed to deactivate routing manager");
-        }
+        winnet::deactivate_routing_manager()
     }
 }
 

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -364,7 +364,7 @@ pub fn routing_manager_add_routes(routes: &[WinNetRoute]) -> bool {
     unsafe { WinNet_AddRoutes(ptr, length) }
 }
 
-pub fn deactivate_routing_manager() -> bool {
+pub fn deactivate_routing_manager() {
     unsafe { WinNet_DeactivateRouteManager() }
 }
 
@@ -406,7 +406,7 @@ mod api {
         // pub fn WinNet_DeleteRoute(route: *const super::WinNetRoute) -> bool;
 
         #[link_name = "WinNet_DeactivateRouteManager"]
-        pub fn WinNet_DeactivateRouteManager() -> bool;
+        pub fn WinNet_DeactivateRouteManager();
 
         #[link_name = "WinNet_EnsureTopMetric"]
         pub fn WinNet_EnsureTopMetric(
@@ -429,7 +429,7 @@ mod api {
         ) -> bool;
 
         #[link_name = "WinNet_ReleaseString"]
-        pub fn WinNet_ReleaseString(string: *mut wchar_t) -> u32;
+        pub fn WinNet_ReleaseString(string: *mut wchar_t);
 
         #[link_name = "WinNet_ActivateConnectivityMonitor"]
         pub fn WinNet_ActivateConnectivityMonitor(
@@ -450,7 +450,7 @@ mod api {
         pub fn WinNet_UnregisterDefaultRouteChangedCallback(registrationHandle: *mut libc::c_void);
 
         #[link_name = "WinNet_DeactivateConnectivityMonitor"]
-        pub fn WinNet_DeactivateConnectivityMonitor() -> bool;
+        pub fn WinNet_DeactivateConnectivityMonitor();
 
         #[link_name = "WinNet_AddDeviceIpAddresses"]
         pub fn WinNet_AddDeviceIpAddresses(


### PR DESCRIPTION
Currently, the daemon simply kills the tunnel state machine thread, which means that some cleanup functions aren't performed. This is because the channel for the state machine isn't closed, as one sender to it in `OfflineMonitor` is kept around until the tunnel thread exits. I fixed this using a weak reference.
There should be enough time for it to stop on its own now, but probably one should also join the other thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1263)
<!-- Reviewable:end -->
