### PR TITLE
Andriod: change no email confirmation dialog buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Improve offline detection logic.
 
+#### Android
+- Change button colors on problem report no email confirmation dialog to match the desktop version.
+
 ### Security
 #### macOS
 - Ship native Node modules unpacked to prevent malware checks by macOS on each run. The malware

--- a/android/src/main/res/layout/confirm_no_email.xml
+++ b/android/src/main/res/layout/confirm_no_email.xml
@@ -15,9 +15,9 @@
               android:text="@string/confirm_no_email" />
     <Button android:id="@+id/send_button"
             android:text="@string/send_anyway"
-            style="@style/GreenButton" />
+            style="@style/RedButton" />
     <Button android:id="@+id/back_button"
             android:layout_marginTop="16dp"
             android:text="@string/back"
-            style="@style/RedButton" />
+            style="@style/BlueButton" />
 </LinearLayout>


### PR DESCRIPTION
Change the colors of the buttons for the no email confirmation dialog for the problem report fragment to match the colors on desktop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1669)
<!-- Reviewable:end -->
