### PR TITLE
Sign select binaries for release builds (Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,27 +368,30 @@ the version of the app you are going to release. For example `2018.3-beta1` or `
 
     Please verify that the script did the right thing before you push the commit and tag it created.
 
-1. When building for macOS, the following environment variables must be set:
-   * `CSC_LINK` - The path to the `.p12` certificate file with the Apple application signing keys.
-     This file must contain both the "Developer ID Application" and the "Developer ID Installer"
-     certificates + private keys. If this environment variable is missing `build.sh` will skip
-     signing.
+1. When building for Windows or macOS, the following environment variables must be set:
+   * `CSC_LINK` - The path to the certificate used for code signing.
+      * Windows: A `.pfx` certificate.
+      * macOS: A `.p12` certificate file with the Apple application signing keys.
+        This file must contain both the "Developer ID Application" and the "Developer ID Installer"
+        certificates + private keys.
    * `CSC_KEY_PASSWORD` - The password to the file given in `CSC_LINK`. If this is not set then
-     `build.sh` will prompt you for it. If you set it yourself, make sure to define it in such a
-     way that it's not stored in your bash history:
-     ```bash
-     export HISTCONTROL=ignorespace
-     export CSC_KEY_PASSWORD='my secret'
-     ```
-   * `NOTARIZE_APPLE_ID` - The AppleId to use when notarizing the app. Only needed on release builds
-   * `NOTARIZE_APPLE_ID_PASSWORD` - The AppleId password for the account in `NOTARIZE_APPLE_ID`.
-     Don't use the real AppleId password! Instead create an app specific password and add that to
-     your keyring. See this documentation: https://github.com/electron/electron-notarize#safety-when-using-appleidpassword
+      `build.sh` will prompt you for it. If you set it yourself, make sure to define it in such a
+      way that it's not stored in your bash history:
+      ```bash
+      export HISTCONTROL=ignorespace
+      export CSC_KEY_PASSWORD='my secret'
+      ```
 
-     Summary:
-     1. Generate app specific password on Apple's AppleId management portal.
-     2. Run `security add-generic-password -a "<apple_id>" -w <app_specific_password> -s "something_something"`
-     3. Set `NOTARIZE_APPLE_ID_PASSWORD="@keychain:something_something"`.
+   * *macOS only*:
+      * `NOTARIZE_APPLE_ID` - The AppleId to use when notarizing the app. Only needed on release builds
+      * `NOTARIZE_APPLE_ID_PASSWORD` - The AppleId password for the account in `NOTARIZE_APPLE_ID`.
+         Don't use the real AppleId password! Instead create an app specific password and add that to
+         your keyring. See this documentation: https://github.com/electron/electron-notarize#safety-when-using-appleidpassword
+
+         Summary:
+         1. Generate app specific password on Apple's AppleId management portal.
+         2. Run `security add-generic-password -a "<apple_id>" -w <app_specific_password> -s "something_something"`
+         3. Set `NOTARIZE_APPLE_ID_PASSWORD="@keychain:something_something"`.
 
 1. Run `./build.sh` on each computer/platform where you want to create a release artifact. This will
     do the following for you:


### PR DESCRIPTION
This is desirable to prove authorship, and because some AV/firewall software complains about unsigned executables. Electron builder signs too many files, including files that are already signed by Microsoft, etc., so select files are signed in `build.sh` instead.

More files could be signed, eg Windows modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1402)
<!-- Reviewable:end -->
