### PR TITLE
Simplify WireGuard configuration

### DIFF
--- a/ios/PacketTunnel/WireguardDevice.swift
+++ b/ios/PacketTunnel/WireguardDevice.swift
@@ -190,7 +190,7 @@ class WireguardDevice {
 
         let resolvedConfiguration = Self.resolveConfiguration(configuration)
         let handle = resolvedConfiguration
-            .baseline()
+            .uapiConfiguration()
             .toRawWireguardConfigString()
             .withCString { wgTurnOn($0, self.tunFd) }
 
@@ -222,13 +222,11 @@ class WireguardDevice {
     }
 
     private func _setConfig(configuration newConfiguration: WireguardConfiguration) -> Result<(), Error> {
-        if let handle = wireguardHandle,
-            let oldResolvedConfigration = self.resolvedConfiguration
-        {
+        if let handle = wireguardHandle {
             let newResolvedConfiguration = Self.resolveConfiguration(newConfiguration)
-            let wireguardCommands = oldResolvedConfigration.transition(to: newResolvedConfiguration)
+            let commands = newResolvedConfiguration.uapiConfiguration()
 
-            Self.setWireguardConfig(handle: handle, commands: wireguardCommands)
+            Self.setWireguardConfig(handle: handle, commands: commands)
 
             self.configuration = newConfiguration
             self.resolvedConfiguration = newResolvedConfiguration
@@ -319,14 +317,11 @@ class WireguardDevice {
                    String(describing: path.availableInterfaces))
 
             // Re-resolve endpoints on network changes
-            if let currentConfiguration = self.configuration,
-                let oldResolvedConfigration = self.resolvedConfiguration
-            {
+            if let currentConfiguration = self.configuration {
                 let newResolvedConfiguration = Self.resolveConfiguration(currentConfiguration)
-                let commands = oldResolvedConfigration.transition(to: newResolvedConfiguration)
+                let commands = newResolvedConfiguration.endpointUapiConfiguration()
 
                 Self.setWireguardConfig(handle: handle, commands: commands)
-
                 self.resolvedConfiguration = newResolvedConfiguration
             }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR simplifies the WireGuard configuration (back to what we had long ago):

1. Always swap the entire WireGuard configuration when changing relays or/and private keys.
1. Use a separate set of commands to update peer endpoints when roaming between networks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1783)
<!-- Reviewable:end -->
