### PR TITLE
Fix `NotificationBanner` update on wrong thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ Line wrap the file at 100 chars.                                              Th
 - Minor adjustment in online/offline detection logic. This change addresses misbehaving drivers
   that report the adapter flags incorrectly.
 
+#### Android
+- Fix crash when a new version event is received while the app is in the main screen.
+
 ### Security
 - Force OpenVPN to use TLS 1.2 or newer. And limit the TLS 1.3 ciphers to only the strongest ones.
   The Mullvad servers have never allowed any insecure ciphers, so this was not really a problem.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/NotificationBanner.kt
@@ -41,6 +41,8 @@ class NotificationBanner(
     private val message: TextView = parentView.findViewById(R.id.notification_message)
     private val icon: View = parentView.findViewById(R.id.notification_icon)
 
+    private var updateJob: Job? = null
+
     private var externalLink: ExternalLink? = null
     private var visible = false
 
@@ -83,11 +85,14 @@ class NotificationBanner(
     }
 
     fun onResume() {
-        versionInfoCache.onUpdate = { update() }
+        versionInfoCache.onUpdate = {
+            updateJob = GlobalScope.launch(Dispatchers.Main) { update() }
+        }
     }
 
     fun onPause() {
         versionInfoCache.onUpdate = null
+        updateJob?.cancel()
         keyManagementController.onPause()
     }
 


### PR DESCRIPTION
Previously, if the app was showing the `ConnectFragment` and a new version event is received, the app would try to update the `NotificationBanner` from the wrong thread (i.e., out of the UI thread). This led to a crash.

This PR makes sure the update is scheduled on the main UI thread.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1304)
<!-- Reviewable:end -->
