### PR TITLE
Only unsubscribe listeners if destroying activity

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -90,14 +90,13 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onStop() {
-        serviceNotifier.unsubscribeAll()
-
         unbindService(serviceConnectionManager)
 
         super.onStop()
     }
 
     override fun onDestroy() {
+        serviceNotifier.unsubscribeAll()
         serviceConnection?.onDestroy()
 
         super.onDestroy()


### PR DESCRIPTION
Previously, `MainActivity` would unsubscribe all service listeners when it was stopping (i.e., going to the background). However, that meant that once it resumed all UI fragments that were sub-classes of `ServiceAwareFragment` would still reference the old service, which might have been stopped or replaced, and wouldn't receive any updates if the service connection is dropped or replaced.

This PR makes sure the listeners are only unsubscribed when the activity is being destroyed, so that `ServiceAwareFragment`s can keep receiving service connection events.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes bug that's not present in any released version**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1426)
<!-- Reviewable:end -->
