### PR TITLE
Fix updated file name of the generated bundle

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -128,7 +128,7 @@ cp  "$SCRIPT_DIR/android/build/outputs/apk/$GRADLE_BUILD_TYPE/android${BUILT_APK
 if [[ "$BUILD_BUNDLE" == "yes" ]]; then
     $GRADLE_CMD --console plain "$BUNDLE_TASK"
 
-    cp  "$SCRIPT_DIR/android/build/outputs/bundle/$GRADLE_BUILD_TYPE/android.aab" \
+    cp  "$SCRIPT_DIR/android/build/outputs/bundle/$GRADLE_BUILD_TYPE/android${BUILT_APK_SUFFIX}.aab" \
         "$SCRIPT_DIR/dist/MullvadVPN-${PRODUCT_VERSION}${FILE_SUFFIX}.aab"
 fi
 


### PR DESCRIPTION
A recent update of Gradle and the Android Gradle Plugin apparently changed the file name of the final bundle build artifact. This PR updates the build script to use the new path.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Build infrastructure fix, not user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1832)
<!-- Reviewable:end -->
