### PR TITLE
Add beta program option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Added signal handlers on Unix platforms to better log critical faults with the daemon.
 - Add WireGuard MTU setting to desktop app.
+- Add option to receive notifications about new beta releases.
 
 #### Android
 - Add option to enable auto-connecting behavior

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,18 +838,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jnix"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jnix-macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1319,7 +1319,7 @@ dependencies = [
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1414,7 +1414,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-paths 0.1.0",
@@ -2446,7 +2446,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.2 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "jsonrpc-macros 8.0.1 (git+https://github.com/mullvad/jsonrpc?branch=mullvad-fork)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2534,7 +2534,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jnix 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jnix 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3278,8 +3278,8 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1981310da491a4f0f815238097d0d43d8072732b5ae5f8bd0d8eadf5bf245402"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-"checksum jnix 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf0e39a7249633ce8d8af6003a28d4a9768974f2f56cc976be2728f5dc5b594f"
-"checksum jnix-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb5b3152556e7d95085b8b5e4b9d527e267cd67eb269c2f7b45279e632b2c5d"
+"checksum jnix 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "78d9227a649cfd98d8054f961ce0aa740d97059ab0476c31dc8f61a53501ab88"
+"checksum jnix-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf6f868f5627933811b867eab0c920c0b0d1a3f672296a269b07fd528dce1f7"
 "checksum jsonrpc-client-core 0.5.0 (git+https://github.com/mullvad/jsonrpc-client-rs?rev=68aac55b)" = "<none>"
 "checksum jsonrpc-client-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f29cb249837420fb0cee7fb0fbf1d22679e121b160e71bb5e0d90b9df241c23e"
 "checksum jsonrpc-client-http 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e642eb74423b9dfcb4512fda167148746b76f788a823cd712fadf409f31d302"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
@@ -4,5 +4,6 @@ data class Settings(
     var accountToken: String?,
     var relaySettings: RelaySettings,
     var allowLan: Boolean,
-    var autoConnect: Boolean
+    var autoConnect: Boolean,
+    var showBetaReleases: Boolean?
 )

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -288,7 +288,6 @@ const tunnelStateSchema = oneOf(
 
 const appVersionInfoSchema = partialObject({
   current_is_supported: boolean,
-  current_is_outdated: boolean,
   latest_stable: string,
   latest: string,
 });
@@ -337,6 +336,7 @@ const settingsSchema = partialObject({
   allow_lan: boolean,
   auto_connect: boolean,
   block_when_disconnected: boolean,
+  show_beta_releases: maybe(boolean),
   bridge_settings: bridgeSettingsSchema,
   bridge_state: enumeration('on', 'auto', 'off'),
   relay_settings: relaySettingsSchema,

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -91,6 +91,7 @@ class ApplicationMain {
     allowLan: false,
     autoConnect: false,
     blockWhenDisconnected: false,
+    showBetaReleases: undefined,
     relaySettings: {
       normal: {
         location: 'any',
@@ -137,7 +138,6 @@ class ApplicationMain {
 
   private upgradeVersion: IAppUpgradeInfo = {
     currentIsSupported: true,
-    currentIsOutdated: false,
     latestStable: '',
     latest: '',
     nextUpgrade: undefined,
@@ -739,16 +739,14 @@ class ApplicationMain {
   }
 
   private setLatestVersion(latestVersionInfo: IAppVersionInfo) {
-    function isBeta(version: string) {
-      return version.includes('-');
-    }
+    const settings = this.settings;
 
     function nextUpgrade(
       current: string,
       latest: string,
       latestStable: string,
     ): string | undefined {
-      if (isBeta(current)) {
+      if (settings.showBetaReleases) {
         return current === latest ? undefined : latest;
       } else {
         return current === latestStable ? undefined : latestStable;

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -577,6 +577,7 @@ export default class AppRenderer {
     reduxSettings.updateAllowLan(newSettings.allowLan);
     reduxSettings.updateEnableIpv6(newSettings.tunnelOptions.generic.enableIpv6);
     reduxSettings.updateBlockWhenDisconnected(newSettings.blockWhenDisconnected);
+    reduxSettings.updateShowBetaReleases(newSettings.showBetaReleases);
     reduxSettings.updateOpenVpnMssfix(newSettings.tunnelOptions.openvpn.mssfix);
     reduxSettings.updateWireguardMtu(newSettings.tunnelOptions.wireguard.mtu);
     reduxSettings.updateBridgeState(newSettings.bridgeState);

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -175,7 +175,7 @@ export default class NotificationArea extends Component<IProps, State> {
           };
         }
 
-        if (version.currentIsOutdated && version.nextUpgrade) {
+        if (version.nextUpgrade && version.nextUpgrade !== version.current) {
           return {
             visible: true,
             type: 'update-available',

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -15,7 +15,9 @@ const mapStateToProps = (state: IReduxState, props: IAppContext) => ({
   expiryLocale: state.userInterface.locale,
   appVersion: state.version.current,
   consistentVersion: state.version.consistent,
-  upToDateVersion: !state.version.currentIsOutdated,
+  upToDateVersion: state.settings.showBetaReleases
+    ? state.version.current === state.version.latest
+    : state.version.current === state.version.latestStable,
   isOffline: state.connection.isBlocked,
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch) => {

--- a/gui/src/renderer/containers/SupportPage.tsx
+++ b/gui/src/renderer/containers/SupportPage.tsx
@@ -12,7 +12,9 @@ const mapStateToProps = (state: IReduxState) => ({
   defaultMessage: state.support.message,
   accountHistory: state.account.accountHistory,
   isOffline: state.connection.isBlocked,
-  outdatedVersion: state.version.currentIsOutdated,
+  outdatedVersion: state.settings.showBetaReleases
+    ? state.version.current !== state.version.latest
+    : state.version.current !== state.version.latestStable,
 });
 
 const mapDispatchToProps = (dispatch: ReduxDispatch) => {

--- a/gui/src/renderer/redux/settings/actions.ts
+++ b/gui/src/renderer/redux/settings/actions.ts
@@ -37,6 +37,11 @@ export interface IUpdateBlockWhenDisconnectedAction {
   blockWhenDisconnected: boolean;
 }
 
+export interface IUpdateShowBetaReleasesAction {
+  type: 'UPDATE_SHOW_BETA_NOTIFICATIONS';
+  showBetaReleases?: boolean;
+}
+
 export interface IUpdateBridgeSettingsAction {
   type: 'UPDATE_BRIDGE_SETTINGS';
   bridgeSettings: BridgeSettingsRedux;
@@ -100,6 +105,7 @@ export type SettingsAction =
   | IUpdateAllowLanAction
   | IUpdateEnableIpv6Action
   | IUpdateBlockWhenDisconnectedAction
+  | IUpdateShowBetaReleasesAction
   | IUpdateBridgeSettingsAction
   | IUpdateBridgeStateAction
   | IUpdateOpenVpnMssfixAction
@@ -162,6 +168,13 @@ function updateBlockWhenDisconnected(
   return {
     type: 'UPDATE_BLOCK_WHEN_DISCONNECTED',
     blockWhenDisconnected,
+  };
+}
+
+function updateShowBetaReleases(showBetaReleases?: boolean): IUpdateShowBetaReleasesAction {
+  return {
+    type: 'UPDATE_SHOW_BETA_NOTIFICATIONS',
+    showBetaReleases,
   };
 }
 
@@ -256,6 +269,7 @@ export default {
   updateAllowLan,
   updateEnableIpv6,
   updateBlockWhenDisconnected,
+  updateShowBetaReleases,
   updateBridgeSettings,
   updateBridgeState,
   updateOpenVpnMssfix,

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -126,6 +126,7 @@ export interface ISettingsReduxState {
   bridgeSettings: BridgeSettingsRedux;
   bridgeState: BridgeState;
   blockWhenDisconnected: boolean;
+  showBetaReleases?: boolean;
   openVpn: {
     mssfix?: number;
   };
@@ -166,6 +167,7 @@ const initialState: ISettingsReduxState = {
   },
   bridgeState: 'auto',
   blockWhenDisconnected: false,
+  showBetaReleases: undefined,
   openVpn: {},
   wireguard: {},
   wireguardKeyState: {
@@ -218,6 +220,12 @@ export default function(
       return {
         ...state,
         blockWhenDisconnected: action.blockWhenDisconnected,
+      };
+
+    case 'UPDATE_SHOW_BETA_NOTIFICATIONS':
+      return {
+        ...state,
+        showBetaReleases: action.showBetaReleases,
       };
 
     case 'UPDATE_OPENVPN_MSSFIX':

--- a/gui/src/renderer/redux/version/reducers.ts
+++ b/gui/src/renderer/redux/version/reducers.ts
@@ -3,7 +3,6 @@ import { ReduxAction } from '../store';
 export interface IVersionReduxState {
   current: string;
   currentIsSupported: boolean;
-  currentIsOutdated: boolean;
   latest?: string;
   latestStable?: string;
   nextUpgrade?: string;
@@ -13,7 +12,6 @@ export interface IVersionReduxState {
 const initialState: IVersionReduxState = {
   current: '',
   currentIsSupported: true,
-  currentIsOutdated: false,
   latest: undefined,
   latestStable: undefined,
   nextUpgrade: undefined,

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -279,7 +279,6 @@ export interface IShadowsocksProxySettings {
 
 export interface IAppVersionInfo {
   currentIsSupported: boolean;
-  currentIsOutdated: boolean;
   latestStable: string;
   latest: string;
 }
@@ -289,6 +288,7 @@ export interface ISettings {
   allowLan: boolean;
   autoConnect: boolean;
   blockWhenDisconnected: boolean;
+  showBetaReleases?: boolean;
   relaySettings: RelaySettings;
   tunnelOptions: ITunnelOptions;
   bridgeSettings: BridgeSettings;

--- a/mullvad-cli/src/cmds/beta_program.rs
+++ b/mullvad-cli/src/cmds/beta_program.rs
@@ -1,0 +1,54 @@
+use crate::{new_rpc_client, Command, Result};
+use clap::value_t_or_exit;
+
+pub struct BetaProgram;
+
+impl Command for BetaProgram {
+    fn name(&self) -> &'static str {
+        "beta-program"
+    }
+
+    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
+        clap::SubCommand::with_name(self.name())
+            .about("Receive notifications about beta updates")
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+            .subcommand(
+                clap::SubCommand::with_name("set")
+                    .about("Change beta notifications setting")
+                    .arg(
+                        clap::Arg::with_name("policy")
+                            .required(true)
+                            .possible_values(&["on", "off"]),
+                    ),
+            )
+            .subcommand(clap::SubCommand::with_name("get").about("Get beta notifications setting"))
+    }
+
+    fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+        match matches.subcommand() {
+            ("get", Some(_)) => {
+                let mut rpc = new_rpc_client()?;
+                let settings = rpc.get_settings()?;
+                let enabled_str = if settings.get_show_beta_releases().unwrap_or(false) {
+                    "on"
+                } else {
+                    "off"
+                };
+                println!("Beta program: {}", enabled_str);
+                Ok(())
+            }
+            ("set", Some(matches)) => {
+                let enabled_str = value_t_or_exit!(matches.value_of("policy"), String);
+
+                let mut rpc = new_rpc_client()?;
+                rpc.set_show_beta_releases(enabled_str == "on")?;
+
+                println!("Beta program: {}", enabled_str);
+                Ok(())
+            }
+            _ => {
+                unreachable!("unhandled comand");
+            }
+        }
+    }
+}

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -7,6 +7,9 @@ pub use self::account::Account;
 mod auto_connect;
 pub use self::auto_connect::AutoConnect;
 
+mod beta_program;
+pub use self::beta_program::BetaProgram;
+
 mod block_when_disconnected;
 pub use self::block_when_disconnected::BlockWhenDisconnected;
 
@@ -45,6 +48,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
     let commands: Vec<Box<dyn Command>> = vec![
         Box::new(Account),
         Box::new(AutoConnect),
+        Box::new(BetaProgram),
         Box::new(BlockWhenDisconnected),
         Box::new(Bridge),
         Box::new(Connect),

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -18,7 +18,15 @@ impl Command for Version {
         println!("Current version: {}", current_version);
         let version_info = rpc.get_version_info()?;
         println!("\tIs supported: {}", version_info.current_is_supported);
-        println!("\tIs up to date: {}", !version_info.current_is_outdated);
+
+        let settings = rpc.get_settings()?;
+        let is_updated = if settings.get_show_beta_releases().unwrap_or(false) {
+            version_info.latest == current_version
+        } else {
+            version_info.latest_stable == current_version
+        };
+        println!("\tIs up to date: {}", is_updated);
+
         if version_info.latest_stable != version_info.latest {
             println!(
                 "Latest version: {} (latest stable: {})",

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -485,7 +485,11 @@ where
         );
         tokio_remote.spawn(|_| version_check_future);
 
-        let settings = settings::load();
+        let mut settings = settings::load();
+
+        if version::is_beta_version() && settings.get_show_beta_releases().is_none() {
+            let _ = settings.set_show_beta_releases(true);
+        }
 
         let account_history = account_history::AccountHistory::new(
             &cache_dir,

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -69,6 +69,10 @@ build_rpc_trait! {
         #[rpc(meta, name = "set_allow_lan")]
         fn set_allow_lan(&self, Self::Metadata, bool) -> BoxFuture<(), Error>;
 
+        /// Set whether to enable the beta program.
+        #[rpc(meta, name = "set_show_beta_releases")]
+        fn set_show_beta_releases(&self, Self::Metadata, bool) -> BoxFuture<(), Error>;
+
         /// Set if the client should allow network communication when in the disconnected state.
         #[rpc(meta, name = "set_block_when_disconnected")]
         fn set_block_when_disconnected(&self, Self::Metadata, bool) -> BoxFuture<(), Error>;
@@ -433,6 +437,15 @@ impl ManagementInterfaceApi for ManagementInterface {
         let (tx, rx) = sync::oneshot::channel();
         let future = self
             .send_command_to_daemon(DaemonCommand::SetAllowLan(tx, allow_lan))
+            .and_then(|_| rx.map_err(|_| Error::internal_error()));
+        Box::new(future)
+    }
+
+    fn set_show_beta_releases(&self, _: Self::Metadata, enabled: bool) -> BoxFuture<(), Error> {
+        log::debug!("set_show_beta_releases({})", enabled);
+        let (tx, rx) = sync::oneshot::channel();
+        let future = self
+            .send_command_to_daemon(DaemonCommand::SetShowBetaReleases(tx, enabled))
             .and_then(|_| rx.map_err(|_| Error::internal_error()));
         Box::new(future)
     }

--- a/mullvad-daemon/src/version.rs
+++ b/mullvad-daemon/src/version.rs
@@ -4,6 +4,10 @@ pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/produc
 /// Contains the date of the git commit this was built from
 pub const COMMIT_DATE: &str = include_str!(concat!(env!("OUT_DIR"), "/git-commit-date.txt"));
 
+pub fn is_beta_version() -> bool {
+    PRODUCT_VERSION.contains("beta")
+}
+
 pub fn log_version() {
     log::info!(
         "Starting {} - {} {}",

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -227,7 +227,6 @@ pub fn load_cache(cache_dir: &Path) -> AppVersionInfo {
             // If we don't have a cache, start out with sane defaults.
             AppVersionInfo {
                 current_is_supported: true,
-                current_is_outdated: false,
                 latest_stable: PRODUCT_VERSION.to_owned(),
                 latest: PRODUCT_VERSION.to_owned(),
             }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -123,6 +123,10 @@ impl DaemonRpcClient {
         self.call("set_allow_lan", &[allow_lan])
     }
 
+    pub fn set_show_beta_releases(&mut self, enabled: bool) -> Result<()> {
+        self.call("set_show_beta_releases", &[enabled])
+    }
+
     pub fn set_block_when_disconnected(&mut self, block_when_disconnected: bool) -> Result<()> {
         self.call("set_block_when_disconnected", &[block_when_disconnected])
     }

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -14,7 +14,7 @@ crate_type = ["cdylib"]
 err-derive = "0.2.1"
 futures = "0.1"
 ipnetwork = "0.15"
-jnix = { version = "0.2.0", features = ["derive"] }
+jnix = { version = "0.2.1", features = ["derive"] }
 jsonrpc-client-core = "0.5"
 jsonrpc-core = "8"
 lazy_static = "1"

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -70,6 +70,7 @@ impl super::SettingsMigration for Migration {
                 block_when_disconnected: old.block_when_disconnected,
                 auto_connect: old.auto_connect,
                 tunnel_options: old.tunnel_options,
+                show_beta_releases: None,
                 settings_version: super::SettingsVersion::V2,
             }),
             VersionedSettings::V2(new) => VersionedSettings::V2(new),

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -76,6 +76,8 @@ pub struct Settings {
     /// might be located.
     #[cfg_attr(target_os = "android", jnix(skip))]
     tunnel_options: TunnelOptions,
+    /// Whether to notify users of beta updates.
+    show_beta_releases: Option<bool>,
     /// Specifies settings schema version
     #[cfg_attr(target_os = "android", jnix(skip))]
     settings_version: migrations::SettingsVersion,
@@ -97,6 +99,7 @@ impl Default for Settings {
             block_when_disconnected: false,
             auto_connect: false,
             tunnel_options: TunnelOptions::default(),
+            show_beta_releases: None,
             settings_version: migrations::SettingsVersion::V2,
         }
     }
@@ -296,6 +299,19 @@ impl Settings {
 
     pub fn get_tunnel_options(&self) -> &TunnelOptions {
         &self.tunnel_options
+    }
+
+    pub fn get_show_beta_releases(&self) -> Option<bool> {
+        self.show_beta_releases.clone()
+    }
+
+    pub fn set_show_beta_releases(&mut self, enabled: bool) -> Result<bool> {
+        if Some(enabled) != self.show_beta_releases {
+            self.show_beta_releases = Some(enabled);
+            self.save().map(|_| true)
+        } else {
+            Ok(false)
+        }
     }
 
     pub fn get_bridge_settings(&self) -> &BridgeSettings {

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -17,6 +17,7 @@ pub struct AppVersionInfo {
     pub current_is_supported: bool,
     /// True if there is a newer version that contains any functional differences compared to the
     /// running version. User should upgrade if they want the latest features and bugfixes.
+    /// DEPRECATED
     pub current_is_outdated: bool,
     pub latest_stable: AppVersion,
     /// Equal to `latest_stable` when the newest release is a stable release. But will contain

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -15,10 +15,6 @@ pub struct AppVersionInfo {
     ///   issues, so using it is no longer recommended.
     /// The user should really upgrade when this is false.
     pub current_is_supported: bool,
-    /// True if there is a newer version that contains any functional differences compared to the
-    /// running version. User should upgrade if they want the latest features and bugfixes.
-    /// DEPRECATED
-    pub current_is_outdated: bool,
     pub latest_stable: AppVersion,
     /// Equal to `latest_stable` when the newest release is a stable release. But will contain
     /// beta versions when those are out for testing.


### PR DESCRIPTION
Small update to allow users to receive notifications about beta releases. If the option is not set explicitly and a beta version is run, then it remains enabled even if the program is later replaced by a stable version.

The GUI is unaffected. The can only be seen in the CLI (`mullvad version`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1560)
<!-- Reviewable:end -->
