### PR TITLE
Fix in-app notification button onclick

### DIFF
--- a/gui/src/renderer/components/AppButton.tsx
+++ b/gui/src/renderer/components/AppButton.tsx
@@ -133,6 +133,8 @@ export class BlockingButton extends React.Component<IBlockingProps, IBlockingSta
           ...child.props,
           disabled: this.state.isBlocked || this.props.disabled,
           onClick: this.onClick,
+          // TODO: Remove when NotificationOpenLinkAction has been converted from ReactXP
+          onPress: this.onClick,
         });
       } else {
         return child;


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/mullvad/mullvadvpn-app/pull/1784 where the buttons in notifications weren't clickable.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1834)
<!-- Reviewable:end -->
