### PR TITLE
Fix connect request without VPN permission not behaving as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix quitting the app sometimes failing.
 - Fix WireGuard key status events being lost by the UI, causing stale information to be shown.
 - Fix time left in account not showing in settings screen.
+- Fix attempt to connect when the app doesn't have the VPN permission.
 
 #### Windows
 - Fix race in network adapter monitor that could result in data corruption and crashes.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -177,6 +177,8 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
                     putExtra(MainActivity.KEY_SHOULD_CONNECT, true)
                 }
 
+                uiState = state
+
                 context.startActivity(activityIntent)
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -172,8 +172,10 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
             if (activity != null) {
                 activity.requestVpnPermission(intent)
             } else {
-                val activityIntent = Intent(context, MainActivity::class.java)
-                    .putExtra(MainActivity.KEY_SHOULD_CONNECT, true)
+                val activityIntent = Intent(context, MainActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    putExtra(MainActivity.KEY_SHOULD_CONNECT, true)
+                }
 
                 context.startActivity(activityIntent)
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -26,5 +26,6 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
         appVersionInfoCache.onDestroy()
         keyStatusListener.onDestroy()
         relayListListener.onDestroy()
+        connectionProxy.mainActivity = null
     }
 }


### PR DESCRIPTION
When the notification button or the quick-settings tile is used to start a connection when the user hasn't granted the VPN permission, the app should start the UI in order to request for the VPN permission.

This isn't working sometimes, and there were multiple causes:

1. Opening the UI crashes on Android 9 and Android 10, because the request to open the UI is incorrect but a bug on Android allowed it work on older versions.
2. After the permission is granted, a connection attempt is retried but is ignored since the connection proxy thinks it's already connecting.
3. If the UI was previously open, the connection proxy thinks it is still open, and refuses to open it.

This PR fixes each of the issues above, by respectively:

1. Adding the missing flag that's required to start an activity from outside another activity.
2. Resetting the UI state when opening the UI to request for the permission, because the service hasn't actually started to connect until the permission has been granted.
3. Resetting the activity reference in the connection proxy when the connection between the activity and the service is severed (for example when the UI is closed).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1774)
<!-- Reviewable:end -->
