### PR TITLE
Rename 'key generate' to 'key regenerate' in the CLI

### DIFF
--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -55,7 +55,7 @@ fn create_wireguard_keys_subcommand() -> clap::App<'static, 'static> {
         .about("Manage your wireguard key")
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::SubCommand::with_name("check"))
-        .subcommand(clap::SubCommand::with_name("generate"))
+        .subcommand(clap::SubCommand::with_name("regenerate"))
         .subcommand(create_wireguard_keys_rotation_interval_subcommand())
 }
 
@@ -131,7 +131,7 @@ impl Tunnel {
 
             ("key", Some(matches)) => match matches.subcommand() {
                 ("check", _) => Self::process_wireguard_key_check(),
-                ("generate", _) => Self::process_wireguard_key_generate(),
+                ("regenerate", _) => Self::process_wireguard_key_generate(),
                 ("rotation-interval", Some(matches)) => match matches.subcommand() {
                     ("get", _) => Self::process_wireguard_rotation_interval_get(),
                     ("set", Some(matches)) => {


### PR DESCRIPTION
This was named `generate` when you had to run this manually. It should probably be called `regenerate` now, consistent with the GUI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1349)
<!-- Reviewable:end -->
