### PR TITLE
Handle no service connection in fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix regression due to which a TAP adapter issue was not given as the specific block reason when
   the tunnel could not be started.
 
+#### Android
+- Fix crash when starting the app right after quitting it.
+
 
 ## [2019.10] - 2019-12-12
 ### Fixed

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import org.joda.time.DateTime
 
-class AccountFragment : ServiceDependentFragment() {
+class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private lateinit var accountExpiryContainer: View
     private lateinit var accountExpiryDisplay: TextView
     private lateinit var accountNumberContainer: View

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -15,7 +15,7 @@ import net.mullvad.mullvadvpn.model.TunnelState
 
 val KEY_IS_TUNNEL_INFO_EXPANDED = "is_tunnel_info_expanded"
 
-class ConnectFragment : ServiceDependentFragment() {
+class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var actionButton: ConnectActionButton
     private lateinit var switchLocationButton: SwitchLocationButton
     private lateinit var headerBar: HeaderBar

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 
-class LoginFragment : ServiceDependentFragment() {
+class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var title: TextView
     private lateinit var subtitle: TextView
     private lateinit var loggingInStatus: View

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -122,6 +122,13 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    fun returnToLaunchScreen() {
+        supportFragmentManager?.beginTransaction()?.apply {
+            replace(R.id.main_fragment, LaunchFragment())
+            commit()
+        }
+    }
+
     fun requestVpnPermission(intent: Intent) {
         startActivityForResult(intent, 0)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
@@ -3,17 +3,12 @@ package net.mullvad.mullvadvpn.ui
 import android.content.Context
 import android.view.View
 import android.widget.TextView
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.joda.time.PeriodType
 
-class RemainingTimeLabel(val context: Context, val accountCache: AccountCache, val view: View) {
+class RemainingTimeLabel(val context: Context, val view: View) {
     private val resources = context.resources
 
     private val expiredColor = resources.getColor(R.color.red)
@@ -21,25 +16,15 @@ class RemainingTimeLabel(val context: Context, val accountCache: AccountCache, v
 
     private val label = view.findViewById<TextView>(R.id.remaining_time)
 
-    private var updateJob: Job? = null
-
-    fun onResume() {
-        accountCache.apply {
-            refetch()
-
-            onAccountDataChange = { _, accountExpiry ->
-                updateJob?.cancel()
-                updateJob = updateLabel(accountExpiry)
-            }
+    var accountExpiry: DateTime? = null
+        set(value) {
+            field = value
+            updateLabel()
         }
-    }
 
-    fun onPause() {
-        accountCache.onAccountDataChange = null
-        updateJob?.cancel()
-    }
+    private fun updateLabel() {
+        val expiry = accountExpiry
 
-    private fun updateLabel(expiry: DateTime?) = GlobalScope.launch(Dispatchers.Main) {
         if (expiry != null) {
             val remainingTime = Duration(DateTime.now(), expiry)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -23,7 +23,7 @@ import net.mullvad.mullvadvpn.relaylist.RelayItemDividerDecoration
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.relaylist.RelayListAdapter
 
-class SelectLocationFragment : ServiceDependentFragment() {
+class SelectLocationFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var relayListAdapter: RelayListAdapter
     private lateinit var relayListContainer: ViewSwitcher
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -30,7 +30,7 @@ import org.joda.time.format.DateTimeFormat
 val RFC3339_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSSSSSSSSS z")
 val KEY_AGE_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm")
 
-class WireguardKeyFragment : ServiceDependentFragment() {
+class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private var currentJob: Job? = null
     private var updateViewsJob: Job? = null
     private var tunnelStateListener: Int? = null


### PR DESCRIPTION
Previous PRs added the `ServiceDependentFragment` super class for fragments that required a connection to the service to operate correctly. This PR continues that work by specifying what should be done when there is no service connection or when it is lost.

Two alternatives are available, the app can go back to the previous fragment, or it can return to the launch screen to await a new service connection.

Most fragments simply had to specify which fallback alternative it used, but the `SettingsFragment` needed some refactoring to make sure no proxy classes were used while there was no service connection.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1377)
<!-- Reviewable:end -->
