### PR TITLE
Formalize what OS versions we support in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Line wrap the file at 100 chars.                                              Th
 - Allow `fc00::/7` instead of `fd00::/8` in the firewall when local network sharing is enabled.
   Should unblock all unique local addresses.
 - Upgrade from Electron 7 to Electron 8.
+- Formalize what operating system versions we support in the [readme](README.md). In practice
+  this means dropped support for Android 5 and 6 and Fedora 28 and 29 right away, Ubuntu 16.04
+  support will end as soon as Ubuntu 20.04 comes out.
 
 #### Windows
 - Windows 7 only: Address packet loss issues with OpenVPN on some systems by reverting the TAP

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ iOS consists of a completely standalone implementation that resides in [ios/](io
 
 There are built and signed releases for macOS, Windows, Linux and Android available on
 [our website](https://mullvad.net/download/) and on
-[Github](https://github.com/mullvad/mullvadvpn-app/releases/).
+[Github](https://github.com/mullvad/mullvadvpn-app/releases/). The Andriod app is also available
+on [Google Play](https://play.google.com/store/apps/details?id=net.mullvad.mullvadvpn).
 Support for iOS is in the making.
 
 You can find our code signing keys as well as instructions for how to cryptographically verify

--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@
 Welcome to the Mullvad VPN client app. This repository contains all the source code for the
 desktop and mobile versions of the app. For desktop this includes the system service/daemon
 ([`mullvad-daemon`](mullvad-daemon/)), a graphical user interface ([GUI](gui/)) and a
-command line interface ([CLI](mullvad-cli/)).
-
-The Android app uses the same backing system service for the tunnel and security but has
-a dedicated frontend in [android/](android/).
-
-iOS consists of a completely standalone implementation that resides in [ios/](ios/)
+command line interface ([CLI](mullvad-cli/)). The Android app uses the same backing
+system service for the tunnel and security but has a dedicated frontend in [android/](android/).
+iOS consists of a completely standalone implementation that resides in [ios/](ios/).
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ Support for iOS is in the making.
 You can find our code signing keys as well as instructions for how to cryptographically verify
 your download on [Mullvad's Open Source page].
 
+### Platform/OS support
+
+These are the operating systems and their versions that the app officially supports. It might
+work on many more versions, but we don't test for those and can't guarantee the quality or
+security.
+
+| OS/Platform | Supported versions |
+|-------------|--------------------|
+| Windows     | 7, 8.1 and 10      |
+| macOS       | The three latest major releases |
+| Linux (Ubuntu)| The two newest LTS releases and the two newest non-LTS releases |
+| Linux (Fedora) | The versions that are not yet [EOL] |
+| Android | The four latest major releases|
+| iOS         | 13 and newer       |
+
+[EOL]: https://fedoraproject.org/wiki/End_of_life
+
 ## Features
 
 Here is a table containing the features of the app accross platforms. This reflects the current

--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ security.
 | Windows     | 7, 8.1 and 10      |
 | macOS       | The three latest major releases |
 | Linux (Ubuntu)| The two newest LTS releases and the two newest non-LTS releases |
-| Linux (Fedora) | The versions that are not yet [EOL] |
+| Linux (Fedora) | The versions that are not yet [EOL](https://fedoraproject.org/wiki/End_of_life) |
+| Linux (Debian) | The versions that are not yet [EOL](https://wiki.debian.org/DebianReleases) |
 | Android | The four latest major releases|
 | iOS         | 13 and newer       |
-
-[EOL]: https://fedoraproject.org/wiki/End_of_life
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ security.
 | Android | The four latest major releases|
 | iOS         | 13 and newer       |
 
+On Linux we test using the Gnome desktop environment. The app should, and probably does work
+in other DEs, but we don't regularly test those.
+
 ## Features
 
 Here is a table containing the features of the app accross platforms. This reflects the current


### PR DESCRIPTION
There has been discussions about what versions of operating systems we should test on and which ones we should say we support. We should of course not say we support something we have not tested ourselves. And we can't test every combination of everything. The general rule of thumb is that we support the versions that the OS vendor still supports. But there are deviations from that rule.

Assigning @richard-mullvad since he is head of the testing. Assigning @jvff since this means we drop support for two Android versions. Assigning @pinkisemils since this means we drop some Fedora support and will soon drop Ubuntu 16.04. Ping @dlon, might be worth for you to know when you get back :)

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1638)
<!-- Reviewable:end -->
