### PR TITLE
Fix uninitialized struct

### DIFF
--- a/windows/winnet/src/winnet/networkadaptermonitor.cpp
+++ b/windows/winnet/src/winnet/networkadaptermonitor.cpp
@@ -148,7 +148,7 @@ std::vector<MIB_IF_ROW2>::iterator NetworkAdapterMonitor::findFilteredAdapter(co
 
 MIB_IF_ROW2 NetworkAdapterMonitor::getAdapter(NET_LUID luid) const
 {
-	MIB_IF_ROW2 rowOut;
+	MIB_IF_ROW2 rowOut = {0};
 	rowOut.InterfaceLuid = luid;
 	const auto status = m_dataProvider->getIfEntry2(&rowOut);
 


### PR DESCRIPTION
As above. The struct needs to be cleared to ensure the `InterfaceIndex` field doesn't contain random garbage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1657)
<!-- Reviewable:end -->
