### PR TITLE
Disable wireguard if no key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Line wrap the file at 100 chars.                                              Th
 - Don't try to replace WireGuard key if account has too many keys already.
 - Fix bogus update notification caused by an outdated cache.
 - Fix layout issues when showing messages in WireGuard key view.
+- Disable WireGuard protocol option if there's no WireGuard key.
 
 #### Windows
 - Fix regression due to which a TAP adapter issue was not given as the specific block reason when

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -3,6 +3,7 @@ import { Component, View } from 'reactxp';
 import { sprintf } from 'sprintf-js';
 import { BridgeState, RelayProtocol, TunnelProtocol } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
+import { WgKeyState } from '../redux/settings/reducers';
 import styles from './AdvancedSettingsStyles';
 import * as Cell from './Cell';
 import { Container, Layout } from './Layout';
@@ -40,6 +41,7 @@ interface IProps {
     protocol?: RelayProtocol;
     port?: number;
   };
+  wireguardKeyState: WgKeyState;
   wireguard: { port?: number };
   mssfix?: number;
   bridgeState: BridgeState;
@@ -64,7 +66,6 @@ export default class AdvancedSettings extends Component<IProps, IState> {
   private portItems: { [key in RelayProtocol]: Array<ISelectorItem<OptionalPort>> };
   private protocolItems: Array<ISelectorItem<OptionalRelayProtocol>>;
   private bridgeStateItems: Array<ISelectorItem<BridgeState>>;
-  private tunnelProtocolItems: Array<ISelectorItem<OptionalTunnelProtocol>>;
   private wireguardPortItems: Array<ISelectorItem<OptionalPort>>;
 
   constructor(props: IProps) {
@@ -96,21 +97,6 @@ export default class AdvancedSettings extends Component<IProps, IState> {
       {
         label: messages.pgettext('advanced-settings-view', 'UDP'),
         value: 'udp',
-      },
-    ];
-
-    this.tunnelProtocolItems = [
-      {
-        label: messages.pgettext('advanced-settings-view', 'Automatic'),
-        value: undefined,
-      },
-      {
-        label: messages.pgettext('advanced-settings-view', 'OpenVPN'),
-        value: 'openvpn',
-      },
-      {
-        label: messages.pgettext('advanced-settings-view', 'WireGuard'),
-        value: 'wireguard',
       },
     ];
 
@@ -155,6 +141,8 @@ export default class AdvancedSettings extends Component<IProps, IState> {
       ? styles.advanced_settings__mssfix_valid_value
       : styles.advanced_settings__mssfix_invalid_value;
     const mssfixValue = this.state.editedMssfix;
+
+    const hasWireguardKey = this.props.wireguardKeyState.type === 'key-set';
 
     return (
       <Layout>
@@ -228,7 +216,7 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                   <View style={styles.advanced_settings__content}>
                     <Selector
                       title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
-                      values={this.tunnelProtocolItems}
+                      values={this.tunnelProtocolItems(hasWireguardKey)}
                       value={this.props.tunnelProtocol}
                       onSelect={this.onSelectTunnelProtocol}
                     />
@@ -347,6 +335,26 @@ export default class AdvancedSettings extends Component<IProps, IState> {
       </Layout>
     );
   }
+
+  private tunnelProtocolItems = (
+    hasWireguardKey: boolean,
+  ): Array<ISelectorItem<OptionalTunnelProtocol>> => {
+    return [
+      {
+        label: messages.pgettext('advanced-settings-view', 'Automatic'),
+        value: undefined,
+      },
+      {
+        label: messages.pgettext('advanced-settings-view', 'OpenVPN'),
+        value: 'openvpn',
+      },
+      {
+        label: messages.pgettext('advanced-settings-view', 'WireGuard'),
+        value: 'wireguard',
+        disabled: !hasWireguardKey,
+      },
+    ];
+  };
 
   private onSelectTunnelProtocol = (protocol?: TunnelProtocol) => {
     this.props.setTunnelProtocol(protocol);

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Component, View } from 'reactxp';
+import { Component, Text, View } from 'reactxp';
 import { sprintf } from 'sprintf-js';
 import { BridgeState, RelayProtocol, TunnelProtocol } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
@@ -213,13 +213,26 @@ export default class AdvancedSettings extends Component<IProps, IState> {
                     )}
                   </Cell.Footer>
 
-                  <View style={styles.advanced_settings__content}>
+                  <View
+                    style={[
+                      styles.advanced_settings__content,
+                      styles.advanced_settings__tunnel_protocol,
+                    ]}>
                     <Selector
                       title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
                       values={this.tunnelProtocolItems(hasWireguardKey)}
                       value={this.props.tunnelProtocol}
                       onSelect={this.onSelectTunnelProtocol}
+                      style={styles.advanced_settings__tunnel_protocol_selector}
                     />
+                    {!hasWireguardKey && (
+                      <Text style={styles.advanced_settings__wg_no_key}>
+                        {messages.pgettext(
+                          'advanced-settings-view',
+                          'To enable WireGuard, generate a key under the "WireGuard key" setting below.',
+                        )}
+                      </Text>
+                    )}
                   </View>
 
                   {this.props.tunnelProtocol !== 'wireguard' ? (
@@ -349,7 +362,12 @@ export default class AdvancedSettings extends Component<IProps, IState> {
         value: 'openvpn',
       },
       {
-        label: messages.pgettext('advanced-settings-view', 'WireGuard'),
+        label: hasWireguardKey
+          ? messages.pgettext('advanced-settings-view', 'WireGuard')
+          : sprintf('%(label)s (%(error)s)', {
+              label: messages.pgettext('advanced-settings-view', 'WireGuard'),
+              error: messages.pgettext('advanced-settings-view-wireguard', 'missing key'),
+            }),
         value: 'wireguard',
         disabled: !hasWireguardKey,
       },

--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -16,11 +16,23 @@ export default {
   advanced_settings__content: Styles.createViewStyle({
     flex: 0,
   }),
-  advanced_settings__selector_section: Styles.createViewStyle({
+  advanced_settings__tunnel_protocol: Styles.createViewStyle({
     marginBottom: 24,
+  }),
+  advanced_settings__tunnel_protocol_selector: Styles.createViewStyle({
+    marginBottom: 0,
   }),
   advanced_settings__wgkeys_cell: Styles.createViewStyle({
     marginBottom: 24,
+  }),
+  advanced_settings__wg_no_key: Styles.createTextStyle({
+    fontFamily: 'Open Sans',
+    fontSize: 13,
+    fontWeight: '800',
+    lineHeight: 20,
+    color: colors.red,
+    marginTop: 12,
+    paddingHorizontal: 24,
   }),
   advanced_settings__cell_hover: Styles.createButtonStyle({
     backgroundColor: colors.blue80,

--- a/gui/src/renderer/components/Selector.tsx
+++ b/gui/src/renderer/components/Selector.tsx
@@ -6,6 +6,7 @@ import * as Cell from './Cell';
 export interface ISelectorItem<T> {
   label: string;
   value: T;
+  disabled?: boolean;
 }
 
 interface ISelectorProps<T> {
@@ -36,6 +37,7 @@ export default class Selector<T> extends Component<ISelectorProps<T>> {
           key={i}
           value={item.value}
           selected={selected}
+          disabled={item.disabled}
           ref={selected ? this.props.selectedCellRef : undefined}
           onSelect={this.props.onSelect}>
           {item.label}
@@ -59,6 +61,7 @@ export default class Selector<T> extends Component<ISelectorProps<T>> {
 interface ISelectorCellProps<T> {
   value: T;
   selected: boolean;
+  disabled?: boolean;
   onSelect: (value: T) => void;
   children?: React.ReactText;
 }
@@ -66,7 +69,10 @@ interface ISelectorCellProps<T> {
 export class SelectorCell<T> extends Component<ISelectorCellProps<T>> {
   public render() {
     return (
-      <Cell.CellButton onPress={this.onPress} selected={this.props.selected}>
+      <Cell.CellButton
+        onPress={this.onPress}
+        selected={this.props.selected}
+        disabled={this.props.disabled}>
         <Cell.Icon
           style={this.props.selected ? undefined : styles.invisibleIcon}
           source="icon-tick"

--- a/gui/src/renderer/containers/AdvancedSettingsPage.tsx
+++ b/gui/src/renderer/containers/AdvancedSettingsPage.tsx
@@ -16,6 +16,7 @@ const mapStateToProps = (state: IReduxState) => {
   return {
     enableIpv6: state.settings.enableIpv6,
     blockWhenDisconnected: state.settings.blockWhenDisconnected,
+    wireguardKeyState: state.settings.wireguardKeyState,
     mssfix: state.settings.openVpn.mssfix,
     bridgeState: state.settings.bridgeState,
     ...protocolAndPort,


### PR DESCRIPTION
The WireGuard option in Settings > Advanced > Tunnel Protocol is now disabled if there is no wireguard key and an error message is shown below.

![Screen Shot 2020-01-27 at 14 38 29](https://user-images.githubusercontent.com/3668602/73179884-8aad8380-4114-11ea-81a6-76cd2ce49d9d.png)

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1419)
<!-- Reviewable:end -->
