### PR TITLE
Refactor to create `service` and `ui` packages

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ForegroundNotificationManager.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.support.v4.app.NotificationCompat
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
 val CHANNEL_ID = "vpn_tunnel_status"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -5,8 +5,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MainActivity
 import net.mullvad.mullvadvpn.model.AppVersionInfo
+import net.mullvad.mullvadvpn.ui.MainActivity
 
 class AppVersionInfoCache(val parentActivity: MainActivity) {
     companion object {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MainActivity
 import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.util.EventNotifier
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/ConnectionProxy.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.util.EventNotifier

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/KeyStatusListener.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.KeygenEvent
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 
 class KeyStatusListener(val asyncDaemon: Deferred<MullvadDaemon>) {
     private var daemon: MullvadDaemon? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -6,12 +6,12 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.relaylist.Relay
 import net.mullvad.mullvadvpn.relaylist.RelayCity
 import net.mullvad.mullvadvpn.relaylist.RelayCountry
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.ConnectivityListener
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -4,12 +4,12 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.RelayConstraints
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.MainActivity
 
 class RelayListListener(val parentActivity: MainActivity) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -4,13 +4,13 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MainActivity
 import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.RelayConstraints
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
+import net.mullvad.mullvadvpn.ui.MainActivity
 
 class RelayListListener(val parentActivity: MainActivity) {
     private val daemon = CompletableDeferred<MullvadDaemon>()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -3,10 +3,10 @@ package net.mullvad.mullvadvpn.dataproxy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MainActivity
 import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.ui.MainActivity
 
 class SettingsListener(val parentActivity: MainActivity) {
     private lateinit var daemon: MullvadDaemon

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -3,9 +3,9 @@ package net.mullvad.mullvadvpn.dataproxy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.MainActivity
 
 class SettingsListener(val parentActivity: MainActivity) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/WwwAuthTokenRetriever.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/WwwAuthTokenRetriever.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 
 class WwwAuthTokenRetriever(val asyncDaemon: Deferred<MullvadDaemon>) {
     private var daemon: MullvadDaemon? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ApiRootCaFile.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ApiRootCaFile.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.service
 
 import android.content.Context
 import java.io.File

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.service
 
 import android.app.Notification
 import android.app.NotificationChannel
@@ -11,6 +11,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.support.v4.app.NotificationCompat
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.MainActivity

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.service
 
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 import net.mullvad.mullvadvpn.model.GeoIpLocation

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.service
 
 import android.content.Intent
 import android.os.Binder

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import org.joda.time.DateTime
 
 class AccountFragment : Fragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInput.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.res.Resources
 import android.text.Editable
@@ -8,7 +8,8 @@ import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.widget.EditText
 import android.widget.ImageButton
-import net.mullvad.mullvadvpn.AccountInputContainer.BorderState
+import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.ui.AccountInputContainer.BorderState
 
 const val MIN_ACCOUNT_TOKEN_LENGTH = 10
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputContainer.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputContainer.kt
@@ -1,8 +1,9 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.LinearLayout
+import net.mullvad.mullvadvpn.R
 
 class AccountInputContainer : LinearLayout {
     enum class BorderState {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputOutlineProvider.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputOutlineProvider.kt
@@ -1,9 +1,10 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.graphics.Outline
 import android.view.View
 import android.view.ViewOutlineProvider
+import net.mullvad.mullvadvpn.R
 
 class AccountInputOutlineProvider(private val context: Context) : ViewOutlineProvider() {
     private val cornerRadius = context.resources.getDimension(R.dimen.account_input_corner_radius)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/BlockingController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/BlockingController.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmNoEmailDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmNoEmailDialogFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.app.Dialog
 import android.content.Context
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import kotlinx.coroutines.CompletableDeferred
+import net.mullvad.mullvadvpn.R
 
 class ConfirmNoEmailDialogFragment : DialogFragment() {
     private var confirmNoEmail: CompletableDeferred<Boolean>? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectActionButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectActionButton.kt
@@ -1,7 +1,8 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.view.View
 import android.widget.Button
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.os.Bundle
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectionStatus.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectionStatus.kt
@@ -1,8 +1,9 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.res.Resources
 import android.view.View
 import android.widget.TextView
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/HeaderBar.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/HeaderBar.kt
@@ -1,7 +1,8 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.res.Resources
 import android.view.View
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
 
 class HeaderBar(val parentView: View, val resources: Resources) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.os.Bundle
@@ -12,6 +12,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 
 class LaunchFragment : Fragment() {
     private lateinit var accountTokenCheckJob: Deferred<Boolean>

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
@@ -1,8 +1,9 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.view.View
 import android.widget.TextView
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.net.Endpoint

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.content.Intent
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 
 class LoginFragment : Fragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginState.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginState.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 enum class LoginState {
     Initial,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -13,8 +13,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.MullvadDaemon
-import net.mullvad.mullvadvpn.MullvadVpnService
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
@@ -24,6 +22,8 @@ import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.dataproxy.SettingsListener
 import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever
+import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.MullvadVpnService
 import net.mullvad.mullvadvpn.util.SmartDeferred
 import net.mullvad.talpid.ConnectivityListener
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.app.Activity
 import android.content.ComponentName
@@ -13,6 +13,9 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.MullvadDaemon
+import net.mullvad.mullvadvpn.MullvadVpnService
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
@@ -11,8 +11,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.BlockableView
-import net.mullvad.mullvadvpn.BlockingController
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.content.Intent
@@ -11,6 +11,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.BlockableView
+import net.mullvad.mullvadvpn.BlockingController
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever
 import net.mullvad.mullvadvpn.model.KeygenEvent

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.os.Bundle
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
 
 class ProblemReportFragment : Fragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.view.View
 import android.widget.TextView
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.joda.time.PeriodType

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.os.Bundle
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.model.Constraint

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.content.Intent
@@ -15,6 +15,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SwitchLocationButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SwitchLocationButton.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.res.Resources
 import android.graphics.drawable.Drawable
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.BlockableView
-import net.mullvad.mullvadvpn.BlockingController
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn
+package net.mullvad.mullvadvpn.ui
 
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -20,6 +20,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.BlockableView
+import net.mullvad.mullvadvpn.BlockingController
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever


### PR DESCRIPTION
This PR is a small refactor that separates all of the classes that were previously in the `net.mullvad.mullvadvpn` root module in two sub-packages: `service` and `ui`. This makes it easier to distinguish if a class is used in the service side of the app or in the UI part of the app.

Note that the division is not perfect, since for example the UI classes are in general dependent of service classes. Service classes are almost independent from the UI, the only exception IIRC is `MullvadVpnService`, because it uses the `MainActivity` in order to request for the VPN permission.

The classes in the other modules (`dataproxy`, `model`, `relaylist`, `util`) haven't been moved, but it might be interesting to reevaluate that in the future. The only exception was `BlockingController`, which was moved into the `ui` module.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1326)
<!-- Reviewable:end -->
