### PR TITLE
Account history was deleted during path migration if the actual path was unchanged

### DIFF
--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -50,7 +50,9 @@ impl AccountHistory {
         rpc_handle: MullvadRestHandle,
         tokio_remote: Remote,
     ) -> Result<AccountHistory> {
-        Self::migrate_from_old_file_location(cache_dir, settings_dir);
+        if cache_dir != settings_dir {
+            Self::migrate_from_old_file_location(cache_dir, settings_dir);
+        }
 
         let mut options = fs::OpenOptions::new();
         #[cfg(unix)]


### PR DESCRIPTION
The history was recently moved from the cache directory to the settings directory. On Windows and macOS, these were the same path, which caused the daemon to delete the history altogether.