### PR TITLE
Fix login with invalid account error

### DIFF
--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -17,7 +17,7 @@ use jnix::{
     FromJava, IntoJava, JnixEnv,
 };
 use mullvad_daemon::{exception_logging, logging, version, Daemon, DaemonCommandChannel};
-use mullvad_rpc::rest::Error as RestError;
+use mullvad_rpc::{rest::Error as RestError, StatusCode};
 use mullvad_types::account::AccountData;
 use std::{
     path::{Path, PathBuf},
@@ -64,7 +64,7 @@ impl From<Result<AccountData, daemon_interface::Error>> for GetAccountDataResult
             Ok(account_data) => GetAccountDataResult::Ok(account_data),
             Err(error) => match error {
                 daemon_interface::Error::RpcError(RestError::ApiError(status, _code))
-                    if status == mullvad_rpc::StatusCode::NOT_FOUND =>
+                    if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN =>
                 {
                     GetAccountDataResult::InvalidAccount
                 }


### PR DESCRIPTION
With the recent change to the REST API, the error that is used to determine if an account is invalid changed. This PR updates the `mullvad-jni` crate to properly handle the new error status code.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any public release.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1688)
<!-- Reviewable:end -->
