### PR TITLE
Move changelog entries invalidly ending up under 2019.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Only reconnect when settings change if a relevant tunnel protocol is used.
+
+
+## [2020.1-beta1] - 2020-02-05
 ### Added
 - Add translations for Finnish and Danish.
 - Copy WireGuard key when clicking on it.
@@ -39,7 +44,6 @@ Line wrap the file at 100 chars.                                              Th
 - Remove WireGuard keys from accounts when they are removed from the local account history.
 - Upgrade from Electron 6 to Electron 7.
 - Disable WireGuard protocol option if there's no WireGuard key.
-- Only reconnect when settings change if a relevant tunnel protocol is used.
 
 #### Android
 - Wait for traffic to be routed through the tunnel device before advertising blocked state.
@@ -54,7 +58,7 @@ Line wrap the file at 100 chars.                                              Th
 - Be more aggressive when installing routes, in effect taking ownership of existing duplicate route
   entries. This allows the daemon to initialize properly even if a previous instance did not have a
   clean shutdown.
-  
+
 ### Fixed
 - Don't try to replace WireGuard key if account has too many keys already.
 - Fix bogus update notification caused by an outdated cache.
@@ -73,6 +77,11 @@ Line wrap the file at 100 chars.                                              Th
   the system service crashing on Windows for newer CPU models.
 
 #### Android
+- Fix notification message to not show `null` version when version check cache is stale right
+  after an update.
+- Fix `null` pointer exception when connectivity event intent has no network info.
+- Fix fast loop trying to fetch location and preventing the device from sleeping. This should
+  improve battery life in some cases.
 - Fix crash when starting the app right after quitting it.
 - Restart background service if it stops responding.
 - Fix crash when VPN permission is revoked, either manually or by starting another VPN app.
@@ -87,11 +96,19 @@ Line wrap the file at 100 chars.                                              Th
   `/etc/resolv.conf` exists.
 
 ### Security
+- Add automatic key rotation for WireGuard (every 7 days by default). This limits the potential
+  for an attacker to correlate traffic with a public key and identity, and reduces the harm of
+  software that might leak the private tunnel IP (since it is no longer fixed).
+
 #### Windows
 - Stop OpenVPN from loading `C:\etc\ssl\openssl.cnf` on start. This file was being loaded when an
   OpenVPN tunnel was being created. Any user could create the file, and the process loading it runs
   as the SYSTEM user. Since the config file allows loading arbitrary code, it was an attack vector
   allowing local unprivileged users to run code as SYSTEM.
+
+#### macOS
+- Limit macOS firewall rules to only allow UDP packets in the rules meant to enable being a DHCPv4
+  *server* when local network sharing is enabled.
 
 
 ## [2019.10] - 2019-12-12
@@ -104,25 +121,10 @@ Line wrap the file at 100 chars.                                              Th
 - Properly tear down routes after disconnecting from WireGuard relays.
 - Fix bug that prohibited WireGuard from working over port 53.
 
-#### Android
-- Fix notification message to update to `null` version when version check cache is stale right
-  after an update.
-- Fix `null` pointer exception when connectivity event intent has no network info.
-- Fix fast loop trying to fetch location and preventing the device from sleeping. This should
-  improve battery life in some cases.
-
 ### Security
-- Add automatic key rotation for WireGuard (every 7 days by default). This limits the potential
-  for an attacker to correlate traffic with a public key and identity, and reduces the harm of
-  software that might leak the private tunnel IP (since it is no longer fixed).
-
 #### Linux
 - Stop [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122) by dropping all packets destined
   for the tunnel IP coming in on some other interface than the tunnel.
-
-#### macOS
-- Limit macOS firewall rules to only allow UDP packets in the rules meant to enable being a DHCPv4
-  *server* when local network sharing is enabled.
 
 
 ## [2019.10-beta2] - 2019-12-05


### PR DESCRIPTION
`master` moved fast when we did the last release. So a lot of stuff eventually ended up under the wrong release header.

This should hopefully fix it. Please check so this seems correct.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1449)
<!-- Reviewable:end -->
