### PR TITLE
Add version suffix on iOS

### DIFF
--- a/ios/MullvadVPN/Bundle+MullvadVersion.swift
+++ b/ios/MullvadVPN/Bundle+MullvadVersion.swift
@@ -1,0 +1,24 @@
+//
+//  Bundle+MullvadVersion.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 29/11/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+
+private let kInfoDictionaryMullvadVersionSuffixKey = "MullvadVersionSuffix"
+
+extension Bundle {
+
+    var mullvadVersion: String? {
+        let shortVersion = infoDictionary?["CFBundleShortVersionString"] as? String
+        let versionSuffix = infoDictionary?[kInfoDictionaryMullvadVersionSuffixKey] as? String
+
+        return [shortVersion, versionSuffix]
+            .compactMap { $0 }
+            .joined(separator: "-")
+    }
+
+}

--- a/ios/MullvadVPN/Info.plist
+++ b/ios/MullvadVPN/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Mullvad VPN</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,11 +17,15 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MullvadVersionSuffix</key>
+	<string>dev1</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios/MullvadVPN/SettingsAccountCell.swift
+++ b/ios/MullvadVPN/SettingsAccountCell.swift
@@ -19,13 +19,6 @@ class SettingsAccountCell: SettingsCell {
         }
     }
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-
-        // Remove the right margin since the accessory view adds it automatically
-        contentView.layoutMargins.right = 0
-    }
-
     private func didUpdateAccountExpiry() {
         if let accountExpiryDate = accountExpiryDate {
             let accountExpiry = AccountExpiry(date: accountExpiryDate)

--- a/ios/MullvadVPN/SettingsCell.swift
+++ b/ios/MullvadVPN/SettingsCell.swift
@@ -7,10 +7,12 @@
 //
 
 import UIKit
+import Combine
 
 class SettingsCell: BasicTableViewCell {
 
-    private let preferredMargins = UIEdgeInsets(top: 14, left: 24, bottom: 14, right: 12)
+    private let preferredMargins = UIEdgeInsets(top: 16, left: 24, bottom: 16, right: 12)
+    private var appDidBecomeActiveSubscriber: AnyCancellable?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -19,6 +21,29 @@ class SettingsCell: BasicTableViewCell {
         selectedBackgroundView?.backgroundColor = UIColor.Cell.selectedAltBackgroundColor
 
         contentView.layoutMargins = preferredMargins
+
+        enableDisclosureViewTintColorFix()
     }
 
+    /// `UITableViewCell` resets the disclosure view image when the app goes in background
+    /// This fix ensures that the image is tinted when the app becomes active again.
+    private func enableDisclosureViewTintColorFix() {
+        appDidBecomeActiveSubscriber = NotificationCenter.default
+            .publisher(for: UIApplication.didBecomeActiveNotification, object: nil)
+            .sink { [weak self] (_) in
+                self?.updateDisclosureViewTintColor()
+        }
+
+        updateDisclosureViewTintColor()
+    }
+
+    /// For some reason the `tintColor` is not applied to standard accessory views.
+    /// Fix this by looking for the accessory button and changing the image rendering mode
+    private func updateDisclosureViewTintColor() {
+        for case let button as UIButton in subviews {
+            if let image = button.backgroundImage(for: .normal)?.withRenderingMode(.alwaysTemplate) {
+                button.setBackgroundImage(image, for: .normal)
+            }
+        }
+    }
 }

--- a/ios/MullvadVPN/SettingsViewController.swift
+++ b/ios/MullvadVPN/SettingsViewController.swift
@@ -52,9 +52,8 @@ class SettingsViewController: UITableViewController {
         let middleSection = StaticTableViewSection()
         let versionRow = StaticTableViewRow(reuseIdentifier: CellIdentifier.appVersion.rawValue) { (_, cell) in
             let cell = cell as! SettingsAppVersionCell
-            let versionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
 
-            cell.versionLabel.text = versionString
+            cell.versionLabel.text = Bundle.main.mullvadVersion
         }
         versionRow.isSelectable = false
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Store version suffix `MullvadVersionSuffix` (i.e dev1, dev2, etc..) in `Info.plist`. Use it to display the exact version in the UI.
1. Hot fix the tintColor of the system disclosure view. For some reason, the disclosure arrow would change the tint color when switching between apps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1311)
<!-- Reviewable:end -->
