### PR TITLE
Report key generation failures

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -82,6 +82,9 @@ type BoxFuture<T, E> = Box<dyn Future<Item = T, Error = E> + Send>;
 
 const TUNNEL_STATE_MACHINE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Timeout for first WireGuard key pushing
+const FIRST_KEY_PUSH_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
 pub enum Error {
@@ -1643,7 +1646,10 @@ where
                 .unwrap_or(true)
             {
                 log::info!("Automatically generating new wireguard key for account");
-                if let Err(e) = self.wireguard_key_manager.generate_key_async(account) {
+                if let Err(e) = self
+                    .wireguard_key_manager
+                    .generate_key_async(account, Some(FIRST_KEY_PUSH_TIMEOUT))
+                {
                     log::error!(
                         "{}",
                         e.display_chain_with_msg("Failed to start generating wireguard key")


### PR DESCRIPTION
To inform the UI clients of failures to generate the first key, the daemon will now receive key generation events about all attempts of the first key generation, both failures and successes. The key generation timeout for the first key generation is also lowered to 5 seconds. This should help with the UX when the user first starts the app and tries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1848)
<!-- Reviewable:end -->
