### PR TITLE
Align subtitle in Launch.tsx

### DIFF
--- a/gui/src/renderer/components/Launch.tsx
+++ b/gui/src/renderer/components/Launch.tsx
@@ -29,6 +29,7 @@ const styles = {
     fontSize: 14,
     lineHeight: 20,
     color: colors.white40,
+    textAlign: 'center',
   }),
 };
 


### PR DESCRIPTION
This PR centers the text in Launch.tsx. The text was previously centered as long as the text was just one line.

<img width="366" alt="Screen Shot 2020-05-15 at 10 21 27" src="https://user-images.githubusercontent.com/3668602/82057358-8311ea80-96c3-11ea-93e6-04553125f469.png">
<img width="366" alt="Screen Shot 2020-05-15 at 10 21 52" src="https://user-images.githubusercontent.com/3668602/82057363-84dbae00-96c3-11ea-80cc-ec6b1d39e576.png">

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1757)
<!-- Reviewable:end -->
