### PR TITLE
Include error code in Windows error exception strings

### DIFF
--- a/windows/driverlogic/src/error.cpp
+++ b/windows/driverlogic/src/error.cpp
@@ -154,9 +154,9 @@ void ThrowSetupApiError(const char *operation, uint32_t code, const char *file, 
 	if (nullptr != message)
 	{
 		std::stringstream ss;
-		ss << operation << ": " << message
-			<< " (0x" << std::setw(8) << std::setfill('0') << std::hex << code << ")"
+		ss << operation << ": 0x" << std::setw(8) << std::setfill('0') << std::hex << code
 			<< std::setw(1) << std::dec
+			<< ": " << message
 			<< " (" << IsolateFilename(file) << ": " << line << ")";
 
 		throw common::error::WindowsException(ss.str().c_str(), code);

--- a/windows/driverlogic/src/error.cpp
+++ b/windows/driverlogic/src/error.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "error.h"
 #include <string>
+#include <ios>
 #include <iomanip>
 #include <sstream>
 #include <map>
@@ -155,6 +156,7 @@ void ThrowSetupApiError(const char *operation, uint32_t code, const char *file, 
 		std::stringstream ss;
 		ss << operation << ": " << message
 			<< " (0x" << std::setw(8) << std::setfill('0') << std::hex << code << ")"
+			<< std::setw(1) << std::dec
 			<< " (" << IsolateFilename(file) << ": " << line << ")";
 
 		throw common::error::WindowsException(ss.str().c_str(), code);


### PR DESCRIPTION
Exceptions logged in Windows modules only contain formatted strings at the moment, no error codes. These can be indecipherable since the encoding is often wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1777)
<!-- Reviewable:end -->
