### PR TITLE
Bump WireGuard ping timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Increase OpenVPN ping timeout from 20 to 25 seconds. Might make working tunnels disconnect
   a bit less frequently.
+- Increase WireGuard ping timeout from 7 to 15 seconds.
 
 #### Linux
 - DNS management with static `/etc/resolv.conf` will now work even when no

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -14,7 +14,7 @@ pub mod wireguard_go;
 pub use self::wireguard_go::WgGoTunnel;
 
 // amount of seconds to run `ping` until it returns.
-const PING_TIMEOUT: u16 = 7;
+const PING_TIMEOUT: u16 = 15;
 
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
Bumping WireGuard ping tmieout from 7 to 15 seconds in hopes of increasing stability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1383)
<!-- Reviewable:end -->
