### PR TITLE
Fix TAP error message regression on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Wait for traffic to be routed through the tunnel device before advertising blocked state.
 
+### Fixed
+#### Windows
+- Fix regression due to which a TAP adapter issue was not given as the specific block reason when
+  the tunnel could not be started.
+
 
 ## [2019.10] - 2019-12-12
 ### Fixed

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -403,6 +403,12 @@ impl TunnelState for ConnectingState {
                                     tunnel::Error::EnableIpv6Error => {
                                         ErrorStateCause::Ipv6Unavailable
                                     }
+                                    #[cfg(windows)]
+                                    tunnel::Error::OpenVpnTunnelMonitoringError(
+                                        tunnel::openvpn::Error::WinnetError(
+                                            crate::winnet::Error::GetTapAlias,
+                                        ),
+                                    ) => ErrorStateCause::TapAdapterProblem,
                                     _ => ErrorStateCause::StartTunnelError,
                                 };
                                 ErrorState::enter(shared_values, block_reason)

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -408,6 +408,9 @@ impl TunnelState for ConnectingState {
                                         tunnel::openvpn::Error::WinnetError(
                                             crate::winnet::Error::GetTapAlias,
                                         ),
+                                    )
+                                    | tunnel::Error::WinnetError(
+                                        crate::winnet::Error::GetTapAlias,
                                     ) => ErrorStateCause::TapAdapterProblem,
                                     _ => ErrorStateCause::StartTunnelError,
                                 };

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -64,6 +64,9 @@ pub fn ensure_top_metric_for_interface(interface_alias: &str) -> Result<bool, Er
 
 /// Checks if IPv6 is enabled for the TAP interface
 pub fn get_tap_interface_ipv6_status() -> Result<bool, Error> {
+    // WinNet_GetTapInterfaceIpv6Status() will fail if the alias cannot be retrieved.
+    // Try to retrieve it first so that we may return a more specific error.
+    let _ = get_tap_interface_alias()?;
     let tap_ipv6_status =
         unsafe { WinNet_GetTapInterfaceIpv6Status(Some(log_sink), logging_context()) };
 


### PR DESCRIPTION
This PR addresses a couple of issues related to error messages:

* `TunnelMonitor::start` (through `WinNet_GetTapInterfaceIpv6Status()`) looks for the TAP adapter alias while attempting to enable IPv6 (using `ensure_ipv6_can_be_used_if_enabled`), but the block reason becomes simply `EnableIpv6Error` even if the underlying error is that the TAP adapter is missing. It should be `TapAdapterProblem`.
\
**Fix**: Distinguish between IPv6 being disabled and failure to obtain IPv6 status, so we can handle the missing TAP case differently.

* Separately from the above issue: If `ConnectingState::enter` fails to start the tunnel due to a TAP problem, it doesn't pass the specific block reason to `ErrorState::enter`, i.e. `TapAdapterProblem`. Instead, it sets the block reason to `StartTunnelError`. (The log contains the actual cause of the problem.)
\
**Fix**: Set the block reason to `TapAdapterProblem` instead of `StartTunnelError`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1367)
<!-- Reviewable:end -->
