### PR TITLE
Windows: Register NSI as a service dependency

### DIFF
--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -302,6 +302,9 @@ fn get_service_info() -> ServiceInfo {
         dependencies: vec![
             // Base Filter Engine
             ServiceDependency::Service(OsString::from("BFE")),
+            // Network Store Interface Service
+            // This service delivers network notifications (e.g. interface addition/deleting etc).
+            ServiceDependency::Service(OsString::from("NSI")),
         ],
         account_name: None, // run as System
         account_password: None,


### PR DESCRIPTION
Mark NSI as a dependency of the Daemon service. The WireGuard project suggested this, and after looking into what NSI does ("This service delivers network notifications (e.g. interface addition/deleting etc)."), it makes sense to add it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1300)
<!-- Reviewable:end -->
