### PR TITLE
Remove unneeded Empty type

### DIFF
--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -631,7 +631,7 @@ mod event_server {
     }
     use proto::{
         openvpn_event_proxy_server::{OpenvpnEventProxy, OpenvpnEventProxyServer},
-        Empty, EventType,
+        EventType,
     };
 
     #[derive(err_derive::Error, Debug)]
@@ -659,7 +659,7 @@ mod event_server {
         async fn event(
             &self,
             request: Request<EventType>,
-        ) -> std::result::Result<Response<Empty>, tonic::Status> {
+        ) -> std::result::Result<Response<()>, tonic::Status> {
             log::info!("OpenVPN event {:?}", request);
 
             let request = request.into_inner();
@@ -669,7 +669,7 @@ mod event_server {
 
             (self.on_event)(event_type, request.env);
 
-            Ok(Response::new(Empty {}))
+            Ok(Response::new(()))
         }
     }
 

--- a/talpid-openvpn-plugin/proto/openvpn_plugin.proto
+++ b/talpid-openvpn-plugin/proto/openvpn_plugin.proto
@@ -2,14 +2,13 @@ syntax = "proto3";
 
 package talpid_openvpn_plugin;
 
+import "google/protobuf/empty.proto";
+
 service OpenvpnEventProxy {
-    rpc Event(EventType) returns (Empty) {}
+    rpc Event(EventType) returns (google.protobuf.Empty) {}
 }
 
 message EventType {
     int32 event = 1;
     map<string, string> env = 2;
-}
-
-message Empty {
 }


### PR DESCRIPTION
Instead of defining an `Empty` message in the proto file, use a well-known type that is appropriately converted into `()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1857)
<!-- Reviewable:end -->
