### PR TITLE
Change tunnel action intents to start the service if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix bug that could lead to Javascript error dialog to appear upon the desktop app termination.
 - Show when the app failed to block all connections after an error in the android and desktop apps.
+- Fix notification action button not working when requesting to connect the tunnel after being
+  disconnected for a long time.
 
 #### macOS
 - Fix firewall rules to properly handle DNS requests over TCP when "Local network sharing" is

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -26,6 +26,12 @@
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="net.mullvad.mullvadvpn.connect_action" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="net.mullvad.mullvadvpn.disconnect_action" />
+            </intent-filter>
         </service>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadTileService"
                  android:label="@string/app_name"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -20,8 +20,8 @@ import net.mullvad.talpid.util.EventNotifier
 
 val CHANNEL_ID = "vpn_tunnel_status"
 val FOREGROUND_NOTIFICATION_ID: Int = 1
-val KEY_CONNECT_ACTION = "connect_action"
-val KEY_DISCONNECT_ACTION = "disconnect_action"
+val KEY_CONNECT_ACTION = "net.mullvad.mullvadvpn.connect_action"
+val KEY_DISCONNECT_ACTION = "net.mullvad.mullvadvpn.disconnect_action"
 
 class ForegroundNotificationManager(
     val service: MullvadVpnService,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -53,15 +53,15 @@ class MullvadTileService : TileService() {
     override fun onClick() {
         super.onClick()
 
-        val tunnelActionKey = if (secured) {
-            KEY_DISCONNECT_ACTION
+        val intent = Intent(this, MullvadVpnService::class.java)
+
+        if (secured) {
+            intent.action = KEY_DISCONNECT_ACTION
         } else {
-            KEY_CONNECT_ACTION
+            intent.action = KEY_CONNECT_ACTION
         }
 
-        val intent = Intent(tunnelActionKey).setPackage("net.mullvad.mullvadvpn")
-
-        sendBroadcast(intent)
+        startService(intent)
     }
 
     override fun onStopListening() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -75,9 +75,12 @@ class MullvadVpnService : TalpidVpnService() {
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         val startResult = super.onStartCommand(intent, flags, startId)
+        val action = intent?.action
 
-        if (intent?.getAction() == VpnService.SERVICE_INTERFACE) {
-            shouldConnect = true
+        if (action == VpnService.SERVICE_INTERFACE || action == KEY_CONNECT_ACTION) {
+            pendingAction = PendingAction.Connect
+        } else if (action == KEY_DISCONNECT_ACTION) {
+            pendingAction = PendingAction.Disconnect
         }
 
         return startResult

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -65,6 +65,16 @@ class MullvadVpnService : TalpidVpnService() {
         setUp()
     }
 
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        val startResult = super.onStartCommand(intent, flags, startId)
+
+        if (intent?.getAction() == VpnService.SERVICE_INTERFACE) {
+            shouldConnect = true
+        }
+
+        return startResult
+    }
+
     override fun onBind(intent: Intent): IBinder {
         bindCount += 1
 
@@ -103,16 +113,6 @@ class MullvadVpnService : TalpidVpnService() {
         fun stop() {
             this@MullvadVpnService.stop()
         }
-    }
-
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val startResult = super.onStartCommand(intent, flags, startId)
-
-        if (intent?.getAction() == VpnService.SERVICE_INTERFACE) {
-            shouldConnect = true
-        }
-
-        return startResult
     }
 
     private fun setUp() {


### PR DESCRIPTION
Previously, the notification action button would send an intent that's only received by the `MullvadVpnService` if it's already running. That wasn't an issue before, since the notification would only be shown if the service was running. However, recent changes made the service not be in "foreground mode" while in the disconnected state, so that the notification could be dismissed. This means that the service could be killed and the notification would still be visible. One user has already ran into the issue and sent a problem report. With the recent inclusion of a quick-settings tile, the issue is now worse since the tile is always visible, even if the service isn't running.

This PR changes how the notification actions and the quick-settings tile actions are sent. They are now sent as intents to start the service, so that if the service isn't already running, it is started. The service was also changed so that it registers to always listen to those intents, and handles them on every start command.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1578)
<!-- Reviewable:end -->
