### PR TITLE
Fix traffic leak when the app starts with "Auto-Connect" enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Line wrap the file at 100 chars.                                              Th
   checks delayed app startup when "block when disconnected" was enabled and performed system network
   requests to Apple.
 
+#### Android
+- Fix failure to create tunnel when app is started with auto-connect enabled. This would sometimes
+  lead to a traffic leak.
+
 
 ## [2020.4-beta2] - 2020-04-08
 ### Added

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
@@ -193,13 +193,19 @@ class NotificationBanner(
                     }
                 }
             }
+            is ErrorStateCause.VpnPermissionDenied -> R.string.vpn_permission_denied_error
         }
 
         // if the error state is null, we can assume that we are secure
         if (errorState?.isBlocking ?: true) {
             showError(R.string.blocking_internet, messageText)
         } else {
-            showError(R.string.not_blocking_internet, R.string.failed_to_block_internet)
+            val updatedMessageText = when (cause) {
+                is ErrorStateCause.VpnPermissionDenied -> messageText
+                else -> R.string.failed_to_block_internet
+            }
+
+            showError(R.string.not_blocking_internet, updatedMessageText)
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -20,7 +20,7 @@ open class TalpidVpnService : VpnService() {
     fun createTun(config: TunConfig): Int {
         if (VpnService.prepare(this) != null) {
             // VPN permission wasn't granted
-            return 0
+            return -1
         }
 
         val builder = Builder().apply {

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -18,6 +18,11 @@ open class TalpidVpnService : VpnService() {
     }
 
     fun createTun(config: TunConfig): Int {
+        if (VpnService.prepare(this) != null) {
+            // VPN permission wasn't granted
+            return 0
+        }
+
         val builder = Builder().apply {
             for (address in config.addresses) {
                 addAddress(address, prefixForAddress(address))

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
@@ -9,4 +9,5 @@ sealed class ErrorStateCause {
     class TunnelParameterError(val error: ParameterGenerationError) : ErrorStateCause()
     class IsOffline : ErrorStateCause()
     class TapAdapterProblem : ErrorStateCause()
+    class VpnPermissionDenied : ErrorStateCause()
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -120,6 +120,9 @@
     server</string>
     <string name="start_tunnel_error">Failed to start tunnel
     connection</string>
+    <string name="vpn_permission_denied_error">VPN permission was
+    denied when creating the tunnel. Please try connecting
+    again.</string>
     <string name="no_matching_relay">No relay server matches the
     current settings</string>
     <string name="no_matching_bridge_relay">No bridge relay server

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -54,6 +54,7 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/talpid/tunnel/ErrorStateCause$TunnelParameterError",
     "net/mullvad/talpid/tunnel/ErrorStateCause$IsOffline",
     "net/mullvad/talpid/tunnel/ErrorStateCause$TapAdapterProblem",
+    "net/mullvad/talpid/tunnel/ErrorStateCause$VpnPermissionDenied",
     "net/mullvad/talpid/tunnel/ParameterGenerationError",
     "net/mullvad/talpid/ConnectivityListener",
     "net/mullvad/talpid/TalpidVpnService",

--- a/talpid-core/src/tunnel/tun_provider/android/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/android/mod.rs
@@ -63,6 +63,9 @@ pub enum Error {
 
     #[error(display = "Failed to create tunnel device")]
     TunnelDeviceError,
+
+    #[error(display = "Permission denied when trying to create tunnel")]
+    PermissionDenied,
 }
 
 /// Factory of tunnel devices on Android.
@@ -338,6 +341,7 @@ impl AndroidTunProvider {
 
         match result {
             JValue::Int(0) => Err(Error::TunnelDeviceError),
+            JValue::Int(-1) => Err(Error::PermissionDenied),
             JValue::Int(fd) => {
                 Self::wait_for_tunnel_up(fd, &config)?;
                 let tun = unsafe { File::from_raw_fd(fd) };

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -27,6 +27,9 @@ use talpid_types::{
 };
 
 #[cfg(target_os = "android")]
+use crate::tunnel::tun_provider;
+
+#[cfg(target_os = "android")]
 const MAX_ATTEMPTS_WITH_SAME_TUN: u32 = 5;
 const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
 
@@ -395,6 +398,14 @@ impl TunnelState for ConnectingState {
                                     | tunnel::Error::WinnetError(
                                         crate::winnet::Error::GetTapAlias,
                                     ) => ErrorStateCause::TapAdapterProblem,
+                                    #[cfg(target_os = "android")]
+                                    tunnel::Error::WireguardTunnelMonitoringError(
+                                        tunnel::wireguard::Error::TunnelError(
+                                            tunnel::wireguard::TunnelError::SetupTunnelDeviceError(
+                                                tun_provider::Error::PermissionDenied,
+                                            ),
+                                        ),
+                                    ) => ErrorStateCause::VpnPermissionDenied,
                                     _ => ErrorStateCause::StartTunnelError,
                                 };
                                 ErrorState::enter(shared_values, block_reason)

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -85,6 +85,9 @@ pub enum ErrorStateCause {
     IsOffline,
     /// A problem with the TAP adapter has been detected.
     TapAdapterProblem,
+    /// The Android VPN permission was denied.
+    #[cfg(target_os = "android")]
+    VpnPermissionDenied,
 }
 
 /// Errors that can occur when generating tunnel parameters.
@@ -130,6 +133,8 @@ impl fmt::Display for ErrorStateCause {
             }
             IsOffline => "This device is offline, no tunnels can be established",
             TapAdapterProblem => "A problem with the TAP adapter has been detected",
+            #[cfg(target_os = "android")]
+            VpnPermissionDenied => "The Android VPN permission was denied when creating the tunnel",
         };
 
         write!(f, "{}", description)


### PR DESCRIPTION
Sometimes, when the app started with the "Auto-Connect" setting enabled, it would fail to create the tunnel device and enter the non-blocking error state. This happened because the `VpnService.prepare()` method wasn't called before trying to create the tunnel.

This is usually not an issue because the `MainActivity` will use the `ConnectionProxy` to connect, which does call `VpnService.prepare()` before sending a `connect` command to the daemon. However, if the daemon decides to connect by itself (like when the "Auto-Connect" setting is enabled), the method isn't called.

This PR fixes the issue by always calling `VpnService.prepare` when connecting. This means it does get called twice when connecting, but if the permission is already granted the calls just return `null`. However, if the permission isn't granted, then the code will now return a new error to indicate that the permission was denied. This new error is used to show a more specific error message in the notification banner.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1680)
<!-- Reviewable:end -->
