### PR TITLE
Fix unnecessary null-check warning

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
@@ -12,11 +12,7 @@ class KeyStatusListener(val daemon: MullvadDaemon) {
     var keyStatus by onKeyStatusChange.notifiable()
 
     init {
-        daemon.onKeygenEvent = { event ->
-            if (event != null) {
-                keyStatus = event
-            }
-        }
+        daemon.onKeygenEvent = { event -> keyStatus = event }
     }
 
     private fun getInitialKeyStatus(): KeygenEvent? {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
@@ -50,8 +50,4 @@ class KeyStatusListener(val daemon: MullvadDaemon) {
         daemon.onKeygenEvent = null
         onKeyStatusChange.unsubscribeAll()
     }
-
-    private fun retryKeyGeneration() = GlobalScope.launch(Dispatchers.Default) {
-        keyStatus = daemon.generateWireguardKey()
-    }
 }


### PR DESCRIPTION
A previous PR that fixed the WireGuard key verification on Android changed the location where null-events were filtered. However, this introduced a warning about an unnecessary null-check. And this is valid, since the daemon doesn't send `null` as a WireGuard key event.

The `keyStatus` property is only `null` if the account doesn't have a WireGuard key. No other actions in the `KeyStatusListener` will generate a `null` key status, so the filtering isn't necessary.

The only location `null` could be returned and directly set to the property was in an unused private method (probably some left-over code from some refactors). This method is now also removed by this PR.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user-visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1838)
<!-- Reviewable:end -->
