### PR TITLE
Clear back stack when returning to the Launch screen after service connection is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix attempt to connect when the app doesn't have the VPN permission.
 - Fix crash that happened sometimes when the WireGuard key was loaded too quickly.
 - Fix crash when entering split-screen mode whilst on the Report a Problem screen.
+- Fix invalid back stack history when connection to service is lost and the app returns to the
+  launch screen.
 
 #### Windows
 - Fix race in network adapter monitor that could result in data corruption and crashes.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.support.v4.app.FragmentActivity
+import android.support.v4.app.FragmentManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -119,9 +120,13 @@ class MainActivity : FragmentActivity() {
     }
 
     fun returnToLaunchScreen() {
-        supportFragmentManager?.beginTransaction()?.apply {
-            replace(R.id.main_fragment, LaunchFragment())
-            commit()
+        supportFragmentManager?.apply {
+            popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+
+            beginTransaction().apply {
+                replace(R.id.main_fragment, LaunchFragment())
+                commit()
+            }
         }
     }
 


### PR DESCRIPTION
When the app loses the connection to the service, it returns to the launch screen while it waits for a reconnection. However, previously the back stack wasn't cleared, which meant that the user could press back and enter an invalid state. This PR fixes that by clearing the back stack when returning to the launch screen.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1807)
<!-- Reviewable:end -->
