### PR TITLE
Add payments

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -120,11 +120,13 @@
 		58CE5E81224146470008646E /* PacketTunnel.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 58CE5E79224146470008646E /* PacketTunnel.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		58D0C79E23F1CEBA00FE9BA7 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D0C79D23F1CEBA00FE9BA7 /* SnapshotHelper.swift */; };
 		58D0C7A223F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D0C7A023F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift */; };
+		58DF28A52417CB4B00E836B0 /* AppStorePaymentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF28A42417CB4B00E836B0 /* AppStorePaymentManager.swift */; };
 		58EC4E6C23915325003F5C5B /* Bundle+MullvadVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EC4E6B23915325003F5C5B /* Bundle+MullvadVersion.swift */; };
 		58F19E35228C15BA00C7710B /* SpinnerActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */; };
 		58FD5BE724192A2C00112C88 /* AppStoreReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */; };
 		58FD5BE92419406000112C88 /* SKRequestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BE82419406000112C88 /* SKRequestPublisher.swift */; };
 		58FD5BEC2420F58A00112C88 /* SKPaymentQueuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEB2420F58A00112C88 /* SKPaymentQueuePublisher.swift */; };
+		58FD5BF624291F1A00112C88 /* AppStorePaymentPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BF524291F1A00112C88 /* AppStorePaymentPublisher.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -256,6 +258,7 @@
 		58D0C79D23F1CEBA00FE9BA7 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		58D0C79F23F1CECF00FE9BA7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		58D0C7A023F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MullvadVPNScreenshots.swift; sourceTree = "<group>"; };
+		58DF28A42417CB4B00E836B0 /* AppStorePaymentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorePaymentManager.swift; sourceTree = "<group>"; };
 		58EC4E6B23915325003F5C5B /* Bundle+MullvadVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+MullvadVersion.swift"; sourceTree = "<group>"; };
 		58ECD29123F178FD004298B6 /* Screenshots.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Screenshots.xcconfig; sourceTree = "<group>"; };
 		58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerActivityIndicatorView.swift; sourceTree = "<group>"; };
@@ -264,6 +267,7 @@
 		58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreReceipt.swift; sourceTree = "<group>"; };
 		58FD5BE82419406000112C88 /* SKRequestPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKRequestPublisher.swift; sourceTree = "<group>"; };
 		58FD5BEB2420F58A00112C88 /* SKPaymentQueuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKPaymentQueuePublisher.swift; sourceTree = "<group>"; };
+		58FD5BF524291F1A00112C88 /* AppStorePaymentPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorePaymentPublisher.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -356,6 +360,8 @@
 				58CE5E63224146200008646E /* AppDelegate.swift */,
 				58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */,
 				58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */,
+				58DF28A42417CB4B00E836B0 /* AppStorePaymentManager.swift */,
+				58FD5BF524291F1A00112C88 /* AppStorePaymentPublisher.swift */,
 				58CE5E6A224146210008646E /* Assets.xcassets */,
 				5845F839236C6A7200B2D93C /* AutoDisposableSink.swift */,
 				589AB4F6227B64450039131E /* BasicTableViewCell.swift */,
@@ -750,6 +756,7 @@
 				58B8743222B25A7600015324 /* WireguardAssociatedAddresses.swift in Sources */,
 				587B08E0229433EB000E6F17 /* LoginState.swift in Sources */,
 				58C6B34F22BB7AC0003C19AD /* IPAddressRange.swift in Sources */,
+				58DF28A52417CB4B00E836B0 /* AppStorePaymentManager.swift in Sources */,
 				582BB1AF229566420055B6EF /* SettingsCell.swift in Sources */,
 				5873884D239E6D7E00E96C4E /* EmbeddedViewContainerView.swift in Sources */,
 				582650862384116F00FA7A86 /* ReplaceNilWithError.swift in Sources */,
@@ -770,6 +777,7 @@
 				5888AD7F2279B6BF0051EB06 /* RelayStatusIndicatorView.swift in Sources */,
 				5867A51C2248F26A005513C0 /* SegueIdentifier.swift in Sources */,
 				58CCA01E2242787B004F3011 /* AccountTextField.swift in Sources */,
+				58FD5BF624291F1A00112C88 /* AppStorePaymentPublisher.swift in Sources */,
 				587AD7CA2342283900E93A53 /* Account.swift in Sources */,
 				58A8BE8323A0F362006B74AC /* UIAlertController+Error.swift in Sources */,
 				587425C12299833500CA2045 /* RootContainerViewController.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		58F19E35228C15BA00C7710B /* SpinnerActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */; };
 		58FD5BE724192A2C00112C88 /* AppStoreReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */; };
 		58FD5BE92419406000112C88 /* SKRequestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BE82419406000112C88 /* SKRequestPublisher.swift */; };
+		58FD5BEC2420F58A00112C88 /* SKPaymentQueuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEB2420F58A00112C88 /* SKPaymentQueuePublisher.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -262,6 +263,7 @@
 		58FBDAAA22A52DC500EB69A3 /* MullvadVPN-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MullvadVPN-Bridging-Header.h"; sourceTree = "<group>"; };
 		58FD5BE624192A2B00112C88 /* AppStoreReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreReceipt.swift; sourceTree = "<group>"; };
 		58FD5BE82419406000112C88 /* SKRequestPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKRequestPublisher.swift; sourceTree = "<group>"; };
+		58FD5BEB2420F58A00112C88 /* SKPaymentQueuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKPaymentQueuePublisher.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -402,6 +404,7 @@
 				58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */,
 				587A01FB23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift */,
 				58FD5BE82419406000112C88 /* SKRequestPublisher.swift */,
+				58FD5BEB2420F58A00112C88 /* SKPaymentQueuePublisher.swift */,
 				58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */,
 				581CBCED229826FD00727D7F /* StaticTableViewDataSource.swift */,
 				5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */,
@@ -737,6 +740,7 @@
 				581CBCEC2298041B00727D7F /* SettingsAppVersionCell.swift in Sources */,
 				5845F83A236C6A7200B2D93C /* AutoDisposableSink.swift in Sources */,
 				5840250422B11AB700E4CFEC /* MullvadEndpoint.swift in Sources */,
+				58FD5BEC2420F58A00112C88 /* SKPaymentQueuePublisher.swift in Sources */,
 				58CCA01822426713004F3011 /* AccountViewController.swift in Sources */,
 				5868585524054096000B8131 /* AppButton.swift in Sources */,
 				5845F842236CBACD00B2D93C /* PacketTunnelIpc.swift in Sources */,

--- a/ios/MullvadVPN/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager.swift
@@ -1,0 +1,352 @@
+//
+//  AppStorePaymentManager.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 10/03/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Combine
+import Foundation
+import StoreKit
+import os
+
+enum InAppPurchase: String {
+    /// Thirty days worth of credit
+    case thirtyDays = "net.mullvad.MullvadVPN.iap.30days"
+}
+
+extension Set where Element == InAppPurchase {
+    var productIdentifiersSet: Set<String> {
+        Set<String>(self.map { $0.rawValue })
+    }
+}
+
+protocol AppStorePaymentObserver: class {
+    func appStorePaymentManager(
+        _ manager: AppStorePaymentManager,
+        transaction: SKPaymentTransaction,
+        didFailWithError error: AppStorePaymentManager.Error)
+
+    func appStorePaymentManager(
+        _ manager: AppStorePaymentManager,
+        transaction: SKPaymentTransaction,
+        didFinishWithResponse response: SendAppStoreReceiptResponse)
+}
+
+/// A type-erasing weak container for `AppStorePaymentObserver`
+private class WeakAnyAppStorePaymentObserver: AppStorePaymentObserver {
+    private(set) weak var inner: AppStorePaymentObserver?
+
+    init(_ inner: AppStorePaymentObserver) {
+        self.inner = inner
+    }
+
+    func appStorePaymentManager(_ manager: AppStorePaymentManager,
+                                transaction: SKPaymentTransaction,
+                                didFailWithError error: AppStorePaymentManager.Error)
+    {
+        inner?.appStorePaymentManager(manager, transaction: transaction, didFailWithError: error)
+    }
+
+    func appStorePaymentManager(_ manager: AppStorePaymentManager,
+                                transaction: SKPaymentTransaction,
+                                didFinishWithResponse response: SendAppStoreReceiptResponse)
+    {
+        inner?.appStorePaymentManager(manager,
+                                      transaction: transaction,
+                                      didFinishWithResponse: response)
+    }
+
+}
+
+protocol AppStorePaymentManagerDelegate: class {
+
+    /// Return the account token associated with the payment.
+    /// Usually called for unfinished transactions coming back after the app was restarted.
+    func appStorePaymentManager(_ manager: AppStorePaymentManager,
+                                didRequestAccountTokenFor payment: SKPayment) -> String?
+}
+
+class AppStorePaymentManager {
+
+    enum SendAppStoreReceiptError: Swift.Error {
+        case read(AppStoreReceipt.Error)
+        case network(MullvadAPI.Error)
+        case server(MullvadAPI.ResponseError)
+    }
+
+    enum Error: Swift.Error {
+        case noAccountSet
+        case storePayment(Swift.Error)
+        case sendReceipt(SendAppStoreReceiptError)
+    }
+
+    /// A shared instance of `AppStorePaymentManager`
+    static let shared = AppStorePaymentManager(queue: SKPaymentQueue.default())
+
+    private let queue: SKPaymentQueue
+    private let apiClient = MullvadAPI()
+
+    private var paymentQueueSubscriber: AnyCancellable?
+    private var sendReceiptSubscriber: AnyCancellable?
+
+    private var observers = [WeakAnyAppStorePaymentObserver]()
+    private let lock = NSRecursiveLock()
+
+    private weak var classDelegate: AppStorePaymentManagerDelegate?
+    weak var delegate: AppStorePaymentManagerDelegate? {
+        get {
+            lock.withCriticalBlock {
+                return classDelegate
+            }
+        }
+        set {
+            lock.withCriticalBlock {
+                classDelegate = newValue
+            }
+        }
+    }
+
+    /// A private hash map that maps each payment to account token
+    private var paymentToAccountToken = [SKPayment: String]()
+
+    init(queue: SKPaymentQueue) {
+        self.queue = queue
+    }
+
+    func startPaymentQueueMonitoring() {
+        paymentQueueSubscriber = queue.publisher.sink { [weak self] (transaction) in
+            self?.handleTransaction(transaction)
+        }
+    }
+
+    // MARK: - Payment observation
+
+    func addPaymentObserver(_ observer: AppStorePaymentObserver) {
+        lock.withCriticalBlock {
+            let isAlreadyObserving = self.observers.contains(where: { $0.inner === observer })
+
+            if !isAlreadyObserving {
+                self.observers.append(WeakAnyAppStorePaymentObserver(observer))
+                self.compactObservers()
+            }
+        }
+    }
+
+    func removePaymentObserver(_ observer: AppStorePaymentObserver) {
+        lock.withCriticalBlock {
+            let index = self.observers.firstIndex(where: { $0.inner === observer })
+            if let index = index {
+                self.observers.remove(at: index)
+            }
+        }
+    }
+
+    private func compactObservers() {
+        lock.withCriticalBlock {
+            observers.removeAll(where: { $0.inner == nil })
+        }
+    }
+
+    private func enumerateObservers(_ body: (AppStorePaymentObserver) -> Void) {
+        lock.withCriticalBlock {
+            observers.forEach { (observer) in
+                body(observer)
+            }
+        }
+    }
+
+    // MARK: - Account token and payment mapping
+
+    private func associateAccountToken(_ token: String, and payment: SKPayment) {
+        lock.withCriticalBlock {
+            paymentToAccountToken[payment] = token
+        }
+    }
+
+    private func deassociateAccountToken(_ payment: SKPayment) -> String? {
+        return lock.withCriticalBlock {
+            if let accountToken = paymentToAccountToken[payment] {
+                paymentToAccountToken.removeValue(forKey: payment)
+                return accountToken
+            } else {
+                return self.classDelegate?
+                    .appStorePaymentManager(self, didRequestAccountTokenFor: payment)
+            }
+        }
+    }
+
+    // MARK: - Products and payments
+
+    func requestProducts(with productIdentifiers: Set<InAppPurchase>)
+        -> SKRequestPublisher<SKProductsRequestSubscription>
+    {
+        let productIdentifiers = productIdentifiers.productIdentifiersSet
+
+        return SKProductsRequest(productIdentifiers: productIdentifiers).publisher
+    }
+
+    func addPayment(_ payment: SKPayment, for accountToken: String) -> AppStorePaymentPublisher {
+        associateAccountToken(accountToken, and: payment)
+
+        return AppStorePaymentPublisher(paymentManager: self, queue: queue, payment: payment)
+    }
+
+    func restorePurchases(for accountToken: String) -> AnyPublisher<SendAppStoreReceiptResponse, AppStorePaymentManager.Error> {
+        return sendAppStoreReceipt(accountToken: accountToken, forceRefresh: true)
+    }
+
+    // MARK: - Private methods
+
+    private func sendAppStoreReceipt(accountToken: String, forceRefresh: Bool) ->
+        AnyPublisher<SendAppStoreReceiptResponse, AppStorePaymentManager.Error>
+    {
+        return AppStoreReceipt.fetch(forceRefresh: forceRefresh)
+            .mapError { SendAppStoreReceiptError.read($0) }
+            .flatMap { (receiptData) in
+                self.apiClient.sendAppStoreReceipt(accountToken: accountToken, receiptData: receiptData)
+                    .mapError { SendAppStoreReceiptError.network($0) }
+                    .flatMap({ (response) in
+                        response.result.mapError { SendAppStoreReceiptError.server($0) }.publisher
+                    })
+        }
+        .receive(on: DispatchQueue.main)
+        .handleEvents(receiveOutput: { (response) in
+            os_log(
+                .info,
+                "AppStore Receipt was processed. Time added: %{public}.2f, New expiry: %{public}s",
+                response.timeAdded, "\(response.newExpiry)")
+        })
+            .mapError { AppStorePaymentManager.Error.sendReceipt($0) }
+            .eraseToAnyPublisher()
+    }
+
+    private func handleTransaction(_ transaction: SKPaymentTransaction) {
+        switch transaction.transactionState {
+        case .deferred:
+            os_log(.debug, "Deferred %{public}s", transaction.payment.productIdentifier)
+
+        case .failed:
+            os_log(.debug, "Failed to purchase %{public}s: %{public}s",
+                   transaction.payment.productIdentifier,
+                   transaction.error?.localizedDescription ?? "No error")
+
+            didFailPurchase(transaction: transaction)
+
+        case .purchased:
+            os_log(.debug, "Purchased %{public}s", transaction.payment.productIdentifier)
+
+            didFinishOrRestorePurchase(transaction: transaction)
+
+        case .purchasing:
+            os_log(.debug, "Purchasing %{public}s", transaction.payment.productIdentifier)
+
+        case .restored:
+            os_log(.debug, "Restored %{public}s", transaction.payment.productIdentifier)
+
+            didFinishOrRestorePurchase(transaction: transaction)
+
+        @unknown default:
+            os_log(.debug, "Unknown transactionState = %{public}d",
+                   transaction.transactionState.rawValue)
+        }
+    }
+
+    private func didFailPurchase(transaction: SKPaymentTransaction) {
+        queue.finishTransaction(transaction)
+
+        enumerateObservers { (observer) in
+            observer.appStorePaymentManager(
+                self,
+                transaction: transaction,
+                didFailWithError: .storePayment(transaction.error!))
+        }
+
+        _ = deassociateAccountToken(transaction.payment)
+    }
+
+    private func didFinishOrRestorePurchase(transaction: SKPaymentTransaction) {
+        let accountToken = deassociateAccountToken(transaction.payment)
+
+        sendReceiptSubscriber = Just(accountToken)
+            .setFailureType(to: AppStorePaymentManager.Error.self)
+            .replaceNil(with: .noAccountSet)
+            .flatMap({ (accountToken) in
+                self.sendAppStoreReceipt(accountToken: accountToken, forceRefresh: false)
+                    .retry(1)
+            })
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] (completion) in
+                guard let self = self else { return }
+
+                switch completion {
+                case .finished:
+                    self.queue.finishTransaction(transaction)
+
+                case .failure(let error):
+                    os_log(.error, "Failed to upload the AppStore receipt: %{public}s",
+                           error.localizedDescription)
+
+                    self.enumerateObservers { (observer) in
+                        observer.appStorePaymentManager(
+                            self,
+                            transaction: transaction,
+                            didFailWithError: error)
+                    }
+                }
+            }, receiveValue: { [weak self] (response) in
+                guard let self = self else { return }
+
+                self.enumerateObservers { (observer) in
+                    observer.appStorePaymentManager(
+                        self,
+                        transaction: transaction,
+                        didFinishWithResponse: response)
+                }
+            })
+    }
+
+}
+
+
+extension AppStorePaymentManager.Error: LocalizedError {
+
+    var errorDescription: String? {
+        switch self {
+        case .noAccountSet:
+            return nil
+        case .storePayment:
+            return NSLocalizedString("AppStore payment", comment: "")
+        case .sendReceipt:
+            return NSLocalizedString("Communication error", comment: "")
+        }
+    }
+
+    var failureReason: String? {
+        switch self {
+        case .storePayment(let storeError):
+            return storeError.localizedDescription
+        case .sendReceipt(.network(let urlError)):
+            return urlError.localizedDescription
+        case .sendReceipt(.server(let serverError)):
+            return serverError.errorDescription
+        case .sendReceipt(.read(.refresh(let storeError))):
+            return storeError.localizedDescription
+        default:
+            return NSLocalizedString("Internal error", comment: "")
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .noAccountSet:
+            return nil
+        case .storePayment:
+            return nil
+        case .sendReceipt:
+            return NSLocalizedString(
+                #"Please retry by using the "Restore purchases" button"#, comment: "")
+        }
+    }
+}

--- a/ios/MullvadVPN/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager.swift
@@ -215,7 +215,7 @@ class AppStorePaymentManager {
         .handleEvents(receiveOutput: { (response) in
             os_log(
                 .info,
-                "AppStore Receipt was processed. Time added: %{public}.2f, New expiry: %{public}s",
+                "AppStore Receipt was processed. Time added: %{public}.2f, New expiry: %{private}s",
                 response.timeAdded, "\(response.newExpiry)")
         })
             .mapError { AppStorePaymentManager.Error.sendReceipt($0) }

--- a/ios/MullvadVPN/AppStorePaymentPublisher.swift
+++ b/ios/MullvadVPN/AppStorePaymentPublisher.swift
@@ -1,0 +1,87 @@
+//
+//  AppStorePaymentPublisher.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 23/03/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Combine
+import Foundation
+import StoreKit
+
+class AppStorePaymentPublisher: Publisher {
+    typealias Output = SendAppStoreReceiptResponse
+    typealias Failure = AppStorePaymentManager.Error
+
+    private let paymentManager: AppStorePaymentManager
+    private let payment: SKPayment
+    private let queue: SKPaymentQueue
+
+    init(paymentManager: AppStorePaymentManager, queue: SKPaymentQueue, payment: SKPayment) {
+        self.paymentManager = paymentManager
+        self.payment = payment
+        self.queue = queue
+    }
+
+    func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+        let subscription = AppStorePaymentSubscription(
+            paymentManager: paymentManager,
+            queue: queue,
+            payment: payment,
+            subscriber: subscriber)
+
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+private class AppStorePaymentSubscription: Subscription, AppStorePaymentObserver {
+
+    typealias Output = SendAppStoreReceiptResponse
+    typealias Failure = AppStorePaymentManager.Error
+
+    private let paymentManager: AppStorePaymentManager
+    private let payment: SKPayment
+    private let queue: SKPaymentQueue
+    private let subscriber: AnySubscriber<Output, Failure>
+
+    init<S>(paymentManager: AppStorePaymentManager, queue: SKPaymentQueue, payment: SKPayment, subscriber: S)
+        where S: Subscriber, S.Input == Output, S.Failure == Failure
+    {
+        self.paymentManager = paymentManager
+        self.payment = payment
+        self.queue = queue
+        self.subscriber = AnySubscriber(subscriber)
+
+        paymentManager.addPaymentObserver(self)
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        queue.add(payment)
+    }
+
+    func cancel() {
+        paymentManager.removePaymentObserver(self)
+    }
+
+    // MARK: - AppStorePaymentObserver
+
+    func appStorePaymentManager(_ manager: AppStorePaymentManager,
+                                transaction: SKPaymentTransaction,
+                                didFinishWithResponse response: SendAppStoreReceiptResponse)
+    {
+        if transaction.payment == payment {
+            _ = subscriber.receive(response)
+            subscriber.receive(completion: .finished)
+        }
+    }
+
+    func appStorePaymentManager(_ manager: AppStorePaymentManager,
+                                transaction: SKPaymentTransaction,
+                                didFailWithError error: AppStorePaymentManager.Error) {
+        if transaction.payment == payment {
+            subscriber.receive(completion: .failure(error))
+        }
+    }
+
+}

--- a/ios/MullvadVPN/SKPaymentQueuePublisher.swift
+++ b/ios/MullvadVPN/SKPaymentQueuePublisher.swift
@@ -1,0 +1,71 @@
+//
+//  SKPaymentQueuePublisher.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 17/03/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Combine
+import Foundation
+import StoreKit
+
+/// A publisher that indefinitely emits the incoming transactions on the given `SKPaymentQueue`,
+/// and never completes.
+struct SKPaymentQueuePublisher: Publisher {
+    typealias Output = SKPaymentTransaction
+    typealias Failure = Never
+
+    private let queue: SKPaymentQueue
+
+    init(queue: SKPaymentQueue) {
+        self.queue = queue
+    }
+
+    func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+        let subscription = SKPaymentQueueSubscription(
+            queue: queue, subscriber: subscriber)
+        subscriber.receive(subscription: subscription)
+    }
+
+}
+
+extension SKPaymentQueue {
+    var publisher: SKPaymentQueuePublisher {
+        return .init(queue: self)
+    }
+}
+
+/// A subscription implementation for the given `SKPaymentQueue`
+private class SKPaymentQueueSubscription: NSObject, Subscription, SKPaymentTransactionObserver {
+    private let queue: SKPaymentQueue
+    private let subscriber: AnySubscriber<SKPaymentTransaction, Never>
+
+    init<S>(queue: SKPaymentQueue, subscriber: S)
+        where S: Subscriber, S.Failure == Never, S.Input == SKPaymentTransaction
+    {
+        self.queue = queue
+        self.subscriber = AnySubscriber(subscriber)
+
+        super.init()
+
+        queue.add(self)
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        // no-op
+    }
+
+    func cancel() {
+        queue.remove(self)
+    }
+
+    // MARK: - SKPaymentTransactionObserver
+
+    func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        for transaction in transactions {
+            _ = subscriber.receive(transaction)
+        }
+    }
+
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

#### General payment flow on iOS

1. The app obtains the `SKProduct` for the given in-app purchase using the in-app purchase ID (hardcoded in the app and on the AppStore servers)
1. The app creates `SKPayment` for the given `SKProduct` with the specified quantity (default: 1) and adds it to `SKPaymentQueue` - a payment queue
1. The system takes care of the payment flow
1. As user proceeds through the payment flow, the app receives updates as `SKPaymentTransaction` objects. In order to receive those updates, the app has to add the `SKPaymentTransactionObserver` to the `SKPaymentQueue`
1. Once the payment has `failed` or succeeded (`purchased`), the transaction has to be removed by calling `queue.finishTransaction(transaction)`. 

   In case the payment succeeded, we keep the transaction in the queue until we upload the App Store receipt to our server. This is done this way to make sure that even if the app crashed or we had issues uploading the receipt to our backend, we would be able to process the same transaction later on.

    For example, when the app restarts and if the system detects unfinished transactions in the queue, it pumps them back and notifies the app. In that case exactly the same flow repeats, except the user has already paid at this point, so we'll continue re-uploading the AppStore receipt to our servers.

#### Edge cases 

1. Normally we build a temporary relationship between the account token and the `SKPayment` itself. The way it's is done is by using an in-memory hash map that connects the payments and account tokens. 

    Apparently this connection breaks after the app restart, as we don't persist any of this data. However the unfinished transactions can still be there, so when the payment manager detects such situation, it asks it's `delegate` to provide the account token. Right now we simply give the payment manager the active account token. This has been discussed extensively and I don't see how else to solve it.

1. It's possible for the user to log out before the transaction is settled. In that case the app will keep the transaction in the queue until the user logs in. The credits are then added to the logged in user (at some point). It's been discussed and there is not much we can do about it right now. 

    In the end there is only one AppStore receipt on the device but multiple mullvad accounts. The backend handles each transaction separately and knows which transactions were booked and which not. Either way, there is a button to "Restore purchases" when that happens so the users can manually attempt to re-submit the AppStore to our backend to make sure that the time is added to the desired account.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1601)
<!-- Reviewable:end -->
