### PR TITLE
Clarify "Block when disconnected" setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 - Use rustls instead of OpenSSL for TLS encryption to the API and GeoIP location service.
 - Move location of the account data (including the WireGuard keys), so that it isn't lost when the
   system cache is cleaned.
+- Rename "Block when disconnected" setting to "Always require VPN" and add additional explanation of the setting.
 
 #### Windows
 - When required, attempt to enable IPv6 for network adapters instead of failing.

--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -210,7 +210,7 @@ export default class ExpiredAccountErrorView extends Component<
         <Text style={styles.fieldLabel}>
           {messages.pgettext(
             'connect-view',
-            'You need to disable “Block when disconnected” in order to access the Internet to add time.',
+            'You need to disable “Always require VPN” in order to access the Internet to add time.',
           )}
         </Text>
         <Text style={styles.fieldLabel}>
@@ -220,7 +220,7 @@ export default class ExpiredAccountErrorView extends Component<
           )}
         </Text>
         <Cell.Container>
-          <Cell.Label>{messages.pgettext('connect-view', 'Block when disconnected')}</Cell.Label>
+          <Cell.Label>{messages.pgettext('connect-view', 'Always require VPN')}</Cell.Label>
           <Cell.Switch
             isOn={this.props.blockWhenDisconnected}
             onChange={this.props.setBlockWhenDisconnected}

--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -10,8 +10,9 @@ const styles = {
   modalAlertBackground: Styles.createViewStyle({
     flex: 1,
     justifyContent: 'center',
-    paddingLeft: 14,
-    paddingRight: 14,
+    paddingHorizontal: 14,
+    paddingTop: 26,
+    paddingBottom: 14,
   }),
   modalAlert: Styles.createViewStyle({
     backgroundColor: colors.darkBlue,
@@ -20,15 +21,15 @@ const styles = {
   }),
   modalAlertIcon: Styles.createViewStyle({
     alignItems: 'center',
-    marginBottom: 12,
-    marginTop: 4,
+    marginTop: 8,
   }),
   modalAlertMessage: Styles.createTextStyle({
     fontFamily: 'Open Sans',
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: '500',
     lineHeight: 20,
     color: colors.white80,
+    marginTop: 16,
   }),
   modalAlertButtonContainer: Styles.createViewStyle({
     marginTop: 16,
@@ -136,9 +137,7 @@ export class ModalAlert extends Component<IModalAlertProps> {
             {this.props.type && (
               <View style={styles.modalAlertIcon}>{this.renderTypeIcon(this.props.type)}</View>
             )}
-            {this.props.message && (
-              <Text style={styles.modalAlertMessage}>{this.props.message}</Text>
-            )}
+            {this.props.message && <ModalMessage>{this.props.message}</ModalMessage>}
             {this.props.children}
             {this.props.buttons.map((button, index) => (
               <View key={index} style={styles.modalAlertButtonContainer}>
@@ -166,4 +165,12 @@ export class ModalAlert extends Component<IModalAlertProps> {
     }
     return <ImageView height={44} width={44} source={source} tintColor={color} />;
   }
+}
+
+interface IModalMessageProps {
+  children?: string;
+}
+
+export function ModalMessage(props: IModalMessageProps) {
+  return <Text style={styles.modalAlertMessage}>{props.children}</Text>;
 }

--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { Component, Styles, Text, View } from 'reactxp';
 import { colors } from '../../config.json';
+import { Scheduler } from '../../shared/scheduler';
 import ImageView from './ImageView';
 
 const MODAL_CONTAINER_ID = 'modalContainer';
@@ -108,18 +109,27 @@ interface IModalAlertProps {
 export class ModalAlert extends Component<IModalAlertProps> {
   private element = document.createElement('div');
   private modalContainer?: Element;
+  private appendScheduler = new Scheduler();
 
   public componentDidMount() {
     const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
     if (modalContainer) {
       this.modalContainer = modalContainer;
-      modalContainer.appendChild(this.element);
+
+      // Mounting the container element immediately results in a graphical issue with the dialog
+      // first rendering with the wrong proportions and then changing to the correct proportions.
+      // Postponing it to the next event cycle solves this issue.
+      this.appendScheduler.schedule(() => {
+        modalContainer.appendChild(this.element);
+      });
     } else {
       throw Error('Modal container not found when mounting modal');
     }
   }
 
   public componentWillUnmount() {
+    this.appendScheduler.cancel();
+
     if (this.modalContainer) {
       this.modalContainer.removeChild(this.element);
     }

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -154,7 +154,7 @@ export default class NotificationArea extends Component<IProps, State> {
           return {
             visible: true,
             type: 'blocking',
-            reason: '',
+            reason: messages.pgettext('in-app-notifications', '“Always require VPN” is enabled.'),
           };
         }
       // fallthrough

--- a/gui/src/shared/scheduler.ts
+++ b/gui/src/shared/scheduler.ts
@@ -1,7 +1,7 @@
 export class Scheduler {
   private timer?: NodeJS.Timeout;
 
-  public schedule(action: () => void, delay: number) {
+  public schedule(action: () => void, delay = 0) {
     this.cancel();
     this.timer = global.setTimeout(action, delay);
   }

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -5,7 +5,7 @@ pub struct BlockWhenDisconnected;
 
 impl Command for BlockWhenDisconnected {
     fn name(&self) -> &'static str {
-        "block-when-disconnected"
+        "always-require-vpn"
     }
 
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
@@ -14,7 +14,7 @@ impl Command for BlockWhenDisconnected {
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
                 clap::SubCommand::with_name("set")
-                    .about("Change the block when disconnected setting")
+                    .about("Change the always require VPN setting")
                     .arg(
                         clap::Arg::with_name("policy")
                             .required(true)
@@ -23,7 +23,7 @@ impl Command for BlockWhenDisconnected {
             )
             .subcommand(
                 clap::SubCommand::with_name("get")
-                    .about("Display the current block when disconnected setting"),
+                    .about("Display the current always require VPN setting"),
             )
     }
 
@@ -43,7 +43,7 @@ impl BlockWhenDisconnected {
     fn set(&self, block_when_disconnected: bool) -> Result<()> {
         let mut rpc = new_rpc_client()?;
         rpc.set_block_when_disconnected(block_when_disconnected)?;
-        println!("Changed block when disconnected setting");
+        println!("Changed always require VPN setting");
         Ok(())
     }
 


### PR DESCRIPTION
This PR aims to clarify the "Block when disconnected" setting, this is accomplished by:
1. Rename the setting to "Always require VPN"
2. Change the text below the setting in the Advanced Settings view
3. Add a confirmation dialog when enabling the setting which further explains it
4. Add an explanation to the in app notification when internet is blocked due to this setting

The setting should be renamed in all user facing texts but not in in the code.

When pressing the setting it is first enabled when the confirmation dialog appears and if the user presses "Enable anyway" the settings is left on and if the user presses "Back" it is disabled. Let me know if we want to wait with enabling it until after the confirmation.

This PR also includes added support for multiple messages in `Modal.tsx` and an added delay for appending the alert to avoid size flickering when opening a modal.

<img width="366" alt="Screen Shot 2020-04-27 at 10 16 14" src="https://user-images.githubusercontent.com/3668602/80378135-807a5d00-889c-11ea-92ed-bafc1db511a1.png">
<img width="366" alt="Screen Shot 2020-04-27 at 10 16 23" src="https://user-images.githubusercontent.com/3668602/80378149-86703e00-889c-11ea-9dc1-b8e40a9e7daa.png">
<img width="366" alt="Screen Shot 2020-04-27 at 10 16 40" src="https://user-images.githubusercontent.com/3668602/80378157-883a0180-889c-11ea-93e5-a15c07c0dbf2.png">

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1682)
<!-- Reviewable:end -->
