### PR TITLE
Make quote usage consistent in GUI

### DIFF
--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -210,7 +210,7 @@ export default class ExpiredAccountErrorView extends Component<
         <Text style={styles.fieldLabel}>
           {messages.pgettext(
             'connect-view',
-            'You need to disable “Always require VPN” in order to access the Internet to add time.',
+            'You need to disable "Always require VPN" in order to access the Internet to add time.',
           )}
         </Text>
         <Text style={styles.fieldLabel}>

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -154,7 +154,7 @@ export default class NotificationArea extends Component<IProps, State> {
           return {
             visible: true,
             type: 'blocking',
-            reason: messages.pgettext('in-app-notifications', '“Always require VPN” is enabled.'),
+            reason: messages.pgettext('in-app-notifications', '"Always require VPN" is enabled.'),
           };
         }
       // fallthrough


### PR DESCRIPTION
This PR changes a few quotes to regular ones (") to make quote usage consistent throughout the GUI.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1716)
<!-- Reviewable:end -->
