### PR TITLE
Change message shown when reconnecting with new wireguard key

### DIFF
--- a/gui/src/renderer/containers/WireguardKeysPage.tsx
+++ b/gui/src/renderer/containers/WireguardKeysPage.tsx
@@ -11,6 +11,7 @@ const mapStateToProps = (state: IReduxState) => ({
   keyState: state.settings.wireguardKeyState,
   isOffline: state.connection.isBlocked,
   locale: state.userInterface.locale,
+  tunnelState: state.connection.status,
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ push, goBack }, dispatch);


### PR DESCRIPTION
Improvement to the message shown when reconnecting with a newly generated wireguard key. Instead of an error message telling the user about being in a blocked state, it shows a green text saying "Reconnecting with new WireGuard key..."

![image](https://user-images.githubusercontent.com/3668602/76444267-fb0e1c80-63c3-11ea-9b0e-6d9769ae5d6e.png)

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1565)
<!-- Reviewable:end -->
