### PR TITLE
Fix IPv6 support

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
   the tunnel.
 - Properly format date intervals close to 1 day or less than 1 minute. Enforce intervals between 1 
   and 90 days to always be displayed in days quantity.
+- Fix a number of errors in DNS64 resolution and IPv6 support.
 
 ## [2020.2] - 2020-04-16
 ### Fixed

--- a/ios/PacketTunnel/AnyIPEndpoint+DNS64.swift
+++ b/ios/PacketTunnel/AnyIPEndpoint+DNS64.swift
@@ -51,12 +51,6 @@ extension AnyIPEndpoint {
 
         freeaddrinfo(resultPointer)
 
-        if "\(resolvedAddress.ip)" == "\(self.ip)" {
-            os_log(.debug, "DNS64: mapped %{public}s to itself", "\(resolvedAddress.ip)")
-        } else {
-            os_log(.debug, "DNS64: mapped %{public}s to %{public}s", "\(self.ip)", "\(resolvedAddress.ip)")
-        }
-
         return .success(resolvedAddress)
     }
 }

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -89,7 +89,11 @@ extension PacketTunnelConfiguration {
 
         return WireguardConfiguration(
             privateKey: tunnelConfig.interface.privateKey,
-            peers: wireguardPeers
+            peers: wireguardPeers,
+            allowedIPs: [
+                IPAddressRange(address: IPv4Address.any, networkPrefixLength: 0),
+                IPAddressRange(address: IPv6Address.any, networkPrefixLength: 0)
+            ]
         )
     }
 }

--- a/ios/PacketTunnel/WireguardConfiguration.swift
+++ b/ios/PacketTunnel/WireguardConfiguration.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2019 Mullvad VPN AB. All rights reserved.
 //
 
-import Combine
 import Foundation
-import os
 
 /// A struct describing a basic WireGuard configuration
 struct WireguardConfiguration {
     var privateKey: WireguardPrivateKey
     var peers: [WireguardPeer]
+    var allowedIPs: [IPAddressRange]
 }
 
 extension WireguardConfiguration {
@@ -28,7 +27,10 @@ extension WireguardConfiguration {
 
         peers.forEach { (peer) in
             commands.append(.peer(peer))
-            commands.append(.allowedIP(peer.anyAllowedIP))
+        }
+
+        allowedIPs.forEach { (ipAddressRange) in
+            commands.append(.allowedIP(ipAddressRange))
         }
 
         return commands
@@ -44,43 +46,34 @@ extension WireguardConfiguration {
 
         let oldPeers = Set(self.peers)
         let newPeers = Set(newConfig.peers)
+        let oldPublicKeys = Set(oldPeers.map { $0.publicKey })
+        let newPublicKeys = Set(newPeers.map { $0.publicKey })
+        let shouldReplacePeers = oldPublicKeys != newPublicKeys
 
         if oldPeers != newPeers {
-            let oldPublicKeys = Set(oldPeers.map { $0.publicKey })
-            let newPublicKeys = Set(newPeers.map { $0.publicKey })
-
             // Avoid using `replace_peers` when updating the existing peers.
-            if oldPublicKeys != newPublicKeys {
+            if shouldReplacePeers {
                 commands.append(.replacePeers)
             }
 
             newPeers.forEach { (peer) in
                 commands.append(.peer(peer))
-                commands.append(.allowedIP(peer.anyAllowedIP))
+            }
+        }
+
+        let oldAllowedIPs = Set(self.allowedIPs)
+        let newAllowedIPs = Set(newConfig.allowedIPs)
+
+        // It looks like the `allowed_ip` table is being flushed when `replace_peers=true` is passed
+        if oldAllowedIPs != newAllowedIPs || shouldReplacePeers {
+            commands.append(.replaceAllowedIPs)
+
+            newAllowedIPs.forEach { (allowedIP) in
+                commands.append(.allowedIP(allowedIP))
             }
         }
 
         return commands
-    }
-
-    func withReresolvedPeers(maxRetryOnFailure: Int = 0) -> AnyPublisher<WireguardConfiguration, Error> {
-        self.peers
-            .publisher
-            .setFailureType(to: Error.self)
-            .flatMap {
-                $0.withReresolvedEndpoint()
-                    .publisher
-                    .retry(maxRetryOnFailure)
-
-        }
-        .collect()
-        .map({ (peers) in
-            WireguardConfiguration(
-                privateKey: self.privateKey,
-                peers: peers
-            )
-        })
-            .eraseToAnyPublisher()
     }
 
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Ensure that all relay IPs are resolved against DNS64 when the tunnel starts. Previously that was only done on network interface changes, i.e wifi -> cell or vice versa.
1. Remove `excludedRoutes` when setting up iOS routes. Previously we used to add the relay IP in there but I think it's not necessary.
1. Cap IPv6 prefix at `/120` due to issues described at https://github.com/WireGuard/wireguard-apple/blob/112545248eaae2d56c0ff7ab7bfc6265f9c38e03/WireGuard/WireGuardNetworkExtension/PacketTunnelSettingsGenerator.swift#L131
1. Enable IPv6 with the following wireguard configuration: `allowed_ip=::0/0`
1. Fix a bug where the relay IPs were re-resolved against the previously resolved configuration. This time around we maintain the original and resolved configurations. The resolved configuration is only used to determine what changes have to be applied to wireguard configuration. The original configuration is used to produce the resolved one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1765)
<!-- Reviewable:end -->
