### PR TITLE
Change message for unknown unsupported version

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
@@ -29,19 +29,25 @@ class VersionInfoNotification(
 
     private fun updateVersionInfo(isOutdated: Boolean, isSupported: Boolean, upgrade: String?) {
         if (isOutdated || !isSupported) {
-            val template: Int
+            if (upgrade != null) {
+                val template: Int
 
-            if (isSupported) {
-                status = StatusLevel.Warning
-                title = updateAvailable
-                template = R.string.update_available_description
+                if (isSupported) {
+                    status = StatusLevel.Warning
+                    title = updateAvailable
+                    template = R.string.update_available_description
+                } else {
+                    status = StatusLevel.Error
+                    title = unsupportedVersion
+                    template = R.string.unsupported_version_description
+                }
+
+                message = context.getString(template, upgrade)
             } else {
                 status = StatusLevel.Error
                 title = unsupportedVersion
-                template = R.string.unsupported_version_description
+                message = context.getString(R.string.unsupported_version_without_upgrade)
             }
-
-            message = context.getString(template, upgrade)
 
             shouldShow = true
         } else {

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -136,6 +136,8 @@
     <string name="unsupported_version">Unsupported version</string>
     <string name="unsupported_version_description">You are running an unsupported app version.
     Please upgrade to %1$s now to ensure your security</string>
+    <string name="unsupported_version_without_upgrade">You are running an unsupported app
+    version.</string>
     <string name="account_credit_expires_soon">Account credit expires soon</string>
     <string name="select_location">Select location</string>
     <string name="select_location_description">While connected, your real location is masked with a


### PR DESCRIPTION
If the user is running an unknown version (which is probably a custom development version), an in-app notification appears to say that the version is not supported. However, the notification would previously say that the user should upgrade to a `null` version. This is because the code was previously assuming that an unsupported version always had a more recent version to upgrade to. This is not true for unknown versions, so this PR fixes that by removing the upgrade part of the message.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1895)
<!-- Reviewable:end -->
