### PR TITLE
Fix crash when leaving WireGuard Key screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fixed bogus or absent update notifications on the desktop app due to incorrect deserialization of
   a struct sent from the daemon.
 
+### Fixed
+#### Android
+- Fix crash when leaving WireGuard Key screen while key is still verifying.
+
 
 ## [2020.4-beta3] - 2020-04-29
 ### Added

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -36,6 +36,9 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     private lateinit var timeAgoFormatter: TimeAgoFormatter
 
+    private var greenColor: Int = 0
+    private var redColor: Int = 0
+
     private var tunnelStateListener: Int? = null
     private var tunnelState: TunnelState = TunnelState.Disconnected()
 
@@ -96,7 +99,11 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     override fun onAttach(context: Context) {
         super.onAttach(context)
 
-        timeAgoFormatter = TimeAgoFormatter(context.resources)
+        val resources = context.resources
+
+        redColor = resources.getColor(R.color.red)
+        greenColor = resources.getColor(R.color.green)
+        timeAgoFormatter = TimeAgoFormatter(resources)
     }
 
     override fun onSafelyCreateView(
@@ -230,9 +237,9 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     private fun updateOfflineStatus() {
         if (reconnectionExpected) {
-            setStatusMessage(R.string.wireguard_key_reconnecting, R.color.green)
+            setStatusMessage(R.string.wireguard_key_reconnecting, greenColor)
         } else {
-            setStatusMessage(R.string.wireguard_key_blocked_state_message, R.color.red)
+            setStatusMessage(R.string.wireguard_key_blocked_state_message, redColor)
         }
     }
 
@@ -241,7 +248,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
             val replacementFailure = keyStatus.replacementFailure
 
             if (replacementFailure != null) {
-                setStatusMessage(failureMessage(replacementFailure), R.color.red)
+                setStatusMessage(failureMessage(replacementFailure), redColor)
             } else {
                 updateKeyIsValid(verificationWasDone, keyStatus.verified)
             }
@@ -252,11 +259,11 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     private fun updateKeyIsValid(verificationWasDone: Boolean, verified: Boolean?) {
         when (verified) {
-            true -> setStatusMessage(R.string.wireguard_key_valid, R.color.green)
-            false -> setStatusMessage(R.string.wireguard_key_invalid, R.color.red)
+            true -> setStatusMessage(R.string.wireguard_key_valid, greenColor)
+            false -> setStatusMessage(R.string.wireguard_key_invalid, redColor)
             null -> {
                 if (verificationWasDone) {
-                    setStatusMessage(R.string.wireguard_key_verification_failure, R.color.red)
+                    setStatusMessage(R.string.wireguard_key_verification_failure, redColor)
                 } else {
                     statusMessage.visibility = View.GONE
                 }
@@ -296,7 +303,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     private fun setStatusMessage(message: Int, color: Int) {
         statusMessage.setText(message)
-        statusMessage.setTextColor(resources.getColor(color))
+        statusMessage.setTextColor(color)
         statusMessage.visibility = View.VISIBLE
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/JobTracker.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/JobTracker.kt
@@ -88,6 +88,7 @@ class JobTracker {
 
             jobs.clear()
             reaperJobs.clear()
+            namedJobs.clear()
         }
     }
 }


### PR DESCRIPTION
Some crash reports contains an `IllegalStateException` in the WireGuard Key screen. When checking the backtrace, it looked like the view was being updated after the fragment was detached (i.e., after the user left the screen). This shouldn't have happened because the background jobs should be cancelled when leaving the screen.

However, it turns out there was a bug in the `JobTracker`. It was cancelling a wrapper "reaper" job instead of cancelling the actual job. This PR fixes that by making sure both jobs are cancelled.

Since the crash happened when calling `getResources()` in the fragment for retrieving a color, the PR also takes a second mitigation of caching the color value so that the call isn't necessary anymore.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1701)
<!-- Reviewable:end -->
