### PR TITLE
Windows: fix filter initialization

### DIFF
--- a/windows/winfw/src/winfw/rules/baseline/permitdhcp.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitdhcp.cpp
@@ -90,7 +90,12 @@ bool PermitDhcp::applyIpv6(IObjectInstaller &objectInstaller) const
 	filterBuilder
 		.key(MullvadGuids::Filter_Baseline_PermitDhcp_Outbound_Request_Ipv6())
 		.name(L"Permit outbound DHCP requests (IPv6)")
-		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+		.description(L"This filter is part of a rule that permits DHCP client traffic")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Max)
+		.permit();
 
 	{
 		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);

--- a/windows/winfw/src/winfw/rules/baseline/permitndp.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitndp.cpp
@@ -28,7 +28,12 @@ bool PermitNdp::apply(IObjectInstaller &objectInstaller)
 	filterBuilder
 		.key(MullvadGuids::Filter_Baseline_PermitNdp_Outbound_Router_Solicitation())
 		.name(L"Permit outbound NDP router solicitation")
-		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+		.description(L"This filter is part of a rule that permits the most central parts of NDP")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Max)
+		.permit();
 
 	{
 		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);


### PR DESCRIPTION
This changeset brings in an updated `libwfp` that has better validation on the filters that are being installed.

It also addresses missing initialization on a couple of IPv6 filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1516)
<!-- Reviewable:end -->
