### PR TITLE
Remove button's default vertical padding

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -17,6 +17,8 @@
            parent="Widget.AppCompat.Button.Borderless">
         <item name="android:layout_height">@dimen/normal_button_height</item>
         <item name="android:layout_width">match_parent</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">20sp</item>


### PR DESCRIPTION
A previous PR removed an attribute from the Button style. The attribute cleared the button's default padding values and reset them all to zero. This was necessary because that forced the chevron on the Select Location button to be pushed to the right edge of the button. However, removing the attribute to fix the chevron position caused another UI glitch: a part of the descenders of the letters inside the button were chopped off.

This PR partially restores the style attribute to reset the button padding. It now only clears the vertical padding, which doesn't affect the Select Location button chevron. By removing the vertical padding, the font descenders now render correctly.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1814)
<!-- Reviewable:end -->
