### PR TITLE
Render ModalAlert into element which is appended on mount

### DIFF
--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -105,13 +105,26 @@ interface IModalAlertProps {
 }
 
 export class ModalAlert extends Component<IModalAlertProps> {
-  public render() {
+  private element = document.createElement('div');
+
+  public componentDidMount() {
     const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
-    if (modalContainer !== null) {
-      return ReactDOM.createPortal(this.renderModal(), modalContainer);
+    if (modalContainer) {
+      modalContainer.appendChild(this.element);
     } else {
-      throw Error('Modal container not found when rendering modal');
+      throw Error('Modal container not found when mounting modal');
     }
+  }
+
+  public componentWillUnmount() {
+    const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
+    if (modalContainer) {
+      modalContainer.removeChild(this.element);
+    }
+  }
+
+  public render() {
+    return ReactDOM.createPortal(this.renderModal(), this.element);
   }
 
   private renderModal() {


### PR DESCRIPTION
Fix to issue where error is thrown if modal is rendered immediately.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
