### PR TITLE
Revert stateless DNS over TCP rules in favour of stateful ones

### DIFF
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -113,18 +113,11 @@ impl Firewall {
                     .quick(true)
                     .interface(&tunnel.interface)
                     .proto(pfctl::Proto::Tcp)
+                    .keep_state(pfctl::StatePolicy::Keep)
+                    .tcp_flags(Self::get_tcp_flags())
                     .to(pfctl::Endpoint::new(tunnel.ipv4_gateway, 53))
                     .build()?;
                 rules.push(allow_tcp_dns_to_relay_rule);
-                let allow_tcp_dns_from_relay_rule = self
-                    .create_rule_builder(FilterRuleAction::Pass)
-                    .direction(pfctl::Direction::In)
-                    .quick(true)
-                    .interface(&tunnel.interface)
-                    .proto(pfctl::Proto::Tcp)
-                    .from(pfctl::Endpoint::new(tunnel.ipv4_gateway, 53))
-                    .build()?;
-                rules.push(allow_tcp_dns_from_relay_rule);
                 let allow_udp_dns_to_relay_rule = self
                     .create_rule_builder(FilterRuleAction::Pass)
                     .direction(pfctl::Direction::Out)
@@ -136,25 +129,18 @@ impl Firewall {
                 rules.push(allow_udp_dns_to_relay_rule);
 
                 if let Some(ipv6_gateway) = tunnel.ipv6_gateway {
-                    let allow_tcp_dns6_to_relay_rule = self
+                    let v6_dns_rule_tcp = self
                         .create_rule_builder(FilterRuleAction::Pass)
                         .direction(pfctl::Direction::Out)
                         .quick(true)
                         .interface(&tunnel.interface)
                         .proto(pfctl::Proto::Tcp)
+                        .keep_state(pfctl::StatePolicy::Keep)
+                        .tcp_flags(Self::get_tcp_flags())
                         .to(pfctl::Endpoint::new(ipv6_gateway, 53))
                         .build()?;
-                    rules.push(allow_tcp_dns6_to_relay_rule);
-                    let allow_tcp_dns6_from_relay_rule = self
-                        .create_rule_builder(FilterRuleAction::Pass)
-                        .direction(pfctl::Direction::In)
-                        .quick(true)
-                        .interface(&tunnel.interface)
-                        .proto(pfctl::Proto::Tcp)
-                        .from(pfctl::Endpoint::new(ipv6_gateway, 53))
-                        .build()?;
-                    rules.push(allow_tcp_dns6_from_relay_rule);
-                    let allow_udp_dns6_to_relay_rule = self
+                    rules.push(v6_dns_rule_tcp);
+                    let v6_dns_rule_udp = self
                         .create_rule_builder(FilterRuleAction::Pass)
                         .direction(pfctl::Direction::Out)
                         .quick(true)
@@ -162,7 +148,7 @@ impl Firewall {
                         .proto(pfctl::Proto::Udp)
                         .to(pfctl::Endpoint::new(ipv6_gateway, 53))
                         .build()?;
-                    rules.push(allow_udp_dns6_to_relay_rule);
+                    rules.push(v6_dns_rule_udp);
                 }
 
                 rules.push(self.get_allow_relay_rule(peer_endpoint)?);


### PR DESCRIPTION
This reverts commit 3c375dcfd8a37ad7d1b49510f90e4359f9478ff9.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR reverts the stateless DNS/TCP rules in favour or stateful as discussed on slack. This makes it simpler in terms of firewall rules management.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1558)
<!-- Reviewable:end -->
