### PR TITLE
Pass resource directory to problem report

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.async
 
 const val PROBLEM_REPORT_FILE = "problem_report.txt"
 
-class MullvadProblemReport(val logDirectory: File) {
+class MullvadProblemReport(val logDirectory: File, val resourceDirectory: File) {
     private val problemReportPath = File(logDirectory, PROBLEM_REPORT_FILE)
 
     private var collectJob: Deferred<Boolean>? = null
@@ -56,7 +56,8 @@ class MullvadProblemReport(val logDirectory: File) {
                             sendProblemReport(
                                 userEmail,
                                 userMessage,
-                                problemReportPath.absolutePath
+                                problemReportPath.absolutePath,
+                                resourceDirectory.absolutePath
                             )
 
                     if (result) {
@@ -81,6 +82,7 @@ class MullvadProblemReport(val logDirectory: File) {
     private external fun sendProblemReport(
         userEmail: String,
         userMessage: String,
-        reportPath: String
+        reportPath: String,
+        resourceDir: String
     ): Boolean
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        problemReport = MullvadProblemReport(filesDir)
+        problemReport = MullvadProblemReport(filesDir, filesDir)
 
         setContentView(R.layout.main)
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -826,14 +826,21 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemRepor
     userEmail: JString<'_>,
     userMessage: JString<'_>,
     outputPath: JString<'_>,
+    resourceDir: JString<'_>,
 ) -> jboolean {
     let env = JnixEnv::from(env);
     let user_email = String::from_java(&env, userEmail);
     let user_message = String::from_java(&env, userMessage);
     let output_path_string = String::from_java(&env, outputPath);
+    let resource_dir = String::from_java(&env, resourceDir);
     let output_path = Path::new(&output_path_string);
 
-    match mullvad_problem_report::send_problem_report(&user_email, &user_message, output_path) {
+    match mullvad_problem_report::send_problem_report(
+        &user_email,
+        &user_message,
+        output_path,
+        &resource_dir.as_ref(),
+    ) {
         Ok(()) => JNI_TRUE,
         Err(error) => {
             log::error!(

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -251,6 +251,22 @@ pub fn send_problem_report(
     user_email: &str,
     user_message: &str,
     report_path: &Path,
+    #[cfg(target_os = "android")] resource_dir: &Path,
+) -> Result<(), Error> {
+    #[cfg(not(target_os = "android"))]
+    let ca_path = mullvad_paths::resources::get_api_ca_path();
+
+    #[cfg(target_os = "android")]
+    let ca_path = resource_dir.join(mullvad_paths::resources::API_CA_FILENAME);
+
+    send_problem_report_inner(user_email, user_message, report_path, &ca_path)
+}
+
+pub fn send_problem_report_inner(
+    user_email: &str,
+    user_message: &str,
+    report_path: &Path,
+    ca_path: &Path,
 ) -> Result<(), Error> {
     let report_content = normalize_newlines(
         read_file_lossy(report_path, REPORT_MAX_SIZE).map_err(|source| {
@@ -263,10 +279,8 @@ pub fn send_problem_report(
     let metadata =
         ProblemReport::parse_metadata(&report_content).unwrap_or_else(|| metadata::collect());
 
-    let ca_path = mullvad_paths::resources::get_api_ca_path();
-
-    let mut rpc_manager = mullvad_rpc::MullvadRpcRuntime::new(ca_path.as_ref())
-        .map_err(Error::CreateRpcClientError)?;
+    let mut rpc_manager =
+        mullvad_rpc::MullvadRpcRuntime::new(ca_path).map_err(Error::CreateRpcClientError)?;
     let rpc_client = mullvad_rpc::ProblemReportProxy::new(rpc_manager.mullvad_rest_handle());
 
     rpc_client


### PR DESCRIPTION
In the recent change to parameterize all the paths in the app, the problem report was left out, and as such, the root cert for the API were being sought in the wrong directory. I've made it so that the problem report sender takes the resource directory as an extra argument.

In an unrelated note, maybe the `mullvad-paths` module should be slimmed down to not contain any of the functions that are now moot on Android? This would involve a lot of ugly `#[cfg(not(target_os = "android"))]`, but these functions really do not make much sense anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1687)
<!-- Reviewable:end -->
