### PR TITLE
Verify tunnel device is up on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+#### Android
+- Wait for traffic to be routed through the tunnel device before advertising blocked state.
 
 
 ## [2019.10] - 2019-12-12
 ### Fixed
-- Fix improved WireGuard port selection
+- Fix improved WireGuard port selection.
 
 #### Windows
 - Register 'NSI' service as a dependency of the daemon service.

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -29,6 +29,7 @@ open class TalpidVpnService : VpnService() {
             }
 
             setMtu(config.mtu)
+            setBlocking(false)
         }
 
         val vpnInterface = builder.establish()

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -39,6 +39,7 @@ tokio-io = "0.1"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.1", features = ["derive"] }
+rand = "0.7"
 
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
I've added code that waits for the tunnel device to be readable before it is returned to be used in the connecting and connected and blocked states of the tunnel state machine. This ensures that higher up the stack, we can rely on the existence of the tunnel device to ensure that traffic is being routed through it.

I've also added some small fixups to the refactor that was merged yesterday - pretty much everything to do with class names that have now changed not being changed everywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1332)
<!-- Reviewable:end -->
