### PR TITLE
Prevent autoconnect on login when account is expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ### Fixed
-- Show both WireGuard and OpenVPN servers in location list when protocol is set to automatic on Linux and macOS.
+- Show both WireGuard and OpenVPN servers in location list when protocol is set to automatic on
+  Linux and macOS.
 - Fix missing in app notification about unsupported version.
+- Prevent auto-connect on login if the account is out of time.
 
 #### Android
 - Fix crash when that happened sometimes when the app tried to start the daemon service on recent

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1108,6 +1108,7 @@ class ApplicationMain {
       }
 
       await this.daemonRpc.setAccount(accountToken);
+      consumePromise(this.autoConnect());
     } catch (error) {
       log.error(`Failed to login: ${error.message}`);
 
@@ -1115,6 +1116,20 @@ class ApplicationMain {
         throw Error(messages.gettext('Invalid account number'));
       } else {
         throw error;
+      }
+    }
+  }
+
+  private async autoConnect() {
+    if (
+      !this.accountData ||
+      !new AccountExpiry(this.accountData.expiry, this.locale).hasExpired()
+    ) {
+      try {
+        log.info('Auto-connecting the tunnel');
+        await this.daemonRpc.connectTunnel();
+      } catch (error) {
+        log.error(`Failed to auto-connect the tunnel: ${error.message}`);
       }
     }
   }

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -242,7 +242,7 @@ export default class AppRenderer {
       await IpcRendererEventChannel.account.login(accountToken);
       actions.account.updateAccountToken(accountToken);
       actions.account.loggedIn();
-      this.redirectToConnect(true);
+      this.redirectToConnect();
     } catch (error) {
       actions.account.loginFailed(error);
     }
@@ -267,7 +267,7 @@ export default class AppRenderer {
       const accountToken = await IpcRendererEventChannel.account.create();
       const accountExpiry = new Date().toISOString();
       actions.account.accountCreated(accountToken, accountExpiry);
-      this.redirectToConnect(false);
+      this.redirectToConnect();
     } catch (error) {
       actions.account.createAccountFailed(error);
     }
@@ -431,20 +431,9 @@ export default class AppRenderer {
     return preferredLocale ? preferredLocale.name : '';
   }
 
-  private redirectToConnect(connect: boolean) {
+  private redirectToConnect() {
     // Redirect the user after some time to allow for the 'Logged in' screen to be visible
-    this.loginTimer = global.setTimeout(async () => {
-      this.memoryHistory.replace('/connect');
-
-      if (connect) {
-        try {
-          log.info('Auto-connecting the tunnel');
-          await this.connectTunnel();
-        } catch (error) {
-          log.error(`Failed to auto-connect the tunnel: ${error.message}`);
-        }
-      }
-    }, 1000);
+    this.loginTimer = global.setTimeout(() => this.memoryHistory.replace('/connect'), 1000);
   }
 
   private loadTranslations(locale: string) {


### PR DESCRIPTION
This PR disables the automatic connect on login for expired accounts. The code performing the auto-connect has been moved to the main process to easier depend on the account verification result.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1820)
<!-- Reviewable:end -->
