### PR TITLE
Update Android build scripts to add build for F-Droid

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,14 @@ android {
         }
     }
 
+    buildTypes {
+        fdroid {
+            initWith release
+            minifyEnabled false
+            signingConfig null
+        }
+    }
+
     sourceSets {
         main {
             assets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,7 +83,7 @@ buildscript {
         google()
 
         maven {
-            url = uri("https://plugins.gradle.org/m2/")
+            url "https://plugins.gradle.org/m2/"
         }
     }
 

--- a/android/fdroid-build/cargo-config.toml.example
+++ b/android/fdroid-build/cargo-config.toml.example
@@ -1,0 +1,15 @@
+[target.aarch64-linux-android]
+ar = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+linker = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+
+[target.armv7-linux-androideabi]
+ar = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar"
+linker = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang"
+
+[target.x86_64-linux-android]
+ar = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar"
+linker = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang"
+
+[target.i686-linux-android]
+ar = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"
+linker = "NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang"

--- a/android/fdroid-build/env.sh
+++ b/android/fdroid-build/env.sh
@@ -1,0 +1,27 @@
+# Sourcing this file prepares the environment for building inside the F-Droid build server
+
+# Ensure Cargo tools are accessible
+source "$HOME/.cargo/env"
+
+# Ensure Go compiler is accessible
+export GOROOT="$HOME/go"
+export PATH="$PATH:$GOROOT/bin"
+
+# Ensure Rust crates know which tools to use for cross-compilation
+export TOOLCHAINS_DIR="$HOME/android-ndk-toolchains"
+
+export AR_i686_linux_android="$TOOLCHAINS_DIR/android21-x86/bin/i686-linux-android-ar"
+export AR_x86_64_linux_android="$TOOLCHAINS_DIR/android21-x86_64/bin/x86_64-linux-android-ar"
+export AR_aarch64_linux_android="$TOOLCHAINS_DIR/android21-arm64/bin/aarch64-linux-android-ar"
+export AR_armv7_linux_androideabi="$TOOLCHAINS_DIR/android21-arm/bin/arm-linux-androideabi-ar"
+
+export CC_i686_linux_android="$TOOLCHAINS_DIR/android21-x86/bin/i686-linux-android21-clang"
+export CC_x86_64_linux_android="$TOOLCHAINS_DIR/android21-x86_64/bin/x86_64-linux-android21-clang"
+export CC_aarch64_linux_android="$TOOLCHAINS_DIR/android21-arm64/bin/aarch64-linux-android21-clang"
+export CC_armv7_linux_androideabi="$TOOLCHAINS_DIR/android21-arm/bin/armv7a-linux-androideabi21-clang"
+
+# Ensure the C cross-compilers are accessible to the libwg-go build
+export ANDROID_TOOLCHAIN_ROOT_arm="$TOOLCHAINS_DIR/android21-arm"
+export ANDROID_TOOLCHAIN_ROOT_x86="$TOOLCHAINS_DIR/android21-x86"
+export ANDROID_TOOLCHAIN_ROOT_arm64="$TOOLCHAINS_DIR/android21-arm64"
+export ANDROID_TOOLCHAIN_ROOT_x86_64="$TOOLCHAINS_DIR/android21-x86_64"

--- a/android/fdroid-build/init.sh
+++ b/android/fdroid-build/init.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -eux
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+REPO_DIR="$SCRIPT_DIR/../../"
+TOOLCHAINS_DIR="$HOME/android-ndk-toolchains"
+
+# Install Rust
+curl -sf -L https://sh.rustup.rs > /tmp/rustup.sh
+chmod +x /tmp/rustup.sh
+/tmp/rustup.sh -y
+source "$HOME/.cargo/env"
+rustup set profile minimal
+rustup target add \
+    i686-linux-android \
+    x86_64-linux-android \
+    aarch64-linux-android \
+    armv7-linux-androideabi
+
+# Install Go
+cd "$HOME"
+curl -sf -L -O https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
+echo "0804bf02020dceaa8a7d7275ee79f7a142f1996bfd0c39216ccb405f93f994c0 go1.13.3.linux-amd64.tar.gz" | sha256sum -c
+tar -xzvf go1.13.3.linux-amd64.tar.gz
+patch -p1 -f -N -r- -d "$HOME/go" < "$REPO_DIR/wireguard/libwg/goruntime-boottime-over-monotonic.diff"
+
+# Prepare standalone NDK toolchains
+mkdir "$TOOLCHAINS_DIR"
+for arch in arm arm64 x86 x86_64; do
+    case "$arch" in
+        "arm64")
+            android_lib_triple="aarch64-linux-android"
+            ;;
+        "x86_64")
+            android_lib_triple="x86_64-linux-android"
+            ;;
+        "arm")
+            android_lib_triple="arm-linux-androideabi"
+            ;;
+        "x86")
+            android_lib_triple="i686-linux-android"
+            ;;
+    esac
+
+    "$NDK_PATH/build/tools/make-standalone-toolchain.sh" --platform=android-21 --arch="$arch" --install-dir="$TOOLCHAINS_DIR/android21-$arch"
+
+    for file in crtbegin_dynamic.o crtend_android.o crtbegin_so.o crtend_so.o; do
+        ln -s "$TOOLCHAINS_DIR/android21-$arch/sysroot/usr/lib/$android_lib_triple/"{21/,}"$file"
+    done
+done
+
+# Configure Cargo for cross-compilation
+sed -e "s|NDK_PATH|$NDK_PATH|g" "$SCRIPT_DIR/cargo-config.toml.example" > "$HOME/.cargo/config"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
 
-PRODUCT_VERSION="$(node -p "require('$SCRIPT_DIR/gui/package.json').version" | sed -Ee 's/\.0//g')"
+PRODUCT_VERSION="$(sed -n -e 's/^ *versionName "\([^"]*\)"$/\1/p' android/build.gradle)"
 BUILD_TYPE="release"
 GRADLE_TASK="assembleRelease"
 BUNDLE_TASK="bundleRelease"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -48,6 +48,16 @@ if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
     fi
 fi
 
+if [ -f "./gradlew" ]; then
+    GRADLE_CMD="./gradlew"
+elif which gradle > /dev/null; then
+    GRADLE_CMD="gradle"
+else
+    echo "ERROR: No gradle command found" >&2
+    echo "       Please either install gradle or restore the gradlew file" >&2
+    exit 2
+fi
+
 if [[ "$BUILD_TYPE" == "debug" || "$(git describe)" != "$PRODUCT_VERSION" ]]; then
     GIT_COMMIT="$(git rev-parse HEAD | head -c 6)"
     PRODUCT_VERSION="${PRODUCT_VERSION}-dev-${GIT_COMMIT}"
@@ -59,7 +69,7 @@ else
 fi
 
 pushd "$SCRIPT_DIR/android"
-./gradlew --console plain clean
+$GRADLE_CMD --console plain clean
 mkdir -p "build/extraJni"
 popd
 
@@ -107,14 +117,14 @@ done
 ./update-relays.sh
 
 cd "$SCRIPT_DIR/android"
-./gradlew --console plain "$GRADLE_TASK"
+$GRADLE_CMD --console plain "$GRADLE_TASK"
 
 mkdir -p "$SCRIPT_DIR/dist"
 cp  "$SCRIPT_DIR/android/build/outputs/apk/$GRADLE_BUILD_TYPE/android${BUILT_APK_SUFFIX}.apk" \
     "$SCRIPT_DIR/dist/MullvadVPN-${PRODUCT_VERSION}${FILE_SUFFIX}.apk"
 
 if [[ "$BUILD_BUNDLE" == "yes" ]]; then
-    ./gradlew --console plain "$BUNDLE_TASK"
+    $GRADLE_CMD --console plain "$BUNDLE_TASK"
 
     cp  "$SCRIPT_DIR/android/build/outputs/bundle/$GRADLE_BUILD_TYPE/android.aab" \
         "$SCRIPT_DIR/dist/MullvadVPN-${PRODUCT_VERSION}${FILE_SUFFIX}.aab"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -8,8 +8,10 @@ cd "$SCRIPT_DIR"
 
 PRODUCT_VERSION="$(sed -n -e 's/^ *versionName "\([^"]*\)"$/\1/p' android/build.gradle)"
 BUILD_TYPE="release"
+GRADLE_BUILD_TYPE="release"
 GRADLE_TASK="assembleRelease"
 BUNDLE_TASK="bundleRelease"
+BUILT_APK_SUFFIX="-release"
 FILE_SUFFIX=""
 CARGO_ARGS="--release"
 BUILD_BUNDLE="no"
@@ -17,10 +19,20 @@ BUILD_BUNDLE="no"
 while [ ! -z "${1:-""}" ]; do
     if [[ "${1:-""}" == "--dev-build" ]]; then
         BUILD_TYPE="debug"
+        GRADLE_BUILD_TYPE="debug"
         GRADLE_TASK="assembleDebug"
         BUNDLE_TASK="bundleDebug"
+        BUILT_APK_SUFFIX="-debug"
         FILE_SUFFIX="-debug"
         CARGO_ARGS=""
+    elif [[ "${1:-""}" == "--fdroid" ]]; then
+        BUILD_TYPE="release"
+        GRADLE_BUILD_TYPE="fdroid"
+        GRADLE_TASK="assembleFdroid"
+        BUNDLE_TASK="bundleFdroid"
+        BUILT_APK_SUFFIX="-fdroid-unsigned"
+        FILE_SUFFIX=""
+        CARGO_ARGS="--release"
     elif [[ "${1:-""}" == "--app-bundle" ]]; then
         BUILD_BUNDLE="yes"
     fi
@@ -28,7 +40,7 @@ while [ ! -z "${1:-""}" ]; do
     shift 1
 done
 
-if [[ "$BUILD_TYPE" == "release" ]]; then
+if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
     if [ ! -f "$SCRIPT_DIR/android/keystore.properties" ]; then
         echo "ERROR: No keystore.properties file found" >&2
         echo "       Please configure the signing keys as described in the README" >&2
@@ -98,13 +110,13 @@ cd "$SCRIPT_DIR/android"
 ./gradlew --console plain "$GRADLE_TASK"
 
 mkdir -p "$SCRIPT_DIR/dist"
-cp  "$SCRIPT_DIR/android/build/outputs/apk/$BUILD_TYPE/android-$BUILD_TYPE.apk" \
+cp  "$SCRIPT_DIR/android/build/outputs/apk/$GRADLE_BUILD_TYPE/android${BUILT_APK_SUFFIX}.apk" \
     "$SCRIPT_DIR/dist/MullvadVPN-${PRODUCT_VERSION}${FILE_SUFFIX}.apk"
 
 if [[ "$BUILD_BUNDLE" == "yes" ]]; then
     ./gradlew --console plain "$BUNDLE_TASK"
 
-    cp  "$SCRIPT_DIR/android/build/outputs/bundle/$BUILD_TYPE/android.aab" \
+    cp  "$SCRIPT_DIR/android/build/outputs/bundle/$GRADLE_BUILD_TYPE/android.aab" \
         "$SCRIPT_DIR/dist/MullvadVPN-${PRODUCT_VERSION}${FILE_SUFFIX}.aab"
 fi
 

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -77,14 +77,14 @@ popd
 
 function restore_metadata_backups() {
     pushd "$SCRIPT_DIR"
-    ./version-metadata.sh restore-backup
+    ./version-metadata.sh restore-backup --skip-gui
     mv Cargo.lock.bak Cargo.lock || true
     popd
 }
 trap 'restore_metadata_backups' EXIT
 
 cp Cargo.lock Cargo.lock.bak
-./version-metadata.sh inject $PRODUCT_VERSION
+./version-metadata.sh inject $PRODUCT_VERSION --skip-gui
 
 ./wireguard/build-wireguard-go.sh --android $EXTRA_WGGO_ARGS
 

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -14,6 +14,7 @@ BUNDLE_TASK="bundleRelease"
 BUILT_APK_SUFFIX="-release"
 FILE_SUFFIX=""
 CARGO_ARGS="--release"
+EXTRA_WGGO_ARGS=""
 BUILD_BUNDLE="no"
 
 while [ ! -z "${1:-""}" ]; do
@@ -33,6 +34,7 @@ while [ ! -z "${1:-""}" ]; do
         BUILT_APK_SUFFIX="-fdroid-unsigned"
         FILE_SUFFIX=""
         CARGO_ARGS="--release"
+        EXTRA_WGGO_ARGS="--no-docker"
     elif [[ "${1:-""}" == "--app-bundle" ]]; then
         BUILD_BUNDLE="yes"
     fi
@@ -84,7 +86,7 @@ trap 'restore_metadata_backups' EXIT
 cp Cargo.lock Cargo.lock.bak
 ./version-metadata.sh inject $PRODUCT_VERSION
 
-./wireguard/build-wireguard-go.sh --android
+./wireguard/build-wireguard-go.sh --android $EXTRA_WGGO_ARGS
 
 
 ARCHITECTURES="aarch64 armv7 x86_64 i686"

--- a/version-metadata.sh
+++ b/version-metadata.sh
@@ -8,6 +8,9 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
+COMMAND="$1"
+shift 1
+
 function inject_version {
     # Regex that only matches valid Mullvad VPN versions. It also captures
     # relevant values into capture groups, read out via BASH_REMATCH[x].
@@ -25,10 +28,21 @@ function inject_version {
     local semver_minor=${BASH_REMATCH[2]}
     local semver_patch="0"
 
-    # Electron GUI
-    cp gui/package.json gui/package.json.bak
-    cp gui/package-lock.json gui/package-lock.json.bak
-    (cd gui/ && npm version "$semver_version" --no-git-tag-version --allow-same-version)
+    if [[ "$2" != "--skip-gui" ]]; then
+        # Electron GUI
+        cp gui/package.json gui/package.json.bak
+        cp gui/package-lock.json gui/package-lock.json.bak
+        (cd gui/ && npm version "$semver_version" --no-git-tag-version --allow-same-version)
+
+        # Windows C++
+        cp dist-assets/windows/version.h dist-assets/windows/version.h.bak
+        cat <<EOF > dist-assets/windows/version.h
+#define MAJOR_VERSION $semver_major
+#define MINOR_VERSION $semver_minor
+#define PATCH_VERSION $semver_patch
+#define PRODUCT_VERSION "$product_version"
+EOF
+    fi
 
     # Rust crates
     sed -i.bak -Ee "s/^version = \"[^\"]+\"\$/version = \"$semver_version\"/g" \
@@ -37,15 +51,6 @@ function inject_version {
         mullvad-problem-report/Cargo.toml \
         mullvad-setup/Cargo.toml \
         talpid-openvpn-plugin/Cargo.toml
-
-    # Windows C++
-    cp dist-assets/windows/version.h dist-assets/windows/version.h.bak
-    cat <<EOF > dist-assets/windows/version.h
-#define MAJOR_VERSION $semver_major
-#define MINOR_VERSION $semver_minor
-#define PATCH_VERSION $semver_patch
-#define PRODUCT_VERSION "$product_version"
-EOF
 
     # Android
     if [[ ("$(uname -s)" == "Linux") ]]; then
@@ -65,17 +70,21 @@ EOF
 
 function restore_backup {
     set +e
-    # Electron GUI
-    mv gui/package.json.bak gui/package.json
-    mv gui/package-lock.json.bak gui/package-lock.json
+
+    if [[ "$1" != "--skip-gui" ]]; then
+        # Electron GUI
+        mv gui/package.json.bak gui/package.json
+        mv gui/package-lock.json.bak gui/package-lock.json
+        # Windows C++
+        mv dist-assets/windows/version.h.bak dist-assets/windows/version.h
+    fi
+
     # Rust crates
     mv mullvad-daemon/Cargo.toml.bak mullvad-daemon/Cargo.toml
     mv mullvad-cli/Cargo.toml.bak mullvad-cli/Cargo.toml
     mv mullvad-problem-report/Cargo.toml.bak mullvad-problem-report/Cargo.toml
     mv mullvad-setup/Cargo.toml.bak mullvad-setup/Cargo.toml
     mv talpid-openvpn-plugin/Cargo.toml.bak talpid-openvpn-plugin/Cargo.toml
-    # Windows C++
-    mv dist-assets/windows/version.h.bak dist-assets/windows/version.h
     # Android
     if [[ ("$(uname -s)" == "Linux") ]]; then
         mv android/build.gradle.bak android/build.gradle
@@ -85,17 +94,21 @@ function restore_backup {
 
 function delete_backup {
     set +e
-    # Electron GUI
-    rm gui/package.json.bak
-    rm gui/package-lock.json.bak
+
+    if [[ "$1" != "--skip-gui" ]]; then
+        # Electron GUI
+        rm gui/package.json.bak
+        rm gui/package-lock.json.bak
+        # Windows C++
+        rm dist-assets/windows/version.h.bak
+    fi
+
     # Rust crates
     rm mullvad-daemon/Cargo.toml.bak
     rm mullvad-cli/Cargo.toml.bak
     rm mullvad-problem-report/Cargo.toml.bak
     rm mullvad-setup/Cargo.toml.bak
     rm talpid-openvpn-plugin/Cargo.toml.bak
-    # Windows C++
-    rm dist-assets/windows/version.h.bak
     # Android
     if [[ ("$(uname -s)" == "Linux") ]]; then
         rm android/build.gradle.bak
@@ -103,15 +116,15 @@ function delete_backup {
     set -e
 }
 
-case "$1" in
+case "$COMMAND" in
     "inject")
-        inject_version "$2"
+        inject_version "$@"
         ;;
     "restore-backup")
-        restore_backup
+        restore_backup "$@"
         ;;
     "delete-backup")
-        delete_backup
+        delete_backup "$@"
         ;;
     *)
         echo "Invalid command"

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -15,6 +15,17 @@ function is_android_build {
     return 1
 }
 
+function build_locally {
+    for arg in "$@"
+    do
+        case "$arg" in
+            "--no-docker")
+                return 0
+        esac
+    done
+    return 1
+}
+
 
 function win_deduce_lib_executable_path {
     msbuild_path="$(which msbuild.exe)"
@@ -82,15 +93,19 @@ function build_android {
     echo "Building for android"
     local docker_image_hash="f432cb779611284ce69aca59a90a8a601171d4c29728561ae32bd228b1699198"
 
-    docker run --rm \
-        -v "$(pwd)/../":/workspace \
-        --entrypoint "/workspace/wireguard/libwg/build-android.sh" \
-        mullvadvpn/mullvad-android-app-build@sha256:$docker_image_hash
+    if build_locally $@; then
+        ./libwg/build-android.sh
+    else
+        docker run --rm \
+            -v "$(pwd)/../":/workspace \
+            --entrypoint "/workspace/wireguard/libwg/build-android.sh" \
+            mullvadvpn/mullvad-android-app-build@sha256:$docker_image_hash
+    fi
 }
 
 function build_wireguard_go {
     if is_android_build $@; then
-        build_android
+        build_android $@
         return
     fi
 

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -7,7 +7,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $script_dir
 
 # Keep a GOPATH in the build directory to maintain a cache of downloaded libraries
-GOPATH=$script_dir/../../build/android-go-path/
+export GOPATH=$script_dir/../../build/android-go-path/
 mkdir -p $GOPATH
 
 for arch in arm arm64 x86_64 x86; do

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 # Ensure we are in the correct directory for the execution of this script
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -38,7 +38,14 @@ for arch in arm arm64 x86_64 x86; do
             ;;
     esac
 
-    eval "$(install-ndk-toolchain $arch)"
+    if which install-ndk-toolchain > /dev/null; then
+        eval "$(install-ndk-toolchain $arch)"
+    else
+        export ANDROID_TOOLCHAIN_ROOT="$(eval "echo \$ANDROID_TOOLCHAIN_ROOT_$arch")"
+        export ANDROID_SYSROOT="${ANDROID_TOOLCHAIN_ROOT}/sysroot"
+        export ANDROID_C_COMPILER="${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_LIB_TRIPLE}-clang"
+    fi
+
     export ANDROID_ARCH_NAME=$arch
     export PATH="$PATH:${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
 


### PR DESCRIPTION
This PR updates the Android build scripts so that the app can be built for distribution on F-Droid.

This required a few changes to the overall build process:

1. Remove the dependency on node-js to determine the Android version
2. Created a separate build type for F-Droid. This is a release build that is not signed, and can be built using `./build-apk.sh --fdroid`.
3. Checks if the `gradlew` script is present before using it, and falls back the system global `gradle` if it is installed.
4. Changed the WireGuard-Go build so that it can be executed without using the Docker image.
5. Modified the `version-metadata.sh` to skip the desktop-specific directories when building for Android.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
