### PR TITLE
Changes to firewall rules with "Allow LAN" enabled

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -74,13 +74,17 @@ The following network traffic is allowed or blocked independent of state:
      * `10.0.0.0/8`
      * `172.16.0.0/12`
      * `192.168.0.0/16`
-     * `169.254.0.0/16`
-     * `fe80::/10`
+     * `169.254.0.0/16` (Link-local IPv4 range)
+     * `fe80::/10` (Link-local IPv6 range)
+     * `fd00::/8` (Unique-local range)
    * Outgoing to any IP in a local, unroutable, multicast network, meaning these:
-     * `224.0.0.0/24` (local subnet IPv4 multicast)
-     * `239.255.255.250/32` (SSDP)
-     * `239.255.255.251/32` (mDNS)
+     * `224.0.0.0/24` (Local subnet IPv4 multicast)
+     * `239.255.0.0/16` (IPv4 local scope. eg. SSDP and mDNS)
+     * `255.255.255.255/32` (Broadcasts to the local network)
+     * `ff01::/16` (Interface-local multicast. Local to a single interface on a node.)
      * `ff02::/16` (Link-local IPv6 multicast. IPv6 equivalent of `224.0.0.0/24`)
+     * `ff03::/16` (Realm-local IPv6 multicast)
+     * `ff04::/16` (Admin-local IPv6 multicast)
      * `ff05::/16` (Site-local IPv6 multicast. Is routable, but should never leave the "site")
    * Incoming DHCPv4 requests and outgoing responses (be a DHCPv4 server):
      * Incoming UDP from `*:68` to `255.255.255.255:67`

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -40,15 +40,13 @@ lazy_static! {
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0), 8).unwrap()),
     ];
     /// When "allow local network" is enabled the app will allow traffic to these networks.
-    pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 6] = [
+    pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 5] = [
         // Local network broadcast. Not routable
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(255, 255, 255, 255), 32).unwrap()),
         // Local subnetwork multicast. Not routable
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
-        // Simple Service Discovery Protocol (SSDP) address
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 255, 250), 32).unwrap()),
-        // mDNS Service Discovery address
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 255, 251), 32).unwrap()),
+        // Local scope (mDNS and SSDP) address
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 0, 0), 16).unwrap()),
         // Link-local IPv6 multicast. IPv6 equivalent of 224.0.0.0/24
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
         // Site-local IPv6 multicast.

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -40,7 +40,9 @@ lazy_static! {
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0), 8).unwrap()),
     ];
     /// When "allow local network" is enabled the app will allow traffic to these networks.
-    pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 5] = [
+    pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 6] = [
+        // Local network broadcast. Not routable
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(255, 255, 255, 255), 32).unwrap()),
         // Local subnetwork multicast. Not routable
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
         // Simple Service Discovery Protocol (SSDP) address

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -31,12 +31,13 @@ pub use self::imp::Error;
 #[cfg(unix)]
 lazy_static! {
     /// When "allow local network" is enabled the app will allow traffic to and from these networks.
-    pub(crate) static ref ALLOWED_LAN_NETS: [IpNetwork; 5] = [
+    pub(crate) static ref ALLOWED_LAN_NETS: [IpNetwork; 6] = [
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(169, 254, 0, 0), 16).unwrap()),
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap()),
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0), 8).unwrap()),
     ];
     /// When "allow local network" is enabled the app will allow traffic to these networks.
     pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 5] = [

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -40,15 +40,21 @@ lazy_static! {
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0), 8).unwrap()),
     ];
     /// When "allow local network" is enabled the app will allow traffic to these networks.
-    pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 5] = [
+    pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 8] = [
         // Local network broadcast. Not routable
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(255, 255, 255, 255), 32).unwrap()),
         // Local subnetwork multicast. Not routable
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
         // Local scope (mDNS and SSDP) address
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 0, 0), 16).unwrap()),
+        // Interface-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff01, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
         // Link-local IPv6 multicast. IPv6 equivalent of 224.0.0.0/24
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+        // Realm-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff03, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+        // Admin-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff04, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
         // Site-local IPv6 multicast.
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
     ];

--- a/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
@@ -90,8 +90,10 @@ bool PermitLan::applyIpv6(IObjectInstaller &objectInstaller) const
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
 
 	const wfp::IpNetwork linkLocal(wfp::IpAddress::Literal6({ 0xFE80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 10);
+	const wfp::IpNetwork uniqueLocal(wfp::IpAddress::Literal6({ 0xFD00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 8);
 
 	conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
+	conditionBuilder.add_condition(ConditionIp::Remote(uniqueLocal));
 
 	if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
 	{

--- a/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
@@ -110,10 +110,16 @@ bool PermitLan::applyIpv6(IObjectInstaller &objectInstaller) const
 
 	conditionBuilder.reset();
 
+	const wfp::IpNetwork interfaceLocalMulticast(wfp::IpAddress::Literal6({ 0xFF01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 16);
 	const wfp::IpNetwork linkLocalMulticast(wfp::IpAddress::Literal6({ 0xFF02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 16);
+	const wfp::IpNetwork realmLocalMulticast(wfp::IpAddress::Literal6({ 0xFF03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 16);
+	const wfp::IpNetwork adminLocalMulticast(wfp::IpAddress::Literal6({ 0xFF04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 16);
 	const wfp::IpNetwork siteLocalMulticast(wfp::IpAddress::Literal6({ 0xFF05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 16);
 
+	conditionBuilder.add_condition(ConditionIp::Remote(interfaceLocalMulticast));
 	conditionBuilder.add_condition(ConditionIp::Remote(linkLocalMulticast));
+	conditionBuilder.add_condition(ConditionIp::Remote(realmLocalMulticast));
+	conditionBuilder.add_condition(ConditionIp::Remote(adminLocalMulticast));
 	conditionBuilder.add_condition(ConditionIp::Remote(siteLocalMulticast));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);

--- a/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
@@ -57,6 +57,9 @@ bool PermitLan::applyIpv4(IObjectInstaller &objectInstaller) const
 
 	conditionBuilder.reset();
 
+	// Local network broadcast.
+	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 255, 255, 255, 255 }), 32)));
+
 	// Local subnet multicast.
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 224, 0, 0, 0 }), 24)));
 

--- a/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
@@ -63,11 +63,8 @@ bool PermitLan::applyIpv4(IObjectInstaller &objectInstaller) const
 	// Local subnet multicast.
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 224, 0, 0, 0 }), 24)));
 
-	// Simple Service Discovery Protocol (SSDP) address.
-	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 239, 255, 255, 250 }), 32)));
-
-	// mDNS Service Discovery address.
-	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 239, 255, 255, 251 }), 32)));
+	// Local scope (SSDP and mDNS)
+	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 239, 255, 0, 0 }), 16)));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }

--- a/windows/winfw/src/winfw/rules/baseline/permitlanservice.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlanservice.cpp
@@ -66,8 +66,10 @@ bool PermitLanService::applyIpv6(IObjectInstaller &objectInstaller) const
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
 
 	const wfp::IpNetwork linkLocal(wfp::IpAddress::Literal6{ 0xFE80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, 10);
+	const wfp::IpNetwork uniqueLocal(wfp::IpAddress::Literal6({ 0xFD00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 8);
 
 	conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
+	conditionBuilder.add_condition(ConditionIp::Remote(uniqueLocal));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }


### PR DESCRIPTION
Changes:
* Allow broadcasts to `255.255.255.255/32`.
* Fewer restrictions to IPv6 multicasting.
* Allow traffic to and from unique-local IPv6 addresses, i.e. `fd00::/8`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1440)
<!-- Reviewable:end -->
