### PR TITLE
Fix error message shown when routes cannot be removed

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -93,10 +93,7 @@ impl ConnectedState {
         #[cfg(windows)]
         shared_values.route_manager.clear_default_route_callbacks();
         if let Err(error) = shared_values.route_manager.clear_routes() {
-            log::error!(
-                "Failed to clear routes: {:?}",
-                error.display_chain_with_msg("Failed to clear routes")
-            );
+            log::error!("{}", error.display_chain_with_msg("Failed to clear routes"));
         }
     }
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -173,10 +173,7 @@ impl ConnectingState {
         #[cfg(windows)]
         shared_values.route_manager.clear_default_route_callbacks();
         if let Err(error) = shared_values.route_manager.clear_routes() {
-            log::error!(
-                "Failed to clear routes: {:?}",
-                error.display_chain_with_msg("Failed to clear routes")
-            );
+            log::error!("{}", error.display_chain_with_msg("Failed to clear routes"));
         }
     }
 


### PR DESCRIPTION
Minor fix. "Failed to clear routes" was shown twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1756)
<!-- Reviewable:end -->
