### PR TITLE
Use `opt-level=s` for the release profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Line wrap the file at 100 chars.                                              Th
 - Updated `wireguard-go` to `v0.0.20200121`
 - Use traffic data from WireGuard to infer connectivity to improve stability of the connection.
 - Remove WireGuard keys from accounts when they are removed from the local account history.
+- Change the optimization level for releases from the default value to `s`, as a temporary fix for
+  the system service crashing on Windows for newer CPU models.
 
 #### Linux
 - DNS management with static `/etc/resolv.conf` will now work even when no

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ members = [
     "talpid-ipc",
 ]
 exclude = ["dist-assets/binaries/shadowsocks-rust"]
+
+[profile.release]
+opt-level = "s"


### PR DESCRIPTION
Adding `opt-level=s` to fix issues on Windows with newer CPUs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1438)
<!-- Reviewable:end -->
