### PR TITLE
Fix crash when running from SD card or from container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Change button colors on problem report no email confirmation dialog to match the desktop version.
+- Fix crash when attempting to run app from the non-default location, such as the SD card or from a
+  different user profile.
 
 ### Security
 #### macOS

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
@@ -40,7 +40,7 @@ class MullvadProblemReport(val logDirectory: File) {
             if (!isActive) {
                 collectJob = GlobalScope.async(Dispatchers.Default) {
                     deleteReportFile()
-                    collectReport(problemReportPath.absolutePath)
+                    collectReport(logDirectory.absolutePath, problemReportPath.absolutePath)
                 }
             }
         }
@@ -77,7 +77,7 @@ class MullvadProblemReport(val logDirectory: File) {
         problemReportPath.delete()
     }
 
-    private external fun collectReport(reportPath: String): Boolean
+    private external fun collectReport(logDirectory: String, reportPath: String): Boolean
     private external fun sendProblemReport(
         userEmail: String,
         userMessage: String,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
@@ -7,9 +7,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 
-const val PROBLEM_REPORT_PATH = "/data/data/net.mullvad.mullvadvpn/problem_report.txt"
+const val PROBLEM_REPORT_FILE = "problem_report.txt"
 
-class MullvadProblemReport {
+class MullvadProblemReport(val logDirectory: File) {
+    private val problemReportPath = File(logDirectory, PROBLEM_REPORT_FILE)
+
     private var collectJob: Deferred<Boolean>? = null
     private var sendJob: Deferred<Boolean>? = null
 
@@ -38,7 +40,7 @@ class MullvadProblemReport {
             if (!isActive) {
                 collectJob = GlobalScope.async(Dispatchers.Default) {
                     deleteReportFile()
-                    collectReport(PROBLEM_REPORT_PATH)
+                    collectReport(problemReportPath.absolutePath)
                 }
             }
         }
@@ -51,7 +53,11 @@ class MullvadProblemReport {
             if (currentJob == null || currentJob.isCompleted) {
                 currentJob = GlobalScope.async(Dispatchers.Default) {
                     val result = (collectJob?.await() ?: false) &&
-                            sendProblemReport(userEmail, userMessage, PROBLEM_REPORT_PATH)
+                            sendProblemReport(
+                                userEmail,
+                                userMessage,
+                                problemReportPath.absolutePath
+                            )
 
                     if (result) {
                         deleteReportFile()
@@ -68,7 +74,7 @@ class MullvadProblemReport {
     }
 
     fun deleteReportFile() {
-        File(PROBLEM_REPORT_PATH).delete()
+        problemReportPath.delete()
     }
 
     private external fun collectReport(reportPath: String): Boolean

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileMigrator.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileMigrator.kt
@@ -1,0 +1,18 @@
+package net.mullvad.mullvadvpn.service
+
+import android.util.Log
+import java.io.File
+
+class FileMigrator(val oldDirectory: File, val newDirectory: File) {
+    fun migrate(fileName: String) {
+        try {
+            val oldPath = File(oldDirectory, fileName)
+
+            if (oldPath.exists()) {
+                oldPath.renameTo(File(newDirectory, fileName))
+            }
+        } catch (exception: Exception) {
+            Log.w("mullvad", "Failed to migrate $fileName from $oldDirectory to $newDirectory")
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
@@ -4,14 +4,16 @@ import android.content.Context
 import java.io.File
 import java.io.FileOutputStream
 
-class FileResourceExtractor(val asset: String, val destination: String) {
+class FileResourceExtractor(val asset: String) {
     fun extract(context: Context) {
-        if (!File(destination).exists()) {
-            extractFile(context)
+        val destination = File(context.filesDir, asset)
+
+        if (!destination.exists()) {
+            extractFile(context, destination)
         }
     }
 
-    private fun extractFile(context: Context) {
+    private fun extractFile(context: Context, destination: File) {
         val destinationStream = FileOutputStream(destination)
 
         context

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
@@ -4,16 +4,16 @@ import android.content.Context
 import java.io.File
 import java.io.FileOutputStream
 
-class FileResourceExtractor(val asset: String) {
-    fun extract(context: Context) {
+class FileResourceExtractor(val context: Context) {
+    fun extract(asset: String) {
         val destination = File(context.filesDir, asset)
 
         if (!destination.exists()) {
-            extractFile(context, destination)
+            extractFile(asset, destination)
         }
     }
 
-    private fun extractFile(context: Context, destination: File) {
+    private fun extractFile(asset: String, destination: File) {
         val destinationStream = FileOutputStream(destination)
 
         context

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -24,7 +24,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
 
     init {
         System.loadLibrary("mullvad_jni")
-        initialize(vpnService, vpnService.cacheDir.absolutePath)
+        initialize(vpnService, vpnService.cacheDir.absolutePath, vpnService.filesDir.absolutePath)
 
         onSettingsChange.notify(getSettings())
     }
@@ -113,7 +113,11 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return verifyWireguardKey(daemonInterfaceAddress)
     }
 
-    private external fun initialize(vpnService: MullvadVpnService, cacheDirectory: String)
+    private external fun initialize(
+        vpnService: MullvadVpnService,
+        cacheDirectory: String,
+        resourceDirectory: String
+    )
     private external fun deinitialize()
 
     private external fun connect(daemonInterfaceAddress: Long)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -24,7 +24,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
 
     init {
         System.loadLibrary("mullvad_jni")
-        initialize(vpnService)
+        initialize(vpnService, vpnService.cacheDir.absolutePath)
 
         onSettingsChange.notify(getSettings())
     }
@@ -113,7 +113,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return verifyWireguardKey(daemonInterfaceAddress)
     }
 
-    private external fun initialize(vpnService: MullvadVpnService)
+    private external fun initialize(vpnService: MullvadVpnService, cacheDirectory: String)
     private external fun deinitialize()
 
     private external fun connect(daemonInterfaceAddress: Long)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -14,10 +14,7 @@ import net.mullvad.talpid.TalpidVpnService
 import net.mullvad.talpid.util.EventNotifier
 
 private const val API_ROOT_CA_FILE = "api_root_ca.pem"
-private const val API_ROOT_CA_PATH = "/data/data/net.mullvad.mullvadvpn/api_root_ca.pem"
-
 private const val RELAYS_FILE = "relays.json"
-private const val RELAYS_PATH = "/data/data/net.mullvad.mullvadvpn/relays.json"
 
 class MullvadVpnService : TalpidVpnService() {
     private enum class PendingAction {
@@ -144,11 +141,8 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun startDaemon() = GlobalScope.launch(Dispatchers.Default) {
-        FileResourceExtractor(API_ROOT_CA_FILE, API_ROOT_CA_PATH)
-            .extract(application)
-
-        FileResourceExtractor(RELAYS_FILE, RELAYS_PATH)
-            .extract(application)
+        FileResourceExtractor(API_ROOT_CA_FILE).extract(application)
+        FileResourceExtractor(RELAYS_FILE).extract(application)
 
         val newDaemon = MullvadDaemon(this@MullvadVpnService).apply {
             onSettingsChange.subscribe { settings ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.VpnService
 import android.os.Binder
 import android.os.IBinder
+import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -185,6 +186,16 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun prepareFiles() {
+        FileMigrator(File("/data/data/net.mullvad.mullvadvpn"), filesDir).apply {
+            migrate(API_ROOT_CA_FILE)
+            migrate(RELAYS_FILE)
+            migrate("settings.json")
+            migrate("daemon.log")
+            migrate("daemon.old.log")
+            migrate("wireguard.log")
+            migrate("wireguard.old.log")
+        }
+
         FileResourceExtractor(this).apply {
             extract(API_ROOT_CA_FILE)
             extract(RELAYS_FILE)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -185,8 +185,10 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun prepareFiles() {
-        FileResourceExtractor(API_ROOT_CA_FILE).extract(application)
-        FileResourceExtractor(RELAYS_FILE).extract(application)
+        FileResourceExtractor(this).apply {
+            extract(API_ROOT_CA_FILE)
+            extract(RELAYS_FILE)
+        }
     }
 
     private fun stop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -141,8 +141,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun startDaemon() = GlobalScope.launch(Dispatchers.Default) {
-        FileResourceExtractor(API_ROOT_CA_FILE).extract(application)
-        FileResourceExtractor(RELAYS_FILE).extract(application)
+        prepareFiles()
 
         val newDaemon = MullvadDaemon(this@MullvadVpnService).apply {
             onSettingsChange.subscribe { settings ->
@@ -183,6 +182,11 @@ class MullvadVpnService : TalpidVpnService() {
             connectivityListener,
             newLocationInfoCache
         ))
+    }
+
+    private fun prepareFiles() {
+        FileResourceExtractor(API_ROOT_CA_FILE).extract(application)
+        FileResourceExtractor(RELAYS_FILE).extract(application)
     }
 
     private fun stop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -19,8 +19,9 @@ class MainActivity : FragmentActivity() {
         val KEY_SHOULD_CONNECT = "should_connect"
     }
 
-    val problemReport = MullvadProblemReport()
     val serviceNotifier = EventNotifier<ServiceConnection?>(null)
+
+    lateinit var problemReport: MullvadProblemReport
 
     private var service: MullvadVpnService.LocalBinder? = null
     private var serviceConnection: ServiceConnection? = null
@@ -64,6 +65,9 @@ class MainActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        problemReport = MullvadProblemReport(filesDir)
+
         setContentView(R.layout.main)
 
         if (savedInstanceState == null) {

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -49,7 +49,7 @@ impl AutoConnect {
 
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        let auto_connect = rpc.get_settings()?.get_auto_connect();
+        let auto_connect = rpc.get_settings()?.auto_connect;
         println!("Autoconnect: {}", if auto_connect { "on" } else { "off" });
         Ok(())
     }

--- a/mullvad-cli/src/cmds/beta_program.rs
+++ b/mullvad-cli/src/cmds/beta_program.rs
@@ -29,7 +29,7 @@ impl Command for BetaProgram {
             ("get", Some(_)) => {
                 let mut rpc = new_rpc_client()?;
                 let settings = rpc.get_settings()?;
-                let enabled_str = if settings.get_show_beta_releases().unwrap_or(false) {
+                let enabled_str = if settings.show_beta_releases.unwrap_or(false) {
                     "on"
                 } else {
                     "off"

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -49,7 +49,7 @@ impl BlockWhenDisconnected {
 
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        let block_when_disconnected = rpc.get_settings()?.get_block_when_disconnected();
+        let block_when_disconnected = rpc.get_settings()?.block_when_disconnected;
         println!(
             "Network traffic will be {} when the VPN is disconnected",
             if block_when_disconnected {

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -162,7 +162,7 @@ impl Bridge {
         let mut rpc = new_rpc_client()?;
         let settings = rpc.get_settings()?;
         println!("Bridge state - {}", settings.get_bridge_state());
-        match settings.get_bridge_settings() {
+        match settings.bridge_settings {
             BridgeSettings::Custom(proxy) => {
                 match proxy {
                     openvpn::ProxySettings::Local(local_proxy) => {

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -49,7 +49,7 @@ impl Lan {
 
     fn get(&self) -> Result<()> {
         let mut rpc = new_rpc_client()?;
-        let allow_lan = rpc.get_settings()?.get_allow_lan();
+        let allow_lan = rpc.get_settings()?.allow_lan;
         println!(
             "Local network sharing setting: {}",
             if allow_lan { "allow" } else { "block" }

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -258,7 +258,7 @@ impl Tunnel {
 
     fn get_tunnel_options() -> Result<TunnelOptions> {
         let mut rpc = new_rpc_client()?;
-        Ok(rpc.get_settings()?.get_tunnel_options().clone())
+        Ok(rpc.get_settings()?.tunnel_options)
     }
 
     fn process_openvpn_mssfix_unset() -> Result<()> {

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -20,7 +20,7 @@ impl Command for Version {
         println!("\tIs supported: {}", version_info.current_is_supported);
 
         let settings = rpc.get_settings()?;
-        let is_updated = if settings.get_show_beta_releases().unwrap_or(false) {
+        let is_updated = if settings.show_beta_releases.unwrap_or(false) {
             version_info.latest == current_version
         } else {
             version_info.latest_stable == current_version

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -37,11 +37,12 @@ use mullvad_types::{
         RelaySettingsUpdate,
     },
     relay_list::{Relay, RelayList},
+    settings::Settings,
     states::{TargetState, TunnelState},
     version::{AppVersion, AppVersionInfo},
     wireguard::KeygenEvent,
 };
-use settings::Settings;
+use settings::SettingsPersister;
 #[cfg(not(target_os = "android"))]
 use std::path::Path;
 use std::{
@@ -436,7 +437,7 @@ pub struct Daemon<L: EventListener> {
     tx: DaemonEventSender,
     reconnection_loop_tx: Option<mpsc::Sender<()>>,
     event_listener: L,
-    settings: Settings,
+    settings: SettingsPersister,
     account_history: account_history::AccountHistory,
     wg_key_proxy: WireguardKeyProxy<HttpHandle>,
     accounts_proxy: AccountsProxy<HttpHandle>,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1255,7 +1255,8 @@ where
     fn set_account(&mut self, account_token: Option<String>) -> Result<bool, settings::Error> {
         let account_changed = self.settings.set_account_token(account_token.clone())?;
         if account_changed {
-            self.event_listener.notify_settings(self.settings.clone());
+            self.event_listener
+                .notify_settings(self.settings.to_settings());
 
             // Bump account history if a token was set
             if let Some(token) = account_token.clone() {
@@ -1355,7 +1356,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "update_relay_settings response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     info!("Initiating tunnel restart because the relay settings changed");
                     self.reconnect_tunnel();
                 }
@@ -1370,7 +1372,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set_allow_lan response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     self.send_tunnel_command(TunnelCommand::AllowLan(allow_lan));
                 }
             }
@@ -1384,7 +1387,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set_show_beta_releases response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                 }
             }
             Err(e) => error!("{}", e.display_chain_with_msg("Unable to save settings")),
@@ -1403,7 +1407,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set_block_when_disconnected response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(
                         block_when_disconnected,
                     ));
@@ -1419,7 +1424,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set auto-connect response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                 }
             }
             Err(e) => error!("{}", e.display_chain_with_msg("Unable to save settings")),
@@ -1432,7 +1438,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set_openvpn_mssfix response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     if let Some(TunnelType::OpenVpn) = self.get_connected_tunnel_type() {
                         info!(
                             "Initiating tunnel restart because the OpenVPN mssfix setting changed"
@@ -1453,7 +1460,8 @@ where
         match self.settings.set_bridge_settings(new_settings) {
             Ok(settings_changes) => {
                 if settings_changes {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     self.reconnect_tunnel();
                 };
                 Self::oneshot_send(tx, Ok(()), "set_bridge_settings");
@@ -1477,7 +1485,8 @@ where
         let result = match self.settings.set_bridge_state(bridge_state) {
             Ok(settings_changed) => {
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     log::info!("Initiating tunnel restart because bridge state changed");
                     self.reconnect_tunnel();
                 }
@@ -1501,7 +1510,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set_enable_ipv6 response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     info!("Initiating tunnel restart because the enable IPv6 setting changed");
                     self.reconnect_tunnel();
                 }
@@ -1516,7 +1526,8 @@ where
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, (), "set_wireguard_mtu response");
                 if settings_changed {
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                     if let Some(TunnelType::Wireguard) = self.get_connected_tunnel_type() {
                         info!(
                             "Initiating tunnel restart because the WireGuard MTU setting changed"
@@ -1549,7 +1560,8 @@ where
                         );
                     }
 
-                    self.event_listener.notify_settings(self.settings.clone());
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
                 }
             }
             Err(e) => error!("{}", e.display_chain_with_msg("Unable to save settings")),
@@ -1697,7 +1709,7 @@ where
     }
 
     fn on_get_settings(&self, tx: oneshot::Sender<Settings>) {
-        Self::oneshot_send(tx, self.settings.clone(), "get_settings response");
+        Self::oneshot_send(tx, self.settings.to_settings(), "get_settings response");
     }
 
     fn oneshot_send<T>(tx: oneshot::Sender<T>, t: T, msg: &'static str) {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -461,6 +461,7 @@ where
     pub fn start(
         log_dir: Option<PathBuf>,
         resource_dir: PathBuf,
+        settings_dir: PathBuf,
         cache_dir: PathBuf,
         event_listener: L,
         command_channel: DaemonCommandChannel,
@@ -507,7 +508,7 @@ where
         );
         tokio_remote.spawn(|_| version_check_future);
 
-        let mut settings = SettingsPersister::load();
+        let mut settings = SettingsPersister::load(&settings_dir);
 
         if version::is_beta_version() && settings.show_beta_releases.is_none() {
             let _ = settings.set_show_beta_releases(true);

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -507,7 +507,7 @@ where
         );
         tokio_remote.spawn(|_| version_check_future);
 
-        let mut settings = settings::load();
+        let mut settings = SettingsPersister::load();
 
         if version::is_beta_version() && settings.get_show_beta_releases().is_none() {
             let _ = settings.set_show_beta_releases(true);

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -111,6 +111,8 @@ fn create_daemon(
     log_dir: Option<PathBuf>,
 ) -> Result<Daemon<ManagementInterfaceEventBroadcaster>, String> {
     let resource_dir = mullvad_paths::get_resource_dir();
+    let settings_dir = mullvad_paths::settings_dir()
+        .map_err(|e| e.display_chain_with_msg("Unable to get settings dir"))?;
     let cache_dir = mullvad_paths::cache_dir()
         .map_err(|e| e.display_chain_with_msg("Unable to get cache dir"))?;
 
@@ -120,6 +122,7 @@ fn create_daemon(
     Daemon::start(
         log_dir,
         resource_dir,
+        settings_dir,
         cache_dir,
         event_listener,
         command_channel,

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -13,7 +13,7 @@ use mullvad_types::{
     location::GeoIpLocation,
     relay_constraints::{BridgeSettings, BridgeState, RelaySettingsUpdate},
     relay_list::RelayList,
-    settings::{self, Settings},
+    settings::Settings,
     states::{TargetState, TunnelState},
     version, wireguard, DaemonEvent,
 };
@@ -582,12 +582,7 @@ impl ManagementInterfaceApi for ManagementInterface {
         let future = self
             .send_command_to_daemon(DaemonCommand::SetBridgeSettings(tx, bridge_settings))
             .and_then(|_| rx.map_err(|_| Error::internal_error()))
-            .and_then(|settings_result| {
-                settings_result.map_err(|error| match error {
-                    settings::Error::InvalidProxyData(reason) => Error::invalid_params(reason),
-                    _ => Error::internal_error(),
-                })
-            });
+            .and_then(|settings_result| settings_result.map_err(|_| Error::internal_error()));
 
         Box::new(future)
     }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -36,6 +36,7 @@ pub struct SettingsPersister {
 }
 
 impl SettingsPersister {
+    /// Loads user settings from file. If no file is present it returns the defaults.
     pub fn load() -> Self {
         let mut settings = Self::load_settings();
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -1,18 +1,14 @@
-#[cfg(windows)]
-use log::{error, warn};
-
 use log::info;
 
 #[cfg(windows)]
-use mullvad_types::settings::Error as SettingsError;
+use {
+    log::{error, warn},
+    mullvad_types::settings::Error as SettingsError,
+    std::io::ErrorKind,
+    talpid_core::logging::windows::log_sink,
+};
 
 pub use mullvad_types::settings::*;
-
-#[cfg(windows)]
-use std::io::ErrorKind;
-
-#[cfg(windows)]
-use talpid_core::logging::windows::log_sink;
 
 pub fn load() -> Settings {
     match Settings::load() {

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -1,4 +1,5 @@
 use log::info;
+use std::ops::{Deref, DerefMut};
 
 #[cfg(windows)]
 use {
@@ -10,8 +11,27 @@ use {
 
 pub use mullvad_types::settings::*;
 
-pub fn load() -> Settings {
-    match Settings::load() {
+#[derive(Debug)]
+pub struct SettingsPersister {
+    settings: Settings,
+}
+
+impl Deref for SettingsPersister {
+    type Target = Settings;
+
+    fn deref(&self) -> &Self::Target {
+        &self.settings
+    }
+}
+
+impl DerefMut for SettingsPersister {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.settings
+    }
+}
+
+pub fn load() -> SettingsPersister {
+    let settings = match Settings::load() {
         Ok(mut settings) => {
             // Force IPv6 to be enabled on Android
             if cfg!(target_os = "android") {
@@ -44,7 +64,9 @@ pub fn load() -> Settings {
             info!("Failed to load settings, using defaults");
             Settings::default()
         }
-    }
+    };
+
+    SettingsPersister { settings }
 }
 
 #[cfg(windows)]

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -16,6 +16,12 @@ pub struct SettingsPersister {
     settings: Settings,
 }
 
+impl SettingsPersister {
+    pub fn to_settings(&self) -> Settings {
+        self.settings.clone()
+    }
+}
+
 impl Deref for SettingsPersister {
     type Target = Settings;
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -1,9 +1,12 @@
 use log::info;
-use mullvad_types::settings::Settings;
+use mullvad_types::{
+    relay_constraints::{BridgeSettings, BridgeState, RelaySettingsUpdate},
+    settings::Settings,
+};
 use std::{
     fs::File,
     io::{self, BufReader, Read},
-    ops::{Deref, DerefMut},
+    ops::Deref,
 };
 use talpid_types::ErrorExt;
 
@@ -122,8 +125,72 @@ impl SettingsPersister {
         }
     }
 
+    /// Resets default settings
+    #[cfg(not(target_os = "android"))]
+    pub fn reset(&mut self) -> Result<(), Error> {
+        self.settings.reset()
+    }
+
     pub fn to_settings(&self) -> Settings {
         self.settings.clone()
+    }
+
+    /// Changes account number to the one given. Also saves the new settings to disk.
+    /// The boolean in the Result indicates if the account token changed or not
+    pub fn set_account_token(&mut self, account_token: Option<String>) -> Result<bool, Error> {
+        self.settings.set_account_token(account_token)
+    }
+
+    pub fn update_relay_settings(&mut self, update: RelaySettingsUpdate) -> Result<bool, Error> {
+        self.settings.update_relay_settings(update)
+    }
+
+    pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<bool, Error> {
+        self.settings.set_allow_lan(allow_lan)
+    }
+
+    pub fn set_block_when_disconnected(
+        &mut self,
+        block_when_disconnected: bool,
+    ) -> Result<bool, Error> {
+        self.settings
+            .set_block_when_disconnected(block_when_disconnected)
+    }
+
+    pub fn set_auto_connect(&mut self, auto_connect: bool) -> Result<bool, Error> {
+        self.settings.set_auto_connect(auto_connect)
+    }
+
+    pub fn set_openvpn_mssfix(&mut self, openvpn_mssfix: Option<u16>) -> Result<bool, Error> {
+        self.settings.set_openvpn_mssfix(openvpn_mssfix)
+    }
+
+    pub fn set_enable_ipv6(&mut self, enable_ipv6: bool) -> Result<bool, Error> {
+        self.settings.set_enable_ipv6(enable_ipv6)
+    }
+
+    pub fn set_wireguard_mtu(&mut self, mtu: Option<u16>) -> Result<bool, Error> {
+        self.settings.set_wireguard_mtu(mtu)
+    }
+
+    pub fn set_wireguard_rotation_interval(
+        &mut self,
+        automatic_rotation: Option<u32>,
+    ) -> Result<bool, Error> {
+        self.settings
+            .set_wireguard_rotation_interval(automatic_rotation)
+    }
+
+    pub fn set_show_beta_releases(&mut self, enabled: bool) -> Result<bool, Error> {
+        self.settings.set_show_beta_releases(enabled)
+    }
+
+    pub fn set_bridge_settings(&mut self, bridge_settings: BridgeSettings) -> Result<bool, Error> {
+        self.settings.set_bridge_settings(bridge_settings)
+    }
+
+    pub fn set_bridge_state(&mut self, bridge_state: BridgeState) -> Result<bool, Error> {
+        self.settings.set_bridge_state(bridge_state)
     }
 }
 
@@ -132,12 +199,6 @@ impl Deref for SettingsPersister {
 
     fn deref(&self) -> &Self::Target {
         &self.settings
-    }
-}
-
-impl DerefMut for SettingsPersister {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.settings
     }
 }
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -30,14 +30,8 @@ pub struct SettingsPersister {
 
 impl SettingsPersister {
     pub fn load() -> Self {
-        let settings = match Self::load_settings_from_file() {
-            Ok(mut settings) => {
-                // Force IPv6 to be enabled on Android
-                if cfg!(target_os = "android") {
-                    let _ = settings.set_enable_ipv6(true);
-                }
-                settings
-            }
+        let mut settings = match Self::load_settings_from_file() {
+            Ok(settings) => settings,
             #[cfg(windows)]
             Err(LoadSettingsError::FileNotFound) => {
                 if Self::migrate_after_windows_update() {
@@ -61,6 +55,11 @@ impl SettingsPersister {
                 Settings::default()
             }
         };
+
+        // Force IPv6 to be enabled on Android
+        if cfg!(target_os = "android") {
+            let _ = settings.set_enable_ipv6(true);
+        }
 
         SettingsPersister { settings }
     }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -16,8 +16,12 @@ use {
     talpid_core::logging::windows::log_sink,
 };
 
-pub use mullvad_types::settings::Error;
 
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    #[error(display = "Settings operation failed")]
+    SettingsError(#[error(source)] mullvad_types::settings::Error),
+}
 
 #[derive(Debug)]
 enum LoadSettingsError {
@@ -138,59 +142,61 @@ impl SettingsPersister {
     /// Changes account number to the one given. Also saves the new settings to disk.
     /// The boolean in the Result indicates if the account token changed or not
     pub fn set_account_token(&mut self, account_token: Option<String>) -> Result<bool, Error> {
-        self.settings.set_account_token(account_token)
+        Ok(self.settings.set_account_token(account_token)?)
     }
 
     pub fn update_relay_settings(&mut self, update: RelaySettingsUpdate) -> Result<bool, Error> {
-        self.settings.update_relay_settings(update)
+        Ok(self.settings.update_relay_settings(update)?)
     }
 
     pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<bool, Error> {
-        self.settings.set_allow_lan(allow_lan)
+        Ok(self.settings.set_allow_lan(allow_lan)?)
     }
 
     pub fn set_block_when_disconnected(
         &mut self,
         block_when_disconnected: bool,
     ) -> Result<bool, Error> {
-        self.settings
-            .set_block_when_disconnected(block_when_disconnected)
+        Ok(self
+            .settings
+            .set_block_when_disconnected(block_when_disconnected)?)
     }
 
     pub fn set_auto_connect(&mut self, auto_connect: bool) -> Result<bool, Error> {
-        self.settings.set_auto_connect(auto_connect)
+        Ok(self.settings.set_auto_connect(auto_connect)?)
     }
 
     pub fn set_openvpn_mssfix(&mut self, openvpn_mssfix: Option<u16>) -> Result<bool, Error> {
-        self.settings.set_openvpn_mssfix(openvpn_mssfix)
+        Ok(self.settings.set_openvpn_mssfix(openvpn_mssfix)?)
     }
 
     pub fn set_enable_ipv6(&mut self, enable_ipv6: bool) -> Result<bool, Error> {
-        self.settings.set_enable_ipv6(enable_ipv6)
+        Ok(self.settings.set_enable_ipv6(enable_ipv6)?)
     }
 
     pub fn set_wireguard_mtu(&mut self, mtu: Option<u16>) -> Result<bool, Error> {
-        self.settings.set_wireguard_mtu(mtu)
+        Ok(self.settings.set_wireguard_mtu(mtu)?)
     }
 
     pub fn set_wireguard_rotation_interval(
         &mut self,
         automatic_rotation: Option<u32>,
     ) -> Result<bool, Error> {
-        self.settings
-            .set_wireguard_rotation_interval(automatic_rotation)
+        Ok(self
+            .settings
+            .set_wireguard_rotation_interval(automatic_rotation)?)
     }
 
     pub fn set_show_beta_releases(&mut self, enabled: bool) -> Result<bool, Error> {
-        self.settings.set_show_beta_releases(enabled)
+        Ok(self.settings.set_show_beta_releases(enabled)?)
     }
 
     pub fn set_bridge_settings(&mut self, bridge_settings: BridgeSettings) -> Result<bool, Error> {
-        self.settings.set_bridge_settings(bridge_settings)
+        Ok(self.settings.set_bridge_settings(bridge_settings)?)
     }
 
     pub fn set_bridge_state(&mut self, bridge_state: BridgeState) -> Result<bool, Error> {
-        self.settings.set_bridge_state(bridge_state)
+        Ok(self.settings.set_bridge_state(bridge_state)?)
     }
 }
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -179,7 +179,7 @@ impl SettingsPersister {
                 "{}",
                 e.display_chain_with_msg("Unable to save default settings")
             );
-            log::error!("Will attempt to remove settings file");
+            log::info!("Will attempt to remove settings file");
             fs::remove_file(&self.path)
                 .map_err(|e| Error::DeleteError(self.path.display().to_string(), e))
         })

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -797,13 +797,16 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_updateR
 pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemReport_collectReport(
     env: JNIEnv<'_>,
     _: JObject<'_>,
+    logDirectory: JString<'_>,
     outputPath: JString<'_>,
 ) -> jboolean {
     let env = JnixEnv::from(env);
+    let log_dir_string = String::from_java(&env, logDirectory);
+    let log_dir = Path::new(&log_dir_string);
     let output_path_string = String::from_java(&env, outputPath);
     let output_path = Path::new(&output_path_string);
 
-    match mullvad_problem_report::collect_report(&[], output_path, Vec::new()) {
+    match mullvad_problem_report::collect_report(&[], output_path, Vec::new(), log_dir) {
         Ok(()) => JNI_TRUE,
         Err(error) => {
             log::error!(

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -179,6 +179,7 @@ fn spawn_daemon(
         let jvm = android_context.jvm.clone();
         let daemon = Daemon::start(
             Some(resource_dir.clone()),
+            resource_dir.clone(),
             resource_dir,
             cache_dir,
             listener,

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -112,7 +112,7 @@ impl Settings {
                 io::BufReader::new(file)
                     .read_to_end(&mut settings_bytes)
                     .map_err(|e| Error::ReadError("Failed to read settings file".to_owned(), e))?;
-                Self::parse_settings(&mut settings_bytes).or_else(|e| {
+                Self::load_from_bytes(&mut settings_bytes).or_else(|e| {
                     log::error!(
                         "{}",
                         e.display_chain_with_msg("Failed to parse settings file")
@@ -127,6 +127,11 @@ impl Settings {
             Err(e) => Err(Error::ReadError(path.display().to_string(), e)),
         }
     }
+
+    pub fn load_from_bytes(bytes: &[u8]) -> Result<Self> {
+        serde_json::from_slice(bytes).map_err(Error::ParseError)
+    }
+
 
     /// Serializes the settings and saves them to the file it was loaded from.
     fn save(&self) -> Result<()> {
@@ -160,10 +165,6 @@ impl Settings {
     fn get_settings_path() -> Result<PathBuf> {
         let dir = ::mullvad_paths::settings_dir().map_err(Error::DirectoryError)?;
         Ok(dir.join(SETTINGS_FILE))
-    }
-
-    fn parse_settings(bytes: &[u8]) -> Result<Settings> {
-        serde_json::from_slice(bytes).map_err(Error::ParseError)
     }
 
     pub fn get_account_token(&self) -> Option<String> {

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -165,7 +165,7 @@ impl Settings {
         })
     }
 
-    fn get_settings_path() -> Result<PathBuf> {
+    pub fn get_settings_path() -> Result<PathBuf> {
         let dir = ::mullvad_paths::settings_dir().map_err(Error::DirectoryError)?;
         Ok(dir.join(SETTINGS_FILE))
     }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -42,9 +42,6 @@ pub enum Error {
     #[error(display = "Unable to write settings to {}", _0)]
     WriteError(String, #[error(source)] io::Error),
 
-    #[error(display = "Invalid OpenVPN proxy configuration: {}", _0)]
-    InvalidProxyData(String),
-
     #[error(display = "Unable to read any version of the settings")]
     NoMatchingVersion,
 }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -7,7 +7,6 @@ use jnix::IntoJava;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::path::PathBuf;
 use talpid_types::net::{openvpn, wireguard, GenericTunnelOptions};
 
 mod migrations;
@@ -17,17 +16,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
 pub enum Error {
-    #[error(display = "Unable to create settings directory")]
-    DirectoryError(#[error(source)] mullvad_paths::Error),
-
     #[error(display = "Malformed settings")]
     ParseError(#[error(source)] serde_json::Error),
 
     #[error(display = "Unable to read any version of the settings")]
     NoMatchingVersion,
 }
-
-static SETTINGS_FILE: &str = "settings.json";
 
 
 /// Mullvad daemon settings.
@@ -89,11 +83,6 @@ impl Settings {
 
     pub fn migrate_from_bytes(bytes: &[u8]) -> Result<Self> {
         migrations::try_migrate_settings(&bytes)
-    }
-
-    pub fn get_settings_path() -> Result<PathBuf> {
-        let dir = ::mullvad_paths::settings_dir().map_err(Error::DirectoryError)?;
-        Ok(dir.join(SETTINGS_FILE))
     }
 
     pub fn get_account_token(&self) -> Option<String> {

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -58,22 +58,22 @@ pub struct Settings {
     account_token: Option<String>,
     relay_settings: RelaySettings,
     #[cfg_attr(target_os = "android", jnix(skip))]
-    bridge_settings: BridgeSettings,
+    pub bridge_settings: BridgeSettings,
     #[cfg_attr(target_os = "android", jnix(skip))]
     bridge_state: BridgeState,
     /// If the daemon should allow communication with private (LAN) networks.
-    allow_lan: bool,
+    pub allow_lan: bool,
     /// Extra level of kill switch. When this setting is on, the disconnected state will block
     /// the firewall to not allow any traffic in or out.
     #[cfg_attr(target_os = "android", jnix(skip))]
-    block_when_disconnected: bool,
+    pub block_when_disconnected: bool,
     /// If the daemon should connect the VPN tunnel directly on start or not.
-    auto_connect: bool,
+    pub auto_connect: bool,
     /// Options that should be applied to tunnels of a specific type regardless of where the relays
     /// might be located.
-    tunnel_options: TunnelOptions,
+    pub tunnel_options: TunnelOptions,
     /// Whether to notify users of beta updates.
-    show_beta_releases: Option<bool>,
+    pub show_beta_releases: Option<bool>,
     /// Specifies settings schema version
     #[cfg_attr(target_os = "android", jnix(skip))]
     settings_version: migrations::SettingsVersion,
@@ -219,10 +219,6 @@ impl Settings {
         }
     }
 
-    pub fn get_allow_lan(&self) -> bool {
-        self.allow_lan
-    }
-
     pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<bool> {
         if allow_lan != self.allow_lan {
             self.allow_lan = allow_lan;
@@ -232,10 +228,6 @@ impl Settings {
         }
     }
 
-    pub fn get_block_when_disconnected(&self) -> bool {
-        self.block_when_disconnected
-    }
-
     pub fn set_block_when_disconnected(&mut self, block_when_disconnected: bool) -> Result<bool> {
         if block_when_disconnected != self.block_when_disconnected {
             self.block_when_disconnected = block_when_disconnected;
@@ -243,10 +235,6 @@ impl Settings {
         } else {
             Ok(false)
         }
-    }
-
-    pub fn get_auto_connect(&self) -> bool {
-        self.auto_connect
     }
 
     pub fn set_auto_connect(&mut self, auto_connect: bool) -> Result<bool> {
@@ -297,14 +285,6 @@ impl Settings {
         }
     }
 
-    pub fn get_tunnel_options(&self) -> &TunnelOptions {
-        &self.tunnel_options
-    }
-
-    pub fn get_show_beta_releases(&self) -> Option<bool> {
-        self.show_beta_releases.clone()
-    }
-
     pub fn set_show_beta_releases(&mut self, enabled: bool) -> Result<bool> {
         if Some(enabled) != self.show_beta_releases {
             self.show_beta_releases = Some(enabled);
@@ -312,10 +292,6 @@ impl Settings {
         } else {
             Ok(false)
         }
-    }
-
-    pub fn get_bridge_settings(&self) -> &BridgeSettings {
-        &self.bridge_settings
     }
 
     pub fn set_bridge_settings(&mut self, bridge_settings: BridgeSettings) -> Result<bool> {

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -132,6 +132,9 @@ impl Settings {
         serde_json::from_slice(bytes).map_err(Error::ParseError)
     }
 
+    pub fn migrate_from_bytes(bytes: &[u8]) -> Result<Self> {
+        migrations::try_migrate_settings(&bytes)
+    }
 
     /// Serializes the settings and saves them to the file it was loaded from.
     fn save(&self) -> Result<()> {

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -98,7 +98,7 @@ impl Settings {
     }
 
     /// Serializes the settings and saves them to the file it was loaded from.
-    fn save(&self) -> Result<()> {
+    pub fn save(&self) -> Result<()> {
         let path = Self::get_settings_path()?;
 
         debug!("Writing settings to {}", path.display());
@@ -121,7 +121,7 @@ impl Settings {
 
     /// Changes account number to the one given. Also saves the new settings to disk.
     /// The boolean in the Result indicates if the account token changed or not
-    pub fn set_account_token(&mut self, mut account_token: Option<String>) -> Result<bool> {
+    pub fn set_account_token(&mut self, mut account_token: Option<String>) -> bool {
         if account_token.as_ref().map(String::len) == Some(0) {
             debug!("Setting empty account token is treated as unsetting it");
             account_token = None;
@@ -135,9 +135,9 @@ impl Settings {
                 info!("Changing account token")
             }
             self.account_token = account_token;
-            self.save().map(|_| true)
+            true
         } else {
-            Ok(false)
+            false
         }
     }
 
@@ -145,7 +145,7 @@ impl Settings {
         self.relay_settings.clone()
     }
 
-    pub fn update_relay_settings(&mut self, update: RelaySettingsUpdate) -> Result<bool> {
+    pub fn update_relay_settings(&mut self, update: RelaySettingsUpdate) -> bool {
         let update_supports_bridge = update.supports_bridge();
         let new_settings = self.relay_settings.merge(update);
         if self.relay_settings != new_settings {
@@ -158,93 +158,9 @@ impl Settings {
             );
 
             self.relay_settings = new_settings;
-            self.save().map(|_| true)
+            true
         } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<bool> {
-        if allow_lan != self.allow_lan {
-            self.allow_lan = allow_lan;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_block_when_disconnected(&mut self, block_when_disconnected: bool) -> Result<bool> {
-        if block_when_disconnected != self.block_when_disconnected {
-            self.block_when_disconnected = block_when_disconnected;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_auto_connect(&mut self, auto_connect: bool) -> Result<bool> {
-        if auto_connect != self.auto_connect {
-            self.auto_connect = auto_connect;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_openvpn_mssfix(&mut self, openvpn_mssfix: Option<u16>) -> Result<bool> {
-        if self.tunnel_options.openvpn.mssfix != openvpn_mssfix {
-            self.tunnel_options.openvpn.mssfix = openvpn_mssfix;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_enable_ipv6(&mut self, enable_ipv6: bool) -> Result<bool> {
-        if self.tunnel_options.generic.enable_ipv6 != enable_ipv6 {
-            self.tunnel_options.generic.enable_ipv6 = enable_ipv6;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_wireguard_mtu(&mut self, mtu: Option<u16>) -> Result<bool> {
-        if self.tunnel_options.wireguard.mtu != mtu {
-            self.tunnel_options.wireguard.mtu = mtu;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_wireguard_rotation_interval(
-        &mut self,
-        automatic_rotation: Option<u32>,
-    ) -> Result<bool> {
-        if self.tunnel_options.wireguard.automatic_rotation != automatic_rotation {
-            self.tunnel_options.wireguard.automatic_rotation = automatic_rotation;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_show_beta_releases(&mut self, enabled: bool) -> Result<bool> {
-        if Some(enabled) != self.show_beta_releases {
-            self.show_beta_releases = Some(enabled);
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    pub fn set_bridge_settings(&mut self, bridge_settings: BridgeSettings) -> Result<bool> {
-        if self.bridge_settings != bridge_settings {
-            self.bridge_settings = bridge_settings;
-            self.save().map(|_| true)
-        } else {
-            Ok(false)
+            false
         }
     }
 
@@ -252,15 +168,15 @@ impl Settings {
         &self.bridge_state
     }
 
-    pub fn set_bridge_state(&mut self, bridge_state: BridgeState) -> Result<bool> {
+    pub fn set_bridge_state(&mut self, bridge_state: BridgeState) -> bool {
         if self.bridge_state != bridge_state {
             self.bridge_state = bridge_state;
             if self.bridge_state == BridgeState::On {
                 self.relay_settings.ensure_bridge_compatibility();
             }
-            self.save().map(|_| true)
+            true
         } else {
-            Ok(false)
+            false
         }
     }
 }


### PR DESCRIPTION
The app would previously crash on Android if it was installed on an SD card or on a container (using for example Android For Word). This happened because the app relied on hard-coded paths for certain things like the settings file, the relay list file, and the log files.

This PR fixes the issue by using the app's cache directory and the app's files directory (as determined by the Android system).

As part of the change, the `Settings` type was refactored so that the file operations were moved from `mullvad-types` to `mullvad-daemon`, and the settings file path can now be specified through a parameter.

If a settings file is found in the old location, it is moved to the new location before the daemon is started.

Still to be done before sending the PR to review:
- [x] Update the problem report handling to use the correct new log directories
- [x] Delete the old file paths when starting to avoid having duplicates

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1662)
<!-- Reviewable:end -->
