### PR TITLE
Sort relay list alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix app not connecting when pressing the notification or quick-settings tile when the service
   isn't running. It would previously just open the app UI and stay in the disconnected state.
 - Fix crash when requesting to connect from notification or quick-settings tile.
+- Fix relay list sort order
 
 
 ## [2020.4-beta3] - 2020-04-29

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayList.kt
@@ -7,7 +7,7 @@ class RelayList {
     val countries: List<RelayCountry>
 
     constructor(model: net.mullvad.mullvadvpn.model.RelayList) {
-        countries = model.countries
+        var relayCountries = model.countries
             .map { country ->
                 val cities = mutableListOf<RelayCity>()
                 val relayCountry = RelayCountry(country.name, country.code, false, cities)
@@ -21,15 +21,22 @@ class RelayList {
                     for (relay in validCityRelays) {
                         relays.add(Relay(relayCity, relay.hostname, relay.active))
                     }
+                    relays.sortBy({ it.name })
 
                     if (relays.isNotEmpty()) {
                         cities.add(relayCity)
                     }
                 }
 
+                cities.sortBy({ it.name })
                 relayCountry
             }
             .filter { country -> country.cities.isNotEmpty() }
+            .toMutableList()
+
+        relayCountries.sortBy({ it.name })
+
+        countries = relayCountries.toList()
     }
 
     fun findItemForLocation(


### PR DESCRIPTION
As the new endpoints no longer return a sorted relay list, the relay list should now be sorted in the client. The GUI already did this, but the Android app did not, with these changes it will. Eventually the sorting will have to be lifted to a higher level anyway, if/when the app becomes internationalized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1713)
<!-- Reviewable:end -->
