### PR TITLE
Move WireGuard related routine to WireguardDevice

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		584B26FF237435A90073B10E /* RelaySelector+RelayCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584B26FD237435990073B10E /* RelaySelector+RelayCache.swift */; };
 		58561C99239A5D1500BD6B5E /* IPEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58561C98239A5D1500BD6B5E /* IPEndpoint.swift */; };
 		58561C9A239A5D1500BD6B5E /* IPEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58561C98239A5D1500BD6B5E /* IPEndpoint.swift */; };
+		5860F1C223A785C600CEA666 /* WireguardDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5860F1C123A785C600CEA666 /* WireguardDevice.swift */; };
+		5860F1C423A8D25F00CEA666 /* WireguardConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5860F1C323A8D25F00CEA666 /* WireguardConfiguration.swift */; };
+		5860F1EB23AA4CF300CEA666 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5860F1EA23AA4CF300CEA666 /* Logging.swift */; };
 		5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */; };
 		5867A51C2248F26A005513C0 /* SegueIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5867A51B2248F26A005513C0 /* SegueIdentifier.swift */; };
 		586AA296234B696B00502875 /* WireguardAssociatedAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B8743122B25A7600015324 /* WireguardAssociatedAddresses.swift */; };
@@ -55,6 +58,7 @@
 		588AE730236200E2009F9F2E /* MutuallyExclusive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588AE72E2362001F009F9F2E /* MutuallyExclusive.swift */; };
 		5894FC492296A8090017471D /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5894FC482296A8090017471D /* CustomButton.swift */; };
 		589AB4F7227B64450039131E /* BasicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589AB4F6227B64450039131E /* BasicTableViewCell.swift */; };
+		58A8BE81239FBE62006B74AC /* IPEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58561C98239A5D1500BD6B5E /* IPEndpoint.swift */; };
 		58ADDB3C227B1BD200FAFEA7 /* JsonRpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ADDB3B227B1BD200FAFEA7 /* JsonRpc.swift */; };
 		58ADDB3E227B1CD900FAFEA7 /* MullvadAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ADDB3D227B1CD900FAFEA7 /* MullvadAPI.swift */; };
 		58AEEF652344A36000C9BBD5 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AEEF642344A36000C9BBD5 /* KeychainError.swift */; };
@@ -154,6 +158,9 @@
 		584B26F3237434D00073B10E /* RelaySelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelectorTests.swift; sourceTree = "<group>"; };
 		584B26FD237435990073B10E /* RelaySelector+RelayCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelaySelector+RelayCache.swift"; sourceTree = "<group>"; };
 		58561C98239A5D1500BD6B5E /* IPEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPEndpoint.swift; sourceTree = "<group>"; };
+		5860F1C123A785C600CEA666 /* WireguardDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireguardDevice.swift; sourceTree = "<group>"; };
+		5860F1C323A8D25F00CEA666 /* WireguardConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireguardConfiguration.swift; sourceTree = "<group>"; };
+		5860F1EA23AA4CF300CEA666 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslucentButtonBlurView.swift; sourceTree = "<group>"; };
 		5866F39B2243B82D00168AE5 /* MullvadVPN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MullvadVPN.entitlements; sourceTree = "<group>"; };
 		5867A51B2248F26A005513C0 /* SegueIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegueIdentifier.swift; sourceTree = "<group>"; };
@@ -354,14 +361,17 @@
 		58CE5E7A224146470008646E /* PacketTunnel */ = {
 			isa = PBXGroup;
 			children = (
-				58C6B36422C10596003C19AD /* AnyIPEndpoint+Wireguard.swift */,
 				58C6B36022C0EC82003C19AD /* AnyIPEndpoint+DNS64.swift */,
+				58C6B36422C10596003C19AD /* AnyIPEndpoint+Wireguard.swift */,
 				58CE5E7D224146470008646E /* Info.plist */,
 				58FBDAA422A52BDA00EB69A3 /* PacketTunnel-Bridging-Header.h */,
 				58CE5E7E224146470008646E /* PacketTunnel.entitlements */,
 				58CE5E7B224146470008646E /* PacketTunnelProvider.swift */,
 				58B8743722B25EAB00015324 /* PacketTunnelSettingsGenerator.swift */,
 				58C6B36622C106FC003C19AD /* WireguardCommand.swift */,
+				5860F1C123A785C600CEA666 /* WireguardDevice.swift */,
+				5860F1C323A8D25F00CEA666 /* WireguardConfiguration.swift */,
+				5860F1EA23AA4CF300CEA666 /* Logging.swift */,
 			);
 			path = PacketTunnel;
 			sourceTree = "<group>";
@@ -580,6 +590,7 @@
 				58B0A2AB238EE6BF00BC001D /* RelayList.swift in Sources */,
 				58B0A2AD238EE6EC00BC001D /* MullvadEndpoint.swift in Sources */,
 				58B0A2A9238EE6A100BC001D /* RelayConstraints.swift in Sources */,
+				58A8BE81239FBE62006B74AC /* IPEndpoint.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -648,6 +659,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5845F83C236C72E300B2D93C /* AutoDisposableSink.swift in Sources */,
+				5860F1C423A8D25F00CEA666 /* WireguardConfiguration.swift in Sources */,
 				58BFA5CD22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */,
 				58BFA5C222A7C92900A6173D /* JsonRpc.swift in Sources */,
 				588AE730236200E2009F9F2E /* MutuallyExclusive.swift in Sources */,
@@ -661,6 +673,8 @@
 				58CE5E7C224146470008646E /* PacketTunnelProvider.swift in Sources */,
 				586AA296234B696B00502875 /* WireguardAssociatedAddresses.swift in Sources */,
 				58B8743B22B788D200015324 /* PacketTunnelSettingsGenerator.swift in Sources */,
+				5860F1EB23AA4CF300CEA666 /* Logging.swift in Sources */,
+				5860F1C223A785C600CEA666 /* WireguardDevice.swift in Sources */,
 				58C6B35522BB87C4003C19AD /* WireguardPrivateKey.swift in Sources */,
 				58AEEF6C2344A49D00C9BBD5 /* TunnelConfigurationManager.swift in Sources */,
 				58C6B35F22BBBFE3003C19AD /* Data+HexCoding.swift in Sources */,

--- a/ios/MullvadVPN/IPEndpoint.swift
+++ b/ios/MullvadVPN/IPEndpoint.swift
@@ -10,7 +10,7 @@ import Foundation
 import Network
 
 /// An abstract struct describing IP address based endpoint
-struct IPEndpont<T> where T: IPAddress {
+struct IPEndpont<T>: Hashable where T: IPAddress & Hashable {
     let ip: T
     let port: UInt16
 }
@@ -36,9 +36,22 @@ typealias IPv4Endpoint = IPEndpont<IPv4Address>
 typealias IPv6Endpoint = IPEndpont<IPv6Address>
 
 /// A enum describing any IP endpoint
-enum AnyIPEndpoint {
+enum AnyIPEndpoint: Hashable {
     case ipv4(IPv4Endpoint)
     case ipv6(IPv6Endpoint)
+}
+
+extension AnyIPEndpoint: Equatable {
+    static func == (lhs: AnyIPEndpoint, rhs: AnyIPEndpoint) -> Bool {
+        switch (lhs, rhs) {
+        case (.ipv4(let a), .ipv4(let b)):
+            return a == b
+        case (.ipv6(let a), .ipv6(let b)):
+            return a == b
+        case (.ipv6, .ipv4), (.ipv4, .ipv6):
+            return false
+        }
+    }
 }
 
 /// Convenience methods for accessing endpoint fields

--- a/ios/MullvadVPN/MullvadEndpoint.swift
+++ b/ios/MullvadVPN/MullvadEndpoint.swift
@@ -10,7 +10,7 @@ import Foundation
 import Network
 
 /// Contains server data needed to connect to a single mullvad endpoint
-struct MullvadEndpoint {
+struct MullvadEndpoint: Equatable {
     let ipv4Relay: IPv4Endpoint
     let ipv6Relay: IPv6Endpoint?
     let ipv4Gateway: IPv4Address

--- a/ios/PacketTunnel/WireguardCommand.swift
+++ b/ios/PacketTunnel/WireguardCommand.swift
@@ -9,9 +9,31 @@
 import Foundation
 import Network
 
-struct WireguardPeer {
+struct WireguardPeer: Hashable {
     let endpoint: AnyIPEndpoint
     let publicKey: Data
+}
+
+extension WireguardPeer {
+
+    func withReresolvedEndpoint() -> Result<WireguardPeer, Error> {
+        self.endpoint.withReresolvedIP()
+            .map { WireguardPeer(endpoint: $0, publicKey: self.publicKey) }
+    }
+
+}
+
+extension WireguardPeer {
+
+    /// Returns a 0.0.0.0/0 for IPv4 and ::0/0 for IPv6
+    var anyAllowedIP: IPAddressRange {
+        switch endpoint {
+        case .ipv4:
+            return IPAddressRange(address: IPv4Address.any, networkPrefixLength: 0)
+        case .ipv6:
+            return IPAddressRange(address: IPv6Address.any, networkPrefixLength: 0)
+        }
+    }
 }
 
 enum WireguardCommand {
@@ -19,7 +41,6 @@ enum WireguardCommand {
     case listenPort(UInt16)
     case replacePeers
     case peer(WireguardPeer)
-    case replaceAllowedIPs
     case allowedIP(IPAddressRange)
 }
 
@@ -45,9 +66,6 @@ extension WireguardCommand {
             return ["public_key=\(keyString)", "endpoint=\(endpointString)"]
                 .joined(separator: "\n")
 
-        case .replaceAllowedIPs:
-            return "replace_allowed_ips=true"
-
         case .allowedIP(let ipAddressRange):
             return "allowed_ip=\(ipAddressRange)"
         }
@@ -56,7 +74,7 @@ extension WireguardCommand {
 }
 
 extension Array where Element == WireguardCommand {
-    func toWireguardConfig() -> String {
+    func toRawWireguardConfigString() -> String {
         map { $0.toRawWireguardCommand() }
             .joined(separator: "\n")
     }

--- a/ios/PacketTunnel/WireguardConfiguration.swift
+++ b/ios/PacketTunnel/WireguardConfiguration.swift
@@ -1,0 +1,86 @@
+//
+//  WireguardConfiguration.swift
+//  PacketTunnel
+//
+//  Created by pronebird on 17/12/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Combine
+import Foundation
+import os
+
+/// A struct describing a basic WireGuard configuration
+struct WireguardConfiguration {
+    var privateKey: WireguardPrivateKey
+    var peers: [WireguardPeer]
+}
+
+extension WireguardConfiguration {
+
+    /// Returns a baseline configuration for WireGuard
+    func baseline() -> [WireguardCommand] {
+        var commands: [WireguardCommand] = [
+            .privateKey(privateKey),
+            .listenPort(0),
+            .replacePeers
+        ]
+
+        peers.forEach { (peer) in
+            commands.append(.peer(peer))
+            commands.append(.allowedIP(peer.anyAllowedIP))
+        }
+
+        return commands
+    }
+
+    /// Returns a WireGuard configuration for transition to the given configuration
+    func transition(to newConfig: WireguardConfiguration) -> [WireguardCommand] {
+        var commands = [WireguardCommand]()
+
+        if self.privateKey != newConfig.privateKey {
+            commands.append(.privateKey(newConfig.privateKey))
+        }
+
+        let oldPeers = Set(self.peers)
+        let newPeers = Set(newConfig.peers)
+
+        if oldPeers != newPeers {
+            let oldPublicKeys = Set(oldPeers.map { $0.publicKey })
+            let newPublicKeys = Set(newPeers.map { $0.publicKey })
+
+            // Avoid using `replace_peers` when updating the existing peers.
+            if oldPublicKeys != newPublicKeys {
+                commands.append(.replacePeers)
+            }
+
+            newPeers.forEach { (peer) in
+                commands.append(.peer(peer))
+                commands.append(.allowedIP(peer.anyAllowedIP))
+            }
+        }
+
+        return commands
+    }
+
+    func withReresolvedPeers(maxRetryOnFailure: Int = 0) -> AnyPublisher<WireguardConfiguration, Error> {
+        self.peers
+            .publisher
+            .setFailureType(to: Error.self)
+            .flatMap {
+                $0.withReresolvedEndpoint()
+                    .publisher
+                    .retry(maxRetryOnFailure)
+
+        }
+        .collect()
+        .map({ (peers) in
+            WireguardConfiguration(
+                privateKey: self.privateKey,
+                peers: peers
+            )
+        })
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/ios/PacketTunnel/WireguardDevice.swift
+++ b/ios/PacketTunnel/WireguardDevice.swift
@@ -1,0 +1,343 @@
+//
+//  WireguardDevice.swift
+//  PacketTunnel
+//
+//  Created by pronebird on 16/12/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Combine
+import Foundation
+import NetworkExtension
+import os
+
+/// A class describing the `wireguard-go` interactions
+///
+/// - Thread safety:
+/// This class is thread safe.
+class WireguardDevice {
+
+    typealias WireguardLogHandler = (WireguardLogLevel, String) -> Void
+
+    /// An error type describing the errors returned by `WireguardDevice`
+    enum Error: Swift.Error {
+        /// A failure to obtain the tunnel device file descriptor
+        case cannotLocateSocketDescriptor
+
+        /// A failure to start the Wireguard backend
+        case start(Int32)
+
+        /// A failure that indicates that Wireguard has not been started yet
+        case notStarted
+
+        /// A failure that indicates that Wireguard has already been started
+        case alreadyStarted
+
+        /// A failure to resolve endpoints
+        case resolveEndpoints(Swift.Error)
+
+        var localizedDescription: String {
+            switch self {
+            case .cannotLocateSocketDescriptor:
+                return "Unable to locate the file descriptor for socket."
+            case .start(let wgErrorCode):
+                return "Failed to start Wireguard. Return code: \(wgErrorCode)"
+            case .notStarted:
+                return "Wireguard has not been started yet"
+            case .alreadyStarted:
+                return "Wireguard has already been started"
+            case .resolveEndpoints(let resolutionError):
+                return "Failed to resolve endpoints: \(resolutionError.localizedDescription)"
+            }
+        }
+    }
+
+    /// A global Wireguard log handler
+    /// It should only be accessed from the `loggingQueue`
+    private static var wireguardLogHandler: WireguardLogHandler?
+
+    /// A private queue used for Wireguard logging
+    private static let loggingQueue = DispatchQueue(
+        label: "net.mullvad.vpn.packet-tunnel.wireguard-device.global-logging-queue",
+        qos: .background
+    )
+
+    /// A private queue used to synchronize access to `WireguardDevice` members
+    private let workQueue = DispatchQueue(
+        label: "net.mullvad.vpn.packet-tunnel.wireguard-device.work-queue"
+    )
+
+    /// A private queue used for network monitor
+    private let networkMonitorQueue = DispatchQueue(
+        label: "net.mullvad.vpn.packet-tunnel.network-monitor"
+    )
+
+    /// Network routes monitor
+    private var networkMonitor: NWPathMonitor?
+
+    /// A subscriber used when resolving peer addresses
+    private var peerResolutionSubscriber: AnyCancellable?
+
+    /// A tunnel device descriptor
+    private let tunFd: Int32
+
+    /// A wireguard internal handle returned by `wgTurnOn` that's used to associate the calls
+    /// with the specific Wireguard tunnel.
+    private var wireguardHandle: Int32?
+
+    /// An instance of `WireguardConfiguration`
+    private var configuration: WireguardConfiguration?
+
+    /// Returns a Wireguard version
+    class var version: String {
+        String(cString: wgVersion())
+    }
+
+    /// Set global Wireguard log handler.
+    /// The given handler is dispatched on a background serial queue.
+    ///
+    /// - Thread safety:
+    /// This function is thread safe
+    class func setLogger(with handler: @escaping WireguardLogHandler) {
+        WireguardDevice.loggingQueue.async {
+            WireguardDevice.wireguardLogHandler = handler
+
+            wgSetLogger { (level, messagePtr) in
+                guard let message = messagePtr.map({ String(cString: $0) }) else { return }
+                let logType = WireguardLogLevel(rawValue: level) ?? .debug
+
+                WireguardDevice.loggingQueue.async {
+                    WireguardDevice.wireguardLogHandler?(logType, message)
+                }
+            }
+        }
+    }
+
+    // MARK: - Initialization
+
+    /// A designated initializer
+    class func fromPacketFlow(_ packetFlow: NEPacketTunnelFlow) -> Result<WireguardDevice, Error> {
+        if let fd = packetFlow.value(forKeyPath: "socket.fileDescriptor") as? Int32 {
+            return .success(.init(tunFd: fd))
+        } else {
+            return .failure(.cannotLocateSocketDescriptor)
+        }
+    }
+
+    /// Private initializer
+    private init(tunFd: Int32) {
+        self.tunFd = tunFd
+    }
+
+    deinit {
+        networkMonitor?.cancel()
+    }
+
+    // MARK: - Public methods
+
+    func start(configuration: WireguardConfiguration) -> AnyPublisher<(), Error> {
+        return Deferred {
+            Future { (fulfill) in
+                fulfill(self._start(configuration: configuration))
+            }
+        }.subscribe(on: workQueue)
+            .eraseToAnyPublisher()
+    }
+
+    func stop() -> AnyPublisher<(), Error> {
+        Deferred {
+            Future { (fulfill) in
+                fulfill(self._stop())
+            }
+        }.subscribe(on: workQueue)
+            .eraseToAnyPublisher()
+    }
+
+    func setConfig(configuration: WireguardConfiguration) -> AnyPublisher<(), Error> {
+        Deferred {
+            Future { (fulfill) in
+                fulfill(self._setConfig(configuration: configuration))
+            }
+        }.subscribe(on: workQueue)
+            .eraseToAnyPublisher()
+    }
+
+    func getInterfaceName() -> String? {
+        var buffer = [UInt8](repeating: 0, count: Int(IFNAMSIZ))
+
+        return buffer.withUnsafeMutableBufferPointer { (mutableBufferPointer) in
+            guard let baseAddress = mutableBufferPointer.baseAddress else { return nil }
+
+            var ifnameSize = socklen_t(IFNAMSIZ)
+            let result = getsockopt(
+                self.tunFd,
+                2 /* SYSPROTO_CONTROL */,
+                2 /* UTUN_OPT_IFNAME */,
+                baseAddress,
+                &ifnameSize)
+
+            if result == 0 {
+                return String(cString: baseAddress)
+            } else {
+                return nil
+            }
+        }
+    }
+
+    // MARK: - Private methods
+
+    private func _start(configuration: WireguardConfiguration) -> Result<(), Error> {
+        guard wireguardHandle == nil else {
+            return .failure(.alreadyStarted)
+        }
+
+        let handle = configuration.baseline().toRawWireguardConfigString()
+            .withGoString { wgTurnOn($0, self.tunFd) }
+
+        if handle < 0 {
+            return .failure(.start(handle))
+        } else {
+            wireguardHandle = handle
+            self.configuration = configuration
+
+            startNetworkMonitor()
+
+            return .success(())
+        }
+    }
+
+    private func _stop() -> Result<(), Error> {
+        if let handle = wireguardHandle {
+            networkMonitor?.cancel()
+            networkMonitor = nil
+
+            wgTurnOff(handle)
+            wireguardHandle = nil
+
+            return .success(())
+        } else {
+            return .failure(.notStarted)
+        }
+    }
+
+    private func _setConfig(configuration: WireguardConfiguration) -> Result<(), Error> {
+        if let handle = wireguardHandle, let activeConfiguration = self.configuration {
+            let wireguardCommands = activeConfiguration.transition(to: configuration)
+
+            Self.setWireguardConfig(handle: handle, commands: wireguardCommands)
+
+            self.configuration = configuration
+
+            return .success(())
+        } else {
+            return .failure(.notStarted)
+        }
+    }
+
+    private class func setWireguardConfig(handle: Int32, commands: [WireguardCommand]) {
+        // Ignore empty payloads
+        guard !commands.isEmpty else { return }
+
+        let rawConfig = commands.toRawWireguardConfigString()
+
+        os_log(.info, log: wireguardDeviceLog, "wgSetConfig:\n%{public}s", rawConfig)
+
+        _ = rawConfig.withGoString { wgSetConfig(handle, $0) }
+    }
+
+    // MARK: - Network monitoring
+
+    private func startNetworkMonitor() {
+        self.networkMonitor?.cancel()
+
+        let networkMonitor = NWPathMonitor()
+        networkMonitor.pathUpdateHandler = { [weak self] (path) in
+            self?.didReceiveNetworkPathUpdate(path: path)
+        }
+        networkMonitor.start(queue: networkMonitorQueue)
+        self.networkMonitor = networkMonitor
+    }
+
+    private func didReceiveNetworkPathUpdate(path: Network.NWPath) {
+        workQueue.async {
+            guard let handle = self.wireguardHandle else { return }
+
+            os_log(.debug, log: wireguardDeviceLog,
+                   "Network change detected. Status: %{public}s, interfaces %{public}s.",
+                   String(describing: path.status),
+                   String(describing: path.availableInterfaces))
+
+            // Re-resolve endpoints on network changes and update Wireguard configuration
+            if let activeConfiguration = self.configuration {
+                self.peerResolutionSubscriber = activeConfiguration
+                    .withReresolvedPeers(maxRetryOnFailure: 1)
+                    .mapError { WireguardDevice.Error.resolveEndpoints($0) }
+                    .sink(receiveCompletion: { (completion) in
+                        switch completion {
+                        case .finished:
+                            os_log(.debug, log: wireguardDeviceLog, "Re-resolved endpoints")
+
+                        case .failure(let error):
+                            os_log(.error, log: wireguardDeviceLog,
+                                   "Failed to re-resolve endpoints: %{public}s",
+                                   error.localizedDescription)
+                        }
+                    }, receiveValue: { (reresolvedConfiguration) in
+                        let commands = activeConfiguration
+                            .transition(to: reresolvedConfiguration)
+
+                        Self.setWireguardConfig(
+                            handle: handle,
+                            commands: commands
+                        )
+                    })
+            }
+
+            // Tell Wireguard to re-open sockets and bind them to the new network interface
+            wgBumpSockets(handle)
+        }
+    }
+}
+
+/// A enum describing Wireguard log levels defined in `api-ios.go` from `wireguard-apple` repository
+enum WireguardLogLevel: Int32 {
+    case debug = 0
+    case info = 1
+    case error = 2
+
+    var osLogType: OSLogType {
+        switch self {
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .error:
+            return .error
+        }
+    }
+}
+
+private extension String {
+    func withGoString<R>(_ block: (_ goString: gostring_t) throws -> R) rethrows -> R {
+        return try withCString { try block(gostring_t(p: $0, n: utf8.count)) }
+    }
+}
+
+extension Network.NWPath.Status: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var output = "NWPath.Status."
+
+        switch self {
+        case .requiresConnection:
+            output += "requiresConnection"
+        case .satisfied:
+            output += "satisfied"
+        case .unsatisfied:
+            output += "unsatisfied"
+        @unknown default:
+            output += "unknown"
+        }
+
+        return output
+    }
+}

--- a/ios/PacketTunnel/WireguardDevice.swift
+++ b/ios/PacketTunnel/WireguardDevice.swift
@@ -238,11 +238,8 @@ class WireguardDevice {
         // Ignore empty payloads
         guard !commands.isEmpty else { return }
 
-        let rawConfig = commands.toRawWireguardConfigString()
-
-        os_log(.info, log: wireguardDeviceLog, "wgSetConfig:\n%{public}s", rawConfig)
-
-        _ = rawConfig.withGoString { wgSetConfig(handle, $0) }
+        _ = commands.toRawWireguardConfigString()
+            .withGoString { wgSetConfig(handle, $0) }
     }
 
     // MARK: - Network monitoring


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Move all WireGuard related routine to a separate class `WireguardDevice`
1. Add `WireguardConfiguration` to hold private key and peers and methods to transition between different configurations by generating a set of `WireguardCommand`s.
1. Retry DNS64 resolution for peers on failure (only once)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1360)
<!-- Reviewable:end -->
