### PR TITLE
Use `JobTracker` in all fragments

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -13,14 +13,11 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.util.JobTracker
 import org.joda.time.DateTime
 
 val KEY_IS_TUNNEL_INFO_EXPANDED = "is_tunnel_info_expanded"
 
 class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
-    private val jobTracker = JobTracker()
-
     private lateinit var actionButton: ConnectActionButton
     private lateinit var switchLocationButton: SwitchLocationButton
     private lateinit var headerBar: HeaderBar

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -5,13 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.TunnelState
 import org.joda.time.DateTime
 
@@ -24,10 +19,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var notificationBanner: NotificationBanner
     private lateinit var status: ConnectionStatus
     private lateinit var locationInfo: LocationInfo
-
-    private lateinit var updateKeyStatusJob: Job
-    private var updateLocationInfoJob: Job? = null
-    private var updateTunnelStateJob: Job? = null
 
     private var isTunnelInfoExpanded = false
 
@@ -68,8 +59,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         switchLocationButton = SwitchLocationButton(view, resources)
         switchLocationButton.onClick = { openSwitchLocationScreen() }
 
-        updateKeyStatusJob = updateKeyStatus(keyStatusListener.keyStatus)
-
         return view
     }
 
@@ -79,13 +68,13 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         notificationBanner.onResume()
 
         keyStatusListener.onKeyStatusChange.subscribe(this) { keyStatus ->
-            updateKeyStatusJob.cancel()
-            updateKeyStatusJob = updateKeyStatus(keyStatus)
+            jobTracker.newUiJob("updateKeyStatus") {
+                notificationBanner.keyState = keyStatus
+            }
         }
 
         locationInfoCache.onNewLocation = { location ->
-            updateLocationInfoJob?.cancel()
-            updateLocationInfoJob = GlobalScope.launch(Dispatchers.Main) {
+            jobTracker.newUiJob("updateLocationInfo") {
                 locationInfo.location = location
             }
         }
@@ -96,8 +85,9 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
 
         connectionProxy.onUiStateChange.subscribe(this) { uiState ->
-            updateTunnelStateJob?.cancel()
-            updateTunnelStateJob = updateTunnelState(uiState, connectionProxy.state)
+            jobTracker.newUiJob("updateTunnelState") {
+                updateTunnelState(uiState, connectionProxy.state)
+            }
         }
 
         accountCache.onAccountDataChange = { _, expiry ->
@@ -117,8 +107,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         keyStatusListener.onKeyStatusChange.unsubscribe(this)
         connectionProxy.onUiStateChange.unsubscribe(this)
 
-        updateLocationInfoJob?.cancel()
-        updateTunnelStateJob?.cancel()
         notificationBanner.onPause()
 
         isTunnelInfoExpanded = locationInfo.isTunnelInfoExpanded
@@ -133,8 +121,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         state.putBoolean(KEY_IS_TUNNEL_INFO_EXPANDED, isTunnelInfoExpanded)
     }
 
-    private fun updateTunnelState(uiState: TunnelState, realState: TunnelState) =
-        GlobalScope.launch(Dispatchers.Main) {
+    private fun updateTunnelState(uiState: TunnelState, realState: TunnelState) {
         notificationBanner.tunnelState = realState
         locationInfo.state = realState
         headerBar.setState(realState)
@@ -142,10 +129,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
         actionButton.tunnelState = uiState
         switchLocationButton.state = uiState
-    }
-
-    private fun updateKeyStatus(keyStatus: KeygenEvent?) = GlobalScope.launch(Dispatchers.Main) {
-        notificationBanner.keyState = keyStatus
     }
 
     private fun openSwitchLocationScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -125,7 +125,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyDestroyView() {
-        jobTracker.cancelAllJobs()
         switchLocationButton.onDestroy()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -12,7 +12,6 @@ import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.ui.widget.Button
-import net.mullvad.mullvadvpn.util.JobTracker
 import org.joda.time.DateTime
 
 class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
@@ -29,7 +28,6 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var loginFailStatus: View
     private lateinit var accountInput: AccountInput
 
-    private val jobTracker = JobTracker()
     private val loggedIn = CompletableDeferred<LoginResult>()
 
     override fun onSafelyCreateView(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -72,10 +72,6 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         jobTracker.cancelJob("advanceToNextScreen")
     }
 
-    override fun onSafelyDestroyView() {
-        jobTracker.cancelAllJobs()
-    }
-
     private suspend fun createAccount() {
         title.setText(R.string.logging_in_title)
         subtitle.setText(R.string.creating_new_account)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -7,10 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.service.AccountCache
@@ -123,7 +120,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
     }
 
-    private fun performLogin(accountToken: String) = GlobalScope.launch(Dispatchers.Main) {
+    private fun performLogin(accountToken: String) {
         jobTracker.newUiJob("login") {
             val loginResult = jobTracker.runOnBackground {
                 val accountDataResult = daemon.getAccountData(accountToken)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -9,13 +9,10 @@ import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.ui.widget.UrlButton
-import net.mullvad.mullvadvpn.util.JobTracker
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import org.joda.time.DateTime
 
 class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
-    private val jobTracker = JobTracker()
-
     private lateinit var headerBar: HeaderBar
 
     private lateinit var buyCreditButton: UrlButton

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -84,7 +84,6 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
     }
 
     override fun onSafelyDestroyView() {
-        jobTracker.cancelAllJobs()
         connectionProxy.onStateChange.unsubscribe(this)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -4,18 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.Settings
 
 class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private lateinit var allowLanToggle: CellSwitch
     private lateinit var autoConnectToggle: CellSwitch
-
-    private var updateUiJob: Job? = null
 
     override fun onSafelyCreateView(
         inflater: LayoutInflater,
@@ -58,8 +52,7 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
     }
 
     private fun updateUi(settings: Settings) {
-        updateUiJob?.cancel()
-        updateUiJob = GlobalScope.launch(Dispatchers.Main) {
+        jobTracker.newUiJob("updateUi") {
             allowLanToggle.state = boolToSwitchState(settings.allowLan)
             autoConnectToggle.state = boolToSwitchState(settings.autoConnect)
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
@@ -2,8 +2,11 @@ package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import android.support.v4.app.Fragment
+import net.mullvad.mullvadvpn.util.JobTracker
 
 abstract class ServiceAwareFragment : Fragment() {
+    val jobTracker = JobTracker()
+
     lateinit var parentActivity: MainActivity
         private set
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
@@ -23,6 +23,12 @@ abstract class ServiceAwareFragment : Fragment() {
         }
     }
 
+    override fun onDestroyView() {
+        jobTracker.cancelAllJobs()
+
+        super.onDestroyView()
+    }
+
     override fun onDetach() {
         parentActivity.serviceNotifier.unsubscribe(this)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -4,9 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
@@ -190,7 +187,7 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
     }
 
     private fun leaveFragment() {
-        GlobalScope.launch(Dispatchers.Main) {
+        jobTracker.newUiJob("leaveFragment") {
             when (onNoService) {
                 OnNoService.GoBack -> parentActivity.onBackPressed()
                 OnNoService.GoToLaunchScreen -> parentActivity.returnToLaunchScreen()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -67,10 +67,6 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         jobTracker.cancelJob("pollAccountData")
     }
 
-    override fun onSafelyDestroyView() {
-        jobTracker.cancelAllJobs()
-    }
-
     private fun updateAccountNumber(rawAccountNumber: String?) {
         val accountText = rawAccountNumber?.let { account ->
             addSpacesToAccountText(account)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -13,14 +13,11 @@ import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.ui.widget.UrlButton
-import net.mullvad.mullvadvpn.util.JobTracker
 import org.joda.time.DateTime
 
 val POLL_INTERVAL: Long = 15 /* s */ * 1000 /* ms */
 
 class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
-    private val jobTracker = JobTracker()
-
     private lateinit var accountLabel: TextView
 
     override fun onSafelyCreateView(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -17,7 +17,6 @@ import net.mullvad.mullvadvpn.ui.widget.CopyableInformationView
 import net.mullvad.mullvadvpn.ui.widget.InformationView
 import net.mullvad.mullvadvpn.ui.widget.InformationView.WhenMissing
 import net.mullvad.mullvadvpn.ui.widget.UrlButton
-import net.mullvad.mullvadvpn.util.JobTracker
 import net.mullvad.mullvadvpn.util.TimeAgoFormatter
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -31,8 +30,6 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         class Generating(val replacing: Boolean) : ActionState()
         class Verifying() : ActionState()
     }
-
-    private val jobTracker = JobTracker()
 
     private lateinit var timeAgoFormatter: TimeAgoFormatter
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -173,8 +173,6 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         if (!(actionState is ActionState.Idle)) {
             actionState = ActionState.Idle(false)
         }
-
-        jobTracker.cancelAllJobs()
     }
 
     private fun updateKeySpinners() {


### PR DESCRIPTION
Previously, the `JobTracker` helper class was extended to have some easier to use methods that allows spawning UI and background tasks. New and updated fragments started using it instead of locally launching with `GlobalDispatch` and having to manage the `Job` instances.

This PR continues that work to refactor all fragments to use the same pattern. Since all the fragments now use a `JobTracker`, a property was added to the `ServiceAwareFragment`, which is a parent class to most fragments. The jobs are also automatically cancelled when the views are destroyed, which is also the most common behavior. Some tasks still need to be manually cancelled when the UI pauses, though.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no use visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1782)
<!-- Reviewable:end -->
