### PR TITLE
Create fragment helper classes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -4,7 +4,6 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.view.LayoutInflater
 import android.view.View
@@ -19,21 +18,13 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import org.joda.time.DateTime
 
-class AccountFragment : Fragment() {
-    private lateinit var parentActivity: MainActivity
-
+class AccountFragment : ServiceDependentFragment() {
     private lateinit var accountExpiryContainer: View
     private lateinit var accountExpiryDisplay: TextView
     private lateinit var accountNumberContainer: View
     private lateinit var accountNumberDisplay: TextView
 
     private var updateViewJob: Job? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        parentActivity = context as MainActivity
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -62,13 +53,13 @@ class AccountFragment : Fragment() {
     override fun onResume() {
         super.onResume()
 
-        parentActivity.accountCache.onAccountDataChange = { accountNumber, accountExpiry ->
+        accountCache.onAccountDataChange = { accountNumber, accountExpiry ->
             updateViewJob = updateView(accountNumber, accountExpiry)
         }
     }
 
     override fun onPause() {
-        parentActivity.accountCache.onAccountDataChange = null
+        accountCache.onAccountDataChange = null
 
         super.onPause()
     }
@@ -116,8 +107,6 @@ class AccountFragment : Fragment() {
     }
 
     private fun clearAccountNumber() = GlobalScope.launch(Dispatchers.Default) {
-        val daemon = parentActivity.daemon.await()
-
         daemon.setAccount(null)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -1,8 +1,6 @@
 package net.mullvad.mullvadvpn.ui
 
-import android.content.Context
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,17 +10,12 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
-import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
-import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
-import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
-import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.TunnelState
 
 val KEY_IS_TUNNEL_INFO_EXPANDED = "is_tunnel_info_expanded"
 
-class ConnectFragment : Fragment() {
+class ConnectFragment : ServiceDependentFragment() {
     private lateinit var actionButton: ConnectActionButton
     private lateinit var switchLocationButton: SwitchLocationButton
     private lateinit var headerBar: HeaderBar
@@ -30,29 +23,11 @@ class ConnectFragment : Fragment() {
     private lateinit var status: ConnectionStatus
     private lateinit var locationInfo: LocationInfo
 
-    private lateinit var parentActivity: MainActivity
-    private lateinit var connectionProxy: ConnectionProxy
-    private lateinit var keyStatusListener: KeyStatusListener
-    private lateinit var locationInfoCache: LocationInfoCache
-    private lateinit var relayListListener: RelayListListener
-    private lateinit var versionInfoCache: AppVersionInfoCache
-
     private lateinit var updateKeyStatusJob: Job
     private var updateTunnelStateJob: Job? = null
 
     private var isTunnelInfoExpanded = false
     private var tunnelStateListener: Int? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        parentActivity = context as MainActivity
-        connectionProxy = parentActivity.connectionProxy
-        keyStatusListener = parentActivity.keyStatusListener
-        locationInfoCache = parentActivity.locationInfoCache
-        relayListListener = parentActivity.relayListListener
-        versionInfoCache = parentActivity.appVersionInfoCache
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,10 +49,8 @@ class ConnectFragment : Fragment() {
         }
 
         headerBar = HeaderBar(view, resources)
-        notificationBanner = NotificationBanner(view,
-                                                context!!,
-                                                versionInfoCache,
-                                                parentActivity.wwwAuthTokenRetriever)
+        notificationBanner =
+            NotificationBanner(view, parentActivity, appVersionInfoCache, wwwAuthTokenRetriever)
         status = ConnectionStatus(view, resources)
 
         locationInfo = LocationInfo(view, context!!)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -1,10 +1,8 @@
 package net.mullvad.mullvadvpn.ui
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -20,9 +18,7 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 
-class LoginFragment : Fragment() {
-    private lateinit var parentActivity: MainActivity
-
+class LoginFragment : ServiceDependentFragment() {
     private lateinit var title: TextView
     private lateinit var subtitle: TextView
     private lateinit var loggingInStatus: View
@@ -34,12 +30,6 @@ class LoginFragment : Fragment() {
 
     private var loginJob: Deferred<Boolean>? = null
     private var advanceToNextScreenJob: Job? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        parentActivity = context as MainActivity
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -100,7 +90,6 @@ class LoginFragment : Fragment() {
     private fun performLogin(accountToken: String) = GlobalScope.launch(Dispatchers.Main) {
         loginJob?.cancel()
         loginJob = GlobalScope.async(Dispatchers.Default) {
-            val daemon = parentActivity.daemon.await()
             val accountDataResult = daemon.getAccountData(accountToken)
 
             when (accountDataResult) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -30,7 +30,7 @@ class MainActivity : FragmentActivity() {
         val KEY_SHOULD_CONNECT = "should_connect"
     }
 
-    var serviceConnection: ServiceConnection? = null
+    private var serviceConnection: ServiceConnection? = null
     private var serviceConnectionSubscription: Int? = null
 
     var daemon = CompletableDeferred<MullvadDaemon>()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.ui
 
+import android.content.Context
 import android.view.View
 import android.widget.TextView
 import kotlinx.coroutines.Dispatchers
@@ -7,14 +8,13 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.joda.time.PeriodType
 
-class RemainingTimeLabel(val parentActivity: MainActivity, val view: View) {
-    private val accountCache = parentActivity.accountCache
-
-    private val resources = parentActivity.resources
+class RemainingTimeLabel(val context: Context, val accountCache: AccountCache, val view: View) {
+    private val resources = context.resources
 
     private val expiredColor = resources.getColor(R.color.red)
     private val normalColor = resources.getColor(R.color.white60)
@@ -24,7 +24,7 @@ class RemainingTimeLabel(val parentActivity: MainActivity, val view: View) {
     private var updateJob: Job? = null
 
     fun onResume() {
-        parentActivity.accountCache.apply {
+        accountCache.apply {
             refetch()
 
             onAccountDataChange = { _, accountExpiry ->
@@ -35,7 +35,7 @@ class RemainingTimeLabel(val parentActivity: MainActivity, val view: View) {
     }
 
     fun onPause() {
-        parentActivity.accountCache.onAccountDataChange = null
+        accountCache.onAccountDataChange = null
         updateJob?.cancel()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
@@ -1,0 +1,47 @@
+package net.mullvad.mullvadvpn.ui
+
+import android.content.Context
+import android.support.v4.app.Fragment
+
+abstract class ServiceAwareFragment : Fragment() {
+    lateinit var parentActivity: MainActivity
+        private set
+
+    var serviceConnection: ServiceConnection? = null
+        private set
+
+    private var subscriptionId: Int? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        parentActivity = context as MainActivity
+
+        subscriptionId = parentActivity.serviceNotifier.subscribe { connection ->
+            configureServiceConnection(connection)
+        }
+    }
+
+    override fun onDetach() {
+        subscriptionId?.let { id ->
+            parentActivity.serviceNotifier.unsubscribe(id)
+        }
+
+        super.onDetach()
+    }
+
+    abstract fun onNewServiceConnection(serviceConnection: ServiceConnection)
+
+    open fun onNoServiceConnection() {
+    }
+
+    private fun configureServiceConnection(connection: ServiceConnection?) {
+        serviceConnection = connection
+
+        if (connection != null) {
+            onNewServiceConnection(connection)
+        } else {
+            onNoServiceConnection()
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -1,0 +1,57 @@
+package net.mullvad.mullvadvpn.ui
+
+import net.mullvad.mullvadvpn.dataproxy.AccountCache
+import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
+import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
+import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
+import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
+import net.mullvad.mullvadvpn.dataproxy.RelayListListener
+import net.mullvad.mullvadvpn.dataproxy.SettingsListener
+import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever
+import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.talpid.ConnectivityListener
+
+open class ServiceDependentFragment : ServiceAwareFragment() {
+    lateinit var accountCache: AccountCache
+        private set
+
+    lateinit var appVersionInfoCache: AppVersionInfoCache
+        private set
+
+    lateinit var connectionProxy: ConnectionProxy
+        private set
+
+    lateinit var connectivityListener: ConnectivityListener
+        private set
+
+    lateinit var daemon: MullvadDaemon
+        private set
+
+    lateinit var keyStatusListener: KeyStatusListener
+        private set
+
+    lateinit var locationInfoCache: LocationInfoCache
+        private set
+
+    lateinit var relayListListener: RelayListListener
+        private set
+
+    lateinit var settingsListener: SettingsListener
+        private set
+
+    lateinit var wwwAuthTokenRetriever: WwwAuthTokenRetriever
+        private set
+
+    override fun onNewServiceConnection(serviceConnection: ServiceConnection) {
+        accountCache = serviceConnection.accountCache
+        appVersionInfoCache = serviceConnection.appVersionInfoCache
+        connectionProxy = serviceConnection.connectionProxy
+        connectivityListener = serviceConnection.connectivityListener
+        daemon = serviceConnection.daemon
+        keyStatusListener = serviceConnection.keyStatusListener
+        locationInfoCache = serviceConnection.locationInfoCache
+        relayListListener = serviceConnection.relayListListener
+        settingsListener = serviceConnection.settingsListener
+        wwwAuthTokenRetriever = serviceConnection.wwwAuthTokenRetriever
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn.ui
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -19,9 +18,7 @@ import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 
-class SettingsFragment : Fragment() {
-    private lateinit var parentActivity: MainActivity
-
+class SettingsFragment : ServiceAwareFragment() {
     private lateinit var accountCache: AccountCache
     private lateinit var versionInfoCache: AppVersionInfoCache
 
@@ -35,12 +32,9 @@ class SettingsFragment : Fragment() {
     private var updateLoggedInStatusJob: Job? = null
     private var updateVersionInfoJob: Job? = null
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        parentActivity = context as MainActivity
-        accountCache = parentActivity.accountCache
-        versionInfoCache = parentActivity.appVersionInfoCache
+    override fun onNewServiceConnection(serviceConnection: ServiceConnection) {
+        accountCache = serviceConnection.accountCache
+        versionInfoCache = serviceConnection.appVersionInfoCache
     }
 
     override fun onCreateView(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -73,7 +73,7 @@ class SettingsFragment : ServiceAwareFragment() {
         appVersionWarning = view.findViewById(R.id.app_version_warning)
         appVersionLabel = view.findViewById<TextView>(R.id.app_version_label)
         appVersionFooter = view.findViewById(R.id.app_version_footer)
-        remainingTimeLabel = RemainingTimeLabel(parentActivity, view)
+        remainingTimeLabel = RemainingTimeLabel(parentActivity, accountCache, view)
 
         return view
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
@@ -21,9 +20,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
-import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
-import net.mullvad.mullvadvpn.dataproxy.WwwAuthTokenRetriever
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.KeygenFailure
 import net.mullvad.mullvadvpn.model.TunnelState
@@ -34,15 +30,11 @@ import org.joda.time.format.DateTimeFormat
 val RFC3339_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSSSSSSSSS z")
 val KEY_AGE_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm")
 
-class WireguardKeyFragment : Fragment() {
+class WireguardKeyFragment : ServiceDependentFragment() {
     private var currentJob: Job? = null
     private var updateViewsJob: Job? = null
     private var tunnelStateListener: Int? = null
     private var tunnelState: TunnelState = TunnelState.Disconnected()
-    private lateinit var connectionProxy: ConnectionProxy
-    private lateinit var keyStatusListener: KeyStatusListener
-    private lateinit var parentActivity: MainActivity
-    private lateinit var wwwTokenRetriever: WwwAuthTokenRetriever
     private lateinit var urlController: BlockingController
     private var generatingKey = false
     private var validatingKey = false
@@ -55,14 +47,6 @@ class WireguardKeyFragment : Fragment() {
     private lateinit var generateSpinner: ProgressBar
     private lateinit var verifyButton: Button
     private lateinit var verifySpinner: ProgressBar
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        parentActivity = context as MainActivity
-        keyStatusListener = parentActivity.keyStatusListener
-        connectionProxy = parentActivity.connectionProxy
-        wwwTokenRetriever = parentActivity.wwwAuthTokenRetriever
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -101,7 +85,7 @@ class WireguardKeyFragment : Fragment() {
 
                 override fun onClick(): Job {
                     return GlobalScope.launch(Dispatchers.Default) {
-                        val token = wwwTokenRetriever.getAuthToken()
+                        val token = wwwAuthTokenRetriever.getAuthToken()
                         val intent = Intent(Intent.ACTION_VIEW,
                                             Uri.parse(keyUrl + "?token=" + token))
                         startActivity(intent)


### PR DESCRIPTION
This PR refactors the fragments so that they have a consistent way to access the functionalities provided by the service. The common code is abstracted away in two super classes.

`ServiceAwareFragment` handles attaching the fragment to the `MainActivity` and registering for service connection events. These events can then be handled by sub-classes with two methods, `onNewServiceConnection` and `onNoServiceConnection`.

`ServiceDependentFragment` is a sub-class of `ServiceAwareFragment` for fragments that require the service connection in order to be shown. It assumes that the service connection will be available as long as the fragment is active, and provides properties for all functionalities exported by the service connection. In future PRs, there will be code for handling what should be done when the connection is lost.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1350)
<!-- Reviewable:end -->
