### PR TITLE
Use Rust 2018 edition idioms in `mullvad-jni`

### DIFF
--- a/mullvad-jni/src/jni_event_listener.rs
+++ b/mullvad-jni/src/jni_event_listener.rs
@@ -38,7 +38,7 @@ enum Event {
 pub struct JniEventListener(mpsc::Sender<Event>);
 
 impl JniEventListener {
-    pub fn spawn(env: &JnixEnv, mullvad_daemon: &JObject) -> Result<Self, Error> {
+    pub fn spawn(env: &JnixEnv<'_>, mullvad_daemon: &JObject<'_>) -> Result<Self, Error> {
         JniEventHandler::spawn(env, mullvad_daemon)
     }
 }
@@ -78,8 +78,8 @@ struct JniEventHandler<'env> {
 
 impl JniEventHandler<'_> {
     pub fn spawn(
-        old_env: &JnixEnv,
-        old_mullvad_ipc_client: &JObject,
+        old_env: &JnixEnv<'_>,
+        old_mullvad_ipc_client: &JObject<'_>,
     ) -> Result<JniEventListener, Error> {
         let (tx, rx) = mpsc::channel();
         let jvm = old_env.get_java_vm().map_err(Error::GetJvmInstance)?;


### PR DESCRIPTION
This PR enables the `#![deny(rust_2018_idioms)]` attribute, so that the Rust 2018 edition idioms are enforced. A few elided lifetimes are made more explicit to comply with the attribute.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1327)
<!-- Reviewable:end -->
