### PR TITLE
Fix NPE when `null` `Intent` is passed to `onStartCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Line wrap the file at 100 chars.                                              Th
   disconnected for a long time.
 - Make the settings screen scrollable, so that the quit button is reachable on small screens.
 - Fix connectivity listener leak causing possible battery usage increase.
+- Fix crash that could sometimes happen when restarting the background service.
 
 #### Windows
 - Fix bug where failing to initialize the route manager could cause the daemon to get stuck in a

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -80,7 +80,7 @@ class MullvadVpnService : TalpidVpnService() {
         setUp()
     }
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val startResult = super.onStartCommand(intent, flags, startId)
         val action = intent?.action
 


### PR DESCRIPTION
One of the problem reports showed that a crash caused the service to restart, and then crash right after it restarted. The cause of the second crash was that a `null` `Intent` was passed to `onStartCommand`. The body of the method was ready to handle a `null` value, but the method signature did not specify that the parameter could be `null`. Apparently, when the signature requires non-null values, Kotlin adds null checks to the start of the method, which will throw a `NullPointerException` if the argument is `null`.

This PR fixes the method signature to accept a `null` `Intent` parameter.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1606)
<!-- Reviewable:end -->
