### PR TITLE
Prefer WireGuard on Unix platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Line wrap the file at 100 chars.                                              Th
   leaking any data during the reconnection.
 
 ### Changed
+- Prefer WireGuard when tunnel protocol is set to _auto_ on Linux and MacOS.
+
 #### Android
 - Allow other apps to request the VPN tunnel to connect or disconnect.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,6 +1251,7 @@ name = "mullvad-daemon"
 version = "2020.1.0"
 dependencies = [
  "android_logger 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -41,11 +41,17 @@ Endpoints may be filtered by:
 Whilst all user selected constraints are always honored, when the user hasn't selected any specific
 constraints, following default ones will take effect:
 
-- If no tunnel protocol is specified for tunnel endpoints, then by default only OpenVPN
-  endpoints will be selected.
+- If no tunnel protocol is specified for tunnel endpoints, then the behavior is different on Windows
+  and other platforms.
+  - On Windows, OpenVPN is used.
+  - On MacOS and Linux, first two connection attempts will use WireGuard, over a random port at
+    first and then port 53. From the third attempt onwards, OpenVPN will be used, alternating
+    between UDP on any port and TCP on port 443.
 
 - If the tunnel protocol is specified as WireGuard without any other protocol constraints, then the
   transport protocol is not applicable as only UDP endpoints exist and any port will be matched.
+  The target port alternates between a random one every two attempts, and port 53 for the next 2
+  attempts.
 
 - If no OpenVPN tunnel constraints are specified, then the first two attempts at selecting a tunnel
   will try to select UDP endpoints on any port, and the third and fourth attempts will filter for

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+cfg-if = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.25"
 err-derive = "0.2.1"


### PR DESCRIPTION
The relay selector is changed to prefer WireGuard on Linux and MacOS, whilst not changing any behavior on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1550)
<!-- Reviewable:end -->
