### PR TITLE
Show account number with spaces on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -28,7 +28,10 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
         view.findViewById<View>(R.id.logout).setOnClickListener { logout() }
 
-        accountNumberView = view.findViewById(R.id.account_number)
+        accountNumberView = view.findViewById<CopyableInformationView>(R.id.account_number).apply {
+            displayFormatter = { rawAccountNumber -> addSpacesToAccountNumber(rawAccountNumber) }
+        }
+
         accountExpiryView = view.findViewById(R.id.account_expiry)
 
         return view
@@ -95,5 +98,18 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
             replace(R.id.main_fragment, LoginFragment())
             commit()
         }
+    }
+
+    private fun addSpacesToAccountNumber(rawAccountNumber: String): String {
+        return rawAccountNumber
+            .asSequence()
+            .fold(StringBuilder()) { formattedAccountNumber, nextDigit ->
+                if ((formattedAccountNumber.length % 5) == 4) {
+                    formattedAccountNumber.append(' ')
+                }
+
+                formattedAccountNumber.append(nextDigit)
+            }
+            .toString()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/InformationView.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/InformationView.kt
@@ -41,6 +41,12 @@ open class InformationView : LinearLayout {
     private val informationDisplay: TextView = findViewById(R.id.information_display)
     private val spinner: View = findViewById(R.id.spinner)
 
+    var displayFormatter: ((String) -> String)? = null
+        set(value) {
+            field = value
+            updateStatus()
+        }
+
     var shouldEnable = false
         set(value) {
             field = value
@@ -150,12 +156,14 @@ open class InformationView : LinearLayout {
             informationDisplay.setTextColor(errorColor)
             informationDisplay.text = error
         } else if (information != null) {
+            val formattedInformation = displayFormatter?.invoke(information) ?: information
+
             informationDisplay.setTextColor(informationColor)
 
-            if (maxLength == 0 || information.length <= maxLength) {
-                informationDisplay.text = information
+            if (maxLength == 0 || formattedInformation.length <= maxLength) {
+                informationDisplay.text = formattedInformation
             } else {
-                informationDisplay.text = information.substring(0, maxLength) + "..."
+                informationDisplay.text = formattedInformation.substring(0, maxLength) + "..."
             }
         }
 


### PR DESCRIPTION
This PR adds a `displayFormatter` property to the `InformationView` and uses that in the Account screen so that it can show the account number with spaces separating every 4 digits. This makes it show the account number like it is shown in the desktop.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1792)
<!-- Reviewable:end -->
