### PR TITLE
Fix NPE when the service is restarted by Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -83,9 +83,9 @@ class MullvadVpnService : TalpidVpnService() {
         }
     }
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val startResult = super.onStartCommand(intent, flags, startId)
-        if (intent.getAction() == VpnService.SERVICE_INTERFACE) {
+        if (intent?.getAction() == VpnService.SERVICE_INTERFACE) {
             runBlocking { daemon.await().connect() }
         }
         return startResult


### PR DESCRIPTION
This PR fixes a `NullPointerException` that happens when the service is restarted by Android after a crash. The `Intent` that is sent to `onStartCommand` is `null` when that happens.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1441)
<!-- Reviewable:end -->
