### PR TITLE
Get rid of duplicate NSIS constants

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -19,40 +19,20 @@
 !define SERVICE_STARTED 0
 !define SERVICE_START_PENDING 2
 
+# Generic return codes for Mullvad nsis plugins
+!define MULLVAD_GENERAL_ERROR 0
+!define MULLVAD_SUCCESS 1
+
 # Return codes from driverlogic::EstablishBaseline
 !define EB_GENERAL_ERROR 0
 !define EB_NO_TAP_ADAPTERS_PRESENT 1
 !define EB_SOME_TAP_ADAPTERS_PRESENT 2
 !define EB_MULLVAD_ADAPTER_PRESENT 3
 
-# Return codes from driverlogic::IdentifyNewAdapter
-!define INA_GENERAL_ERROR 0
-!define INA_SUCCESS 1
-
 # Return codes from driverlogic::RemoveMullvadTap
 !define RMT_GENERAL_ERROR 0
 !define RMT_NO_REMAINING_ADAPTERS 1
 !define RMT_SOME_REMAINING_ADAPTERS 2
-
-# Return codes from driverlogic::Initialize/Deinitialize
-!define DRIVERLOGIC_GENERAL_ERROR 0
-!define DRIVERLOGIC_SUCCESS 1
-
-# Return codes from driverlogic::RollbackTapAliases
-!define RTA_GENERAL_ERROR 0
-!define RTA_SUCCESS 1
-
-# Return codes from tray::PromoteTrayIcon
-!define PTI_GENERAL_ERROR 0
-!define PTI_SUCCESS 1
-
-# Return codes from cleanup::RemoveRelayCache
-!define RRC_GENERAL_ERROR 0
-!define RRC_SUCCESS 1
-
-# Return codes from pathedit::AddSysEnvPath/pathedit::RemoveSysEnvPath
-!define PE_GENERAL_ERROR 0
-!define PE_SUCCESS 1
 
 # Return codes from tapinstall
 !define DEVCON_EXIT_OK 0
@@ -201,7 +181,7 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${DRIVERLOGIC_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		Goto RemoveTap_return_only
 	${EndIf}
 
@@ -260,7 +240,7 @@
 	Pop $0
 	Pop $1
 	
-	${If} $0 != ${DRIVERLOGIC_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		StrCpy $R0 "Failed to initialize plugin 'driverlogic': $1"
 		log::Log $R0
 		Goto InstallDriver_return_only
@@ -326,7 +306,7 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${RTA_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		StrCpy $R0 "Failed to roll back TAP adapter aliases: error $0"
 		log::LogWithDetails $R0 $1
 		Goto InstallDriver_return
@@ -363,7 +343,7 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${INA_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		StrCpy $R0 "Failed to identify new adapter: $1"
 		log::Log $R0
 		Goto InstallDriver_return
@@ -404,7 +384,7 @@
 	Pop $0
 	Pop $1
 	
-	${If} $0 != ${DRIVERLOGIC_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		# Do not update $R0
 		log::Log "Failed to deinitialize plugin 'driverlogic': $1"
 	${EndIf}
@@ -557,7 +537,7 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${PTI_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		log::LogWithDetails "Failed to install Mullvad tray icon" $1
 		Goto InstallTrayIcon_return
 	${EndIf}
@@ -633,7 +613,7 @@
 	Pop $0
 	Pop $1
 	
-	${If} $0 != ${RRC_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		log::Log "Failed to remove relay cache: $1"
 		Goto RemoveRelayCache_return
 	${EndIf}
@@ -667,7 +647,7 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${PE_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		log::Log "AddCLIToEnvironPath() failed: $0 $1"
 		Goto UpdatePath_return
 	${EndIf}
@@ -700,7 +680,7 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${PE_SUCCESS}
+	${If} $0 != ${MULLVAD_SUCCESS}
 		log::Log "RemoveCLIFromEnvironPath() failed: $0 $1"
 		Goto RemovePath_return
 	${EndIf}

--- a/windows/nsis-plugins/nsis-plugins.sln
+++ b/windows/nsis-plugins/nsis-plugins.sln
@@ -36,6 +36,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pathedit", "src\pathedit\pa
 		{B52E2D10-A94A-4605-914A-2DCEF6A757EF} = {B52E2D10-A94A-4605-914A-2DCEF6A757EF}
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{00D73E7B-7B59-402E-B6AA-48E87B0711DB}"
+	ProjectSection(SolutionItems) = preProject
+		src\error.h = src\error.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86

--- a/windows/nsis-plugins/src/cleanup/cleanup.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleanup.cpp
@@ -1,16 +1,11 @@
 #include <stdafx.h>
+#include "../error.h"
 #include "cleaningops.h"
 #include <libcommon/string.h>
 #include <windows.h>
 #include <nsis/pluginapi.h>
 #include <functional>
 #include <vector>
-
-enum class RemoveLogsAndCacheStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
 
 void __declspec(dllexport) NSISCALL RemoveLogsAndCache
 (
@@ -49,14 +44,8 @@ void __declspec(dllexport) NSISCALL RemoveLogsAndCache
 		}
 	}
 
-	pushint(success ? RemoveLogsAndCacheStatus::SUCCESS : RemoveLogsAndCacheStatus::GENERAL_ERROR);
+	pushint(success ? NsisStatus::SUCCESS : NsisStatus::GENERAL_ERROR);
 }
-
-enum class RemoveSettingsStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
 
 void __declspec(dllexport) NSISCALL RemoveSettings
 (
@@ -73,19 +62,13 @@ void __declspec(dllexport) NSISCALL RemoveSettings
 	try
 	{
 		cleaningops::RemoveSettingsServiceUser();
-		pushint(RemoveSettingsStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (...)
 	{
-		pushint(RemoveSettingsStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }
-
-enum class RemoveRelayCacheStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
 
 void __declspec(dllexport) NSISCALL RemoveRelayCache
 (
@@ -104,16 +87,16 @@ void __declspec(dllexport) NSISCALL RemoveRelayCache
 		cleaningops::RemoveRelayCacheServiceUser();
 
 		pushstring(L"");
-		pushint(RemoveRelayCacheStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (const std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(RemoveRelayCacheStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(RemoveRelayCacheStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }

--- a/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
+++ b/windows/nsis-plugins/src/driverlogic/driverlogic.cpp
@@ -1,4 +1,5 @@
 #include <stdafx.h>
+#include "../error.h"
 #include "context.h"
 #include <libcommon/string.h>
 #include <libcommon/valuemapper.h>
@@ -52,11 +53,6 @@ void PinDll()
 //
 // Call this function once during startup.
 //
-enum class InitializeStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS,
-};
 
 void __declspec(dllexport) NSISCALL Initialize
 (
@@ -80,17 +76,17 @@ void __declspec(dllexport) NSISCALL Initialize
 		}
 
 		pushstring(L"");
-		pushint(InitializeStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(InitializeStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(InitializeStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }
 
@@ -227,11 +223,6 @@ void __declspec(dllexport) NSISCALL RemoveMullvadTap
 // By comparing with the previously captured baseline we're able to
 // identify the new adapter.
 //
-enum class IdentifyNewAdapterStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
 
 void __declspec(dllexport) NSISCALL IdentifyNewAdapter
 (
@@ -248,7 +239,7 @@ void __declspec(dllexport) NSISCALL IdentifyNewAdapter
 	if (nullptr == g_context)
 	{
 		pushstring(L"Initialize() function was not called or was not successful");
-		pushint(IdentifyNewAdapterStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 		return;
 	}
 
@@ -259,17 +250,17 @@ void __declspec(dllexport) NSISCALL IdentifyNewAdapter
 		auto adapter = g_context->getNewAdapter();
 
 		pushstring(adapter.alias.c_str());
-		pushint(IdentifyNewAdapterStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(IdentifyNewAdapterStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(IdentifyNewAdapterStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }
 
@@ -279,11 +270,6 @@ void __declspec(dllexport) NSISCALL IdentifyNewAdapter
 // Updating the TAP driver may replace GUIDs and aliases.
 // Use this to restore the aliases to their baseline state.
 //
-enum class RollbackTapAliasesStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
 
 void __declspec(dllexport) NSISCALL RollbackTapAliases
 (
@@ -300,7 +286,7 @@ void __declspec(dllexport) NSISCALL RollbackTapAliases
 	if (nullptr == g_context)
 	{
 		pushstring(L"Initialize() function was not called or was not successful");
-		pushint(RollbackTapAliasesStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 		return;
 	}
 
@@ -310,17 +296,17 @@ void __declspec(dllexport) NSISCALL RollbackTapAliases
 		g_context->rollbackTapAliases();
 
 		pushstring(L"");
-		pushint(RollbackTapAliasesStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (std::exception & err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(RollbackTapAliasesStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(RollbackTapAliasesStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }
 
@@ -329,11 +315,6 @@ void __declspec(dllexport) NSISCALL RollbackTapAliases
 //
 // Call this function once during shutdown.
 //
-enum class DeinitializeStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS,
-};
 
 void __declspec(dllexport) NSISCALL Deinitialize
 (
@@ -352,17 +333,17 @@ void __declspec(dllexport) NSISCALL Deinitialize
 		delete g_context;
 
 		pushstring(L"");
-		pushint(InitializeStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(DeinitializeStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(DeinitializeStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 
 	g_context = nullptr;

--- a/windows/nsis-plugins/src/error.h
+++ b/windows/nsis-plugins/src/error.h
@@ -1,0 +1,20 @@
+#pragma once
+
+//
+// Generic return codes for NSIS plugins
+//
+//
+// Returned on the stack:
+//
+//   GENERAL_ERROR:  Most functions return an error message.
+//   SUCCESS:        Most functions return an empty string.
+//
+// NOTE: While this is generally true, some functions only
+//       push a status code to the stack.
+//
+
+enum NsisStatus
+{
+	GENERAL_ERROR = 0,
+	SUCCESS,
+};

--- a/windows/nsis-plugins/src/pathedit/pathedit.cpp
+++ b/windows/nsis-plugins/src/pathedit/pathedit.cpp
@@ -2,6 +2,7 @@
 //
 
 #include "stdafx.h"
+#include "../error.h"
 #include <windows.h>
 #include <libcommon/string.h>
 #include <libcommon/registry/registry.h>
@@ -96,12 +97,6 @@ std::wstring ReadPathValue(const RegistryKey &pathKey)
 // AddSysEnvPath "C:\path\to\directory"
 //
 
-enum class EnvPathStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
-
 void __declspec(dllexport) NSISCALL AddSysEnvPath
 (
 	HWND hwndParent,
@@ -129,7 +124,7 @@ void __declspec(dllexport) NSISCALL AddSysEnvPath
 		if (SysPathExists(path, pathToAppend))
 		{
 			pushstring(L"");
-			pushint(EnvPathStatus::SUCCESS);
+			pushint(NsisStatus::SUCCESS);
 			return;
 		}
 
@@ -148,17 +143,17 @@ void __declspec(dllexport) NSISCALL AddSysEnvPath
 		);
 
 		pushstring(L"");
-		pushint(EnvPathStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (const std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(EnvPathStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(EnvPathStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }
 
@@ -214,16 +209,16 @@ void __declspec(dllexport) NSISCALL RemoveSysEnvPath
 		}
 
 		pushstring(L"");
-		pushint(EnvPathStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (const std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(EnvPathStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(EnvPathStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }

--- a/windows/nsis-plugins/src/registry/registry.cpp
+++ b/windows/nsis-plugins/src/registry/registry.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "../error.h"
 #include <windows.h>
 #include <libcommon/string.h>
 #include <libcommon/registry/registry.h>
@@ -43,11 +44,6 @@ std::wstring PopString()
 //
 // MoveKey "HKLM\Software\A" "HKLM\Software\B"
 //
-enum class MoveKeyStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
 
 void __declspec(dllexport) NSISCALL MoveKey
 (
@@ -73,16 +69,16 @@ void __declspec(dllexport) NSISCALL MoveKey
 			typedDestination.subkey(), common::registry::RegistryView::Force64);
 
 		pushstring(L"");
-		pushint(MoveKeyStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(MoveKeyStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(MoveKeyStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }

--- a/windows/nsis-plugins/src/tray/tray.cpp
+++ b/windows/nsis-plugins/src/tray/tray.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "../error.h"
 #include "trayparser.h"
 #include "trayjuggler.h"
 #include "resource.h"
@@ -116,11 +117,6 @@ void UpdateRegistry(common::registry::RegistryKey &regkey, const std::wstring &v
 // Ensure the GUI's tray icon is placed in the visible part of the notification area.
 // This is accomplished by updating a binary blob in the registry.
 //
-enum class PromoteTrayIconStatus
-{
-	GENERAL_ERROR = 0,
-	SUCCESS
-};
 
 void __declspec(dllexport) NSISCALL PromoteTrayIcon
 (
@@ -173,16 +169,16 @@ void __declspec(dllexport) NSISCALL PromoteTrayIcon
 		}
 
 		pushstring(L"");
-		pushint(PromoteTrayIconStatus::SUCCESS);
+		pushint(NsisStatus::SUCCESS);
 	}
 	catch (std::exception &err)
 	{
 		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(PromoteTrayIconStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 	catch (...)
 	{
 		pushstring(L"Unspecified error");
-		pushint(PromoteTrayIconStatus::GENERAL_ERROR);
+		pushint(NsisStatus::GENERAL_ERROR);
 	}
 }


### PR DESCRIPTION
Most functions simply return 0 for failure and 1 for success. We can simplify things by sharing defined constants for functions like these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1336)
<!-- Reviewable:end -->
