### PR TITLE
Fix daemon getting stuck in blocked state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Line wrap the file at 100 chars.                                              Th
   button.
 - Show when the app failed to block all connections after an error.
 
+#### Windows
+- Fix bug where failing to initialize the route manager could cause the daemon to get stuck in a
+  blocked state. This only affected WireGuard.
+
 ### Security
 #### Windows
 - Fix issue in daemon where the `block_when_disconnected` setting was sometimes not honored when

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -260,8 +260,16 @@ impl Drop for WinNetRoute {
 }
 
 pub fn activate_routing_manager(routes: &[WinNetRoute]) -> bool {
-    return unsafe { WinNet_ActivateRouteManager(Some(log_sink), logging_context()) }
-        && routing_manager_add_routes(routes);
+    if unsafe { WinNet_ActivateRouteManager(Some(log_sink), logging_context()) } {
+        if routing_manager_add_routes(routes) {
+            true
+        } else {
+            deactivate_routing_manager();
+            false
+        }
+    } else {
+        false
+    }
 }
 
 pub struct WinNetCallbackHandle {


### PR DESCRIPTION
If adding the routes failed, the `RouteManager` was not destroyed. This caused all subsequent connection attempts to fail:
```
[WinNet][ERROR] Cannot activate route manager twice (winnet.cpp: 238)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1556)
<!-- Reviewable:end -->
