### PR TITLE
Use correct expiry notification text on Android

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="less_than_a_minute_ago">less than a minute ago</string>
     <string name="account_credit_expires_in_a_few_minutes">Account credit expires in a few
     minutes</string>
-    <string name="account_credit_has_expired">Account credit has expired</string>
+    <string name="account_credit_has_expired">You have no more VPN time left on this account.</string>
     <string name="out_of_time">Out of time</string>
     <string name="no_more_vpn_time_left">You have no more VPN time left on this account. Either buy
     credit on our website or redeem a voucher.</string>


### PR DESCRIPTION
Changed the notification text for when the account has already expired to match the desktop version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1897)
<!-- Reviewable:end -->
