### PR TITLE
Deny unused parens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
             ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
             linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
       before_script:
-        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables"
+        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens"
         - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar
         - export CC_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang
         - source env.sh aarch64-linux-android

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN_CHANNEL=$1
-export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables"
+export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens"
 
 source env.sh ""
 

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -359,9 +359,8 @@ impl RelaySelector {
             (relay.location.as_ref().unwrap().distance_from(&location) * 1000.0) as i64
         });
         matching_relays.get(0).and_then(|relay| {
-            (self
-                .pick_random_bridge(&relay)
-                .map(|bridge| (bridge, relay.clone())))
+            self.pick_random_bridge(&relay)
+                .map(|bridge| (bridge, relay.clone()))
         })
     }
 


### PR DESCRIPTION
I noticed we had a warning during compile. And it felt like the type we can avoid but can be easy to miss. So I added it to the list of warnings that the CI will deny having.

```
warning: unnecessary parentheses around block return value                                                                                                  
   --> mullvad-daemon/src/relays.rs:362:13
    |                                                                                                                                                       
362 | /             (self                           
363 | |                 .pick_random_bridge(&relay)                                                                                                          
364 | |                 .map(|bridge| (bridge, relay.clone())))                                       
    | |_______________________________________________________^                                                                                              
    |                                                     
    = note: `#[warn(unused_parens)]` on by default                                                                                                           
```

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1611)
<!-- Reviewable:end -->
