### PR TITLE
Add lock in NotifyIpInterfaceChange() callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix WireGuard key status events being lost by the UI, causing stale information to be shown.
 - Fix time left in account not showing in settings screen.
 
+#### Windows
+- Fix race in network adapter monitor that could result in data corruption and crashes.
 
 ## [2020.5-beta1] - 2020-05-18
 ### Added

--- a/windows/winnet/src/winnet/networkadaptermonitor.cpp
+++ b/windows/winnet/src/winnet/networkadaptermonitor.cpp
@@ -276,6 +276,16 @@ void __stdcall NetworkAdapterMonitor::Callback(void *context, MIB_IPINTERFACE_RO
 {
 	auto inst = reinterpret_cast<NetworkAdapterMonitor *>(context);
 
+	//
+	// Calls into this function are supposed to be serialized by Windows.
+	// That's not true on Windows 10 :-(
+	//
+	// This can be easily reproduced by changing the callback to never return,
+	// and observing more events being delivered.
+	//
+
+	std::scoped_lock<std::mutex> lock(inst->m_callbackLock);
+
 	try
 	{
 		inst->callback(hint, updateType);

--- a/windows/winnet/src/winnet/networkadaptermonitor.h
+++ b/windows/winnet/src/winnet/networkadaptermonitor.h
@@ -9,7 +9,7 @@
 #include <windows.h>
 #include <functional>
 #include <vector>
-
+#include <mutex>
 
 class NetworkAdapterMonitor
 {
@@ -58,6 +58,8 @@ private:
 	FilterType m_filter;
 
 	std::shared_ptr<IDataProvider> m_dataProvider;
+
+	std::mutex m_callbackLock;
 
 	MIB_IF_ROW2 getAdapter(NET_LUID luid) const;
 


### PR DESCRIPTION
Add mutex to deal with multiple simultaneous calls to callback. MSDN says that calls to the NotifyIpInterfaceChange() callback are serialized, but that's not accurate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1778)
<!-- Reviewable:end -->
