### PR TITLE
Use unbouded_send() instead of send()

### DIFF
--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -344,14 +344,14 @@ impl KeyManager {
                 match rpc_result {
                     Ok(data) => {
                         // Update account data
-                        let _ = daemon_tx.send(InternalDaemonEvent::WgKeyEvent((
+                        let _ = daemon_tx.unbounded_send(InternalDaemonEvent::WgKeyEvent((
                             account_token_copy,
                             Ok(data.clone()),
                         )));
                         Ok(data.get_public_key())
                     }
                     Err(Error::TooManyKeys) => {
-                        let _ = daemon_tx.send(InternalDaemonEvent::WgKeyEvent((
+                        let _ = daemon_tx.unbounded_send(InternalDaemonEvent::WgKeyEvent((
                             account_token_copy,
                             Err(Error::TooManyKeys),
                         )));


### PR DESCRIPTION
futures::sync::mpsc::UnboundedSender::<T>::send': renamed to `unbounded_send`, with the latter version being deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1396)
<!-- Reviewable:end -->
