### PR TITLE
Fix deserialization of app version information from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Line wrap the file at 100 chars.                                              Th
   isn't running. It would previously just open the app UI and stay in the disconnected state.
 - Fix crash when requesting to connect from notification or quick-settings tile.
 - Fix relay list sort order
+- Fix version update notifications not appearing.
 
 
 ## [2020.4-beta3] - 2020-04-29

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
@@ -2,7 +2,7 @@ package net.mullvad.mullvadvpn.model
 
 data class AppVersionInfo(
     val supported: Boolean,
+    val latest: String,
     val latestStable: String,
-    val latestBeta: String,
-    val latest: String
+    val latestBeta: String
 )


### PR DESCRIPTION
With the recent update to the REST API, there's a small change in the behavior of one of the returned values. The app. version information's `latest_stable` field can now be `null`. This currently only happens on Android since we haven't released a stable version yet.

This PR fixes that by allowing the field to be optional when deserializing. The UI code for desktop and Android was updated to support the nullable value.

The PR also fixes the order of the fields in the `AppVersionInfo` class to match the order in the Rust type so that the conversion is correct.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1714)
<!-- Reviewable:end -->
