### PR TITLE
Remove WireGuard keys when uninstalling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 - Upgrade from Electron 7 to Electron 8.
 - Change version string parsing to never suggest the user to upgrade to an older version.
 - Make connectivity checker more resilient to suspension.
+- Make uninstaller on desktop platforms attempt to remove WireGuard keys from accounts.
 
 #### Android
 - Show a system notification when the account time will soon run out.

--- a/dist-assets/linux/before-remove.sh
+++ b/dist-assets/linux/before-remove.sh
@@ -14,6 +14,8 @@ if [[ "$1" == "upgrade" ]]; then
     exit 0;
 fi
 
+mullvad account clear-history || echo "Failed to remove leftover WireGuard keys"
+
 if which systemctl &> /dev/null; then
     # the user might've disabled or stopped the service themselves already
     systemctl stop mullvad-daemon.service || true

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -13,6 +13,8 @@ fi
 echo "Stopping GUI process ..."
 sudo pkill -x "Mullvad VPN" || echo "No GUI process found"
 
+mullvad account clear-history || echo "Failed to remove leftover WireGuard keys"
+
 echo "Stopping and unloading mullvad-daemon system daemon ..."
 DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"
 sudo launchctl unload -w "$DAEMON_PLIST_PATH"

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -734,6 +734,13 @@
 		nsExec::ExecToStack '"$TEMP\mullvad-setup.exe" prepare-restart'
 		Pop $0
 		Pop $1
+	${Else}
+		# Remove keys
+		SetOutPath "$TEMP"
+		File "${BUILD_RESOURCES_DIR}\mullvad.exe"
+		nsExec::ExecToStack '"$TEMP\mullvad.exe" account clear-history'
+		Pop $0
+		Pop $1
 	${EndIf}
 
 	nsExec::ExecToStack '"$SYSDIR\sc.exe" stop mullvadvpn'

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -31,6 +31,10 @@ impl Command for Account {
                     .about("Removes the account number from the settings"),
             )
             .subcommand(
+                clap::SubCommand::with_name("clear-history")
+                    .about("Clear account history, along with removing all associated keys"),
+            )
+            .subcommand(
                 clap::SubCommand::with_name("create")
                     .about("Creates a new account and sets it as the active one"),
             )
@@ -49,10 +53,12 @@ impl Command for Account {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             let token = value_t_or_exit!(set_matches.value_of("token"), String);
             self.set(Some(token))
-        } else if let Some(_matches) = matches.subcommand_matches("unset") {
-            self.set(None)
         } else if let Some(_matches) = matches.subcommand_matches("get") {
             self.get()
+        } else if let Some(_matches) = matches.subcommand_matches("unset") {
+            self.set(None)
+        } else if let Some(_matches) = matches.subcommand_matches("clear-history") {
+            self.clear_history()
         } else if let Some(_matches) = matches.subcommand_matches("create") {
             self.create()
         } else if let Some(matches) = matches.subcommand_matches("redeem") {
@@ -137,5 +143,12 @@ impl Account {
             mullvad_ipc_client::ErrorKind::JsonRpcError(ref rpc_error) => rpc_error.code.code(),
             _ => 0,
         }
+    }
+
+    fn clear_history(&self) -> Result<()> {
+        let mut rpc = new_rpc_client()?;
+        rpc.clear_account_history()?;
+        println!("Removed account history and all associated keys");
+        Ok(())
     }
 }

--- a/mullvad-ipc-client/src/lib.rs
+++ b/mullvad-ipc-client/src/lib.rs
@@ -195,6 +195,10 @@ impl DaemonRpcClient {
         self.call("set_account", &[account])
     }
 
+    pub fn clear_account_history(&mut self) -> Result<()> {
+        self.call("clear_account_history", &NO_ARGS)
+    }
+
     pub fn set_enable_ipv6(&mut self, enabled: bool) -> Result<()> {
         self.call("set_enable_ipv6", &[enabled])
     }


### PR DESCRIPTION
This PR adds a new RPC to the daemon to clear the account history, which in turn attempts to remove all WireGuard keys. This is then used in the uninstallation scripts before the daemon is shut down.

Originally, I had intended to change `mullvad-setup` and just execute `account_history.clear()` there. This would've allowed clearing of the keys even if the daemon wouldn't be running. The issue with this approach is that `mullvad-setup` would have to resolve the cache and settings directories when being ran as an administrator on Windows - the cache and settings directories are different between the admin user and the _service_ user.

And somewhere along the way, the account history and the wireguard modules in the daemon were updated to use the new style futures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1896)
<!-- Reviewable:end -->
