### PR TITLE
iOS: Remove WireGuard key on logout

### DIFF
--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -42,17 +42,29 @@ class AccountViewController: UIViewController {
     }
 
     @IBAction func doLogout() {
-        logoutSubscriber = Account.shared.logout()
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { (completion) in
-                switch completion {
-                case .failure(let error):
-                    self.presentError(error, preferredStyle: .alert)
+        let message = NSLocalizedString("Logging out. Please wait...",
+                                        comment: "A modal message displayed during log out")
 
-                case .finished:
-                    self.performSegue(withIdentifier: SegueIdentifier.Account.logout.rawValue, sender: self)
-                }
-            })
+        let alertController = UIAlertController(
+            title: nil,
+            message: message,
+            preferredStyle: .alert)
+
+        present(alertController, animated: true) {
+            self.logoutSubscriber = Account.shared.logout()
+                .delay(for: .seconds(1), scheduler: DispatchQueue.main)
+                .sink(receiveCompletion: { (completion) in
+                    switch completion {
+                    case .failure(let error):
+                        alertController.dismiss(animated: true) {
+                            self.presentError(error, preferredStyle: .alert)
+                        }
+
+                    case .finished:
+                        self.performSegue(withIdentifier: SegueIdentifier.Account.logout.rawValue, sender: self)
+                    }
+                })
+        }
     }
 
     @IBAction func copyAccountToken() {

--- a/ios/MullvadVPN/MullvadAPI.swift
+++ b/ios/MullvadVPN/MullvadAPI.swift
@@ -163,6 +163,15 @@ class MullvadAPI {
         return MullvadAPI.makeDataTaskPublisher(request: request)
     }
 
+    func removeWireguardKey(accountToken: String, publicKey: Data) -> AnyPublisher<Response<Bool>, MullvadAPI.Error> {
+        let request = JsonRpcRequest(method: "remove_wg_key", params: [
+            AnyEncodable(accountToken),
+            AnyEncodable(publicKey)
+        ])
+
+        return MullvadAPI.makeDataTaskPublisher(request: request)
+    }
+
     private static func makeDataTaskPublisher<T: Decodable>(request: JsonRpcRequest) -> AnyPublisher<Response<T>, MullvadAPI.Error> {
         return Just(request)
             .encode(encoder: makeJSONEncoder())


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add a call to master to remove the WireGuard key from our servers during log out. 
1. Show a modal alert message that blocks the interface until the log out is done.
1. Ignore Keychain errors when reading the WireGuard public key during log out. This ensures that the user would be able to log out, if for some reason, the app crashed half way through after removing the keychain record. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1412)
<!-- Reviewable:end -->
