### PR TITLE
Animate in-app notification changes on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
@@ -38,6 +38,9 @@ class NotificationBanner : FrameLayout {
     private val animation = ObjectAnimator.ofFloat(this, "translationY", 0.0f).apply {
         addListener(animationListener)
         setDuration(350)
+
+        // Ensure there's time for the layout to finish before making the banner visible
+        setStartDelay(20)
     }
 
     private val container =

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
@@ -28,17 +28,19 @@ class NotificationBanner : FrameLayout {
         }
 
         override fun onAnimationEnd(animation: Animator) {
-            if (reversedAnimation) {
-                // Banner is now hidden
-                val notification = notifications.current
+            synchronized(this@NotificationBanner) {
+                if (reversedAnimation) {
+                    // Banner is now hidden
+                    val notification = notifications.current
 
-                visibility = View.INVISIBLE
+                    visibility = View.INVISIBLE
 
-                if (notification != null) {
-                    // Notification changed, restart animation
-                    update(notification)
-                    reversedAnimation = false
-                    animation.start()
+                    if (notification != null) {
+                        // Notification changed, restart animation
+                        update(notification)
+                        reversedAnimation = false
+                        animation.start()
+                    }
                 }
             }
         }
@@ -70,7 +72,9 @@ class NotificationBanner : FrameLayout {
     private var reversedAnimation = false
 
     val notifications = InAppNotificationController { _ ->
-        animateChange()
+        synchronized(this@NotificationBanner) {
+            animateChange()
+        }
     }
 
     constructor(context: Context) : super(context) {}


### PR DESCRIPTION
In-app notifications appear by sliding out from behind the header bar. They disappear by sliding back into the header bar. However, if the notification changes, it is immediately updated, without any animation. This PR changes that so that if the notification changes, the old notification will slide back behind the header bar, change its contents and then slide back out.

The animation is implemented with an `ObjectAnimator`. It is started whenever the notification must be shown. Before starting the animation, the UI is updated, but still kept invisible. After a delay of 20ms (which should be enough for a new frame to be drawn and therefore for the layout to be complete) the animation starts by making the banner visible and sliding it down.

When the notification changes, the animation is reversed. Once the reverse animation is complete the notification has slid underneath the header. The code then checks if a notification must be shown (indicating that the previous notification has been replaced by a new one instead of being removed), and if so, updates the UI and schedules the slide-out animation to start.

The delay describe above is necessary to prevent the notification from becoming visible before the layout pass is complete. If that happens, when the layout pass completes the notification size may change causing it to jump on the screen, and then the animation values are updated to correct for that, causing it to jump again to the proper location. The delay makes sure any size changes have already been done before the notification is made visible.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1892)
<!-- Reviewable:end -->
