### PR TITLE
Account data cache refetch test

### DIFF
--- a/gui/test/account-data-cache.spec.ts
+++ b/gui/test/account-data-cache.spec.ts
@@ -65,7 +65,7 @@ describe('IAccountData cache', () => {
       );
 
       cache.fetch(dummyAccountToken, {
-        onFinish: spy(),
+        onFinish: () => {},
         onError: (_error: Error) => {
           reject();
           return AccountFetchRetryAction.stop;
@@ -94,7 +94,7 @@ describe('IAccountData cache', () => {
 
       cache.fetch(dummyAccountToken, {
         onFinish: () => reject(),
-        onError: spy((_error: Error) => AccountFetchRetryAction.retry),
+        onError: (_error: Error) => AccountFetchRetryAction.retry,
       });
     });
 
@@ -120,8 +120,8 @@ describe('IAccountData cache', () => {
       setTimeout(resolve, 12000);
 
       cache.fetch(dummyAccountToken, {
-        onFinish: spy(),
-        onError: spy((_error: Error) => AccountFetchRetryAction.stop),
+        onFinish: () => {},
+        onError: (_error: Error) => AccountFetchRetryAction.stop,
       });
     });
 


### PR DESCRIPTION
Adds test for the refetch that is performed in account-data-cache.ts if the account has expired.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1637)
<!-- Reviewable:end -->
