### PR TITLE
Upload PDB files to built artifact host

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -26,4 +26,17 @@ while true; do
     scp -pB "$f.asc" build.mullvad.net:app/$version/ || true
     yes | rm "$f" "$f_checksum" "$f.asc"
   done
+  for f_checksum in pdb-*.sha256; do
+    sleep 1
+    f="${f_checksum/.sha256/}"
+    if ! sha256sum --quiet -c "$f_checksum"; then
+      echo "Failed to verify checksum for $f"
+      continue
+    fi
+
+    ssh build.mullvad.net mkdir -p app/pdb || continue
+    scp -pB "$f" build.mullvad.net:app/pdb/ || continue
+
+    yes | rm "$f" "$f_checksum"
+  done
 done


### PR DESCRIPTION
This PR basically addresses two issues with the build servers. The main thing I'm fixing here is to make it automatically upload pdb files for Windows debugging to the build server artifact host. But while doing so I found we got the wrong hash when doing `git rev-parse $ref` where `$ref` was a tag. Apparently one has to do `git rev-parse $ref^{commit}` to get the hash of the *commit*. `rev-parse` is a strange low level command. I realized later I could have used `git show-ref -s $ref` instead which is a higher level command. But I found that out after getting this to work so I did not feel like fixing what already was fixed.

I also changed so instead of sending a second argument to `build_ref()` being either tag or branch. I instead made the single argument `ref` the "full path" to the git object. So it becomes unique and descriptive in itself.

Probably easier to read this PR one commit at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1376)
<!-- Reviewable:end -->
