### PR TITLE
Change time format

### DIFF
--- a/gui/src/shared/account-expiry.ts
+++ b/gui/src/shared/account-expiry.ts
@@ -18,7 +18,7 @@ export default class AccountExpiry {
   }
 
   public formattedDate(): string {
-    return this.expiry.format('L LTS');
+    return this.expiry.format('lll');
   }
 
   public durationUntilExpiry(): string {

--- a/gui/src/shared/account-expiry.ts
+++ b/gui/src/shared/account-expiry.ts
@@ -22,7 +22,22 @@ export default class AccountExpiry {
   }
 
   public durationUntilExpiry(): string {
-    return this.expiry.fromNow(true);
+    const daysDiff = this.expiry.diff(new Date(), 'days');
+
+    // Below three months we want to show the duration in days. Moments fromNow() method starts
+    // measuring duration in months from 26 days and up.
+    // https://momentjs.com/docs/#/displaying/fromnow/
+    if (daysDiff >= 26 && daysDiff <= 90) {
+      return sprintf(
+        // TRANSLATORS: The remaining time left on the account measured in days.
+        // TRANSLATORS: Available placeholders:
+        // TRANSLATORS: %(duration)s - The remaining time measured in days.
+        messages.pgettext('account-expiry', '%(duration)s days'),
+        { duration: daysDiff },
+      );
+    } else {
+      return this.expiry.fromNow(true);
+    }
   }
 
   public remainingTime(): string {


### PR DESCRIPTION
This PR changes the time format for the account expiry on the settings page to show the remaining time in days if it's less than 3 months.

The time format in the account view has been changed to `lll` to make it more apparent what date format is used. More info on the format can be found here https://momentjs.com/docs/#/displaying/format/.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1633)
<!-- Reviewable:end -->
