### PR TITLE
Handle intents when there's no account token set

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
         </activity>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"
                  android:permission="android.permission.BIND_VPN_SERVICE">

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/SettingsListener.kt
@@ -26,15 +26,6 @@ class SettingsListener(val daemon: MullvadDaemon) {
             }
         }
 
-    var onAllowLanChange: ((Boolean) -> Unit)? = null
-        set(value) {
-            synchronized(this) {
-                field = value
-
-                value?.invoke(settings.allowLan)
-            }
-        }
-
     var onRelaySettingsChange: ((RelaySettings?) -> Unit)? = null
         set(value) {
             synchronized(this) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -64,6 +64,12 @@ class MullvadVpnService : TalpidVpnService() {
             notificationManager.lockedToForeground = value
         }
 
+    private var loggedIn = false
+        set(value) {
+            field = value
+            notificationManager.loggedIn = value
+        }
+
     override fun onCreate() {
         super.onCreate()
 
@@ -140,7 +146,7 @@ class MullvadVpnService : TalpidVpnService() {
 
         val newDaemon = MullvadDaemon(this@MullvadVpnService).apply {
             onSettingsChange.subscribe { settings ->
-                notificationManager.loggedIn = settings?.accountToken != null
+                loggedIn = settings?.accountToken != null
             }
 
             onDaemonStopped = {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
+import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
 import net.mullvad.talpid.util.EventNotifier
 
@@ -84,7 +85,12 @@ class MullvadVpnService : TalpidVpnService() {
         val action = intent?.action
 
         if (action == VpnService.SERVICE_INTERFACE || action == KEY_CONNECT_ACTION) {
-            pendingAction = PendingAction.Connect
+            if (loggedIn) {
+                pendingAction = PendingAction.Connect
+            } else {
+                pendingAction = null
+                openUi()
+            }
         } else if (action == KEY_DISCONNECT_ACTION) {
             pendingAction = PendingAction.Disconnect
         }
@@ -193,5 +199,11 @@ class MullvadVpnService : TalpidVpnService() {
     private fun restart() {
         tearDown()
         setUp()
+    }
+
+    private fun openUi() {
+        val intent = Intent(this, MainActivity::class.java)
+
+        startActivity(intent)
     }
 }


### PR DESCRIPTION
Previously, the notification action button would only be present if there was an account token set. This prevented connect commands to be sent to the daemon which would've caused it to block the connection instead. With the introduction of the quick-settings tile, it's not possible to hide the tile when there is no account set, so the issue of sending the connect command when an account token isn't set resurfaced.

This PR handles the issue by checking if the account token is set when handling the received intent. If it's not set, then the main activity is launched so that the user can log in. The PR also makes the quick settings tile launch the main activity if the tile is long-pressed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1588)
<!-- Reviewable:end -->
