### PR TITLE
Fix crash when starting the service to handle a connect request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash that sometimes happens right after some other unrelated crash.
 - Fix app not connecting when pressing the notification or quick-settings tile when the service
   isn't running. It would previously just open the app UI and stay in the disconnected state.
+- Fix crash when requesting to connect from notification or quick-settings tile.
 
 
 ## [2020.4-beta3] - 2020-04-29

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -265,8 +265,13 @@ class ForegroundNotificationManager(
 
     private fun buildTunnelAction(): NotificationCompat.Action {
         val intent = Intent(tunnelActionKey).setPackage("net.mullvad.mullvadvpn")
-        val pendingIntent =
-            PendingIntent.getBroadcast(service, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT
+
+        val pendingIntent = if (Build.VERSION.SDK_INT >= 26) {
+            PendingIntent.getForegroundService(service, 1, intent, flags)
+        } else {
+            PendingIntent.getService(service, 1, intent, flags)
+        }
 
         val icon = tunnelActionIcon
         val label = service.getString(tunnelActionText)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.service
 
 import android.content.Intent
 import android.graphics.drawable.Icon
+import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import net.mullvad.mullvadvpn.R
@@ -61,7 +62,11 @@ class MullvadTileService : TileService() {
             intent.action = KEY_CONNECT_ACTION
         }
 
-        startService(intent)
+        if (Build.VERSION.SDK_INT >= 26) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
+        }
     }
 
     override fun onStopListening() {


### PR DESCRIPTION
A few crashes with an `IllegalStateException` when starting the service were reported on newer Android versions. Apparently, the cause is that a service can't be requested to be started without either being the result of a user interaction or having a promise that the service will be a foreground service. In theory, this rule is not applied for apps in a dynamic whitelist. This whitelist seems to be getting stricter with every release, since the crashes appear with the frequency increasing with the Android version.

This PR fixes the issue by promising on those newer Android versions that the service will be a foreground service.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1710)
<!-- Reviewable:end -->
