### PR TITLE
Prevent leaks when upgrading on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Fix issue in daemon where the `block_when_disconnected` setting was sometimes not honored when
   stopping the daemon. I.e. traffic could flow freely after the daemon was stopped.
+- When upgrading or reinstalling while connected, exit the daemon in a blocking state to prevent
+  unintended leaks. This only affects upgrades from this release.
 
 
 ## [2020.3] - 2020-02-20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mullvad-setup"
+version = "2020.3.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mullvad-ipc-client 0.1.0",
+ "mullvad-paths 0.1.0",
+ "talpid-core 0.1.0",
+ "talpid-types 0.1.0",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winres 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mullvad-tests"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "mullvad-daemon",
     "mullvad-cli",
+    "mullvad-setup",
     "mullvad-problem-report",
     "mullvad-ipc-client",
     "mullvad-jni",

--- a/build.sh
+++ b/build.sh
@@ -160,6 +160,7 @@ elif [[ ("$(uname -s)" == "MINGW"*) ]]; then
         mullvad.exe
         mullvad-problem-report.exe
         talpid_openvpn_plugin.dll
+        mullvad-setup.exe
     )
 fi
 for binary in ${binaries[*]}; do

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -694,20 +694,6 @@
 	Push $0
 	Push $1
 
-	nsExec::ExecToStack '"$SYSDIR\sc.exe" stop mullvadvpn'
-
-	# Discard return value
-	Pop $0
-
-	Sleep 5000
-
-	nsExec::ExecToStack '"$SYSDIR\sc.exe" delete mullvadvpn'
-
-	# Discard return value
-	Pop $0
-
-	Sleep 1000
-
 	# Check command line arguments
 	Var /GLOBAL FullUninstall
 
@@ -721,6 +707,29 @@
 		log::Initialize LOG_FILE
 	${EndIf}
 	Pop $FullUninstall
+
+	${If} $FullUninstall != 1
+		# Save the target tunnel state if we're upgrading
+		SetOutPath "$TEMP"
+		File "${BUILD_RESOURCES_DIR}\mullvad-setup.exe"
+		nsExec::ExecToStack '"$TEMP\mullvad-setup.exe" prepare-restart'
+		Pop $0
+		Pop $1
+	${EndIf}
+
+	nsExec::ExecToStack '"$SYSDIR\sc.exe" stop mullvadvpn'
+
+	# Discard return value
+	Pop $0
+
+	Sleep 5000
+
+	nsExec::ExecToStack '"$SYSDIR\sc.exe" delete mullvadvpn'
+
+	# Discard return value
+	Pop $0
+
+	Sleep 1000
 
 	log::Log "Running uninstaller for ${PRODUCT_NAME} ${VERSION}"
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -40,22 +40,7 @@
 # electron-builder uses a GUID here rather than the application name.
 !define INSTALL_REGISTRY_KEY "Software\${PRODUCT_NAME}"
 
-#
-# BreakInstallation
-#
-# Aborting the customization step does not undo previous steps taken
-# by the installer (copy files, create shortcut, etc)
-#
-# Therefore we have to break the installed application to
-# prevent users from running a half-installed product
-#
-!macro BreakInstallation
-
-	Delete "$INSTDIR\mullvad vpn.exe"
-
-!macroend
-
-!define BreakInstallation '!insertmacro "BreakInstallation"'
+!define BLOCK_OUTBOUND_IPV4_FILTER_GUID "{a81c5411-0fd0-43a9-a9be-313f299de64f}"
 
 #
 # ExtractTapDriver
@@ -649,8 +634,7 @@
 
 	${If} $R0 != 0
 		MessageBox MB_OK "Fatal error during driver installation: $R0"
-		${BreakInstallation}
-		Abort
+		Goto customInstall_abort_installation
 	${EndIf}
 
 	${ExtractWintun}
@@ -658,20 +642,53 @@
 
 	${If} $R0 != 0
 		MessageBox MB_OK "$R0"
-		${BreakInstallation}
-		Abort
+		Goto customInstall_abort_installation
 	${EndIf}
 
 	${InstallService}
 
 	${If} $R0 != 0
 		MessageBox MB_OK "$R0"
-		${BreakInstallation}
-		Abort
+		Goto customInstall_abort_installation
 	${EndIf}
 
 	${AddCLIToEnvironPath}
 	${InstallTrayIcon}
+
+	Goto customInstall_skip_abort
+
+	customInstall_abort_installation:
+
+	# Aborting the customization step does not undo previous steps taken
+	# by the installer (copy files, create shortcut, etc)
+	#
+	# Therefore we have to break the installed application to
+	# prevent users from running a half-installed product
+	#
+	Delete "$INSTDIR\mullvad vpn.exe"
+
+	nsExec::ExecToStack '"$SYSDIR\netsh.exe" wfp show security FILTER ${BLOCK_OUTBOUND_IPV4_FILTER_GUID}'
+	Pop $0
+	Pop $1
+
+	${If} $0 == 0
+		MessageBox MB_ICONEXCLAMATION|MB_YESNO "Do you wish to unblock your internet access? Doing so will leave you with an unsecure connection." IDNO customInstall_abortInstallation_skip_firewall_revert
+
+		SetOutPath "$TEMP"
+		File "${BUILD_RESOURCES_DIR}\mullvad-setup.exe"
+		File "${BUILD_RESOURCES_DIR}\..\windows\winfw\bin\x64-Release\winfw.dll"
+		nsExec::ExecToStack '"$TEMP\mullvad-setup.exe" reset-firewall'
+		Pop $0
+		Pop $1
+
+		log::Log "Resetting firewall: $0 $1"
+	${EndIf}
+
+	customInstall_abortInstallation_skip_firewall_revert:
+
+	Abort
+
+	customInstall_skip_abort:
 
 	Pop $R0
 
@@ -712,6 +729,7 @@
 		# Save the target tunnel state if we're upgrading
 		SetOutPath "$TEMP"
 		File "${BUILD_RESOURCES_DIR}\mullvad-setup.exe"
+		File "${BUILD_RESOURCES_DIR}\..\windows\winfw\bin\x64-Release\winfw.dll"
 		nsExec::ExecToStack '"$TEMP\mullvad-setup.exe" prepare-restart'
 		Pop $0
 		Pop $1

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -215,9 +215,9 @@ pub enum DaemonCommand {
     FactoryReset(oneshot::Sender<()>),
     /// Makes the daemon exit the main loop and quit.
     Shutdown,
-    /// Saves the target tunnel state and quits in a blocking state. The state is restored
+    /// Saves the target tunnel state and enters a blocking state. The state is restored
     /// upon restart.
-    TemporaryShutdown,
+    PrepareRestart,
 }
 
 /// All events that can happen in the daemon. Sent from various threads and exposed interfaces.
@@ -985,7 +985,7 @@ where
             #[cfg(not(target_os = "android"))]
             FactoryReset(tx) => self.on_factory_reset(tx),
             Shutdown => self.trigger_shutdown_event(),
-            TemporaryShutdown => self.on_temporary_shutdown(),
+            PrepareRestart => self.on_prepare_restart(),
         }
     }
 
@@ -1705,7 +1705,7 @@ where
         self.disconnect_tunnel();
     }
 
-    fn on_temporary_shutdown(&mut self) {
+    fn on_prepare_restart(&mut self) {
         // TODO: See if this can be made to also shut down the daemon
         //       without causing the service to be restarted.
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1668,6 +1668,9 @@ where
     }
 
     fn on_temporary_shutdown(&mut self) {
+        // TODO: See if this can be made to also shut down the daemon
+        //       without causing the service to be restarted.
+
         // Cache the current target state
         let cache_file = self.cache_dir.join(TARGET_START_STATE_FILE);
         log::debug!("Saving tunnel target state to {}", cache_file.display());
@@ -1687,7 +1690,6 @@ where
         if self.target_state == TargetState::Secured {
             self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
         }
-        self.trigger_shutdown_event();
     }
 
     /// Set the target state of the client. If it changed trigger the operations needed to

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -108,6 +108,11 @@ build_rpc_trait! {
         #[rpc(meta, name = "shutdown")]
         fn shutdown(&self, Self::Metadata) -> BoxFuture<(), Error>;
 
+        /// Saves the target tunnel state and quits in a blocking state. The state is restored
+        /// upon restart.
+        #[rpc(meta, name = "temporary_shutdown")]
+        fn temporary_shutdown(&self, Self::Metadata) -> BoxFuture<(), Error>;
+
         /// Get previously used account tokens from the account history
         #[rpc(meta, name = "get_account_history")]
         fn get_account_history(&self, Self::Metadata) -> BoxFuture<Vec<AccountToken>, Error>;
@@ -528,6 +533,11 @@ impl ManagementInterfaceApi for ManagementInterface {
     fn shutdown(&self, _: Self::Metadata) -> BoxFuture<(), Error> {
         log::debug!("shutdown");
         Box::new(self.send_command_to_daemon(DaemonCommand::Shutdown))
+    }
+
+    fn temporary_shutdown(&self, _: Self::Metadata) -> BoxFuture<(), Error> {
+        log::debug!("temporary_shutdown");
+        Box::new(self.send_command_to_daemon(DaemonCommand::TemporaryShutdown))
     }
 
     fn get_account_history(&self, _: Self::Metadata) -> BoxFuture<Vec<AccountToken>, Error> {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -108,10 +108,10 @@ build_rpc_trait! {
         #[rpc(meta, name = "shutdown")]
         fn shutdown(&self, Self::Metadata) -> BoxFuture<(), Error>;
 
-        /// Saves the target tunnel state and quits in a blocking state. The state is restored
+        /// Saves the target tunnel state and enters a blocking state. The state is restored
         /// upon restart.
-        #[rpc(meta, name = "temporary_shutdown")]
-        fn temporary_shutdown(&self, Self::Metadata) -> BoxFuture<(), Error>;
+        #[rpc(meta, name = "prepare_restart")]
+        fn prepare_restart(&self, Self::Metadata) -> BoxFuture<(), Error>;
 
         /// Get previously used account tokens from the account history
         #[rpc(meta, name = "get_account_history")]
@@ -535,9 +535,9 @@ impl ManagementInterfaceApi for ManagementInterface {
         Box::new(self.send_command_to_daemon(DaemonCommand::Shutdown))
     }
 
-    fn temporary_shutdown(&self, _: Self::Metadata) -> BoxFuture<(), Error> {
-        log::debug!("temporary_shutdown");
-        Box::new(self.send_command_to_daemon(DaemonCommand::TemporaryShutdown))
+    fn prepare_restart(&self, _: Self::Metadata) -> BoxFuture<(), Error> {
+        log::debug!("prepare_restart");
+        Box::new(self.send_command_to_daemon(DaemonCommand::PrepareRestart))
     }
 
     fn get_account_history(&self, _: Self::Metadata) -> BoxFuture<Vec<AccountToken>, Error> {

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -223,6 +223,10 @@ impl DaemonRpcClient {
         self.call("shutdown", &NO_ARGS)
     }
 
+    pub fn temporary_shutdown(&mut self) -> Result<()> {
+        self.call("temporary_shutdown", &NO_ARGS)
+    }
+
     pub fn factory_reset(&mut self) -> Result<()> {
         self.call("factory_reset", &NO_ARGS)
     }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -223,8 +223,8 @@ impl DaemonRpcClient {
         self.call("shutdown", &NO_ARGS)
     }
 
-    pub fn temporary_shutdown(&mut self) -> Result<()> {
-        self.call("temporary_shutdown", &NO_ARGS)
+    pub fn prepare_restart(&mut self) -> Result<()> {
+        self.call("prepare_restart", &NO_ARGS)
     }
 
     pub fn factory_reset(&mut self) -> Result<()> {

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "mullvad-setup"
+version = "2020.3.0"
+authors = ["Mullvad VPN"]
+description = "Tool used to manage daemon setup"
+license = "GPL-3.0"
+edition = "2018"
+publish = false
+
+[[bin]]
+name = "mullvad-setup"
+path = "src/main.rs"
+
+[dependencies]
+clap = "2.32"
+env_logger = "0.7"
+err-derive = "0.2.1"
+
+mullvad-ipc-client = { path = "../mullvad-ipc-client" }
+mullvad-paths = { path = "../mullvad-paths" }
+talpid-core = { path = "../talpid-core" }
+talpid-types = { path = "../talpid-types" }
+
+[target.'cfg(windows)'.build-dependencies]
+winres = "0.1"
+winapi = "0.3"
+
+[package.metadata.winres]
+ProductName = "Mullvad VPN"
+CompanyName = "Mullvad VPN AB"
+LegalCopyright = "(c) 2020 Mullvad VPN AB"
+InternalName = "mullvad-setup"
+OriginalFilename = "mullvad-setup.exe"

--- a/mullvad-setup/build.rs
+++ b/mullvad-setup/build.rs
@@ -1,0 +1,18 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let product_version = env!("CARGO_PKG_VERSION").replacen(".0", "", 1);
+    fs::write(out_dir.join("product-version.txt"), &product_version).unwrap();
+
+    #[cfg(windows)]
+    {
+        let mut res = winres::WindowsResource::new();
+        res.set("ProductVersion", &product_version);
+        res.set_language(winapi::um::winnt::MAKELANGID(
+            winapi::um::winnt::LANG_ENGLISH,
+            winapi::um::winnt::SUBLANG_ENGLISH_US,
+        ));
+        res.compile().expect("Unable to generate windows resources");
+    }
+}

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error(display = "Failed to connect to daemon")]
     DaemonConnect(#[error(source)] io::Error),
 
+    #[error(display = "RPC call failed")]
+    DaemonRpcError(#[error(source)] mullvad_ipc_client::Error),
+
     #[error(display = "This command cannot be run if the daemon is active")]
     DaemonIsRunning,
 
@@ -53,7 +56,8 @@ fn main() {
 }
 
 fn prepare_restart() -> Result<(), Error> {
-    Ok(())
+    let mut rpc = new_rpc_client()?;
+    rpc.prepare_restart().map_err(Error::DaemonRpcError)
 }
 
 fn reset_firewall() -> Result<(), Error> {

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -1,0 +1,51 @@
+use clap::{crate_authors, crate_description, crate_name, SubCommand};
+use std::process;
+use talpid_types::ErrorExt;
+
+pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
+
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+}
+
+fn main() {
+    env_logger::init();
+
+    let subcommands = vec![
+        SubCommand::with_name("prepare-restart")
+            .about("Move a running daemon into a blocking state and save its target state"),
+        SubCommand::with_name("reset-firewall")
+            .about("Remove any firewall rules introduced by the daemon"),
+    ];
+
+    let app = clap::App::new(crate_name!())
+        .version(PRODUCT_VERSION)
+        .author(crate_authors!())
+        .about(crate_description!())
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .global_settings(&[
+            clap::AppSettings::DisableHelpSubcommand,
+            clap::AppSettings::VersionlessSubcommands,
+        ])
+        .subcommands(subcommands);
+
+    let matches = app.get_matches();
+    let result = match matches.subcommand_name().expect("Subcommand has no name") {
+        "prepare-restart" => prepare_restart(),
+        "reset-firewall" => reset_firewall(),
+        _ => unreachable!("No command matched"),
+    };
+
+    if let Err(e) = result {
+        eprintln!("{}", e.display_chain());
+        process::exit(1);
+    }
+}
+
+fn prepare_restart() -> Result<(), Error> {
+    Ok(())
+}
+
+fn reset_firewall() -> Result<(), Error> {
+    Ok(())
+}

--- a/version_metadata.sh
+++ b/version_metadata.sh
@@ -39,6 +39,7 @@ case "$1" in
             mullvad-daemon/Cargo.toml \
             mullvad-cli/Cargo.toml \
             mullvad-problem-report/Cargo.toml \
+            mullvad-setup/Cargo.toml \
             talpid-openvpn-plugin/Cargo.toml
 
         # Windows C++
@@ -67,6 +68,7 @@ EOF
         mv mullvad-daemon/Cargo.toml.bak mullvad-daemon/Cargo.toml || true
         mv mullvad-cli/Cargo.toml.bak mullvad-cli/Cargo.toml || true
         mv mullvad-problem-report/Cargo.toml.bak mullvad-problem-report/Cargo.toml || true
+        mv mullvad-setup/Cargo.toml.bak mullvad-setup/Cargo.toml || true
         mv talpid-openvpn-plugin/Cargo.toml.bak talpid-openvpn-plugin/Cargo.toml || true
         # Windows C++
         mv dist-assets/windows/version.h.bak dist-assets/windows/version.h || true
@@ -83,6 +85,7 @@ EOF
         rm mullvad-daemon/Cargo.toml.bak || true
         rm mullvad-cli/Cargo.toml.bak || true
         rm mullvad-problem-report/Cargo.toml.bak || true
+        rm mullvad-setup/Cargo.toml.bak || true
         rm talpid-openvpn-plugin/Cargo.toml.bak || true
         # Windows C++
         rm dist-assets/windows/version.h.bak || true


### PR DESCRIPTION
Save the target tunnel state in a file, and restore this state when the daemon starts again. If the state is saved while connected, the daemon will block until restarted. Then it will automatically connect.

It only works for Windows, but it should be very easy to use it for other desktop OSes. Everything but the installers is platform-independent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1554)
<!-- Reviewable:end -->
