### PR TITLE
Fix settings listener unsubscribing prematurely to settings changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Line wrap the file at 100 chars.                                              Th
   isn't running. It would previously just open the app UI and stay in the disconnected state.
 - Fix crash when requesting to connect from notification or quick-settings tile.
 - Fix version update notifications not appearing.
+- Fix UI losing any settings updates that happen after leaving the app and then coming back.
 
 
 ## [2020.4-beta4] - 2020-05-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Adjust the minimum supported Android version to correctly reflect the supported versions decided
   in 2020.4-beta2. The app will now only install on Android 7 and later (API level 24).
 
-
+### Fixed
 #### Android
 - Fix crash when leaving WireGuard Key screen while key is still verifying.
 - Fix crash that sometimes happens right after some other unrelated crash.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -28,6 +28,5 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
         appVersionInfoCache.onDestroy()
         keyStatusListener.onDestroy()
         relayListListener.onDestroy()
-        settingsListener.onDestroy()
     }
 }


### PR DESCRIPTION
Previously, after leaving the app (by going to the home screen or opening another app, for example) the `SettingsListener` would prematurely unsubscribe for settings events. When the user returned to the app, no further settings events would be received. This led to for example the user logging out and logging in with a different account but the Account page showing the previous account number.

This PR fixes the issue by removing the call to `SettingsListener.onDestroy()` in the `ServiceConnection`. There was already a correct `onDestroy` call in the `ServiceInstance` class.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1721)
<!-- Reviewable:end -->
