### PR TITLE
Fix possible IPv6 traffic leak on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add a reconnect button to disconnect and connect again without closing the tunnel device to avoid
   leaking any data during the reconnection.
 - Add quick settings tile to control the tunnel state.
+- Enable IPv6 traffic through the tunnel.
 
 ### Changed
 - Prefer WireGuard when tunnel protocol is set to _auto_ on Linux and MacOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix issue in daemon where the `block_when_disconnected` setting was sometimes not honored when
   stopping the daemon. I.e. traffic could flow freely after the daemon was stopped.
 
+#### Android
+- Fix issue where IPv6 traffic could leak outside of the tunnel.
+
 
 ## [2020.3] - 2020-02-20
 This release is identical to 2020.3-beta1

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -1,6 +1,9 @@
 package net.mullvad.talpid
 
 import android.net.VpnService
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
 import net.mullvad.talpid.tun_provider.TunConfig
 
 open class TalpidVpnService : VpnService() {
@@ -17,7 +20,7 @@ open class TalpidVpnService : VpnService() {
     fun createTun(config: TunConfig): Int {
         val builder = Builder().apply {
             for (address in config.addresses) {
-                addAddress(address, 32)
+                addAddress(address, prefixForAddress(address))
             }
 
             for (dnsServer in config.dnsServers) {
@@ -39,5 +42,13 @@ open class TalpidVpnService : VpnService() {
 
     fun bypass(socket: Int): Boolean {
         return protect(socket)
+    }
+
+    private fun prefixForAddress(address: InetAddress): Int {
+        when (address) {
+            is Inet4Address -> return 32
+            is Inet6Address -> return 128
+            else -> throw RuntimeException("Invalid IP address (not IPv4 nor IPv6)")
+        }
     }
 }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -16,7 +16,13 @@ use talpid_core::logging::windows::log_sink;
 
 pub fn load() -> Settings {
     match Settings::load() {
-        Ok(settings) => settings,
+        Ok(mut settings) => {
+            // Force IPv6 to be enabled on Android
+            if cfg!(target_os = "android") {
+                let _ = settings.set_enable_ipv6(true);
+            }
+            settings
+        }
         #[cfg(windows)]
         Err(SettingsError::ReadError(ref _path, ref e)) if e.kind() == ErrorKind::NotFound => {
             info!(

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -364,7 +364,10 @@ impl Default for TunnelOptions {
                 mtu: None,
                 automatic_rotation: None,
             },
-            generic: GenericTunnelOptions { enable_ipv6: false },
+            generic: GenericTunnelOptions {
+                // Enable IPv6 be default on Android
+                enable_ipv6: cfg!(target_os = "android"),
+            },
         }
     }
 }


### PR DESCRIPTION
Because on Android the security is not handled by a firewall but by configuring the tunnel routes, it's important to make sure the routes are broad enough to block any leaks. Unfortunately, the IPv6 routes were only configured if IPv6 was enabled, and by default they are disabled.

This PR changes that so that on Android the IPv6 routes are added even if IPv6 is disabled.

The PR also fixes the address prefix assigned to the tunnel for when IPv6 is enabled. Previously the prefix was only assumed to be for IPv4, but now it detects the type of the address correctly and uses the respective prefix.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1585)
<!-- Reviewable:end -->
