### PR TITLE
Fix notification reappearing after quitting the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix version update notifications not appearing.
 - Fix UI losing any settings updates that happen after leaving the app and then coming back.
 - Fix account expiration date disappearing in some circumstances.
+- Fix notification reappearing after quitting the application.
 
 
 ## [2020.4-beta4] - 2020-05-06

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -197,6 +197,7 @@ class ForegroundNotificationManager(
 
     fun onDestroy() {
         serviceNotifier.unsubscribe(listenerId)
+        serviceInstance = null
 
         service.apply {
             unregisterReceiver(connectReceiver)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -38,7 +38,7 @@ class ForegroundNotificationManager(
             synchronized(this) {
                 if (value != null) {
                     connectionProxy = value.connectionProxy.apply {
-                        onStateChange.subscribe { state ->
+                        connectionListenerId = onStateChange.subscribe { state ->
                             tunnelState = state
                         }
                     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -27,6 +27,7 @@ class MullvadVpnService : TalpidVpnService() {
     private val serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
     private var isStopping = false
+    private var loggedIn = false
 
     private var startDaemonJob: Job? = null
 
@@ -67,12 +68,6 @@ class MullvadVpnService : TalpidVpnService() {
         set(value) {
             field = value
             notificationManager.lockedToForeground = value
-        }
-
-    private var loggedIn = false
-        set(value) {
-            field = value
-            notificationManager.loggedIn = value
         }
 
     override fun onCreate() {


### PR DESCRIPTION
Previously, sometimes quitting the app would leave the notification still visible, or causing it to reappear a few moments later. This happened because the `ForegroundNotificationManager` would still listen for tunnel events and update the notification when needed after its `onDestroy` method was called. This meant that when stopping the manager would remove the notification, but shortly afterwards a disconnected event would be received, causing the manager to crate a new notification.

This PR fixes the issue by properly unsubscribing from tunnel events when the manager is stopping.

The PR also refactors how the manager knows if there is an account set or not. Previously it would depend on the service to notify when there is a user logged in or not. However, the service could notify the notification manager after the manager was stopped. The PR changes that so that the service and the manager handle individual login subscriptions.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1731)
<!-- Reviewable:end -->
