### PR TITLE
Fix routing on MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,15 +2624,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "signal-hook"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,7 +2872,6 @@ dependencies = [
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "triggered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3039,11 +3029,14 @@ dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3135,24 +3128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-process"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-reactor"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,22 +3172,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4210,7 +4169,6 @@ dependencies = [
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum shared_child 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8cebcf3a403e4deafaf34dc882c4a1b6a648b43e5670aa2e4bb985914eaeb2d2"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
-"checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
 "checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
 "checksum simple-signal 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53f7da44adcc42667d57483bd93f81295f27d66897804b757573b61b6f13288b"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
@@ -4251,12 +4209,10 @@ dependencies = [
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 "checksum tokio-named-pipes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d282d483052288b2308ba5ee795f5673b159c9bdf63c385a05609da782a5eae"
-"checksum tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8"
 "checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
 "checksum tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
 "checksum tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-"checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -311,7 +311,7 @@ impl DaemonExecutionState {
 
         match self {
             Exiting => {
-                mem::replace(self, Finished);
+                let _ = mem::replace(self, Finished);
             }
             Running | Finished => {}
         };

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -33,9 +33,8 @@ tokio-executor = "0.1"
 uuid = { version = "0.7", features = ["v4"] }
 zeroize = "1"
 chrono = "0.4"
-
 parity-tokio-ipc = "0.7"
-tokio02 = { package = "tokio", version = "0.2", features =  [ "rt-core", "rt-threaded"] }
+tokio02 = { package = "tokio", version = "0.2", features =  [ "io-util", "process", "rt-core", "rt-threaded", "stream"] }
 triggered = "0.1.1"
 tonic = "0.2"
 prost = "0.6"
@@ -43,7 +42,6 @@ prost = "0.6"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17"
-tokio-process = "0.2"
 tokio-io = "0.1"
 
 

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]
+#![recursion_limit = "1024"]
 
 /// Misc FFI utilities.
 #[cfg(windows)]

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -19,7 +19,7 @@ pub use imp::{Error, RouteManager};
 
 /// A netowrk route with a specific network node, destinaiton and an optional metric.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
-struct Route {
+pub struct Route {
     node: Node,
     prefix: IpNetwork,
     metric: Option<u32>,

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -2,14 +2,12 @@
 #![cfg_attr(target_os = "windows", allow(dead_code))]
 // TODO: remove the allow(dead_code) for android once it's up to scratch.
 use super::RequiredRoute;
-use futures01::{
-    sync::{
-        mpsc::{unbounded, UnboundedSender},
-        oneshot,
-    },
-    Future,
+
+use futures::channel::{
+    mpsc::{self, UnboundedSender},
+    oneshot,
 };
-use std::{collections::HashSet, sync::mpsc::sync_channel};
+use std::collections::HashSet;
 use talpid_types::ErrorExt;
 
 #[cfg(target_os = "linux")]
@@ -71,6 +69,7 @@ pub enum RouteManagerCommand {
 /// the route will be adjusted dynamically when the default route changes.
 pub struct RouteManager {
     manage_tx: Option<UnboundedSender<RouteManagerCommand>>,
+    runtime: tokio02::runtime::Runtime,
 }
 
 impl RouteManager {
@@ -78,29 +77,15 @@ impl RouteManager {
     /// Takes a set of network destinations and network nodes as an argument, and applies said
     /// routes.
     pub fn new(required_routes: HashSet<RequiredRoute>) -> Result<Self, Error> {
-        let (manage_tx, manage_rx) = unbounded();
-        let (start_tx, start_rx) = sync_channel(1);
+        let (manage_tx, manage_rx) = mpsc::unbounded();
+        let mut runtime = tokio02::runtime::Runtime::new().expect("Failed to spawn runtime");
+        let manager = runtime.block_on(imp::RouteManagerImpl::new(required_routes))?;
+        runtime.handle().spawn(manager.run(manage_rx));
 
-        std::thread::spawn(
-            move || match imp::RouteManagerImpl::new(required_routes, manage_rx) {
-                Ok(route_manager) => {
-                    let _ = start_tx.send(Ok(()));
-                    if let Err(e) = route_manager.wait() {
-                        log::error!("Route manager failed - {}", e);
-                    }
-                }
-                Err(e) => {
-                    let _ = start_tx.send(Err(Error::PlatformError(e)));
-                }
-            },
-        );
-        match start_rx.recv() {
-            Ok(Ok(())) => Ok(Self {
-                manage_tx: Some(manage_tx),
-            }),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Err(Error::RoutingManagerThreadPanic),
-        }
+        Ok(Self {
+            runtime,
+            manage_tx: Some(manage_tx),
+        })
     }
 
     /// Stops RouteManager and removes all of the applied routes.
@@ -116,7 +101,7 @@ impl RouteManager {
                 return;
             }
 
-            if wait_rx.wait().is_err() {
+            if self.runtime.block_on(wait_rx).is_err() {
                 log::error!("RouteManager paniced while shutting down");
             }
         }
@@ -133,7 +118,7 @@ impl RouteManager {
                 return Err(Error::RouteManagerDown);
             }
 
-            match result_rx.wait() {
+            match self.runtime.block_on(result_rx) {
                 Ok(result) => result.map_err(Error::PlatformError),
                 Err(error) => {
                     log::trace!(

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -148,7 +148,7 @@ impl RouteManager {
 
     /// Route PID-associated packets through the physical interface.
     #[cfg(target_os = "linux")]
-    pub fn enable_exclusions_routes(&self) -> Result<(), Error> {
+    pub fn enable_exclusions_routes(&mut self) -> Result<(), Error> {
         if let Some(tx) = &self.manage_tx {
             let (result_tx, result_rx) = oneshot::channel();
             if tx
@@ -158,7 +158,7 @@ impl RouteManager {
                 return Err(Error::RouteManagerDown);
             }
 
-            match result_rx.wait() {
+            match self.runtime.block_on(result_rx) {
                 Ok(result) => result.map_err(Error::PlatformError),
                 Err(error) => {
                     log::trace!("{}", error.display_chain_with_msg("channel is closed"));
@@ -206,7 +206,7 @@ impl RouteManager {
                 return Err(Error::RouteManagerDown);
             }
 
-            match result_rx.wait() {
+            match self.runtime.block_on(result_rx) {
                 Ok(result) => result.map_err(Error::PlatformError),
                 Err(error) => {
                     log::trace!("{}", error.display_chain_with_msg("channel is closed"));


### PR DESCRIPTION
I've changed the MacOS routing code to not use old futures and rely on tokio 0.2 and also fixed an issue with default route handling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1817)
<!-- Reviewable:end -->
