### PR TITLE
Update forgotten mullvad-setup version

### DIFF
--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mullvad-setup"
-version = "2020.4.0-beta1"
+version = "2020.4.0-beta2"
 authors = ["Mullvad VPN"]
 description = "Tool used to manage daemon setup"
 license = "GPL-3.0"

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -43,6 +43,7 @@ git commit -S -m "Updating version in package files" \
     mullvad-daemon/Cargo.toml \
     mullvad-cli/Cargo.toml \
     mullvad-problem-report/Cargo.toml \
+    mullvad-setup/Cargo.toml \
     talpid-openvpn-plugin/Cargo.toml \
     Cargo.lock \
     android/build.gradle \


### PR DESCRIPTION
`prepare_release.sh` was not updated when the `mullvad-setup` binary was added. So its version bump was not commited as part of making a release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1644)
<!-- Reviewable:end -->
