### PR TITLE
Fix upgrade to null message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Line wrap the file at 100 chars.                                              Th
 - Register 'NSI' service as a dependency of the daemon service.
 - Set daemon service SID type as 'unrestricted'.
 
+#### Android
+- Fix notification message to update to `null` version when version check cache is stale right
+  after an update.
+
 ### Security
 #### Linux
 - Stop [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122) by dropping all packets destined

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -18,8 +18,14 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
     private var appVersionInfo: AppVersionInfo? = null
         set(value) {
             synchronized(this) {
+                upgradeVersion = if (isStable) value?.latestStable else value?.latest
+
+                if (upgradeVersion == version) {
+                    upgradeVersion = null
+                }
+
                 field = value
-                updateUpgradeVersion()
+                onUpdate?.invoke()
             }
         }
 
@@ -80,17 +86,5 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
 
     private fun tearDown() = GlobalScope.launch(Dispatchers.Default) {
         daemon.await().onAppVersionInfoChange = null
-    }
-
-    private fun updateUpgradeVersion() {
-        val target = if (isStable) latestStable else latest
-
-        if (target == version || target == null) {
-            upgradeVersion = null
-        } else {
-            upgradeVersion = target
-        }
-
-        onUpdate?.invoke()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -65,8 +65,6 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
         version = currentVersion
         isStable = !currentVersion.contains("-")
 
-        updateUpgradeVersion()
-
         daemon.onAppVersionInfoChange = { newAppVersionInfo ->
             appVersionInfo = newAppVersionInfo
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -20,11 +20,19 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
             synchronized(this) {
                 upgradeVersion = if (isStable) value?.latestStable else value?.latest
 
-                if (upgradeVersion == version) {
+                if (value != null && upgradeVersion == version) {
                     upgradeVersion = null
+
+                    field = AppVersionInfo(
+                        value.currentIsSupported,
+                        /* currentIsOutdated = */ false,
+                        value.latestStable,
+                        value.latest
+                    )
+                } else {
+                    field = value
                 }
 
-                field = value
                 onUpdate?.invoke()
             }
         }


### PR DESCRIPTION
A bug was detected when a user updates the app. It takes a while for the update version to update the app version info cache. In the meantime, the daemon still sends the stale app version info to the UI. This means that the UI handles a state where `isOutdated == true` but the upgrade target version is the same as the current version. It would then show the notification banner, but include `null` as the target upgrade version.

This PR fixes that by overriding the "app version info" to make sure `isOutdated` is always `false` if the target update version is the same as the current version.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1316)
<!-- Reviewable:end -->
