### PR TITLE
Fix start service in main activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Fixed
+#### Android
+- Fix crash when that happened sometimes when the app tried to start the daemon service on recent
+  Android versions.
 
 
 ## [2020.5-beta1] - 2020-05-18

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.ui
 import android.app.Activity
 import android.content.ComponentName
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.support.v4.app.FragmentActivity
@@ -85,7 +86,12 @@ class MainActivity : FragmentActivity() {
 
         val intent = Intent(this, MullvadVpnService::class.java)
 
-        startService(intent)
+        if (Build.VERSION.SDK_INT >= 26) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
+        }
+
         bindService(intent, serviceConnectionManager, 0)
     }
 


### PR DESCRIPTION
On recent Android versions, a service can only be started with a promise that it will run on the foreground. A previous PR added this promise to a few places by calling the `startForegroundService` API. However, the `MainActivity` wasn't updated because it was incorrectly assumed that since the service runs on the same process as the `MainActivity`, it didn't need to promise to run on the foreground.

This led to some crashes on Android 10 when the activity tried to start the service. This PR fixes that by also changing the code to start the service in the `MainActivity`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1769)
<!-- Reviewable:end -->
