### PR TITLE
Implement creating a new account from the Android app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add shell completions for the mullvad CLI.
 
+#### Android
+- Add possibility to create account from the login screen.
+
 ### Changed
 - Downgrade to Electron 7 due to issues with tray icon in Electron 8.
 - Use rustls instead of OpenSSL for TLS encryption to the API and GeoIP location service.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -33,6 +33,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         connect(daemonInterfaceAddress)
     }
 
+    fun createNewAccount(): String? {
+        return createNewAccount(daemonInterfaceAddress)
+    }
+
     fun disconnect() {
         disconnect(daemonInterfaceAddress)
     }
@@ -121,6 +125,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     private external fun deinitialize()
 
     private external fun connect(daemonInterfaceAddress: Long)
+    private external fun createNewAccount(daemonInterfaceAddress: Long): String?
     private external fun disconnect(daemonInterfaceAddress: Long)
     private external fun generateWireguardKey(daemonInterfaceAddress: Long): KeygenEvent?
     private external fun getAccountData(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
+import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.util.JobTracker
 
 class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
@@ -45,7 +46,8 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         accountInput = AccountInput(view, parentActivity.resources)
         accountInput.onLogin = { accountToken -> login(accountToken) }
 
-        view.findViewById<View>(R.id.create_account).setOnClickListener { createAccount() }
+        view.findViewById<Button>(R.id.create_account)
+            .setOnClickAction("createAccount", jobTracker) { createAccount() }
 
         fetchHistory()
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/JobTracker.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/JobTracker.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.util
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
 class JobTracker {
@@ -47,6 +48,14 @@ class JobTracker {
 
     fun newUiJob(name: String, jobBody: suspend () -> Unit): Long {
         return newJob(name, GlobalScope.launch(Dispatchers.Main) { jobBody() })
+    }
+
+    suspend fun <T> runOnBackground(jobBody: suspend () -> T): T {
+        val job = GlobalScope.async(Dispatchers.Default) { jobBody() }
+
+        newJob(job)
+
+        return job.await()
     }
 
     fun cancelJob(name: String) {

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -1,4 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:mullvad="http://schemas.android.com/apk/res-auto"
               android:id="@+id/main_fragment"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
@@ -139,12 +140,10 @@
                   android:textColor="@color/white80"
                   android:textSize="13sp"
                   android:text="@string/dont_have_an_account" />
-        <Button android:id="@+id/create_account"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="9dp"
-                android:drawableRight="@drawable/icon_extlink"
-                android:text="@string/create_account"
-                style="@style/BlueButton" />
+        <net.mullvad.mullvadvpn.ui.widget.Button android:id="@+id/create_account"
+                                                 android:layout_width="match_parent"
+                                                 android:layout_height="wrap_content"
+                                                 mullvad:buttonColor="blue"
+                                                 mullvad:text="@string/create_account" />
     </LinearLayout>
 </LinearLayout>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="dont_have_an_account">Don\'t have an account
     number?</string>
     <string name="create_account">Create account</string>
+    <string name="creating_new_account">Creating new account</string>
+    <string name="failed_to_create_account">Failed to create account</string>
+    <string name="account_created">Account created</string>
     <string name="settings">Settings</string>
     <string name="settings_account">Account</string>
     <string name="less_than_a_day_left">less than a day

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -47,6 +47,16 @@ impl DaemonInterface {
         Ok(())
     }
 
+    pub fn create_new_account(&self) -> Result<String> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(DaemonCommand::CreateNewAccount(tx))?;
+
+        rx.wait()
+            .map_err(|_| Error::NoResponse)?
+            .map_err(Error::RpcError)
+    }
+
     pub fn disconnect(&self) -> Result<()> {
         let (tx, rx) = oneshot::channel();
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -328,6 +328,31 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_connect
 
 #[no_mangle]
 #[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_createNewAccount<'env>(
+    env: JNIEnv<'env>,
+    _: JObject<'_>,
+    daemon_interface_address: jlong,
+) -> JObject<'env> {
+    let env = JnixEnv::from(env);
+
+    if let Some(daemon_interface) = get_daemon_interface(daemon_interface_address) {
+        match daemon_interface.create_new_account() {
+            Ok(account) => account.into_java(&env).forget(),
+            Err(err) => {
+                log::error!(
+                    "{}",
+                    err.display_chain_with_msg("Failed to create new account")
+                );
+                JObject::null()
+            }
+        }
+    } else {
+        JObject::null()
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_disconnect(
     _: JNIEnv<'_>,
     _: JObject<'_>,


### PR DESCRIPTION
Previously, the `Create account` button on the login screen would open the web browser in order to create an account. This PR changes that so that the Android app behaves like the desktop app by using the API to create a new account number.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1685)
<!-- Reviewable:end -->
