### PR TITLE
Fix error message for routing in MacOS

### DIFF
--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -34,8 +34,8 @@ pub enum Error {
     #[error(display = "Error while running \"route -nv monitor\"")]
     FailedToMonitorRoutes(#[error(source)] io::Error),
 
-    /// No default route in "ip route" output.
-    #[error(display = "No default route in \"ip route\" output")]
+    /// No default route in "route -n get default" output.
+    #[error(display = "No default route in \"route -n get default\" output")]
     NoDefaultRoute,
 
     /// Unexpected output from netstat


### PR DESCRIPTION
This is me fixing a clear case of me applying the infamous CtrlC-CtrlP methodology.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1271)
<!-- Reviewable:end -->
