### PR TITLE
Update the route manager

### DIFF
--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -62,6 +62,9 @@ pub enum Error {
 
     #[error(display = "Unknown device index - {}", _0)]
     UnknownDeviceIndex(u32),
+
+    #[error(display = "Shutting down route manager")]
+    Shutdown,
 }
 
 pub struct RouteManagerImpl {
@@ -443,6 +446,7 @@ impl RouteManagerImplInner {
                 self.cleanup_routes().await;
                 log::trace!("Route manager done");
                 let _ = shutdown_signal.send(());
+                return Err(Error::Shutdown);
             }
             RouteManagerCommand::AddRoutes(routes, result_rx) => {
                 log::debug!("Adding routes: {:?}", routes);

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -444,10 +444,10 @@ impl RouteManagerImplInner {
                 log::trace!("Route manager done");
                 let _ = shutdown_signal.send(());
             }
-            RouteManagerCommand::AddRoutes(routes) => {
+            RouteManagerCommand::AddRoutes(routes, result_rx) => {
                 log::debug!("Adding routes: {:?}", routes);
                 if let Err(error) = self.add_required_routes(routes).await {
-                    log::error!("{}", error.display_chain_with_msg("Failed to add routes"));
+                    let _ = result_rx.send(Err(error));
                 }
             }
             RouteManagerCommand::ClearRoutes => {

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -445,6 +445,10 @@ impl RouteManagerImplInner {
                 log::debug!("Adding routes: {:?}", routes);
                 self.add_required_routes(routes).await?;
             }
+            RouteManagerCommand::ClearRoutes => {
+                log::debug!("Clearing routes");
+                self.cleanup_routes().await;
+            }
         }
         Ok(())
     }

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -105,10 +105,7 @@ impl RouteManagerImpl {
         Ok(manager)
     }
 
-    fn add_required_routes(
-        &mut self,
-        required_routes: HashSet<RequiredRoute>,
-    ) -> Result<()> {
+    fn add_required_routes(&mut self, required_routes: HashSet<RequiredRoute>) -> Result<()> {
         let mut routes_to_apply = vec![];
         let mut default_destinations = HashSet::new();
 

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -1,4 +1,4 @@
-use crate::routing::{NetNode, Node, RequiredRoute, Route};
+use crate::routing::{imp::RouteManagerCommand, NetNode, Node, RequiredRoute, Route};
 
 use ipnetwork::IpNetwork;
 use std::{
@@ -8,7 +8,11 @@ use std::{
     process::{Command, ExitStatus, Stdio},
 };
 
-use futures01::{stream, sync::oneshot, Async, Future, IntoFuture, Stream};
+use futures01::{
+    stream,
+    sync::{mpsc, oneshot},
+    Async, Future, IntoFuture, Stream,
+};
 use tokio_process::{Child, CommandExt};
 
 
@@ -69,18 +73,16 @@ pub struct RouteManagerImpl {
     current_state: RouteManagerState,
     v4_gateway: Option<Node>,
     v6_gateway: Option<Node>,
-    shutdown_rx: Option<oneshot::Receiver<oneshot::Sender<()>>>,
+    manage_rx: Option<mpsc::UnboundedReceiver<RouteManagerCommand>>,
 }
 
 
 impl RouteManagerImpl {
     pub fn new(
         required_routes: HashSet<RequiredRoute>,
-        shutdown_rx: oneshot::Receiver<oneshot::Sender<()>>,
+        manage_rx: mpsc::UnboundedReceiver<RouteManagerCommand>,
     ) -> Result<Self> {
-        let mut applied_routes = HashSet::new();
-        let mut routes_to_apply = vec![];
-        let mut default_destinations = HashSet::new();
+        let change_listener = ChangeListener::new().map_err(Error::FailedToMonitorRoutes)?;
 
         let v4_gateway = Self::get_default_node_cmd("-inet").wait()?;
         let v6_gateway = Self::get_default_node_cmd("-inet6").wait()?;
@@ -88,6 +90,27 @@ impl RouteManagerImpl {
         if v4_gateway.is_none() && v6_gateway.is_none() {
             return Err(Error::NoDefaultRoute);
         }
+
+        let mut manager = Self {
+            default_destinations: HashSet::new(),
+            applied_routes: HashSet::new(),
+            current_state: RouteManagerState::Listening(change_listener),
+            manage_rx: Some(manage_rx),
+            v4_gateway,
+            v6_gateway,
+        };
+
+        manager.add_required_routes(required_routes)?;
+
+        Ok(manager)
+    }
+
+    fn add_required_routes(
+        &mut self,
+        required_routes: HashSet<RequiredRoute>,
+    ) -> Result<()> {
+        let mut routes_to_apply = vec![];
+        let mut default_destinations = HashSet::new();
 
         for route in required_routes {
             match route.node {
@@ -99,47 +122,22 @@ impl RouteManagerImpl {
             }
         }
 
-        let apply_routes_fn = || -> Result<()> {
-            for route in routes_to_apply {
-                Self::add_route(&route).wait()?;
-                applied_routes.insert(route);
-            }
-            for destination in default_destinations.iter() {
-                match (&v4_gateway, &v6_gateway, destination.is_ipv4()) {
-                    (Some(gateway), _, true) | (_, Some(gateway), false) => {
-                        let route = Route::new(gateway.clone(), *destination);
-                        Self::add_route(&route).wait()?;
-                        applied_routes.insert(route);
-                    }
-                    _ => (),
-                };
-            }
-
-            Ok(())
-        };
-
-        if let Err(e) = apply_routes_fn() {
-            log::error!("Failed to apply routes - {}", e);
-            for applied_route in applied_routes.iter() {
-                if let Err(removal_err) = Self::delete_route(applied_route.prefix).wait() {
-                    log::error!(
-                        "Failed to clean up routes after failing to set them up - {}",
-                        removal_err
-                    );
-                }
-            }
-            return Err(e);
+        for route in routes_to_apply {
+            Self::add_route(&route).wait()?;
+            self.applied_routes.insert(route);
         }
-        let change_listener = ChangeListener::new().map_err(Error::FailedToMonitorRoutes)?;
+        for destination in default_destinations.iter() {
+            match (&self.v4_gateway, &self.v6_gateway, destination.is_ipv4()) {
+                (Some(gateway), _, true) | (_, Some(gateway), false) => {
+                    let route = Route::new(gateway.clone(), *destination);
+                    Self::add_route(&route).wait()?;
+                    self.applied_routes.insert(route);
+                }
+                _ => (),
+            };
+        }
 
-        Ok(Self {
-            default_destinations,
-            applied_routes,
-            current_state: RouteManagerState::Listening(change_listener),
-            shutdown_rx: Some(shutdown_rx),
-            v4_gateway,
-            v6_gateway,
-        })
+        Ok(())
     }
 
     // Retrieves the node that's currently used to reach 0.0.0.0/0
@@ -230,10 +228,7 @@ impl RouteManagerImpl {
             .map_err(Error::FailedToAddRoute)
     }
 
-    fn shutdown_future(
-        &self,
-        shutdown_done_tx: Option<oneshot::Sender<()>>,
-    ) -> impl Future<Item = (), Error = ()> + Send {
+    fn cleanup_routes(&self) -> impl Future<Item = (), Error = ()> + Send {
         let remove_route_future = |route: &Route| {
             Self::delete_route(route.prefix).then(|removal| {
                 match removal {
@@ -261,16 +256,21 @@ impl RouteManagerImpl {
                 _ => None,
             }
         }));
-        stream::futures_ordered(routes_to_remove)
-            .for_each(|_| Ok(()))
-            .and_then(|_| {
-                if let Some(tx) = shutdown_done_tx {
-                    if tx.send(()).is_err() {
-                        log::debug!("RouteManager already dropped")
-                    }
+        stream::futures_ordered(routes_to_remove).for_each(|_| Ok(()))
+    }
+
+    fn shutdown_future(
+        &self,
+        shutdown_done_tx: Option<oneshot::Sender<()>>,
+    ) -> impl Future<Item = (), Error = ()> + Send {
+        self.cleanup_routes().and_then(|_| {
+            if let Some(tx) = shutdown_done_tx {
+                if tx.send(()).is_err() {
+                    log::debug!("RouteManager already dropped")
                 }
-                Ok(())
-            })
+            }
+            Ok(())
+        })
     }
 
     fn apply_new_default_routes(
@@ -323,20 +323,35 @@ impl Future for RouteManagerImpl {
     type Item = ();
     type Error = Error;
     fn poll(&mut self) -> Result<Async<()>> {
-        if let Some(mut shutdown_rx) = self.shutdown_rx.take() {
-            match shutdown_rx.poll() {
-                Ok(Async::Ready(shutdown_tx)) => {
-                    self.current_state = RouteManagerState::Shutdown(Box::new(
-                        self.shutdown_future(Some(shutdown_tx)),
-                    ));
-                }
+        if let Some(mut manage_rx) = self.manage_rx.take() {
+            match manage_rx.poll() {
+                Ok(Async::Ready(Some(command))) => match command {
+                    RouteManagerCommand::Shutdown(tx) => {
+                        self.current_state =
+                            RouteManagerState::Shutdown(Box::new(self.shutdown_future(Some(tx))));
+                    }
+                    RouteManagerCommand::AddRoutes(routes, result_tx) => {
+                        self.manage_rx = Some(manage_rx);
+                        log::debug!("Adding routes: {:?}", routes);
+                        if let Err(error) = self.add_required_routes(routes) {
+                            let _ = result_tx.send(Err(error));
+                        } else {
+                            let _ = result_tx.send(Ok(()));
+                        }
+                    }
+                    RouteManagerCommand::ClearRoutes => {
+                        self.manage_rx = Some(manage_rx);
+                        log::debug!("Clearing routes");
+                        let _ = self.cleanup_routes().wait();
+                    }
+                },
                 // handle is already dropped
-                Err(_) => {
+                Ok(Async::Ready(None)) | Err(_) => {
                     self.current_state =
                         RouteManagerState::Shutdown(Box::new(self.shutdown_future(None)));
                 }
                 Ok(Async::NotReady) => {
-                    self.shutdown_rx = Some(shutdown_rx);
+                    self.manage_rx = Some(manage_rx);
                 }
             };
         }

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -108,7 +108,12 @@ impl RouteManager {
     /// Applies the given routes until [`RouteManager::stop`] is called.
     pub fn add_routes(&mut self, routes: HashSet<RequiredRoute>) -> Result<(), Error> {
         if let Some(tx) = &self.manage_tx {
-            let _ = tx.unbounded_send(RouteManagerCommand::AddRoutes(routes));
+            if tx
+                .unbounded_send(RouteManagerCommand::AddRoutes(routes))
+                .is_err()
+            {
+                return Err(Error::RouteManagerDown);
+            }
             Ok(())
         } else {
             Err(Error::RouteManagerDown)
@@ -119,7 +124,9 @@ impl RouteManager {
     /// [`RouteManager::add_routes`].
     pub fn clear_routes(&mut self) -> Result<(), Error> {
         if let Some(tx) = &self.manage_tx {
-            let _ = tx.unbounded_send(RouteManagerCommand::ClearRoutes);
+            if tx.unbounded_send(RouteManagerCommand::ClearRoutes).is_err() {
+                return Err(Error::RouteManagerDown);
+            }
             Ok(())
         } else {
             Err(Error::RouteManagerDown)

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -45,6 +45,7 @@ pub enum Error {
 #[derive(Debug)]
 pub enum RouteManagerCommand {
     AddRoutes(HashSet<RequiredRoute>),
+    ClearRoutes,
     Shutdown(oneshot::Sender<()>),
 }
 
@@ -108,6 +109,17 @@ impl RouteManager {
     pub fn add_routes(&mut self, routes: HashSet<RequiredRoute>) -> Result<(), Error> {
         if let Some(tx) = &self.manage_tx {
             let _ = tx.unbounded_send(RouteManagerCommand::AddRoutes(routes));
+            Ok(())
+        } else {
+            Err(Error::RouteManagerDown)
+        }
+    }
+
+    /// Removes all routes previously applied in [`RouteManager::new`] or
+    /// [`RouteManager::add_routes`].
+    pub fn clear_routes(&mut self) -> Result<(), Error> {
+        if let Some(tx) = &self.manage_tx {
+            let _ = tx.unbounded_send(RouteManagerCommand::ClearRoutes);
             Ok(())
         } else {
             Err(Error::RouteManagerDown)

--- a/talpid-core/src/routing/windows.rs
+++ b/talpid-core/src/routing/windows.rs
@@ -5,9 +5,15 @@ use std::collections::HashSet;
 /// Windows routing errors.
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
-    /// Failure to apply a route
+    /// Failure to initialize route manager
     #[error(display = "Failed to start route manager")]
     FailedToStartManager,
+    /// Failure to add routes
+    #[error(display = "Failed to add routes")]
+    AddRoutesFailed,
+    /// Failure to clear routes
+    #[error(display = "Failed to clear applied routes")]
+    ClearRoutesFailed,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -22,27 +28,15 @@ impl RouteManager {
     /// Creates a new route manager that will apply the provided routes and ensure they exist until
     /// it's stopped.
     pub fn new(required_routes: HashSet<RequiredRoute>) -> Result<Self> {
-        let routes: Vec<_> = required_routes
-            .iter()
-            .map(|route| {
-                let destination = winnet::WinNetIpNetwork::from(route.prefix);
-                match &route.node {
-                    NetNode::DefaultNode => winnet::WinNetRoute::through_default_node(destination),
-                    NetNode::RealNode(node) => {
-                        winnet::WinNetRoute::new(winnet::WinNetNode::from(node), destination)
-                    }
-                }
-            })
-            .collect();
-
-        if !winnet::activate_routing_manager(&routes) {
+        if !winnet::activate_routing_manager() {
             return Err(Error::FailedToStartManager);
         }
-
-        Ok(Self {
+        let manager = Self {
             callback_handles: vec![],
             is_stopped: false,
-        })
+        };
+        manager.add_routes(required_routes)?;
+        Ok(manager)
     }
 
     /// Sets a callback that is called whenever the default route changes.
@@ -67,6 +61,13 @@ impl RouteManager {
         }
     }
 
+    /// Removes all routes previously applied in [`RouteManager::new`] or
+    /// [`RouteManager::add_routes`].
+    pub fn clear_default_route_callbacks(&mut self) {
+        // `WinNetCallbackHandle::drop` removes these callbacks.
+        self.callback_handles.clear();
+    }
+
     /// Stops the routing manager and invalidates the route manager - no new default route callbacks
     /// can be added
     pub fn stop(&mut self) {
@@ -74,6 +75,38 @@ impl RouteManager {
             self.callback_handles.clear();
             winnet::deactivate_routing_manager();
             self.is_stopped = true;
+        }
+    }
+
+    /// Applies the given routes until [`RouteManager::stop`] is called.
+    pub fn add_routes(&self, routes: HashSet<RequiredRoute>) -> Result<()> {
+        let routes: Vec<_> = routes
+            .iter()
+            .map(|route| {
+                let destination = winnet::WinNetIpNetwork::from(route.prefix);
+                match &route.node {
+                    NetNode::DefaultNode => winnet::WinNetRoute::through_default_node(destination),
+                    NetNode::RealNode(node) => {
+                        winnet::WinNetRoute::new(winnet::WinNetNode::from(node), destination)
+                    }
+                }
+            })
+            .collect();
+
+        if winnet::routing_manager_add_routes(&routes) {
+            Ok(())
+        } else {
+            Err(Error::AddRoutesFailed)
+        }
+    }
+
+    /// Removes all routes previously applied in [`RouteManager::new`] or
+    /// [`RouteManager::add_routes`].
+    pub fn clear_routes(&self) -> Result<()> {
+        if winnet::routing_manager_delete_applied_routes() {
+            Ok(())
+        } else {
+            Err(Error::ClearRoutesFailed)
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -90,6 +90,8 @@ impl ConnectedState {
     }
 
     fn reset_routes(shared_values: &mut SharedTunnelStateValues) {
+        #[cfg(windows)]
+        shared_values.route_manager.clear_default_route_callbacks();
         if let Err(error) = shared_values.route_manager.clear_routes() {
             log::error!(
                 "Failed to clear routes: {:?}",

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -170,6 +170,8 @@ impl ConnectingState {
     }
 
     fn reset_routes(shared_values: &mut SharedTunnelStateValues) {
+        #[cfg(windows)]
+        shared_values.route_manager.clear_default_route_callbacks();
         if let Err(error) = shared_values.route_manager.clear_routes() {
             log::error!(
                 "Failed to clear routes: {:?}",

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -289,17 +289,8 @@ impl Drop for WinNetRoute {
     }
 }
 
-pub fn activate_routing_manager(routes: &[WinNetRoute]) -> bool {
-    if unsafe { WinNet_ActivateRouteManager(Some(log_sink), logging_context()) } {
-        if routing_manager_add_routes(routes) {
-            true
-        } else {
-            deactivate_routing_manager();
-            false
-        }
-    } else {
-        false
-    }
+pub fn activate_routing_manager() -> bool {
+    unsafe { WinNet_ActivateRouteManager(Some(log_sink), logging_context()) }
 }
 
 pub struct WinNetCallbackHandle {
@@ -360,6 +351,10 @@ pub fn routing_manager_add_routes(routes: &[WinNetRoute]) -> bool {
     unsafe { WinNet_AddRoutes(ptr, length) }
 }
 
+pub fn routing_manager_delete_applied_routes() -> bool {
+    unsafe { WinNet_DeleteAppliedRoutes() }
+}
+
 pub fn deactivate_routing_manager() {
     unsafe { WinNet_DeactivateRouteManager() }
 }
@@ -399,6 +394,9 @@ mod api {
 
         // #[link_name = "WinNet_DeleteRoute"]
         // pub fn WinNet_DeleteRoute(route: *const super::WinNetRoute) -> bool;
+
+        #[link_name = "WinNet_DeleteAppliedRoutes"]
+        pub fn WinNet_DeleteAppliedRoutes() -> bool;
 
         #[link_name = "WinNet_DeactivateRouteManager"]
         pub fn WinNet_DeactivateRouteManager();

--- a/windows/winnet/src/winnet/routing/routemanager.cpp
+++ b/windows/winnet/src/winnet/routing/routemanager.cpp
@@ -209,27 +209,7 @@ RouteManager::~RouteManager()
 	m_routeMonitorV4.reset();
 	m_routeMonitorV6.reset();
 
-	//
-	// Delete all routes owned by us.
-	//
-
-	for (const auto &record : m_routes)
-	{
-		try
-		{
-			deleteFromRoutingTable(record.registeredRoute);
-		}
-		catch (const std::exception &ex)
-		{
-			std::wstringstream ss;
-
-			ss << L"Failed to delete route as part of cleaning up, Route: "
-				<< FormatRegisteredRoute(record.registeredRoute);
-
-			m_logSink->error(common::string::ToAnsi(ss.str()).c_str());
-			m_logSink->error(ex.what());
-		}
-	}
+	deleteAppliedRoutes();
 }
 
 void RouteManager::addRoutes(const std::vector<Route> &routes)
@@ -300,6 +280,33 @@ void RouteManager::deleteRoutes(const std::vector<Route> &routes)
 			THROW_ERROR("Failed during batch removal of routes");
 		}
 	}
+}
+
+void RouteManager::deleteAppliedRoutes()
+{
+	//
+	// Delete all routes owned by us.
+	//
+
+	for (const auto &record : m_routes)
+	{
+		try
+		{
+			deleteFromRoutingTable(record.registeredRoute);
+		}
+		catch (const std::exception & ex)
+		{
+			std::wstringstream ss;
+
+			ss << L"Failed to delete route while clearing applied routes, Route: "
+				<< FormatRegisteredRoute(record.registeredRoute);
+
+			m_logSink->error(common::string::ToAnsi(ss.str()).c_str());
+			m_logSink->error(ex.what());
+		}
+	}
+
+	m_routes.clear();
 }
 
 RouteManager::CallbackHandle RouteManager::registerDefaultRouteChangedCallback(DefaultRouteChangedCallback callback)

--- a/windows/winnet/src/winnet/routing/routemanager.h
+++ b/windows/winnet/src/winnet/routing/routemanager.h
@@ -32,6 +32,7 @@ public:
 	
 	void addRoutes(const std::vector<Route> &routes);
 	void deleteRoutes(const std::vector<Route> &routes);
+	void deleteAppliedRoutes();
 
 	using DefaultRouteChangedEventType = DefaultRouteMonitor::EventType;
 

--- a/windows/winnet/src/winnet/winnet.cpp
+++ b/windows/winnet/src/winnet/winnet.cpp
@@ -385,6 +385,35 @@ extern "C"
 WINNET_LINKAGE
 bool
 WINNET_API
+WinNet_DeleteAppliedRoutes()
+{
+	AutoLockType lock(g_RouteManagerLock);
+
+	if (nullptr == g_RouteManager)
+	{
+		return false;
+	}
+
+	try
+	{
+		g_RouteManager->deleteAppliedRoutes();
+		return true;
+	}
+	catch (const std::exception & err)
+	{
+		common::error::UnwindException(err, g_RouteManagerLogSink);
+		return false;
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+extern "C"
+WINNET_LINKAGE
+bool
+WINNET_API
 WinNet_DeleteRoute(
 	const WINNET_ROUTE *route
 )

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -173,6 +173,13 @@ WinNet_DeleteRoute(
 	const WINNET_ROUTE *route
 );
 
+extern "C"
+WINNET_LINKAGE
+bool
+WINNET_API
+WinNet_DeleteAppliedRoutes(
+);
+
 enum WINNET_DEFAULT_ROUTE_CHANGED_EVENT_TYPE
 {
 	// Best default route changed.


### PR DESCRIPTION
This makes a few changes to the routing module, mostly in order to simplify code in the split tunneling branch.

The main change is that the `RouteManager` is stored in `SharedTunnelStateValues`. This enables routes to be added later on in the `ConnectedState`, etc., instead of only when the route manager is initialized.

The changes resulted in an issue on Linux where new routes weren't detected sufficiently quickly after the offline monitor recognized the machine to be online, which was worked around by reloading the routes if they're stale.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1743)
<!-- Reviewable:end -->
