### PR TITLE
Add reload and force reload to macOS application menu in dev mode

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1329,10 +1329,15 @@ class ApplicationMain {
   // On macOS, hotkeys are bound to the app menu and won't work if it's not set,
   // even though the app menu itself is not visible because the app does not appear in the dock.
   private setMacOsAppMenu() {
+    const mullvadVpnSubmenu: Electron.MenuItemConstructorOptions[] = [{ role: 'quit' }];
+    if (process.env.NODE_ENV === 'development') {
+      mullvadVpnSubmenu.unshift({ role: 'reload' }, { role: 'forceReload' });
+    }
+
     const template: Electron.MenuItemConstructorOptions[] = [
       {
         label: 'Mullvad VPN',
-        submenu: [{ role: 'quit' }],
+        submenu: mullvadVpnSubmenu,
       },
       {
         label: 'Edit',


### PR DESCRIPTION
Add option for reloading and forceReloading window in development mode on macOS.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1664)
<!-- Reviewable:end -->
