### PR TITLE
Refactor code to manage the Android notification

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -20,24 +20,15 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
         public val EXPIRY_FORMAT = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss z")
     }
 
-    private val jobTracker = JobTracker()
-
-    private var accountNumber: String? = null
-        set(value) {
-            field = value
-            onAccountNumberChange.notify(value)
-        }
-
-    private var accountExpiry: DateTime? = null
-        set(value) {
-            field = value
-            onAccountExpiryChange.notify(value)
-        }
-
-    private var oldAccountExpiry: DateTime? = null
-
     val onAccountNumberChange = EventNotifier<String?>(null)
     val onAccountExpiryChange = EventNotifier<DateTime?>(null)
+
+    private val jobTracker = JobTracker()
+
+    private var accountNumber by onAccountNumberChange.notifiable()
+    private var accountExpiry by onAccountExpiryChange.notifiable()
+
+    private var oldAccountExpiry: DateTime? = null
 
     init {
         settingsListener.accountNumberNotifier.subscribe(this) { accountNumber ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -214,6 +214,8 @@ class ForegroundNotificationManager(
         connectionProxy = null
         settingsListener = null
 
+        service.unregisterReceiver(deviceLockListener)
+
         notificationManager.cancel(FOREGROUND_NOTIFICATION_ID)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -75,7 +75,10 @@ class ForegroundNotificationManager(
         updateNotification()
     }
 
-    private var deviceIsUnlocked by observable(true) { _, _, _ -> updateNotification() }
+    private var deviceIsUnlocked by observable(!keyguardManager.isDeviceLocked) { _, _, _ ->
+        updateNotification()
+    }
+
     private var loggedIn by observable(false) { _, _, _ -> updateNotification() }
 
     private val shouldBeOnForeground

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -1,36 +1,23 @@
 package net.mullvad.mullvadvpn.service
 
 import android.app.KeyguardManager
-import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
 import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
-import android.support.v4.app.NotificationCompat
 import kotlin.properties.Delegates.observable
-import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.ui.MainActivity
-import net.mullvad.talpid.tunnel.ActionAfterDisconnect
+import net.mullvad.mullvadvpn.service.notifications.TunnelStateNotification
 import net.mullvad.talpid.util.EventNotifier
-
-val CHANNEL_ID = "vpn_tunnel_status"
-val FOREGROUND_NOTIFICATION_ID: Int = 1
 
 class ForegroundNotificationManager(
     val service: MullvadVpnService,
     val serviceNotifier: EventNotifier<ServiceInstance?>,
     val keyguardManager: KeyguardManager
 ) {
-    private val notificationManager =
-        service.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-    private val badgeColor = service.resources.getColor(R.color.colorPrimary)
+    private val tunnelStateNotification = TunnelStateNotification(service)
 
     private val deviceLockListener = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -62,116 +49,25 @@ class ForegroundNotificationManager(
         }
     }
 
-    private var onForeground = false
-    private var reconnecting = false
-    private var showingReconnecting = false
-
     private var tunnelState by observable<TunnelState>(TunnelState.Disconnected()) { _, _, state ->
-        reconnecting =
-            (state is TunnelState.Disconnecting &&
-                state.actionAfterDisconnect == ActionAfterDisconnect.Reconnect) ||
-            (state is TunnelState.Connecting && reconnecting)
-
+        tunnelStateNotification.tunnelState = state
         updateNotification()
     }
 
     private var deviceIsUnlocked by observable(!keyguardManager.isDeviceLocked) { _, _, _ ->
-        updateNotification()
+        updateNotificationAction()
     }
 
-    private var loggedIn by observable(false) { _, _, _ -> updateNotification() }
+    private var loggedIn by observable(false) { _, _, _ -> updateNotificationAction() }
+
+    private var onForeground = false
 
     private val shouldBeOnForeground
         get() = lockedToForeground || !(tunnelState is TunnelState.Disconnected)
 
-    private val notificationText: Int
-        get() {
-            val state = tunnelState
-
-            return when (state) {
-                is TunnelState.Disconnected -> R.string.unsecured
-                is TunnelState.Connecting -> {
-                    if (reconnecting) {
-                        R.string.reconnecting
-                    } else {
-                        R.string.connecting
-                    }
-                }
-                is TunnelState.Connected -> R.string.secured
-                is TunnelState.Disconnecting -> {
-                    when (state.actionAfterDisconnect) {
-                        ActionAfterDisconnect.Reconnect -> R.string.reconnecting
-                        else -> R.string.disconnecting
-                    }
-                }
-                is TunnelState.Error -> {
-                    if (state.errorState.isBlocking) {
-                        R.string.blocking_all_connections
-                    } else {
-                        R.string.critical_error
-                    }
-                }
-            }
-        }
-
-    private val tunnelActionText: Int
-        get() {
-            val state = tunnelState
-
-            return when (state) {
-                is TunnelState.Disconnected -> R.string.connect
-                is TunnelState.Connecting -> R.string.cancel
-                is TunnelState.Connected -> R.string.disconnect
-                is TunnelState.Disconnecting -> {
-                    when (state.actionAfterDisconnect) {
-                        ActionAfterDisconnect.Reconnect -> R.string.cancel
-                        else -> R.string.connect
-                    }
-                }
-                is TunnelState.Error -> {
-                    if (state.errorState.isBlocking) {
-                        R.string.disconnect
-                    } else {
-                        R.string.dismiss
-                    }
-                }
-            }
-        }
-
-    private val tunnelActionKey: String
-        get() {
-            val state = tunnelState
-
-            return when (state) {
-                is TunnelState.Disconnected -> MullvadVpnService.KEY_CONNECT_ACTION
-                is TunnelState.Connecting -> MullvadVpnService.KEY_DISCONNECT_ACTION
-                is TunnelState.Connected -> MullvadVpnService.KEY_DISCONNECT_ACTION
-                is TunnelState.Disconnecting -> {
-                    when (state.actionAfterDisconnect) {
-                        ActionAfterDisconnect.Reconnect -> MullvadVpnService.KEY_DISCONNECT_ACTION
-                        else -> MullvadVpnService.KEY_CONNECT_ACTION
-                    }
-                }
-                is TunnelState.Error -> MullvadVpnService.KEY_DISCONNECT_ACTION
-            }
-        }
-
-    private val tunnelActionIcon: Int
-        get() {
-            if (tunnelActionKey == MullvadVpnService.KEY_CONNECT_ACTION) {
-                return R.drawable.icon_notification_connect
-            } else {
-                return R.drawable.icon_notification_disconnect
-            }
-        }
-
-    var lockedToForeground by observable(false) { _, _, _ -> updateNotificationForegroundStatus() }
+    var lockedToForeground by observable(false) { _, _, _ -> updateNotification() }
 
     init {
-        if (Build.VERSION.SDK_INT >= 26) {
-            initChannel()
-        }
-
         serviceNotifier.subscribe(this) { newServiceInstance ->
             connectionProxy = newServiceInstance?.connectionProxy
             settingsListener = newServiceInstance?.settingsListener
@@ -194,32 +90,17 @@ class ForegroundNotificationManager(
 
         service.unregisterReceiver(deviceLockListener)
 
-        notificationManager.cancel(FOREGROUND_NOTIFICATION_ID)
-    }
-
-    private fun initChannel() {
-        val channelName = service.getString(R.string.foreground_notification_channel_name)
-        val importance = NotificationManager.IMPORTANCE_MIN
-        val channel = NotificationChannel(CHANNEL_ID, channelName, importance).apply {
-            description = service.getString(R.string.foreground_notification_channel_description)
-            setShowBadge(true)
-        }
-
-        notificationManager.createNotificationChannel(channel)
+        tunnelStateNotification.visible = false
     }
 
     private fun updateNotification() {
-        if (!reconnecting || !showingReconnecting) {
-            notificationManager.notify(FOREGROUND_NOTIFICATION_ID, buildNotification())
-        }
-
-        updateNotificationForegroundStatus()
-    }
-
-    private fun updateNotificationForegroundStatus() {
         if (shouldBeOnForeground != onForeground) {
             if (shouldBeOnForeground) {
-                service.startForeground(FOREGROUND_NOTIFICATION_ID, buildNotification())
+                service.startForeground(
+                    TunnelStateNotification.NOTIFICATION_ID,
+                    tunnelStateNotification.build()
+                )
+
                 onForeground = true
             } else if (!shouldBeOnForeground) {
                 if (Build.VERSION.SDK_INT >= 24) {
@@ -233,40 +114,7 @@ class ForegroundNotificationManager(
         }
     }
 
-    private fun buildNotification(): Notification {
-        val intent = Intent(service, MainActivity::class.java)
-            .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            .setAction(Intent.ACTION_MAIN)
-
-        val pendingIntent =
-            PendingIntent.getActivity(service, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
-
-        val builder = NotificationCompat.Builder(service, CHANNEL_ID)
-            .setSmallIcon(R.drawable.small_logo_black)
-            .setColor(badgeColor)
-            .setContentTitle(service.getString(notificationText))
-            .setContentIntent(pendingIntent)
-
-        if (loggedIn && deviceIsUnlocked) {
-            builder.addAction(buildTunnelAction())
-        }
-
-        return builder.build()
-    }
-
-    private fun buildTunnelAction(): NotificationCompat.Action {
-        val intent = Intent(tunnelActionKey).setPackage("net.mullvad.mullvadvpn")
-        val flags = PendingIntent.FLAG_UPDATE_CURRENT
-
-        val pendingIntent = if (Build.VERSION.SDK_INT >= 26) {
-            PendingIntent.getForegroundService(service, 1, intent, flags)
-        } else {
-            PendingIntent.getService(service, 1, intent, flags)
-        }
-
-        val icon = tunnelActionIcon
-        val label = service.getString(tunnelActionText)
-
-        return NotificationCompat.Action(icon, label, pendingIntent)
+    private fun updateNotificationAction() {
+        tunnelStateNotification.showAction = loggedIn && deviceIsUnlocked
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -183,18 +183,6 @@ class ForegroundNotificationManager(
             }
         }
 
-    private val connectReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            connectionProxy?.connect()
-        }
-    }
-
-    private val disconnectReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            connectionProxy?.disconnect()
-        }
-    }
-
     var lockedToForeground = false
         set(value) {
             field = value
@@ -212,8 +200,6 @@ class ForegroundNotificationManager(
         }
 
         service.apply {
-            registerReceiver(connectReceiver, IntentFilter(KEY_CONNECT_ACTION))
-            registerReceiver(disconnectReceiver, IntentFilter(KEY_DISCONNECT_ACTION))
             registerReceiver(deviceLockListener, IntentFilter().apply {
                 addAction(Intent.ACTION_USER_PRESENT)
                 addAction(Intent.ACTION_SCREEN_OFF)
@@ -227,11 +213,6 @@ class ForegroundNotificationManager(
         serviceNotifier.unsubscribe(this)
         connectionProxy = null
         settingsListener = null
-
-        service.apply {
-            unregisterReceiver(connectReceiver)
-            unregisterReceiver(disconnectReceiver)
-        }
 
         notificationManager.cancel(FOREGROUND_NOTIFICATION_ID)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -20,8 +20,6 @@ import net.mullvad.talpid.util.EventNotifier
 
 val CHANNEL_ID = "vpn_tunnel_status"
 val FOREGROUND_NOTIFICATION_ID: Int = 1
-val KEY_CONNECT_ACTION = "net.mullvad.mullvadvpn.connect_action"
-val KEY_DISCONNECT_ACTION = "net.mullvad.mullvadvpn.disconnect_action"
 
 class ForegroundNotificationManager(
     val service: MullvadVpnService,
@@ -161,22 +159,22 @@ class ForegroundNotificationManager(
             val state = tunnelState
 
             return when (state) {
-                is TunnelState.Disconnected -> KEY_CONNECT_ACTION
-                is TunnelState.Connecting -> KEY_DISCONNECT_ACTION
-                is TunnelState.Connected -> KEY_DISCONNECT_ACTION
+                is TunnelState.Disconnected -> MullvadVpnService.KEY_CONNECT_ACTION
+                is TunnelState.Connecting -> MullvadVpnService.KEY_DISCONNECT_ACTION
+                is TunnelState.Connected -> MullvadVpnService.KEY_DISCONNECT_ACTION
                 is TunnelState.Disconnecting -> {
                     when (state.actionAfterDisconnect) {
-                        ActionAfterDisconnect.Reconnect -> KEY_DISCONNECT_ACTION
-                        else -> KEY_CONNECT_ACTION
+                        ActionAfterDisconnect.Reconnect -> MullvadVpnService.KEY_DISCONNECT_ACTION
+                        else -> MullvadVpnService.KEY_CONNECT_ACTION
                     }
                 }
-                is TunnelState.Error -> KEY_DISCONNECT_ACTION
+                is TunnelState.Error -> MullvadVpnService.KEY_DISCONNECT_ACTION
             }
         }
 
     private val tunnelActionIcon: Int
         get() {
-            if (tunnelActionKey == KEY_CONNECT_ACTION) {
+            if (tunnelActionKey == MullvadVpnService.KEY_CONNECT_ACTION) {
                 return R.drawable.icon_notification_connect
             } else {
                 return R.drawable.icon_notification_disconnect

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -57,9 +57,9 @@ class MullvadTileService : TileService() {
         val intent = Intent(this, MullvadVpnService::class.java)
 
         if (secured) {
-            intent.action = KEY_DISCONNECT_ACTION
+            intent.action = MullvadVpnService.KEY_DISCONNECT_ACTION
         } else {
-            intent.action = KEY_CONNECT_ACTION
+            intent.action = MullvadVpnService.KEY_CONNECT_ACTION
         }
 
         if (Build.VERSION.SDK_INT >= 26) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -23,6 +23,9 @@ private const val RELAYS_FILE = "relays.json"
 class MullvadVpnService : TalpidVpnService() {
     companion object {
         private val TAG = "mullvad"
+
+        val KEY_CONNECT_ACTION = "net.mullvad.mullvadvpn.connect_action"
+        val KEY_DISCONNECT_ACTION = "net.mullvad.mullvadvpn.disconnect_action"
     }
 
     private enum class PendingAction {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -1,0 +1,61 @@
+package net.mullvad.mullvadvpn.service.notifications
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import android.support.v4.app.NotificationCompat
+import net.mullvad.mullvadvpn.R
+
+class NotificationChannel(
+    val context: Context,
+    val id: String,
+    val name: Int,
+    val description: Int,
+    val importance: Int
+) {
+    private val badgeColor by lazy {
+        context.resources.getColor(R.color.colorPrimary)
+    }
+
+    val notificationManager =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    init {
+        if (Build.VERSION.SDK_INT >= 26) {
+            val channelName = context.getString(name)
+            val channelDescription = context.getString(description)
+
+            val channel = NotificationChannel(id, channelName, importance).apply {
+                description = channelDescription
+                setShowBadge(true)
+            }
+
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    fun buildNotification(intent: PendingIntent, title: Int): Notification {
+        return buildNotification(intent, title, emptyList())
+    }
+
+    fun buildNotification(
+        pendingIntent: PendingIntent,
+        title: Int,
+        actions: List<NotificationCompat.Action>
+    ): Notification {
+        val builder = NotificationCompat.Builder(context, id)
+            .setSmallIcon(R.drawable.small_logo_black)
+            .setColor(badgeColor)
+            .setContentTitle(context.getString(title))
+            .setContentIntent(pendingIntent)
+
+        for (action in actions) {
+            builder.addAction(action)
+        }
+
+        return builder.build()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -1,0 +1,115 @@
+package net.mullvad.mullvadvpn.service.notifications
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.support.v4.app.NotificationCompat
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.ui.MainActivity
+import net.mullvad.talpid.tunnel.ActionAfterDisconnect
+
+class TunnelStateNotification(val context: Context) {
+    companion object {
+        val NOTIFICATION_ID: Int = 1
+    }
+
+    private val channel = NotificationChannel(
+        context,
+        "vpn_tunnel_status",
+        R.string.foreground_notification_channel_name,
+        R.string.foreground_notification_channel_description,
+        NotificationManager.IMPORTANCE_MIN
+    )
+
+    private val notificationText: Int
+        get() = when (val state = tunnelState) {
+            is TunnelState.Disconnected -> R.string.unsecured
+            is TunnelState.Connecting -> {
+                if (reconnecting) {
+                    R.string.reconnecting
+                } else {
+                    R.string.connecting
+                }
+            }
+            is TunnelState.Connected -> R.string.secured
+            is TunnelState.Disconnecting -> {
+                when (state.actionAfterDisconnect) {
+                    ActionAfterDisconnect.Reconnect -> R.string.reconnecting
+                    else -> R.string.disconnecting
+                }
+            }
+            is TunnelState.Error -> {
+                if (state.errorState.isBlocking) {
+                    R.string.blocking_all_connections
+                } else {
+                    R.string.critical_error
+                }
+            }
+        }
+
+    private var reconnecting = false
+    private var showingReconnecting = false
+
+    var showAction by observable(false) { _, _, _ -> update() }
+
+    var tunnelState by observable<TunnelState>(TunnelState.Disconnected()) { _, _, newState ->
+        reconnecting =
+            (newState is TunnelState.Disconnecting &&
+                newState.actionAfterDisconnect == ActionAfterDisconnect.Reconnect) ||
+            (newState is TunnelState.Connecting && reconnecting)
+
+        update()
+    }
+
+    var visible by observable(true) { _, _, newValue ->
+        if (newValue == true) {
+            update()
+        } else {
+            channel.notificationManager.cancel(NOTIFICATION_ID)
+        }
+    }
+
+    private fun update() {
+        if (visible && (!reconnecting || !showingReconnecting)) {
+            channel.notificationManager.notify(NOTIFICATION_ID, build())
+        }
+    }
+
+    fun build(): Notification {
+        val intent = Intent(context, MainActivity::class.java)
+            .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            .setAction(Intent.ACTION_MAIN)
+
+        val pendingIntent =
+            PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+
+        val actions = if (showAction) {
+            listOf(buildAction())
+        } else {
+            emptyList()
+        }
+
+        return channel.buildNotification(pendingIntent, notificationText, actions)
+    }
+
+    private fun buildAction(): NotificationCompat.Action {
+        val action = TunnelStateNotificationAction.from(tunnelState)
+        val label = context.getString(action.text)
+
+        val intent = Intent(action.key).setPackage("net.mullvad.mullvadvpn")
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT
+
+        val pendingIntent = if (Build.VERSION.SDK_INT >= 26) {
+            PendingIntent.getForegroundService(context, 1, intent, flags)
+        } else {
+            PendingIntent.getService(context, 1, intent, flags)
+        }
+
+        return NotificationCompat.Action(action.icon, label, pendingIntent)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotificationAction.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotificationAction.kt
@@ -1,0 +1,54 @@
+package net.mullvad.mullvadvpn.service.notifications
+
+import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.service.MullvadVpnService
+import net.mullvad.talpid.tunnel.ActionAfterDisconnect
+
+enum class TunnelStateNotificationAction {
+    Connect,
+    Disconnect,
+    Cancel,
+    Dismiss;
+
+    companion object {
+        fun from(tunnelState: TunnelState) = when (tunnelState) {
+            is TunnelState.Disconnected -> Connect
+            is TunnelState.Connecting -> Cancel
+            is TunnelState.Connected -> Disconnect
+            is TunnelState.Disconnecting -> {
+                when (tunnelState.actionAfterDisconnect) {
+                    ActionAfterDisconnect.Reconnect -> Cancel
+                    else -> Connect
+                }
+            }
+            is TunnelState.Error -> {
+                if (tunnelState.errorState.isBlocking) {
+                    Disconnect
+                } else {
+                    Dismiss
+                }
+            }
+        }
+    }
+
+    val text
+        get() = when (this) {
+            Connect -> R.string.connect
+            Disconnect -> R.string.disconnect
+            Cancel -> R.string.cancel
+            Dismiss -> R.string.dismiss
+        }
+
+    val key
+        get() = when (this) {
+            Connect -> MullvadVpnService.KEY_CONNECT_ACTION
+            else -> MullvadVpnService.KEY_DISCONNECT_ACTION
+        }
+
+    val icon
+        get() = when (this) {
+            Connect -> R.drawable.icon_notification_connect
+            else -> R.drawable.icon_notification_disconnect
+        }
+}

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -55,3 +55,16 @@ class EventNotifier<T>(private val initialValue: T) {
         notify(newValue)
     }
 }
+
+fun <T> autoSubscribable(id: Any, fallback: T, listener: (T) -> Unit) =
+    observable<EventNotifier<T>?>(null) { _, old, new ->
+        if (old != new) {
+            old?.unsubscribe(id)
+
+            if (new == null) {
+                listener.invoke(fallback)
+            } else {
+                new.subscribe(id, listener)
+            }
+        }
+    }

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -13,7 +13,8 @@ import kotlin.properties.Delegates.observable
 class EventNotifier<T>(private val initialValue: T) {
     private val listeners = HashMap<Any, (T) -> Unit>()
 
-    private var latestEvent = initialValue
+    var latestEvent = initialValue
+        private set
 
     fun notify(event: T) {
         synchronized(this) {


### PR DESCRIPTION
Previously, the Android app only showed one system notification, which showed the current tunnel state and allowed the user to connect or disconnect the tunnel. In the near future, more notifications will be shown, so this PR lays the groundwork to make the notification code more modular and reusable.

This is PR is in draft-mode because a lot of the refactor work is experimental, and should probably go through a few iterations.

Previously, all of the code was handled in the `ForegroundNotificationManager` class. It handled everything from determining what message to show, how to build the notification, and if it should be on the foreground or not. Now, the class is still responsible for the same things, but it relies on other classes for help, and by itself only manages if the notification is on the foreground or not.

The `NotificationChannel` is a new class that contains some generic notification set-up and construction code. It is used by a new `TunnelStateNotification` class, which is responsible for building the notification and setting up how it should look and behave. A new `TunnelStateNotificationAction` `enum` was also created to separate the code relative to the notification action button. All these new classes are now stored in a new `notification` package.

The constants used for describing the notification actions (`KEY_CONNECT_ACTION` and `KEY_DISCONNECT_ACTION`) are now placed inside `MullvadVpnService`'s companion object, so that it's (mostly) equivalent to static class fields. This removes them from the general package scope, which meant it was visible by all classes in the same package and could lead to conflicts.

The PR also uses more of Kotlin's property delegates feature. They allow a property to be handled by a delegate class, which implement the getter and setter for that property's backing field. The `observable` delegate is mostly used to replace the custom setters that only existed to do things when the field changed. These setters still required a `field = value` statement, which is now eliminated by using the `observable` property.

Two custom delegates were also created. The first one is the `EventNotifier.notifiable()` delegate. If a `val notifier = EventNotifier(initialValue)` is created, for example, then a separate field can be delegated with `val value by notifier.notifiable()`, which means that setting the `value` property will also trigger a notification event in the `notifier`.

The second one is the `autoSubscribable`, and is used for properties that store an `EventNotifier`. In a few cases there was a need to keep track of a notifier, and subscribe and unsubscribe to that notifier as it changed. The new delegate handles that automatically, all that's needed to be configured is the "fallback value" for when there is no notifier available, and the listener to be subscribed to the notifier. An example of the code that is replaced by this new delegate is the old `settingsListener` property in the `ForegroundNotificationManager` class.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1833)
<!-- Reviewable:end -->
