### PR TITLE
Upgrade to electron 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Allow `fc00::/7` instead of `fd00::/8` in the firewall when local network sharing is enabled.
   Should unblock all unique local addresses.
+- Upgrade from Electron 7 to Electron 8.
 
 #### Windows
 - Windows 7 only: Address packet loss issues with OpenVPN on some systems by reverting the TAP

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -86,9 +86,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.7.2.tgz",
-      "integrity": "sha512-LSE4LZGMjGS9TloDx0yO44D2UTbaeKRk+QjlhWLiQlikV6J4spgDCjb6z4YIcqmPAwNzlNCnWF4dubytwI+ATA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.9.0.tgz",
+      "integrity": "sha512-OBIKtF6ttIJotDXe4KJMUyTBO4xMii+mFjlA8R4CORuD4HvCUaCK3lPjhdTRCvuEv6gzWNbAvd9DNBv0v780lw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -97,6 +97,7 @@
         "global-agent": "^2.0.2",
         "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
+        "progress": "^2.0.3",
         "sanitize-filename": "^1.6.2",
         "sumchecker": "^3.0.1"
       },
@@ -1356,9 +1357,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.0.tgz",
-      "integrity": "sha512-OElxJ1lUSinuoUnkpOgLmxp0DC4ytEhODEL6QJU0NpxE/mI4rUSh8h1P1Wkvfi3xQEBcxXR2gBIPNYNuaFcAbQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
       "dev": true,
       "optional": true
     },
@@ -1559,6 +1560,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
       "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-equal": {
@@ -1871,9 +1878,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "optional": true
     },
     "chromium-pickle-js": {
@@ -2642,9 +2649,9 @@
       "dev": true
     },
     "electron": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.10.tgz",
-      "integrity": "sha512-UDpS2CfBN3yufCrbET5Ozw1XrLhuANHn+Zs8Vgl/BcBT/MoNbkY79nRFcyxj6pCFrEde9IoNOf+DgNp6altNxw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-8.2.0.tgz",
+      "integrity": "sha512-mnV43gKCrCUMHLmGws/DU/l8LhaxrFD53A4ofwtthdCqOZWGIdk1+eMphiVumXR5a3lC64XVvmXQ2k28i7F/zw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -2653,9 +2660,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.25",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-          "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
+          "version": "12.12.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.31.tgz",
+          "integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg==",
           "dev": true
         }
       }
@@ -4107,15 +4114,26 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "fancy-log": {
@@ -4155,9 +4173,9 @@
       "dev": true
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -5153,25 +5171,25 @@
       }
     },
     "global-agent": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.7.tgz",
-      "integrity": "sha512-ooK7eqGYZku+LgnbfH/Iv0RJ74XfhrBZDlke1QSzcBt0bw1PmJcnRADPAQuFE+R45pKKDTynAr25SBasY2kvow==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
+      "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
-        "core-js": "^3.4.1",
+        "core-js": "^3.6.4",
         "es6-error": "^4.1.1",
-        "matcher": "^2.0.0",
-        "roarr": "^2.14.5",
-        "semver": "^6.3.0",
+        "matcher": "^2.1.0",
+        "roarr": "^2.15.2",
+        "semver": "^7.1.2",
         "serialize-error": "^5.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
           "dev": true,
           "optional": true
         }
@@ -7263,9 +7281,9 @@
       }
     },
     "needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
+      "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
       "optional": true,
       "requires": {
         "debug": "^3.2.6",
@@ -7380,9 +7398,9 @@
       }
     },
     "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
       "optional": true,
       "requires": {
         "abbrev": "1",
@@ -7490,9 +7508,9 @@
       }
     },
     "nseventmonitor": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-0.0.17.tgz",
-      "integrity": "sha512-mGEhUf2q9gaouowzfrMAz+w4nkF4E/o24DR8RsL6k5sUu8kXD5HsZO3vwhRB7gVJnBsMtk6amd5PRpvVm9JAbQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-0.0.18.tgz",
+      "integrity": "sha512-HIjt/87ogh95D+89AuaD7k359YVOY3M3NAjtY49RdN11Bo3EGkaDtMe6XMWs0e0BO68OzoOna1O0doxu++v81Q==",
       "optional": true,
       "requires": {
         "node-pre-gyp": "^0.12.0"
@@ -8902,15 +8920,15 @@
       }
     },
     "roarr": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.14.6.tgz",
-      "integrity": "sha512-qjbw0BEesKA+3XFBPt+KVe1PC/Z6ShfJ4wPlx2XifqH5h2Lj8/KQT5XJTsy3n1Es5kai+BwKALaECW3F70B1cg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
+      "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
         "detect-node": "^2.0.4",
-        "globalthis": "^1.0.0",
+        "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",
         "semver-compare": "^1.0.0",
         "sprintf-js": "^1.1.2"
@@ -11121,12 +11139,13 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yeast": {

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -2873,9 +2873,9 @@
       }
     },
     "electron-log": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-3.0.7.tgz",
-      "integrity": "sha512-W5pjj9DtXjSHaJWH1VWSgBweJxeZ6OEBAIOzSbu6coKFYxXPGRyg9FAILYbnDt0iJT8r6YQqjEnYgmGJn/LoAg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.1.1.tgz",
+      "integrity": "sha512-vkK3rNBOciRiinxrsdgg8hyUia+ct8ZMjBblvKjgNk4uHEDjjSyn313NOwv75xOMVIKlfmYzxaN8kR/oGC33aQ=="
     },
     "electron-mocha": {
       "version": "8.2.1",

--- a/gui/package.json
+++ b/gui/package.json
@@ -35,7 +35,7 @@
     "validated": "^2.0.1"
   },
   "optionalDependencies": {
-    "nseventmonitor": "^0.0.17"
+    "nseventmonitor": "^0.0.18"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -66,7 +66,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "cross-env": "^5.1.3",
-    "electron": "^7.1.10",
+    "electron": "^8.2.0",
     "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.1",
     "electron-mocha": "^8.2.1",

--- a/gui/package.json
+++ b/gui/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "connected-react-router": "^5.0.1",
     "d3-geo-projection": "^2.7.0",
-    "electron-log": "^3.0.7",
+    "electron-log": "^4.1.1",
     "gettext-parser": "^4.0.1",
     "history": "^4.6.1",
     "jsonrpc-lite": "^2.0.7",

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -189,6 +189,10 @@ class ApplicationMain {
 
     this.guiSettings.load();
 
+    // The default value has previously been false but will be changed to true in Electron 9. The
+    // false value has been deprecated in Electron 8. This can be removed when Electron 9 is used.
+    app.allowRendererProcessReuse = true;
+
     app.on('activate', this.onActivate);
     app.on('ready', this.onReady);
     app.on('window-all-closed', () => app.quit());

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -4,6 +4,7 @@ import log from 'electron-log';
 import mkdirp from 'mkdirp';
 import moment from 'moment';
 import * as path from 'path';
+import { sprintf } from 'sprintf-js';
 import * as uuid from 'uuid';
 import AccountExpiry from '../shared/account-expiry';
 import BridgeSettingsBuilder from '../shared/bridge-settings-builder';
@@ -376,6 +377,7 @@ class ApplicationMain {
         this.installGenericMenubarAppWindowHandlers(tray, windowController);
         this.installLinuxWindowCloseHandler(windowController);
         this.setLinuxAppMenu();
+        this.setLinuxTrayMenu(tray, windowController);
         window.setMenuBarVisibility(false);
         break;
       default:
@@ -1355,6 +1357,28 @@ class ApplicationMain {
       },
     ];
     Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  }
+
+  private setLinuxTrayMenu(tray: Tray, windowController: WindowController) {
+    tray.setContextMenu(
+      Menu.buildFromTemplate([
+        {
+          label: sprintf(
+            // TRANSLATORS: The label displayed in the context menu that is opened when the user
+            // TRANSLATORS: clicks the icon in the linux system tray/status bar.
+            // TRANSLATORS: Available placeholder:
+            // TRANSLATORS: %(appname) - Name of the app, i.e. Mullvad VPN
+            messages.pgettext('status-icon-menu', 'Open %(appname)s'),
+            {
+              appname: app.getName(),
+            },
+          ),
+          click: () => {
+            windowController.show();
+          },
+        },
+      ]),
+    );
   }
 
   private addContextMenu(window: BrowserWindow) {

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -440,7 +440,7 @@ function handler<T>(event: string): (handlerFn: (value: T) => void) => void {
 
 type RequestResult<T> = { type: 'success'; value: T } | { type: 'error'; message: string };
 
-// The  Elector API uses the `any` type.
+// The  Electron API uses the `any` type.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function requestHandler<T>(event: string): (fn: (...args: any[]) => Promise<T>) => void {
   return (fn: (...args: any[]) => Promise<T>) => {
@@ -471,7 +471,7 @@ function requestHandler<T>(event: string): (fn: (...args: any[]) => Promise<T>) 
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-// The  Elector API uses the `any` type.
+// The  Electron API uses the `any` type.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function requestSender<T>(event: string): (...args: any[]) => Promise<T> {
   return (...args: any[]): Promise<T> => {

--- a/gui/src/shared/logging.ts
+++ b/gui/src/shared/logging.ts
@@ -42,7 +42,7 @@ export function setupLogging(logFile: string) {
   } else {
     // Configure logging to file
     log.transports.file.level = 'debug';
-    log.transports.file.file = logFile;
+    log.transports.file.resolvePath = (_variables) => logFile;
 
     log.debug(`Logging to ${logFile}`);
   }

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -130,7 +130,7 @@ const config = {
     ],
     afterInstall: distAssets('linux/after-install.sh'),
     afterRemove: distAssets('linux/after-remove.sh'),
-    depends: ['iputils-ping'],
+    depends: ['iputils-ping', 'libappindicator1'],
   },
 
   rpm: {

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -130,7 +130,7 @@ const config = {
     ],
     afterInstall: distAssets('linux/after-install.sh'),
     afterRemove: distAssets('linux/after-remove.sh'),
-    depends: ['iputils-ping', 'libappindicator1'],
+    depends: ['iputils-ping', 'libappindicator3-1'],
   },
 
   rpm: {

--- a/gui/test/setup/main.js
+++ b/gui/test/setup/main.js
@@ -1,5 +1,7 @@
 const log = require('electron-log');
+const { app } = require('electron');
 
 log.transports.console.level = false;
 log.transports.file.level = false;
-log.transports.rendererConsole = null;
+
+app.allowRendererProcessReuse = true;

--- a/gui/test/setup/renderer.ts
+++ b/gui/test/setup/renderer.ts
@@ -7,7 +7,6 @@ import chaiAsPromised from 'chai-as-promised';
 
 log.transports.console.level = false;
 log.transports.file.level = false;
-log.transports.mainConsole = null;
 
 chai.use(spies);
 chai.use(chaiAsPromised);


### PR DESCRIPTION
This PR upgrades Electron from version 7.1.10 to 8.2.0. electron-log is also updated to 4.1.1 which fixes deprecation warnings for electron 8.x

The upgrade to Electron 8 changed the tray icon behavior in Ubuntu and to make everything work smoothly the tray icon context menu has been added to all Linux distributions. It is still possible to open the app immediately by double clicking the icon (at least on Ubuntu).

electron changelog:
https://www.electronjs.org/blog/electron-8-0
electron-log changelog
https://github.com/megahertz/electron-log/blob/HEAD/docs/migration.md

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1620)
<!-- Reviewable:end -->
