### PR TITLE
Fix crash when converting `AppVersionInfo` into a Java class

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -18,7 +18,7 @@ class AppVersionInfoCache(
 
     private val setUpJob = setUp()
 
-    private val settingsListenerId = settingsListener.settingsNotifier.subscribe { settings ->
+    private val settingsListenerId = settingsListener.subscribe { settings ->
         showBetaReleases = settings.showBetaReleases ?: false
     }
 
@@ -29,17 +29,9 @@ class AppVersionInfoCache(
 
                 if (value != null && upgradeVersion == version) {
                     upgradeVersion = null
-
-                    field = AppVersionInfo(
-                        value.currentIsSupported,
-                        /* currentIsOutdated = */ false,
-                        value.latestStable,
-                        value.latest
-                    )
-                } else {
-                    field = value
                 }
 
+                field = value
                 onUpdate?.invoke()
             }
         }
@@ -86,6 +78,7 @@ class AppVersionInfoCache(
 
     fun onDestroy() {
         setUpJob.cancel()
+        settingsListener.unsubscribe(settingsListenerId)
         daemon.onAppVersionInfoChange = null
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -7,7 +7,11 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 
-class AppVersionInfoCache(val context: Context, val daemon: MullvadDaemon) {
+class AppVersionInfoCache(
+    val context: Context,
+    val daemon: MullvadDaemon,
+    val settingsListener: SettingsListener
+) {
     companion object {
         val LEGACY_SHARED_PREFERENCES = "app_version_info_cache"
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -79,8 +79,6 @@ class AppVersionInfoCache(
 
     var version: String? = null
         private set
-    var isStable = true
-        private set
 
     fun onCreate() {
         context.getSharedPreferences(LEGACY_SHARED_PREFERENCES, Context.MODE_PRIVATE)
@@ -99,7 +97,6 @@ class AppVersionInfoCache(
         val currentVersion = daemon.getCurrentVersion()
 
         version = currentVersion
-        isStable = !currentVersion.contains("-")
 
         daemon.onAppVersionInfoChange = { newAppVersionInfo ->
             appVersionInfo = newAppVersionInfo

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -18,6 +18,10 @@ class AppVersionInfoCache(
 
     private val setUpJob = setUp()
 
+    private val settingsListenerId = settingsListener.settingsNotifier.subscribe { settings ->
+        showBetaReleases = settings.showBetaReleases ?: false
+    }
+
     private var appVersionInfo: AppVersionInfo? = null
         set(value) {
             synchronized(this) {
@@ -45,6 +49,9 @@ class AppVersionInfoCache(
             field = value
             value?.invoke()
         }
+
+    var showBetaReleases = false
+        private set
 
     val latestStable
         get() = appVersionInfo?.latestStable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -59,8 +59,15 @@ class AppVersionInfoCache(
         get() = appVersionInfo?.latest
     val isSupported
         get() = appVersionInfo?.currentIsSupported ?: true
-    var isOutdated = false
-        get() = appVersionInfo?.currentIsOutdated ?: false
+
+    val isOutdated: Boolean
+        get() {
+            if (showBetaReleases) {
+                return version != null && latest != null && latest != version
+            } else {
+                return version != null && latestStable != null && latestStable != version
+            }
+        }
 
     var version: String? = null
         private set

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -30,15 +30,6 @@ class AppVersionInfoCache(
             }
         }
 
-    var onUpdate: (() -> Unit)? = null
-        set(value) {
-            field = value
-            value?.invoke()
-        }
-
-    var showBetaReleases = false
-        private set
-
     val latestStable
         get() = appVersionInfo?.latestStable
     val latest
@@ -71,6 +62,15 @@ class AppVersionInfoCache(
                 }
             }
         }
+
+    var onUpdate: (() -> Unit)? = null
+        set(value) {
+            field = value
+            value?.invoke()
+        }
+
+    var showBetaReleases = false
+        private set
 
     var version: String? = null
         private set

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -25,12 +25,6 @@ class AppVersionInfoCache(
     private var appVersionInfo: AppVersionInfo? = null
         set(value) {
             synchronized(this) {
-                upgradeVersion = if (isStable) value?.latestStable else value?.latest
-
-                if (value != null && upgradeVersion == version) {
-                    upgradeVersion = null
-                }
-
                 field = value
                 onUpdate?.invoke()
             }
@@ -61,12 +55,26 @@ class AppVersionInfoCache(
             }
         }
 
+    val upgradeVersion: String?
+        get() {
+            if (showBetaReleases) {
+                if (version == latest) {
+                    return null
+                } else {
+                    return latest
+                }
+            } else {
+                if (version == latestStable) {
+                    return null
+                } else {
+                    return latestStable
+                }
+            }
+        }
+
     var version: String? = null
         private set
     var isStable = true
-        private set
-
-    var upgradeVersion: String? = null
         private set
 
     fun onCreate() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -70,7 +70,12 @@ class AppVersionInfoCache(
         }
 
     var showBetaReleases = false
-        private set
+        private set(value) {
+            if (field != value) {
+                field = value
+                onUpdate?.invoke()
+            }
+        }
 
     var version: String? = null
         private set

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.model
 
 data class AppVersionInfo(
     val currentIsSupported: Boolean,
-    val currentIsOutdated: Boolean,
     val latestStable: String,
     val latest: String
 )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -13,9 +13,9 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val connectionProxy = service.connectionProxy
     val connectivityListener = service.connectivityListener
 
-    val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon)
     val keyStatusListener = KeyStatusListener(daemon)
     val settingsListener = SettingsListener(daemon)
+    val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     val accountCache = AccountCache(settingsListener, daemon)
     var relayListListener = RelayListListener(daemon, settingsListener)
     val locationInfoCache = LocationInfoCache(daemon, connectivityListener, relayListListener)

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [lib]
 crate_type = ["cdylib"]
 
-[dependencies]
+[target.'cfg(target_os = "android")'.dependencies]
 err-derive = "0.2.1"
 futures = "0.1"
 ipnetwork = "0.15"


### PR DESCRIPTION
Previously, the conversion of the `AppVersionInfo` Rust type into the `AppVersionInfo` Java class would fail. This PR fixes that by removing an obsolete property and also replacing the usage of that property.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not present in any released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1568)
<!-- Reviewable:end -->
