### PR TITLE
Fix Welcome screen closing prematurely because of clock mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix invalid back stack history when connection to service is lost and the app returns to the
   launch screen.
 - Fix app leaving settings screen when entering split-screen mode.
+- Fix app sometimes leaving Welcome screen prematurely after creating an account.
 
 #### Windows
 - Fix race in network adapter monitor that could result in data corruption and crashes.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -103,7 +103,9 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
     private fun checkExpiry(maybeExpiry: DateTime?) {
         maybeExpiry?.let { expiry ->
-            if (expiry.isAfterNow()) {
+            val tomorrow = DateTime.now().plusDays(1)
+
+            if (expiry.isAfter(tomorrow)) {
                 jobTracker.newUiJob("advanceToConnectScreen") {
                     advanceToConnectScreen()
                 }


### PR DESCRIPTION
Previously, sometimes the app would leave the Welcome screen right after creating a new account. It would then show the Connect screen but advance to the Out Of Time screen shortly afterwards.

This happened because of an inconsistency when comparing time instants generated with different clocks. A newly created account's expiration time is the account's expiration time, as registered by the API server's clock. The Welcome screen decides the account has been paid for when it detects that the account expiration is after the current time, as registered by the device's clock. That means that an inconsistency of a few seconds can lead the Welcome screen to think that the account has been paid for.

This PR fixes that by adding a margin of error of one day. In most cases the user adds 30 days to the account time, so such a large margin of error shouldn't be a problem (unless the device has been configured with the wrong date). If it ends up being a problem, it's still minor since the user can leave the login screen by logging out and logging back in.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1811)
<!-- Reviewable:end -->
