### PR TITLE
Remove license headers from Rust source code

### DIFF
--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use clap::{crate_authors, crate_description, crate_name};

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 #[macro_use]

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use log::{debug, error, info, warn};

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use lazy_static::lazy_static;

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use clap::{crate_authors, crate_name};

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use chrono::{offset::Utc, DateTime};

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 pub mod account;

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -1,15 +1,7 @@
+//! The core components of the talpidaemon VPN client.
+
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]
-
-//! The core components of the talpidaemon VPN client.
-//!
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
 
 /// Misc FFI utilities.
 #[cfg(windows)]

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2018  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 use crate::{logging::windows::log_sink, tunnel_state_machine::TunnelCommand, winnet};
 use futures::sync::mpsc::UnboundedSender;
 use parking_lot::Mutex;

--- a/talpid-ipc/src/lib.rs
+++ b/talpid-ipc/src/lib.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use futures::Future;

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use openvpn_plugin::{openvpn_plugin, EventResult, EventType};

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -1,11 +1,3 @@
-//! # License
-//!
-//! Copyright (C) 2017  Amagicom AB
-//!
-//! This program is free software: you can redistribute it and/or modify it under the terms of the
-//! GNU General Public License as published by the Free Software Foundation, either version 3 of
-//! the License, or (at your option) any later version.
-
 #![deny(rust_2018_idioms)]
 
 use std::{error::Error, fmt};


### PR DESCRIPTION
According to the license, anyone who copies the source
must attach the header anyway is my understanding.

They are mostly a burden to update. And the vast majority of our files was already missing this header.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1454)
<!-- Reviewable:end -->
