### PR TITLE
Add tunnel-protocol subcomand to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Add `mullvad relay set tunnel-protocol` subcommand to the CLI to specify what tunnel protocol to
+  use
+
 #### Windows
 - Full WireGuard support, GUI and CLI.
 - Install Wintun driver that provides the WireGuard TUN adapter.


### PR DESCRIPTION
I've added another subcommand to the `mullvad relay set` command to allow users to specify which tunnel protocol to use. I'm unsure if `mullvad relay set tunnel` to `mullvad relay set tunnel-constraints` to better signify that the command only sets constraints by which the tunnel is selected rather than selecting a specific tunnel type to be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1270)
<!-- Reviewable:end -->
