### PR TITLE
Prevent overflow in RouteManager

### DIFF
--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -607,8 +607,8 @@ impl RouteManagerImplInner {
                     .destination_prefix(v4_prefix.ip(), v4_prefix.prefix())
                     .table(route.table_id);
 
-                if v4_prefix.size() > 1 {
-                    add_message = add_message.scope(RT_SCOPE_LINK)
+                if v4_prefix.prefix() > 0 && v4_prefix.prefix() < 32 {
+                    add_message = add_message.scope(RT_SCOPE_LINK);
                 }
 
                 if let Some(IpAddr::V4(node_address)) = route.node.get_address() {
@@ -632,8 +632,8 @@ impl RouteManagerImplInner {
                     .destination_prefix(v6_prefix.ip(), v6_prefix.prefix())
                     .table(route.table_id);
 
-                if v6_prefix.size() > 1 {
-                    add_message = add_message.scope(RT_SCOPE_LINK)
+                if v6_prefix.prefix() > 0 && v6_prefix.prefix() < 128 {
+                    add_message = add_message.scope(RT_SCOPE_LINK);
                 }
 
                 if let Some(IpAddr::V6(node_address)) = route.node.get_address() {


### PR DESCRIPTION
`ipnetwork::IpNetwork::size()` overflows if `prefix == 0` since it tries to compute `(2u32).pow(ADDRESS_SIZE_BITS - prefix)`. Avoid this by checking the prefix first.

Cf. test failures here: https://travis-ci.com/github/mullvad/mullvadvpn-app/builds/162446557

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1692)
<!-- Reviewable:end -->
