### PR TITLE
Exit with different exit codes in relay_list binary depending on error

### DIFF
--- a/mullvad-rpc/src/bin/relay_list.rs
+++ b/mullvad-rpc/src/bin/relay_list.rs
@@ -1,16 +1,32 @@
 /// Intended to be used to pre-load a relay list when creating an installer for the Mullvad VPN
 /// app.
 use futures01::future::Future;
-use mullvad_rpc::{MullvadRpcRuntime, RelayListProxy};
+use mullvad_rpc::{rest::Error as RestError, MullvadRpcRuntime, RelayListProxy};
+use std::process;
+use talpid_types::ErrorExt;
 
 fn main() {
     let mut runtime = MullvadRpcRuntime::new().expect("Failed to load runtime");
 
     let relay_list_request = RelayListProxy::new(runtime.mullvad_rest_handle()).relay_list();
 
-    let relay_list = relay_list_request
-        .wait()
-        .expect("Failed to fetch relay list");
-
+    let relay_list = match relay_list_request.wait() {
+        Ok(relay_list) => relay_list,
+        Err(RestError::TimeoutError(_)) => {
+            eprintln!("Request timed out");
+            process::exit(2);
+        }
+        Err(e @ RestError::DeserializeError(_)) => {
+            eprintln!(
+                "{}",
+                e.display_chain_with_msg("Failed to deserialize relay list")
+            );
+            process::exit(3);
+        }
+        Err(e) => {
+            eprintln!("{}", e.display_chain_with_msg("Failed to fetch relay list"));
+            process::exit(1);
+        }
+    };
     println!("{}", serde_json::to_string_pretty(&relay_list).unwrap());
 }

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -41,9 +41,6 @@ pub enum Error {
     #[error(display = "Request timed out")]
     TimeoutError(#[error(source)] tokio::time::Elapsed),
 
-    #[error(display = "Timer error")]
-    TimerError(#[error(source)] tokio::time::Error),
-
     #[error(display = "Failed to deserialize data")]
     DeserializeError(#[error(source)] serde_json::Error),
 
@@ -60,9 +57,6 @@ pub enum Error {
     /// The string given was not a valid URI.
     #[error(display = "Not a valid URI")]
     UriError(#[error(source)] http::uri::InvalidUri),
-
-    #[error(display = "Failed to spawn future in a backwards-compatible fashion")]
-    SpawnError(#[error(source)] tokio::task::JoinError),
 }
 
 /// A service that executes HTTP requests, allowing for on-demand termination of all in-flight

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -44,18 +44,14 @@ pub enum Error {
     #[error(display = "Timer error")]
     TimerError(#[error(source)] tokio::time::Error),
 
-    #[error(display = "Deserialization error")]
-    DeserializationError,
+    #[error(display = "Failed to deserialize data")]
+    DeserializeError(#[error(source)] serde_json::Error),
 
     #[error(display = "Failed to send request to rest client")]
     SendError,
 
     #[error(display = "Failed to receive response from rest client")]
     ReceiveError,
-
-    /// Serde error
-    #[error(display = "Serialization error")]
-    Serde(#[error(source)] serde_json::Error),
 
     /// When the http status code of the response is not 200 OK.
     #[error(display = "Http error. Status code {}", _0)]
@@ -513,7 +509,7 @@ pub async fn deserialize_body<T: serde::de::DeserializeOwned>(mut response: Resp
         body.extend(&chunk?);
     }
 
-    serde_json::from_slice(&body).map_err(Error::Serde)
+    serde_json::from_slice(&body).map_err(Error::DeserializeError)
 }
 
 pub async fn parse_rest_response(


### PR DESCRIPTION
The ops team would like to be able to monitor the relay list endpoint for trouble. So if we modify our relay list fetching binary in the following way they can differentiate between different types of errors on the process exit code.

I found that the `DeserializationError` was completely unused. It was very close that I submitted this PR with the code matching for an error that would never happen :( But I removed the more vaguely named `Serde` error variant and instead started using the (renamed) `DeserializeError`.

I also found that two error variants were never used :( So I cleaned these up.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1749)
<!-- Reviewable:end -->
