### PR TITLE
Increase minimum supported Android API level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Line wrap the file at 100 chars.                                              Th
 - Rename "Block when disconnected" setting to "Always require VPN" and add additional explanation
   of the setting.
 
+#### Android
+- Adjust the minimum supported Android version to correctly reflect the supported versions decided
+  in 2020.4-beta2. The app will now only install on Android 7 and later (API level 24).
+
 ### Fixed
 - Fixed bogus or absent update notifications on the desktop app due to incorrect deserialization of
   a struct sent from the daemon.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId "net.mullvad.mullvadvpn"
-        minSdkVersion 19
+        minSdkVersion 24
         targetSdkVersion 28
         versionCode 20040003
         versionName "2020.4-beta3"


### PR DESCRIPTION
Previously, the minimum supported Android version was specified as `7.0` in the `README` file but the generated app was supporting Android versions from `4.4` (API level 19) onwards (which we weren't testing). This PR updates the app so that it becomes unsupported on versions below `7.0` (API level 24).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1705)
<!-- Reviewable:end -->
