### PR TITLE
Enable on-demand VPN

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -29,6 +29,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Added
 - Format account number in groups of 4 digits separated by whitespace on login screen.
+- Enable on-demand VPN with a single rule to always connect the tunnel when on Wi-Fi or cellular. 
+  Automatically disable on-demand VPN when manually disconnecting the tunnel from GUI to prevent the 
+  tunnel from coming back up.
 
 ## [2020.1] - 2020-04-08
 Initial release. Supports...

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		5888AD89227B18C40051EB06 /* RelayList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5888AD88227B18C40051EB06 /* RelayList.swift */; };
 		588AE72F2362001F009F9F2E /* MutuallyExclusive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588AE72E2362001F009F9F2E /* MutuallyExclusive.swift */; };
 		588AE730236200E2009F9F2E /* MutuallyExclusive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588AE72E2362001F009F9F2E /* MutuallyExclusive.swift */; };
+		58906DE02445C7A5002F0673 /* NEProviderStopReason+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */; };
 		589AB4F7227B64450039131E /* BasicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589AB4F6227B64450039131E /* BasicTableViewCell.swift */; };
 		58A1AA8C23F5584C009F7EA6 /* ConnectionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A1AA8B23F5584B009F7EA6 /* ConnectionPanelView.swift */; };
 		58A8BE81239FBE62006B74AC /* IPEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58561C98239A5D1500BD6B5E /* IPEndpoint.swift */; };
@@ -225,6 +226,7 @@
 		5888AD86227B17950051EB06 /* SelectLocationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationController.swift; sourceTree = "<group>"; };
 		5888AD88227B18C40051EB06 /* RelayList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayList.swift; sourceTree = "<group>"; };
 		588AE72E2362001F009F9F2E /* MutuallyExclusive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutuallyExclusive.swift; sourceTree = "<group>"; };
+		58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NEProviderStopReason+Debug.swift"; sourceTree = "<group>"; };
 		5894E725236B2801008A2793 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		589AB4F6227B64450039131E /* BasicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTableViewCell.swift; sourceTree = "<group>"; };
 		58A1AA8623F43901009F7EA6 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 				58FBDAAA22A52DC500EB69A3 /* MullvadVPN-Bridging-Header.h */,
 				5866F39B2243B82D00168AE5 /* MullvadVPN.entitlements */,
 				588AE72E2362001F009F9F2E /* MutuallyExclusive.swift */,
+				58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */,
 				5811DE4F239014550011EB53 /* NEVPNStatus+Debug.swift */,
 				5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */,
 				58BFA5C522A7C97F00A6173D /* RelayCache.swift */,
@@ -853,6 +856,7 @@
 				582650872384117900FA7A86 /* ReplaceNilWithError.swift in Sources */,
 				58BFA5C722A7C97F00A6173D /* RelayCache.swift in Sources */,
 				58BFA5C022A7C8A900A6173D /* MullvadAPI.swift in Sources */,
+				58906DE02445C7A5002F0673 /* NEProviderStopReason+Debug.swift in Sources */,
 				58AEEF692344A43A00C9BBD5 /* TunnelConfigurationCoder.swift in Sources */,
 				584E96BD240FD4DA00D3334F /* Location.swift in Sources */,
 				58C6B36122C0EC82003C19AD /* AnyIPEndpoint+DNS64.swift in Sources */,

--- a/ios/MullvadVPN/ConnectViewController.swift
+++ b/ios/MullvadVPN/ConnectViewController.swift
@@ -145,7 +145,12 @@ class ConnectViewController: UIViewController, RootContainment, TunnelControlVie
         startStopTunnelSubscriber = TunnelManager.shared.stopTunnel()
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { (completion) in
-                // no-op
+                if case .failure(let error) = completion {
+                    os_log(.error, "Failed to stop the tunnel: %{public}s",
+                           error.localizedDescription)
+
+                    self.presentError(error, preferredStyle: .alert)
+                }
             })
     }
 

--- a/ios/MullvadVPN/NEProviderStopReason+Debug.swift
+++ b/ios/MullvadVPN/NEProviderStopReason+Debug.swift
@@ -1,0 +1,56 @@
+//
+//  NEProviderStopReason+Debug.swift
+//  PacketTunnel
+//
+//  Created by pronebird on 14/04/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import NetworkExtension
+
+extension NEProviderStopReason: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var output = "NEProviderStopReason."
+        switch self {
+        case .none:
+            output += "none"
+        case .userInitiated:
+            output += "userInitiated"
+        case .providerFailed:
+            output += "providerFailed"
+        case .noNetworkAvailable:
+            output += "noNetworkAvailable"
+        case .unrecoverableNetworkChange:
+            output += "unrecoverableNetworkChange"
+        case .providerDisabled:
+            output += "providerDisabled"
+        case .authenticationCanceled:
+            output += "authenticationCanceled"
+        case .configurationFailed:
+            output += "configurationFailed"
+        case .idleTimeout:
+            output += "idleTimeout"
+        case .configurationDisabled:
+            output += "configurationDisabled"
+        case .configurationRemoved:
+            output += "configurationRemoved"
+        case .superceded:
+            output += "superceded"
+        case .userLogout:
+            output += "userLogout"
+        case .userSwitch:
+            output += "userSwitch"
+        case .connectionFailed:
+            output += "connectionFailed"
+        case .sleep:
+            output += "sleep"
+        case .appUpdate:
+            output += "appUpdate"
+        @unknown default:
+            output += "\(self.rawValue)"
+        }
+        return output
+    }
+}
+

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -134,7 +134,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
-        os_log(.default, log: tunnelProviderLog, "Stop tunnel received.")
+        os_log(.default, log: tunnelProviderLog, "Stop tunnel received. Reason: %{public}s", "\(String(reflecting: reason))")
 
         startStopTunnelSubscriber = stopTunnel().sink(receiveCompletion: { (completion) in
             os_log(.default, log: tunnelProviderLog, "Stopped the tunnel")


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)


1. Enable on-demand VPN and add a single rule to connect the tunnel when on Wi-Fi or cellular
1. Disable on-demand VPN when disconnecting the tunnel from GUI to prevent the tunnel from coming back up
1. Log tunnel stop reason. This is something I will need later on for debugging when we start saving logs on disk. This should greatly help to figure out when and why the tunnel is being stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1656)
<!-- Reviewable:end -->
