### PR TITLE
Drop dev1 suffix

### DIFF
--- a/ios/MullvadVPN/Info.plist
+++ b/ios/MullvadVPN/Info.plist
@@ -24,8 +24,6 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MullvadVersionSuffix</key>
-	<string>dev1</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR drops the `dev1` suffix key from `Info.plist` so that the app would display `2020.1` instead of `2020.1-dev1` under the version field in Settings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1439)
<!-- Reviewable:end -->
