### PR TITLE
Fix placeholder color in dark mode

### DIFF
--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -46,6 +46,9 @@ class LoginViewController: UIViewController, UITextFieldDelegate, RootContainmen
         super.viewDidLoad()
 
         accountTextField.inputAccessoryView = keyboardToolbar
+        accountTextField.attributedPlaceholder = NSAttributedString(
+            string: "0000 0000 0000 0000",
+            attributes: [.foregroundColor: UIColor.lightGray])
 
         updateDisplayedMessage()
         updateStatusIcon()

--- a/ios/MullvadVPN/SelectLocationController.swift
+++ b/ios/MullvadVPN/SelectLocationController.swift
@@ -103,12 +103,12 @@ class SelectLocationController: UITableViewController {
                     .map { (filteredRelayList, $0) }
             })
             .receive(on: DispatchQueue.main)
-            .handleEvents(receiveSubscription: { _ in
-                self.activityIndicator.startAnimating()
-            }, receiveCompletion: { _ in
-                self.activityIndicator.stopAnimating()
-            }, receiveCancel: {
-                self.activityIndicator.stopAnimating()
+            .handleEvents(receiveSubscription: { [weak self] _ in
+                self?.activityIndicator.startAnimating()
+            }, receiveCompletion: { [weak self] _ in
+                self?.activityIndicator.stopAnimating()
+            }, receiveCancel: { [weak self] () in
+                self?.activityIndicator.stopAnimating()
             })
             .sink(receiveCompletion: { (completion) in
                 if case .failure(let error) = completion {

--- a/ios/MullvadVPN/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UIColor+Palette.swift
@@ -12,7 +12,7 @@ extension UIColor {
 
     enum AccountTextField {
         enum NormalState {
-            static let borderColor = UIColor(red: 0.10, green: 0.18, blue: 0.27, alpha: 1.0)
+            static let borderColor = secondaryColor
             static let textColor = primaryColor
             static let backgroundColor = UIColor.white
         }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

System colors on iOS adapt based on the UI mode (light or dark). We mostly use fixed colors except for placeholder in the account text field. This PR addresses this issue. Unfortunately there is no dedicated property for placeholder color so I had to use attributed string which accepts a payload with text rendering attributes to override.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1445)
<!-- Reviewable:end -->
