### PR TITLE
Fix linter problems caused by @typescript-eslint/no-explicit-any

### DIFF
--- a/gui/src/main/account-data-cache.ts
+++ b/gui/src/main/account-data-cache.ts
@@ -84,7 +84,7 @@ export default class AccountDataCache {
     }
   }
 
-  private handleFetchError(accountToken: AccountToken, error: any) {
+  private handleFetchError(accountToken: AccountToken, error: Error) {
     let shouldRetry = true;
 
     this.notifyWatchers((watcher) => {

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -446,7 +446,7 @@ export class DaemonRpc {
   public async getRelayLocations(): Promise<IRelayList> {
     const response = await this.transport.send('get_relay_locations');
     try {
-      return camelCaseObjectKeys(validate(relayListSchema, response)) as IRelayList;
+      return camelCaseObjectKeys(validate(relayListSchema, response));
     } catch (error) {
       throw new ResponseParseError(`Invalid response from get_relay_locations: ${error}`, error);
     }
@@ -505,7 +505,7 @@ export class DaemonRpc {
     try {
       const validatedObject = validate(locationSchema, response);
       if (validatedObject) {
-        return camelCaseObjectKeys(validatedObject) as ILocation;
+        return camelCaseObjectKeys(validatedObject);
       } else {
         return undefined;
       }
@@ -517,7 +517,7 @@ export class DaemonRpc {
   public async getState(): Promise<TunnelState> {
     const response = await this.transport.send('get_state');
     try {
-      return camelCaseObjectKeys(validate(tunnelStateSchema, response)) as TunnelState;
+      return camelCaseObjectKeys(validate(tunnelStateSchema, response));
     } catch (error) {
       throw new ResponseParseError('Invalid response from get_state', error);
     }
@@ -526,7 +526,7 @@ export class DaemonRpc {
   public async getSettings(): Promise<ISettings> {
     const response = await this.transport.send('get_settings');
     try {
-      return camelCaseObjectKeys(validate(settingsSchema, response)) as ISettings;
+      return camelCaseObjectKeys(validate(settingsSchema, response));
     } catch (error) {
       throw new ResponseParseError('Invalid response from get_settings', error);
     }
@@ -539,7 +539,7 @@ export class DaemonRpc {
       let daemonEvent: DaemonEvent;
 
       try {
-        daemonEvent = camelCaseObjectKeys(validate(daemonEventSchema, payload)) as DaemonEvent;
+        daemonEvent = camelCaseObjectKeys(validate(daemonEventSchema, payload));
       } catch (error) {
         listener.onError(new ResponseParseError('Invalid payload from daemon_event', error));
         return;
@@ -584,13 +584,13 @@ export class DaemonRpc {
   public async generateWireguardKey(): Promise<KeygenEvent> {
     const response = await this.transport.send('generate_wireguard_key');
     try {
-      const validatedResponse: any = validate(keygenEventSchema, response);
+      const validatedResponse = validate(keygenEventSchema, response);
       switch (validatedResponse) {
         case 'too_many_keys':
         case 'generation_failure':
           return validatedResponse;
         default:
-          return camelCaseObjectKeys(validatedResponse as object) as KeygenEvent;
+          return camelCaseObjectKeys(validatedResponse as object);
       }
     } catch (error) {
       throw new ResponseParseError(`Invalid response from generate_wireguard_key ${error}`);
@@ -618,7 +618,7 @@ export class DaemonRpc {
   public async getVersionInfo(): Promise<IAppVersionInfo> {
     const response = await this.transport.send('get_version_info', [], NETWORK_CALL_TIMEOUT);
     try {
-      return camelCaseObjectKeys(validate(appVersionInfoSchema, response)) as IAppVersionInfo;
+      return camelCaseObjectKeys(validate(appVersionInfoSchema, response));
     } catch (error) {
       throw new ResponseParseError('Invalid response from get_version_info');
     }
@@ -635,16 +635,17 @@ function camelCaseToUnderscore(str: string): string {
     .toLowerCase();
 }
 
-function camelCaseObjectKeys(anObject: { [key: string]: any }) {
-  return transformObjectKeys(anObject, underscoreToCamelCase);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function camelCaseObjectKeys<T>(anObject: { [key: string]: any }): T {
+  return transformObjectKeys(anObject, underscoreToCamelCase) as T;
 }
 
-function underscoreObjectKeys(anObject: { [key: string]: any }) {
+function underscoreObjectKeys<T>(anObject: T): Record<string, unknown> {
   return transformObjectKeys(anObject, camelCaseToUnderscore);
 }
 
 function transformObjectKeys(
-  anObject: { [key: string]: any },
+  anObject: { [key: string]: any }, // eslint-disable-line @typescript-eslint/no-explicit-any
   keyTransformer: (key: string) => string,
 ) {
   for (const sourceKey of Object.keys(anObject)) {

--- a/gui/src/main/jsonrpc-client.ts
+++ b/gui/src/main/jsonrpc-client.ts
@@ -6,6 +6,8 @@ import * as net from 'net';
 import StreamValues from 'stream-json/streamers/StreamValues';
 import * as uuid from 'uuid';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 export interface IUnansweredRequest {
   resolve: (value: any) => void;
   reject: (value: any) => void;

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -181,6 +181,8 @@ export default class WindowController {
     return this.windowValue.isVisible();
   }
 
+  // Electron uses the `any` type.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public send(event: string, ...data: any[]): void {
     this.windowValue.webContents.send(event, ...data);
   }

--- a/gui/src/renderer/components/AppButton.tsx
+++ b/gui/src/renderer/components/AppButton.tsx
@@ -183,7 +183,7 @@ export class BlockingButton extends Component<IBlockingProps, IBlockingState> {
   public render() {
     return React.Children.map(this.props.children, (child) => {
       if (React.isValidElement(child)) {
-        return React.cloneElement(child as React.ReactElement<any>, {
+        return React.cloneElement(child as React.ReactElement, {
           ...child.props,
           disabled: this.state.isBlocked || this.props.disabled,
           onPress: this.onPress,

--- a/gui/src/renderer/components/LocationList.tsx
+++ b/gui/src/renderer/components/LocationList.tsx
@@ -248,10 +248,10 @@ interface IRelayLocationsProps {
   onExpand?: (location: RelayLocation, expand: boolean) => void;
 }
 
-interface ICommonCellProps {
+interface ICommonCellProps<T> {
   location: RelayLocation;
   selected: boolean;
-  ref?: React.Ref<any>;
+  ref?: React.Ref<T>;
 }
 
 export class RelayLocations extends Component<IRelayLocationsProps> {
@@ -269,7 +269,7 @@ export class RelayLocations extends Component<IRelayLocationsProps> {
               expanded={this.isExpanded(countryLocation)}
               onSelect={this.handleSelection}
               onExpand={this.handleExpand}
-              {...this.getCommonCellProps(countryLocation)}>
+              {...this.getCommonCellProps<CountryRow>(countryLocation)}>
               {relayCountry.cities.map((relayCity) => {
                 const cityLocation: RelayLocation = {
                   city: [relayCountry.code, relayCity.code],
@@ -283,7 +283,7 @@ export class RelayLocations extends Component<IRelayLocationsProps> {
                     expanded={this.isExpanded(cityLocation)}
                     onSelect={this.handleSelection}
                     onExpand={this.handleExpand}
-                    {...this.getCommonCellProps(cityLocation)}>
+                    {...this.getCommonCellProps<CityRow>(cityLocation)}>
                     {relayCity.relays.map((relay) => {
                       const relayLocation: RelayLocation = {
                         hostname: [relayCountry.code, relayCity.code, relay.hostname],
@@ -295,7 +295,7 @@ export class RelayLocations extends Component<IRelayLocationsProps> {
                           active={relay.active}
                           hostname={relay.hostname}
                           onSelect={this.handleSelection}
-                          {...this.getCommonCellProps(relayLocation)}
+                          {...this.getCommonCellProps<RelayRow>(relayLocation)}
                         />
                       );
                     })}
@@ -333,12 +333,12 @@ export class RelayLocations extends Component<IRelayLocationsProps> {
     }
   };
 
-  private getCommonCellProps(location: RelayLocation): ICommonCellProps {
+  private getCommonCellProps<T>(location: RelayLocation): ICommonCellProps<T> {
     const selected = this.isSelected(location);
     const ref =
       selected && this.props.selectedElementRef ? this.props.selectedElementRef : undefined;
 
-    return { ref, selected, location };
+    return { ref: ref as React.Ref<T>, selected, location };
   }
 }
 

--- a/gui/src/renderer/components/SvgMap.tsx
+++ b/gui/src/renderer/components/SvgMap.tsx
@@ -182,7 +182,11 @@ export default class SvgMap extends React.Component<IProps, IState> {
     );
   }
 
-  private mergeRsmStyle(style: { [key: string]: any }) {
+  private mergeRsmStyle(style: {
+    default?: React.CSSProperties;
+    hover?: React.CSSProperties;
+    pressed?: React.CSSProperties;
+  }) {
     const defaultStyle = style.default || {};
     return {
       default: defaultStyle,

--- a/gui/src/renderer/redux/store.ts
+++ b/gui/src/renderer/redux/store.ts
@@ -61,6 +61,7 @@ export default function configureStore(
   };
 
   const composeEnhancers: typeof compose = (() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const reduxCompose = window && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
     if (process.env.NODE_ENV === 'development' && reduxCompose) {
       return reduxCompose({ actionCreators });

--- a/gui/src/shared/gettext.ts
+++ b/gui/src/shared/gettext.ts
@@ -22,6 +22,7 @@ export function loadTranslations(currentLocale: string, catalogue: Gettext) {
   }
 
   // NOTE: domain is not publicly exposed
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const domain = (catalogue as any).domain;
 
   for (const locale of preferredLocales) {
@@ -67,6 +68,7 @@ function parseTranslation(locale: string, domain: string, catalogue: Gettext): b
 function setErrorHandler(catalogue: Gettext) {
   catalogue.on('error', (error) => {
     // NOTE: locale is not publicly exposed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const catalogueLocale = (catalogue as any).locale;
 
     // Filter out the "no translation was found" errors for the source language.

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -425,6 +425,8 @@ function handler<T>(event: string): (handlerFn: (value: T) => void) => void {
 
 type RequestResult<T> = { type: 'success'; value: T } | { type: 'error'; message: string };
 
+// The  Elector API uses the `any` type.
+/* eslint-disable @typescript-eslint/no-explicit-any */
 function requestHandler<T>(event: string): (fn: (...args: any[]) => Promise<T>) => void {
   return (fn: (...args: any[]) => Promise<T>) => {
     ipcMain.on(
@@ -452,7 +454,10 @@ function requestHandler<T>(event: string): (fn: (...args: any[]) => Promise<T>) 
     );
   };
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
+// The  Elector API uses the `any` type.
+/* eslint-disable @typescript-eslint/no-explicit-any */
 function requestSender<T>(event: string): (...args: any[]) => Promise<T> {
   return (...args: any[]): Promise<T> => {
     return new Promise((resolve: (result: T) => void, reject: (error: Error) => void) => {
@@ -478,3 +483,4 @@ function requestSender<T>(event: string): (...args: any[]) => Promise<T> {
     });
   };
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/gui/types/validated/index.d.ts
+++ b/gui/types/validated/index.d.ts
@@ -106,6 +106,6 @@ declare module 'validated/object' {
 
   export function validate<T>(
     object: Node<T>,
-    value: any,
+    value: unknown,
   ): ExtractValidateResult<typeof object.validate>;
 }


### PR DESCRIPTION
This PR fixes the code causing @typescript-eslint/no-explicit-any warnings.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1513)
<!-- Reviewable:end -->
