### PR TITLE
Use shared references instead of mutable ones in relay selector

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -82,17 +82,17 @@ impl ParsedRelays {
         }
     }
 
-    pub fn from_relay_list(mut relay_list: RelayList, last_updated: SystemTime) -> Self {
+    pub fn from_relay_list(relay_list: RelayList, last_updated: SystemTime) -> Self {
         let mut relays = Vec::new();
-        for country in &mut relay_list.countries {
+        for country in &relay_list.countries {
             let country_name = country.name.clone();
             let country_code = country.code.clone();
-            for city in &mut country.cities {
+            for city in &country.cities {
                 let city_name = city.name.clone();
                 let city_code = city.code.clone();
                 let latitude = city.latitude;
                 let longitude = city.longitude;
-                for relay in &mut city.relays {
+                for relay in &city.relays {
                     let mut relay_with_location = relay.clone();
                     relay_with_location.location = Some(Location {
                         country: country_name.clone(),


### PR DESCRIPTION
I saw some unnecessary mutability in the relay selector when I was lurking around figuring out requirements for the new relay list format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1529)
<!-- Reviewable:end -->
