### PR TITLE
Fix service initialization race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix crash when removing the service from foreground on Android versions below API level 24.
 - Fix crash that happened in certain situations when retrieving the relay list.
+- Fix crash caused by initialization race condition.
 
 
 ## [2020.1] - 2020-02-10

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -121,8 +121,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private fun startNotificationManager(): ForegroundNotificationManager {
         return ForegroundNotificationManager(this, serviceNotifier).apply {
-            onConnect = { connectionProxy.connect() }
-            onDisconnect = { connectionProxy.disconnect() }
             lockedToForeground = isBound
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -120,7 +120,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun startNotificationManager(): ForegroundNotificationManager {
-        return ForegroundNotificationManager(this, connectionProxy).apply {
+        return ForegroundNotificationManager(this, serviceNotifier).apply {
             onConnect = { connectionProxy.connect() }
             onDisconnect = { connectionProxy.disconnect() }
             lockedToForeground = isBound

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -15,14 +15,13 @@ import net.mullvad.talpid.util.EventNotifier
 
 class MullvadVpnService : TalpidVpnService() {
     private val binder = LocalBinder()
+    private val serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
     private var isStopping = false
 
     private lateinit var daemon: Deferred<MullvadDaemon>
     private lateinit var connectionProxy: ConnectionProxy
     private lateinit var notificationManager: ForegroundNotificationManager
-
-    private var serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
     private var bindCount = 0
         set(value) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -19,6 +19,8 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var isStopping = false
 
+    private var connectionProxy: ConnectionProxy? = null
+
     private lateinit var daemon: Deferred<MullvadDaemon>
     private lateinit var notificationManager: ForegroundNotificationManager
 
@@ -101,6 +103,7 @@ class MullvadVpnService : TalpidVpnService() {
             }
 
             onDaemonStopped = {
+                connectionProxy?.onDestroy()
                 serviceNotifier.notify(null)
 
                 if (!isStopping) {
@@ -109,9 +112,11 @@ class MullvadVpnService : TalpidVpnService() {
             }
         }
 
-        val connectionProxy = ConnectionProxy(this@MullvadVpnService, daemon)
+        val newConnectionProxy = ConnectionProxy(this@MullvadVpnService, newDaemon)
 
-        serviceNotifier.notify(ServiceInstance(daemon, connectionProxy, connectivityListener))
+        connectionProxy = newConnectionProxy
+
+        serviceNotifier.notify(ServiceInstance(daemon, newConnectionProxy, connectivityListener))
 
         daemon
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -20,7 +20,6 @@ class MullvadVpnService : TalpidVpnService() {
     private var isStopping = false
 
     private lateinit var daemon: Deferred<MullvadDaemon>
-    private lateinit var connectionProxy: ConnectionProxy
     private lateinit var notificationManager: ForegroundNotificationManager
 
     private var bindCount = 0
@@ -91,7 +90,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private fun setUp() {
         daemon = startDaemon()
-        connectionProxy = ConnectionProxy(this, daemon)
     }
 
     private fun startDaemon() = GlobalScope.async(Dispatchers.Default) {
@@ -110,6 +108,8 @@ class MullvadVpnService : TalpidVpnService() {
                 }
             }
         }
+
+        val connectionProxy = ConnectionProxy(this@MullvadVpnService, daemon)
 
         serviceNotifier.notify(ServiceInstance(daemon, connectionProxy, connectivityListener))
 
@@ -132,7 +132,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private fun tearDown() {
         stopDaemon()
-        connectionProxy.onDestroy()
     }
 
     private fun restart() {


### PR DESCRIPTION
A few problem reports contained a crash that happened when the service was initialized. The crash occurred when the `ForegroundNotificationManager` was used before it was initialized. This race condition is fixed by this PR through a refactor of the initialization code.

The `ForegroundNotificationManager` is now initialized with the service, and doesn't have to wait until the daemon thread has started. It will listen for service events and use the `ConnectionProxy` created when the daemon is started.

The `ConnectionProxy` is no longer an asynchronous promise, and will only be created when the daemon thread has started.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1479)
<!-- Reviewable:end -->
