### PR TITLE
Use weak references in handleEvents

### DIFF
--- a/ios/MullvadVPN/SelectLocationController.swift
+++ b/ios/MullvadVPN/SelectLocationController.swift
@@ -103,12 +103,12 @@ class SelectLocationController: UITableViewController {
                     .map { (filteredRelayList, $0) }
             })
             .receive(on: DispatchQueue.main)
-            .handleEvents(receiveSubscription: { _ in
-                self.activityIndicator.startAnimating()
-            }, receiveCompletion: { _ in
-                self.activityIndicator.stopAnimating()
-            }, receiveCancel: {
-                self.activityIndicator.stopAnimating()
+            .handleEvents(receiveSubscription: { [weak self] _ in
+                self?.activityIndicator.startAnimating()
+            }, receiveCompletion: { [weak self] _ in
+                self?.activityIndicator.stopAnimating()
+            }, receiveCancel: { [weak self] () in
+                self?.activityIndicator.stopAnimating()
             })
             .sink(receiveCompletion: { (completion) in
                 if case .failure(let error) = completion {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

I have noticed that when leaving the Select location controller, the relay list fetch is not being cancelled. This is due to `loadDataSubscriber` being retained by the controller itself and `handleEvents` closures retaining `self` too. Therefore, the controller instance will not be deallocated until after `handleEvents` executed. This PR changes the retain policy to `weak` enabling controller to go away earlier, i.e when user dismisses it manually, and in turn cancel the relay list fetch, i.e. if there was a networking request happening, it would get cancelled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1444)
<!-- Reviewable:end -->
