### PR TITLE
Stop automatic key rotation when account has too many keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Line wrap the file at 100 chars.                                              Th
 - Wait for traffic to be routed through the tunnel device before advertising blocked state.
 
 ### Fixed
+- Don't try to replace WireGuard key if account has too many keys already.
+
 #### Windows
 - Fix regression due to which a TAP adapter issue was not given as the specific block reason when
   the tunnel could not be started.


### PR DESCRIPTION
Currently, the daemon will execute an RPC against master every 5 seconds if there are too many keys added to an account, as part of automatic key replacement. This is incredibly noisy. To fix this, I've added some code to distinguish between different error kinds and in the case that there are too many keys added to an account, the daemon will not try to replace the key. Notably, the fact that the API returns this specific error means that the key that the client has has been manually removed from the account by the user, so the client should probably not try to automatically add a new one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1371)
<!-- Reviewable:end -->
