### PR TITLE
Allow fc00::/7 instead of fd00::/8 for unique local addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add WireGuard MTU setting.
 
 ### Changed
+- Allow `fc00::/7` instead of `fd00::/8` in the firewall when local network sharing is enabled.
+  Should unblock all unique local addresses.
+
 #### Windows
 - Windows 7 only: Address packet loss issues with OpenVPN on some systems by reverting the TAP
   adapter driver to an older NDIS 5 driver.

--- a/docs/security.md
+++ b/docs/security.md
@@ -76,7 +76,7 @@ The following network traffic is allowed or blocked independent of state:
      * `192.168.0.0/16`
      * `169.254.0.0/16` (Link-local IPv4 range)
      * `fe80::/10` (Link-local IPv6 range)
-     * `fd00::/8` (Unique-local range)
+     * `fc00::/7` (Unique local address (ULA) range)
    * Outgoing to any IP in a local, unroutable, multicast network, meaning these:
      * `224.0.0.0/24` (Local subnet IPv4 multicast)
      * `239.255.0.0/16` (IPv4 local scope. eg. SSDP and mDNS)

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -37,7 +37,7 @@ lazy_static! {
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(169, 254, 0, 0), 16).unwrap()),
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap()),
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0), 8).unwrap()),
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0), 7).unwrap()),
     ];
     /// When "allow local network" is enabled the app will allow traffic to these networks.
     pub(crate) static ref ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 8] = [

--- a/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
@@ -90,7 +90,7 @@ bool PermitLan::applyIpv6(IObjectInstaller &objectInstaller) const
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
 
 	const wfp::IpNetwork linkLocal(wfp::IpAddress::Literal6({ 0xFE80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 10);
-	const wfp::IpNetwork uniqueLocal(wfp::IpAddress::Literal6({ 0xFD00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 8);
+	const wfp::IpNetwork uniqueLocal(wfp::IpAddress::Literal6({ 0xFC00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 7);
 
 	conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
 	conditionBuilder.add_condition(ConditionIp::Remote(uniqueLocal));

--- a/windows/winfw/src/winfw/rules/baseline/permitlanservice.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlanservice.cpp
@@ -66,7 +66,7 @@ bool PermitLanService::applyIpv6(IObjectInstaller &objectInstaller) const
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
 
 	const wfp::IpNetwork linkLocal(wfp::IpAddress::Literal6{ 0xFE80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, 10);
-	const wfp::IpNetwork uniqueLocal(wfp::IpAddress::Literal6({ 0xFD00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 8);
+	const wfp::IpNetwork uniqueLocal(wfp::IpAddress::Literal6({ 0xFC00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 7);
 
 	conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
 	conditionBuilder.add_condition(ConditionIp::Remote(uniqueLocal));


### PR DESCRIPTION
We previously allowed `fd00::/8` as the IPv6 "Unique-local range" when local network sharing was enabled. This is the "defined" half of the ULA (unique local address) space. But all of `fc00::/7` is actually the ULA space even if the first half is "undefined" in a sense. However, the entire `/7` space should not be used on the public internet and is reserved for private networks. So allowing this other half of the space should be fine.

https://en.wikipedia.org/wiki/Reserved_IP_addresses

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1627)
<!-- Reviewable:end -->
