### PR TITLE
Change android release notes to 2020.5-beta2 notes

### DIFF
--- a/android/src/main/play/release-notes/en-US/beta.txt
+++ b/android/src/main/play/release-notes/en-US/beta.txt
@@ -1,7 +1,5 @@
-- Fix many app crashes and bugs.
-- Add possibility to create account from the login screen.
-- Allow submitting voucher codes to add time to the account.
-- Move location of the account data (including the WireGuard keys), so that it isn't lost when the
-  system cache is cleaned.
-- Adjust the minimum supported Android version to correctly reflect the supported versions decided
-  in 2020.4-beta2. The app will now only install on Android 7 and later (API level 24).
+- Show a notification banner warning when the account time will soon run out.
+- Prevent commands to connect or disconnect to be sent when the device is locked.
+- Make all screens scrollable to better handle small screens and split-screen mode.
+- Prevent tapjacking attacks and prohibit screenshots. Fixes audit ticket `MUL-02-003`.
+- Fix various bugs causing random crashes, and UI navigation issues.


### PR DESCRIPTION
This was submitted too late. But now at least they can
be correct in the repo :shrug: 

This was forgotten before the release. But not the end of the world. I will also update the release app docs to include doing this *before* a release next time.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1853)
<!-- Reviewable:end -->
