### PR TITLE
Switch to using ephemeral URLSession configuration

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
   and 90 days to always be displayed in days quantity.
 - Fix a number of errors in DNS64 resolution and IPv6 support.
 - Update the tunnel state when the app returns from suspended state.
+- Disable `URLSession` cache.
 
 ## [2020.2] - 2020-04-16
 ### Fixed

--- a/ios/MullvadVPN/Account.swift
+++ b/ios/MullvadVPN/Account.swift
@@ -106,7 +106,7 @@ class Account {
     static let newAccountExpiryUserInfoKey = "newAccountExpiry"
 
     static let shared = Account()
-    private let rpc = MullvadRpc()
+    private let rpc = MullvadRpc.withEphemeralURLSession()
 
     /// Returns true if user agreed to terms of service, otherwise false
     var isAgreedToTermsOfService: Bool {

--- a/ios/MullvadVPN/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager.swift
@@ -98,7 +98,7 @@ class AppStorePaymentManager {
     static let shared = AppStorePaymentManager(queue: SKPaymentQueue.default())
 
     private let queue: SKPaymentQueue
-    private let rpc = MullvadRpc()
+    private let rpc = MullvadRpc.withEphemeralURLSession()
 
     private var paymentQueueSubscriber: AnyCancellable?
     private var sendReceiptSubscriber: AnyCancellable?

--- a/ios/MullvadVPN/AutomaticKeyRotationManager.swift
+++ b/ios/MullvadVPN/AutomaticKeyRotationManager.swift
@@ -46,7 +46,7 @@ class AutomaticKeyRotationManager {
         var publicKey: WireguardPublicKey
     }
 
-    private let rpc = MullvadRpc()
+    private let rpc = MullvadRpc.withEphemeralURLSession()
     private let persistentKeychainReference: Data
     private var rotateKeySubscriber: AnyCancellable?
 

--- a/ios/MullvadVPN/RelayCache.swift
+++ b/ios/MullvadVPN/RelayCache.swift
@@ -49,17 +49,22 @@ class RelayCache {
         return containerURL.flatMap { URL(fileURLWithPath: "relays.json", relativeTo: $0) }
     }
 
-    init(cacheFileURL: URL, networkSession: URLSession = URLSession.shared) {
+    init(cacheFileURL: URL, networkSession: URLSession) {
         rpc = MullvadRpc(session: networkSession)
         self.cacheFileURL = cacheFileURL
     }
 
-    class func withDefaultLocation() -> Result<RelayCache, RelayCacheError> {
+    class func withDefaultLocation(networkSession: URLSession) -> Result<RelayCache, RelayCacheError> {
         if let cacheFileURL = defaultCacheFileURL {
-            return .success(RelayCache(cacheFileURL: cacheFileURL))
+            return .success(RelayCache(cacheFileURL: cacheFileURL, networkSession: networkSession))
         } else {
             return .failure(.defaultLocationNotFound)
         }
+    }
+
+
+    class func withDefaultLocationAndEphemeralSession() -> Result<RelayCache, RelayCacheError> {
+        return withDefaultLocation(networkSession: URLSession(configuration: .ephemeral))
     }
 
     /// Read the relay cache and update it from remote if needed.

--- a/ios/MullvadVPN/RelaySelector+RelayCache.swift
+++ b/ios/MullvadVPN/RelaySelector+RelayCache.swift
@@ -12,7 +12,7 @@ import Foundation
 extension RelaySelector {
 
     static func loadedFromRelayCache() -> AnyPublisher<RelaySelector, RelayCacheError> {
-        return RelayCache.withDefaultLocation().publisher
+        return RelayCache.withDefaultLocationAndEphemeralSession().publisher
             .flatMap { $0.read() }
             .map { RelaySelector(relayList: $0.relayList) }
             .eraseToAnyPublisher()

--- a/ios/MullvadVPN/SelectLocationController.swift
+++ b/ios/MullvadVPN/SelectLocationController.swift
@@ -19,7 +19,7 @@ enum SelectLocationControllerError: Error {
 
 class SelectLocationController: UITableViewController {
 
-    private let relayCache = try! RelayCache.withDefaultLocation().get()
+    private let relayCache = try! RelayCache.withDefaultLocationAndEphemeralSession().get()
     private var relayList: RelayList?
     private var relayConstraints: RelayConstraints?
     private var expandedItems = [RelayLocation]()

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -290,7 +290,7 @@ class TunnelManager {
     /// A queue used for access synchronization to the TunnelManager members
     private let executionQueue = DispatchQueue(label: "net.mullvad.vpn.tunnel-manager.execution-queue")
 
-    private let rpc = MullvadRpc()
+    private let rpc = MullvadRpc.withEphemeralURLSession()
     private var tunnelProvider: TunnelProviderManagerType?
     private var tunnelIpc: PacketTunnelIpc?
 

--- a/ios/MullvadVPN/WireguardKeysViewController.swift
+++ b/ios/MullvadVPN/WireguardKeysViewController.swift
@@ -66,7 +66,7 @@ class WireguardKeysViewController: UIViewController {
     private var creationDateTimerSubscriber: AnyCancellable?
     private var copyToPasteboardSubscriber: AnyCancellable?
 
-    private let rpc = MullvadRpc()
+    private let rpc = MullvadRpc.withEphemeralURLSession()
 
     private var state: WireguardKeysViewState = .default {
         didSet {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Disable `URLSession` cache by switching to ephemeral configuration. As per docs the main advantage of using the ephemeral configuration is privacy to avoid any API responses to be cached on disk.

>An ephemeral session configuration object is similar to a default session configuration (see default), except that the corresponding session object doesn’t store caches, credential stores, or any session-related data to disk. Instead, session-related data is stored in RAM. The only time an ephemeral session writes data to disk is when you tell it to write the contents of a URL to a file.

https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1410529-ephemeral 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1808)
<!-- Reviewable:end -->
