### PR TITLE
Fix system PATH update

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -850,10 +850,9 @@
 		${BreakInstallation}
 		Abort
 	${EndIf}
-	
-	${InstallTrayIcon}
 
 	${AddCLIToEnvironPath}
+	${InstallTrayIcon}
 
 	Pop $R0
 

--- a/windows/nsis-plugins/src/pathedit/pathedit.cpp
+++ b/windows/nsis-plugins/src/pathedit/pathedit.cpp
@@ -22,8 +22,9 @@ using namespace common::registry;
 using ValueStringType = RegistryKey::ValueStringType;
 using common::string::Lower;
 
-static const wchar_t pathKeyName[] = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
-static const wchar_t pathValName[] = L"Path";
+static constexpr wchar_t pathKeyName[] = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+static constexpr wchar_t pathValName[] = L"Path";
+static constexpr size_t messageTimeoutInterval = 5;
 
 namespace
 {
@@ -138,10 +139,32 @@ void __declspec(dllexport) NSISCALL AddSysEnvPath
 			pathRegKey->flush();
 		}
 
+		DWORD result;
 		THROW_GLE_IF(
-			SendNotifyMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)L"Environment"),
+			SendMessageTimeoutA(
+				HWND_BROADCAST,
+				WM_SETTINGCHANGE,
+				0,
+				(LPARAM)"Environment",
+				SMTO_ABORTIFHUNG,
+				messageTimeoutInterval,
+				&result
+			),
 			0,
-			"SendNotifyMessageW"
+			"SendMessageTimeoutA"
+		);
+		THROW_GLE_IF(
+			SendMessageTimeoutW(
+				HWND_BROADCAST,
+				WM_SETTINGCHANGE,
+				0,
+				(LPARAM)L"Environment",
+				SMTO_ABORTIFHUNG,
+				messageTimeoutInterval,
+				&result
+			),
+			0,
+			"SendMessageTimeoutW"
 		);
 
 		pushstring(L"");
@@ -211,10 +234,32 @@ void __declspec(dllexport) NSISCALL RemoveSysEnvPath
 
 		if (updatedPath)
 		{
+			DWORD result;
 			THROW_GLE_IF(
-				SendNotifyMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)L"Environment"),
+				SendMessageTimeoutA(
+					HWND_BROADCAST,
+					WM_SETTINGCHANGE,
+					0,
+					(LPARAM)"Environment",
+					SMTO_ABORTIFHUNG,
+					messageTimeoutInterval,
+					&result
+				),
 				0,
-				"SendNotifyMessageW"
+				"SendMessageTimeoutA"
+			);
+			THROW_GLE_IF(
+				SendMessageTimeoutW(
+					HWND_BROADCAST,
+					WM_SETTINGCHANGE,
+					0,
+					(LPARAM)L"Environment",
+					SMTO_ABORTIFHUNG,
+					messageTimeoutInterval,
+					&result
+				),
+				0,
+				"SendMessageTimeoutW"
 			);
 		}
 


### PR DESCRIPTION
On some systems, our changes to the system PATH are not reflected in `cmd` when it is run from Win+R. In this case, PATH is inherited from `explorer.exe` rather than read directly from the registry. We already notify `explorer.exe` of the change, which works for some users but not others.
The main reason seems to be that the installer would sometimes restart `explorer.exe` before the PATH was updated, which could result in a race condition. There may also have been a problem relating to Unicode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1401)
<!-- Reviewable:end -->
