### PR TITLE
Remove permission check for tunnel action intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Line wrap the file at 100 chars.                                              Th
 - Add a reconnect button to disconnect and connect again without closing the tunnel device to avoid
   leaking any data during the reconnection.
 
+### Changed
+#### Android
+- Allow other apps to request the VPN tunnel to connect or disconnect.
+
 ### Fixed
 #### Android
 - Make sure the settings screen is scrollable so that devices with small screens can access the quit

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,12 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="net.mullvad.mullvadvpn">
-    <permission android:name="net.mullvad.mullvadvpn.permission.TUNNEL_ACTION"
-                android:protectionLevel="signature" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="net.mullvad.mullvadvpn.permission.TUNNEL_ACTION" />
     <application android:label="@string/app_name"
                  android:icon="@mipmap/ic_launcher"
                  android:roundIcon="@mipmap/ic_launcher"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -22,7 +22,6 @@ val CHANNEL_ID = "vpn_tunnel_status"
 val FOREGROUND_NOTIFICATION_ID: Int = 1
 val KEY_CONNECT_ACTION = "connect_action"
 val KEY_DISCONNECT_ACTION = "disconnect_action"
-val PERMISSION_TUNNEL_ACTION = "net.mullvad.mullvadvpn.permission.TUNNEL_ACTION"
 
 class ForegroundNotificationManager(
     val service: MullvadVpnService,
@@ -190,11 +189,8 @@ class ForegroundNotificationManager(
         }
 
         service.apply {
-            val connectFilter = IntentFilter(KEY_CONNECT_ACTION)
-            val disconnectFilter = IntentFilter(KEY_DISCONNECT_ACTION)
-
-            registerReceiver(connectReceiver, connectFilter, PERMISSION_TUNNEL_ACTION, null)
-            registerReceiver(disconnectReceiver, disconnectFilter, PERMISSION_TUNNEL_ACTION, null)
+            registerReceiver(connectReceiver, IntentFilter(KEY_CONNECT_ACTION))
+            registerReceiver(disconnectReceiver, IntentFilter(KEY_DISCONNECT_ACTION))
         }
 
         updateNotification()


### PR DESCRIPTION
Previously, the app would only act on intents it received to connect or disconnect if it came from inside the app. This PR removes that check, so that other apps can control the tunnel connection.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1548)
<!-- Reviewable:end -->
