### PR TITLE
Windows: Update PermitPing rule

### DIFF
--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -177,13 +177,10 @@ bool FwContext::applyPolicyConnecting
 	{
 		const auto &ph = pingableHosts.value();
 
-		for (const auto &host : ph.hosts)
-		{
-			ruleset.emplace_back(std::make_unique<baseline::PermitPing>(
-				ph.tunnelInterfaceAlias,
-				host
-			));
-		}
+		ruleset.emplace_back(std::make_unique<baseline::PermitPing>(
+			ph.tunnelInterfaceAlias,
+			ph.hosts
+		));
 	}
 
 	return applyRuleset(ruleset);

--- a/windows/winfw/src/winfw/rules/baseline/permitping.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitping.h
@@ -4,6 +4,7 @@
 #include <libwfp/ipaddress.h>
 #include <string>
 #include <optional>
+#include <vector>
 
 namespace rules::baseline
 {
@@ -12,14 +13,15 @@ class PermitPing : public IFirewallRule
 {
 public:
 
-	PermitPing(std::optional<std::wstring> interfaceAlias, const wfp::IpAddress &host);
+	PermitPing(std::optional<std::wstring> interfaceAlias, const std::vector<wfp::IpAddress> &hosts);
 
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
 
 	const std::optional<std::wstring> m_interfaceAlias;
-	const wfp::IpAddress m_host;
+	std::vector<wfp::IpAddress> m_hostsIpv4;
+	std::vector<wfp::IpAddress> m_hostsIpv6;
 
 	bool applyIcmpv4(IObjectInstaller &objectInstaller) const;
 	bool applyIcmpv6(IObjectInstaller &objectInstaller) const;

--- a/windows/winfw/src/winfw/rules/dns/permitnontunnel.cpp
+++ b/windows/winfw/src/winfw/rules/dns/permitnontunnel.cpp
@@ -2,6 +2,7 @@
 #include "permitnontunnel.h"
 #include <winfw/mullvadguids.h>
 #include <winfw/rules/ports.h>
+#include <winfw/rules/shared.h>
 #include <libwfp/filterbuilder.h>
 #include <libwfp/conditionbuilder.h>
 #include <libwfp/conditions/conditionport.h>
@@ -17,31 +18,7 @@ namespace rules::dns
 PermitNonTunnel::PermitNonTunnel(std::optional<std::wstring> tunnelInterfaceAlias, const std::vector<wfp::IpAddress> &hosts)
 	: m_tunnelInterfaceAlias(std::move(tunnelInterfaceAlias))
 {
-	if (hosts.empty())
-	{
-		THROW_ERROR("Invalid argument: No hosts specified");
-	}
-
-	for (const auto &host : hosts)
-	{
-		switch (host.type())
-		{
-			case wfp::IpAddress::Type::Ipv4:
-			{
-				m_hostsIpv4.push_back(host);
-				break;
-			}
-			case wfp::IpAddress::Type::Ipv6:
-			{
-				m_hostsIpv6.push_back(host);
-				break;
-			}
-			default:
-			{
-				THROW_ERROR("Missing case handler in switch clause");
-			}
-		}
-	}
+	SplitAddresses(hosts, m_hostsIpv4, m_hostsIpv6);
 }
 
 bool PermitNonTunnel::apply(IObjectInstaller &objectInstaller)

--- a/windows/winfw/src/winfw/rules/dns/permittunnel.cpp
+++ b/windows/winfw/src/winfw/rules/dns/permittunnel.cpp
@@ -2,6 +2,7 @@
 #include "permittunnel.h"
 #include <winfw/mullvadguids.h>
 #include <winfw/rules/ports.h>
+#include <winfw/rules/shared.h>
 #include <libwfp/filterbuilder.h>
 #include <libwfp/conditionbuilder.h>
 #include <libwfp/conditions/conditionport.h>
@@ -17,31 +18,7 @@ namespace rules::dns
 PermitTunnel::PermitTunnel(const std::wstring &tunnelInterfaceAlias, const std::vector<wfp::IpAddress> &hosts)
 	: m_tunnelInterfaceAlias(tunnelInterfaceAlias)
 {
-	if (hosts.empty())
-	{
-		THROW_ERROR("Invalid argument: No hosts specified");
-	}
-
-	for (const auto &host : hosts)
-	{
-		switch (host.type())
-		{
-			case wfp::IpAddress::Type::Ipv4:
-			{
-				m_hostsIpv4.push_back(host);
-				break;
-			}
-			case wfp::IpAddress::Type::Ipv6:
-			{
-				m_hostsIpv6.push_back(host);
-				break;
-			}
-			default:
-			{
-				THROW_ERROR("Missing case handler in switch clause");
-			}
-		}
-	}
+	SplitAddresses(hosts, m_hostsIpv4, m_hostsIpv6);
 }
 
 bool PermitTunnel::apply(IObjectInstaller &objectInstaller)

--- a/windows/winfw/src/winfw/rules/shared.cpp
+++ b/windows/winfw/src/winfw/rules/shared.cpp
@@ -1,0 +1,40 @@
+#include "stdafx.h"
+#include "shared.h"
+#include <libcommon/error.h>
+
+namespace rules
+{
+
+void SplitAddresses(const IpSet &in, IpSet &outIpv4, IpSet &outIpv6)
+{
+	if (in.empty())
+	{
+		THROW_ERROR("Invalid argument: No hosts specified");
+	}
+
+	outIpv4.clear();
+	outIpv6.clear();
+
+	for (const auto &host : in)
+	{
+		switch (host.type())
+		{
+			case wfp::IpAddress::Type::Ipv4:
+			{
+				outIpv4.push_back(host);
+				break;
+			}
+			case wfp::IpAddress::Type::Ipv6:
+			{
+				outIpv6.push_back(host);
+				break;
+			}
+			default:
+			{
+				THROW_ERROR("Missing case handler in switch clause");
+			}
+		}
+	}
+}
+
+}

--- a/windows/winfw/src/winfw/rules/shared.h
+++ b/windows/winfw/src/winfw/rules/shared.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vector>
+#include <libwfp/ipaddress.h>
+
+namespace rules
+{
+
+using IpSet = std::vector<wfp::IpAddress>;
+
+void SplitAddresses(const IpSet &in, IpSet &outIpv4, IpSet &outIpv6);
+
+}

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="rules\dns\blockall.cpp" />
     <ClCompile Include="rules\dns\permitnontunnel.cpp" />
     <ClCompile Include="rules\dns\permittunnel.cpp" />
+    <ClCompile Include="rules\shared.cpp" />
     <ClCompile Include="sessioncontroller.cpp" />
     <ClCompile Include="sessionrecord.cpp" />
     <ClCompile Include="stdafx.cpp">
@@ -71,6 +72,7 @@
     <ClInclude Include="rules\dns\permitnontunnel.h" />
     <ClInclude Include="rules\dns\permittunnel.h" />
     <ClInclude Include="rules\ports.h" />
+    <ClInclude Include="rules\shared.h" />
     <ClInclude Include="wfpobjecttype.h" />
     <ClInclude Include="rules\ifirewallrule.h" />
     <ClInclude Include="sessioncontroller.h" />

--- a/windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -55,6 +55,9 @@
     <ClCompile Include="rules\dns\permittunnel.cpp">
       <Filter>rules\dns</Filter>
     </ClCompile>
+    <ClCompile Include="rules\shared.cpp">
+      <Filter>rules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -119,6 +122,9 @@
     </ClInclude>
     <ClInclude Include="rules\dns\permittunnel.h">
       <Filter>rules\dns</Filter>
+    </ClInclude>
+    <ClInclude Include="rules\shared.h">
+      <Filter>rules</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The PermitPing rule had a weird design using only a single host. Naturally we want to install the filter once and include a set of hosts in the conditions, in the case there are more than one host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1517)
<!-- Reviewable:end -->
