### PR TITLE
Use an `EventNotifier` for WireGuard key events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash when that happened sometimes when the app tried to start the daemon service on recent
   Android versions.
 - Fix quitting the app sometimes failing.
+- Fix WireGuard key status events being lost by the UI, causing stale information to be shown.
 
 
 ## [2020.5-beta1] - 2020-05-18

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -39,6 +39,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     private var greenColor: Int = 0
     private var redColor: Int = 0
 
+    private var keyStatusListenerId: Int? = null
     private var tunnelStateListener: Int? = null
     private var tunnelState: TunnelState = TunnelState.Disconnected()
 
@@ -161,7 +162,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
             }
         }
 
-        keyStatusListener.onKeyStatusChange = { newKeyStatus ->
+        keyStatusListenerId = keyStatusListener.onKeyStatusChange.subscribe { newKeyStatus ->
             jobTracker.newUiJob("keyStatusUpdate") {
                 keyStatus = newKeyStatus
             }
@@ -175,11 +176,14 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
             connectionProxy.onUiStateChange.unsubscribe(listener)
         }
 
+        keyStatusListenerId?.let { listener ->
+            keyStatusListener.onKeyStatusChange.unsubscribe(listener)
+        }
+
         if (!(actionState is ActionState.Idle)) {
             actionState = ActionState.Idle(false)
         }
 
-        keyStatusListener.onKeyStatusChange = null
         jobTracker.cancelAllJobs()
     }
 


### PR DESCRIPTION
There have been some issues on the WireGuard Key screen where stale information is shown. This seems to happen when WireGuard key events sent from the daemon aren't received by the listener in `WireguardKeyFragment`.

It's not clear why this is happening, but one guess is a race condition when changing the listener callback when the Connect screen pauses after the WireGuard Key screen has resumed.

This PR tries to eliminate that scenario by changing the key listener to use an `EventNotifier` to manage the active listeners. This avoids having a single callback that can be changed by more than one screen.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1771)
<!-- Reviewable:end -->
