### PR TITLE
Support different routing tables in the route manager on Linux

### DIFF
--- a/talpid-core/src/routing/android.rs
+++ b/talpid-core/src/routing/android.rs
@@ -1,6 +1,6 @@
+use crate::routing::RequiredRoute;
 use futures01::{sync::oneshot, Async, Future};
-use ipnetwork::IpNetwork;
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 /// Stub error type for routing errors on Android.
 #[derive(Debug, err_derive::Error)]
@@ -14,7 +14,7 @@ pub struct RouteManagerImpl {
 
 impl RouteManagerImpl {
     pub fn new(
-        _required_routes: HashMap<IpNetwork, super::NetNode>,
+        _required_routes: HashSet<RequiredRoute>,
         shutdown_rx: oneshot::Receiver<oneshot::Sender<()>>,
     ) -> Result<Self, Error> {
         Ok(RouteManagerImpl { shutdown_rx })

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -39,34 +39,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
 pub enum Error {
-    /// Failed to add route.
-    #[error(display = "Failed to add route")]
-    FailedToAddRoute(#[error(source)] io::Error),
-
-    /// Failed to remove route.
-    #[error(display = "Failed to remove route")]
-    FailedToRemoveRoute(#[error(source)] io::Error),
-
-    /// Error while running "ip route".
-    #[error(display = "Error while running \"ip route\"")]
-    FailedToRunIp(#[error(source)] io::Error),
-
-    /// Invocation of `ip route` ended with a non-zero exit code
-    #[error(display = "ip returend a non-zero exit code")]
-    ErrorIpFailed,
-
-    /// Received unexpected output from `ip route`
-    #[error(display = "Received unexpected output from \"ip\"")]
-    UnexpectedOutput,
-
-    /// No default route exists
-    #[error(display = "No default route in \"ip route\" output")]
-    NoDefaultRoute,
-
-    /// Route table change stream failed.
-    #[error(display = "Route change listener failed")]
-    NetlinkConnectionError(#[error(source)] failure::Compat<rtnetlink::Error>),
-
     #[error(display = "Failed to open a netlink connection")]
     ConnectError(#[error(source)] io::Error),
 

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -64,6 +64,8 @@ impl fmt::Display for Route {
 pub struct RequiredRoute {
     prefix: IpNetwork,
     node: NetNode,
+    #[cfg(target_os = "linux")]
+    table_id: u8,
 }
 
 impl RequiredRoute {
@@ -72,7 +74,16 @@ impl RequiredRoute {
         Self {
             node: node.into(),
             prefix,
+            #[cfg(target_os = "linux")]
+            table_id: RT_TABLE_MAIN,
         }
+    }
+
+    /// Sets the routing table ID of the route.
+    #[cfg(target_os = "linux")]
+    pub fn table(mut self, new_id: u8) -> Self {
+        self.table_id = new_id;
+        self
     }
 }
 

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -1,10 +1,9 @@
 #![cfg_attr(target_os = "android", allow(dead_code))]
 #![cfg_attr(target_os = "windows", allow(dead_code))]
 // TODO: remove the allow(dead_code) for android once it's up to scratch.
-use super::NetNode;
+use super::RequiredRoute;
 use futures01::{sync::oneshot, Future};
-use ipnetwork::IpNetwork;
-use std::{collections::HashMap, sync::mpsc::sync_channel};
+use std::{collections::HashSet, sync::mpsc::sync_channel};
 
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]
@@ -43,9 +42,9 @@ pub struct RouteManager {
 
 impl RouteManager {
     /// Constructs a RouteManager and applies the required routes.
-    /// Takes a map of network destinations and network nodes as an argument, and applies said
+    /// Takes a set of network destinations and network nodes as an argument, and applies said
     /// routes.
-    pub fn new(required_routes: HashMap<IpNetwork, NetNode>) -> Result<Self, Error> {
+    pub fn new(required_routes: HashSet<RequiredRoute>) -> Result<Self, Error> {
         let (tx, rx) = oneshot::channel();
         let (start_tx, start_rx) = sync_channel(1);
 


### PR DESCRIPTION
Changes:
* Track routes in tables other the main table in `RouteManager`.
* Explicitly remove default routes when the route manager is destroyed (necessary when they aren't routed through a tunnel interface).
* Replace `HashMap<IpNetwork, super::NetNode>` with `HashSet<RequiredRoute>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1683)
<!-- Reviewable:end -->
