### PR TITLE
Increase OpenVPN ping timeout from 20 to 25 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add translations for Finnish and Danish.
 
 ### Changed
+- Increase OpenVPN ping timeout from 20 to 25 seconds. Might make working tunnels disconnect
+  a bit less frequently.
+
 #### Linux
 - DNS management with static `/etc/resolv.conf` will now work even when no
   `/etc/resolv.conf` exists.

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -21,7 +21,7 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     #[cfg(windows)]
     &["--dev-type", "tun"],
     &["--ping", "4"],
-    &["--ping-exit", "20"],
+    &["--ping-exit", "25"],
     &["--connect-timeout", "30"],
     &["--connect-retry", "0", "0"],
     &["--connect-retry-max", "1"],


### PR DESCRIPTION
20 seconds is already long. But multiple users report
that their tunnels drop out more frequently than
on vanilla OpenVPN. So let's see if increasing this helps

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1378)
<!-- Reviewable:end -->
