### PR TITLE
Refactor subscription IDs in `EventNotifier`

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -19,10 +19,6 @@ class AppVersionInfoCache(
 
     private val setUpJob = setUp()
 
-    private val settingsListenerId = settingsListener.subscribe { settings ->
-        showBetaReleases = settings.showBetaReleases
-    }
-
     private var appVersionInfo: AppVersionInfo? = null
         set(value) {
             synchronized(this) {
@@ -81,6 +77,12 @@ class AppVersionInfoCache(
     var version: String? = null
         private set
 
+    init {
+        settingsListener.subscribe(this) { settings ->
+            showBetaReleases = settings.showBetaReleases
+        }
+    }
+
     fun onCreate() {
         context.getSharedPreferences(LEGACY_SHARED_PREFERENCES, Context.MODE_PRIVATE)
             .edit()
@@ -90,7 +92,7 @@ class AppVersionInfoCache(
 
     fun onDestroy() {
         setUpJob.cancel()
-        settingsListener.unsubscribe(settingsListenerId)
+        settingsListener.unsubscribe(this)
         daemon.onAppVersionInfoChange = null
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -13,9 +13,6 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
     }
 
     private val jobTracker = JobTracker()
-    private val subscriptionId = settingsListener.accountNumberNotifier.subscribe { accountNumber ->
-        handleNewAccountNumber(accountNumber)
-    }
 
     private var accountNumber: String? = null
     private var accountExpiry: DateTime? = null
@@ -27,6 +24,12 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
                 notifyChange()
             }
         }
+
+    init {
+        settingsListener.accountNumberNotifier.subscribe(this) { accountNumber ->
+            handleNewAccountNumber(accountNumber)
+        }
+    }
 
     fun fetchAccountExpiry() {
         accountNumber?.let { account ->
@@ -51,7 +54,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
     }
 
     fun onDestroy() {
-        settingsListener.accountNumberNotifier.unsubscribe(subscriptionId)
+        settingsListener.accountNumberNotifier.unsubscribe(this)
         jobTracker.cancelAllJobs()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -180,7 +180,7 @@ class MullvadVpnService : TalpidVpnService() {
 
         val accountCache = AccountCache(daemon, settingsListener)
 
-        val connectionProxy = ConnectionProxy(this@MullvadVpnService, daemon).apply {
+        val connectionProxy = ConnectionProxy(this, daemon).apply {
             when (pendingAction) {
                 PendingAction.Connect -> {
                     if (loggedIn) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -173,7 +173,7 @@ class MullvadVpnService : TalpidVpnService() {
 
     private fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
         val settingsListener = SettingsListener(daemon, settings).apply {
-            accountNumberNotifier.subscribe { accountNumber ->
+            accountNumberNotifier.subscribe(this@MullvadVpnService) { accountNumber ->
                 loggedIn = accountNumber != null
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -13,10 +13,6 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
 
     private val settingsNotifier: EventNotifier<Settings> = EventNotifier(settings)
 
-    private val listenerId = daemon.onSettingsChange.subscribe { maybeSettings ->
-        maybeSettings?.let { settings -> handleNewSettings(settings) }
-    }
-
     val accountNumberNotifier = EventNotifier(initialSettings.accountToken)
 
     var onRelaySettingsChange: ((RelaySettings?) -> Unit)? = null
@@ -27,8 +23,14 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
             }
         }
 
+    init {
+        daemon.onSettingsChange.subscribe(this) { maybeSettings ->
+            maybeSettings?.let { settings -> handleNewSettings(settings) }
+        }
+    }
+
     fun onDestroy() {
-        daemon.onSettingsChange.unsubscribe(listenerId)
+        daemon.onSettingsChange.unsubscribe(this)
 
         accountNumberNotifier.unsubscribeAll()
         settingsNotifier.unsubscribeAll()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -36,10 +36,6 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
         settingsNotifier.unsubscribeAll()
     }
 
-    fun subscribe(listener: (Settings) -> Unit): Int {
-        return settingsNotifier.subscribe(listener)
-    }
-
     fun subscribe(id: Any, listener: (Settings) -> Unit) {
         settingsNotifier.subscribe(id, listener)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -40,7 +40,11 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
         return settingsNotifier.subscribe(listener)
     }
 
-    fun unsubscribe(id: Int) {
+    fun subscribe(id: Any, listener: (Settings) -> Unit) {
+        settingsNotifier.subscribe(id, listener)
+    }
+
+    fun unsubscribe(id: Any) {
         settingsNotifier.unsubscribe(id)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
@@ -12,16 +12,16 @@ class TunnelStateUpdater(context: Context, serviceNotifier: EventNotifier<Servic
     private var stateSubscriptionId: Int? = null
 
     init {
-        serviceNotifier.subscribe { serviceInstance ->
+        serviceNotifier.subscribe(this) { serviceInstance ->
             onNewServiceInstance(serviceInstance)
         }
     }
 
     private fun onNewServiceInstance(serviceInstance: ServiceInstance?) {
-        stateSubscriptionId?.let { id -> connectionProxy?.onStateChange?.unsubscribe(id) }
+        connectionProxy?.onStateChange?.unsubscribe(this)
 
         connectionProxy = serviceInstance?.connectionProxy?.apply {
-            stateSubscriptionId = onStateChange.subscribe { newState ->
+            onStateChange.subscribe(this@TunnelStateUpdater) { newState ->
                 persistence.state = newState
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -20,7 +20,6 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private lateinit var wireguardMtuInput: CellInput
     private lateinit var wireguardKeysMenu: View
 
-    private var subscriptionId: Int? = null
     private var updateUiJob: Job? = null
 
     override fun onSafelyCreateView(
@@ -53,7 +52,9 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
             }
         }
 
-        settingsListener.subscribe({ settings -> updateUi(settings) })
+        settingsListener.subscribe(this) { settings ->
+            updateUi(settings)
+        }
 
         return view
     }
@@ -68,7 +69,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
     }
 
     override fun onSafelyDestroyView() {
-        subscriptionId?.let { id -> settingsListener.unsubscribe(id) }
+        settingsListener.unsubscribe(this)
         updateUiJob?.cancel()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -33,8 +33,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private var updateTunnelStateJob: Job? = null
 
     private var isTunnelInfoExpanded = false
-    private var keyStatusListenerId: Int? = null
-    private var tunnelStateListener: Int? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -83,7 +81,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
         notificationBanner.onResume()
 
-        keyStatusListenerId = keyStatusListener.onKeyStatusChange.subscribe { keyStatus ->
+        keyStatusListener.onKeyStatusChange.subscribe(this) { keyStatus ->
             updateKeyStatusJob.cancel()
             updateKeyStatusJob = updateKeyStatus(keyStatus)
         }
@@ -100,7 +98,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             switchLocationButton.location = selectedRelayItem
         }
 
-        tunnelStateListener = connectionProxy.onUiStateChange.subscribe { uiState ->
+        connectionProxy.onUiStateChange.subscribe(this) { uiState ->
             updateTunnelStateJob?.cancel()
             updateTunnelStateJob = updateTunnelState(uiState, connectionProxy.state)
         }
@@ -119,13 +117,8 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         locationInfoCache.onNewLocation = null
         relayListListener.onRelayListChange = null
 
-        keyStatusListenerId?.let { listener ->
-            keyStatusListener.onKeyStatusChange.unsubscribe(listener)
-        }
-
-        tunnelStateListener?.let { listener ->
-            connectionProxy.onUiStateChange.unsubscribe(listener)
-        }
+        keyStatusListener.onKeyStatusChange.unsubscribe(this)
+        connectionProxy.onUiStateChange.unsubscribe(this)
 
         updateLocationInfoJob?.cancel()
         updateTunnelStateJob?.cancel()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -26,7 +26,6 @@ class MainActivity : FragmentActivity() {
 
     private var service: MullvadVpnService.LocalBinder? = null
     private var serviceConnection: ServiceConnection? = null
-    private var serviceConnectionSubscription: Int? = null
     private var shouldConnect = false
 
     private val serviceConnectionManager = object : android.content.ServiceConnection {
@@ -35,7 +34,7 @@ class MainActivity : FragmentActivity() {
 
             service = localBinder
 
-            serviceConnectionSubscription = localBinder.serviceNotifier.subscribe { service ->
+            localBinder.serviceNotifier.subscribe(this@MainActivity) { service ->
                 serviceConnection?.onDestroy()
 
                 val newConnection = service?.let { safeService ->
@@ -52,14 +51,8 @@ class MainActivity : FragmentActivity() {
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
-            serviceConnectionSubscription?.let { subscriptionId ->
-                service?.apply {
-                    serviceNotifier.unsubscribe(subscriptionId)
-                }
-            }
-
+            service?.serviceNotifier?.unsubscribe(this@MainActivity)
             serviceConnection = null
-            serviceConnectionSubscription = null
             serviceNotifier.notify(null)
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -22,8 +22,6 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
     private lateinit var disconnectButton: Button
     private lateinit var redeemButton: Button
 
-    private var tunnelStateListener: Int? = null
-
     private var tunnelState: TunnelState = TunnelState.Disconnected()
         set(value) {
             field = value
@@ -61,7 +59,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
             }
         }
 
-        tunnelStateListener = connectionProxy.onStateChange.subscribe() { newState ->
+        connectionProxy.onStateChange.subscribe(this) { newState ->
             jobTracker.newUiJob("updateTunnelState") {
                 tunnelState = newState
             }
@@ -90,10 +88,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
 
     override fun onSafelyDestroyView() {
         jobTracker.cancelAllJobs()
-
-        tunnelStateListener?.let { id ->
-            connectionProxy.onStateChange.unsubscribe(id)
-        }
+        connectionProxy.onStateChange.unsubscribe(this)
     }
 
     private fun showRedeemVoucherDialog() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -15,7 +15,6 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private lateinit var allowLanToggle: CellSwitch
     private lateinit var autoConnectToggle: CellSwitch
 
-    private var subscriptionId: Int? = null
     private var updateUiJob: Job? = null
 
     override fun onSafelyCreateView(
@@ -51,7 +50,9 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
             }
         }
 
-        settingsListener.subscribe({ settings -> updateUi(settings) })
+        settingsListener.subscribe(this) { settings ->
+            updateUi(settings)
+        }
 
         return view
     }
@@ -65,7 +66,7 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
     }
 
     override fun onSafelyDestroyView() {
-        subscriptionId?.let { id -> settingsListener.unsubscribe(id) }
+        settingsListener.unsubscribe(this)
     }
 
     private fun boolToSwitchState(pref: Boolean): CellSwitch.State {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
@@ -30,7 +30,6 @@ class RedeemVoucherDialogFragment : DialogFragment() {
     private lateinit var voucherInput: EditText
 
     private var redeemButton: Button? = null
-    private var subscriptionId: Int? = null
 
     private var daemon: MullvadDaemon? = null
         set(value) {
@@ -49,7 +48,7 @@ class RedeemVoucherDialogFragment : DialogFragment() {
 
         parentActivity = context as MainActivity
 
-        subscriptionId = parentActivity.serviceNotifier.subscribe { connection ->
+        parentActivity.serviceNotifier.subscribe(this) { connection ->
             daemon = connection?.daemon
         }
     }
@@ -111,9 +110,7 @@ class RedeemVoucherDialogFragment : DialogFragment() {
     }
 
     override fun onDetach() {
-        subscriptionId?.let { id ->
-            parentActivity.serviceNotifier.unsubscribe(id)
-        }
+        parentActivity.serviceNotifier.unsubscribe(this)
 
         super.onDetach()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
@@ -10,22 +10,18 @@ abstract class ServiceAwareFragment : Fragment() {
     var serviceConnection: ServiceConnection? = null
         private set
 
-    private var subscriptionId: Int? = null
-
     override fun onAttach(context: Context) {
         super.onAttach(context)
 
         parentActivity = context as MainActivity
 
-        subscriptionId = parentActivity.serviceNotifier.subscribe { connection ->
+        parentActivity.serviceNotifier.subscribe(this) { connection ->
             configureServiceConnection(connection)
         }
     }
 
     override fun onDetach() {
-        subscriptionId?.let { id ->
-            parentActivity.serviceNotifier.unsubscribe(id)
-        }
+        parentActivity.serviceNotifier.unsubscribe(this)
 
         super.onDetach()
     }

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -1,5 +1,13 @@
 package net.mullvad.talpid.util
 
+// Manages listeners interested in receiving events of type T
+//
+// The listeners subscribe using an ID object. This ID is used later on for unsubscribing. The only
+// requirement is that the object uses the default implementation of the `hashCode` and `equals`
+// methods inherited from `Any` (or `Object` in Java).
+//
+// If the ID object class (or any of its super-classes) overrides `hashCode` or `equals`,
+// unsubscribe might not work correctly.
 class EventNotifier<T>(private val initialValue: T) {
     private val listeners = HashMap<Any, (T) -> Unit>()
 

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -11,7 +11,6 @@ package net.mullvad.talpid.util
 class EventNotifier<T>(private val initialValue: T) {
     private val listeners = HashMap<Any, (T) -> Unit>()
 
-    private var idCounter = 0
     private var latestEvent = initialValue
 
     fun notify(event: T) {
@@ -28,17 +27,6 @@ class EventNotifier<T>(private val initialValue: T) {
         synchronized(this) {
             listeners.put(id, listener)
             listener(latestEvent)
-        }
-    }
-
-    fun subscribe(listener: (T) -> Unit): Int {
-        synchronized(this) {
-            val id = idCounter
-
-            idCounter += 1
-            subscribe(id, listener)
-
-            return id
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -1,7 +1,7 @@
 package net.mullvad.talpid.util
 
 class EventNotifier<T>(private val initialValue: T) {
-    private val listeners = HashMap<Int, (T) -> Unit>()
+    private val listeners = HashMap<Any, (T) -> Unit>()
 
     private var idCounter = 0
     private var latestEvent = initialValue
@@ -16,19 +16,25 @@ class EventNotifier<T>(private val initialValue: T) {
         }
     }
 
+    fun subscribe(id: Any, listener: (T) -> Unit) {
+        synchronized(this) {
+            listeners.put(id, listener)
+            listener(latestEvent)
+        }
+    }
+
     fun subscribe(listener: (T) -> Unit): Int {
         synchronized(this) {
             val id = idCounter
 
             idCounter += 1
-            listeners.put(id, listener)
-            listener(latestEvent)
+            subscribe(id, listener)
 
             return id
         }
     }
 
-    fun unsubscribe(id: Int) {
+    fun unsubscribe(id: Any) {
         synchronized(this) {
             listeners.remove(id)
         }


### PR DESCRIPTION
Previously, the `EventNotifier` would keep an internal subscription counter and return the value as subscription IDs that could later be used to unsubscribe a listener. This worked well, however keeping track of the ID was an ergonomic issue.

This PR refactors the `EventNotifier` so that any object can be used as an ID (as long as the `hashCode` and `equals` method of the object ID aren't overridden). This makes it simpler to use, and also allowed two instances of incorrect ID tracking to be fixed (in the `PreferencesFragment` and in the `AdvancedFragment`).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1779)
<!-- Reviewable:end -->
