### PR TITLE
Check if WinNet_ActivateRouteManager succeeds

### DIFF
--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -286,8 +286,8 @@ impl Drop for WinNetRoute {
 }
 
 pub fn activate_routing_manager(routes: &[WinNetRoute]) -> bool {
-    unsafe { WinNet_ActivateRouteManager(Some(log_sink), ptr::null_mut()) };
-    routing_manager_add_routes(routes)
+    return unsafe { WinNet_ActivateRouteManager(Some(log_sink), ptr::null_mut()) }
+        && routing_manager_add_routes(routes);
 }
 
 pub struct WinNetCallbackHandle {
@@ -391,7 +391,10 @@ mod api {
 
     extern "system" {
         #[link_name = "WinNet_ActivateRouteManager"]
-        pub fn WinNet_ActivateRouteManager(sink: Option<LogSink>, sink_context: *mut c_void);
+        pub fn WinNet_ActivateRouteManager(
+            sink: Option<LogSink>,
+            sink_context: *mut c_void,
+        ) -> bool;
 
         #[link_name = "WinNet_AddRoutes"]
         pub fn WinNet_AddRoutes(routes: *const super::WinNetRoute, num_routes: u32) -> bool;


### PR DESCRIPTION
The function signature for `WinNet_ActivateRouteManager` was wrong Rust-side of the daemon, so the daemon code wasn't checking if an invocation was successful. This fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1280)
<!-- Reviewable:end -->
