### PR TITLE
Fix improved port selection for WireGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Fixed
+- Fix improved WireGuard port selection
 
 
 ## [2019.10-beta2] - 2019-12-05

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -288,10 +288,7 @@ impl RelaySelector {
                 // This ensures that if after the first 2 failed attempts the daemon does not
                 // conenct, then afterwards 2 of each 4 successive attempts will try to connect on
                 // port 53.
-                if retry_attempt > 2
-                    && retry_attempt % 4 < 2
-                    && relay_constraints.wireguard_constraints.port.is_any()
-                {
+                if retry_attempt % 4 > 1 && relay_constraints.wireguard_constraints.port.is_any() {
                     relay_constraints.wireguard_constraints.port = Constraint::Only(53);
                 }
             }


### PR DESCRIPTION
Fixing the new and improved relay selection algorithm to actually use port 53 when we fail after the 2nd attempt (on 3rd and 4th) rather than the 6th and 7th.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1310)
<!-- Reviewable:end -->
