### PR TITLE
Fix missing ping timeout event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Line wrap the file at 100 chars.                                              Th
 - Remove city/country labels on map in the desktop app.
 
 ### Fixed
+- Fix app getting stuck in connecting state.
+
 #### Android
 - Fix crash when removing the service from foreground on Android versions below API level 24.
 - Fix crash that happened in certain situations when retrieving the relay list.


### PR DESCRIPTION
Previously, if a ping timeout occurred when connecting the tunnel state machine would not receive an event indicating that the connection attempt failed. This led the app to get stuck in the connecting state, and in some cases the tunnel would eventually start working, leading some users to think that the connecting state was leaking data.

This PR fixes the issue by making sure a ping error is sent to the `WireguardTunnelMonitor`, so that it can close and the tunnel state machine realize the connection attempt failed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1478)
<!-- Reviewable:end -->
