### PR TITLE
Fix overflow bug when using shift operator

### DIFF
--- a/gui/src/main/account-data-cache.ts
+++ b/gui/src/main/account-data-cache.ts
@@ -102,7 +102,8 @@ export default class AccountDataCache {
   private scheduleRetry(accountToken: AccountToken) {
     this.fetchAttempt += 1;
 
-    const delay = Math.min(2048, 1 << (this.fetchAttempt + 2)) * 1000;
+    // Max delay: 2^11 = 2048
+    const delay = Math.pow(2, Math.min(this.fetchAttempt + 2, 11)) * 1000;
 
     log.warn(`Failed to fetch account data. Retrying in ${delay} ms`);
 


### PR DESCRIPTION
Things get funky when `this.fetchAttempt >= 63`, see this:
```
> 1 << 63
-2147483648
> 1 << 64
1
> 1 << 65
2
```

`Math.pow` works fine though, or straight limit on `fetchAttempt` to cap the result at 2048 is even safer/cheaper.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1629)
<!-- Reviewable:end -->
