### PR TITLE
Replace Amagicom AB with Mullvad VPN AB in iOS source files

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -472,7 +472,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1120;
 				LastUpgradeCheck = 1000;
-				ORGANIZATIONNAME = "Amagicom AB";
+				ORGANIZATIONNAME = "Mullvad VPN AB";
 				TargetAttributes = {
 					58B0A29F238EE67E00BC001D = {
 						CreatedOnToolsVersion = 11.2.1;

--- a/ios/MullvadVPN/Account.swift
+++ b/ios/MullvadVPN/Account.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 16/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/AccountExpiry.swift
+++ b/ios/MullvadVPN/AccountExpiry.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 22/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/AccountInputGroupView.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 22/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/AccountTextField.swift
+++ b/ios/MullvadVPN/AccountTextField.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 19/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/ApplicationConfiguration.swift
+++ b/ios/MullvadVPN/ApplicationConfiguration.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 05/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/AutoDisposableSink.swift
+++ b/ios/MullvadVPN/AutoDisposableSink.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 01/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/BasicTableViewCell.swift
+++ b/ios/MullvadVPN/BasicTableViewCell.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/Bundle+MullvadVersion.swift
+++ b/ios/MullvadVPN/Bundle+MullvadVersion.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 29/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/ConnectViewController.swift
+++ b/ios/MullvadVPN/ConnectViewController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/CustomButton.swift
+++ b/ios/MullvadVPN/CustomButton.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 23/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/CustomNavigationBar.swift
+++ b/ios/MullvadVPN/CustomNavigationBar.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 22/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/Data+HexCoding.swift
+++ b/ios/MullvadVPN/Data+HexCoding.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/EmbeddedViewContainerView.swift
+++ b/ios/MullvadVPN/EmbeddedViewContainerView.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 09/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/IPAddressRange.swift
+++ b/ios/MullvadVPN/IPAddressRange.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/IPEndpoint.swift
+++ b/ios/MullvadVPN/IPEndpoint.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 06/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/IpAddress+Codable.swift
+++ b/ios/MullvadVPN/IpAddress+Codable.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 12/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Network

--- a/ios/MullvadVPN/JsonRpc.swift
+++ b/ios/MullvadVPN/JsonRpc.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/KeychainError.swift
+++ b/ios/MullvadVPN/KeychainError.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/10/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/LoginState.swift
+++ b/ios/MullvadVPN/LoginState.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 21/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 19/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/MullvadAPI.swift
+++ b/ios/MullvadVPN/MullvadAPI.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/MullvadEndpoint.swift
+++ b/ios/MullvadVPN/MullvadEndpoint.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 12/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/MutuallyExclusive.swift
+++ b/ios/MullvadVPN/MutuallyExclusive.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 24/10/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/NEVPNStatus+Debug.swift
+++ b/ios/MullvadVPN/NEVPNStatus+Debug.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 28/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/PacketTunnelIpc.swift
+++ b/ios/MullvadVPN/PacketTunnelIpc.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 01/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/RelayCache.swift
+++ b/ios/MullvadVPN/RelayCache.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 05/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/RelayConstraints.swift
+++ b/ios/MullvadVPN/RelayConstraints.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 10/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/RelayList.swift
+++ b/ios/MullvadVPN/RelayList.swift
@@ -4,7 +4,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/RelaySelector+RelayCache.swift
+++ b/ios/MullvadVPN/RelaySelector+RelayCache.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 07/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/RelaySelector.swift
+++ b/ios/MullvadVPN/RelaySelector.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 11/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/RelayStatusIndicatorView.swift
+++ b/ios/MullvadVPN/RelayStatusIndicatorView.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 01/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/ReplaceNilWithError.swift
+++ b/ios/MullvadVPN/ReplaceNilWithError.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 19/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/RootContainerViewController.swift
+++ b/ios/MullvadVPN/RootContainerViewController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 25/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SegueIdentifier.swift
+++ b/ios/MullvadVPN/SegueIdentifier.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 25/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SelectLocationCell.swift
+++ b/ios/MullvadVPN/SelectLocationCell.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SelectLocationController.swift
+++ b/ios/MullvadVPN/SelectLocationController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/SettingsAccountCell.swift
+++ b/ios/MullvadVPN/SettingsAccountCell.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 22/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SettingsAppVersionCell.swift
+++ b/ios/MullvadVPN/SettingsAppVersionCell.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 24/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SettingsBasicCell.swift
+++ b/ios/MullvadVPN/SettingsBasicCell.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 04/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SettingsCell.swift
+++ b/ios/MullvadVPN/SettingsCell.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 22/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SettingsViewController.swift
+++ b/ios/MullvadVPN/SettingsViewController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
+++ b/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 15/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/StaticTableViewDataSource.swift
+++ b/ios/MullvadVPN/StaticTableViewDataSource.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 24/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/TranslucentButtonBlurView.swift
+++ b/ios/MullvadVPN/TranslucentButtonBlurView.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/TunnelConfiguration.swift
+++ b/ios/MullvadVPN/TunnelConfiguration.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 19/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/TunnelConfigurationCoder.swift
+++ b/ios/MullvadVPN/TunnelConfigurationCoder.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/10/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/TunnelConfigurationManager.swift
+++ b/ios/MullvadVPN/TunnelConfigurationManager.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 02/10/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/TunnelControlViewController.swift
+++ b/ios/MullvadVPN/TunnelControlViewController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 01/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 25/09/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/UIAlertController+Error.swift
+++ b/ios/MullvadVPN/UIAlertController+Error.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 11/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/UIColor+Helpers.swift
+++ b/ios/MullvadVPN/UIColor+Helpers.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 06/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UIColor+Palette.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import UIKit

--- a/ios/MullvadVPN/ViewControllerIdentifier.swift
+++ b/ios/MullvadVPN/ViewControllerIdentifier.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 23/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/WebLinks.swift
+++ b/ios/MullvadVPN/WebLinks.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 21/05/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/WireguardAssociatedAddresses.swift
+++ b/ios/MullvadVPN/WireguardAssociatedAddresses.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 13/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/MullvadVPN/WireguardKeysViewController.swift
+++ b/ios/MullvadVPN/WireguardKeysViewController.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 04/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/MullvadVPN/WireguardPrivateKey.swift
+++ b/ios/MullvadVPN/WireguardPrivateKey.swift
@@ -3,7 +3,7 @@
 //  MullvadVPN
 //
 //  Created by pronebird on 20/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import CryptoKit

--- a/ios/MullvadVPNTests/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/RelaySelectorTests.swift
@@ -3,7 +3,7 @@
 //  RelaySelectorTests
 //
 //  Created by pronebird on 07/11/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import XCTest

--- a/ios/PacketTunnel/AnyIPEndpoint+DNS64.swift
+++ b/ios/PacketTunnel/AnyIPEndpoint+DNS64.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 24/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/PacketTunnel/AnyIPEndpoint+Wireguard.swift
+++ b/ios/PacketTunnel/AnyIPEndpoint+Wireguard.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 24/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/PacketTunnel/Logging.swift
+++ b/ios/PacketTunnel/Logging.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 18/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 19/03/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/PacketTunnel/PacketTunnelSettingsGenerator.swift
+++ b/ios/PacketTunnel/PacketTunnelSettingsGenerator.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 13/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/PacketTunnel/WireguardCommand.swift
+++ b/ios/PacketTunnel/WireguardCommand.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 24/06/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation

--- a/ios/PacketTunnel/WireguardConfiguration.swift
+++ b/ios/PacketTunnel/WireguardConfiguration.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 17/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine

--- a/ios/PacketTunnel/WireguardDevice.swift
+++ b/ios/PacketTunnel/WireguardDevice.swift
@@ -3,7 +3,7 @@
 //  PacketTunnel
 //
 //  Created by pronebird on 16/12/2019.
-//  Copyright © 2019 Amagicom AB. All rights reserved.
+//  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
 import Combine


### PR DESCRIPTION
Replacing (almost) all instances of "Amagicom AB" in the iOS directory. The only place left is in `ExportOptions.plist`: `<string>Apple Distribution: Amagicom AB</string>` where the `signingCertificate` string has to match with the existing certificate name. So that part can't be updated now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1460)
<!-- Reviewable:end -->
