### PR TITLE
Limit DHCPv4 server firewall rules to UDP only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Line wrap the file at 100 chars.                                              Th
 - Stop [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122) by dropping all packets destined
   for the tunnel IP coming in on some other interface than the tunnel.
 
+#### macOS
+- Limit macOS firewall rules to only allow UDP packets in the rules meant to enable being a DHCPv4
+  *server* when local network sharing is enabled.
+
 
 ## [2019.10-beta2] - 2019-12-05
 ### Added

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -281,6 +281,7 @@ impl Firewall {
             .quick(true)
             .direction(pfctl::Direction::Out)
             .af(pfctl::AddrFamily::Ipv4)
+            .proto(pfctl::Proto::Udp)
             .from(pfctl::Port::from(super::DHCPV4_SERVER_PORT))
             .to(pfctl::Port::from(super::DHCPV4_CLIENT_PORT))
             .build()?;
@@ -288,6 +289,7 @@ impl Firewall {
             .create_rule_builder(FilterRuleAction::Pass)
             .quick(true)
             .direction(pfctl::Direction::In)
+            .proto(pfctl::Proto::Udp)
             .from(pfctl::Port::from(super::DHCPV4_CLIENT_PORT))
             .to(pfctl::Endpoint::new(
                 Ipv4Addr::BROADCAST,


### PR DESCRIPTION
When going through the security docs I'm writing I noticed how the documentation we had did not specify protocol for the DHCP related rules. And since it should only use UDP I added that to the documentation to make it stricter.

At the same time I noticed that on macOS we did not limit the rules for acting as a DHCP server in the case `allow_lan` was enabled to only UDP. 

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1321)
<!-- Reviewable:end -->
