### PR TITLE
Exclude native modules in asar packaging on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Security
+#### macOS
+- Ship native Node modules unpacked to prevent malware checks by macOS on each run. The malware
+  checks delayed app startup when "block when disconnected" was enabled and performed system network
+  requests to Apple.
 
 
 ## [2020.4-beta2] - 2020-04-08

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -168,6 +168,7 @@ function packMac() {
     targets: builder.Platform.MAC.createTarget(),
     config: {
       ...config,
+      asarUnpack: ['**/*.node'],
       afterPack: (context) => {
         appOutDir = context.appOutDir;
         return Promise.resolve();


### PR DESCRIPTION
This PR makes `electron-builder` exclude native node modules from the asar archive on macOS. They are instead placed in a directory called `app.asar.unpacked` next to `app.asar`. Including the native module in the asar forces Electron to unpack it before executing it and running the extracted executable on macOS resulted in the OS making requests to Apple servers. My guess is that the unpacked executable was placed somewhere outside the app bundle and that made macOS confused.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1643)
<!-- Reviewable:end -->
