### PR TITLE
Disable tunnel actions when the device is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 #### Android
 - Show the remaining account time in the Settings screen in days if it's less than 3 months.
+- Prevent commands to connect or disconnect to be sent when the device is locked.
 
 ### Fixed
 #### Android

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -44,7 +44,6 @@ class ForegroundNotificationManager(
             }
         }
 
-    private var loginListenerId: Int? = null
     private var settingsListener: SettingsListener? = null
         set(value) {
             if (field != value) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.service
 
+import android.app.KeyguardManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -24,12 +25,23 @@ val KEY_DISCONNECT_ACTION = "net.mullvad.mullvadvpn.disconnect_action"
 
 class ForegroundNotificationManager(
     val service: MullvadVpnService,
-    val serviceNotifier: EventNotifier<ServiceInstance?>
+    val serviceNotifier: EventNotifier<ServiceInstance?>,
+    val keyguardManager: KeyguardManager
 ) {
     private val notificationManager =
         service.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     private val badgeColor = service.resources.getColor(R.color.colorPrimary)
+
+    private val deviceLockListener = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val action = intent.action
+
+            if (action == Intent.ACTION_USER_PRESENT || action == Intent.ACTION_SCREEN_OFF) {
+                deviceIsUnlocked = !keyguardManager.isDeviceLocked
+            }
+        }
+    }
 
     private var connectionProxy: ConnectionProxy? = null
         set(value) {
@@ -71,6 +83,14 @@ class ForegroundNotificationManager(
                 (value is TunnelState.Connecting && reconnecting)
 
             updateNotification()
+        }
+
+    private var deviceIsUnlocked = true
+        set(value) {
+            if (field != value) {
+                field = value
+                updateNotification()
+            }
         }
 
     private var loggedIn = false
@@ -194,6 +214,10 @@ class ForegroundNotificationManager(
         service.apply {
             registerReceiver(connectReceiver, IntentFilter(KEY_CONNECT_ACTION))
             registerReceiver(disconnectReceiver, IntentFilter(KEY_DISCONNECT_ACTION))
+            registerReceiver(deviceLockListener, IntentFilter().apply {
+                addAction(Intent.ACTION_USER_PRESENT)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            })
         }
 
         updateNotification()
@@ -262,7 +286,7 @@ class ForegroundNotificationManager(
             .setContentTitle(service.getString(notificationText))
             .setContentIntent(pendingIntent)
 
-        if (loggedIn) {
+        if (loggedIn && deviceIsUnlocked) {
             builder.addAction(buildTunnelAction())
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -71,7 +71,7 @@ class MullvadVpnService : TalpidVpnService() {
         super.onCreate()
 
         keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-        notificationManager = ForegroundNotificationManager(this, serviceNotifier)
+        notificationManager = ForegroundNotificationManager(this, serviceNotifier, keyguardManager)
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
         setUp()


### PR DESCRIPTION
It might be a security issue to allow the app notification or the quick-settings tile to disconnect the tunnel while the device is locked. And it might be an undesired behavior if the device connects the VPN tunnel while it's locked (for example by false touch events while the device is in a pocket).

This PR detects if the device is locked or not in order to improve the behavior. If the device is locked, connect and disconnect commands are ignored when sent by the notification or the quick-settings tile. Also, the notification manager now listens for device lock and unlock events in order to hide the notification action button when the device is locked.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1794)
<!-- Reviewable:end -->
