### PR TITLE
Select OpenVPN relays when no WG key exists

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -769,6 +769,11 @@ where
                         &constraints,
                         self.settings.get_bridge_state(),
                         retry_attempt,
+                        self.account_history
+                            .get(&account_token)
+                            .unwrap_or(None)
+                            .and_then(|entry| entry.wireguard)
+                            .is_some(),
                     )
                     .map_err(|_| ParameterGenerationError::NoMatchingRelay)
                     .and_then(|(relay, endpoint)| {


### PR DESCRIPTION
On MacOS and Linux, automatic relay selection prefers WireGuard over OpenVPN even if the user has no WireGuard key. This results in the user ending up in the error state. These changes introduce a new parameter to the relay generation to signify whether WireGuard key exists or not, which is only taken into account when the tunnel protocol is not strictly specified - so WireGuard will only be preferred on MacOS and Linux only if a key is set, otherwise OpenVPN will be used. This means that if the user explicitly somehow specifies the tunnel protocol to be WireGuard without having a key set, the daemon will still end up in the error state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1641)
<!-- Reviewable:end -->
