### PR TITLE
Only reconnect if using relevant tunnel protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove WireGuard keys from accounts when they are removed from the local account history.
 - Upgrade from Electron 6 to Electron 7.
 - Disable WireGuard protocol option if there's no WireGuard key.
+- Only reconnect when settings change if a relevant tunnel protocol is used.
 
 #### Android
 - Wait for traffic to be routed through the tunnel device before advertising blocked state.


### PR DESCRIPTION
Changes:
* Reconnect when WireGuard key is replaced only if the protocol is WG.
* Reconnect when the WG MTU setting is changed only if using WG.
* Reconnect when mssfix is changed only if using OpenVPN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1448)
<!-- Reviewable:end -->
