### PR TITLE
Fix race condition when setting up a global WireGuard logger

### DIFF
--- a/ios/PacketTunnel/WireguardDevice.swift
+++ b/ios/PacketTunnel/WireguardDevice.swift
@@ -101,14 +101,14 @@ class WireguardDevice {
     class func setLogger(with handler: @escaping WireguardLogHandler) {
         WireguardDevice.loggingQueue.async {
             WireguardDevice.wireguardLogHandler = handler
+        }
 
-            wgSetLogger { (level, messagePtr) in
-                guard let message = messagePtr.map({ String(cString: $0) }) else { return }
-                let logType = WireguardLogLevel(rawValue: level) ?? .debug
+        wgSetLogger { (level, messagePtr) in
+            guard let message = messagePtr.map({ String(cString: $0) }) else { return }
+            let logType = WireguardLogLevel(rawValue: level) ?? .debug
 
-                WireguardDevice.loggingQueue.async {
-                    WireguardDevice.wireguardLogHandler?(logType, message)
-                }
+            WireguardDevice.loggingQueue.async {
+                WireguardDevice.wireguardLogHandler?(logType, message)
             }
         }
     }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Previously when setting up a global logger for WireGuard, I used to dispatch the call to `wgSetLogger` on a `loggingQueue` which caused the first messages emitted by WireGuard-go to not be delivered at all.

This PR makes sure that logger access happens on a background queue, however calls `wgSetLogger` immediately, since it's supposed to be thread safe and even if the closure given to it is called right after, it will be scheduled on a serial `loggingQueue` and will happen after the `WireguardDevice.wireguardLogHandler` is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1390)
<!-- Reviewable:end -->
