### PR TITLE
Show WireGuard servers on Linux and macOS when automatic protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Line wrap the file at 100 chars.                                              Th
 - Prevent commands to connect or disconnect to be sent when the device is locked.
 
 ### Fixed
+- Show both WireGuard and OpenVPN servers in location list when protocol is set to automatic on Linux and macOS.
+
 #### Android
 - Fix crash when that happened sometimes when the app tried to start the daemon service on recent
   Android versions.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -691,10 +691,12 @@ class ApplicationMain {
                     return relay.tunnels.wireguard.length > 0;
 
                   case 'any':
-                    // TODO: once wireguard is stable, by default we should only filter by
-                    // hasToHaveOpenvpn || hasToHaveWg, until then, only filter wireguard
-                    // relays if tunnel constraints specify wireguard tunnels.
-                    return relay.tunnels.openvpn.length > 0;
+                    // TODO: Drop win32 check when Wireguard becomes default on Windows
+                    if (process.platform === 'win32') {
+                      return relay.tunnels.openvpn.length > 0;
+                    } else {
+                      return relay.tunnels.openvpn.length > 0 || relay.tunnels.wireguard.length > 0;
+                    }
 
                   default:
                     return false;


### PR DESCRIPTION
This PR adds WireGuard servers to the location picker when the tunnel protocol is set to automatic on Linux and macOS.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1799)
<!-- Reviewable:end -->
