### PR TITLE
Display the supplied error code in the logs

### DIFF
--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -50,8 +50,8 @@ pub enum Error {
     #[error(display = "Failed to receive response from rest client")]
     ReceiveError,
 
-    /// When the http status code of the response is not 200 OK.
-    #[error(display = "Http error. Status code {}", _0)]
+    /// Unexpected response code
+    #[error(display = "Unexpected response status code {} - {}", _0, _1)]
     ApiError(StatusCode, String),
 
     /// The string given was not a valid URI.


### PR DESCRIPTION
The master API can contain a string that specifies the type of error that was encountered when processing a request, which can be helpful to distinguish between different types of errors, when the HTTP response status code remains the same. But for the code to be helpful, it needs to be logged - these changes achieve just that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1753)
<!-- Reviewable:end -->
