### PR TITLE
Fix crash when entering split-screen mode whilst in the Report a Problem screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix time left in account not showing in settings screen.
 - Fix attempt to connect when the app doesn't have the VPN permission.
 - Fix crash that happened sometimes when the WireGuard key was loaded too quickly.
+- Fix crash when entering split-screen mode whilst on the Report a Problem screen.
 
 #### Windows
 - Fix race in network adapter monitor that could result in data corruption and crashes.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
@@ -5,7 +5,9 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 
 const val PROBLEM_REPORT_FILE = "problem_report.txt"
 
@@ -14,6 +16,7 @@ class MullvadProblemReport(val logDirectory: File) {
 
     private var collectJob: Deferred<Boolean>? = null
     private var sendJob: Deferred<Boolean>? = null
+    private var deleteJob: Job? = null
 
     var confirmNoEmail: CompletableDeferred<Boolean>? = null
 
@@ -39,7 +42,7 @@ class MullvadProblemReport(val logDirectory: File) {
         synchronized(this) {
             if (!isActive) {
                 collectJob = GlobalScope.async(Dispatchers.Default) {
-                    deleteReportFile()
+                    deleteReportFile().join()
                     collectReport(logDirectory.absolutePath, problemReportPath.absolutePath)
                 }
             }
@@ -73,8 +76,19 @@ class MullvadProblemReport(val logDirectory: File) {
         }
     }
 
-    fun deleteReportFile() {
-        problemReportPath.delete()
+    fun deleteReportFile(): Job {
+        synchronized(this) {
+            val oldDeleteJob = deleteJob
+
+            val job = GlobalScope.launch(Dispatchers.Default) {
+                oldDeleteJob?.join()
+                problemReportPath.delete()
+            }
+
+            deleteJob = job
+
+            return job
+        }
     }
 
     private external fun collectReport(logDirectory: String, reportPath: String): Boolean

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -20,9 +20,8 @@ class MainActivity : FragmentActivity() {
         val KEY_SHOULD_CONNECT = "should_connect"
     }
 
+    val problemReport = MullvadProblemReport()
     val serviceNotifier = EventNotifier<ServiceConnection?>(null)
-
-    lateinit var problemReport: MullvadProblemReport
 
     private var service: MullvadVpnService.LocalBinder? = null
     private var serviceConnection: ServiceConnection? = null
@@ -60,7 +59,7 @@ class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        problemReport = MullvadProblemReport(filesDir)
+        problemReport.logDirectory.complete(filesDir)
 
         setContentView(R.layout.main)
 


### PR DESCRIPTION
Apparently, when entering split-screen mode the `Activity.onCreate` method is called with o non-null `savedInstanceState: Bundle`, and this makes the `super.onCreate` initialize the previously shown fragments and call their `Fragment.onAttach` methods.

The issue is that when this happens, the `ProblemReportFragment.onAttach` expects the `MainActivity.problemReport` object to be initialized, but it's only initialized *after* the `super.onCreate` call finishes.

This means that (for example) when you enter split-screen mode whilst on the Report a Problem screen, the steps described above will be executed and the app will crash because the fragment will try to access an uninitialized `MullvadProblemReport`.

This PR fixes that by making sure that the `problemReport` object is initialized sooner, and that the report collection behavior waits until the log directory is set by `MainActivity.onCreate`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1805)
<!-- Reviewable:end -->
