### PR TITLE
Fix some race conditions when restarting the app

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -72,6 +72,8 @@ class MullvadVpnService : TalpidVpnService() {
             }
 
             onDaemonStopped = {
+                serviceNotifier.notify(null)
+
                 if (!isStopping) {
                     restart()
                 }
@@ -105,7 +107,6 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun tearDown() {
-        serviceNotifier.notify(null)
         stopDaemon()
 
         connectionProxy.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -26,7 +26,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
     private var updateViewJob: Job? = null
 
-    override fun onCreateView(
+    override fun onSafelyCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -50,18 +50,14 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         return view
     }
 
-    override fun onResume() {
-        super.onResume()
-
+    override fun onSafelyResume() {
         accountCache.onAccountDataChange = { accountNumber, accountExpiry ->
             updateViewJob = updateView(accountNumber, accountExpiry)
         }
     }
 
-    override fun onPause() {
+    override fun onSafelyPause() {
         accountCache.onAccountDataChange = null
-
-        super.onPause()
     }
 
     private fun updateView(accountNumber: String?, accountExpiry: DateTime?) =

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -36,7 +36,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             savedInstanceState?.getBoolean(KEY_IS_TUNNEL_INFO_EXPANDED, false) ?: false
     }
 
-    override fun onCreateView(
+    override fun onSafelyCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -70,9 +70,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         return view
     }
 
-    override fun onResume() {
-        super.onResume()
-
+    override fun onSafelyResume() {
         locationInfo.isTunnelInfoExpanded = isTunnelInfoExpanded
 
         notificationBanner.onResume()
@@ -96,7 +94,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
     }
 
-    override fun onPause() {
+    override fun onSafelyPause() {
         keyStatusListener.onKeyStatusChange = null
         locationInfoCache.onNewLocation = null
         relayListListener.onRelayListChange = null
@@ -109,17 +107,13 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         notificationBanner.onPause()
 
         isTunnelInfoExpanded = locationInfo.isTunnelInfoExpanded
-
-        super.onPause()
     }
 
-    override fun onDestroyView() {
+    override fun onSafelyDestroyView() {
         switchLocationButton.onDestroy()
-
-        super.onDestroyView()
     }
 
-    override fun onSaveInstanceState(state: Bundle) {
+    override fun onSafelySaveInstanceState(state: Bundle) {
         isTunnelInfoExpanded = locationInfo.isTunnelInfoExpanded
         state.putBoolean(KEY_IS_TUNNEL_INFO_EXPANDED, isTunnelInfoExpanded)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -31,7 +31,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private var loginJob: Deferred<Boolean>? = null
     private var advanceToNextScreenJob: Job? = null
 
-    override fun onCreateView(
+    override fun onSafelyCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -54,17 +54,15 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         return view
     }
 
-    override fun onResume() {
-        super.onResume()
+    override fun onSafelyResume() {
         advanceToNextScreenJob = GlobalScope.launch(Dispatchers.Main) {
             loggedIn.join()
             openConnectScreen()
         }
     }
 
-    override fun onPause() {
+    override fun onSafelyPause() {
         advanceToNextScreenJob?.cancel()
-        super.onPause()
     }
 
     private fun createAccount() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -26,7 +26,6 @@ class MainActivity : FragmentActivity() {
     private var serviceConnection: ServiceConnection? = null
     private var serviceConnectionSubscription: Int? = null
     private var shouldConnect = false
-    private var shouldStopService = false
 
     private val serviceConnectionManager = object : android.content.ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
@@ -93,10 +92,6 @@ class MainActivity : FragmentActivity() {
     override fun onStop() {
         serviceNotifier.unsubscribeAll()
 
-        if (shouldStopService) {
-            service?.apply { stop() }
-        }
-
         unbindService(serviceConnectionManager)
 
         super.onStop()
@@ -134,7 +129,7 @@ class MainActivity : FragmentActivity() {
     }
 
     fun quit() {
-        shouldStopService = true
+        service?.stop()
         finishAndRemoveTask()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -41,7 +41,7 @@ class SelectLocationFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
         }
     }
 
-    override fun onCreateView(
+    override fun onSafelyCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -58,24 +58,18 @@ class SelectLocationFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
         return view
     }
 
-    override fun onResume() {
-        super.onResume()
-
+    override fun onSafelyResume() {
         relayListListener.onRelayListChange = { relayList, selectedItem ->
             updateRelayListJob = updateRelayList(relayList, selectedItem)
         }
     }
 
-    override fun onPause() {
+    override fun onSafelyPause() {
         relayListListener.onRelayListChange = null
-
-        super.onPause()
     }
 
-    override fun onDestroyView() {
+    override fun onSafelyDestroyView() {
         updateRelayListJob?.cancel()
-
-        super.onDestroyView()
     }
 
     fun close() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -62,6 +62,8 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
         private set
 
     override fun onNewServiceConnection(serviceConnection: ServiceConnection) {
+        // This method is always either called first or after an `onNoServiceConnection`, so the
+        // initialization of the fields doesn't have to be synchronized
         accountCache = serviceConnection.accountCache
         appVersionInfoCache = serviceConnection.appVersionInfoCache
         connectionProxy = serviceConnection.connectionProxy

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -48,7 +48,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     private lateinit var verifyButton: Button
     private lateinit var verifySpinner: ProgressBar
 
-    override fun onCreateView(
+    override fun onSafelyCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -280,7 +280,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         }
     }
 
-    override fun onPause() {
+    override fun onSafelyPause() {
         tunnelStateListener?.let { listener ->
             connectionProxy.onUiStateChange.unsubscribe(listener)
         }
@@ -291,12 +291,9 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         validatingKey = false
         generatingKey = false
         urlController.onPause()
-        super.onPause()
     }
 
-    override fun onResume() {
-        super.onResume()
-
+    override fun onSafelyResume() {
         tunnelStateListener = connectionProxy.onUiStateChange.subscribe { uiState ->
             tunnelState = uiState
             updateViewsJob?.cancel()

--- a/android/src/main/res/layout/missing_service.xml
+++ b/android/src/main/res/layout/missing_service.xml
@@ -1,0 +1,6 @@
+<FrameLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+</FrameLayout>


### PR DESCRIPTION
This PR performs a few fixes to avoid some crashes that occurred when certain conditions where right.

First of all, the `MainActivity` now requests the service to stop earlier. 

Secondly, the service will now notify a loss of connection immediately after it realizes that the daemon thread has stopped.

And lastly, the `ServiceDependentFragment` was refactored so that the lifecycle methods are guarded correctly. Previously, the initialization code would detect that the service connection was missing, but the lifecycle methods still had to be called before handling the missing connection by (for example) switching to a new fragment. Since the sub-class always assumed that the connection was available, the lifecycle methods would perform some calls that lead to crashes due to the missing service connection.

Now, the guarded lifecycle methods of the sub-class are only called when the service connection is known to be available. If it's known to not be available, the sub-class methods are skipped and a placeholder UI is built, so the lifecycle methods are actually handled by `ServiceDependentFragment` instead of forwarding them to the sub-class.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1389)
<!-- Reviewable:end -->
