### PR TITLE
Use `Arc<JavaVM>` in `AndroidContext`

### DIFF
--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -22,7 +22,7 @@ use mullvad_daemon::{logging, version, Daemon, DaemonCommandSender};
 use mullvad_types::account::AccountData;
 use std::{
     path::{Path, PathBuf},
-    sync::{mpsc, Once},
+    sync::{mpsc, Arc, Once},
     thread,
 };
 use talpid_types::{android::AndroidContext, ErrorExt};
@@ -141,7 +141,7 @@ fn initialize(
 
 fn create_android_context(env: &JnixEnv, vpn_service: JObject) -> Result<AndroidContext, Error> {
     Ok(AndroidContext {
-        jvm: env.get_java_vm().map_err(Error::GetJvmInstance)?,
+        jvm: Arc::new(env.get_java_vm().map_err(Error::GetJvmInstance)?),
         vpn_service: env
             .new_global_ref(vpn_service)
             .map_err(Error::CreateGlobalReference)?,

--- a/talpid-core/src/offline/android.rs
+++ b/talpid-core/src/offline/android.rs
@@ -10,7 +10,7 @@ use jnix::{
     },
     JnixEnv,
 };
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
 use talpid_types::{android::AndroidContext, ErrorExt};
 
 #[derive(err_derive::Error, Debug)]
@@ -41,7 +41,7 @@ pub enum Error {
 }
 
 pub struct MonitorHandle {
-    jvm: JavaVM,
+    jvm: Arc<JavaVM>,
     class: GlobalRef,
     object: GlobalRef,
 }

--- a/talpid-core/src/tunnel/tun_provider/android.rs
+++ b/talpid-core/src/tunnel/tun_provider/android.rs
@@ -12,6 +12,7 @@ use std::{
     fs::File,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     os::unix::io::{AsRawFd, FromRawFd, RawFd},
+    sync::Arc,
 };
 use talpid_types::android::AndroidContext;
 
@@ -45,7 +46,7 @@ pub enum Error {
 
 /// Factory of tunnel devices on Android.
 pub struct AndroidTunProvider {
-    jvm: JavaVM,
+    jvm: Arc<JavaVM>,
     class: GlobalRef,
     object: GlobalRef,
     active_tun: Option<File>,

--- a/talpid-types/src/android/mod.rs
+++ b/talpid-types/src/android/mod.rs
@@ -1,19 +1,8 @@
 use jnix::jni::{objects::GlobalRef, JavaVM};
+use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct AndroidContext {
-    pub jvm: JavaVM,
+    pub jvm: Arc<JavaVM>,
     pub vpn_service: GlobalRef,
-}
-
-impl Clone for AndroidContext {
-    fn clone(&self) -> Self {
-        let jvm_pointer = self.jvm.get_java_vm_pointer();
-        let jvm =
-            unsafe { JavaVM::from_raw(jvm_pointer).expect("Failed to get pointer to Java VM") };
-
-        AndroidContext {
-            jvm,
-            vpn_service: self.vpn_service.clone(),
-        }
-    }
 }


### PR DESCRIPTION
This PR implements a small improvement following the suggestion given in https://github.com/jni-rs/jni-rs/issues/217

Instead of working around the missing `Clone` implementation for `JavaVM`, it wraps the `JavaVM` with an `Arc`. This allows replacing the custom `Clone` implementation with a `derive(Clone)`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Change is not user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1302)
<!-- Reviewable:end -->
