### PR TITLE
Fix account expiration disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash when requesting to connect from notification or quick-settings tile.
 - Fix version update notifications not appearing.
 - Fix UI losing any settings updates that happen after leaving the app and then coming back.
+- Fix account expiration date disappearing in some circumstances.
 
 
 ## [2020.4-beta4] - 2020-05-06

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -27,22 +27,23 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
         }
 
     fun fetchAccountExpiry() {
-        jobTracker.newBackgroundJob("fetch") {
-            val accountNumber = this@AccountCache.accountNumber
-            val accountData = accountNumber?.let { account ->
-                val result = daemon.getAccountData(account)
+        accountNumber?.let { accountNumberUsedForFetch ->
+            jobTracker.newBackgroundJob("fetch") {
+                val accountData = accountNumberUsedForFetch?.let { account ->
+                    val result = daemon.getAccountData(account)
 
-                when (result) {
-                    is GetAccountDataResult.Ok -> result.accountData
-                    else -> null
+                    when (result) {
+                        is GetAccountDataResult.Ok -> result.accountData
+                        else -> null
+                    }
                 }
-            }
 
-            synchronized(this@AccountCache) {
-                if (this@AccountCache.accountNumber === accountNumber) {
-                    accountData?.expiry?.let { expiry ->
-                        accountExpiry = DateTime.parse(expiry, EXPIRY_FORMAT)
-                        notifyChange()
+                synchronized(this@AccountCache) {
+                    if (this@AccountCache.accountNumber === accountNumberUsedForFetch) {
+                        accountData?.expiry?.let { expiry ->
+                            accountExpiry = DateTime.parse(expiry, EXPIRY_FORMAT)
+                            notifyChange()
+                        }
                     }
                 }
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -40,11 +40,10 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
 
             synchronized(this@AccountCache) {
                 if (this@AccountCache.accountNumber === accountNumber) {
-                    accountExpiry = accountData?.expiry?.let { expiry ->
-                        DateTime.parse(expiry, EXPIRY_FORMAT)
+                    accountData?.expiry?.let { expiry ->
+                        accountExpiry = DateTime.parse(expiry, EXPIRY_FORMAT)
+                        notifyChange()
                     }
-
-                    notifyChange()
                 }
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AccountCache.kt
@@ -1,23 +1,20 @@
 package net.mullvad.mullvadvpn.dataproxy
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SettingsListener
+import net.mullvad.mullvadvpn.util.JobTracker
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
 val EXPIRY_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss z")
 
 class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
+    private val jobTracker = JobTracker()
     private val subscriptionId = settingsListener.accountNumberNotifier.subscribe { accountNumber ->
         handleNewAccountNumber(accountNumber)
     }
 
-    private var fetchJob: Job? = null
     private var accountNumber: String? = null
     private var accountExpiry: DateTime? = null
 
@@ -29,15 +26,33 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
             }
         }
 
-    fun refetch() {
-        fetchJob?.cancel()
-        fetchJob = fetchAccountExpiry()
+    fun fetchAccountExpiry() {
+        jobTracker.newBackgroundJob("fetch") {
+            val accountNumber = this@AccountCache.accountNumber
+            val accountData = accountNumber?.let { account ->
+                val result = daemon.getAccountData(account)
+
+                when (result) {
+                    is GetAccountDataResult.Ok -> result.accountData
+                    else -> null
+                }
+            }
+
+            synchronized(this@AccountCache) {
+                if (this@AccountCache.accountNumber === accountNumber) {
+                    accountExpiry = accountData?.expiry?.let { expiry ->
+                        DateTime.parse(expiry, EXPIRY_FORMAT)
+                    }
+
+                    notifyChange()
+                }
+            }
+        }
     }
 
     fun onDestroy() {
         settingsListener.accountNumberNotifier.unsubscribe(subscriptionId)
-
-        fetchJob?.cancel()
+        jobTracker.cancelAllJobs()
     }
 
     private fun handleNewAccountNumber(newAccountNumber: String?) {
@@ -46,29 +61,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
             accountExpiry = null
 
             notifyChange()
-            refetch()
-        }
-    }
-
-    private fun fetchAccountExpiry() = GlobalScope.launch(Dispatchers.Default) {
-        val accountNumber = this@AccountCache.accountNumber
-        val accountData = accountNumber?.let { account ->
-            val result = daemon.getAccountData(account)
-
-            when (result) {
-                is GetAccountDataResult.Ok -> result.accountData
-                else -> null
-            }
-        }
-
-        synchronized(this@AccountCache) {
-            if (this@AccountCache.accountNumber === accountNumber) {
-                accountExpiry = accountData?.expiry?.let { expiry ->
-                    DateTime.parse(expiry, EXPIRY_FORMAT)
-                }
-
-                notifyChange()
-            }
+            fetchAccountExpiry()
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -1,8 +1,6 @@
-package net.mullvad.mullvadvpn.dataproxy
+package net.mullvad.mullvadvpn.service
 
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
-import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.SettingsListener
 import net.mullvad.mullvadvpn.util.JobTracker
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -189,6 +189,8 @@ class MullvadVpnService : TalpidVpnService() {
             }
         }
 
+        val accountCache = AccountCache(daemon, settingsListener)
+
         val connectionProxy = ConnectionProxy(this@MullvadVpnService, daemon).apply {
             when (pendingAction) {
                 PendingAction.Connect -> {
@@ -209,6 +211,7 @@ class MullvadVpnService : TalpidVpnService() {
 
         instance = ServiceInstance(
             daemon,
+            accountCache,
             connectionProxy,
             connectivityListener,
             locationInfoCache,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -4,12 +4,14 @@ import net.mullvad.talpid.ConnectivityListener
 
 data class ServiceInstance(
     val daemon: MullvadDaemon,
+    val accountCache: AccountCache,
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,
     val locationInfoCache: LocationInfoCache,
     val settingsListener: SettingsListener
 ) {
     fun onDestroy() {
+        accountCache.onDestroy()
         connectionProxy.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn.ui
 
-import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
@@ -8,6 +7,7 @@ import net.mullvad.mullvadvpn.service.ServiceInstance
 
 class ServiceConnection(private val service: ServiceInstance, val mainActivity: MainActivity) {
     val daemon = service.daemon
+    val accountCache = service.accountCache
     val connectionProxy = service.connectionProxy
     val connectivityListener = service.connectivityListener
     val locationInfoCache = service.locationInfoCache
@@ -15,7 +15,6 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
 
     val keyStatusListener = KeyStatusListener(daemon)
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
-    val accountCache = AccountCache(daemon, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)
 
     init {
@@ -24,7 +23,6 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     }
 
     fun onDestroy() {
-        accountCache.onDestroy()
         appVersionInfoCache.onDestroy()
         keyStatusListener.onDestroy()
         relayListListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -8,10 +8,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
+import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -121,7 +121,7 @@ class SettingsFragment : ServiceAwareFragment() {
 
     private fun configureListeners() {
         accountCache?.apply {
-            refetch()
+            fetchAccountExpiry()
 
             onAccountDataChange = { account, expiry ->
                 updateAccountInfoJob?.cancel()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.AccountCache
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
+import net.mullvad.mullvadvpn.service.AccountCache
 import org.joda.time.DateTime
 
 class SettingsFragment : ServiceAwareFragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -52,7 +52,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
         jobTracker.newBackgroundJob("pollAccountData") {
             while (true) {
-                accountCache.refetch()
+                accountCache.fetchAccountExpiry()
                 delay(POLL_INTERVAL)
             }
         }


### PR DESCRIPTION
Previously, the app would lose track of the account expiration date on various circumstances. For example, when network connection was lost, when leaving the app and returning to it, or when the expiration date was reached.

This PR fixes the separate causes for the issue. First, it doesn't overwrite a valid expiration with a `null` value when fetching an updated expiration fails. Second, it moves the account cache to the service, so that when the user leaves the UI the account cache (and its cached value) is destroyed.

The PR also performs a small refactor in the account cache. The class now uses the `JobTracker` helper class, and the fetch isn't started if the current account number is `null` (i.e., when an account number isn't set).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1722)
<!-- Reviewable:end -->
