### PR TITLE
Refactor settings module in mullvad-daemon

### DIFF
--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -12,7 +12,7 @@ use std::{
 use talpid_types::ErrorExt;
 
 #[cfg(windows)]
-use {log::warn, talpid_core::logging::windows::log_sink};
+use talpid_core::logging::windows::log_sink;
 
 
 static SETTINGS_FILE: &str = "settings.json";
@@ -41,6 +41,10 @@ enum LoadSettingsError {
 
     #[error(display = "Unable to parse settings file")]
     ParseError(#[error(source)] mullvad_types::settings::Error),
+
+    #[cfg(windows)]
+    #[error(display = "Failed to restore Windows Update backup: {}", _0)]
+    WinMigrationError(ffi::WinUtilMigrationStatus),
 }
 
 
@@ -119,41 +123,15 @@ impl SettingsPersister {
     ) -> Result<(Settings, bool), LoadSettingsError> {
         info!("No settings file found. Attempting migration from Windows Update backup location");
 
-        if Self::migrate_after_windows_update() {
-            let result = Self::load_settings_from_file(path);
-
-            match &result {
-                Ok(_) => info!("Successfully loaded migrated settings"),
-                Err(_) => warn!("Failed to load migrated settings, using defaults"),
-            }
-
-            result
-        } else {
-            Err(LoadSettingsError::Other)
-        }
+        Self::migrate_after_windows_update()?;
+        Self::load_settings_from_file(path)
     }
 
     #[cfg(windows)]
-    fn migrate_after_windows_update() -> bool {
-        match unsafe {
+    fn migrate_after_windows_update() -> Result<(), LoadSettingsError> {
+        unsafe {
             ffi::WinUtil_MigrateAfterWindowsUpdate(Some(log_sink), b"Settings migrator\0".as_ptr())
-        } {
-            ffi::WinUtilMigrationStatus::Success => {
-                info!("Migration completed successfully");
-                true
-            }
-            ffi::WinUtilMigrationStatus::Aborted => {
-                error!("Migration was aborted to avoid overwriting current settings");
-                false
-            }
-            ffi::WinUtilMigrationStatus::NothingToMigrate => {
-                info!("Could not migrate settings - no backup present");
-                false
-            }
-            ffi::WinUtilMigrationStatus::Failed | _ => {
-                error!("Migration failed");
-                false
-            }
+                .into()
         }
     }
 
@@ -299,8 +277,10 @@ impl Deref for SettingsPersister {
 
 #[cfg(windows)]
 mod ffi {
+    use std::fmt;
     use talpid_core::logging::windows::LogSink;
 
+    #[derive(Debug)]
     #[allow(dead_code)]
     #[repr(u32)]
     pub enum WinUtilMigrationStatus {
@@ -308,7 +288,31 @@ mod ffi {
         Aborted = 1,
         NothingToMigrate = 2,
         Failed = 3,
-        Dummy = 9001,
+    }
+
+    impl fmt::Display for WinUtilMigrationStatus {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            use WinUtilMigrationStatus::*;
+            write!(
+                f,
+                "{}",
+                match self {
+                    Success => "Migration completed successfully",
+                    Aborted => "Migration was aborted to avoid overwriting current settings",
+                    NothingToMigrate => "Could not migrate settings - no backup present",
+                    Failed => "Migration failed",
+                }
+            )
+        }
+    }
+
+    impl Into<Result<(), super::LoadSettingsError>> for WinUtilMigrationStatus {
+        fn into(self) -> Result<(), super::LoadSettingsError> {
+            match self {
+                WinUtilMigrationStatus::Success => Ok(()),
+                val => Err(super::LoadSettingsError::WinMigrationError(val)),
+            }
+        }
     }
 
     #[allow(non_snake_case)]


### PR DESCRIPTION
Changes:
* Use `fs::read` instead of `BufReader`.
* Log causes of failures to load the settings.
* Reorganize Windows Update backup code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1729)
<!-- Reviewable:end -->
