### PR TITLE
Windows: Fix WINFW deinitialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ Line wrap the file at 100 chars.                                              Th
   button.
 - Show when the app failed to block all connections after an error.
 
+### Security
+#### Windows
+- Fix issue in daemon where the `block_when_disconnected` setting was sometimes not honored when
+  stopping the daemon. I.e. traffic could flow freely after the daemon was stopped.
+
 
 ## [2020.3] - 2020-02-20
 This release is identical to 2020.3-beta1

--- a/windows/winfw/src/extras/cli/commands/winfw/deinit.cpp
+++ b/windows/winfw/src/extras/cli/commands/winfw/deinit.cpp
@@ -28,7 +28,7 @@ void Deinit::handleRequest(const std::vector<std::wstring> &arguments)
 		THROW_ERROR("Invalid argument(s). Cannot complete request.");
 	}
 
-	m_messageSink((WinFw_Deinitialize()
+	m_messageSink((WinFw_Deinitialize(WINFW_CLEANUP_POLICY_RESET_FIREWALL)
 		? L"Deinitialization completed successfully."
 		: L"Deinitialization failed. See above for details, if any."));
 }

--- a/windows/winfw/src/extras/cli/commands/winfw/policy.cpp
+++ b/windows/winfw/src/extras/cli/commands/winfw/policy.cpp
@@ -111,8 +111,8 @@ void Policy::processConnecting(const KeyValuePairs &arguments)
 
 	auto success = WinFw_ApplyPolicyConnecting
 	(
-		settings,
-		relay,
+		&settings,
+		&relay,
 		nullptr
 	);
 
@@ -140,8 +140,8 @@ void Policy::processConnected(const KeyValuePairs &arguments)
 
 	auto success = WinFw_ApplyPolicyConnected
 	(
-		settings,
-		relay,
+		&settings,
+		&relay,
 		GetArgumentValue(arguments, L"tunnel").c_str(),
 		GetArgumentValue(arguments, L"dns").c_str(),
 		nullptr
@@ -160,7 +160,7 @@ void Policy::processBlocked(const KeyValuePairs &arguments)
 		GetArgumentValue(arguments, L"lan")
 	);
 
-	auto success = WinFw_ApplyPolicyBlocked(settings);
+	auto success = WinFw_ApplyPolicyBlocked(&settings);
 
 	m_messageSink((success
 		? L"Successfully applied policy."

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -43,6 +43,16 @@ public:
 
 	bool reset();
 
+	enum class Policy
+	{
+		Connecting,
+		Connected,
+		Blocked,
+		None,
+	};
+
+	Policy activePolicy() const;
+
 	using Ruleset = std::vector<std::unique_ptr<rules::IFirewallRule> >;
 
 private:
@@ -62,4 +72,5 @@ private:
 	std::unique_ptr<SessionController> m_sessionController;
 
 	uint32_t m_baseline;
+	Policy m_activePolicy;
 };

--- a/windows/winfw/src/winfw/sessioncontroller.cpp
+++ b/windows/winfw/src/winfw/sessioncontroller.cpp
@@ -1,10 +1,10 @@
 #include "stdafx.h"
 #include "sessioncontroller.h"
 #include "wfpobjecttype.h"
-#include "libwfp/objectinstaller.h"
-#include "libwfp/objectdeleter.h"
-#include "libwfp/transaction.h"
-#include "libcommon/memory.h"
+#include <libwfp/objectinstaller.h>
+#include <libwfp/objectdeleter.h>
+#include <libwfp/transaction.h>
+#include <libcommon/memory.h>
 #include <libcommon/error.h>
 #include <utility>
 
@@ -63,26 +63,6 @@ SessionController::SessionController(std::unique_ptr<wfp::FilterEngine> &&engine
 	, m_identityRegistry(MullvadGuids::Registry(MullvadGuids::IdentityQualifier::OnlyCurrent))
 	, m_activeTransaction(false)
 {
-}
-
-SessionController::~SessionController()
-{
-	//
-	// TODO: Review destruction of this instance and its owner.
-	//
-
-	try
-	{
-		executeTransaction([this](SessionController &, wfp::FilterEngine &)
-		{
-			reset();
-			return true;
-		});
-	}
-	catch (...)
-	{
-		return;
-	}
 }
 
 bool SessionController::addProvider(wfp::ProviderBuilder &providerBuilder)

--- a/windows/winfw/src/winfw/sessioncontroller.h
+++ b/windows/winfw/src/winfw/sessioncontroller.h
@@ -3,8 +3,8 @@
 #include "iobjectinstaller.h"
 #include "sessionrecord.h"
 #include "mullvadguids.h"
-#include "libwfp/filterengine.h"
-#include "libwfp/iidentifiable.h"
+#include <libwfp/filterengine.h>
+#include <libwfp/iidentifiable.h>
 #include <functional>
 #include <atomic>
 #include <memory>
@@ -15,7 +15,6 @@ class SessionController : public IObjectInstaller
 public:
 
 	SessionController(std::unique_ptr<wfp::FilterEngine> &&engine);
-	~SessionController();
 
 	bool addProvider(wfp::ProviderBuilder &providerBuilder) override;
 	bool addSublayer(wfp::SublayerBuilder &sublayerBuilder) override;

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -92,6 +92,16 @@ WinFw_InitializeBlocked(
 	void *logSinkContext
 );
 
+enum WINFW_CLEANUP_POLICY
+{
+	// Continue blocking if this happens to be the active policy
+	// otherwise reset the firewall.
+	WINFW_CLEANUP_POLICY_CONTINUE_BLOCKING = 0,
+
+	// Remove all objects that have been registered with WFP.
+	WINFW_CLEANUP_POLICY_RESET_FIREWALL = 1,
+};
+
 //
 // Deinitialize:
 //
@@ -101,7 +111,9 @@ extern "C"
 WINFW_LINKAGE
 bool
 WINFW_API
-WinFw_Deinitialize();
+WinFw_Deinitialize(
+	WINFW_CLEANUP_POLICY cleanupPolicy
+);
 
 //
 // PingableHosts:


### PR DESCRIPTION
These changes make the `winfw` deinitialization more flexible. It's now possible to instruct `winfw` to leave the `blocked` policy behind, if this happens to be the active policy.

The default caller (code inside `talpid-core`) is mostly stateless and doesn't know which policy is active, or we might have used a different design for this.

NOTE: This fixes the accidental removal of the `blocked` policy during shutdown, but more fixes are needed in the Rust code to ensure a correct shutdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1549)
<!-- Reviewable:end -->
