### PR TITLE
Add 2020.3[-beta1] to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,19 @@ Line wrap the file at 100 chars.                                              Th
   leaking any data during the reconnection.
 
 ### Fixed
-- Fix stack overflow caused by WireGuard key rotation timers.
-
 #### Android
 - Make sure the settings screen is scrollable so that devices with small screens can access the quit
   button.
+
+
+## [2020.3] - 2020-02-20
+This release is identical to 2020.3-beta1
+
+
+## [2020.3-beta1] - 2020-02-20
+### Security
+- Fix stack overflow caused by WireGuard key rotation timers. When the daemon crashed it was
+  restarted automatically. But it did not connect (depending on settings), leaving a leak.
 
 
 ## [2020.2] - 2020-02-13


### PR DESCRIPTION
Porting the 2020.3[-beta1] changelog entries from the release branch back to `master`

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1522)
<!-- Reviewable:end -->
