### PR TITLE
Stop CVE-2019-14899 by dropping packets to tunnel IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix improved WireGuard port selection
 
+### Security
+#### Linux
+- Stop [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122) by dropping all packets destined
+  for the tunnel IP coming in on some other interface than the tunnel.
+
 
 ## [2019.10-beta2] - 2019-12-05
 ### Added


### PR DESCRIPTION
Stops an attacker on the same network from discovering the tunnel IP of the device running this app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1315)
<!-- Reviewable:end -->
