### PR TITLE
Separate Windows routing implementation from Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Register 'NSI' service as a dependency of the daemon service.
 - Set daemon service SID type as 'unrestricted'.
+- Properly tear down routes after disconnecting from WireGuard relays
 
 #### Android
 - Fix notification message to update to `null` version when version check cache is stale right

--- a/talpid-core/src/routing/linux/change_listener.rs
+++ b/talpid-core/src/routing/linux/change_listener.rs
@@ -1,7 +1,6 @@
-use super::{
-    super::{Node, Route},
-    RouteChange,
-};
+use crate::routing::{Node, Route};
+
+use super::RouteChange;
 use futures::{future::Either, sync::mpsc, Async, Future, Stream};
 use std::{collections::BTreeMap, io, net::IpAddr};
 

--- a/talpid-core/src/routing/linux/mod.rs
+++ b/talpid-core/src/routing/linux/mod.rs
@@ -1,4 +1,4 @@
-use super::{NetNode, Node, Route};
+use crate::routing::{NetNode, Node, Route};
 
 use ipnetwork::IpNetwork;
 use std::{
@@ -401,12 +401,12 @@ fn parse_ip_route_show_line(line: &str, ip_version: IpVersion) -> Option<Route> 
     if node_ip.is_none() && device.is_none() {
         None
     } else {
-        let node = super::Node {
+        let node = Node {
             ip: node_ip,
             device,
         };
 
-        Some(super::Route {
+        Some(Route {
             node,
             prefix,
             metric,

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -1,4 +1,4 @@
-use super::{NetNode, Node, Route};
+use crate::routing::{NetNode, Node, Route};
 
 use ipnetwork::IpNetwork;
 use std::{

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -1,0 +1,92 @@
+#![cfg_attr(target_os = "android", allow(dead_code))]
+#![cfg_attr(target_os = "windows", allow(dead_code))]
+// TODO: remove the allow(dead_code) for android once it's up to scratch.
+use super::NetNode;
+use futures::{sync::oneshot, Future};
+use ipnetwork::IpNetwork;
+use std::collections::HashMap;
+
+#[cfg(target_os = "macos")]
+#[path = "macos.rs"]
+mod imp;
+
+#[cfg(target_os = "linux")]
+#[path = "linux/mod.rs"]
+mod imp;
+
+#[cfg(target_os = "android")]
+#[path = "android.rs"]
+mod imp;
+
+pub use imp::Error as PlatformError;
+
+/// Errors that can be encountered whilst initializing RouteManager
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// Routing manager thread panicked before starting routing manager
+    #[error(display = "Routing manager thread panicked before starting routing manager")]
+    RoutingManagerThreadPanic,
+    /// Platform sepcific error occured
+    #[error(display = "Failed to create route manager")]
+    FailedToInitializeManager(#[error(source)] imp::Error),
+    /// Failed to spawn route manager future
+    #[error(display = "Failed to spawn route manager on the provided executor")]
+    FailedToSpawnManager,
+}
+
+/// RouteManager applies a set of routes to the route table.
+/// If a destination has to be routed through the default node,
+/// the route will be adjusted dynamically when the default route changes.
+pub struct RouteManager {
+    tx: Option<oneshot::Sender<oneshot::Sender<()>>>,
+}
+
+impl RouteManager {
+    /// Constructs a RouteManager and applies the required routes.
+    /// Takes a map of network destinations and network nodes as an argument, and applies said
+    /// routes.
+    pub fn new(required_routes: HashMap<IpNetwork, NetNode>) -> Result<Self, Error> {
+        let (tx, rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+
+        std::thread::spawn(
+            move || match imp::RouteManagerImpl::new(required_routes, rx) {
+                Ok(route_manager) => {
+                    let _ = start_tx.send(Ok(()));
+                    if let Err(e) = route_manager.wait() {
+                        log::error!("Route manager failed - {}", e);
+                    }
+                }
+                Err(e) => {
+                    let _ = start_tx.send(Err(Error::FailedToInitializeManager(e)));
+                }
+            },
+        );
+        match start_rx.wait() {
+            Ok(Ok(())) => Ok(Self { tx: Some(tx) }),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(Error::RoutingManagerThreadPanic),
+        }
+    }
+
+    /// Stops RouteManager and removes all of the applied routes.
+    pub fn stop(&mut self) {
+        if let Some(tx) = self.tx.take() {
+            let (wait_tx, wait_rx) = oneshot::channel();
+            if tx.send(wait_tx).is_err() {
+                log::error!("RouteManager already down!");
+                return;
+            }
+
+            if wait_rx.wait().is_err() {
+                log::error!("RouteManager paniced while shutting down");
+            }
+        }
+    }
+}
+
+impl Drop for RouteManager {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}


### PR DESCRIPTION
To better maintain both codebases, I've separated out Windows' routing manager from
the unix routing implementations to better ensure correctness. This allows for a trivial fix for lifetime issues with the route manager on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1325)
<!-- Reviewable:end -->
