### PR TITLE
Fix suspend issue for WG key rotation

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -480,7 +480,7 @@ where
                     .get_tunnel_options()
                     .wireguard
                     .automatic_rotation
-                    .map(|hours| 60 * hours),
+                    .map(|hours| Duration::from_secs(60u64 * 60u64 * hours as u64)),
             );
         }
 
@@ -1378,7 +1378,7 @@ where
                         self.wireguard_key_manager.set_rotation_interval(
                             &mut self.account_history,
                             token,
-                            interval.map(|hours| 60 * hours),
+                            interval.map(|hours| Duration::from_secs(60u64 * 60u64 * hours as u64)),
                         );
                     }
 
@@ -1462,7 +1462,7 @@ where
                             .get_tunnel_options()
                             .wireguard
                             .automatic_rotation
-                            .map(|hours| 60 * hours),
+                            .map(|hours| Duration::from_secs(60u64 * 60u64 * hours as u64)),
                     );
 
                     Ok(keygen_event)


### PR DESCRIPTION
The existing timer didn't account for computers being suspended, potentially delaying key replacement by a long period of time. Fixed by using a repeating timer with a short interval.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1410)
<!-- Reviewable:end -->
