### PR TITLE
Automatically enable IPv6 interface for TUN/TAP adapter on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,16 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Downgrade to Electron 7 due to issues with tray icon in Electron 8.
 
+#### Windows
+- When required, attempt to enable IPv6 for network adapters instead of failing.
+
 ### Fixed
 - Enable IPv6 in WireGuard regardless of the specified MTU value, previously IPv6 was disabled if
   the MTU was below 1380.
 
 #### Windows
 - Improve offline detection logic.
+- Enable missing IPv6 interface on the WireGuard TUN adapter when it has been disabled.
 
 #### Android
 - Change button colors on problem report no email confirmation dialog to match the desktop version.

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -369,14 +369,6 @@ fn try_enabling_ipv6(tunnel_parameters: &TunnelParameters) -> Result<()> {
 
     let guid = match tunnel_parameters {
         TunnelParameters::OpenVpn(..) => {
-            // TODO: This status check can be removed if it is certain
-            // that `enable_ipv6_for_adapter` is reliable.
-            let status =
-                crate::winnet::get_tap_interface_ipv6_status().map_err(Error::WinnetError)?;
-            if status {
-                return Ok(());
-            }
-
             let alias = crate::winnet::get_tap_interface_alias().map_err(Error::WinnetError)?;
             guid_string =
                 crate::winnet::interface_alias_to_guid(&alias).map_err(Error::WinnetError)?;

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -94,32 +94,6 @@ pub fn enable_ipv6_for_adapter(interface_guid: &str) -> Result<(), Error> {
     }
 }
 
-/// Checks if IPv6 is enabled for the TAP interface
-pub fn get_tap_interface_ipv6_status() -> Result<bool, Error> {
-    // WinNet_GetTapInterfaceIpv6Status() will fail if the alias cannot be retrieved.
-    // Try to retrieve it first so that we may return a more specific error.
-    let _ = get_tap_interface_alias()?;
-    let tap_ipv6_status =
-        unsafe { WinNet_GetTapInterfaceIpv6Status(Some(log_sink), logging_context()) };
-
-    match tap_ipv6_status {
-        // Enabled
-        0 => Ok(true),
-        // Disabled
-        1 => Ok(false),
-        // Failure
-        2 => Err(Error::GetIpv6Status),
-        // Unexpected value
-        i => {
-            log::error!(
-                "Unexpected return code from WinNet_GetTapInterfaceIpv6Status: {}",
-                i
-            );
-            Err(Error::GetIpv6Status)
-        }
-    }
-}
-
 /// Dynamically determines the alias of the TAP adapter.
 pub fn get_tap_interface_alias() -> Result<OsString, Error> {
     let mut alias_ptr: *mut wchar_t = ptr::null_mut();
@@ -442,12 +416,6 @@ mod api {
             sink: Option<LogSink>,
             sink_context: *const u8,
         ) -> bool;
-
-        #[link_name = "WinNet_GetTapInterfaceIpv6Status"]
-        pub fn WinNet_GetTapInterfaceIpv6Status(
-            sink: Option<LogSink>,
-            sink_context: *const u8,
-        ) -> u32;
 
         #[link_name = "WinNet_GetTapInterfaceAlias"]
         pub fn WinNet_GetTapInterfaceAlias(

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -25,6 +25,10 @@ pub enum Error {
     #[error(display = "Failed to enable IPv6 on the network interface")]
     EnableIpv6,
 
+    /// Failed to enable IPv6 on the network interface.
+    #[error(display = "Failed to obtain GUID for the network interface")]
+    GetInterfaceGuid,
+
     /// Failed to read IPv6 status on the TAP network interface.
     #[error(display = "Failed to read IPv6 status on the TAP network interface")]
     GetIpv6Status,
@@ -71,13 +75,13 @@ pub fn ensure_best_metric_for_interface(interface_alias: &str) -> Result<bool, E
 }
 
 /// Enables IPv6 for a given interface.
-pub fn enable_ipv6_for_adapter(interface_alias: &OsStr) -> Result<(), Error> {
-    let interface_alias_ws =
-        WideCString::from_os_str(interface_alias).map_err(Error::InvalidInterfaceAlias)?;
+pub fn enable_ipv6_for_adapter(interface_guid: &str) -> Result<(), Error> {
+    let interface_guid_ws =
+        WideCString::from_str(interface_guid).map_err(Error::InvalidInterfaceAlias)?;
 
     let result = unsafe {
         WinNet_EnableIpv6ForAdapter(
-            interface_alias_ws.as_ptr(),
+            interface_guid_ws.as_ptr(),
             Some(log_sink),
             logging_context(),
         )
@@ -131,6 +135,30 @@ pub fn get_tap_interface_alias() -> Result<OsString, Error> {
     unsafe { WinNet_ReleaseString(alias_ptr) };
 
     Ok(alias.to_os_string())
+}
+
+/// Determines the interface guid for a given adapter alias.
+pub fn interface_alias_to_guid(interface_alias: &OsStr) -> Result<String, Error> {
+    let interface_alias =
+        WideCString::from_os_str(interface_alias).map_err(Error::InvalidInterfaceAlias)?;
+    let mut guid_ptr: *mut wchar_t = ptr::null_mut();
+    let status = unsafe {
+        WinNet_InterfaceAliasToGuid(
+            interface_alias.as_ptr(),
+            &mut guid_ptr as *mut _,
+            Some(log_sink),
+            logging_context(),
+        )
+    };
+
+    if !status {
+        return Err(Error::GetInterfaceGuid);
+    }
+
+    let guid = unsafe { WideCString::from_ptr_str(guid_ptr) };
+    unsafe { WinNet_ReleaseString(guid_ptr) };
+
+    Ok(guid.to_string_lossy())
 }
 
 #[allow(dead_code)]
@@ -424,6 +452,14 @@ mod api {
         #[link_name = "WinNet_GetTapInterfaceAlias"]
         pub fn WinNet_GetTapInterfaceAlias(
             tunnel_interface_alias: *mut *mut wchar_t,
+            sink: Option<LogSink>,
+            sink_context: *const u8,
+        ) -> bool;
+
+        #[link_name = "WinNet_InterfaceAliasToGuid"]
+        pub fn WinNet_InterfaceAliasToGuid(
+            interface_alias: *const wchar_t,
+            interface_guid: *mut *mut wchar_t,
             sink: Option<LogSink>,
             sink_context: *const u8,
         ) -> bool;

--- a/windows/winnet/src/winnet/netconfig.cpp
+++ b/windows/winnet/src/winnet/netconfig.cpp
@@ -1,0 +1,259 @@
+#include "stdafx.h"
+#include "netconfig.h"
+#include <stdexcept>
+#include <sstream>
+#include <windows.h>
+#include <netcfgx.h>
+#include <devguid.h>
+#include <libcommon/error.h>
+#include <libcommon/string.h>
+#include <libcommon/memory.h>
+#include <libshared/network/interfaceutils.h>
+
+
+namespace
+{
+
+const wchar_t NETCFG_LOCK_CLIENT_NAME[] = L"MULLVAD";
+constexpr uint16_t NETCFG_LOCK_TIMEOUT = 5000; // milliseconds
+const wchar_t NETCFG_IPV6_COMPONENT_NAME[] = L"MS_TCPIP6";
+
+void SetIpv6BindingForBindName(INetCfg *netCfg, const std::wstring &bindName, bool enable)
+{
+	INetCfgComponent *transactionComponent = nullptr;
+	HRESULT result = netCfg->FindComponent(NETCFG_IPV6_COMPONENT_NAME, &transactionComponent);
+
+	if (S_OK != result)
+	{
+		THROW_ERROR("Failed to obtain transaction component");
+	}
+
+	INetCfgComponentBindings *bindings = nullptr;
+	result = transactionComponent->QueryInterface(
+		IID_INetCfgComponentBindings,
+		reinterpret_cast<void**>(&bindings)
+	);
+
+	transactionComponent->Release();
+	transactionComponent = nullptr;
+
+	if (S_OK != result)
+	{
+		std::wstringstream ss;
+		ss << L"Failed to obtain component bindings for ";
+		ss << NETCFG_IPV6_COMPONENT_NAME;
+		THROW_ERROR(common::string::ToAnsi(ss.str()).c_str());
+	}
+
+	IEnumNetCfgBindingPath *pathsEnum = NULL;
+	result = bindings->EnumBindingPaths(EBP_BELOW, &pathsEnum);
+
+	bindings->Release();
+	bindings = nullptr;
+
+	if (S_OK != result)
+	{
+		THROW_ERROR("Failed to acquire binding path enumerator");
+	}
+
+	common::memory::ScopeDestructor pathsEnumDestructor;
+	pathsEnumDestructor += [&pathsEnum]() {
+		pathsEnum->Release();
+		pathsEnum = nullptr;
+	};
+
+	INetCfgBindingPath *bindingPath = NULL;
+
+	result = pathsEnum->Next(1, &bindingPath, nullptr);
+
+	for (; S_OK == result; result = pathsEnum->Next(1, &bindingPath, nullptr))
+	{
+		common::memory::ScopeDestructor bindingPathDestructor;
+		bindingPathDestructor += [&bindingPath]() {
+			bindingPath->Release();
+			bindingPath = nullptr;
+		};
+
+		IEnumNetCfgBindingInterface *enumInterface = nullptr;
+		HRESULT enumResult = bindingPath->EnumBindingInterfaces(&enumInterface);
+
+		if (S_OK != enumResult)
+		{
+			THROW_ERROR("Failed to acquire binding path interfaces");
+		}
+
+		common::memory::ScopeDestructor interfaceEnumDestructor;
+		interfaceEnumDestructor += [&enumInterface]() {
+			enumInterface->Release();
+			enumInterface = nullptr;
+		};
+
+		INetCfgBindingInterface *iface = nullptr;
+
+		while (S_OK == enumInterface->Next(1, &iface, nullptr))
+		{
+			INetCfgComponent *cfgComponent = nullptr;
+
+			auto status = iface->GetLowerComponent(&cfgComponent);
+
+			iface->Release();
+			iface = nullptr;
+
+			if (S_OK != status)
+			{
+				THROW_ERROR("Failed to acquire binding interface component");
+			}
+
+			wchar_t *componentBindName = 0;
+
+			status = cfgComponent->GetBindName(&componentBindName);
+
+			cfgComponent->Release();
+			cfgComponent = nullptr;
+
+			if (S_OK != status)
+			{
+				THROW_ERROR("Failed to acquire bind name");
+			}
+
+			bool matchesBindName = (0 == _wcsicmp(bindName.c_str(), componentBindName));
+			CoTaskMemFree(componentBindName);
+
+			if (matchesBindName)
+			{
+				//
+				// Apply the changes and exit the function
+				//
+
+				result = bindingPath->Enable(enable);
+				if (S_OK != result)
+				{
+					THROW_ERROR("Failed to set IPv6 status");
+				}
+				netCfg->Apply();
+
+				return;
+			}
+		}
+	}
+}
+
+std::wstring FindAdapterGuidForAlias(const std::wstring &alias)
+{
+	const auto adapters = shared::network::InterfaceUtils::GetAllAdapters(
+		AF_UNSPEC,
+		GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST
+	);
+	for (auto it = adapters.begin(); it != adapters.end(); ++it)
+	{
+		if (0 == it->alias().compare(alias))
+		{
+			return it->guid();
+		}
+	}
+
+	throw std::runtime_error("Cannot find GUID for given alias");
+}
+
+} // anonymous namespace
+
+
+void EnableIpv6ForAdapter(const std::wstring &alias)
+{
+	std::wstring adapterGuid = FindAdapterGuidForAlias(alias);
+
+	//
+	// Initialize COM
+	//
+
+	HRESULT result = CoInitialize(nullptr);
+
+	if (S_OK != result)
+	{
+		std::stringstream ss;
+		ss << "Failed to initialize COM: " << result;
+		THROW_ERROR(ss.str().c_str());
+	}
+
+	common::memory::ScopeDestructor scopeDest;
+	scopeDest += []() {
+		CoUninitialize();
+	};
+
+	//
+	// Initialize INetCfg
+	//
+
+	INetCfg *netCfg = nullptr;
+	result = CoCreateInstance(
+		CLSID_CNetCfg,
+		nullptr,
+		CLSCTX_INPROC_SERVER,
+		IID_INetCfg,
+		reinterpret_cast<void**>(&netCfg)
+	);
+
+	if (S_OK != result)
+	{
+		std::stringstream ss;
+		ss << "Failed to create INetCfg instance: " << result;
+		THROW_ERROR(ss.str().c_str());
+
+	}
+
+	scopeDest += [&netCfg]() { netCfg->Release(); };
+
+	INetCfgLock *netCfgLock = nullptr;
+	result = netCfg->QueryInterface(IID_INetCfgLock, reinterpret_cast<void**>(&netCfgLock));
+
+	if (S_OK != result)
+	{
+		std::stringstream ss;
+		ss << "Failed to obtain INetCfg lock interface: " << result;
+		THROW_ERROR(ss.str().c_str());
+	}
+
+	scopeDest += [&netCfgLock]() {
+		netCfgLock->Release();
+	};
+
+	wchar_t *blockingApplication = nullptr;
+
+	// NOTE: This should be done before initializing INetCfg
+	result = netCfgLock->AcquireWriteLock(
+		NETCFG_LOCK_TIMEOUT,
+		NETCFG_LOCK_CLIENT_NAME,
+		&blockingApplication
+	);
+
+	if (S_OK != result)
+	{
+		std::wstringstream ss;
+		ss << L"Failed to acquire write lock";
+		if (nullptr != blockingApplication)
+		{
+			ss << L" due to application: " << blockingApplication;
+		}
+		ss << ". (" << result << ")";
+
+		THROW_ERROR(common::string::ToAnsi(ss.str()).c_str());
+	}
+
+	scopeDest += [&]() {
+		CoTaskMemFree(blockingApplication);
+		netCfgLock->ReleaseWriteLock();
+	};
+
+	result = netCfg->Initialize(nullptr);
+
+	if (S_OK != result)
+	{
+		std::stringstream ss;
+		ss << "Failed to initialize INetCfg: " << result;
+		THROW_ERROR(ss.str().c_str());
+	}
+
+	scopeDest += [&netCfg]() { netCfg->Uninitialize(); };
+
+	SetIpv6BindingForBindName(netCfg, adapterGuid, true);
+}

--- a/windows/winnet/src/winnet/netconfig.cpp
+++ b/windows/winnet/src/winnet/netconfig.cpp
@@ -138,30 +138,11 @@ void SetIpv6BindingForBindName(INetCfg *netCfg, const std::wstring &bindName, bo
 	}
 }
 
-std::wstring FindAdapterGuidForAlias(const std::wstring &alias)
-{
-	const auto adapters = shared::network::InterfaceUtils::GetAllAdapters(
-		AF_UNSPEC,
-		GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST
-	);
-	for (auto it = adapters.begin(); it != adapters.end(); ++it)
-	{
-		if (0 == it->alias().compare(alias))
-		{
-			return it->guid();
-		}
-	}
-
-	throw std::runtime_error("Cannot find GUID for given alias");
-}
-
 } // anonymous namespace
 
 
-void EnableIpv6ForAdapter(const std::wstring &alias)
+void EnableIpv6ForAdapter(const std::wstring &adapterGuid)
 {
-	std::wstring adapterGuid = FindAdapterGuidForAlias(alias);
-
 	//
 	// Initialize COM
 	//
@@ -190,7 +171,7 @@ void EnableIpv6ForAdapter(const std::wstring &alias)
 		nullptr,
 		CLSCTX_INPROC_SERVER,
 		IID_INetCfg,
-		reinterpret_cast<void**>(&netCfg)
+		reinterpret_cast<void **>(&netCfg)
 	);
 
 	if (S_OK != result)
@@ -204,7 +185,7 @@ void EnableIpv6ForAdapter(const std::wstring &alias)
 	scopeDest += [&netCfg]() { netCfg->Release(); };
 
 	INetCfgLock *netCfgLock = nullptr;
-	result = netCfg->QueryInterface(IID_INetCfgLock, reinterpret_cast<void**>(&netCfgLock));
+	result = netCfg->QueryInterface(IID_INetCfgLock, reinterpret_cast<void **>(&netCfgLock));
 
 	if (S_OK != result)
 	{

--- a/windows/winnet/src/winnet/netconfig.h
+++ b/windows/winnet/src/winnet/netconfig.h
@@ -2,4 +2,4 @@
 
 #include <string>
 
-void EnableIpv6ForAdapter(const std::wstring &alias);
+void EnableIpv6ForAdapter(const std::wstring &guid);

--- a/windows/winnet/src/winnet/netconfig.h
+++ b/windows/winnet/src/winnet/netconfig.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+void EnableIpv6ForAdapter(const std::wstring &alias);

--- a/windows/winnet/src/winnet/winnet.cpp
+++ b/windows/winnet/src/winnet/winnet.cpp
@@ -94,47 +94,6 @@ WinNet_EnableIpv6ForAdapter(
 
 extern "C"
 WINNET_LINKAGE
-WINNET_GTII_STATUS
-WINNET_API
-WinNet_GetTapInterfaceIpv6Status(
-	MullvadLogSink logSink,
-	void *logSinkContext
-)
-{
-	try
-	{
-		MIB_IPINTERFACE_ROW iface = { 0 };
-
-		iface.InterfaceLuid = NetworkInterfaces::GetInterfaceLuid(InterfaceUtils::GetTapInterfaceAlias());
-		iface.Family = AF_INET6;
-
-		const auto status = GetIpInterfaceEntry(&iface);
-
-		if (NO_ERROR == status)
-		{
-			return WINNET_GTII_STATUS_ENABLED;
-		}
-
-		if (ERROR_NOT_FOUND == status)
-		{
-			return WINNET_GTII_STATUS_DISABLED;
-		}
-
-		THROW_WINDOWS_ERROR(status, "Resolve TAP IPv6 interface");
-	}
-	catch (const std::exception &err)
-	{
-		shared::logging::UnwindAndLog(logSink, logSinkContext, err);
-		return WINNET_GTII_STATUS_FAILURE;
-	}
-	catch (...)
-	{
-		return WINNET_GTII_STATUS_FAILURE;
-	}
-}
-
-extern "C"
-WINNET_LINKAGE
 bool
 WINNET_API
 WinNet_GetTapInterfaceAlias(

--- a/windows/winnet/src/winnet/winnet.cpp
+++ b/windows/winnet/src/winnet/winnet.cpp
@@ -4,6 +4,7 @@
 #include "offlinemonitor.h"
 #include "routing/routemanager.h"
 #include "converters.h"
+#include "netconfig.h"
 #include <libshared/logging/logsinkadapter.h>
 #include <libshared/logging/unwind.h>
 #include <libshared/network/interfaceutils.h>
@@ -62,6 +63,34 @@ WinNet_EnsureBestMetric(
 		return WINNET_EBM_STATUS_FAILURE;
 	}
 };
+
+extern "C"
+WINNET_LINKAGE
+bool
+WINNET_API
+WinNet_EnableIpv6ForAdapter(
+	const wchar_t *deviceAlias,
+	MullvadLogSink logSink,
+	void *logSinkContext
+)
+{
+	try
+	{
+		if (nullptr == deviceAlias)
+		{
+			THROW_ERROR("Invalid argument: deviceAlias");
+		}
+
+		EnableIpv6ForAdapter(deviceAlias);
+		return true;
+	}
+	catch (const std::exception & err)
+	{
+		shared::logging::UnwindAndLog(logSink, logSinkContext, err);
+		return false;
+	}
+	return false;
+}
 
 extern "C"
 WINNET_LINKAGE

--- a/windows/winnet/src/winnet/winnet.def
+++ b/windows/winnet/src/winnet/winnet.def
@@ -3,7 +3,6 @@ EXPORTS
 	WinNet_EnsureBestMetric
 	WinNet_InterfaceAliasToGuid
 	WinNet_EnableIpv6ForAdapter
-	WinNet_GetTapInterfaceIpv6Status
 	WinNet_GetTapInterfaceAlias
 	WinNet_ReleaseString
 	WinNet_ActivateConnectivityMonitor

--- a/windows/winnet/src/winnet/winnet.def
+++ b/windows/winnet/src/winnet/winnet.def
@@ -1,6 +1,7 @@
 LIBRARY winnet
 EXPORTS
 	WinNet_EnsureBestMetric
+	WinNet_EnableIpv6ForAdapter
 	WinNet_GetTapInterfaceIpv6Status
 	WinNet_GetTapInterfaceAlias
 	WinNet_ReleaseString

--- a/windows/winnet/src/winnet/winnet.def
+++ b/windows/winnet/src/winnet/winnet.def
@@ -1,6 +1,7 @@
 LIBRARY winnet
 EXPORTS
 	WinNet_EnsureBestMetric
+	WinNet_InterfaceAliasToGuid
 	WinNet_EnableIpv6ForAdapter
 	WinNet_GetTapInterfaceIpv6Status
 	WinNet_GetTapInterfaceAlias

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -33,6 +33,16 @@ WinNet_EnsureBestMetric(
 	void *logSinkContext
 );
 
+extern "C"
+WINNET_LINKAGE
+bool
+WINNET_API
+WinNet_EnableIpv6ForAdapter(
+	const wchar_t *deviceAlias,
+	MullvadLogSink logSink,
+	void *logSinkContext
+);
+
 enum WINNET_GTII_STATUS
 {
 	WINNET_GTII_STATUS_ENABLED = 0,

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -38,7 +38,7 @@ WINNET_LINKAGE
 bool
 WINNET_API
 WinNet_EnableIpv6ForAdapter(
-	const wchar_t *deviceAlias,
+	const wchar_t *deviceGuid,
 	MullvadLogSink logSink,
 	void *logSinkContext
 );
@@ -65,6 +65,17 @@ bool
 WINNET_API
 WinNet_GetTapInterfaceAlias(
 	wchar_t **alias,
+	MullvadLogSink logSink,
+	void *logSinkContext
+);
+
+extern "C"
+WINNET_LINKAGE
+bool
+WINNET_API
+WinNet_InterfaceAliasToGuid(
+	const wchar_t *alias,
+	wchar_t **guid,
 	MullvadLogSink logSink,
 	void *logSinkContext
 );

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -43,22 +43,6 @@ WinNet_EnableIpv6ForAdapter(
 	void *logSinkContext
 );
 
-enum WINNET_GTII_STATUS
-{
-	WINNET_GTII_STATUS_ENABLED = 0,
-	WINNET_GTII_STATUS_DISABLED = 1,
-	WINNET_GTII_STATUS_FAILURE = 2,
-};
-
-extern "C"
-WINNET_LINKAGE
-WINNET_GTII_STATUS
-WINNET_API
-WinNet_GetTapInterfaceIpv6Status(
-	MullvadLogSink logSink,
-	void *logSinkContext
-);
-
 extern "C"
 WINNET_LINKAGE
 bool

--- a/windows/winnet/src/winnet/winnet.vcxproj
+++ b/windows/winnet/src/winnet/winnet.vcxproj
@@ -28,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="converters.cpp" />
+    <ClCompile Include="netconfig.cpp" />
     <ClCompile Include="networkadaptermonitor.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="InterfacePair.cpp" />
@@ -42,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="converters.h" />
+    <ClInclude Include="netconfig.h" />
     <ClInclude Include="networkadaptermonitor.h" />
     <ClInclude Include="InterfacePair.h" />
     <ClInclude Include="offlinemonitor.h" />

--- a/windows/winnet/src/winnet/winnet.vcxproj.filters
+++ b/windows/winnet/src/winnet/winnet.vcxproj.filters
@@ -21,6 +21,7 @@
       <Filter>routing</Filter>
     </ClCompile>
     <ClCompile Include="converters.cpp" />
+    <ClCompile Include="netconfig.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -43,6 +44,7 @@
       <Filter>routing</Filter>
     </ClInclude>
     <ClInclude Include="converters.h" />
+    <ClInclude Include="netconfig.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="winnet.def" />


### PR DESCRIPTION
The changes are intended to address a couple of things:
* Currently when IPv6 is enabled in the app (i.e., in the tunnel), it fails to connect if no IPv6 interface is available for the network adapter itself. Now we try to enable it before connecting.
* It's not possible to connect using WireGuard if the IPv6 interface is disabled for the adapter, even using only IPv4. The updates work around the issue by *always* attempting to enable the IPv6 interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1676)
<!-- Reviewable:end -->
