### PR TITLE
Remove seconds from displayed account expiration timestamp

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -12,6 +12,10 @@ import net.mullvad.mullvadvpn.ui.widget.InformationView
 import org.joda.time.DateTime
 
 class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
+    private val dateStyle = DateFormat.MEDIUM
+    private val timeStyle = DateFormat.SHORT
+    private val expiryFormatter = DateFormat.getDateTimeInstance(dateStyle, timeStyle)
+
     private lateinit var accountExpiryView: InformationView
     private lateinit var accountNumberView: CopyableInformationView
 
@@ -53,18 +57,11 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         accountNumberView.information = accountNumber
 
         if (accountExpiry != null) {
-            accountExpiryView.information = formatExpiry(accountExpiry)
+            accountExpiryView.information = expiryFormatter.format(accountExpiry.toDate())
         } else {
             accountExpiryView.information = null
             accountCache.fetchAccountExpiry()
         }
-    }
-
-    private fun formatExpiry(expiry: DateTime): String {
-        val expiryInstant = expiry.toDate()
-        val formatter = DateFormat.getDateTimeInstance()
-
-        return formatter.format(expiryInstant)
     }
 
     private fun logout() {


### PR DESCRIPTION
On other platforms, the account expiration timestamp doesn't include seconds (since it's always zero). This PR updates the Android app to behave the same.

An expiry formater is configured to show shorter time information. The formater is now stored in the fragment so that it can be reused if needed without having to create a new temporary object.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1793)
<!-- Reviewable:end -->
