### PR TITLE
Silence h2 crate in `logging`

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -25,6 +25,7 @@ pub enum Error {
 }
 
 pub const SILENCED_CRATES: &[&str] = &[
+    "h2",
     "jsonrpc_core",
     // jsonrpc_core does some logging under the "rpc" target as well.
     "rpc",


### PR DESCRIPTION
h2 is a dependency of hyper. It logs a lot of very verbose stuff that ends up in daemon.log due to the `talpid-openvpn-plugin` crate indirectly depending on it:

```
[2020-06-16 14:45:09.713][h2::codec::framed_write][DEBUG] send; frame=Settings { flags: (0x0), initial_window_size: 1048576 }
[2020-06-16 14:45:09.713][h2::codec::framed_write][DEBUG] send; frame=WindowUpdate { stream_id: StreamId(0), size_increment: 983041 }
[2020-06-16 14:45:17.450][h2::codec::framed_read][DEBUG] received; frame=Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152 }
[2020-06-16 14:45:17.450][h2::codec::framed_write][DEBUG] send; frame=Settings { flags: (0x1: ACK) }
[2020-06-16 14:45:17.450][h2::codec::framed_read][DEBUG] received; frame=WindowUpdate { stream_id: StreamId(0), size_increment: 5177345 }
[2020-06-16 14:45:17.450][h2::codec::framed_read][DEBUG] received; frame=Settings { flags: (0x1: ACK) }
[2020-06-16 14:45:17.450][h2::proto::settings][DEBUG] received settings ACK; applying Settings { flags: (0x0), initial_window_size: 1048576 }
[2020-06-16 14:45:17.450][h2::codec::framed_read][DEBUG] received; frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[2020-06-16 14:45:17.450][h2::codec::framed_read][DEBUG] received; frame=Data { stream_id: StreamId(1) }
[2020-06-16 14:45:17.450][h2::codec::framed_read][DEBUG] received; frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1850)
<!-- Reviewable:end -->
