### PR TITLE
Handle IAP fetch failure and switch to non-renewable subscription

### DIFF
--- a/ios/MullvadVPN/AccountExpiry.swift
+++ b/ios/MullvadVPN/AccountExpiry.swift
@@ -25,7 +25,7 @@ class AccountExpiry {
     }
 
     var isExpired: Bool {
-        return date < Date()
+        return date <= Date()
     }
 
     var formattedRemainingTime: String? {

--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -93,7 +93,7 @@ class AccountViewController: UIViewController {
         purchaseButton.isLoading = true
 
         requestProductsSubscriber = AppStorePaymentManager.shared.requestProducts(with: [.thirtyDays])
-            .retry(1)
+            .retry(10)
             .receive(on: DispatchQueue.main)
             .restrictUserInterfaceInteraction(with: self.purchaseButtonInteractionRestriction, animated: true)
             .sink(receiveCompletion: { [weak self] (completion) in

--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -30,7 +30,8 @@ class AccountViewController: UIViewController {
     private lazy var purchaseButtonInteractionRestriction =
         UserInterfaceInteractionRestriction(scheduler: DispatchQueue.main) {
             [weak self] (enableUserInteraction, _) in
-            self?.purchaseButton.isEnabled = enableUserInteraction
+            // Make sure to disable the button if the product is not loaded
+            self?.purchaseButton.isEnabled = enableUserInteraction && self?.product != nil
     }
 
     private lazy var viewControllerInteractionRestriction =
@@ -97,9 +98,11 @@ class AccountViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .restrictUserInterfaceInteraction(with: self.purchaseButtonInteractionRestriction, animated: true)
             .sink(receiveCompletion: { [weak self] (completion) in
-                if case .finished = completion {
-                    self?.purchaseButton.isLoading = false
+                if case .failure(let error) = completion {
+                    self?.didFailLoadingProducts(with: error)
                 }
+
+                self?.purchaseButton.isLoading = false
                 }, receiveValue: { [weak self] (response) in
                     if let product = response.products.first {
                         self?.setProduct(product, animated: true)
@@ -118,6 +121,15 @@ class AccountViewController: UIViewController {
                 comment: "The buy button title: <TITLE> (<PRICE>). The order can be changed by swapping %1 and %2."
         )
         let title = String(format: format, localizedTitle, localizedPrice)
+
+        purchaseButton.setTitle(title, for: .normal)
+    }
+
+    private func didFailLoadingProducts(with error: Error) {
+        let title = NSLocalizedString(
+            "Cannot connect to AppStore",
+            comment: "The buy button title displayed when unable to load the price of subscription"
+        )
 
         purchaseButton.setTitle(title, for: .normal)
     }

--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -110,9 +110,15 @@ class AccountViewController: UIViewController {
     private func setProduct(_ product: SKProduct, animated: Bool) {
         self.product = product
 
+        let localizedTitle = product.customLocalizedTitle ?? ""
         let localizedPrice = product.localizedPrice ?? ""
-        let title = String(format: NSLocalizedString("%@ (%@)", comment: ""),
-                           product.localizedTitle, localizedPrice)
+
+        let format = NSLocalizedString(
+                "%1$@ (%2$@)",
+                comment: "The buy button title: <TITLE> (<PRICE>). The order can be changed by swapping %1 and %2."
+        )
+        let title = String(format: format, localizedTitle, localizedPrice)
+
         purchaseButton.setTitle(title, for: .normal)
     }
 

--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -31,7 +31,9 @@ class AccountViewController: UIViewController {
         UserInterfaceInteractionRestriction(scheduler: DispatchQueue.main) {
             [weak self] (enableUserInteraction, _) in
             // Make sure to disable the button if the product is not loaded
-            self?.purchaseButton.isEnabled = enableUserInteraction && self?.product != nil
+            self?.purchaseButton.isEnabled = enableUserInteraction &&
+                self?.product != nil &&
+                AppStorePaymentManager.canMakePayments
     }
 
     private lazy var viewControllerInteractionRestriction =
@@ -73,7 +75,12 @@ class AccountViewController: UIViewController {
             updateAccountExpiry(expiryDate: expiryDate)
         }
 
-        requestStoreProducts()
+        // Make sure to disable IAPs when payments are restricted
+        if AppStorePaymentManager.canMakePayments {
+            requestStoreProducts()
+        } else {
+            setPaymentsRestricted()
+        }
     }
 
     // MARK: - Private methods
@@ -132,6 +139,13 @@ class AccountViewController: UIViewController {
         )
 
         purchaseButton.setTitle(title, for: .normal)
+    }
+
+    private func setPaymentsRestricted() {
+        let title = NSLocalizedString("Payments restricted", comment: "")
+
+        purchaseButton.setTitle(title, for: .normal)
+        purchaseButton.isEnabled = false
     }
 
     private func setEnableUserInteraction(_ enableUserInteraction: Bool, animated: Bool) {

--- a/ios/MullvadVPN/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager.swift
@@ -11,12 +11,25 @@ import Foundation
 import StoreKit
 import os
 
-enum InAppPurchase: String {
-    /// Thirty days worth of credit
-    case thirtyDays = "net.mullvad.MullvadVPN.iap.30days"
+enum AppStoreSubscription: String {
+    /// Thirty days non-renewable subscription
+    case thirtyDays = "net.mullvad.MullvadVPN.subscription.30days"
+
+    var localizedTitle: String {
+        switch self {
+        case .thirtyDays:
+            return NSLocalizedString("Add 30 days time", comment: "")
+        }
+    }
 }
 
-extension Set where Element == InAppPurchase {
+extension SKProduct {
+    var customLocalizedTitle: String? {
+        return AppStoreSubscription(rawValue: productIdentifier)?.localizedTitle
+    }
+}
+
+extension Set where Element == AppStoreSubscription {
     var productIdentifiersSet: Set<String> {
         Set<String>(self.map { $0.rawValue })
     }
@@ -179,7 +192,7 @@ class AppStorePaymentManager {
 
     // MARK: - Products and payments
 
-    func requestProducts(with productIdentifiers: Set<InAppPurchase>)
+    func requestProducts(with productIdentifiers: Set<AppStoreSubscription>)
         -> SKRequestPublisher<SKProductsRequestSubscription>
     {
         let productIdentifiers = productIdentifiers.productIdentifiersSet

--- a/ios/MullvadVPN/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager.swift
@@ -124,6 +124,11 @@ class AppStorePaymentManager {
     /// A private hash map that maps each payment to account token
     private var paymentToAccountToken = [SKPayment: String]()
 
+    /// Returns true if the device is able to make payments
+    class var canMakePayments: Bool {
+        return SKPaymentQueue.canMakePayments()
+    }
+
     init(queue: SKPaymentQueue) {
         self.queue = queue
     }

--- a/ios/MullvadVPN/ConnectViewController.swift
+++ b/ios/MullvadVPN/ConnectViewController.swift
@@ -154,12 +154,8 @@ class ConnectViewController: UIViewController, RootContainment, TunnelControlVie
 
         showedAccountView = true
 
-        switch Account.shared.expiry?.compare(Date()) {
-        case .orderedAscending, .orderedSame:
+        if let accountExpiry = Account.shared.expiry, AccountExpiry(date: accountExpiry).isExpired {
             rootContainerController?.showSettings(navigateTo: .account, animated: true)
-
-        default:
-            break
         }
     }
 

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -169,6 +169,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate, RootContainmen
         beginLogin(method: .newAccount)
 
         accountTextField.text = ""
+        updateKeyboardToolbar()
 
         loginSubscriber = Account.shared.loginWithNewAccount()
             .receive(on: DispatchQueue.main)


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Retry IAP request 10 times
1. Swift from consumable IAP to non-renewable subscription
1. Move IAP products titles into the app for easier localisation and workaround issues when AppStore decides to not return the localised titles from their servers because the IAP was rejected
1. Disable "buy" button and display "Cannot connect to AppStore"  label instead upon failure to obtain the list of IAPs from AppStore
1. Disable "buy" button when device cannot make payments (i.e restricted by parental control)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1624)
<!-- Reviewable:end -->
