### PR TITLE
Update install.log encoding

### DIFF
--- a/windows/nsis-plugins/src/log/log.cpp
+++ b/windows/nsis-plugins/src/log/log.cpp
@@ -237,7 +237,7 @@ void __declspec(dllexport) NSISCALL Initialize
 
 				const auto logfile = decltype(logpath)(logpath).append(L"install.log");
 
-				g_logger = new Logger(std::make_unique<AnsiFileLogSink>(logfile));
+				g_logger = new Logger(std::make_unique<Utf8FileLogSink>(logfile));
 
 				break;
 

--- a/windows/nsis-plugins/src/log/logger.h
+++ b/windows/nsis-plugins/src/log/logger.h
@@ -21,15 +21,15 @@ public:
 	void log(const std::wstring &message) override {}
 };
 
-class AnsiFileLogSink : public ILogSink
+class Utf8FileLogSink : public ILogSink
 {
 public:
 
-	AnsiFileLogSink(const std::wstring &file, bool append = true, bool flush = false);
-	~AnsiFileLogSink();
+	Utf8FileLogSink(const std::wstring &file, bool append = true, bool flush = false);
+	~Utf8FileLogSink();
 
-	AnsiFileLogSink(const AnsiFileLogSink &) = delete;
-	AnsiFileLogSink &operator=(const AnsiFileLogSink &) = delete;
+	Utf8FileLogSink(const Utf8FileLogSink &) = delete;
+	Utf8FileLogSink &operator=(const Utf8FileLogSink &) = delete;
 
 	void log(const std::wstring &message) override;
 


### PR DESCRIPTION
Use UTF-8 instead of CP-1252 (or ANSI). Unicode symbols are now displayed correctly instead of replaced with "?"s. E.g.
```
[2020-02-18 11:38:43.681] Failed to create virtual adapter: error 0
[2020-02-18 11:38:43.681]     Enumerable network TAP adapters
[2020-02-18 11:38:43.681]         Adapter
[2020-02-18 11:38:43.681]             Guid: {2763D6AD-A42D-4FAF-8089-C5E2E0151762}
[2020-02-18 11:38:43.681]             Name: Mullvad VPN TAP Adapter
[2020-02-18 11:38:43.681]             Alias: 汉字 åäö
[2020-02-18 11:38:43.681]             Device instance ID: ROOT\NET\0000
[2020-02-18 11:38:43.681]     Identified more TAP adapters than expected (driverlogic.cpp: 718)
```
Non-ASCII characters (127 < value < 256) in CP-1252 from old log entries may be screwed up, but these only occurred rarely (eg in TAP adapter names). Rather than convert old log entries, I simply let them be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1503)
<!-- Reviewable:end -->
