### PR TITLE
Wait for WireGuard key-event before auto-connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Line wrap the file at 100 chars.                                              Th
   Linux and macOS.
 - Fix missing in app notification about unsupported version.
 - Prevent auto-connect on login if the account is out of time.
+- Fix race that caused WireGuard key upload to fail which could cause the "too many keys" error and
+  the tunnel to invalidly fall back to OpenVPN.
 
 #### Android
 - Fix crash when that happened sometimes when the app tried to start the daemon service on recent


### PR DESCRIPTION
This PR makes the app wait for a WireGuard key-event before starting to connect. Connecting before the api request was done resulted in fallbacking to OpenVPN and leaving unused keys.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1849)
<!-- Reviewable:end -->
