### PR TITLE
Fix OpenVPN being unable to send packets to the relay on Windows 7

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -564,8 +564,6 @@ where
             tunnel_state_machine_shutdown_tx,
             #[cfg(target_os = "android")]
             android_context,
-            #[cfg(windows)]
-            Self::get_approved_applications(),
         )
         .map_err(Error::TunnelError)?;
 
@@ -634,16 +632,6 @@ where
         }
 
         Ok(daemon)
-    }
-
-    #[cfg(windows)]
-    fn get_approved_applications() -> Vec<PathBuf> {
-        let resource_dir = mullvad_paths::get_resource_dir();
-        vec![
-            resource_dir.join("mullvad-daemon.exe"),
-            resource_dir.join("openvpn.exe"),
-            resource_dir.join("sslocal.exe"),
-        ]
     }
 
     /// Consume the `Daemon` and run the main event loop. Blocks until an error happens or a

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -69,8 +69,6 @@ fn reset_firewall() -> Result<(), Error> {
     let mut firewall = Firewall::new(FirewallArguments {
         initialize_blocked: false,
         allow_lan: None,
-        #[cfg(windows)]
-        approved_applications: vec!["foobar".into()],
     })
     .map_err(Error::FirewallError)?;
 

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -94,6 +94,9 @@ pub enum FirewallPolicy {
         pingable_hosts: Vec<IpAddr>,
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
+        /// A process that is allowed to send packets to the relay.
+        #[cfg(windows)]
+        relay_client: PathBuf,
     },
 
     /// Allow traffic only to server and over tunnel interface
@@ -104,6 +107,9 @@ pub enum FirewallPolicy {
         tunnel: crate::tunnel::TunnelMetadata,
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
+        /// A process that is allowed to send packets to the relay.
+        #[cfg(windows)]
+        relay_client: PathBuf,
     },
 
     /// Block all network traffic in and out from the computer.
@@ -120,6 +126,7 @@ impl fmt::Display for FirewallPolicy {
                 peer_endpoint,
                 pingable_hosts,
                 allow_lan,
+                ..
             } => write!(
                 f,
                 "Connecting to {} with gateways {}, {} LAN",
@@ -135,6 +142,7 @@ impl fmt::Display for FirewallPolicy {
                 peer_endpoint,
                 tunnel,
                 allow_lan,
+                ..
             } => write!(
                 f,
                 "Connected to {} over \"{}\" (ip: {}, v4 gw: {}, v6 gw: {:?}), {} LAN",
@@ -171,9 +179,6 @@ pub struct FirewallArguments {
     pub initialize_blocked: bool,
     /// This argument is required for the blocked state to configure the firewall correctly.
     pub allow_lan: Option<bool>,
-    /// List of applications that are approved for communicating with the relay.
-    #[cfg(windows)]
-    pub approved_applications: Vec<PathBuf>,
 }
 
 impl Firewall {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -190,7 +190,7 @@ impl TunnelMonitor {
                     "openvpn.exe"
                 }
             }
-            _ => "mullvad-daemon.exe",
+            _ => return std::env::current_exe().unwrap(),
         };
         resource_dir.join(process_string)
     }

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -175,6 +175,26 @@ impl TunnelMonitor {
         }
     }
 
+    /// Returns a path to an executable that communicates with relay servers.
+    #[cfg(windows)]
+    pub fn get_relay_client(resource_dir: &Path, params: &TunnelParameters) -> PathBuf {
+        let resource_dir = resource_dir.to_path_buf();
+        let process_string = match params {
+            TunnelParameters::OpenVpn(params) => {
+                if let Some(proxy) = &params.proxy {
+                    match proxy {
+                        openvpn_types::ProxySettings::Shadowsocks(..) => "sslocal.exe",
+                        _ => "openvpn.exe",
+                    }
+                } else {
+                    "openvpn.exe"
+                }
+            }
+            _ => "mullvad-daemon.exe",
+        };
+        resource_dir.join(process_string)
+    }
+
     fn start_wireguard_tunnel<L>(
         params: &wireguard_types::TunnelParameters,
         log: Option<PathBuf>,

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -16,6 +16,10 @@ use talpid_types::{
     BoxedError, ErrorExt,
 };
 
+#[cfg(windows)]
+use crate::tunnel::TunnelMonitor;
+
+
 pub struct ConnectedStateBootstrap {
     pub metadata: TunnelMetadata,
     pub tunnel_events: mpsc::UnboundedReceiver<TunnelEvent>,
@@ -55,6 +59,11 @@ impl ConnectedState {
             peer_endpoint,
             tunnel: self.metadata.clone(),
             allow_lan: shared_values.allow_lan,
+            #[cfg(windows)]
+            relay_client: TunnelMonitor::get_relay_client(
+                &shared_values.resource_dir,
+                &self.tunnel_parameters,
+            ),
         };
         shared_values.firewall.apply_policy(policy)
     }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -60,6 +60,8 @@ impl ConnectingState {
             peer_endpoint,
             pingable_hosts: gateway_list_from_params(params),
             allow_lan: shared_values.allow_lan,
+            #[cfg(windows)]
+            relay_client: TunnelMonitor::get_relay_client(&shared_values.resource_dir, &params),
         };
         shared_values.firewall.apply_policy(policy)
     }

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -7,20 +7,20 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <string>
 #include <optional>
 
 class FwContext
 {
 public:
 
-	FwContext(uint32_t timeout, const std::vector<std::wstring> &approvedApplications);
+	FwContext(uint32_t timeout);
 
 	// This ctor applies the "blocked" policy.
 	FwContext
 	(
 		uint32_t timeout,
-		const WinFwSettings &settings,
-		const std::vector<std::wstring> &approvedApplications
+		const WinFwSettings &settings
 	);
 
 	struct PingableHosts
@@ -33,6 +33,7 @@ public:
 	(
 		const WinFwSettings &settings,
 		const WinFwRelay &relay,
+		const std::wstring &relayClient,
 		const std::optional<PingableHosts> &pingableHosts
 	);
 
@@ -40,6 +41,7 @@ public:
 	(
 		const WinFwSettings &settings,
 		const WinFwRelay &relay,
+		const std::wstring &relayClient,
 		const std::wstring &tunnelInterfaceAlias,
 		const std::vector<wfp::IpAddress> &tunnelDnsServers
 	);
@@ -73,8 +75,6 @@ private:
 
 	bool applyRuleset(const Ruleset &ruleset);
 	bool applyRulesetDirectly(const Ruleset &ruleset, SessionController &controller);
-
-	const std::vector<std::wstring> m_approvedApplications;
 
 	std::unique_ptr<SessionController> m_sessionController;
 

--- a/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
+++ b/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
@@ -63,19 +63,15 @@ PermitVpnRelay::PermitVpnRelay
 	const wfp::IpAddress &relay,
 	uint16_t relayPort,
 	Protocol protocol,
-	const std::vector<std::wstring> &approvedApplications,
+	const std::wstring &relayClient,
 	Sublayer sublayer
 )
 	: m_relay(relay)
 	, m_relayPort(relayPort)
 	, m_protocol(protocol)
-	, m_approvedApplications(approvedApplications)
+	, m_relayClient(relayClient)
 	, m_sublayer(sublayer)
 {
-	if (m_approvedApplications.empty())
-	{
-		THROW_ERROR("Cannot configure relay access without list of approved applications");
-	}
 }
 
 bool PermitVpnRelay::apply(IObjectInstaller &objectInstaller)
@@ -101,11 +97,7 @@ bool PermitVpnRelay::apply(IObjectInstaller &objectInstaller)
 	conditionBuilder.add_condition(ConditionIp::Remote(m_relay));
 	conditionBuilder.add_condition(ConditionPort::Remote(m_relayPort));
 	conditionBuilder.add_condition(CreateProtocolCondition(m_protocol));
-
-	for (const auto &app : m_approvedApplications)
-	{
-		conditionBuilder.add_condition(std::make_unique<ConditionApplication>(app));
-	}
+	conditionBuilder.add_condition(std::make_unique<ConditionApplication>(m_relayClient));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }

--- a/windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
+++ b/windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
@@ -3,7 +3,6 @@
 #include <winfw/rules/ifirewallrule.h>
 #include <libwfp/ipaddress.h>
 #include <string>
-#include <vector>
 
 namespace rules::multi
 {
@@ -29,7 +28,7 @@ public:
 		const wfp::IpAddress &relay,
 		uint16_t relayPort,
 		Protocol protocol,
-		const std::vector<std::wstring> &approvedApplications,
+		const std::wstring &relayClient,
 		Sublayer sublayer
 	);
 	
@@ -40,7 +39,7 @@ private:
 	const wfp::IpAddress m_relay;
 	const uint16_t m_relayPort;
 	const Protocol m_protocol;
-	const std::vector<std::wstring> m_approvedApplications;
+	const std::wstring m_relayClient;
 	const Sublayer m_sublayer;
 };
 

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -45,17 +45,6 @@ typedef struct tag_WinFwRelay
 }
 WinFwRelay;
 
-//
-// This structure is used to define the set of applications
-// that are allowed to communicate with the relay.
-//
-typedef struct tag_WinFwApprovedApplications
-{
-	const wchar_t **apps;
-	size_t numApps;
-}
-WinFwApprovedApplications;
-
 #pragma pack(pop)
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -78,7 +67,6 @@ bool
 WINFW_API
 WinFw_Initialize(
 	uint32_t timeout,
-	WinFwApprovedApplications *approvedApplications,
 	MullvadLogSink logSink,
 	void *logSinkContext
 );
@@ -100,7 +88,6 @@ WINFW_API
 WinFw_InitializeBlocked(
 	uint32_t timeout,
 	const WinFwSettings *settings,
-	WinFwApprovedApplications *approvedApplications,
 	MullvadLogSink logSink,
 	void *logSinkContext
 );
@@ -160,6 +147,7 @@ WINFW_API
 WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
 	const WinFwRelay *relay,
+	const wchar_t *relayClient,
 	const PingableHosts *pingableHosts
 );
 
@@ -186,6 +174,7 @@ WINFW_API
 WinFw_ApplyPolicyConnected(
 	const WinFwSettings *settings,
 	const WinFwRelay *relay,
+	const wchar_t *relayClient,
 	const wchar_t *tunnelInterfaceAlias,
 	const wchar_t *v4DnsHost,
 	const wchar_t *v6DnsHost


### PR DESCRIPTION
On Windows 7, the firewall rules are not correctly interpreted. If the daemon is approved to send packets to the server at the same time as openvpn.exe is, packets from the OpenVPN process are blocked anyway. Only one process needs to be permitted to communicate with the server at a time, so with the updates, the daemon does that instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1839)
<!-- Reviewable:end -->
