### PR TITLE
Lower the MTU limit for WireGuard/IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 - Downgrade to Electron 7 due to issues with tray icon in Electron 8.
 
 ### Fixed
+- Enable IPv6 in WireGuard regardless of the specified MTU value, previously IPv6 was disabled if
+  the MTU was below 1380.
+
 #### Windows
 - Improve offline detection logic.
 


### PR DESCRIPTION
When investigating IPv6 issues on MacOS, I noticed that I had to change the MTU to get IPv6 to work, even if it was originally set above the minimum MTU for IPv6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1671)
<!-- Reviewable:end -->
