### PR TITLE
Add changelog entry about openssl.cnf escalation attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix crash when starting the app right after quitting it.
 
+### Security
+#### Windows
+- Stop OpenVPN from loading `C:\etc\ssl\openssl.cnf` on start. This file was being loaded when an
+  OpenVPN tunnel was being created. Any user could create the file, and the process loading it runs
+  as the SYSTEM user. Since the config file allows loading arbitrary code, it was an attack vector
+  allowing local unprivileged users to run code as SYSTEM.
+
 
 ## [2019.10] - 2019-12-12
 ### Fixed


### PR DESCRIPTION
I already merged the submodule bump to master. But I realized this should really be in the changelog. So here comes the PR for the changelog entry. Does this explanation of the issue/fix sound reasonable to you?

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1384)
<!-- Reviewable:end -->
