### PR TITLE
Remove gconf2 cruft from readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt install build-essential \
 	gcc \
 	libdbus-1-dev \
 	rpm \
-	gconf2 \
 	go2 \
 	binutils \
 	curl \

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ The host has to have the following installed:
 ```bash
 # For building the daemon
 sudo apt install gcc libdbus-1-dev
-# For running the frontend app
-sudo apt install gconf2
 # For building the installer
 sudo apt install rpm
 ```


### PR DESCRIPTION
Fixes #1269 

Seems gconf is indeed not a dependency of Electron any more: https://github.com/electron/electron/pull/19498

So we can safely remove it from our readme and docker file. This should have no impact on actual releases since they have not depended on gconf for a long time. But this makes the documentation more in sync with reality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1272)
<!-- Reviewable:end -->
