### PR TITLE
Increase robustness of network adapter iteration

### DIFF
--- a/windows/nsis-plugins/src/driverlogic/context.cpp
+++ b/windows/nsis-plugins/src/driverlogic/context.cpp
@@ -274,15 +274,28 @@ std::set<Context::NetworkAdapter> GetTapAdapters()
 		// Construct NetworkAdapter
 		//
 
-		const std::wstring guid = GetNetCfgInstanceId(devInfo, devInfoData);
-		GUID guidObj = common::Guid::FromString(guid);
+		try
+		{
+			const std::wstring guid = GetNetCfgInstanceId(devInfo, devInfoData);
+			GUID guidObj = common::Guid::FromString(guid);
 
-		adapters.emplace(Context::NetworkAdapter(
-			guid,
-			GetDeviceStringProperty(devInfo, &devInfoData, &DEVPKEY_Device_DriverDesc),
-			nci.getConnectionName(guidObj),
-			GetDeviceInstanceId(devInfo, &devInfoData)
-		));
+			adapters.emplace(Context::NetworkAdapter(
+				guid,
+				GetDeviceStringProperty(devInfo, &devInfoData, &DEVPKEY_Device_DriverDesc),
+				nci.getConnectionName(guidObj),
+				GetDeviceInstanceId(devInfo, &devInfoData)
+			));
+		}
+		catch (const std::exception &e)
+		{
+			//
+			// Log exception and skip this adapter
+			//
+
+			std::string msg = "Skipping TAP adapter due to exception caught while iterating: ";
+			msg.append(e.what());
+			PluginLog(std::wstring(msg.begin(), msg.end()));
+		}
 	}
 
 	return adapters;


### PR DESCRIPTION
There's been one report of `NciGetConnectionName` failing. Unknown why. But there's no reason to fail everything in this case, since it may be that some errors only affect network adapters irrelevant to us. Thus, we should simply log the error and skip the adapter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1354)
<!-- Reviewable:end -->
