### PR TITLE
Add account expiry warning notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
-- Add reconnect button to the desktop app
+- Add reconnect button to the desktop app.
 - Add monochrome option for the tray icon on Windows and Linux.
+- Show OS notification when account is close to expiry on desktop platforms.
 
 #### Android
 - Add option to enable or disable local network sharing.

--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { sprintf } from 'sprintf-js';
 import config from '../config.json';
+import AccountExpiry from '../shared/account-expiry';
 import { TunnelState } from '../shared/daemon-rpc-types';
 import { messages } from '../shared/gettext';
 
@@ -150,6 +151,23 @@ export default class NotificationController {
     const notification = new Notification({
       title: this.notificationTitle,
       body: messages.pgettext('notifications', 'Wireguard key generation failed'),
+      silent: true,
+      icon: this.notificationIcon,
+    });
+    this.scheduleNotification(notification);
+  }
+
+  public closeToExpiryNotification(accountExpiry: AccountExpiry) {
+    const duration = accountExpiry.durationUntilExpiry();
+    const notification = new Notification({
+      title: this.notificationTitle,
+      body: sprintf(
+        // TRANSLATORS: The system notification displayed to the user when the account credit is close to expiry.
+        // TRANSLATORS: Available placeholder:
+        // TRANSLATORS: %(duration)s - remaining time, e.g. "2 days"
+        messages.pgettext('notifications', 'Account credit expires in %(duration)s'),
+        { duration },
+      ),
       silent: true,
       icon: this.notificationIcon,
     });

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Component, Text, View } from 'reactxp';
+import AccountExpiry from '../../shared/account-expiry';
 import { messages } from '../../shared/gettext';
-import AccountExpiry from '../lib/account-expiry';
 import styles from './AccountStyles';
 import * as AppButton from './AppButton';
 import ClipboardLabel from './ClipboardLabel';

--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Component, Styles, View } from 'reactxp';
 import { links } from '../../config.json';
+import AccountExpiry from '../../shared/account-expiry';
 import NotificationAreaContainer from '../containers/NotificationAreaContainer';
-import AccountExpiry from '../lib/account-expiry';
 import { AuthFailureKind, parseAuthFailure } from '../lib/auth-failure';
 import { IConnectionReduxState } from '../redux/connection/reducers';
 import { IVersionReduxState } from '../redux/version/reducers';

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -13,8 +13,8 @@ import {
   NotificationTitle,
 } from './NotificationBanner';
 
+import AccountExpiry from '../../shared/account-expiry';
 import { ErrorStateCause, TunnelParameterError, TunnelState } from '../../shared/daemon-rpc-types';
-import AccountExpiry from '../lib/account-expiry';
 import { parseAuthFailure } from '../lib/auth-failure';
 import { IVersionReduxState } from '../redux/version/reducers';
 

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Component, Text, View } from 'reactxp';
 import { colors, links } from '../../config.json';
+import AccountExpiry from '../../shared/account-expiry';
 import { messages } from '../../shared/gettext';
-import AccountExpiry from '../lib/account-expiry';
 import * as AppButton from './AppButton';
 import * as Cell from './Cell';
 import { Container, Layout } from './Layout';

--- a/gui/src/renderer/containers/ConnectPage.tsx
+++ b/gui/src/renderer/containers/ConnectPage.tsx
@@ -3,10 +3,10 @@ import log from 'electron-log';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { sprintf } from 'sprintf-js';
+import AccountExpiry from '../../shared/account-expiry';
 import { messages } from '../../shared/gettext';
 import Connect from '../components/Connect';
 import withAppContext, { IAppContext } from '../context';
-import AccountExpiry from '../lib/account-expiry';
 import { IRelayLocationRedux, RelaySettingsRedux } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 

--- a/gui/src/renderer/containers/NotificationAreaContainer.tsx
+++ b/gui/src/renderer/containers/NotificationAreaContainer.tsx
@@ -2,9 +2,9 @@ import { connect } from 'react-redux';
 
 import { shell } from 'electron';
 import { links } from '../../config.json';
+import AccountExpiry from '../../shared/account-expiry';
 import NotificationArea from '../components/NotificationArea';
 import withAppContext, { IAppContext } from '../context';
-import AccountExpiry from '../lib/account-expiry';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 
 const mapStateToProps = (state: IReduxState, _props: IAppContext) => ({

--- a/gui/src/shared/account-expiry.ts
+++ b/gui/src/shared/account-expiry.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { sprintf } from 'sprintf-js';
-import { messages } from '../../shared/gettext';
+import { messages } from './gettext';
 
 export default class AccountExpiry {
   private expiry: moment.Moment;
@@ -21,8 +21,12 @@ export default class AccountExpiry {
     return this.expiry.format('L LTS');
   }
 
+  public durationUntilExpiry(): string {
+    return this.expiry.fromNow(true);
+  }
+
   public remainingTime(): string {
-    const duration = this.expiry.fromNow(true);
+    const duration = this.durationUntilExpiry();
 
     return sprintf(
       // TRANSLATORS: The remaining time left on the account displayed across the app.

--- a/gui/test/components/NotificationArea.spec.tsx
+++ b/gui/test/components/NotificationArea.spec.tsx
@@ -2,8 +2,8 @@ import moment from 'moment';
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import NotificationArea from '../../src/renderer/components/NotificationArea';
+import AccountExpiry from '../../src/shared/account-expiry';
 import { AfterDisconnect } from '../../src/shared/daemon-rpc-types';
-import AccountExpiry from '../../src/renderer/lib/account-expiry';
 import { expect } from 'chai';
 
 describe('components/NotificationArea', () => {


### PR DESCRIPTION
This PR adds a system notification which is shown when the account credit is about to run out. The notification will show once every 12 hours or when the app is restarted.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1472)
<!-- Reviewable:end -->
