### PR TITLE
Use `EventNotifier` in `AccountCache`

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -65,8 +65,8 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
 
     private fun handleNewAccountNumber(newAccountNumber: String?) {
         synchronized(this) {
-            accountNumber = newAccountNumber
             accountExpiry = null
+            accountNumber = newAccountNumber
 
             fetchAccountExpiry()
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -42,20 +42,25 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
     }
 
     override fun onSafelyResume() {
-        accountCache.onAccountDataChange = { accountNumber, accountExpiry ->
-            jobTracker.newUiJob("updateView") {
-                updateView(accountNumber, accountExpiry)
+        accountCache.onAccountNumberChange.subscribe(this) { accountNumber ->
+            jobTracker.newUiJob("updateAccountNumber") {
+                accountNumberView.information = accountNumber
+            }
+        }
+
+        accountCache.onAccountExpiryChange.subscribe(this) { accountExpiry ->
+            jobTracker.newUiJob("updateAccountExpiry") {
+                updateAccountExpiry(accountExpiry)
             }
         }
     }
 
     override fun onSafelyPause() {
-        accountCache.onAccountDataChange = null
+        accountCache.onAccountNumberChange.unsubscribe(this)
+        accountCache.onAccountExpiryChange.unsubscribe(this)
     }
 
-    private fun updateView(accountNumber: String?, accountExpiry: DateTime?) {
-        accountNumberView.information = accountNumber
-
+    private fun updateAccountExpiry(accountExpiry: DateTime?) {
         if (accountExpiry != null) {
             accountExpiryView.information = expiryFormatter.format(accountExpiry.toDate())
         } else {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -90,7 +90,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             }
         }
 
-        accountCache.onAccountDataChange = { _, expiry ->
+        accountCache.onAccountExpiryChange.subscribe(this) { expiry ->
             if (expiry?.isBeforeNow() ?: false) {
                 openOutOfTimeScreen()
             } else if (expiry != null) {
@@ -100,10 +100,10 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyPause() {
-        accountCache.onAccountDataChange = null
         locationInfoCache.onNewLocation = null
         relayListListener.onRelayListChange = null
 
+        accountCache.onAccountExpiryChange.unsubscribe(this)
         keyStatusListener.onKeyStatusChange.unsubscribe(this)
         connectionProxy.onUiStateChange.unsubscribe(this)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -66,7 +66,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
     }
 
     override fun onSafelyResume() {
-        accountCache.onAccountDataChange = { _, expiry ->
+        accountCache.onAccountExpiryChange.subscribe(this) { expiry ->
             checkExpiry(expiry)
         }
 
@@ -79,7 +79,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
     }
 
     override fun onSafelyPause() {
-        accountCache.onAccountDataChange = null
+        accountCache.onAccountExpiryChange.unsubscribe(this)
         jobTracker.cancelJob("pollAccountData")
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -49,8 +49,11 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyResume() {
-        accountCache.onAccountDataChange = { account, expiry ->
+        accountCache.onAccountNumberChange.subscribe(this) { account ->
             updateAccountNumber(account)
+        }
+
+        accountCache.onAccountExpiryChange.subscribe(this) { expiry ->
             checkExpiry(expiry)
         }
 
@@ -63,7 +66,8 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyPause() {
-        accountCache.onAccountDataChange = null
+        accountCache.onAccountNumberChange.unsubscribe(this)
+        accountCache.onAccountExpiryChange.unsubscribe(this)
         jobTracker.cancelJob("pollAccountData")
     }
 

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -30,6 +30,12 @@ class EventNotifier<T>(private val initialValue: T) {
         }
     }
 
+    fun hasListeners(): Boolean {
+        synchronized(this) {
+            return !listeners.isEmpty()
+        }
+    }
+
     fun unsubscribe(id: Any) {
         synchronized(this) {
             listeners.remove(id)


### PR DESCRIPTION
This PR replaces the account data callback in the `AccountCache` with two `EventNotifier`s, one for the account number and one for the account cache. This makes it more straightforward to handle the listeners, and also allows multiple listeners while also avoiding any race condition when swapping the callback. In some cases, usage of the callback is replaced with two listeners to keep the behavior, but in many places only one listener is necessary.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1791)
<!-- Reviewable:end -->
