### PR TITLE
Remove service bind counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix crash when that happened sometimes when the app tried to start the daemon service on recent
   Android versions.
+- Fix quitting the app sometimes failing.
 
 
 ## [2020.5-beta1] - 2020-05-18

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -58,12 +58,6 @@ class MullvadVpnService : TalpidVpnService() {
             }
         }
 
-    private var bindCount = 0
-        set(value) {
-            field = value
-            isBound = bindCount != 0
-        }
-
     private var isBound = false
         set(value) {
             field = value
@@ -93,13 +87,13 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     override fun onBind(intent: Intent): IBinder {
-        bindCount += 1
+        isBound = true
 
         return super.onBind(intent) ?: binder
     }
 
     override fun onRebind(intent: Intent) {
-        bindCount += 1
+        isBound = true
 
         if (isStopping) {
             restart()
@@ -112,7 +106,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     override fun onUnbind(intent: Intent): Boolean {
-        bindCount -= 1
+        isBound = false
 
         return true
     }


### PR DESCRIPTION
Previously, a bind counter was introduced to keep track of when the UI is connected to the service. This allowed the service to keep the foreground notification up while the UI was shown. However, there's a strange issue where sometimes the app doesn't quit correctly, where it keeps running after quitting.

After reading through Android's documentation, it appears that the service's `onUnbind` is only called _after all client connections have been disconnected_. This means that the counter is unnecessary and incorrect. Therefore, this PR removes it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1770)
<!-- Reviewable:end -->
