### PR TITLE
Clean-up unnecessary code after deploying `ServiceConnection`

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -52,14 +52,9 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     inner class LocalBinder : Binder() {
-        val daemon
-            get() = this@MullvadVpnService.daemon
         val serviceNotifier
             get() = this@MullvadVpnService.serviceNotifier
-        val connectionProxy
-            get() = this@MullvadVpnService.connectionProxy
-        val connectivityListener
-            get() = this@MullvadVpnService.connectivityListener
+
         val resetComplete
             get() = this@MullvadVpnService.resetComplete
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -55,9 +55,6 @@ class MullvadVpnService : TalpidVpnService() {
         val serviceNotifier
             get() = this@MullvadVpnService.serviceNotifier
 
-        val resetComplete
-            get() = this@MullvadVpnService.resetComplete
-
         fun stop() {
             this@MullvadVpnService.stop()
         }


### PR DESCRIPTION
This PR is a clean-up PR, refactoring a few things that became unnecessary after adding the `ServiceConnection`.

It does contain a small fix, since now the reset of the service is improved so that `onRebind` only restarts it if the service is actually stopping. Previously, that would only be true for the first time, and since the `resetComplete` variable was never reset to `null`, it would execute `onRebind` multiple times even if it wasn't stopping afterwards.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1351)
<!-- Reviewable:end -->
