### PR TITLE
Unpack relay list from APK when upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Add possibility to create account from the login screen.
 - Add welcome screen for newly created accounts.
+- App will now use packaged relay list if it's newer than the cached one.
 
 ### Changed
 - Move location of the account data (including the WireGuard keys), so that it isn't lost when the

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
@@ -5,10 +5,10 @@ import java.io.File
 import java.io.FileOutputStream
 
 class FileResourceExtractor(val context: Context) {
-    fun extract(asset: String) {
+    fun extract(asset: String, force: Boolean = false) {
         val destination = File(context.filesDir, asset)
 
-        if (!destination.exists()) {
+        if (!destination.exists() || force) {
             extractFile(asset, destination)
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -185,9 +185,12 @@ class MullvadVpnService : TalpidVpnService() {
             migrate("wireguard.old.log")
         }
 
+        val shouldOverwriteRelayList =
+            lastUpdatedTime() > File(filesDir, RELAYS_FILE).lastModified()
+
         FileResourceExtractor(this).apply {
             extract(API_ROOT_CA_FILE)
-            extract(RELAYS_FILE)
+            extract(RELAYS_FILE, shouldOverwriteRelayList)
         }
     }
 
@@ -240,5 +243,9 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
         startActivity(intent)
+    }
+
+    private fun lastUpdatedTime(): Long {
+        return packageManager.getPackageInfo(packageName, 0).lastUpdateTime
     }
 }


### PR DESCRIPTION
Now the Mullvad VPN service will compare the date it was last installed with the last modification date of the relay list to ensure that it ends up using the most recent relay list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1708)
<!-- Reviewable:end -->
