### PR TITLE
Fix upgrade script on Linux

### DIFF
--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -3,7 +3,7 @@ set -eu
 
 if which systemctl &> /dev/null; then
     if systemctl status mullvad-daemon &> /dev/null; then
-        /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart
+        /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
         systemctl stop mullvad-daemon.service
         systemctl disable mullvad-daemon.service
     fi


### PR DESCRIPTION
Somehow I only caught this when installing the RPM. `mullvad-setup` will be executed even if it does not exist, causing it to fail on upgrades from versions that don't have it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1615)
<!-- Reviewable:end -->
