### PR TITLE
Remove use of spread operator for action data in reducers

### DIFF
--- a/gui/src/renderer/redux/account/reducers.ts
+++ b/gui/src/renderer/redux/account/reducers.ts
@@ -28,85 +28,63 @@ export default function (
     case 'START_LOGIN':
       return {
         ...state,
-        ...{
-          status: { type: 'logging in', method: 'existing_account' },
-          accountToken: action.accountToken,
-        },
+        status: { type: 'logging in', method: 'existing_account' },
+        accountToken: action.accountToken,
       };
     case 'LOGGED_IN':
       return {
         ...state,
-        ...{
-          status: { type: 'ok', method: 'existing_account' },
-        },
+        status: { type: 'ok', method: 'existing_account' },
       };
     case 'LOGIN_FAILED':
       return {
         ...state,
-        ...{
-          status: { type: 'failed', method: 'existing_account', error: action.error },
-          accountToken: undefined,
-        },
+        status: { type: 'failed', method: 'existing_account', error: action.error },
+        accountToken: undefined,
       };
     case 'LOGGED_OUT':
       return {
         ...state,
-        ...{
-          status: { type: 'none' },
-          accountToken: undefined,
-          expiry: undefined,
-        },
+        status: { type: 'none' },
+        accountToken: undefined,
+        expiry: undefined,
       };
     case 'RESET_LOGIN_ERROR':
       return {
         ...state,
-        ...{
-          status: { type: 'none' },
-        },
+        status: { type: 'none' },
       };
     case 'START_CREATE_ACCOUNT':
       return {
         ...state,
-        ...{
-          status: { type: 'logging in', method: 'new_account' },
-        },
+        status: { type: 'logging in', method: 'new_account' },
       };
     case 'CREATE_ACCOUNT_FAILED':
       return {
         ...state,
-        ...{
-          status: { type: 'failed', method: 'new_account', error: action.error },
-        },
+        status: { type: 'failed', method: 'new_account', error: action.error },
       };
     case 'ACCOUNT_CREATED':
       return {
         ...state,
-        ...{
-          status: { type: 'ok', method: 'new_account' },
-          accountToken: action.token,
-          expiry: action.expiry,
-        },
+        status: { type: 'ok', method: 'new_account' },
+        accountToken: action.token,
+        expiry: action.expiry,
       };
     case 'UPDATE_ACCOUNT_TOKEN':
       return {
         ...state,
-        ...{
-          accountToken: action.token,
-        },
+        accountToken: action.token,
       };
     case 'UPDATE_ACCOUNT_HISTORY':
       return {
         ...state,
-        ...{
-          accountHistory: action.accountHistory,
-        },
+        accountHistory: action.accountHistory,
       };
     case 'UPDATE_ACCOUNT_EXPIRY':
       return {
         ...state,
-        ...{
-          expiry: action.expiry,
-        },
+        expiry: action.expiry,
       };
   }
 

--- a/gui/src/renderer/redux/connection/reducers.ts
+++ b/gui/src/renderer/redux/connection/reducers.ts
@@ -33,7 +33,17 @@ export default function (
 ): IConnectionReduxState {
   switch (action.type) {
     case 'NEW_LOCATION':
-      return { ...state, ...action.newLocation };
+      return {
+        ...state,
+        ipv4: action.newLocation.ipv4,
+        ipv6: action.newLocation.ipv6,
+        country: action.newLocation.country,
+        city: action.newLocation.city,
+        latitude: action.newLocation.latitude,
+        longitude: action.newLocation.longitude,
+        hostname: action.newLocation.hostname,
+        bridgeHostname: action.newLocation.bridgeHostname,
+      };
 
     case 'UPDATE_BLOCK_STATE':
       return { ...state, isBlocked: action.isBlocked };

--- a/gui/src/renderer/redux/version/reducers.ts
+++ b/gui/src/renderer/redux/version/reducers.ts
@@ -28,7 +28,10 @@ export default function (
     case 'UPDATE_LATEST':
       return {
         ...state,
-        ...action.latestInfo,
+        nextUpgrade: action.latestInfo.nextUpgrade,
+        supported: action.latestInfo.supported,
+        latest: action.latestInfo.latest,
+        latestStable: action.latestInfo.latestStable,
       };
 
     case 'UPDATE_VERSION':


### PR DESCRIPTION
This PR replaces the use of the spread operator for the action data in reducers. This is to workaround this design limitation of typescript: https://github.com/microsoft/TypeScript/issues/17422

There are two properties that are sent to the reducer which aren't part of the state and have therefore been omitted:
* `latestBeta` in the `'UPDATE_LATEST'` action
* `mullvadExitIP` in the `'NEW_LOCATION'` action

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1821)
<!-- Reviewable:end -->
