### PR TITLE
Rename all usages of currentIsSupported to just supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Show both WireGuard and OpenVPN servers in location list when protocol is set to automatic on Linux and macOS.
+- Fix missing in app notification about unsupported version.
 
 #### Android
 - Fix crash when that happened sometimes when the app tried to start the daemon service on recent

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -65,7 +65,7 @@ export interface ICurrentAppVersionInfo {
   gui: string;
   daemon: string;
   isConsistent: boolean;
-  currentIsBeta: boolean;
+  isBeta: boolean;
 }
 
 export interface IAppUpgradeInfo extends IAppVersionInfo {
@@ -138,7 +138,7 @@ class ApplicationMain {
     daemon: '',
     gui: '',
     isConsistent: true,
-    currentIsBeta: false,
+    isBeta: false,
   };
 
   private upgradeVersion: IAppUpgradeInfo = {
@@ -744,7 +744,7 @@ class ApplicationMain {
       daemon: daemonVersion,
       gui: guiVersion,
       isConsistent: daemonVersion === guiVersion,
-      currentIsBeta: guiVersion.includes('beta'),
+      isBeta: guiVersion.includes('beta'),
     };
 
     this.currentVersion = versionInfo;

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -734,7 +734,7 @@ export default class AppRenderer {
     this.reduxActions.version.updateVersion(
       versionInfo.gui,
       versionInfo.isConsistent,
-      versionInfo.currentIsBeta,
+      versionInfo.isBeta,
     );
   }
 

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -167,7 +167,7 @@ export default class NotificationArea extends Component<IProps, State> {
           };
         }
 
-        if (!version.currentIsSupported && version.nextUpgrade) {
+        if (!version.supported && version.nextUpgrade) {
           return {
             visible: true,
             type: 'unsupported-version',

--- a/gui/src/renderer/containers/PreferencesPage.tsx
+++ b/gui/src/renderer/containers/PreferencesPage.tsx
@@ -11,7 +11,7 @@ const mapStateToProps = (state: IReduxState) => ({
   autoStart: state.settings.autoStart,
   allowLan: state.settings.allowLan,
   showBetaReleases: state.settings.showBetaReleases,
-  isBeta: state.version.currentIsBeta,
+  isBeta: state.version.isBeta,
   autoConnect: state.settings.guiSettings.autoConnect,
   enableSystemNotifications: state.settings.guiSettings.enableSystemNotifications,
   monochromaticIcon: state.settings.guiSettings.monochromaticIcon,

--- a/gui/src/renderer/redux/version/actions.ts
+++ b/gui/src/renderer/redux/version/actions.ts
@@ -13,7 +13,7 @@ export interface IUpdateVersionAction {
   type: 'UPDATE_VERSION';
   version: string;
   consistent: boolean;
-  currentIsBeta: boolean;
+  isBeta: boolean;
 }
 
 export type VersionAction = IUpdateLatestAction | IUpdateVersionAction;
@@ -28,13 +28,13 @@ function updateLatest(latestInfo: IUpdateLatestActionPayload): IUpdateLatestActi
 function updateVersion(
   version: string,
   consistent: boolean,
-  currentIsBeta: boolean,
+  isBeta: boolean,
 ): IUpdateVersionAction {
   return {
     type: 'UPDATE_VERSION',
     version,
     consistent,
-    currentIsBeta,
+    isBeta,
   };
 }
 

--- a/gui/src/renderer/redux/version/reducers.ts
+++ b/gui/src/renderer/redux/version/reducers.ts
@@ -2,8 +2,8 @@ import { ReduxAction } from '../store';
 
 export interface IVersionReduxState {
   current: string;
-  currentIsSupported: boolean;
-  currentIsBeta: boolean;
+  supported: boolean;
+  isBeta: boolean;
   latest?: string;
   latestStable?: string;
   nextUpgrade: string | null;
@@ -12,8 +12,8 @@ export interface IVersionReduxState {
 
 const initialState: IVersionReduxState = {
   current: '',
-  currentIsSupported: true,
-  currentIsBeta: false,
+  supported: true,
+  isBeta: false,
   latest: undefined,
   latestStable: undefined,
   nextUpgrade: null,
@@ -36,7 +36,7 @@ export default function (
         ...state,
         current: action.version,
         consistent: action.consistent,
-        currentIsBeta: action.currentIsBeta,
+        isBeta: action.isBeta,
       };
 
     default:

--- a/gui/test/components/NotificationArea.spec.tsx
+++ b/gui/test/components/NotificationArea.spec.tsx
@@ -9,9 +9,9 @@ import { expect } from 'chai';
 describe('components/NotificationArea', () => {
   const defaultVersion = {
     consistent: true,
-    currentIsSupported: true,
+    supported: true,
     current: '2018.2',
-    currentIsBeta: false,
+    isBeta: false,
     latest: '2018.2-beta1',
     latestStable: '2018.2',
     nextUpgrade: null,
@@ -191,7 +191,7 @@ describe('components/NotificationArea', () => {
         }}
         version={{
           ...defaultVersion,
-          currentIsSupported: false,
+          supported: false,
           current: '2018.1',
           nextUpgrade: '2018.2',
         }}


### PR DESCRIPTION
A few places were missed when renaming it a while ago. `currentIsBeta` has
also been renamed for more consistent naming.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1816)
<!-- Reviewable:end -->
