### PR TITLE
Add account history drop-down in login fragment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Add option to enable or disable local network sharing.
+- Show account history in login fragment
 
 ### Changed
 - Change project copyright and company name from Amagicom AB to Mullvad VPN AB

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -45,6 +45,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return getAccountData(daemonInterfaceAddress, accountToken)
     }
 
+    fun getAccountHistory(): ArrayList<String> {
+        return getAccountHistory(daemonInterfaceAddress)
+    }
+
     fun getWwwAuthToken(): String {
         return getWwwAuthToken(daemonInterfaceAddress)
     }
@@ -107,6 +111,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         daemonInterfaceAddress: Long,
         accountToken: String
     ): GetAccountDataResult
+    private external fun getAccountHistory(daemonInterfaceAddress: Long): ArrayList<String>
     private external fun getWwwAuthToken(daemonInterfaceAddress: Long): String
     private external fun getCurrentLocation(daemonInterfaceAddress: Long): GeoIpLocation?
     private external fun getCurrentVersion(daemonInterfaceAddress: Long): String

--- a/android/src/main/res/drawable/account_history_background.xml
+++ b/android/src/main/res/drawable/account_history_background.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape xmlns:android="http://schemas.android.com/apk/res/android">
+      <corners android:radius="@dimen/account_input_corner_radius" />
+      <solid android:color="@color/darkBlue" />
+    </shape>
+  </item>
+  <item android:top="0dp" android:right="1dp" android:bottom="1dp"
+  android:left="1dp">
+    <shape xmlns:android="http://schemas.android.com/apk/res/android">
+      <corners android:radius="@dimen/account_input_corner_radius" />
+      <solid android:color="@color/white" />
+    </shape>
+  </item>
+</layer-list>

--- a/android/src/main/res/drawable/account_history_list_divider.xml
+++ b/android/src/main/res/drawable/account_history_list_divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+      android:shape="rectangle">
+<solid android:color="@color/darkBlue" />
+</shape>

--- a/android/src/main/res/layout/account_history_entry.xml
+++ b/android/src/main/res/layout/account_history_entry.xml
@@ -1,0 +1,13 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+   <TextView android:id="@+id/account_history_entry_text_view"
+     android:layout_width="fill_parent"
+     android:layout_height="wrap_content"
+     android:textColor="@color/blue"
+     android:padding="10dip"
+     android:textSize="16dip"
+     android:textStyle="bold"/>
+</LinearLayout>

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -138,6 +138,15 @@
                     android:src="@drawable/login_button_arrow"
                     />
         </net.mullvad.mullvadvpn.ui.AccountInputContainer>
+
+        <ListView android:id="@+id/account_history_list"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:divider="@drawable/account_history_list_divider"
+                android:dividerHeight="1dp"
+                android:visibility="invisible"
+                android:background="@drawable/account_history_background"
+                />
         <Space
                 android:layout_width="match_parent"
                 android:layout_height="0dp"

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -86,6 +86,14 @@ impl DaemonInterface {
             .map_err(Error::RpcError)
     }
 
+    pub fn get_account_history(&self) -> Result<Vec<String>> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::GetAccountHistory(tx))?;
+
+        rx.wait().map_err(|_| Error::NoResponse)
+    }
+
     pub fn get_www_auth_token(&self) -> Result<String> {
         let (tx, rx) = oneshot::channel();
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -408,6 +408,31 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_verifyW
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_getAccountHistory<'env>(
+    env: JNIEnv<'env>,
+    _: JObject<'_>,
+    daemon_interface_address: jlong,
+) -> JObject<'env> {
+    let env = JnixEnv::from(env);
+
+    match get_daemon_interface(daemon_interface_address) {
+        Some(daemon_interface) => daemon_interface
+            .get_account_history()
+            .map(|history| history.into_java(&env).forget())
+            .unwrap_or_else(|err| {
+                log::error!(
+                    "{}",
+                    err.display_chain_with_msg("Failed to get account history")
+                );
+                JObject::null()
+            }),
+        None => JObject::null(),
+    }
+}
+
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_getAccountData<'env>(
     env: JNIEnv<'env>,
     _: JObject<'_>,


### PR DESCRIPTION
These changes add a `ListView` containing the account history as fetched from the daemon in the login fragment when the user sends a touch event to the account number input view.

Some deficiencies which should be addressed in future PRs:
- the history list won't be dismissed by pressing the _back_ button
- there's no way to delete individual items

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1475)
<!-- Reviewable:end -->
