### PR TITLE
Update `jnix` dependency to fix JNI local reference leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash when starting the app right after quitting it.
 - Restart background service if it stops responding.
 - Fix crash when VPN permission is revoked, either manually or by starting another VPN app.
+- Fix crash caused by local JNI reference table overflow after running for a long time.
 
 ### Security
 #### Windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,18 +838,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jnix"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jnix-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1315,7 +1315,7 @@ dependencies = [
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1410,7 +1410,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-paths 0.1.0",
@@ -2430,7 +2430,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2517,7 +2517,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3237,8 +3237,8 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1981310da491a4f0f815238097d0d43d8072732b5ae5f8bd0d8eadf5bf245402"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-"checksum jnix 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "14b5a1a12dc744e2a28311fec971a88ed9ff44cc882fe8ed0824609e32b0d36a"
-"checksum jnix-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6381b00e7628f4d3971b9851ffff686dffdde91d15c5ab16621fcee7a52a946"
+"checksum jnix 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c244e71af201111c76e49605d5bd5d9eec8b937fc2b3338df8a5f7d40f06c68"
+"checksum jnix-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a32499eb857b5570686b83f1202584bcaa85dba4b97a9d5a4c822d96b6543fd"
 "checksum jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)" = "<none>"
 "checksum jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f29cb249837420fb0cee7fb0fbf1d22679e121b160e71bb5e0d90b9df241c23e"
 "checksum jsonrpc-client-http 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e642eb74423b9dfcb4512fda167148746b76f788a823cd712fadf409f31d302"

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -13,7 +13,7 @@ crate_type = ["cdylib"]
 err-derive = "0.2.1"
 futures = "0.1"
 ipnetwork = "0.15"
-jnix = { version = "0.1", features = ["derive"] }
+jnix = { version = "0.1.1", features = ["derive"] }
 jsonrpc-client-core = "0.5"
 jsonrpc-core = "8"
 lazy_static = "1"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -20,4 +20,4 @@ talpid-types = { path = "../talpid-types" }
 mullvad-paths = { path = "../mullvad-paths" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.1", features = ["derive"] }
+jnix = { version = "0.1.1", features = ["derive"] }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -38,7 +38,7 @@ tokio-io = "0.1"
 
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.1", features = ["derive"] }
+jnix = { version = "0.1.1", features = ["derive"] }
 rand = "0.7"
 
 

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -15,4 +15,4 @@ rand = "0.7"
 err-derive = "0.2.1"
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.1", features = ["derive"] }
+jnix = { version = "0.1.1", features = ["derive"] }


### PR DESCRIPTION
Previously, converting an `IpAddr`, `Ipv4Addr` or `Ipv6Addr` into a Java `InetAddress` object would leak a `Class` object reference in the local reference table. After a while, the app could crash due to overflowing the local reference table.

This PR updates the `jnix` dependency to a version that includes a fix for the local reference leak.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1394)
<!-- Reviewable:end -->
