### PR TITLE
Install zsh shell completions to /usr/share instead of /usr/local/share

### DIFF
--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -154,7 +154,7 @@ const config = {
       distAssets('linux/problem-report-link') + '=/usr/bin/mullvad-problem-report',
       distAssets('shell-completions/mullvad.bash') +
         '=/usr/share/bash-completion/completions/mullvad',
-      distAssets('shell-completions/_mullvad') + '=/usr/local/share/zsh/site-functions/_mullvad',
+      distAssets('shell-completions/_mullvad') + '=/usr/share/zsh/site-functions/_mullvad',
     ],
     afterInstall: distAssets('linux/after-install.sh'),
     afterRemove: distAssets('linux/after-remove.sh'),


### PR DESCRIPTION
Tries to fix #1861. Also it seems more correct to not use `/usr/local` for this.

I tried it only on Fedora 31 so far but the completions work after this move.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1869)
<!-- Reviewable:end -->
