### PR TITLE
Appstore receipt handling

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		58D0C7A223F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D0C7A023F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift */; };
 		58EC4E6C23915325003F5C5B /* Bundle+MullvadVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EC4E6B23915325003F5C5B /* Bundle+MullvadVersion.swift */; };
 		58F19E35228C15BA00C7710B /* SpinnerActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */; };
+		58FD5BE92419406000112C88 /* SKRequestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BE82419406000112C88 /* SKRequestPublisher.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -258,6 +259,7 @@
 		58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerActivityIndicatorView.swift; sourceTree = "<group>"; };
 		58FBDAA422A52BDA00EB69A3 /* PacketTunnel-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PacketTunnel-Bridging-Header.h"; sourceTree = "<group>"; };
 		58FBDAAA22A52DC500EB69A3 /* MullvadVPN-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MullvadVPN-Bridging-Header.h"; sourceTree = "<group>"; };
+		58FD5BE82419406000112C88 /* SKRequestPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKRequestPublisher.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -396,6 +398,7 @@
 				58CCA01122424D11004F3011 /* SettingsViewController.swift */,
 				58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */,
 				587A01FB23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift */,
+				58FD5BE82419406000112C88 /* SKRequestPublisher.swift */,
 				58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */,
 				581CBCED229826FD00727D7F /* StaticTableViewDataSource.swift */,
 				5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */,
@@ -711,6 +714,7 @@
 				58EC4E6C23915325003F5C5B /* Bundle+MullvadVersion.swift in Sources */,
 				58BA693123EADA6A009DC256 /* SimulatorTunnelProvider.swift in Sources */,
 				58A1AA8C23F5584C009F7EA6 /* ConnectionPanelView.swift in Sources */,
+				58FD5BE92419406000112C88 /* SKRequestPublisher.swift in Sources */,
 				582BB1B52295780F0055B6EF /* AccountExpiry.swift in Sources */,
 				582BB1B3229574F40055B6EF /* SettingsAccountCell.swift in Sources */,
 				58CCA010224249A1004F3011 /* ConnectViewController.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		58D0C7A223F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D0C7A023F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift */; };
 		58EC4E6C23915325003F5C5B /* Bundle+MullvadVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EC4E6B23915325003F5C5B /* Bundle+MullvadVersion.swift */; };
 		58F19E35228C15BA00C7710B /* SpinnerActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */; };
+		58FD5BE724192A2C00112C88 /* AppStoreReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */; };
 		58FD5BE92419406000112C88 /* SKRequestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BE82419406000112C88 /* SKRequestPublisher.swift */; };
 /* End PBXBuildFile section */
 
@@ -259,6 +260,7 @@
 		58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerActivityIndicatorView.swift; sourceTree = "<group>"; };
 		58FBDAA422A52BDA00EB69A3 /* PacketTunnel-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PacketTunnel-Bridging-Header.h"; sourceTree = "<group>"; };
 		58FBDAAA22A52DC500EB69A3 /* MullvadVPN-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MullvadVPN-Bridging-Header.h"; sourceTree = "<group>"; };
+		58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreReceipt.swift; sourceTree = "<group>"; };
 		58FD5BE82419406000112C88 /* SKRequestPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKRequestPublisher.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -351,6 +353,7 @@
 				5868585424054096000B8131 /* AppButton.swift */,
 				58CE5E63224146200008646E /* AppDelegate.swift */,
 				58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */,
+				58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */,
 				58CE5E6A224146210008646E /* Assets.xcassets */,
 				5845F839236C6A7200B2D93C /* AutoDisposableSink.swift */,
 				589AB4F6227B64450039131E /* BasicTableViewCell.swift */,
@@ -751,6 +754,7 @@
 				5888AD83227B11080051EB06 /* SelectLocationCell.swift in Sources */,
 				58CE5E66224146200008646E /* LoginViewController.swift in Sources */,
 				5877152E23981C5B001F8237 /* SettingsBasicCell.swift in Sources */,
+				58FD5BE724192A2C00112C88 /* AppStoreReceipt.swift in Sources */,
 				5835B7CC233B76CB0096D79F /* TunnelManager.swift in Sources */,
 				58ADDB3C227B1BD200FAFEA7 /* JsonRpc.swift in Sources */,
 				581CBCEE229826FD00727D7F /* StaticTableViewDataSource.swift in Sources */,

--- a/ios/MullvadVPN/AppStoreReceipt.swift
+++ b/ios/MullvadVPN/AppStoreReceipt.swift
@@ -1,0 +1,79 @@
+//
+//  AppStoreReceipt.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 11/03/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Combine
+import Foundation
+import StoreKit
+
+enum AppStoreReceipt {
+    enum Error: Swift.Error {
+        /// AppStore receipt file does not exist or file URL is not available
+        case doesNotExist
+
+        /// IO error
+        case io(Swift.Error)
+
+        /// Failure to refresh the receipt from AppStore
+        case refresh(Swift.Error)
+
+        var localizedDescription: String {
+            switch self {
+            case .doesNotExist:
+                return "AppStore receipt file does not exist on disk"
+            case .io(let ioError):
+                return "Read error: \(ioError.localizedDescription)"
+            case .refresh(let refreshError):
+                return "Receipt refresh error: \(refreshError.localizedDescription)"
+            }
+        }
+    }
+
+    /// Read AppStore receipt from disk
+    static func readFromDisk() -> Result<Data, Error> {
+        guard let appStoreReceiptURL = Bundle.main.appStoreReceiptURL else {
+            return .failure(.doesNotExist)
+        }
+
+        return Result { try Data(contentsOf: appStoreReceiptURL) }
+            .mapError { (error) -> Error in
+                if let ioError = error as? CocoaError, ioError.code == .fileNoSuchFile {
+                    return .doesNotExist
+                } else {
+                    return .io(error)
+                }
+        }
+    }
+
+    /// Read AppStore receipt from disk or refresh it from the AppStore if it's missing
+    /// This call may trigger a sign in with AppStore prompt to appear
+    static func fetch(forceRefresh: Bool = false, receiptProperties: [String: Any]? = nil) -> AnyPublisher<Data, Error> {
+        let refreshReceiptPublisher = Deferred {
+            SKReceiptRefreshRequest(receiptProperties: receiptProperties)
+                .publisher
+                .mapError { .refresh($0) }
+                .flatMap({ _ -> Result<Data, Error>.Publisher in
+                    return self.readFromDisk().publisher
+                })
+        }
+
+        if forceRefresh {
+            return refreshReceiptPublisher.eraseToAnyPublisher()
+        } else {
+            return Deferred { self.readFromDisk().publisher }
+                .catch({ (readError) -> AnyPublisher<Data, Error> in
+                    // Refresh the receipt from AppStore if it's not on disk
+                    if case .doesNotExist = readError {
+                        return refreshReceiptPublisher.eraseToAnyPublisher()
+                    } else {
+                        return Fail(error: readError).eraseToAnyPublisher()
+                    }
+                })
+                .eraseToAnyPublisher()
+        }
+    }
+}

--- a/ios/MullvadVPN/MullvadAPI.swift
+++ b/ios/MullvadVPN/MullvadAPI.swift
@@ -38,6 +38,22 @@ enum DeferReasonError: Error {
     case server(MullvadAPI.ResponseError)
 }
 
+/// A response received when sending the AppStore receipt to the backend
+struct SendAppStoreReceiptResponse: Codable {
+    let timeAdded: TimeInterval
+    let newExpiry: Date
+
+    /// Returns a formatted string for the `timeAdded` interval, i.e "30 days"
+    var formattedTimeAdded: String? {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour]
+        formatter.unitsStyle = .full
+        formatter.maximumUnitCount = 1
+
+        return formatter.string(from: timeAdded)
+    }
+}
+
 class MullvadAPI {
     private let session: URLSession
 
@@ -167,6 +183,15 @@ class MullvadAPI {
         let request = JsonRpcRequest(method: "remove_wg_key", params: [
             AnyEncodable(accountToken),
             AnyEncodable(publicKey)
+        ])
+
+        return MullvadAPI.makeDataTaskPublisher(request: request)
+    }
+
+    func sendAppStoreReceipt(accountToken: String, receiptData: Data) -> AnyPublisher<Response<SendAppStoreReceiptResponse>, MullvadAPI.Error> {
+        let request = JsonRpcRequest(method: "apple_payment", params: [
+            AnyEncodable(accountToken),
+            AnyEncodable(receiptData)
         ])
 
         return MullvadAPI.makeDataTaskPublisher(request: request)

--- a/ios/MullvadVPN/SKRequestPublisher.swift
+++ b/ios/MullvadVPN/SKRequestPublisher.swift
@@ -1,0 +1,121 @@
+//
+//  SKRequestPublisher.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 11/03/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Combine
+import Foundation
+import StoreKit
+
+/// A protocol that formalizes the interface of all of the subclasses of
+/// `SKRequestSubscription<Output>`
+protocol SKRequestSubscriptionProtocol: Subscription {
+    associatedtype Output
+    associatedtype Failure: Error
+
+    init<S: Subscriber>(request: SKRequest, subscriber: S)
+        where S.Input == Output, S.Failure == Failure
+}
+
+/// A base implementation of subscription that handles the `SKRequest`.
+class SKRequestSubscription<Output>: NSObject, Subscription, SKRequestDelegate,
+    SKRequestSubscriptionProtocol
+{
+    typealias Failure = Error
+
+    private let request: SKRequest
+    fileprivate let subscriber: AnySubscriber<Output, Failure>
+
+    required init<S: Subscriber>(request: SKRequest, subscriber: S)
+        where S.Input == Output, S.Failure == Failure
+    {
+        self.request = request
+        self.subscriber = AnySubscriber(subscriber)
+
+        super.init()
+        request.delegate = self
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        request.start()
+    }
+
+    func cancel() {
+        request.cancel()
+    }
+
+    // MARK: - SKRequestDelegate
+
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        subscriber.receive(completion: .failure(error))
+    }
+
+    func requestDidFinish(_ request: SKRequest) {
+        subscriber.receive(completion: .finished)
+    }
+}
+
+/// A subscription that emits the `SKProductsResponse` upon request completion
+class SKProductsRequestSubscription: SKRequestSubscription<SKProductsResponse>,
+    SKProductsRequestDelegate
+{
+
+    // MARK: - SKProductsRequestDelegate
+
+    func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
+        _ = self.subscriber.receive(response)
+    }
+
+}
+
+/// A subscription for requesting the AppStore receipt refresh
+class SKRefreshRequestSubscription: SKRequestSubscription<()> {
+    override func requestDidFinish(_ request: SKRequest) {
+        // Emit void so that publishers using this subscription could be chained
+        _ = self.subscriber.receive(())
+
+        super.requestDidFinish(request)
+    }
+}
+
+/// A base implementation of publisher that runs `SKRequest`s
+class SKRequestPublisher<SubscriptionType>: Publisher
+    where SubscriptionType: SKRequestSubscriptionProtocol
+{
+    typealias Output = SubscriptionType.Output
+    typealias Failure = SubscriptionType.Failure
+
+    fileprivate let request: SKRequest
+
+    init(request: SKRequest) {
+        self.request = request
+    }
+
+    func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+        let subscription = SubscriptionType(request: request, subscriber: subscriber)
+
+        subscriber.receive(subscription: subscription)
+    }
+
+}
+
+protocol SKRequestPublishing {
+    associatedtype SubscriptionType: SKRequestSubscriptionProtocol
+
+    var publisher: SKRequestPublisher<SubscriptionType> { get }
+}
+
+extension SKProductsRequest: SKRequestPublishing {
+    var publisher: SKRequestPublisher<SKProductsRequestSubscription> {
+        return .init(request: self)
+    }
+}
+
+extension SKReceiptRefreshRequest: SKRequestPublishing {
+    var publisher: SKRequestPublisher<SKRefreshRequestSubscription> {
+        return .init(request: self)
+    }
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add Mullvad API call to submit the AppStore receipt to the backend
1. Add custom Combine publishers for working with `SKRequest` and its subclasses:
    1. `SKProductsRequest` - a request to load the list of available in-app purchases from the AppStore that includes a lot of metadata including the localized price for the in-app purchase
    1. `SKReceiptRefreshRequest` - a request to load the most recent and up-to-date App Store receipt from Apple servers.
1. Add `AppStoreReceipt` helper to be able to read the receipt from disk, or load it from AppStore. `AppStoreReceipt.fetch` does 2-in-1, it would automatically pull the receipt from the Apple servers if the one is not found on disk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1598)
<!-- Reviewable:end -->
