### PR TITLE
Fix ownership check in settings migration after Windows updates

### DIFF
--- a/windows/winutil/src/winutil/migration.cpp
+++ b/windows/winutil/src/winutil/migration.cpp
@@ -67,9 +67,10 @@ MigrationStatus MigrateAfterWindowsUpdate()
 		throw std::runtime_error("Could not determine owner of backup directory");
 	}
 
-	if (FALSE == IsWellKnownSid(sid, WinLocalSystemSid))
+	if (FALSE == IsWellKnownSid(sid, WinLocalSystemSid)
+		&& FALSE == IsWellKnownSid(sid, WinBuiltinAdministratorsSid))
 	{
-		throw std::runtime_error("Backup directory is not owned by SYSTEM");
+		throw std::runtime_error("Backup directory is not owned by SYSTEM or Built-in Administrators");
 	}
 
 	//


### PR DESCRIPTION
The backup created by Windows update may be owned by "built-in administrators" rather than SYSTEM.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1278)
<!-- Reviewable:end -->
