### PR TITLE
Fix incorrect "update available" notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Don't try to replace WireGuard key if account has too many keys already.
+- Fix bogus update notification caused by an outdated cache.
 
 #### Windows
 - Fix regression due to which a TAP adapter issue was not given as the specific block reason when

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -407,22 +407,7 @@ where
             &cache_dir,
         );
 
-        let app_version_info = match version_check::load_cache(&cache_dir) {
-            Ok(app_version_info) => app_version_info,
-            Err(error) => {
-                log::warn!(
-                    "{}",
-                    error.display_chain_with_msg("Unable to load cached version info")
-                );
-                // If we don't have a cache, start out with sane defaults.
-                AppVersionInfo {
-                    current_is_supported: true,
-                    current_is_outdated: false,
-                    latest_stable: version::PRODUCT_VERSION.to_owned(),
-                    latest: version::PRODUCT_VERSION.to_owned(),
-                }
-            }
-        };
+        let app_version_info = version_check::load_cache(&cache_dir);
         let version_check_future = version_check::VersionUpdater::new(
             rpc_handle.clone(),
             cache_dir.clone(),


### PR DESCRIPTION
Fixes a minor version check problem where the app mistakenly claimed that the version was still outdated following an update. It was caused by the "outdated" flag being cached.

(This should have cleared after five minutes, since that was when the cache was first updated. But if that failed, it would linger for six hours or more.)

Cf. #1342.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1388)
<!-- Reviewable:end -->
