### PR TITLE
Regenerate private key on iOS

### DIFF
--- a/ios/MullvadVPN/MutuallyExclusive.swift
+++ b/ios/MullvadVPN/MutuallyExclusive.swift
@@ -13,12 +13,15 @@ extension Publishers {
 
     /// A publisher that blocks the given DispatchQueue until the produced publisher reported the
     /// completion.
-    final class MutuallyExclusive<PublisherType, Context>: Publisher where PublisherType: Publisher, Context: Scheduler {
+    final class MutuallyExclusive<PublisherType, Context>: Publisher
+        where
+        PublisherType: Publisher,
+        Context: Scheduler
+    {
+        typealias MakePublisherBlock = () -> PublisherType
 
         typealias Output = PublisherType.Output
         typealias Failure = PublisherType.Failure
-
-        typealias MakePublisherBlock = () -> PublisherType
 
         private let exclusivityQueue: Context
         private let executionQueue: Context
@@ -32,27 +35,100 @@ extension Publishers {
         }
 
         func receive<S>(subscriber: S) where S : Subscriber, S.Failure == Failure, S.Input == Output {
-            exclusivityQueue.schedule {
-                let sema = DispatchSemaphore(value: 0)
-                let releaseLock = {
-                    _ = sema.signal()
-                }
+            let subscription = MutuallyExclusive.Subscription(
+                subscriber: subscriber,
+                createPublisher: createPublisher,
+                exclusivityQueue: exclusivityQueue,
+                executionQueue: executionQueue)
 
-                self.executionQueue.schedule {
-                    self.createPublisher()
-                        .handleEvents(receiveCompletion: { _ in
-                            releaseLock()
-                        }, receiveCancel: {
-                            releaseLock()
-                        })
-                        .subscribe(subscriber)
-                }
-
-                sema.wait()
-            }
+            subscriber.receive(subscription: subscription)
         }
     }
+}
 
+private extension Publishers.MutuallyExclusive {
+
+    /// A subscription used by `MutuallyExclusive` publisher
+    final class Subscription<SubscriberType, PublisherType, Context>: Combine.Subscription
+        where
+        SubscriberType: Subscriber, PublisherType: Publisher,
+        PublisherType.Output == SubscriberType.Input,
+        PublisherType.Failure == SubscriberType.Failure,
+        Context: Scheduler
+    {
+        typealias MakePublisherBlock = () -> PublisherType
+
+        private let subscriber: SubscriberType
+        private var innerSubscriber: AnyCancellable?
+        private let createPublisher: MakePublisherBlock
+
+        private let exclusivityQueue: Context
+        private let executionQueue: Context
+        private let sema = DispatchSemaphore(value: 0)
+
+        private let cancelLock = NSLock()
+        private var isCancelled = false
+
+        init(subscriber: SubscriberType,
+             createPublisher: @escaping MakePublisherBlock,
+             exclusivityQueue: Context,
+             executionQueue: Context)
+        {
+            self.subscriber = subscriber
+            self.createPublisher = createPublisher
+            self.exclusivityQueue = exclusivityQueue
+            self.executionQueue = executionQueue
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            self.exclusivityQueue.schedule {
+                self.executionQueue.schedule {
+                    self.cancelLock.withCriticalBlock {
+                        guard !self.isCancelled else { return }
+
+                        self.innerSubscriber = self.createPublisher()
+                            .sink(receiveCompletion: { [weak self] (completion) in
+                                guard let self = self else { return }
+
+                                self.subscriber.receive(completion: completion)
+                                self.signalSemaphore()
+                            }, receiveValue: { [weak self] (output) in
+                                _ = self?.subscriber.receive(output)
+                            })
+                    }
+                }
+                self.sema.wait()
+            }
+        }
+
+        func cancel() {
+            cancelLock.withCriticalBlock {
+                guard !isCancelled else { return }
+
+                isCancelled = true
+
+                innerSubscriber?.cancel()
+                innerSubscriber = nil
+
+                signalSemaphore()
+            }
+        }
+
+        private func signalSemaphore() {
+            _ = sema.signal()
+        }
+
+    }
+
+}
+
+private extension NSLock {
+    func withCriticalBlock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+
+        return body()
+    }
 }
 
 typealias MutuallyExclusive = Publishers.MutuallyExclusive

--- a/ios/MullvadVPN/RelayCache.swift
+++ b/ios/MullvadVPN/RelayCache.swift
@@ -15,8 +15,8 @@ enum RelayCacheError: Error {
     case defaultLocationNotFound
     case io(Error)
     case coding(Error)
-    case network(MullvadAPIError)
-    case server(JsonRpcResponseError)
+    case network(MullvadAPI.Error)
+    case server(JsonRpcResponseError<MullvadAPI.ResponseCode>)
 }
 
 /// A enum describing the source of the relay list

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -69,7 +69,7 @@ enum SetAccountError: Error {
     /// A failure to push the wireguard key
     case pushWireguardKey(PushWireguardKeyError)
 
-    /// A failure to set up the tunnel
+    /// A failure to set up a tunnel
     case setup(SetupTunnelError)
 }
 

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -320,7 +320,7 @@ class TunnelManager {
                     }
 
                     // Send wireguard key to the server
-                    let publicKey = tunnelConfig.interface.privateKey.publicKeyRawRepresentation
+                    let publicKey = tunnelConfig.interface.privateKey.publicKey.rawRepresentation
 
                     return self.apiClient.pushWireguardKey(accountToken: accountToken, publicKey: publicKey)
                         .mapError { (networkError) -> SetAccountError in

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -76,8 +76,8 @@ enum UnsetAccountError: Error {
 }
 
 enum PushWireguardKeyError: Error {
-    case network(MullvadAPIError)
-    case server(JsonRpcResponseError)
+    case transport(MullvadAPI.Error)
+    case server(MullvadAPI.ResponseError)
 }
 
 enum UpdateTunnelConfigurationError: Error {
@@ -324,8 +324,8 @@ class TunnelManager {
 
                     return self.apiClient.pushWireguardKey(accountToken: accountToken, publicKey: publicKey)
                         .mapError { (networkError) -> SetAccountError in
-                            return .pushWireguardKey(.network(networkError))
-                    }.flatMap { (response: JsonRpcResponse<WireguardAssociatedAddresses>) in
+                            return .pushWireguardKey(.transport(networkError))
+                    }.flatMap { (response: MullvadAPI.Response<WireguardAssociatedAddresses>) in
                         return response.result.publisher
                             .mapError { (serverError) -> SetAccountError in
                                 return .pushWireguardKey(.server(serverError))


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add generic `ResponseCode` to `JsonRpcResponseError`. Ergonomic change to automate decoding of `Int` error codes into `enum`s.
1. Scope `MullvadAPIError` into `MullvadAPI` as `Error`.
1. Rework `MutuallyExclusivePublisher` to use `Subscription`. This improves thread safety, cancellation handling and fixes the issue when the publisher going out of scope was taking down the downstream subscribers along with it. This was spotted when using `receive(on:)` publishers in the circumstance where the upstream publisher failed with error.
1. Add `creationDate` metadata to `WireguardPrivateKey` and introduce `WireguardPublicKey` structure.
1. Add `TunnelManager` facilities to obtain the public WireGuard key and regenerate the private key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1361)
<!-- Reviewable:end -->
