### PR TITLE
Implement reconnect cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add `mullvad relay set tunnel-protocol` subcommand to the CLI to specify what tunnel protocol to
   use
+- Add `mullvad reconnect` subcommand to the CLI to make the app pick a new server and reconnect.
 
 #### Windows
 - Full WireGuard support, GUI and CLI.

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -7,11 +7,11 @@ pub use self::account::Account;
 mod auto_connect;
 pub use self::auto_connect::AutoConnect;
 
+mod block_when_disconnected;
+pub use self::block_when_disconnected::BlockWhenDisconnected;
+
 mod bridge;
 pub use self::bridge::Bridge;
-
-mod status;
-pub use self::status::Status;
 
 mod connect;
 pub use self::connect::Connect;
@@ -19,17 +19,20 @@ pub use self::connect::Connect;
 mod disconnect;
 pub use self::disconnect::Disconnect;
 
-mod block_when_disconnected;
-pub use self::block_when_disconnected::BlockWhenDisconnected;
+mod lan;
+pub use self::lan::Lan;
+
+mod reconnect;
+pub use self::reconnect::Reconnect;
 
 mod relay;
 pub use self::relay::Relay;
 
-mod lan;
-pub use self::lan::Lan;
-
 mod reset;
 pub use self::reset::Reset;
+
+mod status;
+pub use self::status::Status;
 
 mod tunnel;
 pub use self::tunnel::Tunnel;
@@ -46,6 +49,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         Box::new(Bridge),
         Box::new(Connect),
         Box::new(Disconnect),
+        Box::new(Reconnect),
         Box::new(Lan),
         Box::new(Relay),
         Box::new(Reset),

--- a/mullvad-cli/src/cmds/reconnect.rs
+++ b/mullvad-cli/src/cmds/reconnect.rs
@@ -1,0 +1,22 @@
+use crate::{new_rpc_client, Command, Result};
+use talpid_types::ErrorExt;
+
+pub struct Reconnect;
+
+impl Command for Reconnect {
+    fn name(&self) -> &'static str {
+        "reconnect"
+    }
+
+    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
+        clap::SubCommand::with_name(self.name()).about("Command the client to reconnect")
+    }
+
+    fn run(&self, _matches: &clap::ArgMatches<'_>) -> Result<()> {
+        let mut rpc = new_rpc_client()?;
+        if let Err(e) = rpc.reconnect() {
+            eprintln!("{}", e.display_chain());
+        }
+        Ok(())
+    }
+}

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -782,6 +782,7 @@ where
         }
         match event {
             SetTargetState(tx, state) => self.on_set_target_state(tx, state),
+            Reconnect => self.on_reconnect(),
             GetState(tx) => self.on_get_state(tx),
             GetCurrentLocation(tx) => self.on_get_current_location(tx),
             CreateNewAccount(tx) => self.on_create_new_account(tx),
@@ -916,6 +917,14 @@ where
             warn!("Ignoring target state change request due to shutdown");
         }
         Self::oneshot_send(tx, Ok(()), "target state");
+    }
+
+    fn on_reconnect(&mut self) {
+        if self.target_state == TargetState::Secured || self.tunnel_state.is_blocked() {
+            self.connect_tunnel();
+        } else {
+            debug!("Ignoring reconnect command. Currently not in secured state");
+        }
     }
 
     fn on_get_state(&self, tx: oneshot::Sender<TunnelState>) {

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -99,6 +99,10 @@ impl DaemonRpcClient {
         self.call("disconnect", &NO_ARGS)
     }
 
+    pub fn reconnect(&mut self) -> Result<()> {
+        self.call("reconnect", &NO_ARGS)
+    }
+
     pub fn create_new_account(&mut self) -> Result<()> {
         self.call("create_new_account", &NO_ARGS)
     }

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -69,6 +69,13 @@ impl DaemonInterface {
         Ok(())
     }
 
+    // TODO: Implement this all the way on Android. This method is currently unused.
+    #[allow(dead_code)]
+    pub fn reconnect(&self) -> Result<()> {
+        self.send_command(ManagementCommand::Reconnect)?;
+        Ok(())
+    }
+
     pub fn generate_wireguard_key(&self) -> Result<KeygenEvent> {
         let (tx, rx) = oneshot::channel();
 


### PR DESCRIPTION
I had an idea a long time ago. But I did not bring it up with anyone until today. To have a button to allow reconnects without ever opening up the firewall. So the same as hitting disconnect/cancel and then "secure my connection" again directly after, but without having a small window of possible leaks.

Jan and Richard liked the idea.
* Allows you to cycle to a new server at any point
* Allows you to retry a connection attempt if stuck in the blocked state
* Allows aborting connection attempts that take longer than you expect them to take etc.

I did nothing in the GUI yet. This is more of a side-feature, so I did not want to spend much time on it suddenly. But implementing it in the CLI was very very simple. So I went ahead and did so. Now we have the feature here. We can add it to the GUI when we have another GUI developer :)

The extra changes is just me sorting stuff that had become a bit messy :)

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1273)
<!-- Reviewable:end -->
