### PR TITLE
Format AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,42 +1,31 @@
-<manifest
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        package="net.mullvad.mullvadvpn"
-        >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          package="net.mullvad.mullvadvpn">
     <permission android:name="net.mullvad.mullvadvpn.permission.TUNNEL_ACTION"
-            android:protectionLevel="signature"
-            />
-
+                android:protectionLevel="signature" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="net.mullvad.mullvadvpn.permission.TUNNEL_ACTION" />
-
-    <application
-            android:label="@string/app_name"
-            android:icon="@mipmap/ic_launcher"
-            android:roundIcon="@mipmap/ic_launcher"
-            android:theme="@style/AppTheme"
-            android:allowBackup="false"
-            tools:ignore="GoogleAppIndexingWarning"
-            >
-        <activity
-                android:name="net.mullvad.mullvadvpn.ui.MainActivity"
-                android:label="@string/app_name"
-                android:configChanges="orientation"
-                android:screenOrientation="portrait"
-                android:windowSoftInputMode="adjustPan"
-                >
+    <application android:label="@string/app_name"
+                 android:icon="@mipmap/ic_launcher"
+                 android:roundIcon="@mipmap/ic_launcher"
+                 android:theme="@style/AppTheme"
+                 android:allowBackup="false"
+                 tools:ignore="GoogleAppIndexingWarning">
+        <activity android:name="net.mullvad.mullvadvpn.ui.MainActivity"
+                  android:label="@string/app_name"
+                  android:configChanges="orientation"
+                  android:screenOrientation="portrait"
+                  android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"
+                 android:permission="android.permission.BIND_VPN_SERVICE">
 
-        <service
-                android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"
-                android:permission="android.permission.BIND_VPN_SERVICE"
-                >
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>

--- a/ci/ci-android-xml.sh
+++ b/ci/ci-android-xml.sh
@@ -20,12 +20,11 @@ function tidy-up-android-xml {
 # Autoformats Android XML files and returns 0 if no files were actually changed, or 1 if files were changed
 function tidy-verify-xml {
     tidy-up-android-xml
-    if (( $(git diff android/src/main/AndroidManifest.xml android/src/main/res/ | wc -l) > 0 )); then
-        echo "android/src/main contains files that were changed, XML is not formatted properly"
-        git diff -- android/src/main/AndroidManifest.xml android/src/main/res
-        return 1;
-    else
+    if git diff --exit-code -- android/src/main/AndroidManifest.xml android/src/main/res; then
         echo "Android XML files are correctly formatted"
         return 0;
+    else
+        echo "android/src/main contains files that were changed, XML is not formatted properly"
+        return 1;
     fi
 }

--- a/ci/ci-android-xml.sh
+++ b/ci/ci-android-xml.sh
@@ -21,7 +21,7 @@ function tidy-up-android-xml {
 function tidy-verify-xml {
     tidy-up-android-xml
     if (( $(git diff android/src/main/AndroidManifest.xml android/src/main/res/ | wc -l) > 0 )); then
-        echo "android/src/main contains that were changed, XML is not formatted properly"
+        echo "android/src/main contains files that were changed, XML is not formatted properly"
         git diff -- android/src/main/AndroidManifest.xml android/src/main/res
         return 1;
     else

--- a/ci/ci-android-xml.sh
+++ b/ci/ci-android-xml.sh
@@ -4,7 +4,6 @@
 
 # Autoformats Android XML files
 function tidy-up-android-xml {
-
     tidy -xml \
         -m  \
         -i  \
@@ -13,6 +12,7 @@ function tidy-up-android-xml {
         --indent-spaces 4 \
         --literal-attributes yes \
         android/src/main/AndroidManifest.xml android/src/main/res/*/*.xml
+
     # FIXME - when tidy learns to not leave whitespace around, remove the line below - https://github.com/htacg/tidy-html5/issues/864
     find android/src/main/ -name '*.xml' -exec sed -i -e 's/[ \t]*$//' '{}' ';'
 }
@@ -20,6 +20,7 @@ function tidy-up-android-xml {
 # Autoformats Android XML files and returns 0 if no files were actually changed, or 1 if files were changed
 function tidy-verify-xml {
     tidy-up-android-xml
+
     if git diff --exit-code -- android/src/main/AndroidManifest.xml android/src/main/res; then
         echo "Android XML files are correctly formatted"
         return 0

--- a/ci/ci-android-xml.sh
+++ b/ci/ci-android-xml.sh
@@ -12,17 +12,17 @@ function tidy-up-android-xml {
         --indent-attributes yes \
         --indent-spaces 4 \
         --literal-attributes yes \
-        android/src/main/res/*/*.xml
+        android/src/main/AndroidManifest.xml android/src/main/res/*/*.xml
     # FIXME - when tidy learns to not leave whitespace around, remove the line below - https://github.com/htacg/tidy-html5/issues/864
-    find android/src/main/res/ -name '*.xml' -exec sed -i -e 's/[ \t]*$//' '{}' ';'
+    find android/src/main/ -name '*.xml' -exec sed -i -e 's/[ \t]*$//' '{}' ';'
 }
 
 # Autoformats Android XML files and returns 0 if no files were actually changed, or 1 if files were changed
 function tidy-verify-xml {
     tidy-up-android-xml
-    if (( $(git diff android/src/main/res/ | wc -l) > 0 )); then
-        echo "android/src/main/res contains that were changed, XML is not formatted properly"
-        git diff android/src/main/res/
+    if (( $(git diff android/src/main/AndroidManifest.xml android/src/main/res/ | wc -l) > 0 )); then
+        echo "android/src/main contains that were changed, XML is not formatted properly"
+        git diff -- android/src/main/AndroidManifest.xml android/src/main/res
         return 1;
     else
         echo "Android XML files are correctly formatted"

--- a/ci/ci-android-xml.sh
+++ b/ci/ci-android-xml.sh
@@ -22,9 +22,9 @@ function tidy-verify-xml {
     tidy-up-android-xml
     if git diff --exit-code -- android/src/main/AndroidManifest.xml android/src/main/res; then
         echo "Android XML files are correctly formatted"
-        return 0;
+        return 0
     else
         echo "android/src/main contains files that were changed, XML is not formatted properly"
-        return 1;
+        return 1
     fi
 }


### PR DESCRIPTION
I realized that the `AndroidManifest.xml` file wasn't formatted because it's not in the `res` sub-directory. I updated the script to also format it, but I also tweaked the script a bit hoping to make it simpler. Let me know what you think.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1546)
<!-- Reviewable:end -->
