### PR TITLE
Cleanup talpid-core's WireGuard module

### DIFF
--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -15,6 +15,7 @@ use talpid_types::net::{wireguard as wireguard_types, TunnelParameters};
 #[cfg(not(target_os = "android"))]
 pub mod openvpn;
 
+/// A module for all WireGuard related tunnel management.
 pub mod wireguard;
 
 /// A module for low level platform specific tunnel device management.

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -60,7 +60,7 @@ pub struct ConnectivityMonitor {
 
 
 impl ConnectivityMonitor {
-    pub fn new(
+    pub(super) fn new(
         addr: Ipv4Addr,
         interface: String,
         tunnel_handle: Weak<Mutex<Option<Box<dyn Tunnel>>>>,
@@ -82,7 +82,7 @@ impl ConnectivityMonitor {
 
     // checks if the tunnel has ever worked. Intended to check if a connection to a tunnel is
     // successfull at the start of a connection.
-    pub fn establish_connectivity(&mut self) -> Result<bool, Error> {
+    pub(super) fn establish_connectivity(&mut self) -> Result<bool, Error> {
         if self.conn_state.connected() {
             return Ok(true);
         }
@@ -99,7 +99,7 @@ impl ConnectivityMonitor {
         Ok(false)
     }
 
-    pub fn run(&mut self) -> Result<(), Error> {
+    pub(super) fn run(&mut self) -> Result<(), Error> {
         self.wait_loop(REGULAR_LOOP_SLEEP)
     }
 

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use super::{Error, Tunnel};
+use super::{Tunnel, TunnelError};
 
 /// Sleep time used when initially establishing connectivity
 const DELAY_ON_INITIAL_SETUP: Duration = Duration::from_millis(50);
@@ -25,6 +25,18 @@ const TRAFFIC_TIMEOUT: Duration = Duration::from_secs(120);
 const PING_TIMEOUT: Duration = Duration::from_secs(15);
 /// Number of seconds to wait between sending ICMP packets
 const SECONDS_PER_PING: Duration = Duration::from_secs(3);
+
+/// Connectivity monitor errors
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// Failed to read tunnel's configuration
+    #[error(display = "Failed to read tunnel's configuration")]
+    ConfigReadError(TunnelError),
+
+    /// Failed to send ping
+    #[error(display = "Ping monitor failed")]
+    PingError(#[error(source)] crate::ping_monitor::Error),
+}
 
 
 /// Verifies if a connection to a tunnel is working.
@@ -144,7 +156,7 @@ impl ConnectivityMonitor {
             .lock()
             .ok()?
             .as_ref()
-            .map(|tunnel| tunnel.get_config())
+            .map(|tunnel| tunnel.get_tunnel_stats().map_err(Error::ConfigReadError))
     }
 
     fn maybe_send_ping(&mut self) -> Result<(), Error> {

--- a/talpid-core/src/tunnel/wireguard/stats.rs
+++ b/talpid-core/src/tunnel/wireguard/stats.rs
@@ -1,5 +1,4 @@
 #[derive(err_derive::Error, Debug, PartialEq)]
-#[error(no_from)]
 pub enum Error {
     #[error(display = "Failed to parse integer from string \"_0\"")]
     IntParseError(String, #[error(source)] std::num::ParseIntError),

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -295,16 +295,18 @@ fn get_openvpn_proxy_settings(
 }
 
 fn should_retry(error: &tunnel::Error) -> bool {
+    #[cfg(not(windows))]
+    use tunnel::wireguard::{Error, TunnelError};
     match error {
         #[cfg(not(windows))]
-        tunnel::Error::WireguardTunnelMonitoringError(
-            tunnel::wireguard::Error::RecoverableStartWireguardError,
-        ) => true,
+        tunnel::Error::WireguardTunnelMonitoringError(Error::TunnelError(
+            TunnelError::RecoverableStartWireguardError,
+        )) => true,
 
         #[cfg(target_os = "android")]
-        tunnel::Error::WireguardTunnelMonitoringError(tunnel::wireguard::Error::BypassError(_)) => {
-            true
-        }
+        tunnel::Error::WireguardTunnelMonitoringError(Error::TunnelError(
+            TunnelError::BypassError(_),
+        )) => true,
 
         _ => false,
     }


### PR DESCRIPTION
I've done 2 cleanup things here:
- document all the public types in `talpid-core::tunnel::wireguard` and decrease visibility of types that don't need to be as public
- factor out the error types better so that `talpid-core::tunnel::wireguard::Error` is more `WireguardMonitor` specific, and have each submodule define it's own error type. Additionally, the `trait Tunnel` now returns it's own error type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1515)
<!-- Reviewable:end -->
