### PR TITLE
Fix graphical glitch when ConnectionPanel labels overflowing

### DIFF
--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -49,6 +49,7 @@ const styles = {
   caption: Styles.createTextStyle({
     fontFamily: 'Open Sans',
     fontSize: 13,
+    lineHeight: 15,
     fontWeight: '600',
     color: 'rgb(255, 255, 255)',
     flex: 0,
@@ -57,6 +58,7 @@ const styles = {
   value: Styles.createTextStyle({
     fontFamily: 'Open Sans',
     fontSize: 13,
+    lineHeight: 15,
     fontWeight: '600',
     color: 'rgb(255, 255, 255)',
     letterSpacing: -0.2,


### PR DESCRIPTION
Text components are 1px higher now than before to make room for characters reaching below the baseline.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1435)
<!-- Reviewable:end -->
