### PR TITLE
Properly handle the DNS over TCP when "Local network sharing" is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix bug that could lead to Javascript error dialog to appear upon the desktop app termination.
 
+#### macOS
+- Fix firewall rules to properly handle DNS requests over TCP when "Local network sharing" is 
+  disabled. Previously DNS requests over TCP would timeout.
+
 #### Android
 - Make sure the settings screen is scrollable so that devices with small screens can access the quit
   button.

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -113,6 +113,8 @@ impl Firewall {
                     .quick(true)
                     .interface(&tunnel.interface)
                     .proto(pfctl::Proto::Tcp)
+                    .keep_state(pfctl::StatePolicy::Keep)
+                    .tcp_flags(Self::get_tcp_flags())
                     .to(pfctl::Endpoint::new(tunnel.ipv4_gateway, 53))
                     .build()?;
                 rules.push(allow_tcp_dns_to_relay_rule);
@@ -133,6 +135,8 @@ impl Firewall {
                         .quick(true)
                         .interface(&tunnel.interface)
                         .proto(pfctl::Proto::Tcp)
+                        .keep_state(pfctl::StatePolicy::Keep)
+                        .tcp_flags(Self::get_tcp_flags())
                         .to(pfctl::Endpoint::new(ipv6_gateway, 53))
                         .build()?;
                     rules.push(v6_dns_rule_tcp);


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

DNS requests over TCP time out when "Local network sharing" is disabled. The reason for that seems to lay in fact that we don't allow the inbound reply traffic for DNS over TCP. 

The reason why DNS over TCP worked with "Local network sharing" enabled is because the LAN rules allow the inbound traffic from LAN networks, the `10.x.x.x` is normally used for relays.

~This PR adds a "keep state" flag to the corresponding firewall rules which automatically allows the inbound traffic on permitted outbound DNS connections towards the relay IP on both IPv4 and IPv6 protocols.~

~I didn't add the "keep state" for UDP requests though as I don't fully understand how PF handles them and why they do work right now without the keep_state.~

Note that this PR now adds contra inbound rules instead of `keep state` due to the raised concerns of performance implications when using stateful rules. While I think the effect is slightly different, as stateful rules allow the corresponding inbound traffic, while contra rules allow all of the inbound traffic on port 53. On the side note I don't think our relays forward 53 so we should be safe to use contra rules as they are likely cheaper to handle for firewall.

The firewall rules diff:

```diff
diff --git a/before.txt b/after.txt
index 621ceb8..dfa8f2f 100644
--- a/before.txt
+++ b/after.txt
@@ -7,8 +7,10 @@ pass in quick inet6 proto udp from fe80::/10 port = 547 to fe80::/10 port = 546
 pass out quick inet6 proto ipv6-icmp from any to ff02::2 no state
 pass in quick inet6 proto ipv6-icmp from fe80::/10 to any no state
 pass out quick on utun2 inet proto tcp from any to 10.16.0.1 port = 53 no state
+pass in quick on utun2 inet proto tcp from 10.16.0.1 port = 53 to any no state
 pass out quick on utun2 inet proto udp from any to 10.16.0.1 port = 53 no state
 pass out quick on utun2 inet6 proto tcp from any to fdda:d0d0:cafe:1301:: port = 53 no state
+pass in quick on utun2 inet6 proto tcp from fdda:d0d0:cafe:1301:: port = 53 to any no state
 pass out quick on utun2 inet6 proto udp from any to fdda:d0d0:cafe:1301:: port = 53 no state
 pass out quick inet proto udp from any to 185.213.154.131 port = 1301 flags S/SA keep state
 block drop out quick proto tcp from any to any port = 53
```

We used `trello.com` for testing because it contained the large DNS record didn't fit into 512 bytes and couldn't be sent over UDP. 

However, note that Trello.com have changed their DNS records overnight. The updated DNS records fit into 512 bytes and can be received over UDP, so when testing, make sure to explicitly specify the target network protocol manually as the default UDP with TCP fallback will always succeed from now on. I prefer `dig` to `nslookup` as the former has an easy way to flip the network protocol.

### Diagnostics and Testing

#### `master` branch

##### Use TCP to query DNS:

> dig +tcp trello.com      
> ;; Connection to 10.15.0.1#53(10.15.0.1) for trello.com failed: timed out.
> ;; Connection to 10.15.0.1#53(10.15.0.1) for trello.com failed: timed out.
> 
> ; <<>> DiG 9.10.6 <<>> +tcp trello.com
> ;; global options: +cmd
> ;; connection timed out; no servers could be reached
> ;; Connection to 10.15.0.1#53(10.15.0.1) for trello.com failed: timed out.

##### Use UDP to query DNS

> dig +notcp trello.com 
> 
> ; <<>> DiG 9.10.6 <<>> +notcp trello.com
> ;; global options: +cmd
> ;; Got answer:
> ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 63542
> ;; flags: qr rd ra; QUERY: 1, ANSWER: 16, AUTHORITY: 6, ADDITIONAL: 1
> 
> ;; OPT PSEUDOSECTION:
> ; EDNS: version: 0, flags:; udp: 4096
> ;; QUESTION SECTION:
> ;trello.com.			IN	A
> 
> ;; ANSWER SECTION:
> trello.com.		60	IN	A	34.194.54.59
> trello.com.		60	IN	A	52.70.217.50
> trello.com.		60	IN	A	35.168.209.194
> trello.com.		60	IN	A	52.6.153.70
> trello.com.		60	IN	A	35.153.188.151
> trello.com.		60	IN	A	35.169.189.227
> trello.com.		60	IN	A	52.201.199.7
> trello.com.		60	IN	A	52.201.193.183
> trello.com.		60	IN	A	34.198.36.182
> trello.com.		60	IN	A	52.21.187.94
> trello.com.		60	IN	A	52.201.196.202
> trello.com.		60	IN	A	34.198.52.186
> trello.com.		60	IN	A	52.7.7.177
> trello.com.		60	IN	A	52.0.119.41
> trello.com.		60	IN	A	52.71.5.176
> trello.com.		60	IN	A	52.23.149.18
> 
> ;; AUTHORITY SECTION:
> trello.com.		168202	IN	NS	a28-66.akam.net.
> trello.com.		168202	IN	NS	a3-67.akam.net.
> trello.com.		168202	IN	NS	a4-64.akam.net.
> trello.com.		168202	IN	NS	a1-158.akam.net.
> trello.com.		168202	IN	NS	a22-65.akam.net.
> trello.com.		168202	IN	NS	a7-65.akam.net.
> 
> ;; Query time: 94 msec
> ;; SERVER: 10.15.0.1#53(10.15.0.1)
> ;; WHEN: Fri Mar 06 10:44:45 CET 2020
> ;; MSG SIZE  rcvd: 426


#### `fix-dns-over-tcp-when-lan-sharing-enabled-macos` branch

##### Use TCP to query DNS:

> dig +tcp trello.com
> 
> ; <<>> DiG 9.10.6 <<>> +tcp trello.com
> ;; global options: +cmd
> ;; Got answer:
> ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 59849
> ;; flags: qr rd ra; QUERY: 1, ANSWER: 16, AUTHORITY: 6, ADDITIONAL: 1
> 
> ;; OPT PSEUDOSECTION:
> ; EDNS: version: 0, flags:; udp: 4096
> ;; QUESTION SECTION:
> ;trello.com.			IN	A
> 
> ;; ANSWER SECTION:
> trello.com.		58	IN	A	52.70.217.50
> trello.com.		58	IN	A	52.0.119.41
> trello.com.		58	IN	A	52.201.199.7
> trello.com.		58	IN	A	52.21.187.94
> trello.com.		58	IN	A	52.201.193.183
> trello.com.		58	IN	A	52.7.7.177
> trello.com.		58	IN	A	34.198.36.182
> trello.com.		58	IN	A	52.6.153.70
> trello.com.		58	IN	A	35.168.209.194
> trello.com.		58	IN	A	35.169.189.227
> trello.com.		58	IN	A	34.194.54.59
> trello.com.		58	IN	A	35.153.188.151
> trello.com.		58	IN	A	52.71.5.176
> trello.com.		58	IN	A	52.23.149.18
> trello.com.		58	IN	A	34.198.52.186
> trello.com.		58	IN	A	52.201.196.202
> 
> ;; AUTHORITY SECTION:
> trello.com.		167919	IN	NS	a4-64.akam.net.
> trello.com.		167919	IN	NS	a3-67.akam.net.
> trello.com.		167919	IN	NS	a22-65.akam.net.
> trello.com.		167919	IN	NS	a28-66.akam.net.
> trello.com.		167919	IN	NS	a7-65.akam.net.
> trello.com.		167919	IN	NS	a1-158.akam.net.
> 
> ;; Query time: 54 msec
> ;; SERVER: 10.9.0.1#53(10.9.0.1)
> ;; WHEN: Fri Mar 06 10:49:28 CET 2020
> ;; MSG SIZE  rcvd: 426

##### Use UDP to query DNS 

> dig +notcp trello.com
> 
> ; <<>> DiG 9.10.6 <<>> +notcp trello.com
> ;; global options: +cmd
> ;; Got answer:
> ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24600
> ;; flags: qr rd ra; QUERY: 1, ANSWER: 16, AUTHORITY: 6, ADDITIONAL: 1
> 
> ;; OPT PSEUDOSECTION:
> ; EDNS: version: 0, flags:; udp: 4096
> ;; QUESTION SECTION:
> ;trello.com.			IN	A
> 
> ;; ANSWER SECTION:
> trello.com.		35	IN	A	52.0.119.41
> trello.com.		35	IN	A	52.7.7.177
> trello.com.		35	IN	A	34.198.52.186
> trello.com.		35	IN	A	52.201.199.7
> trello.com.		35	IN	A	52.21.187.94
> trello.com.		35	IN	A	52.70.217.50
> trello.com.		35	IN	A	52.23.149.18
> trello.com.		35	IN	A	35.153.188.151
> trello.com.		35	IN	A	35.168.209.194
> trello.com.		35	IN	A	52.71.5.176
> trello.com.		35	IN	A	52.6.153.70
> trello.com.		35	IN	A	52.201.196.202
> trello.com.		35	IN	A	34.194.54.59
> trello.com.		35	IN	A	52.201.193.183
> trello.com.		35	IN	A	35.169.189.227
> trello.com.		35	IN	A	34.198.36.182
> 
> ;; AUTHORITY SECTION:
> trello.com.		167896	IN	NS	a1-158.akam.net.
> trello.com.		167896	IN	NS	a28-66.akam.net.
> trello.com.		167896	IN	NS	a3-67.akam.net.
> trello.com.		167896	IN	NS	a4-64.akam.net.
> trello.com.		167896	IN	NS	a22-65.akam.net.
> trello.com.		167896	IN	NS	a7-65.akam.net.
> 
> ;; Query time: 59 msec
> ;; SERVER: 10.9.0.1#53(10.9.0.1)
> ;; WHEN: Fri Mar 06 10:49:51 CET 2020
> ;; MSG SIZE  rcvd: 426

#### Why does it work with Local Network sharing enabled?

When LAN sharing is enabled, the firewall is configured to pass some of the inbound local traffic, including the traffic originating from the `10.x.x.x` range, which covers our relay as well, so basically LAN rules allow all inbound traffic from our relay IP.

The firewall rules diff when enabling the LAN sharing:

```diff
diff --git a/after.txt b/after-allow-lan.txt
index dfa8f2f..f8311dc 100644
--- a/after.txt
+++ b/after-allow-lan.txt
@@ -16,4 +16,21 @@ pass out quick inet proto udp from any to 185.213.154.131 port = 1301 flags S/SA
 block drop out quick proto tcp from any to any port = 53
 block drop out quick proto udp from any to any port = 53
 pass quick on utun2 all flags S/SA keep state
+pass out quick inet from any to 10.0.0.0/8 no state
+pass in quick inet from 10.0.0.0/8 to any no state
+pass out quick inet from any to 172.16.0.0/12 no state
+pass in quick inet from 172.16.0.0/12 to any no state
+pass out quick inet from any to 192.168.0.0/16 no state
+pass in quick inet from 192.168.0.0/16 to any no state
+pass out quick inet from any to 169.254.0.0/16 no state
+pass in quick inet from 169.254.0.0/16 to any no state
+pass out quick inet6 from any to fe80::/10 no state
+pass in quick inet6 from fe80::/10 to any no state
+pass out quick inet from any to 224.0.0.0/24 no state
+pass out quick inet from any to 239.255.255.250 no state
+pass out quick inet from any to 239.255.255.251 no state
+pass out quick inet6 from any to ff02::/16 no state
+pass out quick inet6 from any to ff05::/16 no state
+pass out quick inet proto udp from any port = 67 to any port = 68 no state
+pass in quick inet proto udp from any port = 68 to 255.255.255.255 port = 67 no state
 block drop quick all
```

As you can see the following rule made inbound DNS over TCP possible:

```
pass in quick inet from 10.0.0.0/8 to any no state
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1557)
<!-- Reviewable:end -->
