### PR TITLE
Add log categories

### DIFF
--- a/ios/PacketTunnel/Logging.swift
+++ b/ios/PacketTunnel/Logging.swift
@@ -1,0 +1,21 @@
+//
+//  Logging.swift
+//  PacketTunnel
+//
+//  Created by pronebird on 18/12/2019.
+//  Copyright © 2019 Amagicom AB. All rights reserved.
+//
+
+import Foundation
+import os
+
+private let kLogSubsystem = "net.mullvad.vpn.packet-tunnel"
+
+/// A Wireguard event log
+let wireguardLog = OSLog(subsystem: kLogSubsystem, category: "WireGuard")
+
+/// A general tunnel provider log
+let tunnelProviderLog = OSLog(subsystem: kLogSubsystem, category: "Tunnel Provider")
+
+/// A WireguardDevice log
+let wireguardDeviceLog = OSLog(subsystem: kLogSubsystem, category: "WireGuard Device")


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Not sure if it's a victim of rogue rebase or I simply forgot to commit that file, but this has to be a part of PacketTunnel and I am pretty sure that Xcode project references this file.

This file simply mentions the log categories used in PacketTunnel, there are three separate categories:

1. WireGuard-go log (aka `WireGuard`)
1. Tunnel Provider log
1. `WireguardDevice` class log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1375)
<!-- Reviewable:end -->
