### PR TITLE
Fix crash in `SettingsListener` that happens with other crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 #### Android
 - Fix crash when leaving WireGuard Key screen while key is still verifying.
+- Fix crash that sometimes happens right after some other unrelated crash.
 
 
 ## [2020.4-beta3] - 2020-04-29

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.SettingsListener
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.SettingsListener
 
 class AppVersionInfoCache(
     val context: Context,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -9,6 +9,7 @@ import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.SettingsListener
 
 class RelayListListener(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
     private val setUpJob = setUp()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -69,7 +69,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return getRelayLocations(daemonInterfaceAddress)
     }
 
-    fun getSettings(): Settings {
+    fun getSettings(): Settings? {
         return getSettings(daemonInterfaceAddress)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -164,6 +164,27 @@ class MullvadVpnService : TalpidVpnService() {
             }
         }
 
+        setUpInstance(daemon)
+    }
+
+    private fun prepareFiles() {
+        FileMigrator(File("/data/data/net.mullvad.mullvadvpn"), filesDir).apply {
+            migrate(API_ROOT_CA_FILE)
+            migrate(RELAYS_FILE)
+            migrate("settings.json")
+            migrate("daemon.log")
+            migrate("daemon.old.log")
+            migrate("wireguard.log")
+            migrate("wireguard.old.log")
+        }
+
+        FileResourceExtractor(this).apply {
+            extract(API_ROOT_CA_FILE)
+            extract(RELAYS_FILE)
+        }
+    }
+
+    private fun setUpInstance(daemon: MullvadDaemon) {
         val connectionProxy = ConnectionProxy(this@MullvadVpnService, daemon).apply {
             when (pendingAction) {
                 PendingAction.Connect -> connect()
@@ -184,23 +205,6 @@ class MullvadVpnService : TalpidVpnService() {
             locationInfoCache,
             settingsListener
         )
-    }
-
-    private fun prepareFiles() {
-        FileMigrator(File("/data/data/net.mullvad.mullvadvpn"), filesDir).apply {
-            migrate(API_ROOT_CA_FILE)
-            migrate(RELAYS_FILE)
-            migrate("settings.json")
-            migrate("daemon.log")
-            migrate("daemon.old.log")
-            migrate("wireguard.log")
-            migrate("wireguard.old.log")
-        }
-
-        FileResourceExtractor(this).apply {
-            extract(API_ROOT_CA_FILE)
-            extract(RELAYS_FILE)
-        }
     }
 
     private fun stop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -175,8 +175,15 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
         val locationInfoCache = LocationInfoCache(daemon, connectionProxy, connectivityListener)
+        val settingsListener = SettingsListener(daemon)
 
-        instance = ServiceInstance(daemon, connectionProxy, connectivityListener, locationInfoCache)
+        instance = ServiceInstance(
+            daemon,
+            connectionProxy,
+            connectivityListener,
+            locationInfoCache,
+            settingsListener
+        )
     }
 
     private fun prepareFiles() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -7,4 +7,9 @@ data class ServiceInstance(
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,
     val locationInfoCache: LocationInfoCache
-)
+) {
+    fun onDestroy() {
+        connectionProxy.onDestroy()
+        locationInfoCache.onDestroy()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -6,10 +6,12 @@ data class ServiceInstance(
     val daemon: MullvadDaemon,
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,
-    val locationInfoCache: LocationInfoCache
+    val locationInfoCache: LocationInfoCache,
+    val settingsListener: SettingsListener
 ) {
     fun onDestroy() {
         connectionProxy.onDestroy()
         locationInfoCache.onDestroy()
+        settingsListener.onDestroy()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -1,8 +1,7 @@
-package net.mullvad.mullvadvpn.dataproxy
+package net.mullvad.mullvadvpn.service
 
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
-import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.util.EventNotifier
 
 class SettingsListener(val daemon: MullvadDaemon) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -4,8 +4,8 @@ import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.talpid.util.EventNotifier
 
-class SettingsListener(val daemon: MullvadDaemon) {
-    var settings: Settings = daemon.getSettings()
+class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings) {
+    var settings: Settings = initialSettings
         private set(value) {
             settingsNotifier.notify(value)
             field = value

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -4,7 +4,6 @@ import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
-import net.mullvad.mullvadvpn.dataproxy.SettingsListener
 import net.mullvad.mullvadvpn.service.ServiceInstance
 
 class ServiceConnection(private val service: ServiceInstance, val mainActivity: MainActivity) {
@@ -12,9 +11,9 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val connectionProxy = service.connectionProxy
     val connectivityListener = service.connectivityListener
     val locationInfoCache = service.locationInfoCache
+    val settingsListener = service.settingsListener
 
     val keyStatusListener = KeyStatusListener(daemon)
-    val settingsListener = SettingsListener(daemon)
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     val accountCache = AccountCache(settingsListener, daemon)
     var relayListListener = RelayListListener(daemon, settingsListener)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -12,10 +12,10 @@ import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
-import net.mullvad.mullvadvpn.dataproxy.SettingsListener
 import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.SettingsListener
 import net.mullvad.talpid.ConnectivityListener
 
 abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceAwareFragment() {


### PR DESCRIPTION
Previously, some crash in the app (or a panic in the daemon) could cause the app to crash with a `null` pointer exception because it assumed that the daemon would always return a valid `Settings` object. However, `null` is returned instead if the daemon is in an error state, like right after a panic and before it has restarted.

This PR fixes the issue by changing the app architecture a bit. The `SettingsListener` was moved to the `service` package, and now requires a valid `Settings` object in its constructor. This means that the `MullvadVpnService` is now responsible for fetching the initial settings from the daemon. If that fails, the service can safely restart the initialization.

As part of this PR, the service was also refactored to make it simpler to handle the initialization and tear down of the classes managed by a service instance. This now happens through an `instance` property.

As a consequence of the changes, the `LaunchFragment` was simplified as well to use the `SettingsListener` directly instead of fetching the settings manually.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1696)
<!-- Reviewable:end -->
