### PR TITLE
Don't stop the service when VPN permission is revoked

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -114,7 +114,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     override fun onRevoke() {
-        stop()
+        pendingAction = PendingAction.Disconnect
     }
 
     override fun onUnbind(intent: Intent): Boolean {


### PR DESCRIPTION
Previously, the app would follow the default behavior when handling the `onRevoke` call. The method is called in different situations, when "Always-On VPN" is disabled, when another VPN app is granted permission to connect, or when the user manually removes the permission to the app. The default behavior was to stop the background service.

However, this led to an issue with the recent "Auto-Connect" feature. The background service is registered to be restarted if stopped unless it is killed by the Android system. Therefore, when `onRevoke` is called, the background service would stop but then restart, and if "Auto-Connect" was configured it would try to connect again. However, in some situations the app would be too fast and Android would not grant a tunnel for the connection to continue. This led the app to enter the non-blocking error state.

This PR changes the behavior so that the app doesn't stop when `onRevoke` is called, but simply disconnects the tunnel and keeps running in the background until Android decides to kill it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any released version**.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1605)
<!-- Reviewable:end -->
