### PR TITLE
Fix cleanup of log files

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -13,7 +13,6 @@
 #
 
 # TAP device hardware ID
-!define DEPRECATED_TAP_HARDWARE_ID "tap0901"
 !define TAP_HARDWARE_ID "tapmullvad0901"
 
 # "sc" exit code

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -614,7 +614,7 @@
 
 	Push $R0
 
-	log::Initialize LOG_FILE
+	log::Initialize ${LOG_FILE}
 
 	log::Log "Running installer for ${PRODUCT_NAME} ${VERSION}"
 	log::LogWindowsVersion
@@ -720,10 +720,10 @@
 	${GetOptions} $0 "/S" $1
 	${If} ${Errors}
 		Push 1
-		log::Initialize LOG_VOID
+		log::Initialize ${LOG_VOID}
 	${Else}
 		Push 0
-		log::Initialize LOG_FILE
+		log::Initialize ${LOG_FILE}
 	${EndIf}
 	Pop $FullUninstall
 


### PR DESCRIPTION
`C:\ProgramData\Mullvad VPN` is not deleted upon a full uninstall. This is because the void logger isn't initialized correctly due to a typo, and the file `install.log` is in use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1704)
<!-- Reviewable:end -->
