### PR TITLE
Upgrade Gradle and the Android Gradle plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,3 @@
-import org.jmailen.gradle.kotlinter.tasks.FormatTask
-import org.jmailen.gradle.kotlinter.tasks.LintTask
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
@@ -98,23 +95,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20'
-        classpath 'org.jmailen.gradle:kotlinter-gradle:1.22.0'
     }
 }
-
-task lintKotlin(type: LintTask, group: 'verification') {
-    source files('src/main/kotlin')
-    reports = [
-        'plain': file('build/reports/kotlin-lint-report.txt'),
-    ]
-}
-
-task format(type: FormatTask, group: 'formatting') {
-    source files('src/main/kotlin')
-    report file('build/reports/kotlin-format-report.txt')
-}
-
-lint.dependsOn lintKotlin
 
 task copyExtraAssets(type: Copy) {
     from "$repoRootPath/dist-assets"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -93,7 +93,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.6.0'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20'
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip


### PR DESCRIPTION
We've previously been stuck to an old Gradle version because we could only update it together with the Android Gradle plugin. When we attempted to upgrade the build stopped working, so that ended up being postponed.

Now, In order to use the Gradle Play Publisher plugin, we need to update. Luckily, it seems that whatever caused the build to break in the past is either fixed or not an issue anymore. The upgrade was therefore rather trivial.

I also took the opportunity to remove some old lint and format plugins that we weren't using.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tools update, not user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1787)
<!-- Reviewable:end -->
