### PR TITLE
Show Android notification when account time is running out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+#### Android
+- Show a system notification when the account time will soon run out.
 
 
 ## [2020.5-beta2] - 2020-06-16

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -68,11 +68,9 @@ class MullvadVpnService : TalpidVpnService() {
             }
         }
 
-    private var isBound = false
-        set(value) {
-            field = value
-            notificationManager.lockedToForeground = value
-        }
+    private var isBound by observable(false) { _, _, isBound ->
+        notificationManager.lockedToForeground = isBound
+    }
 
     override fun onCreate() {
         super.onCreate()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -8,6 +8,7 @@ import android.os.Binder
 import android.os.IBinder
 import android.util.Log
 import java.io.File
+import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -41,14 +42,12 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var startDaemonJob: Job? = null
 
-    private var instance: ServiceInstance? = null
-        set(value) {
-            if (field != value) {
-                field?.onDestroy()
-                field = value
-                serviceNotifier.notify(value)
-            }
+    private var instance by observable<ServiceInstance?>(null) { _, oldInstance, newInstance ->
+        if (newInstance != oldInstance) {
+            oldInstance?.onDestroy()
+            serviceNotifier.notify(newInstance)
         }
+    }
 
     private lateinit var keyguardManager: KeyguardManager
     private lateinit var notificationManager: ForegroundNotificationManager

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -1,0 +1,76 @@
+package net.mullvad.mullvadvpn.service.notifications
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.R
+import org.joda.time.DateTime
+import org.joda.time.Duration
+
+class AccountExpiryNotification(val context: Context) {
+    companion object {
+        val NOTIFICATION_ID: Int = 2
+    }
+
+    private val resources = context.resources
+
+    private val buyMoreTimeUrl = Uri.parse(resources.getString(R.string.account_url))
+
+    private val channel = NotificationChannel(
+        context,
+        "mullvad_account_time",
+        R.string.account_time_notification_channel_name,
+        R.string.account_time_notification_channel_description,
+        NotificationManager.IMPORTANCE_HIGH
+    )
+
+    var accountExpiry by observable<DateTime?>(null) { _, oldValue, newValue ->
+        if (oldValue != newValue) {
+            if (newValue != null) {
+                channel.notificationManager.notify(NOTIFICATION_ID, build(newValue))
+            } else {
+                channel.notificationManager.cancel(NOTIFICATION_ID)
+            }
+        }
+    }
+
+    private fun build(expiry: DateTime): Notification {
+        val intent = Intent(Intent.ACTION_VIEW, buyMoreTimeUrl)
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT
+        val pendingIntent = PendingIntent.getActivity(context, 1, intent, flags)
+
+        return channel.buildNotification(pendingIntent, format(expiry))
+    }
+
+    private fun format(expiry: DateTime): String {
+        val remainingTime = Duration(DateTime.now(), expiry)
+
+        if (remainingTime.isShorterThan(Duration.ZERO)) {
+            return resources.getString(R.string.account_credit_has_expired)
+        } else {
+            val remainingTimeInfo = remainingTime.toPeriodTo(expiry)
+
+            if (remainingTimeInfo.days >= 1) {
+                return getRemainingText(
+                    R.plurals.account_credit_expires_in_days,
+                    remainingTime.standardDays.toInt()
+                )
+            } else if (remainingTimeInfo.hours >= 1) {
+                return getRemainingText(
+                    R.plurals.account_credit_expires_in_hours,
+                    remainingTime.standardHours.toInt()
+                )
+            } else {
+                return resources.getString(R.string.account_credit_expires_in_a_few_minutes)
+            }
+        }
+    }
+
+    private fun getRemainingText(pluralId: Int, quantity: Int): String {
+        return resources.getQuantityString(pluralId, quantity, quantity)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -37,6 +37,10 @@ class NotificationChannel(
         }
     }
 
+    fun buildNotification(intent: PendingIntent, title: String): Notification {
+        return buildNotification(intent, title, emptyList())
+    }
+
     fun buildNotification(intent: PendingIntent, title: Int): Notification {
         return buildNotification(intent, title, emptyList())
     }
@@ -46,10 +50,18 @@ class NotificationChannel(
         title: Int,
         actions: List<NotificationCompat.Action>
     ): Notification {
+        return buildNotification(pendingIntent, context.getString(title), actions)
+    }
+
+    fun buildNotification(
+        pendingIntent: PendingIntent,
+        title: String,
+        actions: List<NotificationCompat.Action>
+    ): Notification {
         val builder = NotificationCompat.Builder(context, id)
             .setSmallIcon(R.drawable.small_logo_black)
             .setColor(badgeColor)
-            .setContentTitle(context.getString(title))
+            .setContentTitle(title)
             .setContentIntent(pendingIntent)
 
         for (action in actions) {

--- a/android/src/main/res/values/plurals.xml
+++ b/android/src/main/res/values/plurals.xml
@@ -32,4 +32,12 @@
         <item quantity="one">a year ago</item>
         <item quantity="other">%d years ago</item>
     </plurals>
+    <plurals name="account_credit_expires_in_days">
+        <item quantity="one">Account credit expires in a day</item>
+        <item quantity="other">Account credit expires in %d days</item>
+    </plurals>
+    <plurals name="account_credit_expires_in_hours">
+        <item quantity="one">Account credit expires in an hour</item>
+        <item quantity="other">Account credit expires in %d hours</item>
+    </plurals>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="foreground_notification_channel_name">VPN tunnel status</string>
     <string name="foreground_notification_channel_description">Shows current VPN tunnel
     status</string>
+    <string name="account_time_notification_channel_name">Account time reminders</string>
+    <string name="account_time_notification_channel_description">Shows reminders when the account
+    time is about to expire</string>
     <string name="connecting_to_daemon">Connecting to Mullvad system service...</string>
     <string name="login_title">Login</string>
     <string name="login_description">Enter your account number</string>
@@ -41,6 +44,9 @@
     <string name="settings_account">Account</string>
     <string name="less_than_a_day_left">less than a day left</string>
     <string name="less_than_a_minute_ago">less than a minute ago</string>
+    <string name="account_credit_expires_in_a_few_minutes">Account credit expires in a few
+    minutes</string>
+    <string name="account_credit_has_expired">Account credit has expired</string>
     <string name="out_of_time">Out of time</string>
     <string name="no_more_vpn_time_left">You have no more VPN time left on this account. Either buy
     credit on our website or redeem a voucher.</string>


### PR DESCRIPTION
This PR implements the same behavior present in the desktop app, where a system notification is shown when the account time will expire in less than two days.

Clicking on the notification will open the web page to buy more credit. However, if the user takes too long to open the notification, the authentication token will have expired. I think that the worst case is that he'll have to enter his account number again on the website, which I think isn't a big problem.

If the notification is dismissed by the user, it will reappear twelve hours later if no credit was added.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1854)
<!-- Reviewable:end -->
