### PR TITLE
Update `build-apk.sh` script to also build Android App Bundle

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -43,7 +43,7 @@ EOF
 }
 
 upload() {
-  for f in MullvadVPN-*.{deb,rpm,exe,pkg,apk}; do
+  for f in MullvadVPN-*.{deb,rpm,exe,pkg,apk,aab}; do
     sha256sum "$f" > "$f.sha256"
     case "$(uname -s)" in
       # Linux is both the build and upload server. Just move directly to target dir
@@ -116,7 +116,7 @@ build_ref() {
       ;;
     Linux*)
       echo "Building Android APK"
-      ./build-apk.sh || return 0
+      ./build-apk.sh --app-bundle || return 0
       ;;
   esac
 

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -9,7 +9,7 @@ cd $UPLOAD_DIR
 
 while true; do
   sleep 10
-  for f_checksum in MullvadVPN-*.{deb,rpm,exe,pkg,apk}.sha256; do
+  for f_checksum in MullvadVPN-*.{deb,rpm,exe,pkg,apk,aab}.sha256; do
     sleep 1
     f="${f_checksum/.sha256/}"
     if ! sha256sum --quiet -c "$f_checksum"; then
@@ -17,7 +17,7 @@ while true; do
       continue
     fi
 
-    version=$(echo $f | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm|.apk)/\1/g')
+    version=$(echo $f | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm|\.apk|\.aab)/\1/g')
     ssh build.mullvad.net mkdir -p "app/$version" || continue
     scp -pB "$f" build.mullvad.net:app/$version/ || continue
 


### PR DESCRIPTION
To publish to the Play store, Android App Bundles are needed. This PR updates the `build-apk.sh` script to add an `--app-bundle` flag that.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1616)
<!-- Reviewable:end -->
