### PR TITLE
Fix Wintun file redirection issue on Windows 7

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -406,14 +406,13 @@
 #
 !macro RemoveWintun
 	Push $0
+	Push $1
 
 	log::Log "RemoveWintun()"
 
-	${DisableX64FSRedirection}
 	msiutil::SilentUninstall "$TEMP\mullvad-wintun-amd64.msi"
 	Pop $0
 	Pop $1
-	${EnableX64FSRedirection}
 
 	${If} $0 != ${MULLVAD_SUCCESS}
 		StrCpy $R0 "Failed to remove Wintun: error $0"
@@ -423,8 +422,12 @@
 
 	log::Log "RemoveWintun() completed successfully"
 
+	Push 0
+	Pop $R0
+
 	RemoveWintun_return_only:
 
+	Pop $1
 	Pop $0
 
 !macroend
@@ -443,12 +446,11 @@
 	log::Log "InstallWintun()"
 
 	Push $0
+	Push $1
 
-	${DisableX64FSRedirection}
 	msiutil::SilentInstall "$TEMP\mullvad-wintun-amd64.msi"
 	Pop $0
 	Pop $1
-	${EnableX64FSRedirection}
 
 	${If} $0 != ${MULLVAD_SUCCESS}
 		StrCpy $R0 "Failed to install Wintun: error $0"
@@ -463,6 +465,7 @@
 
 	InstallWintun_return:
 
+	Pop $1
 	Pop $0
 
 !macroend

--- a/windows/nsis-plugins/src/msiutil/msiutil.cpp
+++ b/windows/nsis-plugins/src/msiutil/msiutil.cpp
@@ -125,6 +125,7 @@ void __declspec(dllexport) NSISCALL SilentInstall
 			ss << L"Install failed: " << installResult;
 			pushstring(ss.str().c_str());
 			pushint(NsisStatus::GENERAL_ERROR);
+			return;
 		}
 
 		pushstring(L"");
@@ -189,9 +190,10 @@ void __declspec(dllexport) NSISCALL SilentUninstall
 		if (ERROR_SUCCESS != installResult)
 		{
 			std::wstringstream ss;
-			ss << L"Install failed: " << installResult;
+			ss << L"Uninstall failed: " << installResult;
 			pushstring(ss.str().c_str());
 			pushint(NsisStatus::GENERAL_ERROR);
+			return;
 		}
 
 		pushstring(L"");


### PR DESCRIPTION
This PR addresses two problems. Firstly, the installer fails on Windows 7 when setting up Wintun. This is because file system redirection is disabled, which causes the MSI library to fail. Secondly, the NSIS stack is messed up if an error occurs while an MSI installer is run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1413)
<!-- Reviewable:end -->
