### PR TITLE
Fix JNI method entrypoint name for destructor

### DIFF
--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -287,7 +287,7 @@ fn get_daemon_interface_address(env: &JnixEnv<'_>, this: &JObject<'_>) -> *mut D
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub extern "system" fn Java_net_mullvad_mullvadvpn_MullvadDaemon_deinitialize(
+pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_deinitialize(
     env: JNIEnv<'_>,
     this: JObject<'_>,
 ) {


### PR DESCRIPTION
This PR fixes the name of the function implementing the JNI method that's called when the garbage collector destroys `MullvadDaemon`.

In theory, having the JNI entrypoint with a wrong name should cause the app to crash, but such behavior hasn't been noticed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not present in any publicly released version**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1427)
<!-- Reviewable:end -->
