### PR TITLE
Fix handling of connect command when starting service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix crash when leaving WireGuard Key screen while key is still verifying.
 - Fix crash that sometimes happens right after some other unrelated crash.
+- Fix app not connecting when pressing the notification or quick-settings tile when the service
+  isn't running. It would previously just open the app UI and stay in the disconnected state.
 
 
 ## [2020.4-beta3] - 2020-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,9 @@ Line wrap the file at 100 chars.                                              Th
   in 2020.4-beta2. The app will now only install on Android 7 and later (API level 24).
 
 ### Fixed
-- Fixed bogus or absent update notifications on the desktop app due to incorrect deserialization of
-  a struct sent from the daemon.
+- Fix bogus or absent update notifications on the desktop app due to incorrect deserialization of a
+  struct sent from the daemon.
 
-### Fixed
 #### Android
 - Fix crash when leaving WireGuard Key screen while key is still verifying.
 - Fix crash that sometimes happens right after some other unrelated crash.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -13,6 +13,10 @@ import org.joda.time.format.DateTimeFormat
 val EXPIRY_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss z")
 
 class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
+    private val subscriptionId = settingsListener.accountNumberNotifier.subscribe { accountNumber ->
+        handleNewAccountNumber(accountNumber)
+    }
+
     private var fetchJob: Job? = null
     private var accountNumber: String? = null
     private var accountExpiry: DateTime? = null
@@ -25,19 +29,13 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
             }
         }
 
-    init {
-        settingsListener.onAccountNumberChange = { accountNumber ->
-            handleNewAccountNumber(accountNumber)
-        }
-    }
-
     fun refetch() {
         fetchJob?.cancel()
         fetchJob = fetchAccountExpiry()
     }
 
     fun onDestroy() {
-        settingsListener.onAccountNumberChange = null
+        settingsListener.accountNumberNotifier.unsubscribe(subscriptionId)
 
         fetchJob?.cancel()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -12,7 +12,7 @@ import org.joda.time.format.DateTimeFormat
 
 val EXPIRY_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss z")
 
-class AccountCache(val settingsListener: SettingsListener, val daemon: MullvadDaemon) {
+class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
     private var fetchJob: Job? = null
     private var accountNumber: String? = null
     private var accountExpiry: DateTime? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -152,10 +152,6 @@ class MullvadVpnService : TalpidVpnService() {
         prepareFiles()
 
         val daemon = MullvadDaemon(this@MullvadVpnService).apply {
-            onSettingsChange.subscribe { settings ->
-                loggedIn = settings?.accountToken != null
-            }
-
             onDaemonStopped = {
                 instance = null
 
@@ -206,7 +202,12 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
         val locationInfoCache = LocationInfoCache(daemon, connectionProxy, connectivityListener)
-        val settingsListener = SettingsListener(daemon, settings)
+
+        val settingsListener = SettingsListener(daemon, settings).apply {
+            accountNumberNotifier.subscribe { accountNumber ->
+                loggedIn = accountNumber != null
+            }
+        }
 
         instance = ServiceInstance(
             daemon,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -34,9 +34,7 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
         }
 
     fun onDestroy() {
-        if (listenerId != -1) {
-            daemon.onSettingsChange.unsubscribe(listenerId)
-        }
+        daemon.onSettingsChange.unsubscribe(listenerId)
 
         settingsNotifier.unsubscribeAll()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -15,7 +15,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
 
     val keyStatusListener = KeyStatusListener(daemon)
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
-    val accountCache = AccountCache(settingsListener, daemon)
+    val accountCache = AccountCache(daemon, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)
 
     init {


### PR DESCRIPTION
Some previous changes broke how the `loggedIn` property could be used to determine if the app should connect or open the UI for the user to log in. Since the service would check if it was logged in before the property was correctly set, it would always assume that the user wasn't logged in and open the UI instead of connecting.

This PR fixes that by refactoring how the property is updated and only checking it after it is known that the latest value was set by settings listener.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1709)
<!-- Reviewable:end -->
