### PR TITLE
Copy WireGuard key when clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add translations for Finnish and Danish.
+- Copy WireGuard key when clicking on it.
 
 ### Changed
 - Increase OpenVPN ping timeout from 20 to 25 seconds. Might make working tunnels disconnect

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -50,7 +50,6 @@ export default class Account extends Component<IProps> {
                     <ClipboardLabel
                       style={styles.account__row_value}
                       value={this.props.accountToken || ''}
-                      message={messages.pgettext('account-view', 'COPIED TO CLIPBOARD!')}
                     />
                   </View>
 

--- a/gui/src/renderer/components/ClipboardLabel.tsx
+++ b/gui/src/renderer/components/ClipboardLabel.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Clipboard, Component, Text, Types } from 'reactxp';
+import { messages } from '../../shared/gettext';
 
 interface IProps {
   value: string;
@@ -16,7 +17,7 @@ interface IState {
 export default class ClipboardLabel extends Component<IProps, IState> {
   public static defaultProps: Partial<IProps> = {
     delay: 3000,
-    message: 'Copied!',
+    message: messages.gettext('COPIED TO CLIPBOARD!'),
   };
 
   public state: IState = {

--- a/gui/src/renderer/components/ClipboardLabel.tsx
+++ b/gui/src/renderer/components/ClipboardLabel.tsx
@@ -3,6 +3,7 @@ import { Clipboard, Component, Text, Types } from 'reactxp';
 
 interface IProps {
   value: string;
+  displayValue?: string;
   delay: number;
   message: string;
   style?: Types.TextStyleRuleSet;
@@ -31,9 +32,10 @@ export default class ClipboardLabel extends Component<IProps, IState> {
   }
 
   public render() {
+    const displayValue = this.props.displayValue || this.props.value;
     return (
       <Text style={this.props.style} onPress={this.handlePress}>
-        {this.state.showsMessage ? this.props.message : this.props.value}
+        {this.state.showsMessage ? this.props.message : displayValue}
       </Text>
     );
   }

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -6,6 +6,7 @@ import { sprintf } from 'sprintf-js';
 import { messages } from '../../shared/gettext';
 import { IWgKey, WgKeyState } from '../redux/settings/reducers';
 import * as AppButton from './AppButton';
+import ClipboardLabel from './ClipboardLabel';
 import ImageView from './ImageView';
 import { Container, Layout } from './Layout';
 import { BackBarItem, NavigationBar, NavigationContainer, NavigationItems } from './NavigationBar';
@@ -166,10 +167,15 @@ export default class WireguardKeys extends Component<IProps> {
       case 'being-verified':
       case 'key-set':
         // mimicking the truncating of the key from website
+        const publicKey = this.props.keyState.key.publicKey;
         return (
           <View title={this.props.keyState.key.publicKey}>
             <Text style={styles.wgkeys__row_value}>
-              {this.props.keyState.key.publicKey.substring(0, 20) + '...'}
+              <ClipboardLabel
+                value={publicKey}
+                displayValue={publicKey.substring(0, 20) + '...'}
+                message={messages.pgettext('account-view', 'COPIED TO CLIPBOARD!')}
+              />
             </Text>
           </View>
         );

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -171,11 +171,7 @@ export default class WireguardKeys extends Component<IProps> {
         return (
           <View title={this.props.keyState.key.publicKey}>
             <Text style={styles.wgkeys__row_value}>
-              <ClipboardLabel
-                value={publicKey}
-                displayValue={publicKey.substring(0, 20) + '...'}
-                message={messages.pgettext('account-view', 'COPIED TO CLIPBOARD!')}
-              />
+              <ClipboardLabel value={publicKey} displayValue={publicKey.substring(0, 20) + '...'} />
             </Text>
           </View>
         );


### PR DESCRIPTION
This PR adds functionally to copy WireGuard key when clicking on it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1428)
<!-- Reviewable:end -->
