### PR TITLE
Clean status bar when taking screenshots

### DIFF
--- a/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
+++ b/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
@@ -42,16 +42,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "584B26F0237434D00073B10E"
-               BuildableName = "RelaySelectorTests.xctest"
-               BlueprintName = "RelaySelectorTests"
-               ReferencedContainer = "container:MullvadVPN.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "58D0C79223F1CE7000FE9BA7"
                BuildableName = "MullvadVPNScreenshots.xctest"
                BlueprintName = "MullvadVPNScreenshots"

--- a/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPNScreenshots.xcscheme
+++ b/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPNScreenshots.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1130"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -28,6 +28,42 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       systemAttachmentLifetime = "keepNever">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "xcrun simctl boot &quot;${TARGET_DEVICE_IDENTIFIER}&quot;&#10;xcrun simctl status_bar &quot;${TARGET_DEVICE_IDENTIFIER}&quot; override \&#10;    --time &quot;9:41&quot; \&#10;    --dataNetwork wifi \&#10;    --wifiMode active \&#10;    --wifiBars 3 \&#10;    --cellularMode notSupported \&#10;    --batteryState charged \&#10;    --batteryLevel 100&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "58D0C79223F1CE7000FE9BA7"
+                     BuildableName = "MullvadVPNScreenshots.xctest"
+                     BlueprintName = "MullvadVPNScreenshots"
+                     ReferencedContainer = "container:MullvadVPN.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "xcrun simctl status_bar &quot;${TARGET_DEVICE_IDENTIFIER}&quot; clear&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "58D0C79223F1CE7000FE9BA7"
+                     BuildableName = "MullvadVPNScreenshots.xctest"
+                     BlueprintName = "MullvadVPNScreenshots"
+                     ReferencedContainer = "container:MullvadVPN.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- Add pre-action to UI Testing target to override the status bar on iOS simulator so that it always displays "9:41" time, Wi-Fi (all bars) on, battery 100% charged
- Add post-action to undo the statubar overrides.
- Remove dangling reference to `RelaySelectorTests` that was incorporated into `MullvadVPNTests` long ago

It's hard to read those scripts in Xcode project file as they are escaped, here is the source bash scripts:

Pre-action:

```
xcrun simctl boot "${TARGET_DEVICE_IDENTIFIER}"
xcrun simctl status_bar "${TARGET_DEVICE_IDENTIFIER}" override \
    --time "9:41" \
    --dataNetwork wifi \
    --wifiMode active \
    --wifiBars 3 \
    --cellularMode notSupported \
    --batteryState charged \
    --batteryLevel 100
```

Post-action:

```
xcrun simctl status_bar "${TARGET_DEVICE_IDENTIFIER}" clear
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1501)
<!-- Reviewable:end -->
