### PR TITLE
Remove usage of Mullvad email in crate manifests

### DIFF
--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mullvad-cli"
 version = "2019.10.0"
 authors = [
-    "Mullvad VPN <admin@mullvad.net>",
+    "Mullvad VPN",
     "Andrej Mihajlov <and@mullvad.net>",
     "Emīls Piņķis <emils@mullvad.net>",
     "Erik Larkö <erik@mullvad.net>",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mullvad-daemon"
 version = "2019.10.0"
 authors = [
-    "Mullvad VPN <admin@mullvad.net>",
+    "Mullvad VPN",
     "Andrej Mihajlov <and@mullvad.net>",
     "Emīls Piņķis <emils@mullvad.net>",
     "Erik Larkö <erik@mullvad.net>",

--- a/mullvad-ipc-client/Cargo.toml
+++ b/mullvad-ipc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-ipc-client"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "RPC client for Mullvad daemon"
 license = "GPL-3.0"
 edition = "2018"

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-jni"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "JNI interface for the Mullvad daemon"
 license = "GPL-3.0"
 edition = "2018"

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-paths"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "Mullvad VPN application paths and directories"
 license = "GPL-3.0"
 edition = "2018"

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mullvad-problem-report"
 version = "2019.10.0"
 authors = [
-    "Mullvad VPN <admin@mullvad.net>",
+    "Mullvad VPN",
     "Andrej Mihajlov <and@mullvad.net>",
     "Emīls Piņķis <emils@mullvad.net>",
     "Erik Larkö <erik@mullvad.net>",

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-rpc"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "Mullvad VPN RPC clients. Providing an interface to query our infrastructure for information."
 license = "GPL-3.0"
 edition = "2018"

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-tests"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "Mullvad test specific modules and binaries"
 license = "GPL-3.0"
 edition = "2018"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mullvad-types"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "Common base data structures for Mullvad VPN client"
 license = "GPL-3.0"
 edition = "2018"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "talpid-core"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "Privacy preserving and secure VPN client library"
 license = "GPL-3.0"
 edition = "2018"

--- a/talpid-ipc/Cargo.toml
+++ b/talpid-ipc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "talpid-ipc"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "IPC client and server for talpid"
 license = "GPL-3.0"
 edition = "2018"

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "talpid-openvpn-plugin"
 version = "2019.10.0"
 authors = [
-    "Mullvad VPN <admin@mullvad.net>",
+    "Mullvad VPN",
     "Andrej Mihajlov <and@mullvad.net>",
     "Emīls Piņķis <emils@mullvad.net>",
     "Erik Larkö <erik@mullvad.net>",

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "talpid-types"
 version = "0.1.0"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 description = "Common base structures for talpid"
 license = "GPL-3.0"
 edition = "2018"


### PR DESCRIPTION
The email address used in the author field is slowly being phased away, so it should be removed from all places it appears in.

This PR updates all package manifests to remove the email from the authors' field.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1397)
<!-- Reviewable:end -->
