### PR TITLE
Rework cancellable delay

### DIFF
--- a/ios/MullvadVPN/CancellableDelayPublisher.swift
+++ b/ios/MullvadVPN/CancellableDelayPublisher.swift
@@ -9,136 +9,24 @@
 import Foundation
 import Combine
 
-extension Publishers {
-
-    class CancellableDelay<Upstream, Context>: Publisher where Upstream: Publisher, Context: Scheduler
-    {
-        typealias Output = Upstream.Output
-        typealias Failure = Upstream.Failure
-
-        private let scheduler: Context
-        private let delay: Context.SchedulerTimeType.Stride
-
-        private let upstream: Upstream
-
-        init(upstream: Upstream, scheduler: Context, delay: Context.SchedulerTimeType.Stride) {
-            self.scheduler = scheduler
-            self.delay = delay
-            self.upstream = upstream
-        }
-
-        func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
-            let subscription = Subscription(
-                upstream: upstream,
-                downstream: subscriber,
-                scheduler: scheduler,
-                delay: delay)
-
-            subscriber.receive(subscription: subscription)
-        }
-    }
-
-}
-
-private extension Publishers.CancellableDelay {
-
-    class Subscription<Upstream, Downstream, Context>: Combine.Subscription, Subscriber
-        where
-        Upstream: Publisher,
-        Downstream: Subscriber,
-        Context: Scheduler,
-        Upstream.Output == Downstream.Input,
-        Upstream.Failure == Downstream.Failure
-    {
-        typealias Input = Downstream.Input
-        typealias Failure = Downstream.Failure
-
-        private let upstream: Upstream
-        private let downstream: Downstream
-
-        private let cancelLock = NSRecursiveLock()
-        private let scheduler: Context
-        private let delay: Context.SchedulerTimeType.Stride
-        private var demand: Subscribers.Demand = .unlimited
-        private var isCancelled = false
-        private var innerSubscription: Combine.Subscription?
-
-        init(upstream: Upstream, downstream: Downstream, scheduler: Context, delay: Context.SchedulerTimeType.Stride) {
-            self.upstream = upstream
-            self.downstream = downstream
-            self.scheduler = scheduler
-            self.delay = delay
-        }
-
-        func request(_ demand: Subscribers.Demand) {
-            cancelLock.withCriticalBlock {
-                guard !self.isCancelled else { return }
-
-                self.demand = demand
-                self.upstream.subscribe(self)
-            }
-        }
-
-        func receive(_ input: Input) -> Subscribers.Demand {
-            return self.cancelLock.withCriticalBlock { () -> Subscribers.Demand in
-                delay { [weak self] in
-                    _ = self?.downstream.receive(input)
-                }
-
-                // Expects the demand to decrease linearly
-                self.demand -= 1
-
-                return self.demand
-            }
-        }
-
-        func receive(completion: Subscribers.Completion<Failure>) {
-            delay { [weak self] in
-                self?.downstream.receive(completion: completion)
-            }
-        }
-
-        func receive(subscription: Combine.Subscription) {
-            self.cancelLock.withCriticalBlock {
-                guard !self.isCancelled else { return }
-
-                subscription.request(self.demand)
-
-                self.innerSubscription = subscription
-            }
-        }
-
-        func cancel() {
-            cancelLock.withCriticalBlock {
-                isCancelled = true
-
-                innerSubscription?.cancel()
-            }
-        }
-
-        private func delay(_ action: @escaping () -> Void) {
-            let date = self.scheduler.now.advanced(by: self.delay)
-
-            self.scheduler.schedule(after: date) { [weak self] in
-                guard let self = self else { return }
-
-                self.cancelLock.withCriticalBlock {
-                    if !self.isCancelled {
-                        action()
-                    }
-                }
-            }
-        }
-
-    }
-}
-
 extension Publisher {
 
+    /// This is a `delay` operator implementation that respects cancellation
     func cancellableDelay<S>(for delay: S.SchedulerTimeType.Stride, scheduler: S)
-        -> Publishers.CancellableDelay<Self, S> where S: Scheduler
+        -> Publishers.FlatMap<PassthroughSubject<Self.Output, Self.Failure>, Self>
+        where S: Scheduler
     {
-        return Publishers.CancellableDelay(upstream: self, scheduler: scheduler, delay: delay)
-    }
+        return self.flatMap { (value) -> PassthroughSubject<Output, Failure> in
+            let subject = PassthroughSubject<Output, Failure>()
+            let date = scheduler.now.advanced(by: delay)
 
+            // `PassthroughSubject` does not emit values, nor completion after cancellation
+            scheduler.schedule(after: date) {
+                subject.send(value)
+                subject.send(completion: .finished)
+            }
+
+            return subject
+        }
+    }
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

I found a way to rework the complex CancellableDelay using a combination of `FlatMap` + `PassthroughSubject`. `PassthroughSubject` acts as a conduit and it properly handles cancellation unlike the standard `.delay` operator.

The only downside is that `Scheduler.schedule` does not return a `Cancellable` object so we can't cancel the timer, however it has no side-effect as `PassthroughSubject` simply ignores any events or values sent (`.send`) after it has already been cancelled. Given that we don't have many delays used across the app, I figured it's a good trade off vs. complexity we had before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1725)
<!-- Reviewable:end -->
