### PR TITLE
Ignore touch events when app has its UI obscured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 - Show the remaining account time in the Settings screen in days if it's less than 3 months.
 - Prevent commands to connect or disconnect to be sent when the device is locked.
 - Make all screens scrollable to better handle small screens and split-screen mode.
+- Ignore touch events when another view is shown on top of the app in order to prevent tapjacking
+  attacks.
 
 #### Linux
 - Send an ICMP reject message or TCP reset packet when blocking outgoing packets to prevent

--- a/android/src/main/res/layout/main.xml
+++ b/android/src/main/res/layout/main.xml
@@ -1,4 +1,5 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              android:id="@+id/main_fragment"
              android:layout_width="match_parent"
-             android:layout_height="match_parent" />
+             android:layout_height="match_parent"
+             android:filterTouchesWhenObscured="true" />


### PR DESCRIPTION
Some Android UI elements from other apps can be shown over part of the Mullvad app's UI. This can open up the possibility of an attack called [tapjacking](https://blog.trendmicro.com/trendlabs-security-intelligence/tapjacking-an-untapped-threat-in-android/). This PR mitigates such possibility by telling Android to ignore touch events when the app UI is obscured by something.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1823)
<!-- Reviewable:end -->
