### PR TITLE
Fix invalid account error being mistakenly reported as network error

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -23,7 +23,8 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
-
+### Fixed
+- Fix "invalid account" error that was mistakenly reported as "network error" during log in.
 
 ## [2020.1] - 2020-04-08
 Initial release. Supports...

--- a/ios/MullvadVPN/Account.swift
+++ b/ios/MullvadVPN/Account.swift
@@ -26,7 +26,6 @@ enum AccountError: Error {
 
 /// A enum describing the error emitted during login
 enum AccountLoginError: Error {
-    case invalidAccount
     case network(MullvadAPI.Error)
     case communication(MullvadAPI.ResponseError)
     case tunnelConfiguration(TunnelManagerError)
@@ -57,11 +56,14 @@ extension AccountError: LocalizedError {
         case .createNew(.network), .createNew(.communication):
             return NSLocalizedString("Failed to create new account", comment: "")
 
-        case .login(.invalidAccount):
+        case .login(.communication(let serverError)) where serverError.code == .accountDoesNotExist:
             return NSLocalizedString("Invalid account", comment: "")
 
-        case .login(.network), .login(.communication):
+        case .login(.network):
             return NSLocalizedString("Network error", comment: "")
+
+        case .login(.communication):
+            return NSLocalizedString("Server error", comment: "")
 
         case .login(.tunnelConfiguration(.setAccount(let setAccountError))),
              .createNew(.tunnelConfiguration(.setAccount(let setAccountError))):


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

As the title says, in a rush a must have introduced the regression just before the release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1652)
<!-- Reviewable:end -->
