### PR TITLE
Overwrite install.log instead of appending to it

### DIFF
--- a/windows/nsis-plugins/src/log/log.cpp
+++ b/windows/nsis-plugins/src/log/log.cpp
@@ -237,7 +237,7 @@ void __declspec(dllexport) NSISCALL Initialize
 
 				const auto logfile = decltype(logpath)(logpath).append(L"install.log");
 
-				g_logger = new Logger(std::make_unique<Utf8FileLogSink>(logfile));
+				g_logger = new Logger(std::make_unique<Utf8FileLogSink>(logfile, false));
 
 				break;
 

--- a/windows/nsis-plugins/src/log/logger.cpp
+++ b/windows/nsis-plugins/src/log/logger.cpp
@@ -26,6 +26,7 @@ Utf8FileLogSink::Utf8FileLogSink(const std::wstring &file, bool append, bool flu
 
 		if (FALSE == seekStatus)
 		{
+			CloseHandle(m_logfile);
 			THROW_WINDOWS_ERROR(GetLastError(), "Seek to end offset in existing log file");
 		}
 	}


### PR DESCRIPTION
Some sensitive information used to be logged here. This was fixed in https://github.com/mullvad/mullvadvpn-app/pull/1521. But it could still end up in problem reports since updating the app only appended to the existing log. Fix by overwriting the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1706)
<!-- Reviewable:end -->
