### PR TITLE
Show in-app warning when account time is running out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 #### Android
 - Add buttons to buy credit and redeem voucher in Account screen.
+- Show a notification banner warning when the account time will soon run out.
 
 ### Changed
 #### Android

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -102,6 +102,10 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             } else if (expiry != null) {
                 scheduleNextAccountExpiryCheck(expiry)
             }
+
+            jobTracker.newUiJob("updateAccountExpiry") {
+                notificationBanner.accountExpiry = expiry
+            }
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
@@ -82,17 +82,8 @@ class NotificationBanner(
         newListener?.invoke(height)
     }
 
-    var keyState: KeygenEvent? = null
-        set(value) {
-            field = value
-            update()
-        }
-
-    var tunnelState: TunnelState = TunnelState.Disconnected()
-        set(value) {
-            field = value
-            update()
-        }
+    var keyState by observable<KeygenEvent?>(null) { _, _, _ -> update() }
+    var tunnelState by observable<TunnelState>(TunnelState.Disconnected()) { _, _, _ -> update() }
 
     init {
         banner.setOnClickListener { onClick() }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/NotificationBanner.kt
@@ -31,13 +31,18 @@ class NotificationBanner(
     val versionInfoCache: AppVersionInfoCache,
     val daemon: MullvadDaemon
 ) {
-    enum class ExternalLink { Download, KeyManagement }
+    enum class ExternalLink {
+        BuyMoreTime,
+        Download,
+        KeyManagement
+    }
 
     private val resources = context.resources
     private val timeLeftFormatter = TimeLeftFormatter(resources)
 
-    private val keyManagementUrl = context.getString(R.string.wg_key_url)
+    private val buyMoreTimeUrl = context.getString(R.string.account_url)
     private val downloadUrl = Uri.parse(context.getString(R.string.download_url))
+    private val keyManagementUrl = context.getString(R.string.wg_key_url)
 
     private val errorImage = resources.getDrawable(R.drawable.icon_notification_error, null)
     private val warningImage = resources.getDrawable(R.drawable.icon_notification_warning, null)
@@ -78,6 +83,7 @@ class NotificationBanner(
             }
 
             private fun buildUrl() = when (externalLink) {
+                ExternalLink.BuyMoreTime -> Uri.parse(buyMoreTimeUrl + buildUrlTokenParameter())
                 ExternalLink.Download -> downloadUrl
                 ExternalLink.KeyManagement -> Uri.parse(keyManagementUrl + buildUrlTokenParameter())
                 null -> null
@@ -192,6 +198,8 @@ class NotificationBanner(
 
         if (expiry != null && expiry.isBefore(threeDaysFromNow)) {
             val timeLeft = timeLeftFormatter.format(expiry)
+
+            externalLink = ExternalLink.BuyMoreTime
 
             show(warningImage, R.string.account_credit_expires_soon, timeLeft)
         } else {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RemainingTimeLabel.kt
@@ -4,12 +4,13 @@ import android.content.Context
 import android.view.View
 import android.widget.TextView
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.util.TimeLeftFormatter
 import org.joda.time.DateTime
 import org.joda.time.Duration
-import org.joda.time.PeriodType
 
 class RemainingTimeLabel(val context: Context, val view: View) {
     private val resources = context.resources
+    private val formatter = TimeLeftFormatter(resources)
 
     private val expiredColor = resources.getColor(R.color.red)
     private val normalColor = resources.getColor(R.color.white60)
@@ -32,21 +33,7 @@ class RemainingTimeLabel(val context: Context, val view: View) {
                 label.setText(R.string.out_of_time)
                 label.setTextColor(expiredColor)
             } else {
-                val remainingTimeInfo =
-                    remainingTime.toPeriodTo(expiry, PeriodType.yearMonthDayTime())
-
-                if (remainingTimeInfo.years > 0) {
-                    label.setText(getRemainingText(R.plurals.years_left, remainingTimeInfo.years))
-                } else if (remainingTimeInfo.months >= 3) {
-                    label.setText(getRemainingText(R.plurals.months_left, remainingTimeInfo.months))
-                } else if (remainingTimeInfo.months > 0 || remainingTimeInfo.days >= 1) {
-                    label.setText(
-                        getRemainingText(R.plurals.days_left, remainingTime.standardDays.toInt())
-                    )
-                } else {
-                    label.setText(R.string.less_than_a_day_left)
-                }
-
+                label.setText(formatter.format(expiry, remainingTime))
                 label.setTextColor(normalColor)
             }
         } else {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/TimeLeftFormatter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/TimeLeftFormatter.kt
@@ -1,0 +1,38 @@
+package net.mullvad.mullvadvpn.util
+
+import android.content.res.Resources
+import net.mullvad.mullvadvpn.R
+import org.joda.time.DateTime
+import org.joda.time.Duration
+import org.joda.time.PeriodType
+
+class TimeLeftFormatter(val resources: Resources) {
+    fun format(accountExpiry: DateTime): String {
+        val remainingTime = Duration(DateTime.now(), accountExpiry)
+
+        return format(accountExpiry, remainingTime)
+    }
+
+    fun format(accountExpiry: DateTime, remainingTime: Duration): String {
+        if (remainingTime.isShorterThan(Duration.ZERO)) {
+            return resources.getString(R.string.out_of_time)
+        } else {
+            val remainingTimeInfo =
+                remainingTime.toPeriodTo(accountExpiry, PeriodType.yearMonthDayTime())
+
+            if (remainingTimeInfo.years > 0) {
+                return getRemainingText(R.plurals.years_left, remainingTimeInfo.years)
+            } else if (remainingTimeInfo.months >= 3) {
+                return getRemainingText(R.plurals.months_left, remainingTimeInfo.months)
+            } else if (remainingTimeInfo.months > 0 || remainingTimeInfo.days >= 1) {
+                return getRemainingText(R.plurals.days_left, remainingTime.standardDays.toInt())
+            } else {
+                return resources.getString(R.string.less_than_a_day_left)
+            }
+        }
+    }
+
+    private fun getRemainingText(pluralId: Int, quantity: Int): String {
+        return resources.getQuantityString(pluralId, quantity, quantity)
+    }
+}

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="unsupported_version">Unsupported version</string>
     <string name="unsupported_version_description">You are running an unsupported app version.
     Please upgrade to %1$s now to ensure your security</string>
+    <string name="account_credit_expires_soon">Account credit expires soon</string>
     <string name="select_location">Select location</string>
     <string name="select_location_description">While connected, your real location is masked with a
     private and secure location in the selected region</string>


### PR DESCRIPTION
Previously, the app did not notify the user that the account's time was close to its expiration. This lead to some users losing connectivity and taking a while to understand why that happened. This PR adds an in-app notification to let the user know when the remaining time in the account is less than three days.

The notification is clickable and opens the account page in the website that allows the user to buy more time.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1824)
<!-- Reviewable:end -->
