### PR TITLE
Render ModalAlert in portal

### DIFF
--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
+import ReactDOM from 'react-dom';
 import { Component, Styles, Text, View } from 'reactxp';
 import { colors } from '../../config.json';
 import ImageView from './ImageView';
+
+const MODAL_CONTAINER_ID = 'modalContainer';
 
 const styles = {
   modalAlertBackground: Styles.createViewStyle({
@@ -82,7 +85,11 @@ interface IModalContainerProps {
 }
 
 export const ModalContainer: React.FC = (props: IModalContainerProps) => {
-  return <div style={{ position: 'relative', flex: 1 }}>{props.children}</div>;
+  return (
+    <div id={MODAL_CONTAINER_ID} style={{ position: 'relative', flex: 1 }}>
+      <ModalContent>{props.children}</ModalContent>
+    </div>
+  );
 };
 
 export enum ModalAlertType {
@@ -98,6 +105,15 @@ interface IModalAlertProps {
 
 export class ModalAlert extends Component<IModalAlertProps> {
   public render() {
+    const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
+    if (modalContainer !== null) {
+      return ReactDOM.createPortal(this.renderModal(), modalContainer);
+    } else {
+      throw Error('Modal container not found when rendering modal');
+    }
+  }
+
+  private renderModal() {
     return (
       <ModalBackground>
         <View style={styles.modalAlertBackground}>

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -5,7 +5,7 @@ import { messages } from '../../shared/gettext';
 import * as AppButton from './AppButton';
 import ImageView from './ImageView';
 import { Container, Layout } from './Layout';
-import { ModalAlert, ModalAlertType, ModalContainer, ModalContent } from './Modal';
+import { ModalAlert, ModalAlertType, ModalContainer } from './Modal';
 import { BackBarItem, NavigationBar, NavigationItems } from './NavigationBar';
 import SettingsHeader, { HeaderSubTitle, HeaderTitle } from './SettingsHeader';
 import styles from './SupportStyles';
@@ -129,30 +129,28 @@ export default class Support extends Component<ISupportProps, ISupportState> {
     const content = this.renderContent();
 
     return (
-      <Layout>
-        <Container>
-          <ModalContainer>
-            <ModalContent>
-              <View style={styles.support}>
-                <NavigationBar>
-                  <NavigationItems>
-                    <BackBarItem action={this.props.onClose}>
-                      {// TRANSLATORS: Back button in navigation bar
-                      messages.pgettext('navigation-bar', 'Settings')}
-                    </BackBarItem>
-                  </NavigationItems>
-                </NavigationBar>
-                <View style={styles.support__container}>
-                  {header}
-                  {content}
-                </View>
+      <ModalContainer>
+        <Layout>
+          <Container>
+            <View style={styles.support}>
+              <NavigationBar>
+                <NavigationItems>
+                  <BackBarItem action={this.props.onClose}>
+                    {// TRANSLATORS: Back button in navigation bar
+                    messages.pgettext('navigation-bar', 'Settings')}
+                  </BackBarItem>
+                </NavigationItems>
+              </NavigationBar>
+              <View style={styles.support__container}>
+                {header}
+                {content}
               </View>
-            </ModalContent>
+            </View>
             {sendState === SendState.Confirm && this.renderNoEmailDialog()}
             {showOutdatedVersionWarning && this.renderOutdateVersionWarningDialog()}
-          </ModalContainer>
-        </Container>
-      </Layout>
+          </Container>
+        </Layout>
+      </ModalContainer>
     );
   }
 


### PR DESCRIPTION
This PR adds a container for modals to be rendered in and renders them in that element using portals.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1594)
<!-- Reviewable:end -->
