### PR TITLE
Don't allow Android to recreate the Activity when entering split-screen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash when entering split-screen mode whilst on the Report a Problem screen.
 - Fix invalid back stack history when connection to service is lost and the app returns to the
   launch screen.
+- Fix app leaving settings screen when entering split-screen mode.
 
 #### Windows
 - Fix race in network adapter monitor that could result in data corruption and crashes.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
                  tools:ignore="GoogleAppIndexingWarning">
         <activity android:name="net.mullvad.mullvadvpn.ui.MainActivity"
                   android:label="@string/app_name"
-                  android:configChanges="orientation"
+                  android:configChanges="orientation|screenSize|screenLayout"
                   android:screenOrientation="portrait"
                   android:windowSoftInputMode="adjustPan">
             <intent-filter>


### PR DESCRIPTION
Previously, when entering split-screen mode, Android would handle it with the default behavior for a configuration change. This led to the `MainActivity` being destroyed and recreated. When this happened, the activity was created to quickly for it to reestablish connection to the service. That led the active fragment to fallback to return to the launch screen.

This PR changes that so that the activity isn't recreated, and the current active fragment can stay operational.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1809)
<!-- Reviewable:end -->
