### PR TITLE
Retry fetching account expiry on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix UI losing any settings updates that happen after leaving the app and then coming back.
 - Fix account expiration date disappearing in some circumstances.
 - Fix notification reappearing after quitting the application.
+- Retry when fetching account expiration fails.
 
 
 ## [2020.4] - 2020-05-12

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -33,7 +33,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
             jobTracker.newBackgroundJob("fetch") {
                 var retryAttempt = 0
 
-                while (true) {
+                while (onAccountDataChange != null) {
                     val result = daemon.getAccountData(account)
 
                     if (result is GetAccountDataResult.Ok) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -43,6 +43,10 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
     override fun onSafelyResume() {
         accountCache.onAccountDataChange = { accountNumber, accountExpiry ->
             updateViewJob = updateView(accountNumber, accountExpiry)
+
+            if (accountExpiry == null) {
+                accountCache.fetchAccountExpiry()
+            }
         }
     }
 


### PR DESCRIPTION
Previously, if fetching the account data (which is mostly the account expiration date) fails, the UI would simply consider that the account had no expiry. This PR changes that so that the `AccountCache` class retries to fetch the data if it fails, using an exponential backoff between each attempt.

The retries only happen if there's a listener attached to handle the data. Otherwise the retries stop. Therefore, the Account screen now will attempt to fetch the account data if it sees that the expiry is `null`. This is because previously the Account screen would never fetch the data since the Settings screen would fetch it first. However, if the fetch started in the Settings screen fails and the user enters the Account screen, the retries are cancelled when the listener from the Settings screen is detached. If the retries are cancelled, the expiry remains `null`, and that's how the Account screen detects it should resume the retries by requesting a new fetch.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1746)
<!-- Reviewable:end -->
