### PR TITLE
Remove deprecated use of Error::description()

### DIFF
--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -56,10 +56,6 @@ impl fmt::Display for BoxedError {
 }
 
 impl Error for BoxedError {
-    fn description(&self) -> &str {
-        self.0.description()
-    }
-
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         self.0.source()
     }

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -2,7 +2,6 @@
 use jnix::IntoJava;
 use serde::{Deserialize, Serialize};
 use std::{
-    error::Error,
     fmt,
     net::{IpAddr, SocketAddr},
     str::FromStr,
@@ -173,13 +172,7 @@ pub struct TransportProtocolParseError;
 
 impl fmt::Display for TransportProtocolParseError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str(self.description())
-    }
-}
-
-impl Error for TransportProtocolParseError {
-    fn description(&self) -> &str {
-        "Not a valid transport protocol"
+        fmt.write_str("Not a valid transport protocol")
     }
 }
 


### PR DESCRIPTION
Remove deprecated uses of `Error::description()`.
I've only removed the implementations and uses of `description()` in our types, but I've not checked if this breaks any logging in our case. I doubt it does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1370)
<!-- Reviewable:end -->
