### PR TITLE
Improve wireguard port selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Line wrap the file at 100 chars.                                              Th
 - Notifications shown when connecting to a server include its location.
 - Upgrade OpenVPN from 2.4.7 to 2.4.8.
 - Upgrade OpenSSL from 1.1.1c to 1.1.1d.
+- When using WireGuard without specifying a specific relay port, port 53 will be used after 2
+  failed connection attempts for 2 out of 4 each successive connection attempts
 
 #### Windows
 - Use a larger icon in notifications on Windows 10.

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -285,6 +285,15 @@ impl RelaySelector {
             Constraint::Only(TunnelProtocol::Wireguard) => {
                 relay_constraints.wireguard_constraints =
                     original_constraints.wireguard_constraints;
+                // This ensures that if after the first 2 failed attempts the daemon does not
+                // conenct, then afterwards 2 of each 4 successive attempts will try to connect on
+                // port 53.
+                if retry_attempt > 2
+                    && retry_attempt % 4 < 2
+                    && relay_constraints.wireguard_constraints.port.is_any()
+                {
+                    relay_constraints.wireguard_constraints.port = Constraint::Only(53);
+                }
             }
         }
 


### PR DESCRIPTION
To improve the chances of connecting, attempt connecting using port 53 after 2 failed connection attempts, when using WireGuard without any port constraints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1308)
<!-- Reviewable:end -->
