### PR TITLE
Secure screens with potentially sensitive data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 - Make all screens scrollable to better handle small screens and split-screen mode.
 - Ignore touch events when another view is shown on top of the app in order to prevent tapjacking
   attacks.
+- Prevent screens showing potentially sensitive data from being recorded.
 
 #### Linux
 - Send an ICMP reject message or TCP reset packet when blocking outgoing packets to prevent

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -15,6 +15,8 @@ import net.mullvad.mullvadvpn.ui.widget.UrlButton
 import org.joda.time.DateTime
 
 class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
+    override val isSecureScreen = true
+
     private val dateStyle = DateFormat.MEDIUM
     private val timeStyle = DateFormat.SHORT
     private val expiryFormatter = DateFormat.getDateTimeInstance(dateStyle, timeStyle)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -13,6 +13,7 @@ import android.view.WindowManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
 import net.mullvad.mullvadvpn.service.MullvadVpnService
@@ -111,7 +112,10 @@ class MainActivity : FragmentActivity() {
     fun enterSecureScreen(screen: Fragment) {
         synchronized(this) {
             visibleSecureScreens.add(screen)
-            window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+
+            if (!BuildConfig.DEBUG) {
+                window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            }
         }
     }
 
@@ -119,7 +123,7 @@ class MainActivity : FragmentActivity() {
         synchronized(this) {
             visibleSecureScreens.remove(screen)
 
-            if (visibleSecureScreens.isEmpty()) {
+            if (!BuildConfig.DEBUG && visibleSecureScreens.isEmpty()) {
                 window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -6,8 +6,10 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentActivity
 import android.support.v4.app.FragmentManager
+import android.view.WindowManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -27,6 +29,7 @@ class MainActivity : FragmentActivity() {
     private var service: MullvadVpnService.LocalBinder? = null
     private var serviceConnection: ServiceConnection? = null
     private var shouldConnect = false
+    private var visibleSecureScreens = HashSet<Fragment>()
 
     private val serviceConnectionManager = object : android.content.ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
@@ -103,6 +106,23 @@ class MainActivity : FragmentActivity() {
         serviceConnection?.onDestroy()
 
         super.onDestroy()
+    }
+
+    fun enterSecureScreen(screen: Fragment) {
+        synchronized(this) {
+            visibleSecureScreens.add(screen)
+            window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    fun leaveSecureScreen(screen: Fragment) {
+        synchronized(this) {
+            visibleSecureScreens.remove(screen)
+
+            if (visibleSecureScreens.isEmpty()) {
+                window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            }
+        }
     }
 
     fun openSettings() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
@@ -7,6 +7,8 @@ import net.mullvad.mullvadvpn.util.JobTracker
 abstract class ServiceAwareFragment : Fragment() {
     val jobTracker = JobTracker()
 
+    open val isSecureScreen = false
+
     lateinit var parentActivity: MainActivity
         private set
 
@@ -17,6 +19,10 @@ abstract class ServiceAwareFragment : Fragment() {
         super.onAttach(context)
 
         parentActivity = context as MainActivity
+
+        if (isSecureScreen) {
+            parentActivity.enterSecureScreen(this)
+        }
 
         parentActivity.serviceNotifier.subscribe(this) { connection ->
             configureServiceConnection(connection)
@@ -31,6 +37,10 @@ abstract class ServiceAwareFragment : Fragment() {
 
     override fun onDetach() {
         parentActivity.serviceNotifier.unsubscribe(this)
+
+        if (isSecureScreen) {
+            parentActivity.leaveSecureScreen(this)
+        }
 
         super.onDetach()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -25,6 +25,8 @@ import org.joda.time.format.DateTimeFormat
 val RFC3339_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSSSSSSSSS z")
 
 class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
+    override val isSecureScreen = true
+
     sealed class ActionState {
         class Idle(val verified: Boolean) : ActionState()
         class Generating(val replacing: Boolean) : ActionState()


### PR DESCRIPTION
Some screens show sensitive information such as the account number, the WireGuard key or the user's reply-to email address after sending a problem report. This information might be accidentally recorded by a screenshot or shown in the recent apps view. This PR makes sure to configure the `FLAG_SECURE` window flag when such information might be shown, to prevent this information to be recorded somewhere.

The Problem Report screen will only set the flag if the user's reply-to email is shown in the screen after the problem report has been sent successfully. The WireGuard Key screen and the Account screen are both marked with flag every time they are visible.

In order to make it simpler and less error-prone to mark screens as secure, the `MainActivity` holds a counter of currently visible secure screens. The counter is only incremented by an `enterSecureScreen()` method and is only decremented by a `leaveSecureScreen()` method. The `ServiceAwareFragment` (which is a super-class to most of the screens) contains a helper `isSecureScreen` read-only property that sub-classes can override and set to `true`. When it is set to `true`, the fragment will call `enterSecureScreen()` as soon as it is added to the activity (and before it is made visible) and will call `leaveSecureScreen()` just before it is removed from the activity (and after its views have been destroyed).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1822)
<!-- Reviewable:end -->
