### PR TITLE
Switch to using DispatchWallTime and DispatchSourceTimer in key rotation

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -366,7 +366,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             persistentKeychainReference: persistentKeychainReference
         )
 
-        keyRotationManager.keyRotationEventHandler = { (keyRotationEvent) in
+        keyRotationManager.eventHandler = { (keyRotationEvent) in
             self.reloadTunnel().autoDisposableSink(
                 cancellableSet: self.cancellableSet,
                 receiveCompletion: { (completion) in


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

After doing some testing we figured that `DispatchTime` relies on device uptime which doesn't tick when the device is hibernated causing timers to fire much later than expected. With `DispatchWallTime` the timers that are due would fire immediately on wake up.

1. `DispatchTime` is relative to system clock that ticks since boot
1. `DispatchWallTime` - An absolute point in time according to the wall clock, with microsecond precision.

I also decided to go with `DispatchSourceTimer` instead of `DispatchQueue.asyncAfter` because I am not entirely sure that the timer created internally by `DispatchQueue.asyncAfter` is cancelled upon the work item (`DispatchWorkItem`) cancellation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1759)
<!-- Reviewable:end -->
