### PR TITLE
Improve fetching and caching the location information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Line wrap the file at 100 chars.                                              Th
 - Make the settings screen scrollable, so that the quit button is reachable on small screens.
 - Fix connectivity listener leak causing possible battery usage increase.
 - Fix crash that could sometimes happen when restarting the background service.
+- Fix incorrect location information sometimes shown in main screen.
 
 #### Windows
 - Fix bug where failing to initialize the route manager could cause the daemon to get stuck in a

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.dataproxy
+package net.mullvad.mullvadvpn.service
 
 import android.content.Context
 import android.content.Intent
@@ -10,7 +10,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.util.EventNotifier

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -12,7 +12,6 @@ import android.content.IntentFilter
 import android.os.Build
 import android.support.v4.app.NotificationCompat
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.dataproxy
+package net.mullvad.mullvadvpn.service
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -12,7 +12,6 @@ import net.mullvad.mullvadvpn.relaylist.Relay
 import net.mullvad.mullvadvpn.relaylist.RelayCity
 import net.mullvad.mullvadvpn.relaylist.RelayCountry
 import net.mullvad.mullvadvpn.relaylist.RelayItem
-import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.ConnectivityListener
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -30,7 +30,7 @@ class LocationInfoCache(
 
     private val connectivityListenerId =
         connectivityListener.connectivityNotifier.subscribe { isConnected ->
-            if (isConnected) {
+            if (isConnected && state is TunnelState.Disconnected) {
                 fetchLocation()
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -129,8 +129,6 @@ class LocationInfoCache(
 
     private fun cancelFetch() {
         synchronized(this) {
-            activeFetch?.cancel()
-
             if (fetchIdIsActive) {
                 fetchIdCounter += 1
                 fetchIdIsActive = false
@@ -141,8 +139,6 @@ class LocationInfoCache(
     private fun fetchLocation(isRealLocation: Boolean) {
         val fetchId = newFetchId()
         val previousFetch = activeFetch
-
-        previousFetch?.cancel()
 
         activeFetch = GlobalScope.launch(Dispatchers.Main) {
             var newLocation: GeoIpLocation? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -153,11 +153,13 @@ class LocationInfoCache(
                 newLocation = executeFetch().await()
             }
 
-            if (newLocation != null && fetchId == fetchIdCounter) {
-                location = newLocation
+            synchronized(this@LocationInfoCache) {
+                if (newLocation != null && fetchId == fetchIdCounter) {
+                    location = newLocation
 
-                if (isRealLocation) {
-                    lastKnownRealLocation = newLocation
+                    if (isRealLocation) {
+                        lastKnownRealLocation = newLocation
+                    }
                 }
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -176,7 +176,8 @@ class MullvadVpnService : TalpidVpnService() {
             pendingAction = null
         }
 
-        val newLocationInfoCache = LocationInfoCache(newDaemon, connectivityListener)
+        val newLocationInfoCache =
+            LocationInfoCache(newDaemon, newConnectionProxy, connectivityListener)
 
         daemon = newDaemon
         connectionProxy = newConnectionProxy

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -33,6 +33,7 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var connectionProxy: ConnectionProxy? = null
     private var daemon: MullvadDaemon? = null
+    private var locationInfoCache: LocationInfoCache? = null
     private var startDaemonJob: Job? = null
 
     private lateinit var notificationManager: ForegroundNotificationManager
@@ -156,6 +157,7 @@ class MullvadVpnService : TalpidVpnService() {
             }
 
             onDaemonStopped = {
+                locationInfoCache?.onDestroy()
                 connectionProxy?.onDestroy()
                 serviceNotifier.notify(null)
 
@@ -175,10 +177,18 @@ class MullvadVpnService : TalpidVpnService() {
             pendingAction = null
         }
 
+        val newLocationInfoCache = LocationInfoCache(newDaemon, connectivityListener)
+
         daemon = newDaemon
         connectionProxy = newConnectionProxy
+        locationInfoCache = newLocationInfoCache
 
-        serviceNotifier.notify(ServiceInstance(newDaemon, newConnectionProxy, connectivityListener))
+        serviceNotifier.notify(ServiceInstance(
+            newDaemon,
+            newConnectionProxy,
+            connectivityListener,
+            newLocationInfoCache
+        ))
     }
 
     private fun stop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -6,5 +6,6 @@ import net.mullvad.talpid.ConnectivityListener
 data class ServiceInstance(
     val daemon: MullvadDaemon,
     val connectionProxy: ConnectionProxy,
-    val connectivityListener: ConnectivityListener
+    val connectivityListener: ConnectivityListener,
+    val locationInfoCache: LocationInfoCache
 )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn.service
 
-import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.talpid.ConnectivityListener
 
 data class ServiceInstance(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
@@ -1,7 +1,7 @@
 package net.mullvad.mullvadvpn.service.tunnelstate
 
 import android.content.Context
-import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
+import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.ServiceInstance
 import net.mullvad.talpid.util.EventNotifier
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -86,6 +86,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
 
         relayListListener.onRelayListChange = { _, selectedRelayItem ->
+            locationInfoCache.selectedRelay = selectedRelayItem
             switchLocationButton.location = selectedRelayItem
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -123,7 +123,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private fun updateTunnelState(uiState: TunnelState, realState: TunnelState) =
         GlobalScope.launch(Dispatchers.Main) {
         notificationBanner.tunnelState = realState
-        locationInfoCache.state = realState
         locationInfo.state = realState
         headerBar.setState(realState)
         status.setState(realState)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -24,6 +24,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var locationInfo: LocationInfo
 
     private lateinit var updateKeyStatusJob: Job
+    private var updateLocationInfoJob: Job? = null
     private var updateTunnelStateJob: Job? = null
 
     private var isTunnelInfoExpanded = false
@@ -82,7 +83,10 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
 
         locationInfoCache.onNewLocation = { location ->
-            locationInfo.location = location
+            updateLocationInfoJob?.cancel()
+            updateLocationInfoJob = GlobalScope.launch(Dispatchers.Main) {
+                locationInfo.location = location
+            }
         }
 
         relayListListener.onRelayListChange = { _, selectedRelayItem ->
@@ -105,6 +109,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             connectionProxy.onUiStateChange.unsubscribe(listener)
         }
 
+        updateLocationInfoJob?.cancel()
         updateTunnelStateJob?.cancel()
         notificationBanner.onPause()
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -18,7 +18,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     val accountCache = AccountCache(settingsListener, daemon)
     var relayListListener = RelayListListener(daemon, settingsListener)
-    val locationInfoCache = LocationInfoCache(daemon, connectivityListener, relayListListener)
+    val locationInfoCache = LocationInfoCache(daemon, connectivityListener)
 
     init {
         appVersionInfoCache.onCreate()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -3,7 +3,6 @@ package net.mullvad.mullvadvpn.ui
 import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
-import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.dataproxy.SettingsListener
 import net.mullvad.mullvadvpn.service.ServiceInstance
@@ -12,13 +11,13 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val daemon = service.daemon
     val connectionProxy = service.connectionProxy
     val connectivityListener = service.connectivityListener
+    val locationInfoCache = service.locationInfoCache
 
     val keyStatusListener = KeyStatusListener(daemon)
     val settingsListener = SettingsListener(daemon)
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     val accountCache = AccountCache(settingsListener, daemon)
     var relayListListener = RelayListListener(daemon, settingsListener)
-    val locationInfoCache = LocationInfoCache(daemon, connectivityListener)
 
     init {
         appVersionInfoCache.onCreate()
@@ -29,7 +28,6 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
         accountCache.onDestroy()
         appVersionInfoCache.onDestroy()
         keyStatusListener.onDestroy()
-        locationInfoCache.onDestroy()
         relayListListener.onDestroy()
         settingsListener.onDestroy()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -12,9 +12,9 @@ import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
-import net.mullvad.mullvadvpn.dataproxy.LocationInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.dataproxy.SettingsListener
+import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.ConnectivityListener
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -10,10 +10,10 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
-import net.mullvad.mullvadvpn.dataproxy.ConnectionProxy
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.dataproxy.SettingsListener
+import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.ConnectivityListener


### PR DESCRIPTION
Previously, some race conditions could occur that led to incorrect location information being shown. Also, many requests were sent, which led to some delays.

This PR tries to fix those issues by changing how the fetches are handled and moving the `LocationInfoCache` to be managed by the background service. Moving the class means that the UI can reuse the same instance, instead of creating a new one every time the UI starts. This should reduce the number of requests.

The fetch queue was rewritten to track each fetch individually, and discarding the fetch result if a more recent fetch was requested.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1607)
<!-- Reviewable:end -->
