### PR TITLE
Stop location fetch when offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Line wrap the file at 100 chars.                                              Th
   The Mullvad servers have never allowed any insecure ciphers, so this was not really a problem.
   Just one extra safety precaution.
 
+#### Android
+- Don't try to fetch location when the app knows that it has no connectivity. This should reduce
+  wake-ups (improving battery life) and also fix very large log files consuming storage space.
 
 ## [2019.10-beta1] - 2019-11-06
 This release is for Android only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -42,7 +42,7 @@ class MainActivity : FragmentActivity() {
     val problemReport = MullvadProblemReport()
     var settingsListener = SettingsListener(this)
     var relayListListener = RelayListListener(this)
-    val locationInfoCache = LocationInfoCache(daemon, relayListListener)
+    val locationInfoCache = LocationInfoCache(daemon, connectivityListener, relayListListener)
     val accountCache = AccountCache(settingsListener, daemon)
     val wwwAuthTokenRetriever = WwwAuthTokenRetriever(daemon)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MainActivity.kt
@@ -22,12 +22,15 @@ import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.dataproxy.SettingsListener
 import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever
 import net.mullvad.mullvadvpn.util.SmartDeferred
+import net.mullvad.talpid.ConnectivityListener
 
 class MainActivity : FragmentActivity() {
     companion object {
         val KEY_SHOULD_CONNECT = "should_connect"
     }
 
+    var connectivityListener = CompletableDeferred<ConnectivityListener>()
+        private set
     var daemon = CompletableDeferred<MullvadDaemon>()
         private set
     var service = CompletableDeferred<MullvadVpnService.LocalBinder>()
@@ -55,6 +58,7 @@ class MainActivity : FragmentActivity() {
                 localBinder.resetComplete?.await()
                 service.complete(localBinder)
                 daemon.complete(localBinder.daemon.await())
+                connectivityListener.complete(localBinder.connectivityListener)
             }
         }
 
@@ -67,6 +71,7 @@ class MainActivity : FragmentActivity() {
 
             service = CompletableDeferred<MullvadVpnService.LocalBinder>()
             daemon = CompletableDeferred<MullvadDaemon>()
+            connectivityListener = CompletableDeferred<ConnectivityListener>()
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadDaemon.kt
@@ -9,7 +9,7 @@ import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.util.EventNotifier
+import net.mullvad.talpid.util.EventNotifier
 
 class MullvadDaemon(val vpnService: MullvadVpnService) {
     val onSettingsChange = EventNotifier<Settings?>(null)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/MullvadVpnService.kt
@@ -56,6 +56,8 @@ class MullvadVpnService : TalpidVpnService() {
             get() = this@MullvadVpnService.daemon
         val connectionProxy
             get() = this@MullvadVpnService.connectionProxy
+        val connectivityListener
+            get() = this@MullvadVpnService.connectivityListener
         val resetComplete
             get() = this@MullvadVpnService.resetComplete
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.MainActivity
 import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.util.EventNotifier
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
+import net.mullvad.talpid.util.EventNotifier
 
 val ANTICIPATED_STATE_TIMEOUT_MS = 1500L
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -12,10 +12,12 @@ import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.relaylist.Relay
 import net.mullvad.mullvadvpn.relaylist.RelayCity
 import net.mullvad.mullvadvpn.relaylist.RelayCountry
+import net.mullvad.talpid.ConnectivityListener
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
 class LocationInfoCache(
     val daemon: Deferred<MullvadDaemon>,
+    val connectivityListener: Deferred<ConnectivityListener>,
     val relayListListener: RelayListListener
 ) {
     private var lastKnownRealLocation: GeoIpLocation? = null
@@ -112,10 +114,10 @@ class LocationInfoCache(
         daemon.await().getCurrentLocation()
     }
 
-    private fun shouldRetryFetch(): Boolean {
+    private suspend fun shouldRetryFetch(): Boolean {
         val state = this.state
 
-        return state is TunnelState.Disconnected ||
-            state is TunnelState.Connected
+        return connectivityListener.await().isConnected &&
+            (state is TunnelState.Disconnected || state is TunnelState.Connected)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -23,6 +23,14 @@ class LocationInfoCache(
     private var lastKnownRealLocation: GeoIpLocation? = null
     private var activeFetch: Job? = null
 
+    private val connectivityListenerId = GlobalScope.async(Dispatchers.Default) {
+        connectivityListener.await().connectivityNotifier.subscribe { isConnected ->
+            if (isConnected) {
+                fetchLocation()
+            }
+        }
+    }
+
     var onNewLocation: ((GeoIpLocation?) -> Unit)? = null
         set(value) {
             field = value

--- a/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -7,8 +7,11 @@ import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
 import android.net.NetworkInfo.DetailedState
+import net.mullvad.talpid.util.EventNotifier
 
 class ConnectivityListener : BroadcastReceiver() {
+    val connectivityNotifier = EventNotifier(true)
+
     var isConnected = true
         private set(value) {
             field = value
@@ -16,6 +19,8 @@ class ConnectivityListener : BroadcastReceiver() {
             if (senderAddress != 0L) {
                 notifyConnectivityChange(value, senderAddress)
             }
+
+            connectivityNotifier.notify(value)
         }
 
     var senderAddress = 0L

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.util
+package net.mullvad.talpid.util
 
 class EventNotifier<T>(private val initialValue: T) {
     private val listeners = HashMap<Int, (T) -> Unit>()


### PR DESCRIPTION
Previously, the code to fetch the location based on the IP address would retry in case of failure. This did not consider if the app new that all attempts would fail because the device had no connectivity. The consequence was that it entered an infinite retry loop, which kept the device awake and kept writing error messages to the log file.

This PR makes sure the location fetch is only performed if there is connectivity.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1299)
<!-- Reviewable:end -->
