### PR TITLE
Update to correct PATH for MSBuild.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The host has to have the following installed:
 - `msbuild.exe` available in `%PATH%`. If you installed Visual Studio Community edition, the
   binary can be found under:
   ```
-  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\<VERSION>\Bin\amd64
+  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\amd64
   ```
 
 - `bash` installed as well as a few base unix utilities, including `sed` and `tail`.


### PR DESCRIPTION
For VS2019 the path to MSBuild.exe was wrong. It seems to now be under `Current` rather than `<VERSION>`. I don't know if it was correct or wrong before either, but at the moment it's definitely not pointing to where the binary is :)

Anything else we have realized we need to update?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1290)
<!-- Reviewable:end -->
