### PR TITLE
Log less sensitive info in install.log

### DIFF
--- a/windows/nsis-plugins/src/msiutil/msiutil.cpp
+++ b/windows/nsis-plugins/src/msiutil/msiutil.cpp
@@ -67,6 +67,12 @@ int WINAPI InstallerHandler(
 	LPCWSTR message
 )
 {
+	// Do not log potentially sensitive information
+	if (0 == _wcsnicmp(message, L"Property", _countof(L"Property") - sizeof(L'\0')))
+	{
+		return 0;
+	}
+
 	PluginLog(message);
 	// return 0 to pass it on to the installer
 	return 0;


### PR DESCRIPTION
The Wintun installation log contains somewhat sensitive information, some of which is not redacted. This PR removes all of the "Property" log entries, which contain all of the sensitive information I've seen (e.g. computer name and user name).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1521)
<!-- Reviewable:end -->
