### PR TITLE
Windows: Fix service config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix improved WireGuard port selection
 
+#### Windows
+- Register 'NSI' service as a dependency of the daemon service.
+- Set daemon service SID type as 'unrestricted'.
+
 ### Security
 #### Linux
 - Stop [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122) by dropping all packets destined

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,7 @@ dependencies = [
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=48d755b0afbf259ba547d4defc3e9340d1436cf6)",
+ "windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=1d5f9cc65658429414f2d62e4581e5a3e2532b99)",
  "winres 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "windows-service"
 version = "0.2.0"
-source = "git+https://github.com/mullvad/windows-service-rs.git?rev=48d755b0afbf259ba547d4defc3e9340d1436cf6#48d755b0afbf259ba547d4defc3e9340d1436cf6"
+source = "git+https://github.com/mullvad/windows-service-rs.git?rev=1d5f9cc65658429414f2d62e4581e5a3e2532b99#1d5f9cc65658429414f2d62e4581e5a3e2532b99"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3455,7 +3455,7 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"
-"checksum windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=48d755b0afbf259ba547d4defc3e9340d1436cf6)" = "<none>"
+"checksum windows-service 0.2.0 (git+https://github.com/mullvad/windows-service-rs.git?rev=1d5f9cc65658429414f2d62e4581e5a3e2532b99)" = "<none>"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum winres 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4fb510bbfe5b8992ff15f77a2e6fe6cf062878f0eda00c0f44963a807ca5dc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -55,7 +55,7 @@ simple-signal = "1.1"
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"
-windows-service = { git = "https://github.com/mullvad/windows-service-rs.git", rev = "48d755b0afbf259ba547d4defc3e9340d1436cf6" }
+windows-service = { git = "https://github.com/mullvad/windows-service-rs.git", rev = "1d5f9cc65658429414f2d62e4581e5a3e2532b99" }
 winapi = { version = "0.3", features = ["errhandlingapi", "handleapi", "libloaderapi", "synchapi", "tlhelp32", "winbase", "winerror", "winuser"] }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -311,6 +311,9 @@ fn get_service_info() -> ServiceInfo {
         dependencies: vec![
             // Base Filter Engine
             ServiceDependency::Service(OsString::from("BFE")),
+            // Network Store Interface Service
+            // This service delivers network notifications (e.g. interface addition/deleting etc).
+            ServiceDependency::Service(OsString::from("NSI")),
         ],
         account_name: None, // run as System
         account_password: None,

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -15,8 +15,8 @@ use windows_service::{
     service::{
         Service, ServiceAccess, ServiceAction, ServiceActionType, ServiceControl, ServiceControlAccept,
         ServiceDependency, ServiceErrorControl, ServiceExitCode, ServiceFailureActions,
-        ServiceFailureResetPeriod, ServiceInfo, ServiceStartType, ServiceState, ServiceStatus,
-        ServiceType,
+        ServiceFailureResetPeriod, ServiceInfo, ServiceSidType, ServiceStartType, ServiceState,
+        ServiceStatus, ServiceType,
     },
     service_control_handler::{self, ServiceControlHandlerResult, ServiceStatusHandle},
     service_dispatcher,
@@ -290,7 +290,15 @@ pub fn install_service() -> Result<(), InstallError> {
         .map_err(InstallError::CreateService)?;
     service
         .set_failure_actions_on_non_crash_failures(true)
-        .map_err(InstallError::CreateService)
+        .map_err(InstallError::CreateService)?;
+
+    // Change how the service SID is added to the service process token.
+    // WireGuard needs this.
+    service
+        .set_config_service_sid_info(ServiceSidType::Unrestricted)
+        .map_err(InstallError::CreateService)?;
+
+    Ok(())
 }
 
 fn open_update_service(service_manager: &ServiceManager) -> Result<Service, windows_service::Error> {


### PR DESCRIPTION
Notably, two configuration items are changed:

- The list of dependencies (adding `NSI`).
- The service SID info (set as `UNRESTRICTED`).

The code that handles service installation is also updated so ensure the configuration on an existing service is refreshed. This, however, turned out to not be required since in practice we always remove the previous service before installing the new one, during an update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1313)
<!-- Reviewable:end -->
