### PR TITLE
Fix deserialization of AppVersionInfo in GUI

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -293,9 +293,10 @@ const tunnelStateSchema = oneOf(
 );
 
 const appVersionInfoSchema = partialObject({
-  current_is_supported: boolean,
-  latest_stable: string,
+  supported: boolean,
   latest: string,
+  latest_stable: string,
+  latest_beta: string,
 });
 
 export class ConnectionObserver {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -139,8 +139,9 @@ class ApplicationMain {
   };
 
   private upgradeVersion: IAppUpgradeInfo = {
-    currentIsSupported: true,
+    supported: true,
     latestStable: '',
+    latestBeta: '',
     latest: '',
     nextUpgrade: undefined,
   };
@@ -781,7 +782,7 @@ class ApplicationMain {
       process.env.NODE_ENV !== 'development' &&
       !this.shouldSuppressNotifications(true) &&
       currentVersionInfo.isConsistent &&
-      !latestVersionInfo.currentIsSupported &&
+      !latestVersionInfo.supported &&
       upgradeVersion
     ) {
       this.notificationController.notifyUnsupportedVersion(upgradeVersion);

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -278,9 +278,10 @@ export interface IShadowsocksProxySettings {
 }
 
 export interface IAppVersionInfo {
-  currentIsSupported: boolean;
-  latestStable: string;
+  supported: boolean;
   latest: string;
+  latestStable: string;
+  latestBeta: string;
 }
 
 export interface ISettings {


### PR DESCRIPTION
The fields of `AppVersionInfo` were recently changed, but the GUI was not updated. This caused deserialization of the struct to fail when the frontend tried to update the version state. A false update notification was seen in Settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1699)
<!-- Reviewable:end -->
