### PR TITLE
Fix translation of "System default" after selecting that in language settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix bogus update notification caused by an outdated cache.
 - Fix layout issues when showing messages in WireGuard key view.
 - Disable WireGuard protocol option if there's no WireGuard key.
+- Fix translation of "System default" after selecting "System default" in language settings.
 
 #### Windows
 - Fix regression due to which a TAP adapter issue was not given as the specific block reason when

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -392,7 +392,7 @@ export default class AppRenderer {
     IpcRendererEventChannel.guiSettings.setPreferredLocale(preferredLocale);
   }
 
-  private getPreferredLocaleDisplayName(localeCode: string): string {
+  public getPreferredLocaleDisplayName(localeCode: string): string {
     const preferredLocale = this.getPreferredLocaleList().find((item) => item.code === localeCode);
 
     return preferredLocale ? preferredLocale.name : '';
@@ -691,9 +691,6 @@ export default class AppRenderer {
   private setGuiSettings(guiSettings: IGuiSettingsState) {
     this.guiSettings = guiSettings;
     this.reduxActions.settings.updateGuiSettings(guiSettings);
-    this.reduxActions.userInterface.updatePreferredLocaleName(
-      this.getPreferredLocaleDisplayName(guiSettings.preferredLocale),
-    );
   }
 
   private setAccountExpiry(expiry?: string) {

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -3,10 +3,13 @@ import { remote, shell } from 'electron';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Settings from '../components/Settings';
+import withAppContext, { IAppContext } from '../context';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 
-const mapStateToProps = (state: IReduxState) => ({
-  preferredLocaleDisplayName: state.userInterface.preferredLocaleName,
+const mapStateToProps = (state: IReduxState, props: IAppContext) => ({
+  preferredLocaleDisplayName: props.app.getPreferredLocaleDisplayName(
+    state.settings.guiSettings.preferredLocale,
+  ),
   loginState: state.account.status,
   accountExpiry: state.account.expiry,
   expiryLocale: state.userInterface.locale,
@@ -29,7 +32,9 @@ const mapDispatchToProps = (dispatch: ReduxDispatch) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Settings);
+export default withAppContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(Settings),
+);

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -5,11 +5,6 @@ export interface IUpdateLocaleAction {
   locale: string;
 }
 
-export interface IUpdatePreferredLocaleNameAction {
-  type: 'UPDATE_PREFERRED_LOCALE_NAME';
-  name: string;
-}
-
 export interface IUpdateWindowArrowPositionAction {
   type: 'UPDATE_WINDOW_ARROW_POSITION';
   arrowPosition: number;
@@ -26,7 +21,6 @@ export interface ISetLocationScopeAction {
 
 export type UserInterfaceAction =
   | IUpdateLocaleAction
-  | IUpdatePreferredLocaleNameAction
   | IUpdateWindowArrowPositionAction
   | IUpdateConnectionInfoOpenAction
   | ISetLocationScopeAction;
@@ -35,13 +29,6 @@ function updateLocale(locale: string): IUpdateLocaleAction {
   return {
     type: 'UPDATE_LOCALE',
     locale,
-  };
-}
-
-function updatePreferredLocaleName(name: string): IUpdatePreferredLocaleNameAction {
-  return {
-    type: 'UPDATE_PREFERRED_LOCALE_NAME',
-    name,
   };
 }
 
@@ -67,7 +54,6 @@ function setLocationScope(scope: LocationScope): ISetLocationScopeAction {
 
 export default {
   updateLocale,
-  updatePreferredLocaleName,
   updateWindowArrowPosition,
   toggleConnectionPanel,
   setLocationScope,

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -7,7 +7,6 @@ export enum LocationScope {
 
 export interface IUserInterfaceReduxState {
   locale: string;
-  preferredLocaleName: string;
   arrowPosition?: number;
   connectionPanelVisible: boolean;
   locationScope: LocationScope;
@@ -15,7 +14,6 @@ export interface IUserInterfaceReduxState {
 
 const initialState: IUserInterfaceReduxState = {
   locale: 'en',
-  preferredLocaleName: 'English',
   connectionPanelVisible: false,
   locationScope: LocationScope.relay,
 };
@@ -27,9 +25,6 @@ export default function(
   switch (action.type) {
     case 'UPDATE_LOCALE':
       return { ...state, locale: action.locale };
-
-    case 'UPDATE_PREFERRED_LOCALE_NAME':
-      return { ...state, preferredLocaleName: action.name };
 
     case 'UPDATE_WINDOW_ARROW_POSITION':
       return { ...state, arrowPosition: action.arrowPosition };


### PR DESCRIPTION
This fixes the display of "System default" when selected in languages. The issue before was that the name selected language was saved to the redux state before the translations switched to the new language. Now only the locale code is saved in the state and is translated to a language name when needed. 

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1434)
<!-- Reviewable:end -->
