### PR TITLE
Fix WireGuard IPv6 issue on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
   the tunnel could not be started.
 - Fix occasional failure to shut down the old daemon process during installation by killing it if
   necessary.
+- Make WireGuard work with IPv6 enabled even if there is no functioning TAP adapter for OpenVPN.
 
 #### Android
 - Fix crash when starting the app right after quitting it.


### PR DESCRIPTION
Connecting to the tunnel could fail if using IPv6 and WireGuard on Windows with a broken or non-existent TAP adapter, because the IPv6 check would unconditionally look up the IPv6 status of the (OpenVPN) TAP adapter. Fixed by only doing this when using OpenVPN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1391)
<!-- Reviewable:end -->
