### PR TITLE
Use newer android docker image to build wireugard-go for Android

### DIFF
--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -72,16 +72,15 @@ function unix_target_triple {
 function build_unix {
     echo "Building wireguard-go for $1"
     pushd wireguard-go
-        go build -v -o libwg.a -buildmode c-archive
         target_triple_dir="../../build/lib/$(unix_target_triple)"
         mkdir -p $target_triple_dir
-        mv libwg.a $target_triple_dir
+        go build -v -o $target_triple_dir/libwg.a -buildmode c-archive
     popd
 }
 
 function build_android {
     echo "Building for android"
-    local docker_image_hash="d73fdea1108cd75d7eb09f8894fe6892dc502a2d62c39b4f75072e777398f477"
+    local docker_image_hash="f432cb779611284ce69aca59a90a8a601171d4c29728561ae32bd228b1699198"
 
     docker run --rm \
         -v "$(pwd)/../":/workspace \

--- a/wireguard/wireguard-go/Android.mk
+++ b/wireguard/wireguard-go/Android.mk
@@ -2,7 +2,6 @@
 #
 # Copyright © 2017-2019 WireGuard LLC. All Rights Reserved.
 
-BUILDDIR ?= $(CURDIR)/build
 DESTDIR ?= $(CURDIR)/../../android/build/extraJni/$(ANDROID_ABI)
 
 NDK_GO_ARCH_MAP_x86 := 386
@@ -27,27 +26,12 @@ GOBUILDOS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GOBUILDVERSION := 1.12
 GOBUILDTARBALL := https://dl.google.com/go/go$(GOBUILDVERSION).$(GOBUILDOS)-$(GOBUILDARCH).tar.gz
 GOBUILDVERSION_NEEDED := go version go$(GOBUILDVERSION) $(GOBUILDOS)/$(GOBUILDARCH)
-export GOROOT := $(BUILDDIR)/goroot
-export GOPATH := $(BUILDDIR)/gopath
-export PATH := $(GOROOT)/bin:$(PATH)
-GOBUILDVERSION_CURRENT := $(shell $(GOROOT)/bin/go version 2>/dev/null)
-ifneq ($(GOBUILDVERSION_NEEDED),$(GOBUILDVERSION_CURRENT))
-$(shell rm -f $(GOROOT)/bin/go)
-endif
-$(GOROOT)/bin/go:
-	rm -rf "$(GOROOT)"
-	mkdir -p "$(GOROOT)"
-	curl "$(GOBUILDTARBALL)" | tar -C "$(GOROOT)" --strip-components=1 -xzf - || { rm -rf "$(GOROOT)"; exit 1; }
-	patch -p1 -f -N -r- -d "$(GOROOT)" < goruntime-boottime-over-monotonic.diff || { rm -rf "$(GOROOT)"; exit 1; }
 
-$(shell test "$$(cat $(BUILDDIR)/.gobuildversion 2>/dev/null)" = "$(GOBUILDVERSION_CURRENT)" || rm -f "$(DESTDIR)/libwg.so")
-
-$(DESTDIR)/libwg.so: $(GOROOT)/bin/go
+$(DESTDIR)/libwg.so:
 	mkdir -p $(DESTDIR)
-	go get -tags "linux android" || { chmod -fR +w "$(GOPATH)/pkg/mod"; rm -rf "$(GOPATH)/pkg/mod"; exit 1; }
+	go get -tags "linux android"
 	chmod -fR +w "$(GOPATH)/pkg/mod"
 	go build -tags "linux android" -ldflags="-X main.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/wireguard" -v -o "$@" -buildmode c-shared
-	go version > $(BUILDDIR)/.gobuildversion
 	rm -f $(DESTDIR)/libwg.h
 
 

--- a/wireguard/wireguard-go/build-android.sh
+++ b/wireguard/wireguard-go/build-android.sh
@@ -6,6 +6,9 @@ set -e
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $script_dir
 
+# Keep a GOPATH in the build directory to maintain a cache of downloaded libraries
+GOPATH=$script_dir/../../build/android-go-path/
+mkdir -p $GOPATH
 
 for arch in arm arm64 x86_64 x86; do
     case "$arch" in
@@ -13,37 +16,30 @@ for arch in arm arm64 x86_64 x86; do
             export ANDROID_LLVM_TRIPLE="aarch64-linux-android"
             export ANDROID_LIB_TRIPLE="aarch64-linux-android"
             export RUST_TARGET_TRIPLE="aarch64-linux-android"
-            export RUST_LLVM_ARCH="aarch64"
             export ANDROID_ABI="arm64-v8a"
             ;;
         "x86_64")
             export ANDROID_LLVM_TRIPLE="x86_64-linux-android"
             export ANDROID_LIB_TRIPLE="x86_64-linux-android"
             export RUST_TARGET_TRIPLE="x86_64-linux-android"
-            export RUST_LLVM_ARCH="x86_64"
             export ANDROID_ABI="x86_64"
             ;;
         "arm")
             export ANDROID_LLVM_TRIPLE="armv7a-linux-androideabi"
             export ANDROID_LIB_TRIPLE="arm-linux-androideabi"
             export RUST_TARGET_TRIPLE="armv7-linux-androideabi"
-            export RUST_LLVM_ARCH="armv7"
             export ANDROID_ABI="armeabi-v7a"
             ;;
         "x86")
             export ANDROID_LLVM_TRIPLE="i686-linux-android"
             export ANDROID_LIB_TRIPLE="i686-linux-android"
             export RUST_TARGET_TRIPLE="i686-linux-android"
-            export RUST_LLVM_ARCH="i686"
             export ANDROID_ABI="x86"
             ;;
     esac
 
-    export ANDROID_ARCH_NAME="$arch"
-    export ANDROID_TOOLCHAIN_ROOT="/opt/android/toolchains/android21-${RUST_LLVM_ARCH}"
-    export ANDROID_SYSROOT="${ANDROID_TOOLCHAIN_ROOT}/sysroot"
-    export ANDROID_C_COMPILER="${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_LLVM_TRIPLE}21-clang"
-
+    eval "$(install-ndk-toolchain $arch)"
+    export ANDROID_ARCH_NAME=$arch
     export PATH="$PATH:${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
     # Build Wireguard-Go
@@ -62,5 +58,7 @@ for arch in arm arm64 x86_64 x86; do
     cp ../../android/build/extraJni/$ANDROID_ABI/libwg.so ../../build/lib/$RUST_TARGET_TRIPLE
     chmod 777 ../../android/build/extraJni/$ANDROID_ABI/libwg.so ../../build/lib/$RUST_TARGET_TRIPLE
     rm -rf build
-
 done
+
+# ensure `git clean -fd` does not require root permissions
+find $GOPATH -exec chmod +rw {} \;

--- a/wireguard/wireguard-go/go.sum
+++ b/wireguard/wireguard-go/go.sum
@@ -21,6 +21,7 @@ golang.org/x/sys v0.0.0-20190618155005-516e3c20635f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191003212358-c178f38b412c h1:6Zx7DRlKXf79yfxuQ/7GqV3w2y7aDsk6bGg0MzF5RVU=
 golang.org/x/sys v0.0.0-20191003212358-c178f38b412c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.zx2c4.com/wireguard v0.0.20190518-0.20190605110920-108c37a05639 h1:AoX5+g0OBk+KqTTMVl4YPFZ9ioU2tPW1YwtzaVWdORA=


### PR DESCRIPTION
Use newer android docker image to build wireguard-go libraries in CI to
speed up builds. The main change is that NDK toolchains will now be
installed at runtime to decrease the size (and thus the time it takes to
download) the Docker image.


Seems like the newer Go version for Android also pulls in a newer dependency - this shouldn't be an issue, unless this becomes a common occurrence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1465)
<!-- Reviewable:end -->
