### PR TITLE
Use system settings to conenct on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Wait for traffic to be routed through the tunnel device before advertising blocked state.
+- Connect automatically if `MullvadVpnService` is started with an intent which
+  has the `android.net.VpnService` action. Effectively, this should enable
+  _Always On_ behavior on Android versions where it's supported.
 
 ### Fixed
 - Don't try to replace WireGuard key if account has too many keys already.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service
 
 import android.content.Intent
+import android.net.VpnService
 import android.os.Binder
 import android.os.IBinder
 import kotlinx.coroutines.Deferred
@@ -59,6 +60,14 @@ class MullvadVpnService : TalpidVpnService() {
         fun stop() {
             this@MullvadVpnService.stop()
         }
+    }
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        val startResult = super.onStartCommand(intent, flags, startId)
+        if (intent.getAction() == VpnService.SERVICE_INTERFACE) {
+            runBlocking { daemon.await().connect() }
+        }
+        return startResult
     }
 
     private fun setUp() {


### PR DESCRIPTION
These changes ensure the deamon will attempt to connect to a tunnel on startup if the VPN service was started by the system. This allows the application to honor the _Always On_ system setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1429)
<!-- Reviewable:end -->
