### PR TITLE
Find all default routes in RouteManager

### DIFF
--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -225,7 +225,7 @@ impl RouteManagerImplInner {
     async fn get_default_routes_inner(&self, version: IpVersion) -> Result<HashSet<Route>> {
         let mut routes = HashSet::new();
         let mut route_request = self.handle.route().get(version).execute();
-        if let Some(route) = route_request
+        while let Some(route) = route_request
             .try_next()
             .await
             .map_err(failure::Fail::compat)
@@ -236,7 +236,7 @@ impl RouteManagerImplInner {
                     routes.insert(default_route);
                 }
             }
-        };
+        }
         Ok(routes)
     }
 


### PR DESCRIPTION
I noticed that the daemon would sometimes not identify the default routes, so that I could not connect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1684)
<!-- Reviewable:end -->
