### PR TITLE
Windows: Fix module interfaces

### DIFF
--- a/windows/windns/src/windns/windns.cpp
+++ b/windows/windns/src/windns/windns.cpp
@@ -255,6 +255,12 @@ WinDns_Set(
 		return false;
 	}
 
+	if (nullptr == interfaceAlias)
+	{
+		g_LogSink->error("Invalid argument: interfaceAlias");
+		return false;
+	}
+
 	//
 	// Check the settings on the adapter.
 	// If it already has the exact same settings we need, we're done.
@@ -277,12 +283,12 @@ WinDns_Set(
 			return true;
 		}
 	}
-	catch (const std::exception & ex)
+	catch (const std::exception &err)
 	{
 		std::stringstream ss;
 
 		ss << "Failed to evaluate DNS settings on adapter with alias \""
-			<< common::string::ToAnsi(interfaceAlias) << "\": " << ex.what();
+			<< common::string::ToAnsi(interfaceAlias) << "\": " << err.what();
 
 		g_LogSink->info(ss.str().c_str());
 	}

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -9,8 +9,6 @@
 namespace
 {
 
-uint32_t g_timeout = 0;
-
 MullvadLogSink g_logSink = nullptr;
 void *g_logSinkContext = nullptr;
 
@@ -65,14 +63,14 @@ WinFw_Initialize(
 	}
 
 	// Convert seconds to milliseconds.
-	g_timeout = timeout * 1000;
+	uint32_t timeout_ms = timeout * 1000;
 
 	g_logSink = logSink;
 	g_logSinkContext = logSinkContext;
 
 	try
 	{
-		g_fwContext = new FwContext(g_timeout);
+		g_fwContext = new FwContext(timeout_ms);
 	}
 	catch (std::exception &err)
 	{
@@ -112,14 +110,14 @@ WinFw_InitializeBlocked(
 	}
 
 	// Convert seconds to milliseconds.
-	g_timeout = timeout * 1000;
+	uint32_t timeout_ms = timeout * 1000;
 
 	g_logSink = logSink;
 	g_logSinkContext = logSinkContext;
 
 	try
 	{
-		g_fwContext = new FwContext(g_timeout, settings);
+		g_fwContext = new FwContext(timeout_ms, settings);
 	}
 	catch (std::exception &err)
 	{

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -53,23 +53,23 @@ WinFw_Initialize(
 	void *logSinkContext
 )
 {
-	if (nullptr != g_fwContext)
-	{
-		//
-		// This is an error.
-		// The existing instance may have a different timeout etc.
-		//
-		return false;
-	}
-
-	// Convert seconds to milliseconds.
-	uint32_t timeout_ms = timeout * 1000;
-
-	g_logSink = logSink;
-	g_logSinkContext = logSinkContext;
-
 	try
 	{
+		if (nullptr != g_fwContext)
+		{
+			//
+			// This is an error.
+			// The existing instance may have a different timeout etc.
+			//
+			THROW_ERROR("Cannot initialize WINFW twice");
+		}
+
+		// Convert seconds to milliseconds.
+		uint32_t timeout_ms = timeout * 1000;
+
+		g_logSink = logSink;
+		g_logSinkContext = logSinkContext;
+
 		g_fwContext = new FwContext(timeout_ms);
 	}
 	catch (std::exception &err)
@@ -95,29 +95,34 @@ bool
 WINFW_API
 WinFw_InitializeBlocked(
 	uint32_t timeout,
-	const WinFwSettings &settings,
+	const WinFwSettings *settings,
 	MullvadLogSink logSink,
 	void *logSinkContext
 )
 {
-	if (nullptr != g_fwContext)
-	{
-		//
-		// This is an error.
-		// The existing instance may have a different timeout etc.
-		//
-		return false;
-	}
-
-	// Convert seconds to milliseconds.
-	uint32_t timeout_ms = timeout * 1000;
-
-	g_logSink = logSink;
-	g_logSinkContext = logSinkContext;
-
 	try
 	{
-		g_fwContext = new FwContext(timeout_ms, settings);
+		if (nullptr != g_fwContext)
+		{
+			//
+			// This is an error.
+			// The existing instance may have a different timeout etc.
+			//
+			THROW_ERROR("Cannot initialize WINFW twice");
+		}
+
+		if (nullptr == settings)
+		{
+			THROW_ERROR("Invalid argument: settings");
+		}
+
+		// Convert seconds to milliseconds.
+		uint32_t timeout_ms = timeout * 1000;
+
+		g_logSink = logSink;
+		g_logSinkContext = logSinkContext;
+
+		g_fwContext = new FwContext(timeout_ms, *settings);
 	}
 	catch (std::exception &err)
 	{
@@ -156,8 +161,8 @@ WINFW_LINKAGE
 bool
 WINFW_API
 WinFw_ApplyPolicyConnecting(
-	const WinFwSettings &settings,
-	const WinFwRelay &relay,
+	const WinFwSettings *settings,
+	const WinFwRelay *relay,
 	const PingableHosts *pingableHosts
 )
 {
@@ -168,7 +173,17 @@ WinFw_ApplyPolicyConnecting(
 
 	try
 	{
-		return g_fwContext->applyPolicyConnecting(settings, relay, ConvertPingableHosts(pingableHosts));
+		if (nullptr == settings)
+		{
+			THROW_ERROR("Invalid argument: settings");
+		}
+
+		if (nullptr == relay)
+		{
+			THROW_ERROR("Invalid argument: relay");
+		}
+
+		return g_fwContext->applyPolicyConnecting(*settings, *relay, ConvertPingableHosts(pingableHosts));
 	}
 	catch (std::exception &err)
 	{
@@ -189,8 +204,8 @@ WINFW_LINKAGE
 bool
 WINFW_API
 WinFw_ApplyPolicyConnected(
-	const WinFwSettings &settings,
-	const WinFwRelay &relay,
+	const WinFwSettings *settings,
+	const WinFwRelay *relay,
 	const wchar_t *tunnelInterfaceAlias,
 	const wchar_t *v4DnsHost,
 	const wchar_t *v6DnsHost
@@ -203,6 +218,26 @@ WinFw_ApplyPolicyConnected(
 
 	try
 	{
+		if (nullptr == settings)
+		{
+			THROW_ERROR("Invalid argument: settings");
+		}
+
+		if (nullptr == relay)
+		{
+			THROW_ERROR("Invalid argument: relay");
+		}
+
+		if (nullptr == tunnelInterfaceAlias)
+		{
+			THROW_ERROR("Invalid argument: tunnelInterfaceAlias");
+		}
+
+		if (nullptr == v4DnsHost)
+		{
+			THROW_ERROR("Invalid argument: v4DnsHost");
+		}
+
 		std::vector<wfp::IpAddress> tunnelDnsServers = { wfp::IpAddress(v4DnsHost) };
 
 		if (nullptr != v6DnsHost)
@@ -211,8 +246,8 @@ WinFw_ApplyPolicyConnected(
 		}
 
 		return g_fwContext->applyPolicyConnected(
-			settings,
-			relay,
+			*settings,
+			*relay,
 			tunnelInterfaceAlias,
 			tunnelDnsServers
 		);
@@ -236,7 +271,7 @@ WINFW_LINKAGE
 bool
 WINFW_API
 WinFw_ApplyPolicyBlocked(
-	const WinFwSettings &settings
+	const WinFwSettings *settings
 )
 {
 	if (nullptr == g_fwContext)
@@ -246,7 +281,12 @@ WinFw_ApplyPolicyBlocked(
 
 	try
 	{
-		return g_fwContext->applyPolicyBlocked(settings);
+		if (nullptr == settings)
+		{
+			THROW_ERROR("Invalid argument: settings");
+		}
+
+		return g_fwContext->applyPolicyBlocked(*settings);
 	}
 	catch (std::exception &err)
 	{

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -87,7 +87,7 @@ bool
 WINFW_API
 WinFw_InitializeBlocked(
 	uint32_t timeout,
-	const WinFwSettings &settings,
+	const WinFwSettings *settings,
 	MullvadLogSink logSink,
 	void *logSinkContext
 );
@@ -133,8 +133,8 @@ WINFW_LINKAGE
 bool
 WINFW_API
 WinFw_ApplyPolicyConnecting(
-	const WinFwSettings &settings,
-	const WinFwRelay &relay,
+	const WinFwSettings *settings,
+	const WinFwRelay *relay,
 	const PingableHosts *pingableHosts
 );
 
@@ -159,8 +159,8 @@ WINFW_LINKAGE
 bool
 WINFW_API
 WinFw_ApplyPolicyConnected(
-	const WinFwSettings &settings,
-	const WinFwRelay &relay,
+	const WinFwSettings *settings,
+	const WinFwRelay *relay,
 	const wchar_t *tunnelInterfaceAlias,
 	const wchar_t *v4DnsHost,
 	const wchar_t *v6DnsHost
@@ -177,7 +177,7 @@ WINFW_LINKAGE
 bool
 WINFW_API
 WinFw_ApplyPolicyBlocked(
-	const WinFwSettings &settings
+	const WinFwSettings *settings
 );
 
 //

--- a/windows/winnet/src/winnet/winnet.cpp
+++ b/windows/winnet/src/winnet/winnet.cpp
@@ -43,6 +43,11 @@ WinNet_EnsureBestMetric(
 {
 	try
 	{
+		if (nullptr == deviceAlias)
+		{
+			THROW_ERROR("Invalid argument: deviceAlias");
+		}
+
 		NetworkInterfaces interfaces;
 		return interfaces.SetBestMetricForInterfacesByAlias(deviceAlias) ?
 			WINNET_EBM_STATUS_METRIC_SET : WINNET_EBM_STATUS_METRIC_NO_CHANGE;
@@ -111,6 +116,11 @@ WinNet_GetTapInterfaceAlias(
 {
 	try
 	{
+		if (nullptr == alias)
+		{
+			THROW_ERROR("Invalid argument: alias");
+		}
+
 		const auto currentAlias = InterfaceUtils::GetTapInterfaceAlias();
 
 		auto stringBuffer = new wchar_t[currentAlias.size() + 1];
@@ -164,6 +174,11 @@ WinNet_ActivateConnectivityMonitor(
 		if (nullptr != g_OfflineMonitor)
 		{
 			THROW_ERROR("Cannot activate connectivity monitor twice");
+		}
+
+		if (nullptr == callback)
+		{
+			THROW_ERROR("Invalid argument: callback");
 		}
 
 		auto forwarder = [callback, callbackContext](bool connected)
@@ -257,6 +272,11 @@ WinNet_AddRoutes(
 
 	try
 	{
+		if (nullptr == routes)
+		{
+			THROW_ERROR("Invalid argument: routes");
+		}
+
 		g_RouteManager->addRoutes(winnet::ConvertRoutes(routes, numRoutes));
 		return true;
 	}
@@ -300,6 +320,11 @@ WinNet_DeleteRoutes(
 
 	try
 	{
+		if (nullptr == routes)
+		{
+			THROW_ERROR("Invalid argument: routes");
+		}
+
 		g_RouteManager->deleteRoutes(winnet::ConvertRoutes(routes, numRoutes));
 		return true;
 	}
@@ -344,6 +369,16 @@ WinNet_RegisterDefaultRouteChangedCallback(
 
 	try
 	{
+		if (nullptr == callback)
+		{
+			THROW_ERROR("Invalid argument: callback");
+		}
+
+		if (nullptr == registrationHandle)
+		{
+			THROW_ERROR("Invalid argument: registrationHandle");
+		}
+
 		auto forwarder = [callback, context](RouteManager::DefaultRouteChangedEventType eventType,
 			ADDRESS_FAMILY family, const std::optional<InterfaceAndGateway> &route)
 		{
@@ -469,6 +504,16 @@ WinNet_AddDeviceIpAddresses(
 {
 	try
 	{
+		if (nullptr == deviceAlias)
+		{
+			THROW_ERROR("Invalid argument: deviceAlias")
+		}
+
+		if (nullptr == addresses)
+		{
+			THROW_ERROR("Invalid argument: addresses")
+		}
+
 		NET_LUID luid;
 
 		if (0 != ConvertInterfaceAliasToLuid(deviceAlias, &luid))


### PR DESCRIPTION
I had noticed `winfw` was using references in its public functions, in several instances. So I created a branch to address this, but turns out `winfw` was the only module with this issue. Anyway, this branch also adds parameter validation on all public functions in the C++ modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1510)
<!-- Reviewable:end -->
