### PR TITLE
Restart service on daemon crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Fix crash when starting the app right after quitting it.
+- Restart background service if it stops responding.
 
 ### Security
 #### Windows

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -20,6 +20,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     var onKeygenEvent: ((KeygenEvent) -> Unit)? = null
     var onRelayListChange: ((RelayList) -> Unit)? = null
     var onTunnelStateChange: ((TunnelState) -> Unit)? = null
+    var onDaemonStopped: (() -> Unit)? = null
 
     init {
         System.loadLibrary("mullvad_jni")
@@ -136,6 +137,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
 
     private fun notifyTunnelStateEvent(event: TunnelState) {
         onTunnelStateChange?.invoke(event)
+    }
+
+    private fun notifyDaemonStopped() {
+        onDaemonStopped?.invoke()
     }
 
     private fun finalize() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -34,8 +34,7 @@ class MullvadVpnService : TalpidVpnService() {
 
     override fun onRebind(intent: Intent) {
         if (isStopping) {
-            tearDown()
-            setUp()
+            restart()
             isStopping = false
         }
     }
@@ -71,6 +70,12 @@ class MullvadVpnService : TalpidVpnService() {
             onSettingsChange.subscribe { settings ->
                 notificationManager.loggedIn = settings?.accountToken != null
             }
+
+            onDaemonStopped = {
+                if (!isStopping) {
+                    restart()
+                }
+            }
         }
 
         serviceNotifier.notify(ServiceInstance(daemon, connectionProxy, connectivityListener))
@@ -105,5 +110,10 @@ class MullvadVpnService : TalpidVpnService() {
 
         connectionProxy.onDestroy()
         notificationManager.onDestroy()
+    }
+
+    private fun restart() {
+        tearDown()
+        setUp()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -46,7 +46,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     override fun onDestroy() {
         tearDown()
-        daemon.cancel()
         super.onDestroy()
     }
 
@@ -88,19 +87,22 @@ class MullvadVpnService : TalpidVpnService() {
 
     private fun stop() {
         isStopping = true
+        stopDaemon()
+        stopSelf()
+    }
 
-        serviceNotifier.notify(null)
-
+    private fun stopDaemon() {
         if (daemon.isCompleted) {
             runBlocking { daemon.await().shutdown() }
         } else {
             daemon.cancel()
         }
-
-        stopSelf()
     }
 
     private fun tearDown() {
+        serviceNotifier.notify(null)
+        stopDaemon()
+
         connectionProxy.onDestroy()
         notificationManager.onDestroy()
     }


### PR DESCRIPTION
Previously, the daemon could crash in certain situations and the UI would still be presented, but in a stale state and all requests to the daemon would fail.

This PR changes the `MullvadVpnService` so that it can detect when the daemon thread stops and handle it accordingly. If it has stopped unexpectedly, the service is restarted so that the UI is notified that the connection to the service has been lost and can then reconnect to it when it's available with a new daemon thread running.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1385)
<!-- Reviewable:end -->
