### PR TITLE
Dismiss notification after service has stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Line wrap the file at 100 chars.                                              Th
 - Restart background service if it stops responding.
 - Fix crash when VPN permission is revoked, either manually or by starting another VPN app.
 - Fix crash caused by local JNI reference table overflow after running for a long time.
+- Dismiss notification after service has stopped.
 
 ### Security
 #### Windows

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -169,6 +169,8 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
 
             stopForeground(true)
         }
+
+        notificationManager.cancel(FOREGROUND_NOTIFICATION_ID)
     }
 
     private fun initChannel() {


### PR DESCRIPTION
Previously, the app could enter a state where the notification would still be visible even after the service had stopped. In this state, the information would be stale and the buttons wouldn't work.

This PR fixes that by forcefully dismissing the notification when the service stops.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1431)
<!-- Reviewable:end -->
