### PR TITLE
Change how remaining time in account is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+#### Android
+- Show the remaining account time in the Settings screen in days if it's less than 3 months.
+
 ### Fixed
 #### Android
 - Fix crash when that happened sometimes when the app tried to start the daemon service on recent

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
@@ -37,10 +37,12 @@ class RemainingTimeLabel(val context: Context, val view: View) {
 
                 if (remainingTimeInfo.years > 0) {
                     label.setText(getRemainingText(R.plurals.years_left, remainingTimeInfo.years))
-                } else if (remainingTimeInfo.months > 0) {
+                } else if (remainingTimeInfo.months >= 3) {
                     label.setText(getRemainingText(R.plurals.months_left, remainingTimeInfo.months))
-                } else if (remainingTimeInfo.days > 0) {
-                    label.setText(getRemainingText(R.plurals.days_left, remainingTimeInfo.days))
+                } else if (remainingTimeInfo.months > 0 || remainingTimeInfo.days >= 1) {
+                    label.setText(
+                        getRemainingText(R.plurals.days_left, remainingTime.standardDays.toInt())
+                    )
                 } else {
                     label.setText(R.string.less_than_a_day_left)
                 }


### PR DESCRIPTION
Previously, the app would show the remaining account time in the Settings screen using the most significant unit available. However, this led to some confusion when the remaining time is more than a month but less than three months. If the user had for example 59 days remaining, the screen would say the user had "1 month left".

This PR changes that so that the app behaves like the desktop version, where it shows the remaining time in days if it's less than 90 days. Here the implementation is slightly different, since it checks if there is less than 3 months instead, and that means that it can show "91 days remaining" or "3 months remaining" when it has 89 days remaining, depending on the months.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1789)
<!-- Reviewable:end -->
