### PR TITLE
Change fish completions directory and only symlink if directory exists

### DIFF
--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -49,6 +49,7 @@ EOM
 )
 
 ZSH_COMPLETIONS_DIR="/usr/local/share/zsh/site-functions/"
+FISH_COMPLETIONS_DIR="/usr/local/share/fish/vendor_completions.d/"
 
 "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" prepare-restart || true
 
@@ -63,7 +64,9 @@ mkdir -p /usr/local/bin
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad" /usr/local/bin/mullvad
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-problem-report" /usr/local/bin/mullvad-problem-report
 
-ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad.fish" /usr/share/fish/vendor_completions.d
+if [ -d "$FISH_COMPLETIONS_DIR" ]; then
+    ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad.fish" $FISH_COMPLETIONS_DIR
+fi
 
 mkdir -p "$ZSH_COMPLETIONS_DIR"
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/_mullvad" "$ZSH_COMPLETIONS_DIR/_mullvad"

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -18,8 +18,14 @@ DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"
 sudo launchctl unload -w "$DAEMON_PLIST_PATH"
 sudo rm -f "$DAEMON_PLIST_PATH"
 
-echo "Removing shell completion symlink ..."
+echo "Removing zsh shell completion symlink ..."
 sudo rm -f /usr/local/share/zsh/site-functions/_mullvad
+
+FISH_COMPLETIONS_PATH="/usr/local/share/fish/vendor_completions.d/mullvad.fish"
+if [ -h "$FISH_COMPLETIONS_PATH" ]; then
+    echo "Removing fish shell completion symlink ..."
+    sudo rm -f "$FISH_COMPLETIONS_PATH"
+fi
 
 echo "Removing CLI symlinks from /usr/local/bin/ ..."
 sudo rm -f /usr/local/bin/mullvad /usr/local/bin/mullvad-problem-report

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -53,6 +53,7 @@ const config = {
       { from: distAssets('binaries/x86_64-apple-darwin/sslocal'), to: '.' },
       { from: distAssets('uninstall_macos.sh'), to: './uninstall.sh' },
       { from: distAssets('shell-completions/_mullvad'), to: '.' },
+      { from: distAssets('shell-completions/mullvad.fish'), to: '.' },
     ],
   },
 


### PR DESCRIPTION
This PR updates the fish shell completions directory on macOS since this seems to be the one in use. [Both directories are mentioned in the docs](https://fishshell.com/docs/current/#where-to-put-com). It also prevents adding the completions if the directory doesn't exist since that made `postinstall.sh` fail.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1888)
<!-- Reviewable:end -->
