### PR TITLE
Fix kotlin lints

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -22,7 +22,7 @@ class SettingsListener(val daemon: MullvadDaemon) {
         set(value) {
             synchronized(this) {
                 field = value
-                value?.invoke(settings?.accountToken)
+                value?.invoke(settings.accountToken)
             }
         }
 
@@ -31,9 +31,7 @@ class SettingsListener(val daemon: MullvadDaemon) {
             synchronized(this) {
                 field = value
 
-                settings?.let { safeSettings ->
-                    value?.invoke(safeSettings.allowLan)
-                }
+                value?.invoke(settings.allowLan)
             }
         }
 
@@ -41,7 +39,7 @@ class SettingsListener(val daemon: MullvadDaemon) {
         set(value) {
             synchronized(this) {
                 field = value
-                value?.invoke(settings?.relaySettings)
+                value?.invoke(settings.relaySettings)
             }
         }
 
@@ -63,11 +61,11 @@ class SettingsListener(val daemon: MullvadDaemon) {
 
     private fun handleNewSettings(newSettings: Settings) {
         synchronized(this) {
-            if (settings?.accountToken != newSettings.accountToken) {
+            if (settings.accountToken != newSettings.accountToken) {
                 onAccountNumberChange?.invoke(newSettings.accountToken)
             }
 
-            if (settings?.relaySettings != newSettings.relaySettings) {
+            if (settings.relaySettings != newSettings.relaySettings) {
                 onRelaySettingsChange?.invoke(newSettings.relaySettings)
             }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInput.kt
@@ -82,7 +82,7 @@ class AccountInput(
         input.apply {
             addTextChangedListener(InputWatcher())
             setOnTouchListener(OnTouchListener {
-                view, event ->
+                _, event ->
                 if (MotionEvent.ACTION_UP == event.getAction()) {
                     shouldShowAccountHistory = true
                 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -36,8 +36,8 @@ class MainActivity : FragmentActivity() {
             serviceConnectionSubscription = localBinder.serviceNotifier.subscribe { service ->
                 serviceConnection?.onDestroy()
 
-                val newConnection = service?.let { service ->
-                    ServiceConnection(service, this@MainActivity)
+                val newConnection = service?.let { safeService ->
+                    ServiceConnection(safeService, this@MainActivity)
                 }
 
                 serviceConnection = newConnection

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -30,9 +30,7 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
 
         allowLanToggle = view.findViewById<CellSwitch>(R.id.allow_lan_toggle).apply {
-            settingsListener.settings?.let { settings ->
-                forcefullySetState(boolToSwitchState(settings.allowLan))
-            }
+            forcefullySetState(boolToSwitchState(settingsListener.settings.allowLan))
 
             listener = { state ->
                 when (state) {
@@ -43,9 +41,7 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
 
         autoConnectToggle = view.findViewById<CellSwitch>(R.id.auto_connect_toggle).apply {
-            settingsListener.settings?.let { settings ->
-                forcefullySetState(boolToSwitchState(settings.autoConnect))
-            }
+            forcefullySetState(boolToSwitchState(settingsListener.settings.autoConnect))
 
             listener = { state ->
                 when (state) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -78,6 +78,7 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
             when (state) {
                 State.Uninitialized -> state = State.Initialized
                 State.WaitingForReconnection -> state = State.Paused
+                else -> {}
             }
         }
     }


### PR DESCRIPTION
Small changes inspired by the kotlin compiler warnings. The only left-over lints stem from the fact that we use deprecated functions to get the color resource IDs and deprecated ways of listening for network changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1528)
<!-- Reviewable:end -->
