### PR TITLE
Fix android buildscript

### DIFF
--- a/wireguard/wireguard-go/build-android.sh
+++ b/wireguard/wireguard-go/build-android.sh
@@ -60,4 +60,7 @@ for arch in arm arm64 x86_64 x86; do
     chmod 777 ../../android/build/extraJni/*
     mkdir -p ../../build/lib/$RUST_TARGET_TRIPLE
     cp ../../android/build/extraJni/$ANDROID_ABI/libwg.so ../../build/lib/$RUST_TARGET_TRIPLE
+    chmod 777 ../../android/build/extraJni/$ANDROID_ABI/libwg.so ../../build/lib/$RUST_TARGET_TRIPLE
+    rm -rf build
+
 done


### PR DESCRIPTION
Change the `wireguard-go` buildscripts for Android to cleanup after themselves a bit better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1418)
<!-- Reviewable:end -->
