### PR TITLE
Remove wireguard key generation error

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -583,7 +583,6 @@ class ApplicationMain {
     switch (event) {
       case 'too_many_keys':
       case 'generation_failure':
-        this.notificationController.notifyKeyGenerationFailed();
         this.wireguardPublicKey = undefined;
         break;
       default:

--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -79,9 +79,21 @@ export default class NotificationController {
         break;
       case 'error':
         if (tunnelState.details.isBlocking) {
-          this.showTunnelStateNotification(
-            messages.pgettext('notifications', 'Blocked all connections'),
-          );
+          if (
+            tunnelState.details.cause.reason === 'tunnel_parameter_error' &&
+            tunnelState.details.cause.details === 'no_wireguard_key'
+          ) {
+            this.showTunnelStateNotification(
+              messages.pgettext(
+                'notifications',
+                'Blocking internet: Valid WireGuard key is missing',
+              ),
+            );
+          } else {
+            this.showTunnelStateNotification(
+              messages.pgettext('notifications', 'Blocking internet'),
+            );
+          }
         } else {
           this.showTunnelStateNotification(
             messages.pgettext('notifications', 'Critical error (your attention is required)'),

--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -160,16 +160,6 @@ export default class NotificationController {
     });
   }
 
-  public notifyKeyGenerationFailed() {
-    const notification = new Notification({
-      title: this.notificationTitle,
-      body: messages.pgettext('notifications', 'Wireguard key generation failed'),
-      silent: true,
-      icon: this.notificationIcon,
-    });
-    this.scheduleNotification(notification);
-  }
-
   public closeToExpiryNotification(accountExpiry: AccountExpiry) {
     const duration = accountExpiry.durationUntilExpiry();
     const notification = new Notification({

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -52,7 +52,7 @@ function getTunnelParameterMessage(err: TunnelParameterError): string {
     case 'no_wireguard_key':
       return messages.pgettext(
         'in-app-notifications',
-        'WireGuard key not published to our servers. You can manage your key in Advanced settings.',
+        'Valid WireGuard key is missing. Manage keys under Advanced settings.',
       );
     case 'custom_tunnel_host_resultion_error':
       return messages.pgettext(


### PR DESCRIPTION
This PR removes the notification that is displayed when the app fails to publish/generate a wireguard key and is left without a key. It also improves the current notification that is displayed when the app fails to connect due to not having a valid wireguard key.

All notifcations about connectivity being blocked has been changed from `blocked all connections` to `blocking internet` to align it with the in-app notification.

<img width="366" alt="Screen Shot 2020-04-29 at 15 14 42" src="https://user-images.githubusercontent.com/3668602/80604801-7a1de980-8a32-11ea-96bc-ce1ebce92f9c.png">
<img width="382" alt="Screen Shot 2020-04-29 at 16 02 44" src="https://user-images.githubusercontent.com/3668602/80605118-eb5d9c80-8a32-11ea-9590-a7c396940fbb.png">



Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1694)
<!-- Reviewable:end -->
