### PR TITLE
Always enable beta update notifications in beta versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Ignore case when setting the relay or bridge location in the CLI.
 - Upgrade OpenVPN from 2.4.8 to 2.4.9 and the OpenSSL version it uses from 1.1.1d to 1.1.1g.
 - Upgrade shadowsocks-rust to version 1.8.10
+- Always enable the beta program when running a beta version.
 
 #### Android
 - Adjust the minimum supported Android version to correctly reflect the supported versions decided

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -20,7 +20,7 @@ class AppVersionInfoCache(
     private val setUpJob = setUp()
 
     private val settingsListenerId = settingsListener.subscribe { settings ->
-        showBetaReleases = settings.showBetaReleases ?: false
+        showBetaReleases = settings.showBetaReleases
     }
 
     private var appVersionInfo: AppVersionInfo? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
@@ -6,5 +6,5 @@ data class Settings(
     var allowLan: Boolean,
     var autoConnect: Boolean,
     var tunnelOptions: TunnelOptions,
-    var showBetaReleases: Boolean?
+    var showBetaReleases: Boolean
 )

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -343,7 +343,7 @@ const settingsSchema = partialObject({
   allow_lan: boolean,
   auto_connect: boolean,
   block_when_disconnected: boolean,
-  show_beta_releases: maybe(boolean),
+  show_beta_releases: boolean,
   bridge_settings: bridgeSettingsSchema,
   bridge_state: enumeration('on', 'auto', 'off'),
   relay_settings: relaySettingsSchema,

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -92,7 +92,7 @@ class ApplicationMain {
     allowLan: false,
     autoConnect: false,
     blockWhenDisconnected: false,
-    showBetaReleases: undefined,
+    showBetaReleases: false,
     relaySettings: {
       normal: {
         location: 'any',

--- a/gui/src/renderer/components/Preferences.tsx
+++ b/gui/src/renderer/components/Preferences.tsx
@@ -18,7 +18,7 @@ export interface IProps {
   autoStart: boolean;
   autoConnect: boolean;
   allowLan: boolean;
-  showBetaReleases?: boolean;
+  showBetaReleases: boolean;
   enableSystemNotifications: boolean;
   monochromaticIcon: boolean;
   startMinimized: boolean;
@@ -170,7 +170,7 @@ export default class Preferences extends Component<IProps> {
                         {messages.pgettext('preferences-view', 'Beta program')}
                       </Cell.Label>
                       <Cell.Switch
-                        isOn={this.props.showBetaReleases || false}
+                        isOn={this.props.showBetaReleases}
                         onChange={this.props.setShowBetaReleases}
                       />
                     </Cell.Container>

--- a/gui/src/renderer/redux/settings/actions.ts
+++ b/gui/src/renderer/redux/settings/actions.ts
@@ -39,7 +39,7 @@ export interface IUpdateBlockWhenDisconnectedAction {
 
 export interface IUpdateShowBetaReleasesAction {
   type: 'UPDATE_SHOW_BETA_NOTIFICATIONS';
-  showBetaReleases?: boolean;
+  showBetaReleases: boolean;
 }
 
 export interface IUpdateBridgeSettingsAction {
@@ -171,7 +171,7 @@ function updateBlockWhenDisconnected(
   };
 }
 
-function updateShowBetaReleases(showBetaReleases?: boolean): IUpdateShowBetaReleasesAction {
+function updateShowBetaReleases(showBetaReleases: boolean): IUpdateShowBetaReleasesAction {
   return {
     type: 'UPDATE_SHOW_BETA_NOTIFICATIONS',
     showBetaReleases,

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -126,7 +126,7 @@ export interface ISettingsReduxState {
   bridgeSettings: BridgeSettingsRedux;
   bridgeState: BridgeState;
   blockWhenDisconnected: boolean;
-  showBetaReleases?: boolean;
+  showBetaReleases: boolean;
   openVpn: {
     mssfix?: number;
   };
@@ -167,7 +167,7 @@ const initialState: ISettingsReduxState = {
   },
   bridgeState: 'auto',
   blockWhenDisconnected: false,
-  showBetaReleases: undefined,
+  showBetaReleases: false,
   openVpn: {},
   wireguard: {},
   wireguardKeyState: {

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -289,7 +289,7 @@ export interface ISettings {
   allowLan: boolean;
   autoConnect: boolean;
   blockWhenDisconnected: boolean;
-  showBetaReleases?: boolean;
+  showBetaReleases: boolean;
   relaySettings: RelaySettings;
   tunnelOptions: ITunnelOptions;
   bridgeSettings: BridgeSettings;

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -20,7 +20,7 @@ impl Command for Version {
         println!("\tIs supported: {}", version_info.supported);
 
         let settings = rpc.get_settings()?;
-        let is_updated = if settings.show_beta_releases.unwrap_or(false) {
+        let is_updated = if settings.show_beta_releases {
             version_info.latest == current_version
         } else {
             version_info.latest_stable == current_version

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -498,7 +498,7 @@ where
 
         let mut settings = SettingsPersister::load(&settings_dir);
 
-        if version::is_beta_version() && settings.show_beta_releases.is_none() {
+        if version::is_beta_version() {
             let _ = settings.set_show_beta_releases(true);
         }
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -231,10 +231,8 @@ impl SettingsPersister {
     }
 
     pub fn set_show_beta_releases(&mut self, show_beta_releases: bool) -> Result<bool, Error> {
-        let should_save = Self::update_field(
-            &mut self.settings.show_beta_releases,
-            Some(show_beta_releases),
-        );
+        let should_save =
+            Self::update_field(&mut self.settings.show_beta_releases, show_beta_releases);
         self.update(should_save)
     }
 

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -70,7 +70,7 @@ impl super::SettingsMigration for Migration {
                 block_when_disconnected: old.block_when_disconnected,
                 auto_connect: old.auto_connect,
                 tunnel_options: old.tunnel_options,
-                show_beta_releases: None,
+                show_beta_releases: false,
                 settings_version: super::SettingsVersion::V2,
             }),
             VersionedSettings::V2(new) => VersionedSettings::V2(new),

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -48,7 +48,7 @@ pub struct Settings {
     /// might be located.
     pub tunnel_options: TunnelOptions,
     /// Whether to notify users of beta updates.
-    pub show_beta_releases: Option<bool>,
+    pub show_beta_releases: bool,
     /// Specifies settings schema version
     #[cfg_attr(target_os = "android", jnix(skip))]
     settings_version: migrations::SettingsVersion,
@@ -70,7 +70,7 @@ impl Default for Settings {
             block_when_disconnected: false,
             auto_connect: false,
             tunnel_options: TunnelOptions::default(),
-            show_beta_releases: None,
+            show_beta_releases: false,
             settings_version: migrations::SettingsVersion::V2,
         }
     }


### PR DESCRIPTION
And prevent them from being disabled, so that users don't receive notifications advising them to download the latest stable version if it's older than the last beta version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1751)
<!-- Reviewable:end -->
