### PR TITLE
Show appropriate error screen when Android fails to block the network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Make sure the settings screen is scrollable so that devices with small screens can access the quit
   button.
+- Show when the app failed to block all connections after an error.
 
 
 ## [2020.3] - 2020-02-20

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -103,8 +103,7 @@ class ForegroundNotificationManager(
                     if (state.errorState.isBlocking) {
                         R.string.blocking_all_connections
                     } else {
-                        // TODO Revise use of message when the app fails to block traffic
-                        R.string.unsecured
+                        R.string.critical_error
                     }
                 }
             }
@@ -124,7 +123,13 @@ class ForegroundNotificationManager(
                         else -> R.string.connect
                     }
                 }
-                is TunnelState.Error -> R.string.disconnect
+                is TunnelState.Error -> {
+                    if (state.errorState.isBlocking) {
+                        R.string.disconnect
+                    } else {
+                        R.string.dismiss
+                    }
+                }
             }
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectActionButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectActionButton.kt
@@ -46,7 +46,13 @@ class ConnectActionButton(val parentView: View) {
                 }
                 is TunnelState.Connecting -> connecting()
                 is TunnelState.Connected -> connected()
-                is TunnelState.Error -> connected()
+                is TunnelState.Error -> {
+                    if (value.errorState.isBlocking) {
+                        connected()
+                    } else {
+                        blockError()
+                    }
+                }
             }
 
             field = value
@@ -74,12 +80,20 @@ class ConnectActionButton(val parentView: View) {
     }
 
     private fun action() {
-        when (tunnelState) {
+        val state = tunnelState
+
+        when (state) {
             is TunnelState.Disconnected -> onConnect?.invoke()
             is TunnelState.Disconnecting -> onConnect?.invoke()
             is TunnelState.Connecting -> onCancel?.invoke()
             is TunnelState.Connected -> onDisconnect?.invoke()
-            is TunnelState.Error -> onDisconnect?.invoke()
+            is TunnelState.Error -> {
+                if (state.errorState.isBlocking) {
+                    onDisconnect?.invoke()
+                } else {
+                    onCancel?.invoke()
+                }
+            }
         }
     }
 
@@ -95,6 +109,10 @@ class ConnectActionButton(val parentView: View) {
 
     private fun connected() {
         redButton(R.string.disconnect)
+    }
+
+    private fun blockError() {
+        redButton(R.string.dismiss)
     }
 
     private fun redButton(text: Int) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectionStatus.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectionStatus.kt
@@ -55,13 +55,12 @@ class ConnectionStatus(val parentView: View, val resources: Resources) {
     private fun errorState(isBlocking: Boolean) {
         spinner.visibility = View.GONE
 
-        // TODO: revise how to best inform the user about us not blocking
-        // traffic
-        text.setTextColor(securedTextColor)
         if (isBlocking) {
+            text.setTextColor(securedTextColor)
             text.setText(R.string.blocked_connection)
         } else {
-            text.setText(R.string.blocked_connection)
+            text.setTextColor(unsecuredTextColor)
+            text.setText(R.string.error_state)
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
@@ -196,13 +196,11 @@ class NotificationBanner(
         }
 
         // if the error state is null, we can assume that we are secure
-        val blockMessage = if (errorState?.isBlocking ?: true) {
-                R.string.blocking_internet
-            } else {
-                R.string.not_blocking_internet
-            }
-
-        showError(blockMessage, messageText)
+        if (errorState?.isBlocking ?: true) {
+            showError(R.string.blocking_internet, messageText)
+        } else {
+            showError(R.string.not_blocking_internet, R.string.failed_to_block_internet)
+        }
     }
 
     private fun showError(titleText: Int, messageText: Int?) {

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="disconnecting">Disconnecting</string>
     <string name="secured">Secured</string>
     <string name="unsecured">Unsecured</string>
+    <string name="critical_error">Critical error (your attention is
+    required)</string>
     <string name="blocking_all_connections">Blocking all
     connections</string>
     <string name="foreground_notification_channel_name">VPN tunnel
@@ -89,6 +91,7 @@
     <string name="connect">Secure my connection</string>
     <string name="cancel">Cancel</string>
     <string name="disconnect">Disconnect</string>
+    <string name="dismiss">Dismiss</string>
     <string name="switch_location">Switch location</string>
     <string name="wireguard">WireGuard</string>
     <string name="tcp">TCP</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -99,8 +99,11 @@
     <string name="in_address">In %1$s:%2$d %3$s</string>
     <string name="out_address">Out %1$s</string>
     <string name="blocking_internet">Blocking internet</string>
-    <string name="not_blocking_internet">Failed to block
-    internet</string>
+    <string name="not_blocking_internet">You might be leaking
+    network traffic</string>
+    <string name="failed_to_block_internet">Failed to block all
+    network traffic. Please troubleshoot or report the problem to
+    us.</string>
     <string name="auth_failed">Account authentication
     failed.</string>
     <string name="ipv6_unavailable">Could not configure


### PR DESCRIPTION
This PR tweaks the UI to show that there is a critical error if the app detects that blocking the network connections fails. The main objective is to make it very clear to the user that if this happens the app is in a critical state and it may be leaking data.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1536)
<!-- Reviewable:end -->
