### PR TITLE
Fix check if relay has WireGuard tunnels

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
@@ -2,5 +2,5 @@ package net.mullvad.mullvadvpn.model
 
 data class Relay(val hostname: String, val active: Boolean, val tunnels: RelayTunnels) {
     val hasWireguardTunnels
-        get() = tunnels.wireguard.isEmpty()
+        get() = !tunnels.wireguard.isEmpty()
 }


### PR DESCRIPTION
This PR fixes an inverted condition check that led to only WireGuard relays not being displayed in the relay list.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug in an unreleased version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1301)
<!-- Reviewable:end -->
