### PR TITLE
Respect includeInCountry when handling country constraints

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -24,6 +24,11 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Fixed
+- Fix relay selection for country wide constraints by respecting the `include_in_country` 
+  parameter.
+
+## [2020.2] - 2020-04-16
+### Fixed
 - Fix "invalid account" error that was mistakenly reported as "network error" during log in.
 - Fix parsing of pre-formatted account numbers when pasting from pasteboard on login screen.
 

--- a/ios/MullvadVPN/RelaySelector.swift
+++ b/ios/MullvadVPN/RelaySelector.swift
@@ -74,7 +74,8 @@ struct RelaySelector {
             case .only(let relayConstraint):
                 switch relayConstraint {
                 case .country(let countryCode):
-                    return relayWithLocation.location.countryCode == countryCode
+                    return relayWithLocation.location.countryCode == countryCode &&
+                        relayWithLocation.relay.includeInCountry
 
                 case .city(let countryCode, let cityCode):
                     return relayWithLocation.location.countryCode == countryCode &&


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

If user has `country` constraint set, then servers with `include_in_country: false` should be ignored. This PR fixes this omission in relay selector logic.

Rust source: https://github.com/mullvad/mullvadvpn-app/blob/2489837d85d914852cc0740987d9b6ab4f26d256/mullvad-daemon/src/relays.rs#L544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1678)
<!-- Reviewable:end -->
