### PR TITLE
Handle loss of VPN permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix crash when starting the app right after quitting it.
 - Restart background service if it stops responding.
+- Fix crash when VPN permission is revoked, either manually or by starting another VPN app.
 
 ### Security
 #### Windows

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -39,6 +39,10 @@ class MullvadVpnService : TalpidVpnService() {
         }
     }
 
+    override fun onRevoke() {
+        stop()
+    }
+
     override fun onUnbind(intent: Intent): Boolean {
         return true
     }


### PR DESCRIPTION
The VPN permission granted to the app by the user can be revoked at any time, either when the user manually revokes it or when the user grants the permission to a different VPN app.

Previously, when the permission was revoked nothing was done, which led to a crash when certain operations were attempted when reconnecting. This PR changes that so that when the permission is revoked, the service is stopped.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1392)
<!-- Reviewable:end -->
