### PR TITLE
Throttle geo. IP location fetch retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix notification message to update to `null` version when version check cache is stale right
   after an update.
 - Fix `null` pointer exception when connectivity event intent has no network info.
+- Fix fast loop trying to fetch location and preventing the device from sleeping. This should
+  improve battery life in some cases.
 
 ### Security
 #### Linux

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.TunnelState
@@ -14,6 +15,10 @@ import net.mullvad.mullvadvpn.relaylist.RelayCountry
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.ConnectivityListener
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
+
+const val DELAY_SCALE: Long = 50
+const val MAX_DELAY: Long = 30 * 60 * 1000
+const val MAX_RETRIES: Int = 17 // ceil(log2(MAX_DELAY / DELAY_SCALE) + 1)
 
 class LocationInfoCache(
     val daemon: Deferred<MullvadDaemon>,
@@ -98,10 +103,14 @@ class LocationInfoCache(
 
         activeFetch = GlobalScope.launch(Dispatchers.Main) {
             var newLocation: GeoIpLocation? = null
+            var retry = 0
 
             previousFetch?.join()
 
             while (newLocation == null && shouldRetryFetch() && state == initialState) {
+                delayFetch(retry)
+                retry += 1
+
                 newLocation = executeFetch().await()
             }
 
@@ -120,6 +129,20 @@ class LocationInfoCache(
 
     private fun executeFetch() = GlobalScope.async(Dispatchers.Default) {
         daemon.await().getCurrentLocation()
+    }
+
+    private suspend fun delayFetch(retryAttempt: Int) {
+        var duration = 0L
+
+        // The first attempt has no delay
+        if (retryAttempt >= MAX_RETRIES) {
+            duration = MAX_DELAY
+        } else if (retryAttempt >= 1) {
+            val exponent = retryAttempt - 1
+            duration = (1L shl exponent) * DELAY_SCALE
+        }
+
+        delay(duration)
     }
 
     private suspend fun shouldRetryFetch(): Boolean {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -73,6 +73,10 @@ class LocationInfoCache(
             }
         }
 
+    fun onDestroy() {
+        activeFetch?.cancel()
+    }
+
     private fun locationFromSelectedRelay(): GeoIpLocation? {
         val relayItem = relayListListener.selectedRelayItem
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -121,6 +121,7 @@ class MainActivity : FragmentActivity() {
         accountCache.onDestroy()
         appVersionInfoCache.onDestroy()
         keyStatusListener.onDestroy()
+        locationInfoCache.onDestroy()
         relayListListener.onDestroy()
         settingsListener.onDestroy()
 


### PR DESCRIPTION
Previously, the `LocationInfoCache` would retry to fetch the location after each failure immediately. If the device had some connectivity issues (that weren't detected by the `ConnectivityListener`), the retries would occur very quickly in a tight loop. This meant that the device wouldn't get the chance to idle, and would drain battery quickly.

This PR fixes that by implementing an exponential back-off strategy for delaying the retries, limited to a maximum of 30 minutes.

The PR also fixes another scenario where closing the UI still kept fetching the location information.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1339)
<!-- Reviewable:end -->
