### PR TITLE
Fix unhandled exception error thrown by desktop GUI

### DIFF
--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -133,6 +133,7 @@ class AttachedToTrayWindowPositioning implements IWindowPositioning {
 export default class WindowController {
   private width: number;
   private height: number;
+  private webContentsValue: WebContents;
   private windowPositioning: IWindowPositioning;
   private isWindowReady = false;
 
@@ -141,13 +142,14 @@ export default class WindowController {
   }
 
   get webContents(): WebContents {
-    return this.windowValue.webContents;
+    return this.webContentsValue;
   }
 
   constructor(private windowValue: BrowserWindow, tray: Tray) {
     const [width, height] = windowValue.getSize();
     this.width = width;
     this.height = height;
+    this.webContentsValue = windowValue.webContents;
     this.windowPositioning =
       process.platform === 'linux'
         ? new StandaloneWindowPositioning()
@@ -184,7 +186,7 @@ export default class WindowController {
   // Electron uses the `any` type.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public send(event: string, ...data: any[]): void {
-    this.windowValue.webContents.send(event, ...data);
+    this.webContentsValue.send(event, ...data);
   }
 
   private showImmediately() {
@@ -205,7 +207,7 @@ export default class WindowController {
   private notifyUpdateWindowShape() {
     const shapeParameters = this.windowPositioning.getWindowShapeParameters(this.windowValue);
 
-    IpcMainEventChannel.windowShape.notify(this.windowValue.webContents, shapeParameters);
+    IpcMainEventChannel.windowShape.notify(this.webContentsValue, shapeParameters);
   }
 
   // Installs display event handlers to update the window position on any changes in the display or


### PR DESCRIPTION
…nts on already destroyed window

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

After running a couple of tests I found that `BrowserWindow.webContents` accessor throws an exception when accessed after the window is already destroyed. 

Since all of the IPC code is already guarded with `webContents.isDestroyed()` checks, the simplest solution was to obtain the reference to `webContents` once in `WindowController.constructor` and use it directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1551)
<!-- Reviewable:end -->
