### PR TITLE
Fix right chevron position in Select Location button

### DIFF
--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -193,7 +193,6 @@
                 android:paddingHorizontal="8dp"
                 android:text="@string/switch_location"
                 android:drawableRight="@drawable/icon_chevron"
-                android:paddingRight="8dp"
                 style="@style/White20Button" />
         <LinearLayout android:layout_width="match_parent"
                       android:layout_height="wrap_content"

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -17,7 +17,6 @@
            parent="Widget.AppCompat.Button.Borderless">
         <item name="android:layout_height">@dimen/normal_button_height</item>
         <item name="android:layout_width">match_parent</item>
-        <item name="android:padding">0dp</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">20sp</item>


### PR DESCRIPTION
This PR fixes the padding in the Select Location button. Previously the chevron was placed too close to the right button edge, and with the appropriate padding some space is added.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI fix.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1802)
<!-- Reviewable:end -->
