### PR TITLE
Fix app restarting if service is rebound temporarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix Connect screen sometimes becoming unusually tall. This ended up causing the screen to be
   scrolled up and made the UI elements unable to be seen until the user scrolled down.
+- Fix app restarting itself after quitting.
 
 
 ## [2020.5] - 2020-06-25

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -41,6 +41,7 @@ class MullvadVpnService : TalpidVpnService() {
     private val serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
     private var isStopping = false
+    private var shouldStop = false
     private var loggedIn = false
 
     private var startDaemonJob: Job? = null
@@ -121,6 +122,15 @@ class MullvadVpnService : TalpidVpnService() {
             }
         }
 
+        if (shouldStop) {
+            shouldStop = false
+
+            if (isStopping) {
+                restart()
+                isStopping = false
+            }
+        }
+
         return startResult
     }
 
@@ -148,6 +158,10 @@ class MullvadVpnService : TalpidVpnService() {
     override fun onUnbind(intent: Intent): Boolean {
         Log.d(TAG, "Closed all connections to service")
         isBound = false
+
+        if (shouldStop) {
+            stop()
+        }
 
         return true
     }
@@ -240,6 +254,7 @@ class MullvadVpnService : TalpidVpnService() {
     private fun stop() {
         Log.d(TAG, "Stopping service")
         isStopping = true
+        shouldStop = true
         stopDaemon()
         stopSelf()
     }


### PR DESCRIPTION
The app has long had a weird bug where sometimes it wouldn't quit properly, restarting itself a few seconds later. There has been a few attempts at fixing that, but it is still present in the latest release. From recent problem reports that have extra debug information, it seems that Android is rebinding the service temporarily while it is shutting down. This causes the service to think that the UI is connected to it, and cancels the shutdown (or rather, effectively restarts after the shutdown is complete).

This PR changes that so that to add a flag to store if the service was requested to stop. Now, if it is temporarily rebound it will still restart, but it will continue the shutdown process by scheduling itself to stop later on when it becomes unbound again.

In effect, this means that the shutdown is only cancelled if the service is requested to start again (in the `onStartCommand` callback), which is what is called by the UI when it starts.

Hopefully this should now fix the issue. There's a chance that Android might misbehave and continuously rebind and unbind to the service while it is shutting down, effectively preventing it from properly stopping. I hope that is not a case, since that would require the service to stop anyway while still bound, which is not an issue but not recommended according to the Android documentation. But if the issue still does exist, then this solution will have to be extended in the future to maybe forcefully stop after two or three rebinds without a start command.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1870)
<!-- Reviewable:end -->
