### PR TITLE
Fix null termination in talpid-ipc

### DIFF
--- a/talpid-ipc/src/win.rs
+++ b/talpid-ipc/src/win.rs
@@ -143,11 +143,7 @@ pub fn deny_network_access<T: AsRef<OsStr>>(ipc_path: T) -> Result<(), io::Error
         )
     };
     if result != ERROR_SUCCESS {
-        // A non-zero error code in WinError.h
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("SetEntriesInAclW failed: {}", result),
-        ));
+        return Err(io::Error::from_raw_os_error(result as i32));
     }
 
     let result = unsafe {
@@ -165,11 +161,7 @@ pub fn deny_network_access<T: AsRef<OsStr>>(ipc_path: T) -> Result<(), io::Error
     unsafe { LocalFree(new_dacl as *mut _) };
 
     if result != ERROR_SUCCESS {
-        // A non-zero error code in WinError.h
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("SetSecurityInfo failed: {}", result),
-        ));
+        return Err(io::Error::from_raw_os_error(result as i32));
     }
 
     Ok(())

--- a/talpid-ipc/src/win.rs
+++ b/talpid-ipc/src/win.rs
@@ -71,7 +71,8 @@ impl Drop for WinHandle {
 }
 
 pub fn deny_network_access<T: AsRef<OsStr>>(ipc_path: T) -> Result<(), io::Error> {
-    let ipc_w: Vec<_> = ipc_path.as_ref().encode_wide().collect();
+    let mut ipc_w: Vec<_> = ipc_path.as_ref().encode_wide().collect();
+    ipc_w.push(0u16);
 
     let pipe_handle = unsafe {
         CreateFileW(


### PR DESCRIPTION
In #1830, [`OsStrExt::encode_wide`](https://doc.rust-lang.org/std/os/windows/ffi/trait.OsStrExt.html#tymethod.encode_wide) was used, but a null terminator was not added to the resulting vector. In practice, the string must have been null-terminated anyway, but this PR adds one explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1840)
<!-- Reviewable:end -->
