### PR TITLE
Improve prepare release

### DIFF
--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -28,7 +28,13 @@ echo "Updating version in metadata files..."
 
 echo "Syncing Cargo.lock with new version numbers"
 source env.sh ""
-cargo +stable build
+# If cargo exits with a non zero exit status and it's not a timeout (exit code 124) it's an error
+set +e
+timeout 5s cargo +stable build
+if [[ $? != 0 && $? != 124 ]]; then
+    exit 1
+fi
+set -e
 
 echo "Commiting metadata changes to git..."
 git commit -S -m "Updating version in package files" \

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -53,15 +53,9 @@ git tag -s $PRODUCT_VERSION -m $PRODUCT_VERSION
 
 ./version_metadata.sh delete-backup
 
-echo "==================================================="
-echo "DONE preparing for a release! Now do the following:"
-echo " 1. Push the commit and tag created by this script"
-echo "    after you have verified they are correct"
-echo "     $ git push"
-echo "     $ git push origin $PRODUCT_VERSION"
-echo " 2. On each platform where you want to create a"
-echo "    release artifact, check out the tag and build:"
-echo "     $ git fetch"
-echo "     $ git checkout $PRODUCT_VERSION"
-echo "     $ ./build.sh"
-echo "==================================================="
+echo "================================================="
+echo "| DONE preparing for a release!                 |"
+echo "|    Now push the tag created by this script    |"
+echo "|    after you have verified it is correct:     |"
+echo "|        $ git push origin $PRODUCT_VERSION     |"
+echo "================================================="


### PR DESCRIPTION
Slightly improve the `prepare_release.sh` script. This script is used to bump the version in all relevant files and add a signed git tag.

The `cargo build` part was only needed because it indirectly updates `Cargo.lock` with the new versions. But we did not actually need to build anything. So having it behind a timer solves the issue of having to wait a long time. Ugly, but I don't have a better solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1518)
<!-- Reviewable:end -->
