### PR TITLE
Move all driver setup code into driverlogic

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -27,8 +27,6 @@
 # Return codes from driverlogic
 !define DL_GENERAL_ERROR 0
 !define DL_GENERAL_SUCCESS 1
-!define DL_DELETE_NO_ADAPTERS_REMAIN 2
-!define DL_DELETE_SOME_ADAPTERS_REMAIN 3
 
 # Log targets
 !define LOG_FILE 0
@@ -198,22 +196,6 @@
 		log::Log $R0
 
 		Goto RemoveVanillaTap_return
-	${EndIf}
-
-	${If} $0 == ${DL_DELETE_NO_ADAPTERS_REMAIN}
-		log::Log "Removing vanilla TAP adapter driver since it is no longer in use"
-
-		nsExec::ExecToStack '"$TEMP\tap-driver\driverlogic.exe" remove ${DEPRECATED_TAP_HARDWARE_ID}'
-
-		Pop $0
-		Pop $1
-
-		${If} $0 != ${DL_GENERAL_SUCCESS}
-			StrCpy $R0 "Failed to remove TAP driver: $1"
-			log::Log $R0
-
-			Goto RemoveVanillaTap_return
-		${EndIf}
 	${EndIf}
 
 	log::Log "RemoveVanillaTap() completed successfully"

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -60,27 +60,27 @@
 !define BreakInstallation '!insertmacro "BreakInstallation"'
 
 #
-# ExtractDriver
+# ExtractTapDriver
 #
 # Extract the correct driver for the current platform
-# placing it into $TEMP\driver
+# placing it into $TEMP\tap-driver
 #
-!macro ExtractDriver
+!macro ExtractTapDriver
 
-	SetOutPath "$TEMP\driver"
+	SetOutPath "$TEMP\tap-driver"
 
 	File "${BUILD_RESOURCES_DIR}\..\windows\driverlogic\bin\x64-Release\driverlogic.exe"
-	File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\driver\*"
+	File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\tap-driver\*"
 
 	${If} ${AtLeastWin10}
-		File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\driver\win10\*"
+		File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\tap-driver\win10\*"
 	${Else}
-		File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\driver\win8\*"
+		File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\tap-driver\win8\*"
 	${EndIf}
 	
 !macroend
 
-!define ExtractDriver '!insertmacro "ExtractDriver"'
+!define ExtractTapDriver '!insertmacro "ExtractTapDriver"'
 
 #
 # ExtractWintun
@@ -165,7 +165,7 @@
 	Push $0
 	Push $1
 
-	nsExec::ExecToStack '"$TEMP\driver\driverlogic.exe" remove ${TAP_HARDWARE_ID}'
+	nsExec::ExecToStack '"$TEMP\tap-driver\driverlogic.exe" remove ${TAP_HARDWARE_ID}'
 	Pop $0
 	Pop $1
 
@@ -188,7 +188,7 @@
 
 	log::Log "RemoveVanillaTap()"
 
-	nsExec::ExecToStack '"$TEMP\driver\driverlogic.exe" remove-vanilla-tap'
+	nsExec::ExecToStack '"$TEMP\tap-driver\driverlogic.exe" remove-vanilla-tap'
 
 	Pop $0
 	Pop $1
@@ -203,13 +203,13 @@
 	${If} $0 == ${DL_DELETE_NO_ADAPTERS_REMAIN}
 		log::Log "Removing vanilla TAP adapter driver since it is no longer in use"
 
-		nsExec::ExecToStack '"$TEMP\driver\driverlogic.exe" remove ${DEPRECATED_TAP_HARDWARE_ID}'
+		nsExec::ExecToStack '"$TEMP\tap-driver\driverlogic.exe" remove ${DEPRECATED_TAP_HARDWARE_ID}'
 
 		Pop $0
 		Pop $1
 
 		${If} $0 != ${DL_GENERAL_SUCCESS}
-			StrCpy $R0 "Failed to remove driver: $1"
+			StrCpy $R0 "Failed to remove TAP driver: $1"
 			log::Log $R0
 
 			Goto RemoveVanillaTap_return
@@ -231,17 +231,17 @@
 !define RemoveVanillaTap '!insertmacro "RemoveVanillaTap"'
 
 #
-# InstallDriver
+# InstallTapDriver
 #
-# Install tunnel driver or update it if already present on the system
+# Install OpenVPN TAP adapter driver
 #
 # Returns: 0 in $R0 on success, otherwise an error message in $R0
 #
-!macro InstallDriver
+!macro InstallTapDriver
 
-	Var /GLOBAL InstallDriver_TapName
+	Var /GLOBAL InstallTapDriver_TapName
 
-	log::Log "InstallDriver()"
+	log::Log "InstallTapDriver()"
 	
 	Push $0
 	Push $1
@@ -257,7 +257,7 @@
 	${IfNot} ${AtLeastWin10}
 		log::Log "Adding OpenVPN certificate to the certificate store"
 
-		nsExec::ExecToStack '"$SYSDIR\certutil.exe" -f -addstore TrustedPublisher "$TEMP\driver\driver.cer"'
+		nsExec::ExecToStack '"$SYSDIR\certutil.exe" -f -addstore TrustedPublisher "$TEMP\tap-driver\driver.cer"'
 		Pop $0
 		Pop $1
 
@@ -268,7 +268,7 @@
 	${EndIf}
 
 	log::Log "Creating new virtual adapter"
-	nsExec::ExecToStack '"$TEMP\driver\driverlogic.exe" install "$TEMP\driver\OemVista.inf"'
+	nsExec::ExecToStack '"$TEMP\tap-driver\driverlogic.exe" install "$TEMP\tap-driver\OemVista.inf"'
 
 	Pop $0
 	Pop $1
@@ -276,11 +276,11 @@
 	${If} $0 != ${DL_GENERAL_SUCCESS}
 		StrCpy $R0 "Failed to create virtual adapter: error $0"
 		log::LogWithDetails $R0 $1
-		Goto InstallDriver_return
+		Goto InstallTapDriver_return
 	${EndIf}
 
 	log::Log "Identifying recently added adapter"
-	nsExec::ExecToStack '"$TEMP\driver\driverlogic.exe" find-tap'
+	nsExec::ExecToStack '"$TEMP\tap-driver\driverlogic.exe" find-tap'
 
 	Pop $0
 	Pop $1
@@ -288,10 +288,10 @@
 	${If} $0 != ${DL_GENERAL_SUCCESS}
 		StrCpy $R0 "Failed to identify new adapter: $1"
 		log::Log $R0
-		Goto InstallDriver_return
+		Goto InstallTapDriver_return
 	${EndIf}
 
-	StrCpy $InstallDriver_TapName $1
+	StrCpy $InstallTapDriver_TapName $1
 	
 	log::Log "New virtual adapter is named $\"$1$\""
 	log::Log "Renaming adapter to $\"Mullvad$\""
@@ -305,26 +305,26 @@
 		StrCpy $R0 "Failed to rename virtual adapter: error $0"
 		log::LogWithDetails $R0 $1
 
-		${ForceRenameAdapter} $InstallDriver_TapName "Mullvad"
+		${ForceRenameAdapter} $InstallTapDriver_TapName "Mullvad"
 
 		${If} $R0 != 0
-			Goto InstallDriver_return
+			Goto InstallTapDriver_return
 		${EndIf}
 	${EndIf}
 
-	log::Log "InstallDriver() completed successfully"
+	log::Log "InstallTapDriver() completed successfully"
 	
 	Push 0
 	Pop $R0
 	
-	InstallDriver_return:
+	InstallTapDriver_return:
 
 	Pop $1
 	Pop $0
 	
 !macroend
 
-!define InstallDriver '!insertmacro "InstallDriver"'
+!define InstallTapDriver '!insertmacro "InstallTapDriver"'
 
 #
 # RemoveWintun
@@ -755,8 +755,8 @@
 
 	${RemoveRelayCache}
 	
-	${ExtractDriver}
-	${InstallDriver}
+	${ExtractTapDriver}
+	${InstallTapDriver}
 
 	${If} $R0 != 0
 		MessageBox MB_OK "Fatal error during driver installation: $R0"
@@ -838,7 +838,7 @@
 	${RemoveCLIFromEnvironPath}
 
 	# Remove the TAP adapter
-	${ExtractDriver}
+	${ExtractTapDriver}
 	${RemoveBrandedTap}
 
 	# If not ran silently

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -30,12 +30,6 @@
 !define DL_DELETE_NO_ADAPTERS_REMAIN 2
 !define DL_DELETE_SOME_ADAPTERS_REMAIN 3
 
-# Return codes from tapinstall
-!define DEVCON_EXIT_OK 0
-!define DEVCON_EXIT_REBOOT 1
-!define DEVCON_EXIT_FAIL 2
-!define DEVCON_EXIT_USAGE 3
-
 # Log targets
 !define LOG_FILE 0
 !define LOG_VOID 1
@@ -171,7 +165,7 @@
 	Push $0
 	Push $1
 
-	nsExec::ExecToStack '"$TEMP\driver\tapinstall.exe" remove ${TAP_HARDWARE_ID}'
+	nsExec::ExecToStack '"$TEMP\driver\driverlogic.exe" remove ${TAP_HARDWARE_ID}'
 	Pop $0
 	Pop $1
 
@@ -209,13 +203,12 @@
 	${If} $0 == ${DL_DELETE_NO_ADAPTERS_REMAIN}
 		log::Log "Removing vanilla TAP adapter driver since it is no longer in use"
 
-		nsExec::ExecToStack '"$TEMP\driver\tapinstall.exe" remove ${DEPRECATED_TAP_HARDWARE_ID}'
+		nsExec::ExecToStack '"$TEMP\driver\driverlogic.exe" remove ${DEPRECATED_TAP_HARDWARE_ID}'
 
 		Pop $0
 		Pop $1
 
-		${If} $0 != ${DEVCON_EXIT_OK}
-		${AndIf} $0 != ${DEVCON_EXIT_REBOOT}
+		${If} $0 != ${DL_GENERAL_SUCCESS}
 			StrCpy $R0 "Failed to remove driver: $1"
 			log::Log $R0
 
@@ -280,8 +273,7 @@
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${DEVCON_EXIT_OK}
-	${AndIf} $0 != ${DEVCON_EXIT_REBOOT}
+	${If} $0 != ${DL_GENERAL_SUCCESS}
 		StrCpy $R0 "Failed to create virtual adapter: error $0"
 		log::LogWithDetails $R0 $1
 		Goto InstallDriver_return

--- a/windows/driverlogic/src/driverlogic.cpp
+++ b/windows/driverlogic/src/driverlogic.cpp
@@ -558,6 +558,25 @@ NetworkAdapter FindBrandedTap()
 	return *added.begin();
 }
 
+void RemoveTapDriver(const std::wstring &tapHardwareId)
+{
+	ForEachDevice(tapHardwareId, [&](HDEVINFO devInfo, PSP_DEVINFO_DATA devInfoData) {
+		try
+		{
+			DeleteDevice(devInfo, devInfoData);
+		}
+		catch (const std::exception & e)
+		{
+			//
+			// Skip this adapter
+			//
+
+			std::cerr << "Skipping TAP adapter due to exception caught while iterating: "
+				<< e.what() << std::endl;
+		}
+	});
+}
+
 enum class DeletionResult
 {
 	NO_REMAINING_TAP_ADAPTERS,
@@ -634,6 +653,15 @@ int wmain(int argc, const wchar_t * argv[], const wchar_t * [])
 			}
 
 			UpdateTapDriver(argv[2]);
+		}
+		else if (0 == _wcsicmp(argv[1], L"remove"))
+		{
+			if (3 != argc)
+			{
+				goto INVALID_ARGUMENTS;
+			}
+
+			RemoveTapDriver(argv[2]);
 		}
 		else if (0 == _wcsicmp(argv[1], L"remove-vanilla-tap"))
 		{

--- a/windows/driverlogic/src/driverlogic.cpp
+++ b/windows/driverlogic/src/driverlogic.cpp
@@ -14,6 +14,7 @@
 #include <devguid.h>
 #include <devpkey.h>
 #include <newdev.h>
+#include <cfgmgr32.h>
 
 
 namespace
@@ -259,6 +260,13 @@ std::wstring GetNetCfgInstanceId(HDEVINFO devInfo, const SP_DEVINFO_DATA &devInf
 
 void DeleteDevice(HDEVINFO devInfo, SP_DEVINFO_DATA * devInfoData)
 {
+	wchar_t devId[MAX_DEVICE_ID_LEN];
+	if (CR_SUCCESS != CM_Get_Device_IDW(devInfoData->DevInst, devId, sizeof(devId) / sizeof(devId[0]), 0))
+	{
+		// skip
+		return;
+	}
+
 	SP_REMOVEDEVICE_PARAMS rmdParams = { 0 };
 	rmdParams.ClassInstallHeader.cbSize = sizeof(SP_CLASSINSTALL_HEADER);
 	rmdParams.ClassInstallHeader.InstallFunction = DIF_REMOVE;


### PR DESCRIPTION
Update to add a removal function to `driverlogic` and get rid of `tapinstall.exe`. Most driver setup code has already been moved into `driverlogic.exe`, but currently we still use `tapinstall`/`devcon` to remove drivers/devices. Also, some cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1446)
<!-- Reviewable:end -->
