### PR TITLE
Improve WIreGuard key rotation

### DIFF
--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -79,8 +79,6 @@ impl KeyManager {
         account_history: &mut AccountHistory,
         account_token: AccountToken,
     ) {
-        log::debug!("reset_rotation");
-
         match account_history
             .get(&account_token)
             .map(|entry| entry.map(|entry| entry.wireguard.map(|wg| wg.get_public_key())))
@@ -103,8 +101,6 @@ impl KeyManager {
         account_token: AccountToken,
         auto_rotation_interval: Option<Duration>,
     ) {
-        log::debug!("set_rotation_interval");
-
         self.auto_rotation_interval =
             auto_rotation_interval.unwrap_or(DEFAULT_AUTOMATIC_KEY_ROTATION);
 
@@ -343,8 +339,6 @@ impl KeyManager {
         rotation_interval_secs: u64,
         account_token: AccountToken,
     ) -> impl Future<Item = (), Error = ()> + Send {
-        log::debug!("create_automatic_rotation");
-
         tokio_timer::wheel()
             .build()
             .interval(AUTOMATIC_ROTATION_RETRY_DELAY)
@@ -381,6 +375,7 @@ impl KeyManager {
             return;
         }
 
+        log::debug!("Starting automatic key rotation job");
         // Schedule cancellable series of repeating rotation tasks
         let fut = Self::create_automatic_rotation(
             self.daemon_tx.clone(),


### PR DESCRIPTION
The current key rotation code doesn't log when the rotation future stops, which makes it hard to debug, and it doesn't actually stop when the RPC fails because there are too many keys in an account. These changes fix said issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1520)
<!-- Reviewable:end -->
