### PR TITLE
Windows: Improve route installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Use a branded TAP driver for OpenVPN to prevent conflicts with other software and solve issues
   related to driver upgrades. Also use the NDIS 6 driver on Windows 7.
-
+- Be more aggressive when installing routes, in effect taking ownership of existing duplicate route
+  entries. This allows the daemon to initialize properly even if a previous instance did not have a
+  clean shutdown.
+  
 ### Fixed
 - Don't try to replace WireGuard key if account has too many keys already.
 - Fix bogus update notification caused by an outdated cache.

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -160,7 +160,7 @@ impl WgGoTunnel {
     #[cfg(target_os = "windows")]
     pub unsafe extern "system" fn default_route_changed_callback(
         event_type: winnet::WinNetDefaultRouteChangeEventType,
-        address_family: winnet::WinNetIpFamily,
+        address_family: winnet::WinNetAddrFamily,
         interface_luid: u64,
         _ctx: *mut libc::c_void,
     ) {

--- a/windows/winnet/src/winnet/converters.cpp
+++ b/windows/winnet/src/winnet/converters.cpp
@@ -1,0 +1,118 @@
+#include <stdafx.h>
+#include "converters.h"
+#include <libcommon/error.h>
+#include <cstdint>
+
+using namespace winnet::routing;
+
+namespace
+{
+
+SOCKADDR_INET IpToNative(const WINNET_IP &from)
+{
+	SOCKADDR_INET to = { 0 };
+
+	switch (from.family)
+	{
+		case WINNET_ADDR_FAMILY_IPV4:
+		{
+			to.Ipv4.sin_family = AF_INET;
+			to.Ipv4.sin_addr.s_addr = *reinterpret_cast<const uint32_t*>(from.bytes);
+
+			break;
+		}
+		case WINNET_ADDR_FAMILY_IPV6:
+		{
+			to.Ipv6.sin6_family = AF_INET6;
+			memcpy(to.Ipv6.sin6_addr.u.Byte, from.bytes, 16);
+
+			break;
+		}
+		default:
+		{
+			THROW_ERROR("Invalid network address family");
+		}
+	}
+
+	return to;
+}
+
+} // anonymous namespace
+
+namespace winnet
+{
+
+Network ConvertNetwork(const WINNET_IP_NETWORK &in)
+{
+	//
+	// Convert WINNET_IPNETWORK into Network aka IP_ADDRESS_PREFIX
+	//
+
+	Network out = { 0 };
+
+	out.PrefixLength = in.prefix;
+	out.Prefix = IpToNative(in.addr);
+
+	return out;
+}
+
+std::optional<Node> ConvertNode(const WINNET_NODE *in)
+{
+	if (nullptr == in)
+	{
+		return std::nullopt;
+	}
+
+	if (nullptr == in->deviceName && nullptr == in->gateway)
+	{
+		THROW_ERROR("Invalid 'WINNET_NODE' definition");
+	}
+
+	std::optional<std::wstring> deviceName;
+	std::optional<NodeAddress> gateway;
+
+	if (nullptr != in->deviceName)
+	{
+		deviceName = in->deviceName;
+	}
+
+	if (nullptr != in->gateway)
+	{
+		gateway = IpToNative(*in->gateway);
+	}
+
+	return Node(deviceName, gateway);
+}
+
+std::vector<Route> ConvertRoutes(const WINNET_ROUTE *routes, uint32_t numRoutes)
+{
+	std::vector<Route> out;
+
+	out.reserve(numRoutes);
+
+	for (size_t i = 0; i < numRoutes; ++i)
+	{
+		out.emplace_back(Route
+		{
+			ConvertNetwork(routes[i].network),
+			ConvertNode(routes[i].node)
+		});
+	}
+
+	return out;
+}
+
+std::vector<SOCKADDR_INET> ConvertAddresses(const WINNET_IP *addresses, uint32_t numAddresses)
+{
+	std::vector<SOCKADDR_INET> out;
+	out.reserve(numAddresses);
+
+	for (uint32_t i = 0; i < numAddresses; ++i)
+	{
+		out.emplace_back(IpToNative(addresses[i]));
+	}
+
+	return out;
+}
+
+}

--- a/windows/winnet/src/winnet/converters.h
+++ b/windows/winnet/src/winnet/converters.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "winnet.h"
+#include "routing/types.h"
+#include <optional>
+#include <vector>
+
+namespace winnet
+{
+
+routing::Network ConvertNetwork(const WINNET_IP_NETWORK &in);
+std::optional<routing::Node> ConvertNode(const WINNET_NODE *in);
+std::vector<routing::Route> ConvertRoutes(const WINNET_ROUTE *routes, uint32_t numRoutes);
+std::vector<SOCKADDR_INET> ConvertAddresses(const WINNET_IP *addresses, uint32_t numAddresses);
+
+}

--- a/windows/winnet/src/winnet/routing/helpers.cpp
+++ b/windows/winnet/src/winnet/routing/helpers.cpp
@@ -3,7 +3,6 @@
 #include <ws2def.h>
 #include <in6addr.h>
 #include <numeric>
-//#include <netioapi.h>
 #include <libcommon/error.h>
 #include <libcommon/memory.h>
 

--- a/windows/winnet/src/winnet/routing/helpers.h
+++ b/windows/winnet/src/winnet/routing/helpers.h
@@ -41,6 +41,5 @@ std::vector<const SOCKET_ADDRESS *> IsolateGatewayAddresses
 
 bool AddressPresent(const std::vector<const SOCKET_ADDRESS *> &hay, const SOCKADDR_INET *needle);
 
-//NodeAddress ConvertSocketAddress(const SOCKET_ADDRESS *sa);
 
 }

--- a/windows/winnet/src/winnet/routing/routemanager.cpp
+++ b/windows/winnet/src/winnet/routing/routemanager.cpp
@@ -604,6 +604,11 @@ void RouteManager::defaultRouteChanged(ADDRESS_FAMILY family, DefaultRouteMonito
 
 	for (auto &it : affectedRoutes)
 	{
+		//
+		// We can't update the existing route because defining characteristics are being changed.
+		// So removing and adding again is the only option.
+		//
+
 		try
 		{
 			deleteFromRoutingTable(it->registeredRoute);

--- a/windows/winnet/src/winnet/routing/routemanager.h
+++ b/windows/winnet/src/winnet/routing/routemanager.h
@@ -30,10 +30,7 @@ public:
 	RouteManager &operator=(RouteManager &&) = delete;
 	
 	void addRoutes(const std::vector<Route> &routes);
-	void addRoute(const Route &route);
-
 	void deleteRoutes(const std::vector<Route> &routes);
-	void deleteRoute(const Route &route);
 
 	using DefaultRouteChangedEventType = DefaultRouteMonitor::EventType;
 

--- a/windows/winnet/src/winnet/routing/types.cpp
+++ b/windows/winnet/src/winnet/routing/types.cpp
@@ -39,6 +39,10 @@ bool Node::operator==(const Node &rhs) const
 			return false;
 		}
 	}
+	else if (rhs.m_deviceName.has_value())
+	{
+		return false;
+	}
 
 	if (m_gateway.has_value())
 	{
@@ -47,6 +51,10 @@ bool Node::operator==(const Node &rhs) const
 		{
 			return false;
 		}
+	}
+	else if (rhs.m_gateway.has_value())
+	{
+		return false;
 	}
 
 	return true;

--- a/windows/winnet/src/winnet/routing/types.h
+++ b/windows/winnet/src/winnet/routing/types.h
@@ -7,9 +7,6 @@
 #include <ws2def.h>
 #include <ws2ipdef.h>
 #include <iphlpapi.h>
-//#include <netioapi.h>
-//#include <functional>
-
 
 namespace winnet::routing
 {

--- a/windows/winnet/src/winnet/winnet.cpp
+++ b/windows/winnet/src/winnet/winnet.cpp
@@ -366,10 +366,10 @@ WinNet_RegisterDefaultRouteChangedCallback(
 			// Translate the family type.
 			//
 
-			static const std::pair<ADDRESS_FAMILY, WINNET_IP_FAMILY> familyMap[] =
+			static const std::pair<ADDRESS_FAMILY, WINNET_ADDR_FAMILY> familyMap[] =
 			{
-				{ static_cast<ADDRESS_FAMILY>(AF_INET), WINNET_IP_FAMILY_V4 },
-				{ static_cast<ADDRESS_FAMILY>(AF_INET6), WINNET_IP_FAMILY_V6 }
+				{ static_cast<ADDRESS_FAMILY>(AF_INET), WINNET_ADDR_FAMILY_IPV4 },
+				{ static_cast<ADDRESS_FAMILY>(AF_INET6), WINNET_ADDR_FAMILY_IPV6 }
 			};
 
 			const auto translatedFamily = common::ValueMapper::Map<>(family, familyMap);

--- a/windows/winnet/src/winnet/winnet.cpp
+++ b/windows/winnet/src/winnet/winnet.cpp
@@ -428,31 +428,7 @@ WinNet_AddRoute(
 	const WINNET_ROUTE *route
 )
 {
-	AutoLockType lock(g_RouteManagerLock);
-
-	if (nullptr == g_RouteManager)
-	{
-		return false;
-	}
-
-	try
-	{
-		g_RouteManager->addRoute
-		(
-			Route{ ConvertNetwork(route->network), ConvertNode(route->node) }
-		);
-
-		return true;
-	}
-	catch (const std::exception &err)
-	{
-		common::error::UnwindException(err, g_RouteManagerLogSink);
-		return false;
-	}
-	catch (...)
-	{
-		return false;
-	}
+	return WinNet_AddRoutes(route, 1);
 }
 
 extern "C"
@@ -495,31 +471,7 @@ WinNet_DeleteRoute(
 	const WINNET_ROUTE *route
 )
 {
-	AutoLockType lock(g_RouteManagerLock);
-
-	if (nullptr == g_RouteManager)
-	{
-		return false;
-	}
-
-	try
-	{
-		g_RouteManager->deleteRoute
-		(
-			Route{ ConvertNetwork(route->network), ConvertNode(route->node) }
-		);
-
-		return true;
-	}
-	catch (const std::exception &err)
-	{
-		common::error::UnwindException(err, g_RouteManagerLogSink);
-		return false;
-	}
-	catch (...)
-	{
-		return false;
-	}
+	return WinNet_DeleteRoutes(route, 1);
 }
 
 extern "C"

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -177,20 +177,14 @@ enum WINNET_DEFAULT_ROUTE_CHANGED_EVENT_TYPE
 	WINNET_DEFAULT_ROUTE_CHANGED_EVENT_TYPE_REMOVED = 1,
 };
 
-enum WINNET_IP_FAMILY
-{
-	WINNET_IP_FAMILY_V4 = 0,
-	WINNET_IP_FAMILY_V6 = 1,
-};
-
 typedef void (WINNET_API *WinNetDefaultRouteChangedCallback)
 (
 	WINNET_DEFAULT_ROUTE_CHANGED_EVENT_TYPE eventType,
 
-	// Signals which IP family the event relates to.
-	WINNET_IP_FAMILY family,
+	// Indicates which IP family the event relates to.
+	WINNET_ADDR_FAMILY family,
 
-	// For update events, signals the interface associated with the new best default route.
+	// For update events, indicates the interface associated with the new best default route.
 	uint64_t interfaceLuid,
 
 	void *context

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -91,26 +91,25 @@ WINNET_API
 WinNet_DeactivateConnectivityMonitor(
 );
 
-enum WINNET_IP_TYPE
+enum WINNET_ADDR_FAMILY
 {
-	WINNET_IP_TYPE_IPV4 = 0,
-	WINNET_IP_TYPE_IPV6 = 1,
+	WINNET_ADDR_FAMILY_IPV4 = 0,
+	WINNET_ADDR_FAMILY_IPV6 = 1,
 };
-
-typedef struct tag_WINNET_IPNETWORK
-{
-	WINNET_IP_TYPE type;
-	uint8_t bytes[16];	// Network byte order.
-	uint8_t prefix;
-}
-WINNET_IPNETWORK;
 
 typedef struct tag_WINNET_IP
 {
-	WINNET_IP_TYPE type;
+	WINNET_ADDR_FAMILY family;
 	uint8_t bytes[16];	// Network byte order.
 }
 WINNET_IP;
+
+typedef struct tag_WINNET_IP_NETWORK
+{
+	uint8_t prefix;
+	WINNET_IP addr;
+}
+WINNET_IP_NETWORK;
 
 typedef struct tag_WINNET_NODE
 {
@@ -121,7 +120,7 @@ WINNET_NODE;
 
 typedef struct tag_WINNET_ROUTE
 {
-	WINNET_IPNETWORK network;
+	WINNET_IP_NETWORK network;
 	const WINNET_NODE *node;
 }
 WINNET_ROUTE;

--- a/windows/winnet/src/winnet/winnet.vcxproj
+++ b/windows/winnet/src/winnet/winnet.vcxproj
@@ -27,6 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="converters.cpp" />
     <ClCompile Include="networkadaptermonitor.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="InterfacePair.cpp" />
@@ -40,6 +41,7 @@
     <ClCompile Include="winnet.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="converters.h" />
     <ClInclude Include="networkadaptermonitor.h" />
     <ClInclude Include="InterfacePair.h" />
     <ClInclude Include="offlinemonitor.h" />

--- a/windows/winnet/src/winnet/winnet.vcxproj.filters
+++ b/windows/winnet/src/winnet/winnet.vcxproj.filters
@@ -20,6 +20,7 @@
     <ClCompile Include="routing\routemanager.cpp">
       <Filter>routing</Filter>
     </ClCompile>
+    <ClCompile Include="converters.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -41,6 +42,7 @@
     <ClInclude Include="routing\routemanager.h">
       <Filter>routing</Filter>
     </ClInclude>
+    <ClInclude Include="converters.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="winnet.def" />


### PR DESCRIPTION
These changes primarily address how routes are being installed. We're now more aggressive with overwriting existing routes.

The old logic in `addRoutes()` was a little flawed because the `Route` type doesn't map 1:1 to the `RegisteredRoute` type. Also, the `Node` type's `operator==` was flawed.

There are also a number of changes that improve and simplify the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1437)
<!-- Reviewable:end -->
