### PR TITLE
Fix leak of connectivity listener subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Make sure the settings screen is scrollable so that devices with small screens can access the quit
   button.
+- Fix connectivity listener leak causing possible battery usage increase.
 
 #### Windows
 - Fix bug where failing to initialize the route manager could cause the daemon to get stuck in a

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/LocationInfoCache.kt
@@ -72,6 +72,7 @@ class LocationInfoCache(
         }
 
     fun onDestroy() {
+        connectivityListener.connectivityNotifier.unsubscribe(connectivityListenerId)
         activeFetch?.cancel()
     }
 


### PR DESCRIPTION
The `LocationInfoCache` subscribes to connectivity events on a `ConnectivityListener` instance. This happens every time the UI connects to the service. However, there was no explicit unsubscribe event, so the `LocationInfoCache` would only unsubscribe if the service stopped.

Since the UI connects to the service every time the app is opened, many `LocationInfoCache`s would subscribe to `ConnectivityListener` events. After connectivity is lost and restored, all listeners would schedule to fetch the current geo IP location. This would result in unnecessary repeated requests to be sent.

This PR adds an unsubscribe request that is sent when the `LocationInfoCache` is destroyed when the UI disconnects from the service.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1576)
<!-- Reviewable:end -->
