### PR TITLE
Create empty dns config if /etc/resolv.conf doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Line wrap the file at 100 chars.                                              Th
 - Add translations for Finnish and Danish.
 
 ### Changed
+#### Linux
+- DNS management with static `/etc/resolv.conf` will now work even when no
+  `/etc/resolv.conf` exists.
+
 #### Android
 - Wait for traffic to be routed through the tunnel device before advertising blocked state.
 

--- a/talpid-core/src/dns/linux/static_resolv_conf.rs
+++ b/talpid-core/src/dns/linux/static_resolv_conf.rs
@@ -172,6 +172,10 @@ impl DnsWatcher {
 }
 
 fn read_config() -> Result<Config> {
+    if !std::path::Path::new(RESOLV_CONF_PATH).exists() {
+        return Ok(Config::new());
+    }
+
     let contents = fs::read_to_string(RESOLV_CONF_PATH)
         .map_err(|e| Error::ReadResolvConf(RESOLV_CONF_PATH, e))?;
     let config = Config::parse(&contents).map_err(|e| Error::ParseError(RESOLV_CONF_PATH, e))?;


### PR DESCRIPTION
Some users have reported issues with running our daemon when no `/etc/resolv.conf` exists. As such, I've changed it so that when we're reading it, if the file does not exist, we assume an empty config and continue on as usual. The side effect is that after disconnecting from our tunnel, there will exist an empty `/etc/resolv.conf` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1373)
<!-- Reviewable:end -->
