### PR TITLE
Ignore case when setting locations in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
   of the setting.
 - Embed TLS certificates used for HTTPS into the binary rather than loading them from disk at
   runtime
+- Ignore case when setting the relay or bridge location in the CLI.
 
 #### Android
 - Adjust the minimum supported Android version to correctly reflect the supported versions decided


### PR DESCRIPTION
Currently when setting a country code, city code, or hostname in the CLI, the selected location (or hostname) is case-sensitive. In practice, this means it will not match an available location unless all characters are lowercase.

This was improved by converting the inputs to lowercase strings. E.g., this will work now:

```
mullvad relay set location Se gOt se9-WireGuard
```

The parsing of the relay list was also updated to ensure that these fields must be lowercase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1724)
<!-- Reviewable:end -->
