### PR TITLE
Add auto-connect setting on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Add option to enable or disable local network sharing.
 - Show account history in login fragment
+- Add option to enable auto-connecting behavior
 
 ### Changed
 - Change project copyright and company name from Amagicom AB to Mullvad VPN AB

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
@@ -3,5 +3,6 @@ package net.mullvad.mullvadvpn.model
 data class Settings(
     var accountToken: String?,
     var relaySettings: RelaySettings,
-    var allowLan: Boolean
+    var allowLan: Boolean,
+    var autoConnect: Boolean
 )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -89,6 +89,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         setAllowLan(daemonInterfaceAddress, allowLan)
     }
 
+    fun setAutoConnect(autoConnect: Boolean) {
+        setAutoConnect(daemonInterfaceAddress, autoConnect)
+    }
+
     fun shutdown() {
         shutdown(daemonInterfaceAddress)
     }
@@ -122,6 +126,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     private external fun getWireguardKey(daemonInterfaceAddress: Long): PublicKey?
     private external fun setAccount(daemonInterfaceAddress: Long, accountToken: String?)
     private external fun setAllowLan(daemonInterfaceAddress: Long, allowLan: Boolean)
+    private external fun setAutoConnect(daemonInterfaceAddress: Long, alwaysOn: Boolean)
     private external fun shutdown(daemonInterfaceAddress: Long)
     private external fun updateRelaySettings(
         daemonInterfaceAddress: Long,

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -34,7 +34,7 @@ open class TalpidVpnService : VpnService() {
 
         val vpnInterface = builder.establish()
 
-        return vpnInterface.detachFd()
+        return vpnInterface?.detachFd() ?: 0
     }
 
     fun bypass(socket: Int): Boolean {

--- a/android/src/main/res/layout/preferences.xml
+++ b/android/src/main/res/layout/preferences.xml
@@ -41,6 +41,40 @@
             android:textStyle="bold"
             android:text="@string/settings_preferences"
             />
+    <LinearLayout android:id="@+id/auto_connect"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:paddingHorizontal="16dp"
+            android:background="@drawable/cell_button_background"
+            android:gravity="center"
+            >
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="17dp"
+                android:textColor="@color/white"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:text="@string/auto_connect"
+                />
+        <net.mullvad.mullvadvpn.ui.CellSwitch android:id="@+id/auto_connect_toggle"
+                android:layout_width="52dp"
+                android:layout_height="32dp"
+                android:layout_weight="0"
+                />
+    </LinearLayout>
+    <TextView android:id="@+id/auto_connect_footer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:paddingHorizontal="24dp"
+            android:textColor="@color/white60"
+            android:textSize="13sp"
+            android:text="@string/auto_connect_footer"
+            />
     <LinearLayout android:id="@+id/allow_lan"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -45,6 +45,10 @@
     <string name="allow_lan_footer">
         Allows access to other devices on the same network for sharing, printing etc.
     </string>
+    <string name="auto_connect">Auto-connect</string>
+    <string name="auto_connect_footer">
+        Automatically connect to a server when the app launches.
+    </string>
 
     <string name="problem_report_description">
         To help you more effectively, your app\'s log file will be attached to this message. Your

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -184,6 +184,14 @@ impl DaemonInterface {
         rx.wait().map_err(|_| Error::NoResponse)
     }
 
+    pub fn set_auto_connect(&self, auto_connect: bool) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(ManagementCommand::SetAutoConnect(tx, auto_connect))?;
+
+        rx.wait().map_err(|_| Error::NoResponse)
+    }
+
     pub fn shutdown(&self) -> Result<()> {
         self.send_command(ManagementCommand::Shutdown)
     }

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -694,6 +694,28 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_setAllo
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_setAutoConnect(
+    env: JNIEnv<'_>,
+    _: JObject<'_>,
+    daemon_interface_address: jlong,
+    auto_connect: jboolean,
+) {
+    let env = JnixEnv::from(env);
+
+    if let Some(daemon_interface) = get_daemon_interface(daemon_interface_address) {
+        let auto_connect = bool::from_java(&env, auto_connect);
+
+        if let Err(error) = daemon_interface.set_auto_connect(auto_connect) {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to set auto-connect")
+            );
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_shutdown(
     _: JNIEnv<'_>,
     _: JObject<'_>,

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -71,7 +71,6 @@ pub struct Settings {
     #[cfg_attr(target_os = "android", jnix(skip))]
     block_when_disconnected: bool,
     /// If the daemon should connect the VPN tunnel directly on start or not.
-    #[cfg_attr(target_os = "android", jnix(skip))]
     auto_connect: bool,
     /// Options that should be applied to tunnels of a specific type regardless of where the relays
     /// might be located.

--- a/talpid-core/src/tunnel/tun_provider/android/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/android/mod.rs
@@ -60,6 +60,9 @@ pub enum Error {
 
     #[error(display = "Timed out while waiting for tunnel device to receive data")]
     TunnelDeviceTimeout,
+
+    #[error(display = "Failed to create tunnel device")]
+    TunnelDeviceError,
 }
 
 /// Factory of tunnel devices on Android.
@@ -334,6 +337,7 @@ impl AndroidTunProvider {
             .map_err(|cause| Error::CallMethod("createTun", cause))?;
 
         match result {
+            JValue::Int(0) => Err(Error::TunnelDeviceError),
             JValue::Int(fd) => {
                 Self::wait_for_tunnel_up(fd, &config)?;
                 let tun = unsafe { File::from_raw_fd(fd) };


### PR DESCRIPTION
I've added a slider in the preferences fragment to enable auto-connecting in the daemon for Android.
This involves a change in the daemon on Android to enter the error state when the daemon attempts to auto-connect on start after the OS has revoked our VPN permission. The current solution only enables auto-connecting when the app starts - to start the VPN connection on boot, the user has to manually change the setting in Android's system settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1488)
<!-- Reviewable:end -->
