### PR TITLE
Log Wintun install

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -410,11 +410,14 @@
 	log::Log "RemoveWintun()"
 
 	${DisableX64FSRedirection}
-	ExecWait '"$SYSDIR\msiexec.exe" /x "$TEMP\mullvad-wintun-amd64.msi" /qn /norestart' $0
+	msiutil::SilentUninstall "$TEMP\mullvad-wintun-amd64.msi"
+	Pop $0
+	Pop $1
 	${EnableX64FSRedirection}
 
-	${If} $0 != 0
-		log::Log "Failed to remove Wintun: error $0"
+	${If} $0 != ${MULLVAD_SUCCESS}
+		StrCpy $R0 "Failed to remove Wintun: error $0"
+		log::LogWithDetails $R0 $1
 		Goto RemoveWintun_return_only
 	${EndIf}
 
@@ -442,12 +445,14 @@
 	Push $0
 
 	${DisableX64FSRedirection}
-	ExecWait '"$SYSDIR\msiexec.exe" /i "$TEMP\mullvad-wintun-amd64.msi" /qn /norestart' $0
+	msiutil::SilentInstall "$TEMP\mullvad-wintun-amd64.msi"
+	Pop $0
+	Pop $1
 	${EnableX64FSRedirection}
 
-	${If} $0 != 0
+	${If} $0 != ${MULLVAD_SUCCESS}
 		StrCpy $R0 "Failed to install Wintun: error $0"
-		log::Log $R0
+		log::LogWithDetails $R0 $1
 		Goto InstallWintun_return
 	${EndIf}
 

--- a/windows/nsis-plugins/nsis-plugins.sln
+++ b/windows/nsis-plugins/nsis-plugins.sln
@@ -43,6 +43,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "string", "src\string\string.vcxproj", "{645B4CB5-623A-41CC-8B05-2268A5AE6C47}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msiutil", "src\msiutil\msiutil.vcxproj", "{83487059-2549-4DF9-A785-A4FD5211234B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B52E2D10-A94A-4605-914A-2DCEF6A757EF} = {B52E2D10-A94A-4605-914A-2DCEF6A757EF}
+		{1344152F-2BAD-4198-8E51-31AAC32BFBB2} = {1344152F-2BAD-4198-8E51-31AAC32BFBB2}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -81,6 +87,10 @@ Global
 		{645B4CB5-623A-41CC-8B05-2268A5AE6C47}.Debug|x86.Build.0 = Debug|Win32
 		{645B4CB5-623A-41CC-8B05-2268A5AE6C47}.Release|x86.ActiveCfg = Release|Win32
 		{645B4CB5-623A-41CC-8B05-2268A5AE6C47}.Release|x86.Build.0 = Release|Win32
+		{83487059-2549-4DF9-A785-A4FD5211234B}.Debug|x86.ActiveCfg = Debug|Win32
+		{83487059-2549-4DF9-A785-A4FD5211234B}.Debug|x86.Build.0 = Debug|Win32
+		{83487059-2549-4DF9-A785-A4FD5211234B}.Release|x86.ActiveCfg = Release|Win32
+		{83487059-2549-4DF9-A785-A4FD5211234B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/windows/nsis-plugins/src/msiutil/dllmain.cpp
+++ b/windows/nsis-plugins/src/msiutil/dllmain.cpp
@@ -1,0 +1,11 @@
+#include "stdafx.h"
+#include <windows.h>
+
+BOOL APIENTRY DllMain(HMODULE, DWORD reason, LPVOID)
+{
+	//
+	// Avoid doing work in DllMain since the loader lock is held
+	//
+
+	return TRUE;
+}

--- a/windows/nsis-plugins/src/msiutil/msiutil.cpp
+++ b/windows/nsis-plugins/src/msiutil/msiutil.cpp
@@ -1,0 +1,210 @@
+#include "stdafx.h"
+#include <msi.h>
+#include <windows.h>
+#include <nsis/pluginapi.h>
+#include "../error.h"
+#include <log/log.h>
+#include <libcommon/string.h>
+#include <stdexcept>
+
+namespace
+{
+
+std::wstring PopString()
+{
+	//
+	// NSIS functions popstring() and popstringn() require that you definitely size the buffer
+	// before popping the string. Let's do it ourselves instead.
+	//
+
+	if (!g_stacktop || !*g_stacktop)
+	{
+		throw std::runtime_error("NSIS variable stack is corrupted");
+	}
+
+	stack_t *th = *g_stacktop;
+
+	std::wstring copy(th->text);
+
+	*g_stacktop = th->next;
+	GlobalFree((HGLOBAL)th);
+
+	return copy;
+}
+
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+
+void PinDll()
+{
+	//
+	// Apparently NSIS loads and unloads the plugin module for EVERY call it makes to the plugin.
+	// This makes it kind of difficult to maintain state.
+	//
+	// We can work around this by incrementing the module reference count.
+	// When NSIS calls FreeLibrary() the reference count decrements and becomes one.
+	//
+
+	wchar_t self[MAX_PATH];
+
+	if (0 == GetModuleFileNameW((HINSTANCE)&__ImageBase, self, _countof(self)))
+	{
+		throw std::runtime_error("Failed to pin plugin module");
+	}
+
+	//
+	// For some reason, NSIS frees this particular DLL more times than it loads it
+	// so we have to up the reference count significantly.
+	//
+	for (int i = 0; i < 100; ++i)
+	{
+		LoadLibraryW(self);
+	}
+}
+
+int WINAPI InstallerHandler(
+	LPVOID context,
+	UINT type,
+	LPCWSTR message
+)
+{
+	PluginLog(message);
+	// return 0 to pass it on to the installer
+	return 0;
+}
+
+} // anonymous namespace
+
+
+//
+// SilentInstall "installer.msi"
+//
+// Performs a silent install and logs the results.
+//
+// Return: Empty string and NsisStatus::SUCCESS on success.
+//         Otherwise an error string and NsisStatus::GENERAL_ERROR.
+//
+
+void __declspec(dllexport) NSISCALL SilentInstall
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	try
+	{
+		const auto msiFile = PopString();
+
+		MsiSetInternalUI(INSTALLUILEVEL_NONE, nullptr);
+		MsiSetExternalUIW(
+			InstallerHandler,
+			INSTALLLOGMODE_INFO |
+			INSTALLLOGMODE_WARNING |
+			INSTALLLOGMODE_ERROR |
+			INSTALLLOGMODE_FATALEXIT |
+			INSTALLLOGMODE_OUTOFDISKSPACE |
+			INSTALLLOGMODE_RMFILESINUSE |
+			INSTALLLOGMODE_FILESINUSE,
+			nullptr
+		);
+
+		const auto installResult = MsiInstallProductW(
+			msiFile.c_str(),
+			L"ACTION=INSTALL "
+			L"REBOOT=ReallySuppress"
+		);
+
+		if (ERROR_SUCCESS != installResult)
+		{
+			std::wstringstream ss;
+			ss << L"Install failed: " << installResult;
+			pushstring(ss.str().c_str());
+			pushint(NsisStatus::GENERAL_ERROR);
+		}
+
+		pushstring(L"");
+		pushint(NsisStatus::SUCCESS);
+	}
+	catch (std::exception & err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(NsisStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(NsisStatus::GENERAL_ERROR);
+	}
+}
+
+//
+// SilentUninstall "installer.msi"
+//
+// Performs a silent uninstall and logs the results.
+//
+// Return: Empty string and NsisStatus::SUCCESS on success.
+//         Otherwise an error string and NsisStatus::GENERAL_ERROR.
+//
+
+void __declspec(dllexport) NSISCALL SilentUninstall
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t **stacktop,
+	extra_parameters *extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	try
+	{
+		const auto msiFile = PopString();
+
+		MsiSetInternalUI(INSTALLUILEVEL_NONE, nullptr);
+		MsiSetExternalUIW(
+			InstallerHandler,
+			INSTALLLOGMODE_INFO |
+			INSTALLLOGMODE_WARNING |
+			INSTALLLOGMODE_ERROR |
+			INSTALLLOGMODE_FATALEXIT |
+			INSTALLLOGMODE_OUTOFDISKSPACE |
+			INSTALLLOGMODE_RMFILESINUSE |
+			INSTALLLOGMODE_FILESINUSE,
+			nullptr
+		);
+
+		const auto installResult = MsiInstallProductW(
+			msiFile.c_str(),
+			L"REMOVE=ALL "
+			L"REBOOT=ReallySuppress"
+		);
+
+		if (ERROR_SUCCESS != installResult)
+		{
+			std::wstringstream ss;
+			ss << L"Install failed: " << installResult;
+			pushstring(ss.str().c_str());
+			pushint(NsisStatus::GENERAL_ERROR);
+		}
+
+		pushstring(L"");
+		pushint(NsisStatus::SUCCESS);
+	}
+	catch (std::exception & err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(NsisStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(NsisStatus::GENERAL_ERROR);
+	}
+}

--- a/windows/nsis-plugins/src/msiutil/msiutil.def
+++ b/windows/nsis-plugins/src/msiutil/msiutil.def
@@ -1,0 +1,6 @@
+LIBRARY msiutil
+
+EXPORTS
+
+SilentInstall
+SilentUninstall

--- a/windows/nsis-plugins/src/msiutil/msiutil.vcxproj
+++ b/windows/nsis-plugins/src/msiutil/msiutil.vcxproj
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{83487059-2549-4DF9-A785-A4FD5211234B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>msiutil</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)bin\temp\$(Platform)-$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)bin\temp\$(Platform)-$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;MSIUTIL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/;$(ProjectDir)../../../windows-libraries/src/;$(ProjectDir)../</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <AdditionalLibraryDirectories>$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>msi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
+      <ModuleDefinitionFile>msiutil.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;MSIUTIL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/;$(ProjectDir)../../../windows-libraries/src/;$(ProjectDir)../</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <AdditionalLibraryDirectories>$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>msi.lib;log.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
+      <ModuleDefinitionFile>msiutil.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="msiutil.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="msiutil.def" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/windows/nsis-plugins/src/msiutil/msiutil.vcxproj.filters
+++ b/windows/nsis-plugins/src/msiutil/msiutil.vcxproj.filters
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="stdafx.cpp" />
+    <ClCompile Include="msiutil.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="msiutil.def" />
+  </ItemGroup>
+</Project>

--- a/windows/nsis-plugins/src/msiutil/stdafx.cpp
+++ b/windows/nsis-plugins/src/msiutil/stdafx.cpp
@@ -1,0 +1,8 @@
+// stdafx.cpp : source file that includes just the standard includes
+// driverlogic.pch will be the pre-compiled header
+// stdafx.obj will contain the pre-compiled type information
+
+#include "stdafx.h"
+
+// TODO: reference any additional headers you need in STDAFX.H
+// and not in this file

--- a/windows/nsis-plugins/src/msiutil/stdafx.h
+++ b/windows/nsis-plugins/src/msiutil/stdafx.h
@@ -1,0 +1,16 @@
+// stdafx.h : include file for standard system include files,
+// or project specific include files that are used frequently, but
+// are changed infrequently
+//
+
+#pragma once
+
+#include "targetver.h"
+
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+// Windows Header Files:
+#include <windows.h>
+
+
+
+// TODO: reference additional headers your program requires here

--- a/windows/nsis-plugins/src/msiutil/targetver.h
+++ b/windows/nsis-plugins/src/msiutil/targetver.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <WinSDKVer.h>
+
+#define _WIN32_WINNT _WIN32_WINNT_WIN7
+
+#include <SDKDDKVer.h>


### PR DESCRIPTION
Some users have had issues with Wintun. By default, the log ends up in the temp directory, and `msiexec` only lets you specify a new file for output. The API was used so that the logging could be directed to install.log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1395)
<!-- Reviewable:end -->
