### PR TITLE
HACK: Allow relays on port 53 in WinFw

### DIFF
--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -167,7 +167,8 @@ bool FwContext::applyPolicyConnected
 	ruleset.emplace_back(std::make_unique<rules::RestrictDns>(
 		tunnelInterfaceAlias,
 		wfp::IpAddress(v4DnsHost),
-		(v6DnsHost != nullptr) ? std::make_unique<wfp::IpAddress>(v6DnsHost) : nullptr
+		(v6DnsHost != nullptr) ? std::make_unique<wfp::IpAddress>(v6DnsHost) : nullptr,
+		(relay.port == 53) ? std::make_unique<wfp::IpAddress>(relay.ip) : nullptr
 	));
 
 	return applyRuleset(ruleset);

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -52,6 +52,7 @@ DetailedWfpObjectRegistry MullvadGuids::BuildDetailedRegistry()
 	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitVpnTunnel_Outbound_Ipv6()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Tunnel_Ipv4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_HACK_TO_ALLOW_RELAY_ON_PORT_53()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Ipv6()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, FilterRestrictDns_Outbound_Tunnel_Ipv6()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, FilterPermitVpnTunnelService_Ipv4()));
@@ -467,6 +468,20 @@ const GUID &MullvadGuids::FilterRestrictDns_Outbound_Tunnel_Ipv4()
 		0xb23e,
 		0x4ab4,
 		{ 0x8e, 0x2f, 0xc7, 0x6, 0x55, 0x5f, 0x94, 0xff }
+	};
+
+	return g;
+}
+
+//static
+const GUID& MullvadGuids::FilterRestrictDns_HACK_TO_ALLOW_RELAY_ON_PORT_53()
+{
+	static const GUID g =
+	{
+		0x6a613b73,
+		0x7308,
+		0x4ae4,
+		{ 0x91, 0x7d, 0xd2, 0xa2, 0x29, 0x17, 0xcc, 0x3f }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -58,6 +58,7 @@ public:
 
 	static const GUID &FilterRestrictDns_Outbound_Ipv4();
 	static const GUID &FilterRestrictDns_Outbound_Tunnel_Ipv4();
+	static const GUID &FilterRestrictDns_HACK_TO_ALLOW_RELAY_ON_PORT_53();
 	static const GUID &FilterRestrictDns_Outbound_Ipv6();
 	static const GUID &FilterRestrictDns_Outbound_Tunnel_Ipv6();
 

--- a/windows/winfw/src/winfw/rules/restrictdns.cpp
+++ b/windows/winfw/src/winfw/rules/restrictdns.cpp
@@ -12,10 +12,14 @@ using namespace wfp::conditions;
 namespace rules
 {
 
-RestrictDns::RestrictDns(const std::wstring &tunnelInterfaceAlias, const wfp::IpAddress v4DnsHost, std::unique_ptr<wfp::IpAddress> v6DnsHost)
+RestrictDns::RestrictDns(const std::wstring& tunnelInterfaceAlias,
+	const wfp::IpAddress v4DnsHost,
+	std::unique_ptr<wfp::IpAddress> v6DnsHost,
+	std::unique_ptr<wfp::IpAddress> relay)
 	: m_tunnelInterfaceAlias(tunnelInterfaceAlias)
 	, m_v4DnsHost(v4DnsHost)
 	, m_v6DnsHost(std::move(v6DnsHost))
+	, m_relayHost(std::move(relay))
 
 {
 }
@@ -32,6 +36,30 @@ bool RestrictDns::apply(IObjectInstaller &objectInstaller)
 	//
 	// TODO: Have each rule specify requirements?
 	//
+
+	if (nullptr != m_relayHost) {
+
+		filterBuilder
+			.key(MullvadGuids::FilterRestrictDns_Outbound_Ipv4())
+			.name(L"Permit relay connection over port 53 (IPv4)")
+			.key(MullvadGuids::FilterRestrictDns_HACK_TO_ALLOW_RELAY_ON_PORT_53())
+			.description(L"This filter is part of a rule that restricts DNS traffic")
+			.provider(MullvadGuids::Provider())
+			.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
+			.sublayer(MullvadGuids::SublayerBlacklist())
+			.weight(wfp::FilterBuilder::WeightClass::Max)
+			.permit();
+
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
+
+		conditionBuilder.add_condition(ConditionPort::Remote(53));
+		conditionBuilder.add_condition(ConditionIp::Remote(*m_relayHost, CompareEq()));
+
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
+	}
 
 	filterBuilder
 		.key(MullvadGuids::FilterRestrictDns_Outbound_Ipv4())

--- a/windows/winfw/src/winfw/rules/restrictdns.h
+++ b/windows/winfw/src/winfw/rules/restrictdns.h
@@ -11,7 +11,7 @@ class RestrictDns : public IFirewallRule
 {
 public:
 
-	RestrictDns(const std::wstring &tunnelInterfaceAlias, const wfp::IpAddress v4DnsHost, std::unique_ptr<wfp::IpAddress> v6DnsHost);
+	RestrictDns(const std::wstring &tunnelInterfaceAlias, const wfp::IpAddress v4DnsHost, std::unique_ptr<wfp::IpAddress> v6DnsHost, std::unique_ptr<wfp::IpAddress> relay);
 
 	bool apply(IObjectInstaller &objectInstaller) override;
 
@@ -20,6 +20,8 @@ private:
 	const std::wstring m_tunnelInterfaceAlias;
 	const wfp::IpAddress m_v4DnsHost;
 	const std::unique_ptr<wfp::IpAddress> m_v6DnsHost;
+	// If connecting to relay on port 53, the traffic to port 53 should be allowed.
+	const std::unique_ptr<wfp::IpAddress> m_relayHost;
 
 };
 


### PR DESCRIPTION
Add extra permissive filter in the blacklist sublayer to allow packets going to
the tunnel host if the daemon is trying to connect to the tunnel over port 53.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1338)
<!-- Reviewable:end -->
