### PR TITLE
Fix WireGuard key errors in key management screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash when VPN permission is revoked, either manually or by starting another VPN app.
 - Fix crash caused by local JNI reference table overflow after running for a long time.
 - Dismiss notification after service has stopped.
+- Don't show missing connectivity error message in WireGuard key management screen if a
+  reconnection is expected to happen.
 
 #### Linux
 - DNS management with static `/etc/resolv.conf` will now work even when no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Line wrap the file at 100 chars.                                              Th
 - Dismiss notification after service has stopped.
 - Don't show missing connectivity error message in WireGuard key management screen if a
   reconnection is expected to happen.
+- Fix showing new key as invalid immediately after regeneration.
 
 #### Linux
 - DNS management with static `/etc/resolv.conf` will now work even when no

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/KeyStatusListener.kt
@@ -42,7 +42,7 @@ class KeyStatusListener(val daemon: MullvadDaemon) {
         val oldStatus = keyStatus
         val newStatus = daemon.generateWireguardKey()
         val newFailure = newStatus?.failure()
-        if (oldStatus is KeygenEvent.NewKey && newStatus != null) {
+        if (oldStatus is KeygenEvent.NewKey && newFailure != null) {
             keyStatus = KeygenEvent.NewKey(oldStatus.publicKey,
                             oldStatus.verified,
                             newFailure)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -2,7 +2,7 @@ package net.mullvad.mullvadvpn.model
 
 sealed class KeygenEvent {
     class NewKey(val publicKey: PublicKey) : KeygenEvent() {
-        var verified: Boolean? = false
+        var verified: Boolean? = null
             private set
         var replacementFailure: KeygenFailure? = null
             private set

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -227,16 +227,14 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
         when (tunnelState) {
             is TunnelState.Connecting, is TunnelState.Disconnecting -> {
-                statusMessage.setText(R.string.wireguard_key_connectivity)
-                statusMessage.visibility = View.VISIBLE
+                setStatusMessage(R.string.wireguard_key_connectivity, R.color.red)
                 generateButton.visibility = View.GONE
                 generateSpinner.visibility = View.VISIBLE
                 verifyButton.visibility = View.GONE
                 verifySpinner.visibility = View.VISIBLE
             }
             is TunnelState.Error -> {
-                statusMessage.setText(R.string.wireguard_key_blocked_state_message)
-                statusMessage.visibility = View.VISIBLE
+                setStatusMessage(R.string.wireguard_key_blocked_state_message, R.color.red)
                 generateButton.setClickable(false)
                 generateButton.setAlpha(0.5f)
                 verifyButton.setClickable(false)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -18,6 +18,7 @@ import java.util.TimeZone
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.KeygenEvent
@@ -39,6 +40,18 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     private var generatingKey = false
     private var validatingKey = false
 
+    private var resetReconnectionExpectedJob: Job? = null
+    private var reconnectionExpected = false
+        set(value) {
+            field = value
+
+            resetReconnectionExpectedJob?.cancel()
+
+            if (value == true) {
+                resetReconnectionExpected()
+            }
+        }
+
     private lateinit var publicKey: TextView
     private lateinit var publicKeyAge: TextView
     private lateinit var statusMessage: TextView
@@ -47,6 +60,17 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     private lateinit var generateSpinner: ProgressBar
     private lateinit var verifyButton: Button
     private lateinit var verifySpinner: ProgressBar
+
+    private fun resetReconnectionExpected() {
+        resetReconnectionExpectedJob = GlobalScope.launch(Dispatchers.Main) {
+            delay(20_000)
+
+            if (reconnectionExpected) {
+                reconnectionExpected = false
+                updateViews()
+            }
+        }
+    }
 
     override fun onSafelyCreateView(
         inflater: LayoutInflater,
@@ -227,11 +251,13 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
         when (tunnelState) {
             is TunnelState.Connecting, is TunnelState.Disconnecting -> {
-                setStatusMessage(R.string.wireguard_key_connectivity, R.color.red)
-                generateButton.visibility = View.GONE
-                generateSpinner.visibility = View.VISIBLE
-                verifyButton.visibility = View.GONE
-                verifySpinner.visibility = View.VISIBLE
+                if (!reconnectionExpected) {
+                    setStatusMessage(R.string.wireguard_key_connectivity, R.color.red)
+                    generateButton.visibility = View.GONE
+                    generateSpinner.visibility = View.VISIBLE
+                    verifyButton.visibility = View.GONE
+                    verifySpinner.visibility = View.VISIBLE
+                }
             }
             is TunnelState.Error -> {
                 setStatusMessage(R.string.wireguard_key_blocked_state_message, R.color.red)
@@ -247,9 +273,15 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     private fun onGenerateKeyPress() {
         currentJob?.cancel()
-        generatingKey = true
-        validatingKey = false
+
+        synchronized(this) {
+            generatingKey = true
+            validatingKey = false
+            reconnectionExpected = !(tunnelState is TunnelState.Disconnected)
+        }
+
         updateViews()
+
         currentJob = GlobalScope.launch(Dispatchers.Main) {
             keyStatusListener.generateKey().join()
             generatingKey = false
@@ -286,6 +318,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         keyStatusListener.onKeyStatusChange = null
         currentJob?.cancel()
         updateViewsJob?.cancel()
+        resetReconnectionExpectedJob?.cancel()
         validatingKey = false
         generatingKey = false
         urlController.onPause()
@@ -293,7 +326,16 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     override fun onSafelyResume() {
         tunnelStateListener = connectionProxy.onUiStateChange.subscribe { uiState ->
-            tunnelState = uiState
+            synchronized(this@WireguardKeyFragment) {
+                tunnelState = uiState
+
+                if (generatingKey) {
+                    reconnectionExpected = !(tunnelState is TunnelState.Disconnected)
+                } else if (tunnelState is TunnelState.Connected) {
+                    reconnectionExpected = false
+                }
+            }
+
             updateViewsJob?.cancel()
             updateViewsJob = updateViewJob()
         }


### PR DESCRIPTION
Previously, two issues were happening. The first one was that when the tunnel was up and the user requested to regenerate the key, an error message would quickly flash while the tunnel reconnected. The message wasn't actually reporting an error, because the reconnection was expected. This PR fixes this first issue by only showing the error message if the reconnection isn't expected. A reconnection is expected right after generating a key. If the reconnection doesn't happen within 20 seconds, the connectivity error is allowed to be shown.

The second issue was that when regenerating the key, the screen would show the new key as `Invalid`. This happened because when converting the Rust type to Java, the default value for `verified` was `false`, when it should've been `null`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1447)
<!-- Reviewable:end -->
