### PR TITLE
Fix race condition in `KeyStatusListener`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix WireGuard key status events being lost by the UI, causing stale information to be shown.
 - Fix time left in account not showing in settings screen.
 - Fix attempt to connect when the app doesn't have the VPN permission.
+- Fix crash that happened sometimes when the WireGuard key was loaded too quickly.
 
 #### Windows
 - Fix race in network adapter monitor that could result in data corruption and crashes.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
@@ -7,9 +7,7 @@ import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.talpid.util.EventNotifier
 
 class KeyStatusListener(val daemon: MullvadDaemon) {
-    private val setUpJob = setUp()
-
-    val onKeyStatusChange = EventNotifier<KeygenEvent?>(null)
+    val onKeyStatusChange = EventNotifier(getInitialKeyStatus())
 
     var keyStatus: KeygenEvent? = null
         private set(value) {
@@ -17,16 +15,17 @@ class KeyStatusListener(val daemon: MullvadDaemon) {
             value?.let { newKeyStatus -> onKeyStatusChange.notify(newKeyStatus) }
         }
 
-    private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
+    init {
         daemon.onKeygenEvent = { event -> keyStatus = event }
-        val wireguardKey = daemon.getWireguardKey()
-        if (wireguardKey != null) {
-            keyStatus = KeygenEvent.NewKey(wireguardKey, null, null)
+    }
+
+    private fun getInitialKeyStatus(): KeygenEvent? {
+        return daemon.getWireguardKey()?.let { wireguardKey ->
+            KeygenEvent.NewKey(wireguardKey, null, null)
         }
     }
 
     fun generateKey() = GlobalScope.launch(Dispatchers.Default) {
-        setUpJob.join()
         val oldStatus = keyStatus
         val newStatus = daemon.generateWireguardKey()
         val newFailure = newStatus?.failure()
@@ -40,7 +39,6 @@ class KeyStatusListener(val daemon: MullvadDaemon) {
     }
 
     fun verifyKey() = GlobalScope.launch(Dispatchers.Default) {
-        setUpJob.join()
         val verified = daemon.verifyWireguardKey()
         // Only update verification status if the key is actually there
         when (val state = keyStatus) {
@@ -53,13 +51,11 @@ class KeyStatusListener(val daemon: MullvadDaemon) {
     }
 
     fun onDestroy() {
-        setUpJob.cancel()
         daemon.onKeygenEvent = null
         onKeyStatusChange.unsubscribeAll()
     }
 
     private fun retryKeyGeneration() = GlobalScope.launch(Dispatchers.Default) {
-        setUpJob.join()
         keyStatus = daemon.generateWireguardKey()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
@@ -1,10 +1,9 @@
-package net.mullvad.mullvadvpn.dataproxy
+package net.mullvad.mullvadvpn.service
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.KeygenEvent
-import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.util.EventNotifier
 
 class KeyStatusListener(val daemon: MullvadDaemon) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -185,8 +185,6 @@ class MullvadVpnService : TalpidVpnService() {
             }
         }
 
-        val accountCache = AccountCache(daemon, settingsListener)
-
         val connectionProxy = ConnectionProxy(this, daemon).apply {
             when (pendingAction) {
                 PendingAction.Connect -> {
@@ -203,16 +201,7 @@ class MullvadVpnService : TalpidVpnService() {
             pendingAction = null
         }
 
-        val locationInfoCache = LocationInfoCache(daemon, connectionProxy, connectivityListener)
-
-        instance = ServiceInstance(
-            daemon,
-            accountCache,
-            connectionProxy,
-            connectivityListener,
-            locationInfoCache,
-            settingsListener
-        )
+        instance = ServiceInstance(daemon, connectionProxy, connectivityListener, settingsListener)
     }
 
     private fun stop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -2,14 +2,15 @@ package net.mullvad.mullvadvpn.service
 
 import net.mullvad.talpid.ConnectivityListener
 
-data class ServiceInstance(
+class ServiceInstance(
     val daemon: MullvadDaemon,
-    val accountCache: AccountCache,
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,
-    val locationInfoCache: LocationInfoCache,
     val settingsListener: SettingsListener
 ) {
+    val accountCache = AccountCache(daemon, settingsListener)
+    val locationInfoCache = LocationInfoCache(daemon, connectionProxy, connectivityListener)
+
     fun onDestroy() {
         accountCache.onDestroy()
         connectionProxy.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -9,11 +9,13 @@ class ServiceInstance(
     val settingsListener: SettingsListener
 ) {
     val accountCache = AccountCache(daemon, settingsListener)
+    val keyStatusListener = KeyStatusListener(daemon)
     val locationInfoCache = LocationInfoCache(daemon, connectionProxy, connectivityListener)
 
     fun onDestroy() {
         accountCache.onDestroy()
         connectionProxy.onDestroy()
+        keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.ui
 
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
-import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.ServiceInstance
 
@@ -10,10 +9,10 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val accountCache = service.accountCache
     val connectionProxy = service.connectionProxy
     val connectivityListener = service.connectivityListener
+    val keyStatusListener = service.keyStatusListener
     val locationInfoCache = service.locationInfoCache
     val settingsListener = service.settingsListener
 
-    val keyStatusListener = KeyStatusListener(daemon)
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)
 
@@ -24,7 +23,6 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
 
     fun onDestroy() {
         appVersionInfoCache.onDestroy()
-        keyStatusListener.onDestroy()
         relayListListener.onDestroy()
         connectionProxy.mainActivity = null
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -6,10 +6,10 @@ import android.view.View
 import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
-import net.mullvad.mullvadvpn.dataproxy.KeyStatusListener
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.ConnectionProxy
+import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SettingsListener


### PR DESCRIPTION
When the `KeyStatusListener` was refactored to use an `EventNotifier`, a small bug was introduced. The `setUp` function expects the notifier object to be initialized so that it can use it, but the notifier is only initialized after the `setUpJob` co-routine is spawned. That means that if the daemon is fast enough when returning the key, there will be an attempt to access the notifier before it is initialized.

The simple fix would have been to simply change the order of operations, but I figured that it would be better to have the initialization code run on the same thread. In order to do this, the class was moved into the `service` package, and now it's created by the service and reused by the UI while the service is running.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1806)
<!-- Reviewable:end -->
