### PR TITLE
Update GUI tests for beta program changes

### DIFF
--- a/gui/test/components/NotificationArea.spec.tsx
+++ b/gui/test/components/NotificationArea.spec.tsx
@@ -10,7 +10,6 @@ describe('components/NotificationArea', () => {
   const defaultVersion = {
     consistent: true,
     currentIsSupported: true,
-    currentIsOutdated: false,
     current: '2018.2',
     latest: '2018.2-beta1',
     latestStable: '2018.2',
@@ -196,7 +195,6 @@ describe('components/NotificationArea', () => {
         version={{
           ...defaultVersion,
           currentIsSupported: false,
-          currentIsOutdated: true,
           current: '2018.1',
           nextUpgrade: '2018.2',
         }}
@@ -219,7 +217,6 @@ describe('components/NotificationArea', () => {
         }}
         version={{
           ...defaultVersion,
-          currentIsOutdated: true,
           current: '2018.2',
           latest: '2018.4-beta2',
           latestStable: '2018.3',
@@ -245,7 +242,6 @@ describe('components/NotificationArea', () => {
         }}
         version={{
           ...defaultVersion,
-          currentIsOutdated: true,
           current: '2018.4-beta1',
           latest: '2018.4-beta3',
           latestStable: '2018.3',


### PR DESCRIPTION
This fixes a compilation error in the tests which was introduced when the `currentIsOutdated` prop was removed from `NotificationArea`. Compilation errors seems to make the test fail silently.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1589)
<!-- Reviewable:end -->
