### PR TITLE
 Make sure `stopForeground` works on API 21 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Line wrap the file at 100 chars.                                              Th
 - Only reconnect when settings change if a relevant tunnel protocol is used.
 - Adjust padding of tray icon on Windows and Linux to better match other icons.
 
+### Fixed
+#### Android
+- Fix crash when removing the service from foreground on Android versions below API level 24.
+
 
 ## [2020.1-beta1] - 2020-02-05
 ### Added

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -207,7 +207,12 @@ class ForegroundNotificationManager(val service: Service, val connectionProxy: C
                 service.startForeground(FOREGROUND_NOTIFICATION_ID, buildNotification())
                 onForeground = true
             } else if (!shouldBeOnForeground) {
-                service.stopForeground(Service.STOP_FOREGROUND_DETACH)
+                if (Build.VERSION.SDK_INT >= 24) {
+                    service.stopForeground(Service.STOP_FOREGROUND_DETACH)
+                } else {
+                    service.stopForeground(false)
+                }
+
                 onForeground = false
             }
         }


### PR DESCRIPTION
A recent change to allow the notification to be dismissed introduced a call to `stopForeground` with a signature that's only present on API level 24 onwards. This PR changes the call so that it is compatible with the minimum API level 21 again.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1462)
<!-- Reviewable:end -->
