### PR TITLE
Fix `null` pointer exception in `RelayListListener`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 #### Android
 - Fix crash when removing the service from foreground on Android versions below API level 24.
+- Fix crash that happened in certain situations when retrieving the relay list.
 
 
 ## [2020.1-beta1] - 2020-02-05

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -59,7 +59,7 @@ class RelayListListener(val daemon: MullvadDaemon, val settingsListener: Setting
         val relayLocations = daemon.getRelayLocations()
 
         synchronized(this) {
-            if (relayList == null) {
+            if (relayList == null && relayLocations != null) {
                 relayListChanged(RelayList(relayLocations))
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -57,7 +57,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return getCurrentVersion(daemonInterfaceAddress)
     }
 
-    fun getRelayLocations(): RelayList {
+    fun getRelayLocations(): RelayList? {
         return getRelayLocations(daemonInterfaceAddress)
     }
 
@@ -106,7 +106,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     private external fun getWwwAuthToken(daemonInterfaceAddress: Long): String
     private external fun getCurrentLocation(daemonInterfaceAddress: Long): GeoIpLocation?
     private external fun getCurrentVersion(daemonInterfaceAddress: Long): String
-    private external fun getRelayLocations(daemonInterfaceAddress: Long): RelayList
+    private external fun getRelayLocations(daemonInterfaceAddress: Long): RelayList?
     private external fun getSettings(daemonInterfaceAddress: Long): Settings
     private external fun getState(daemonInterfaceAddress: Long): TunnelState
     private external fun getVersionInfo(daemonInterfaceAddress: Long): AppVersionInfo?


### PR DESCRIPTION
In a few situations, the `getRelayLocations` call to the daemon can return `null`. This usually happens if the daemon has stopped. If this happens during an initial relay list fetch, the app crashes. This PR fixes the `RelayListListener` so it doesn't crash. The fix makes it also more transparent that the returned relay list may be `null`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1455)
<!-- Reviewable:end -->
