### PR TITLE
Include additional debug symbols (.pdb) in builds

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -127,7 +127,7 @@ build_ref() {
     MINGW*|MSYS_NT*)
       sign_win || return 0
       echo "Packaging all PDB files..."
-      find ./windows/ -iname "*.pdb" | tar -cJf $SCRIPT_DIR/pdb/$current_hash.tar.xz -T -
+      find ./windows/ ./target/release/mullvad-daemon.pdb ./target/release/mullvad.pdb ./target/release/mullvad-problem-report.pdb -iname "*.pdb" | tar -cJf $SCRIPT_DIR/pdb/$current_hash.tar.xz -T -
       ;;
     Linux*)
       echo "Building Android APK"


### PR DESCRIPTION
We're missing symbols for the daemon, CLI, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1365)
<!-- Reviewable:end -->
