### PR TITLE
Improve conncheck resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Upgrade from Electron 7 to Electron 8.
 - Change version string parsing to never suggest the user to upgrade to an older version.
+- Make connectivity checker more resilient to suspension.
 
 #### Android
 - Show a system notification when the account time will soon run out.

--- a/talpid-core/src/ping_monitor/unix.rs
+++ b/talpid-core/src/ping_monitor/unix.rs
@@ -35,6 +35,21 @@ impl Pinger {
         Ok(())
     }
 
+    pub fn reset(&mut self) {
+        let processes = std::mem::replace(&mut self.processes, vec![]);
+        for proc in processes {
+            if proc
+                .try_wait()
+                .map(|maybe_stopped| maybe_stopped.is_none())
+                .unwrap_or(false)
+            {
+                if let Err(err) = proc.kill() {
+                    log::error!("Failed to kill ping process - {}", err);
+                }
+            }
+        }
+    }
+
     fn try_deplete_process_list(&mut self) {
         self.processes.retain(|child| {
             match child.try_wait() {


### PR DESCRIPTION
Improve the resiliency of the connectivity monitor against suspension.

To help improve the resiliency of WireGuard connections during sleep/darkwake on MacOS and in general on other platforms, the connectivity monitor will reset it's traffic data every time it detects that it's been sleeping for far too long.

I'll test this out on Android and under load on desktop platforms to see how this affects the time it takes to detect an unconnectable relay, since now the connetivity check will potentially be more lenient when it tries to establish connectivity on a new connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1878)
<!-- Reviewable:end -->
