### PR TITLE
Fix crash in `ConnectivityManager` due to missing `NetworkInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix notification message to update to `null` version when version check cache is stale right
   after an update.
+- Fix `null` pointer exception when connectivity event intent has no network info.
 
 ### Security
 #### Linux

--- a/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -42,7 +42,9 @@ class ConnectivityListener : BroadcastReceiver() {
         val networkInfo =
             intent.getParcelableExtra<NetworkInfo>(ConnectivityManager.EXTRA_NETWORK_INFO)
 
-        if (networkInfo.type != ConnectivityManager.TYPE_VPN) {
+        if (networkInfo == null) {
+            checkConnectionState(context)
+        } else if (networkInfo.type != ConnectivityManager.TYPE_VPN) {
             if (networkInfo.detailedState == DetailedState.DISCONNECTED) {
                 checkConnectionState(context)
             } else if (networkInfo.detailedState == DetailedState.CONNECTED) {

--- a/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -59,6 +59,7 @@ class ConnectivityListener : BroadcastReceiver() {
 
         isConnected = connectivityManager.allNetworks
             .map({ network -> connectivityManager.getNetworkInfo(network) })
+            .filterNotNull()
             .any({ networkInfo ->
                 networkInfo.type != ConnectivityManager.TYPE_VPN &&
                     networkInfo.detailedState == DetailedState.CONNECTED


### PR DESCRIPTION
Apparently, not every connectivity related intent will contain the network information. Therefore, requesting such information from the `Intent` will return `null` and lead to a crash when trying to use that information.

This PR fixes the issue by checking if the information is `null` first. If it is, connectivity is rechecked manually. Otherwise, the previous behavior is kept.

This PR also includes an extra precaution by filtering out `null` `NetworkInfo` objects when obtaining the information of all networks in the `checkConnectionState` method.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1317)
<!-- Reviewable:end -->
