### PR TITLE
Upgrade OpenVPN to 2.4.9, OpenSSL to 1.1.1g and shadowsocks-rust to 1.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Line wrap the file at 100 chars.                                              Th
 - Embed TLS certificates used for HTTPS into the binary rather than loading them from disk at
   runtime
 - Ignore case when setting the relay or bridge location in the CLI.
+- Upgrade OpenVPN from 2.4.8 to 2.4.9 and the OpenSSL version it uses from 1.1.1d to 1.1.1g.
+- Upgrade shadowsocks-rust to version 1.8.10
 
 #### Android
 - Adjust the minimum supported Android version to correctly reflect the supported versions decided

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -87,7 +87,6 @@ for ARCHITECTURE in $ARCHITECTURES; do
     esac
 
     echo "Building mullvad-daemon for $TARGET"
-    source env.sh "$TARGET"
     cargo +stable build $CARGO_ARGS --target "$TARGET" --package mullvad-jni
 
     cp -a "$SCRIPT_DIR/dist-assets/binaries/$TARGET" "$SCRIPT_DIR/android/build/extraJni/$ABI"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -89,7 +89,6 @@ for ARCHITECTURE in $ARCHITECTURES; do
     echo "Building mullvad-daemon for $TARGET"
     cargo +stable build $CARGO_ARGS --target "$TARGET" --package mullvad-jni
 
-    cp -a "$SCRIPT_DIR/dist-assets/binaries/$TARGET" "$SCRIPT_DIR/android/build/extraJni/$ABI"
     cp "$SCRIPT_DIR/target/$TARGET/$BUILD_TYPE/libmullvad_jni.so" "$SCRIPT_DIR/android/build/extraJni/$ABI/"
 done
 

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ RUSTC_VERSION=`rustc +stable --version`
 PRODUCT_VERSION=$(node -p "require('./gui/package.json').version" | sed -Ee 's/\.0//g')
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$SCRIPT_DIR/target"}
 
-source env.sh ""
+source env.sh
 
 if [[ "${1:-""}" != "--dev-build" ]]; then
     BUILD_MODE="release"

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -5,7 +5,7 @@ set -eux
 RUST_TOOLCHAIN_CHANNEL=$1
 export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens"
 
-source env.sh ""
+source env.sh
 
 case "$(uname -s)" in
   Linux*|Darwin*)

--- a/env.sh
+++ b/env.sh
@@ -2,29 +2,19 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -n "$1" ]; then
-    TARGET="$1"
-else
-    TARGET=""
-fi
-
-if [ -z "$TARGET" ]; then
-    case "$(uname -s)" in
-      Linux*)
-        TARGET="x86_64-unknown-linux-gnu"
-        ;;
-      Darwin*)
-        TARGET="x86_64-apple-darwin"
-        ;;
-      MINGW*|MSYS_NT*)
-        TARGET="x86_64-pc-windows-msvc"
-        ;;
-    esac
-fi
+case "$(uname -s)" in
+  Linux*)
+    TARGET="x86_64-unknown-linux-gnu"
+    ;;
+  Darwin*)
+    TARGET="x86_64-apple-darwin"
+    ;;
+  MINGW*|MSYS_NT*)
+    TARGET="x86_64-pc-windows-msvc"
+    ;;
+esac
 
 case "$TARGET" in
-  *android*)
-    ;;
   *linux*)
     export LIBMNL_LIB_DIR="$SCRIPT_DIR/dist-assets/binaries/$TARGET"
     export LIBNFTNL_LIB_DIR="$SCRIPT_DIR/dist-assets/binaries/$TARGET"

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -27,7 +27,7 @@ echo "Updating version in metadata files..."
 ./version-metadata.sh inject $PRODUCT_VERSION
 
 echo "Syncing Cargo.lock with new version numbers"
-source env.sh ""
+source env.sh
 # If cargo exits with a non zero exit status and it's not a timeout (exit code 124) it's an error
 set +e
 timeout 5s cargo +stable build

--- a/talpid-core/src/proxy/shadowsocks.rs
+++ b/talpid-core/src/proxy/shadowsocks.rs
@@ -204,7 +204,7 @@ impl ShadowsocksProxyMonitor {
 
     fn parse_port(logline: &str) -> Result<u16> {
         // TODO: Compile once and reuse.
-        let re = Regex::new(r"(?:TCP Listening on \d+\.\d+\.\d+\.\d+:)(\d+$)").unwrap();
+        let re = Regex::new(r"(?:TCP listening on \d+\.\d+\.\d+\.\d+:)(\d+$)").unwrap();
 
         if let Some(captures) = re.captures(logline) {
             return Ok(captures[1].parse().map_err(|_| {


### PR DESCRIPTION
Main repo PR bumping the binary submodule. In relation to https://github.com/mullvad/mullvadvpn-app-binaries/pull/65.

The Android builds were broken. So I had to update some stuff around that. As such I bring @jvff in for review as well.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1740)
<!-- Reviewable:end -->
