### PR TITLE
Less dirty working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@
 /windows/**/*.user
 /android/keystore.properties
 /android/local.properties
+/wireguard/wireguard-go/libwg.h
 **/.vs/
 *.bak

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -52,7 +52,7 @@ function build_windows {
 
         target_dir=../../build/lib/x86_64-pc-windows-msvc/
         mkdir -p $target_dir
-        cp libwg.dll libwg.lib $target_dir
+        mv libwg.dll libwg.lib $target_dir
     popd
 }
 
@@ -75,7 +75,7 @@ function build_unix {
         go build -v -o libwg.a -buildmode c-archive
         target_triple_dir="../../build/lib/$(unix_target_triple)"
         mkdir -p $target_triple_dir
-        cp libwg.a $target_triple_dir
+        mv libwg.a $target_triple_dir
     popd
 }
 


### PR DESCRIPTION
I currently have two files in my git list of untracked files. This PR aims to make the build process not scatter untracked files. It seems like we don't need the header, so I'll just ignore it. Do you think this is a viable solution?

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1463)
<!-- Reviewable:end -->
