### PR TITLE
Fix account expiry not showing up in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
   Android versions.
 - Fix quitting the app sometimes failing.
 - Fix WireGuard key status events being lost by the UI, causing stale information to be shown.
+- Fix time left in account not showing in settings screen.
 
 
 ## [2020.5-beta1] - 2020-05-18

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -33,7 +33,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
             jobTracker.newBackgroundJob("fetch") {
                 var retryAttempt = 0
 
-                while (onAccountDataChange != null) {
+                do {
                     val result = daemon.getAccountData(account)
 
                     if (result is GetAccountDataResult.Ok) {
@@ -45,7 +45,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
 
                     retryAttempt += 1
                     delay(calculateRetryFetchDelay(retryAttempt))
-                }
+                } while (onAccountDataChange != null)
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -121,12 +121,12 @@ class SettingsFragment : ServiceAwareFragment() {
 
     private fun configureListeners() {
         accountCache?.apply {
-            fetchAccountExpiry()
-
             onAccountDataChange = { account, expiry ->
                 updateAccountInfoJob?.cancel()
                 updateAccountInfoJob = updateAccountInfo(account != null, expiry)
             }
+
+            fetchAccountExpiry()
         }
 
         versionInfoCache?.apply {


### PR DESCRIPTION
A previous PR added retries if fetching the account expiry fails. An optimization was also added, where the idea was that it would only retry if there was a listener attached to receive the results. However, the implementation checked for that condition before running any fetch attempt, including the first attempt.

This condition impacted the settings screen, since it requested the fetch before setting up the listener. Therefore, what ended up happening was that the check was made before the listener was configured, and therefore it decided to not actually fetch the account expiry ever.

This PR fixes the issue with two changes. First, the settings screen configures the listener before requesting the account cache to fetch the account expiry. Second, the condition check was changed so that it only affects retry attempts, and not the first attempt.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1773)
<!-- Reviewable:end -->
