### PR TITLE
Use NDIS 5 TAP adapter driver on Windows 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Add WireGuard MTU setting.
 
+### Changed
+#### Windows
+- Windows 7 only: Address packet loss issues with OpenVPN on some systems by reverting the TAP
+  adapter driver to an older NDIS 5 driver.
+
 
 ## [2020.4-beta1] - 2020-03-30
 ### Added

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -57,8 +57,10 @@
 
 	${If} ${AtLeastWin10}
 		File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\tap-driver\win10\*"
-	${Else}
+	${ElseIf} ${AtLeastWin8}
 		File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\tap-driver\win8\*"
+	${Else}
+		File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\tap-driver\win7\*"
 	${EndIf}
 	
 !macroend


### PR DESCRIPTION
This should fix some packet loss/speed issues that Windows 7 users are having.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1625)
<!-- Reviewable:end -->
