### PR TITLE
Stop version updater on shutdown

### DIFF
--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -124,6 +124,10 @@ impl<T: From<AppVersionInfo>> Future for VersionUpdater<T> {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         loop {
+            if self.update_sender.is_closed() {
+                log::warn!("Version update receiver is closed, stopping version updater");
+                return Ok(Async::Ready(()));
+            }
             let next_state = match &mut self.state {
                 VersionUpdaterState::Sleeping(timer) => match timer.poll() {
                     Ok(Async::NotReady) => return Ok(Async::NotReady),

--- a/talpid-core/src/mpsc.rs
+++ b/talpid-core/src/mpsc.rs
@@ -1,9 +1,10 @@
-use std::{marker::PhantomData, sync::mpsc};
+use futures::sync::mpsc::{SendError, UnboundedSender};
+use std::marker::PhantomData;
 
 /// Abstraction over an `mpsc::Sender` that first converts the value to another type before sending.
 #[derive(Debug, Clone)]
 pub struct IntoSender<T, U> {
-    sender: mpsc::Sender<U>,
+    sender: UnboundedSender<U>,
     _marker: PhantomData<T>,
 }
 
@@ -12,16 +13,16 @@ where
     T: Into<U>,
 {
     /// Converts the `T` into a `U` and sends it on the channel.
-    pub fn send(&self, t: T) -> Result<(), mpsc::SendError<U>> {
-        self.sender.send(t.into())
+    pub fn send(&self, t: T) -> Result<(), SendError<U>> {
+        self.sender.unbounded_send(t.into())
     }
 }
 
-impl<T, U> From<mpsc::Sender<U>> for IntoSender<T, U>
+impl<T, U> From<UnboundedSender<U>> for IntoSender<T, U>
 where
     T: Into<U>,
 {
-    fn from(sender: mpsc::Sender<U>) -> Self {
+    fn from(sender: UnboundedSender<U>) -> Self {
         IntoSender {
             sender,
             _marker: PhantomData,
@@ -32,7 +33,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{sync::mpsc, thread};
+    use futures::{sync::mpsc, Stream};
+    use std::thread;
 
     #[derive(Debug, Eq, PartialEq)]
     enum Inner {
@@ -54,25 +56,29 @@ mod tests {
 
     #[test]
     fn sender() {
-        let (tx, rx) = mpsc::channel::<Outer>();
+        let (tx, rx) = mpsc::unbounded();
         let inner_tx: IntoSender<Inner, Outer> = tx.clone().into();
 
-        tx.send(Outer::Other).unwrap();
+        tx.unbounded_send(Outer::Other).unwrap();
         inner_tx.send(Inner::Two).unwrap();
 
-        assert_eq!(Outer::Other, rx.recv().unwrap());
-        assert_eq!(Outer::Inner(Inner::Two), rx.recv().unwrap());
+        let mut sync_rx = rx.wait();
+
+        assert_eq!(Outer::Other, sync_rx.next().unwrap().unwrap());
+        assert_eq!(Outer::Inner(Inner::Two), sync_rx.next().unwrap().unwrap());
     }
 
     #[test]
     fn send_between_thread() {
-        let (tx, rx) = mpsc::channel::<Outer>();
+        let (tx, rx) = mpsc::unbounded();
         let inner_tx: IntoSender<Inner, Outer> = tx.clone().into();
 
         thread::spawn(move || {
             inner_tx.send(Inner::One).unwrap();
         });
 
-        assert_eq!(Outer::Inner(Inner::One), rx.recv().unwrap());
+        let mut sync_rx = rx.wait();
+
+        assert_eq!(Outer::Inner(Inner::One), sync_rx.next().unwrap().unwrap());
     }
 }


### PR DESCRIPTION
This PR changes the version updater so that it can be stopped when the daemon is stopped.

It does this by using an `UnboundedSender` instead of a closure to notify of version updates. The `UnboundedSender` has a helpful `is_closed` method that can determine if the receiving end has been closed. If it has, the daemon has stopped, and therefore the version updater should stop as well.

In order to use an `UnboundedSender` the `std::sync::mpsc::Sender` that was used for internal daemon events had to replaced. In general, the change is pretty similar for all cases, where `.send` becomes `.unbounded_send`. `IntoSender` was also updated to use `UnboundedSender`, which makes the conversion even simpler.

The only additional complexity is in the receiving end, since `UnboundedReceiver` is a `Stream`. To use it as `std::sync::mpsc::Receiver` was used before, the `.wait` method is used to convert it into a blocking iterator. The only difference is that the iterator has as its `Item` a `Result`, so an extra `unwrap` is necessary (for the case where all senders have been closed, which should never happen).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1356)
<!-- Reviewable:end -->
