### PR TITLE
Update security document with restrictions to allow relay rule

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -122,13 +122,23 @@ been established and verified to work. Then it transitions to the [connected] st
 In this state, network traffic to the IP+port+protocol combination used for the first hop of the
 VPN tunnel is allowed on all interfaces, together with responses to this outgoing traffic.
 First hop means the bridge server if one is used, otherwise the VPN server directly.
+This IP+port+protocol combination should only be allowed for the process establishing the
+VPN tunnel, or only administrator level processes, depending on what the platform firewall
+allows restricting. On Windows the rule only allows processes from binaries in certain paths.
+On Linux and macOS the rule only allows packets from processes running as `root`.
+This process/user check is important to not allow unprivileged programs
+to leak packets to this IP outside the tunnel, as those packets can be fingerprinted.
+
 Examples:
 1. No bridge is used and the tunnel protocol is OpenVPN trying to connect with UDP to a VPN
-  server at IP `a.b.c.d` port `1301` - Allow traffic to `a.b.c.d:1301/UDP` and incoming matching
-  traffic.
+  server at IP `a.b.c.d` port `1301` - Allow traffic to `a.b.c.d:1301/UDP` for `openvpn.exe`
+  or any process running as `root`, and incoming matching traffic.
 1. Connecting to the same VPN server, but via a bridge. The bridge is at IP `e.f.g.h` and the
-  proxy service listens on TCP port `443` - Allow traffic to `e.f.g.h:443/TCP` and incoming matching
+  proxy service listens on TCP port `443` - Allow traffic to `e.f.g.h:443/TCP` for
+  `sslocal.exe` or any process running as `root`, and incoming matching
   traffic. Do not allow any direct communication with the VPN server.
+1. Connecting to `a.b.c.d` port `1234` using WireGuard: Allow `a.b.c.d:1234/UDP` for
+  `mullvad-daemon.exe` or any process running as `root`.
 
 If connecting via WireGuard, this state allows ICMP packets to and from the in-tunnel IPs
 (both v4 and v6) of the relay server the app is currently connecting to. That means the private


### PR DESCRIPTION
This fixes audit finding MUL-02-002 and MUL-02-004.

Does this documentation update reflect the current implementation and do you agree with the formulation?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1866)
<!-- Reviewable:end -->
