### PR TITLE
Move account history into the settings directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Downgrade to Electron 7 due to issues with tray icon in Electron 8.
 - Use rustls instead of OpenSSL for TLS encryption to the API and GeoIP location service.
+- Move location of the account data (including the WireGuard keys), so that it isn't lost when the
+  system cache is cleaned.
 
 #### Windows
 - When required, attempt to enable IPv6 for network adapters instead of failing.

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -45,7 +45,7 @@ pub struct AccountHistory {
 
 impl AccountHistory {
     pub fn new(
-        cache_dir: &Path,
+        settings_dir: &Path,
         rpc_handle: MullvadRestHandle,
         tokio_remote: Remote,
     ) -> Result<AccountHistory> {
@@ -61,7 +61,7 @@ impl AccountHistory {
             // a share mode of zero ensures exclusive access to the file to *this* process
             options.share_mode(0);
         }
-        let path = cache_dir.join(ACCOUNT_HISTORY_FILE);
+        let path = settings_dir.join(ACCOUNT_HISTORY_FILE);
         log::info!("Opening account history file in {}", path.display());
         let mut reader = options
             .write(true)

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -504,6 +504,7 @@ where
         }
 
         let account_history = account_history::AccountHistory::new(
+            &cache_dir,
             &settings_dir,
             rpc_handle.clone(),
             core_handle.remote.clone(),

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -504,7 +504,7 @@ where
         }
 
         let account_history = account_history::AccountHistory::new(
-            &cache_dir,
+            &settings_dir,
             rpc_handle.clone(),
             core_handle.remote.clone(),
         )


### PR DESCRIPTION
The account history file contains a cache of the most recently used accounts and their WireGuard keys. The file was previously stored in the cache directory, which in general is not a problem since the data is ephemeral. However, every time the cache is cleared the WireGuard key is lost. This means the app has to regenerate the key the next time it runs. After regenerating a few times, the maximum key limit is reached, and the user has to manually clean-up the stale keys.

This PR improves the UX by moving the account history file to the settings directory, where it isn't cleared periodically. This should considerably reduce the number of times the user has to clean-up the stale keys.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1690)
<!-- Reviewable:end -->
