### PR TITLE
Start with correct menubar icon

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -323,11 +323,7 @@ class ApplicationMain {
     const tray = this.createTray();
 
     const windowController = new WindowController(window, tray);
-    const trayIconController = new TrayIconController(
-      tray,
-      'unsecured',
-      this.guiSettings.monochromaticIcon,
-    );
+    const trayIconController = new TrayIconController(tray, this.guiSettings.monochromaticIcon);
 
     this.registerWindowListener(windowController);
     this.registerIpcListeners();

--- a/gui/src/main/keyframe-animation.ts
+++ b/gui/src/main/keyframe-animation.ts
@@ -25,14 +25,9 @@ export default class KeyframeAnimation {
     return this.currentFrameValue;
   }
 
-  // This setter is only meant to be used when running tests
-  // @internal
   set currentFrame(newValue: number) {
-    if (process.env.NODE_ENV === 'test') {
-      this.currentFrameValue = newValue;
-    } else {
-      throw new Error('The setter for currentFrame is only available in test environment.');
-    }
+    this.currentFrameValue = newValue;
+    this.render();
   }
 
   set onFrame(newValue: OnFrameFn | undefined) {

--- a/gui/test/keyframe-animation.spec.ts
+++ b/gui/test/keyframe-animation.spec.ts
@@ -78,7 +78,7 @@ describe('lib/keyframe-animation', function() {
       seq.push(frame);
     };
     animation.onFinish = () => {
-      expect(seq).to.be.deep.equal([0, 1, 2, 3, 4]);
+      expect(seq).to.be.deep.equal([0, 0, 1, 2, 3, 4]);
       expect(animation.currentFrame).to.be.equal(4);
       done();
     };
@@ -94,7 +94,7 @@ describe('lib/keyframe-animation', function() {
       seq.push(frame);
     };
     animation.onFinish = () => {
-      expect(seq).to.be.deep.equal([4, 3, 2]);
+      expect(seq).to.be.deep.equal([4, 4, 3, 2]);
       expect(animation.currentFrame).to.be.equal(2);
       done();
     };
@@ -110,7 +110,7 @@ describe('lib/keyframe-animation', function() {
       seq.push(frame);
     };
     animation.onFinish = () => {
-      expect(seq).to.be.deep.equal([4, 3, 2, 1]);
+      expect(seq).to.be.deep.equal([4, 4, 3, 2, 1]);
       expect(animation.currentFrame).to.be.equal(1);
       done();
     };


### PR DESCRIPTION
If the app is started when the daemon is already connected, the menubar icon animates from disconnected to connected. This gives the impression that the user wasn't already connected. This PR solves that by starting the app with the correct menubar icon.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1609)
<!-- Reviewable:end -->
