### PR TITLE
Create `ServiceConnection` classes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -1,18 +1,18 @@
 package net.mullvad.mullvadvpn.dataproxy
 
 import android.content.Context
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.AppVersionInfo
-import net.mullvad.mullvadvpn.ui.MainActivity
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 
-class AppVersionInfoCache(val parentActivity: MainActivity) {
+class AppVersionInfoCache(val context: Context, val daemon: Deferred<MullvadDaemon>) {
     companion object {
         val LEGACY_SHARED_PREFERENCES = "app_version_info_cache"
     }
 
-    private val daemon = parentActivity.daemon
     private val setUpJob = setUp()
 
     private var appVersionInfo: AppVersionInfo? = null
@@ -61,7 +61,7 @@ class AppVersionInfoCache(val parentActivity: MainActivity) {
         private set
 
     fun onCreate() {
-        parentActivity.getSharedPreferences(LEGACY_SHARED_PREFERENCES, Context.MODE_PRIVATE)
+        context.getSharedPreferences(LEGACY_SHARED_PREFERENCES, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .commit()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -1,14 +1,14 @@
 package net.mullvad.mullvadvpn.dataproxy
 
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.ui.MainActivity
 
-class SettingsListener(val parentActivity: MainActivity) {
+class SettingsListener(val asyncDaemon: Deferred<MullvadDaemon>) {
     private lateinit var daemon: MullvadDaemon
 
     private val setUpJob = setUp()
@@ -41,7 +41,7 @@ class SettingsListener(val parentActivity: MainActivity) {
     }
 
     private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
-        daemon = parentActivity.daemon.await()
+        daemon = asyncDaemon.await()
 
         listenerId = daemon.onSettingsChange.subscribe { maybeSettings ->
             maybeSettings?.let { settings -> handleNewSettings(settings) }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,0 +1,10 @@
+package net.mullvad.mullvadvpn.service
+
+import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
+import net.mullvad.talpid.ConnectivityListener
+
+data class ServiceInstance(
+    val daemon: MullvadDaemon,
+    val connectionProxy: ConnectionProxy,
+    val connectivityListener: ConnectivityListener
+)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -53,7 +53,7 @@ class MainActivity : FragmentActivity() {
     private var serviceToStop: MullvadVpnService.LocalBinder? = null
     private var waitForDaemonJob: Job? = null
 
-    private val serviceConnection = object : ServiceConnection {
+    private val serviceConnectionManager = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
             val localBinder = binder as MullvadVpnService.LocalBinder
 
@@ -99,7 +99,7 @@ class MainActivity : FragmentActivity() {
         val intent = Intent(this, MullvadVpnService::class.java)
 
         startService(intent)
-        bindService(intent, serviceConnection, 0)
+        bindService(intent, serviceConnectionManager, 0)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
@@ -110,7 +110,7 @@ class MainActivity : FragmentActivity() {
         quitJob?.cancel()
 
         serviceToStop?.apply { stop() }
-        unbindService(serviceConnection)
+        unbindService(serviceConnectionManager)
 
         super.onStop()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -44,7 +44,7 @@ class MainActivity : FragmentActivity() {
     val keyStatusListener = KeyStatusListener(daemon)
     val problemReport = MullvadProblemReport()
     var settingsListener = SettingsListener(daemon)
-    var relayListListener = RelayListListener(this)
+    var relayListListener = RelayListListener(daemon, settingsListener)
     val locationInfoCache = LocationInfoCache(daemon, connectivityListener, relayListListener)
     val accountCache = AccountCache(settingsListener, daemon)
     val wwwAuthTokenRetriever = WwwAuthTokenRetriever(daemon)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : FragmentActivity() {
     var service = CompletableDeferred<MullvadVpnService.LocalBinder>()
         private set
 
-    var appVersionInfoCache = AppVersionInfoCache(this)
+    var appVersionInfoCache = AppVersionInfoCache(this, daemon)
     val connectionProxy = SmartDeferred(configureConnectionProxy())
     val keyStatusListener = KeyStatusListener(daemon)
     val problemReport = MullvadProblemReport()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : FragmentActivity() {
     val connectionProxy = SmartDeferred(configureConnectionProxy())
     val keyStatusListener = KeyStatusListener(daemon)
     val problemReport = MullvadProblemReport()
-    var settingsListener = SettingsListener(this)
+    var settingsListener = SettingsListener(daemon)
     var relayListListener = RelayListListener(this)
     val locationInfoCache = LocationInfoCache(daemon, connectivityListener, relayListListener)
     val accountCache = AccountCache(settingsListener, daemon)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -25,11 +25,10 @@ import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayItemDividerDecoration
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.relaylist.RelayListAdapter
-import net.mullvad.mullvadvpn.util.SmartDeferred
 
 class SelectLocationFragment : Fragment() {
     private lateinit var parentActivity: MainActivity
-    private lateinit var connectionProxy: SmartDeferred<ConnectionProxy>
+    private lateinit var connectionProxy: ConnectionProxy
     private lateinit var relayListListener: RelayListListener
 
     private lateinit var relayListContainer: ViewSwitcher
@@ -129,7 +128,7 @@ class SelectLocationFragment : Fragment() {
         val keyStatus = parentActivity.keyStatusListener.keyStatus
 
         if (keyStatus == null || keyStatus is KeygenEvent.NewKey) {
-            connectionProxy.awaitThen { connect() }
+            connectionProxy.connect()
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -1,0 +1,38 @@
+package net.mullvad.mullvadvpn.ui
+
+import kotlinx.coroutines.CompletableDeferred
+import net.mullvad.mullvadvpn.dataproxy.AccountCache
+import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
+import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
+import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
+import net.mullvad.mullvadvpn.dataproxy.RelayListListener
+import net.mullvad.mullvadvpn.dataproxy.SettingsListener
+import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever
+import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.ServiceInstance
+import net.mullvad.talpid.ConnectivityListener
+
+class ServiceConnection(private val service: ServiceInstance, val mainActivity: MainActivity) {
+    private val asyncDaemon = CompletableDeferred<MullvadDaemon>()
+    private val asyncConnectivityListener = CompletableDeferred<ConnectivityListener>()
+
+    val daemon = service.daemon
+    val connectionProxy = service.connectionProxy
+    val connectivityListener = service.connectivityListener
+
+    val appVersionInfoCache = AppVersionInfoCache(mainActivity, asyncDaemon)
+    val keyStatusListener = KeyStatusListener(asyncDaemon)
+    val settingsListener = SettingsListener(asyncDaemon)
+    val accountCache = AccountCache(settingsListener, asyncDaemon)
+    var relayListListener = RelayListListener(asyncDaemon, settingsListener)
+    val locationInfoCache =
+        LocationInfoCache(asyncDaemon, asyncConnectivityListener, relayListListener)
+    val wwwAuthTokenRetriever = WwwAuthTokenRetriever(asyncDaemon)
+
+    init {
+        asyncDaemon.complete(daemon)
+        asyncConnectivityListener.complete(connectivityListener)
+
+        connectionProxy.mainActivity = mainActivity
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -32,7 +32,20 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     init {
         asyncDaemon.complete(daemon)
         asyncConnectivityListener.complete(connectivityListener)
+        appVersionInfoCache.onCreate()
 
         connectionProxy.mainActivity = mainActivity
+    }
+
+    fun onDestroy() {
+        asyncDaemon.cancel()
+        asyncConnectivityListener.cancel()
+
+        accountCache.onDestroy()
+        appVersionInfoCache.onDestroy()
+        keyStatusListener.onDestroy()
+        locationInfoCache.onDestroy()
+        relayListListener.onDestroy()
+        settingsListener.onDestroy()
     }
 }


### PR DESCRIPTION
This PR creates two `ServiceConnection` classes in the `ui` and the `service` packages. 

The `MullvadVpnService` is refactored so that it sends `service.ServiceConnection` instances every time it has finished setting up. When it is stopping, it will send a `null` marker.

The `service.ServiceConnection` class contains the objects exported by the service, which include the daemon, the connection proxy and the connectivity listener.

The `MainActivity` handles service connection events by wrapping it with a `ui.ServiceConnection`, which initializes the extra helper classes from the `dataproxy` package.

Future PRs will forward this `ui.ServiceConnection` object to the UI fragments, but currently it is only used as the source of the classes exported from the `MainActivity` to the fragments.

The main advantage of having the `ui.ServiceConnection` is that all of the internal objects are initialized when received, so they can be used directly as soon as an object is received.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1340)
<!-- Reviewable:end -->
