### PR TITLE
Fix undesired button movement in WireGuard Key screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -224,8 +224,8 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     private fun updateStatusMessage() {
         when (val state = actionState) {
-            is ActionState.Generating -> statusMessage.visibility = View.GONE
-            is ActionState.Verifying -> statusMessage.visibility = View.GONE
+            is ActionState.Generating -> statusMessage.visibility = View.INVISIBLE
+            is ActionState.Verifying -> statusMessage.visibility = View.INVISIBLE
             is ActionState.Idle -> {
                 if (hasConnectivity) {
                     updateKeyStatus(state.verified, keyStatus)
@@ -254,7 +254,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
                 updateKeyIsValid(verificationWasDone, keyStatus.verified)
             }
         } else {
-            statusMessage.visibility = View.GONE
+            statusMessage.visibility = View.INVISIBLE
         }
     }
 
@@ -266,7 +266,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
                 if (verificationWasDone) {
                     setStatusMessage(R.string.wireguard_key_verification_failure, redColor)
                 } else {
-                    statusMessage.visibility = View.GONE
+                    statusMessage.visibility = View.INVISIBLE
                 }
             }
         }
@@ -298,7 +298,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     private fun updateVerifyingKeySpinner() {
         verifyingKeySpinner.visibility = when (actionState) {
             is ActionState.Verifying -> View.VISIBLE
-            else -> View.GONE
+            else -> View.INVISIBLE
         }
     }
 


### PR DESCRIPTION
Recent testing showed that when verifying a key, the position of the buttons below the status message may jump a little. This happens because the UI changes the view used for layout measurements, and the spinner may have a different height than the status message text.

This PR fixes the issue by making sure both views are always used in the layout measurements. In theory, the spinner is taller than the text so it could use only the spinner for measurements. However, that may change if the user changes the font size for accessibility reasons, so I found it simpler to just use both views.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1837)
<!-- Reviewable:end -->
