### PR TITLE
Deny unused variables in Rust on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
             ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
             linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
       before_script:
-        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut"
+        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables"
         - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar
         - export CC_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang
         - source env.sh aarch64-linux-android

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN_CHANNEL=$1
-export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut"
+export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables"
 
 source env.sh ""
 

--- a/talpid-core/src/tunnel/tun_provider/android.rs
+++ b/talpid-core/src/tunnel/tun_provider/android.rs
@@ -134,7 +134,6 @@ impl AndroidTunProvider {
                 .map_err(Error::Select)?
                 > 0
             {
-                let elapsed = start.elapsed();
                 return Ok(());
             }
             // have to add tun_fd back into the bitset


### PR DESCRIPTION
We got an unused variable warning on Android. This seems like the type of warning we want to guard ourselves against.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1358)
<!-- Reviewable:end -->
