### PR TITLE
Smoothen padding change in the Connect screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/UnderNotificationBannerBehavior.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/UnderNotificationBannerBehavior.kt
@@ -20,7 +20,11 @@ class UnderNotificationBannerBehavior(
         body: ScrollView,
         dependency: View
     ): Boolean {
-        val newPaddingTop = dependency.height
+        val newPaddingTop = if (dependency.visibility == View.VISIBLE) {
+            dependency.height + dependency.translationY.toInt()
+        } else {
+            0
+        }
 
         body.getChildAt(0).apply {
             if (paddingTop != newPaddingTop) {


### PR DESCRIPTION
Previously, the padding inside the Connect screen below the header bar is updated immediately after the in-app notification was changed. This caused the Connect screen view to jump a bit when the view is in scrolling mode (for example when the app is in split-screen mode). This PR animates the padding change so that it becomes smooth. There is still a lag between the animations (probably due to extra layouts required), but removing the lag would probably require a much more complex solution.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1894)
<!-- Reviewable:end -->
