### PR TITLE
Fix channel closing prematurely when sending tunnel command

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -27,7 +27,6 @@ use crate::management_interface::{
     BoxFuture, ManagementInterfaceEventBroadcaster, ManagementInterfaceServer,
 };
 use futures::{
-    executor,
     future::{self, Executor},
     sync::{mpsc::UnboundedSender, oneshot},
     Future,
@@ -1511,8 +1510,8 @@ where
     }
 
     fn send_tunnel_command(&mut self, command: TunnelCommand) {
-        let mut sink = executor::spawn(UnboundedSender::clone(&self.tunnel_command_tx));
-        sink.wait_send(command)
+        self.tunnel_command_tx
+            .unbounded_send(command)
             .expect("Tunnel state machine has stopped");
     }
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1511,7 +1511,7 @@ where
     }
 
     fn send_tunnel_command(&mut self, command: TunnelCommand) {
-        let mut sink = executor::spawn(Arc::make_mut(&mut self.tunnel_command_tx));
+        let mut sink = executor::spawn(UnboundedSender::clone(&self.tunnel_command_tx));
         sink.wait_send(command)
             .expect("Tunnel state machine has stopped");
     }


### PR DESCRIPTION
While rebasing the offline monitor for Android, I noticed that the offline events weren't properly sent to the tunnel state machine after the tunnel was connected for the first time. After investigating the issue, I think the cause is that `Arc::make_mut` ensures that it is the sole owner of the inner data (the channel sender), so the `Weak` reference used in the offline monitor is closed.

This PR tries to fix that by not closing other references, and manually cloning the inner type so that the sink can use its own handle to the sender channel.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1295)
<!-- Reviewable:end -->
