### PR TITLE
Add ChainedError and DisplayChainedError protocols

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -99,6 +99,7 @@
 		58B0A2AD238EE6EC00BC001D /* MullvadEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */; };
 		58B8743222B25A7600015324 /* WireguardAssociatedAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B8743122B25A7600015324 /* WireguardAssociatedAddresses.swift */; };
 		58B8743B22B788D200015324 /* PacketTunnelSettingsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B8743722B25EAB00015324 /* PacketTunnelSettingsGenerator.swift */; };
+		58B9EB152489139B00095626 /* DisplayChainedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B9EB142489139B00095626 /* DisplayChainedError.swift */; };
 		58BA692E23E99EFF009DC256 /* Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA692D23E99EFF009DC256 /* Locking.swift */; };
 		58BA692F23E99F5B009DC256 /* Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA692D23E99EFF009DC256 /* Locking.swift */; };
 		58BA693123EADA6A009DC256 /* SimulatorTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */; };
@@ -139,6 +140,8 @@
 		58F19E35228C15BA00C7710B /* SpinnerActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */; };
 		58F840AF2464382C0044E708 /* KeychainItemRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840AE2464382C0044E708 /* KeychainItemRevision.swift */; };
 		58F840B02464382C0044E708 /* KeychainItemRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840AE2464382C0044E708 /* KeychainItemRevision.swift */; };
+		58F840B22464491D0044E708 /* ChainedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840B12464491D0044E708 /* ChainedError.swift */; };
+		58F840B32464491D0044E708 /* ChainedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840B12464491D0044E708 /* ChainedError.swift */; };
 		58FAEDEF245069C700CB0F5B /* KeychainAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FAEDEB245059F000CB0F5B /* KeychainAttributes.swift */; };
 		58FAEDF1245069CA00CB0F5B /* KeychainAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FAEDEB245059F000CB0F5B /* KeychainAttributes.swift */; };
 		58FAEDF4245088B300CB0F5B /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AEEF642344A36000C9BBD5 /* KeychainError.swift */; };
@@ -264,6 +267,7 @@
 		58B0A2A4238EE67E00BC001D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		58B8743122B25A7600015324 /* WireguardAssociatedAddresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireguardAssociatedAddresses.swift; sourceTree = "<group>"; };
 		58B8743722B25EAB00015324 /* PacketTunnelSettingsGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelSettingsGenerator.swift; sourceTree = "<group>"; };
+		58B9EB142489139B00095626 /* DisplayChainedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayChainedError.swift; sourceTree = "<group>"; };
 		58BA692D23E99EFF009DC256 /* Locking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locking.swift; sourceTree = "<group>"; };
 		58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorTunnelProvider.swift; sourceTree = "<group>"; };
 		58BFA5C522A7C97F00A6173D /* RelayCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCache.swift; sourceTree = "<group>"; };
@@ -300,6 +304,7 @@
 		58ECD29123F178FD004298B6 /* Screenshots.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Screenshots.xcconfig; sourceTree = "<group>"; };
 		58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerActivityIndicatorView.swift; sourceTree = "<group>"; };
 		58F840AE2464382C0044E708 /* KeychainItemRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItemRevision.swift; sourceTree = "<group>"; };
+		58F840B12464491D0044E708 /* ChainedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainedError.swift; sourceTree = "<group>"; };
 		58FAEDEB245059F000CB0F5B /* KeychainAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAttributes.swift; sourceTree = "<group>"; };
 		58FAEDF6245088E100CB0F5B /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		58FAEDFC24533A5500CB0F5B /* KeychainMatchLimit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainMatchLimit.swift; sourceTree = "<group>"; };
@@ -418,11 +423,13 @@
 				589AB4F6227B64450039131E /* BasicTableViewCell.swift */,
 				58EC4E6B23915325003F5C5B /* Bundle+MullvadVersion.swift */,
 				584E96B9240D791E00D3334F /* CancellableDelayPublisher.swift */,
+				58F840B12464491D0044E708 /* ChainedError.swift */,
 				58A1AA8B23F5584B009F7EA6 /* ConnectionPanelView.swift */,
 				58CCA00F224249A1004F3011 /* ConnectViewController.swift */,
 				58A99ED2240014A0006599E9 /* ConsentViewController.swift */,
 				582BB1B0229569620055B6EF /* CustomNavigationBar.swift */,
 				58C6B35D22BBBFE3003C19AD /* Data+HexCoding.swift */,
+				58B9EB142489139B00095626 /* DisplayChainedError.swift */,
 				5873884C239E6D7E00E96C4E /* EmbeddedViewContainerView.swift */,
 				58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */,
 				58CE5E6F224146210008646E /* Info.plist */,
@@ -855,6 +862,7 @@
 				58CCA01222424D11004F3011 /* SettingsViewController.swift in Sources */,
 				58FD5BF42428C67600112C88 /* InAppPurchaseButton.swift in Sources */,
 				589AB4F7227B64450039131E /* BasicTableViewCell.swift in Sources */,
+				58B9EB152489139B00095626 /* DisplayChainedError.swift in Sources */,
 				5888AD7F2279B6BF0051EB06 /* RelayStatusIndicatorView.swift in Sources */,
 				5867A51C2248F26A005513C0 /* SegueIdentifier.swift in Sources */,
 				58CCA01E2242787B004F3011 /* AccountTextField.swift in Sources */,
@@ -872,6 +880,7 @@
 				58FD5BF22424F7D700112C88 /* UserInterfaceInteractionRestriction.swift in Sources */,
 				5811DE50239014550011EB53 /* NEVPNStatus+Debug.swift in Sources */,
 				58C3A4B222456F1B00340BDB /* AccountInputGroupView.swift in Sources */,
+				58F840B22464491D0044E708 /* ChainedError.swift in Sources */,
 				58FAEDFF24533A7000CB0F5B /* KeychainReturn.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -915,6 +924,7 @@
 				584E96BD240FD4DA00D3334F /* Location.swift in Sources */,
 				58FAEDF8245088E100CB0F5B /* Keychain.swift in Sources */,
 				58C6B36122C0EC82003C19AD /* AnyIPEndpoint+DNS64.swift in Sources */,
+				58F840B32464491D0044E708 /* ChainedError.swift in Sources */,
 				58C6B36722C106FC003C19AD /* WireguardCommand.swift in Sources */,
 				58561C9A239A5D1500BD6B5E /* IPEndpoint.swift in Sources */,
 				588534BF246193D90018B744 /* AutomaticKeyRotationManager.swift in Sources */,

--- a/ios/MullvadVPN/ChainedError.swift
+++ b/ios/MullvadVPN/ChainedError.swift
@@ -1,0 +1,58 @@
+//
+//  ErrorChain.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 07/05/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import os
+
+/// A protocol describing errors that can be chained together
+protocol ChainedError: LocalizedError {
+    /// A source error when available
+    var source: Error? { get }
+}
+
+extension ChainedError {
+
+    var source: Error? {
+        let reflection = Mirror(reflecting: self)
+
+        if case .enum = reflection.displayStyle {
+            for child in reflection.children {
+                if let associatedError = child.value as? Error {
+                    return associatedError
+                }
+            }
+        }
+
+        return nil
+    }
+
+    /// Creates a string representation of the entire error chain.
+    /// An extra `message` is added at the start of the chain when given
+    func displayChain(message: String? = nil) -> String {
+        var s = message.map { "Error: \($0)\nCaused by: \(self.localizedDescription)" }
+            ?? "Error: \(self.localizedDescription)"
+
+        for sourceError in makeChainIterator() {
+            s.append("\nCaused by: \(sourceError.localizedDescription)")
+        }
+
+        return s
+    }
+
+    func logChain(message: String? = nil, log: OSLog = .default) {
+        os_log(.error, log: log, "%{public}s", displayChain(message: message))
+    }
+
+    private func makeChainIterator() -> AnyIterator<Error> {
+        var current: Error? = self
+        return AnyIterator { () -> Error? in
+            current = (current as? ChainedError)?.source
+            return current
+        }
+    }
+}

--- a/ios/MullvadVPN/DisplayChainedError.swift
+++ b/ios/MullvadVPN/DisplayChainedError.swift
@@ -1,0 +1,13 @@
+//
+//  DisplayChainedError.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 04/06/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+protocol DisplayChainedError {
+    var errorChainDescription: String? { get }
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

### ChainedError

The idea behind is to be able to automatically traverse the error tree to be able to log errors effortlessly. Consider the following common example of Error type:

```swift
enum MyError: Error {
  case myFault
  case systemFault(SystemError)
}
```

It's common to implement `LocalizedError` to produce error descriptions:

```swift
extension MyError: LocalizedError {
  var errorDescription: String? {
     switch self {
         case .myFault:
             return "It's my fault!"
         case .systemFault(let systemError):
            return "I blame 🍎 because \(systemError.errorDescription)"
     }
  }
}
```

However as the Error tree grows and the more efforts are needed to print error messages. it becomes obvious that there should be a more or less standardised way of formatting an error tree and that each leaf does not have to deal with formatting the downstream errors.

I took inspiration from Rust `ErrorChain` and so I've added a `ChainedError` protocol. The protocol itself comes with default implementation that automatically formats errors in similar fashion as aforementioned  Rust library. With `ChainedError` it's possible to rewrite the piece above as:

```swift
extension MyError: ChainedError {
  var errorDescription: String? {
     switch self {
         case .myFault:
             return "It's my fault!"
         case .systemFault(let systemError):
            return "I blame 🍎"
     }
  }
}
```

and then with `ChainedError` it becomes very easy:

```swift
let message = MyError.systemFault(<System error goes here>).displayChain()

// message contains:
// Error: I blame 🍎
// Caused by: <System error message goes here>
```

It's also possible to pass an optional `message` to prefix the error chain output.

```
myError.displayChain(message: "Cannot start VPN")
```

Outputs:

```
Error: Cannot start VPN
Caused by: I blame 🍎
Caused by: <System error message goes here>
```

### DisplayChainedError

The second protocol defined here is formal and really is about traversing the underlying error tree in order to produce a description of what happened.

```swift
protocol DisplayChainedError {
    var errorChainDescription: String? { get }
}
```

For example the implementation for RPC errors might look as something like this:

```swift
extension MullvadRpc.Error: DisplayChainedError {
    var errorChainDescription: String? {
        switch self {
        case .network(let urlError):
            // Return a system description of URLError
            return urlError.localizedDescription

        case .server(let serverError):
            if let knownErrorDescription = serverError.errorDescription {
                 // Return a description if translated by the app
                return knownErrorDescription
            } else {
                // Otherwise display what is likely an English string returned along with RPC message
                return String(
                    format: NSLocalizedString("Server error: %@", comment: ""),
                    serverError.message
                )
            }

        case .encoding:
            return NSLocalizedString("Server request encoding error", comment: "")

        case .decoding:
            return NSLocalizedString("Server response decoding error", comment: "")
        }
    }
}
```

It's worth to note that the standard `LocalizedError` protocol already defines a bunch of fields and I could just perhaps reuse:

```swift
protocol LocalizedError : Error {
    var errorDescription: String? { get }
    var failureReason: String? { get }
    var recoverySuggestion: String? { get }
    var helpAnchor: String? { get }
}
```

We already use `errorDescription` to produce a leaf error message and we could reuse `failureReason` to produce a sub-tree message by traversing it instead of introducing `DisplayChainedError` with separate `var errorChainDescription: String?` field. I don't have a strong opinion here to be fair, so I am seeking yours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1900)
<!-- Reviewable:end -->
