### PR TITLE
Swap country and city text labels on Android

### DIFF
--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -145,7 +145,7 @@
                 android:text="@string/unsecured_connection"
                 android:textAllCaps="true"
                 />
-        <TextView android:id="@+id/country"
+        <TextView android:id="@+id/city"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="24dp"
@@ -154,7 +154,7 @@
                 android:textStyle="bold"
                 android:text=""
                 />
-        <TextView android:id="@+id/city"
+        <TextView android:id="@+id/country"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="24dp"


### PR DESCRIPTION
On Android, when showing the location, the country was previously shown above the city. This is different from the desktop, which shows the country below the city. This PR fixes that by swapping the two text views in the layout file.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1495)
<!-- Reviewable:end -->
