### PR TITLE
Allow notification to be dismissed when disconnected and UI is not shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 - Connect automatically if `MullvadVpnService` is started with an intent which
   has the `android.net.VpnService` action. Effectively, this should enable
   _Always On_ behavior on Android versions where it's supported.
+- Allow notification to be dismissed when the UI is not shown and the tunnel is disconnected.
 
 #### Windows
 - Use a branded TAP driver for OpenVPN to prevent conflicts with other software and solve issues

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -50,7 +50,7 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
         }
 
     private val shouldBeOnForeground
-        get() = !(tunnelState is TunnelState.Disconnected)
+        get() = lockedToForeground || !(tunnelState is TunnelState.Disconnected)
 
     private val notificationText: Int
         get() {
@@ -142,10 +142,17 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
 
     var onConnect: (() -> Unit)? = null
     var onDisconnect: (() -> Unit)? = null
+
     var loggedIn = false
         set(value) {
             field = value
             updateNotification()
+        }
+
+    var lockedToForeground = false
+        set(value) {
+            field = value
+            updateNotificationForegroundStatus()
         }
 
     init {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -31,6 +31,13 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
     private var isBound = false
+        set(value) {
+            field = value
+
+            if (this::notificationManager.isInitialized) {
+                notificationManager.lockedToForeground = value
+            }
+        }
 
     override fun onCreate() {
         super.onCreate()
@@ -116,6 +123,7 @@ class MullvadVpnService : TalpidVpnService() {
         return ForegroundNotificationManager(this, connectionProxy).apply {
             onConnect = { connectionProxy.connect() }
             onDisconnect = { connectionProxy.disconnect() }
+            lockedToForeground = isBound
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -24,16 +24,28 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
+    private var bindCount = 0
+        set(value) {
+            field = value
+            isBound = bindCount != 0
+        }
+
+    private var isBound = false
+
     override fun onCreate() {
         super.onCreate()
         setUp()
     }
 
     override fun onBind(intent: Intent): IBinder {
+        bindCount += 1
+
         return super.onBind(intent) ?: binder
     }
 
     override fun onRebind(intent: Intent) {
+        bindCount += 1
+
         if (isStopping) {
             restart()
             isStopping = false
@@ -45,6 +57,8 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     override fun onUnbind(intent: Intent): Boolean {
+        bindCount -= 1
+
         return true
     }
 


### PR DESCRIPTION
Previously, the notification would always be visible so that the service wouldn't get prematurely killed by Android. The only way to dismiss the notification was to quit the app manually.

This PR changes that so that the notification can be swiped away when the tunnel is down and the UI is not shown. The service will still be running, but it may be killed at any time by the Android system. If the tunnel is connected or if the Mullvad app is in the foreground, the service will stay in the foreground and hence the notification will be kept always visible. As soon as the user switches to a different app, the notification may be dismissed if/when the tunnel is disconnected.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1433)
<!-- Reviewable:end -->
