### PR TITLE
Build Android without using standalone toolchains

### DIFF
--- a/android/fdroid-build/env.sh
+++ b/android/fdroid-build/env.sh
@@ -8,20 +8,14 @@ export GOROOT="$HOME/go"
 export PATH="$PATH:$GOROOT/bin"
 
 # Ensure Rust crates know which tools to use for cross-compilation
-export TOOLCHAINS_DIR="$HOME/android-ndk-toolchains"
+export TOOLCHAIN_DIR="$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
-export AR_i686_linux_android="$TOOLCHAINS_DIR/android21-x86/bin/i686-linux-android-ar"
-export AR_x86_64_linux_android="$TOOLCHAINS_DIR/android21-x86_64/bin/x86_64-linux-android-ar"
-export AR_aarch64_linux_android="$TOOLCHAINS_DIR/android21-arm64/bin/aarch64-linux-android-ar"
-export AR_armv7_linux_androideabi="$TOOLCHAINS_DIR/android21-arm/bin/arm-linux-androideabi-ar"
+export AR_i686_linux_android="$TOOLCHAIN_DIR/i686-linux-android-ar"
+export AR_x86_64_linux_android="$TOOLCHAIN_DIR/x86_64-linux-android-ar"
+export AR_aarch64_linux_android="$TOOLCHAIN_DIR/aarch64-linux-android-ar"
+export AR_armv7_linux_androideabi="$TOOLCHAIN_DIR/arm-linux-androideabi-ar"
 
-export CC_i686_linux_android="$TOOLCHAINS_DIR/android21-x86/bin/i686-linux-android21-clang"
-export CC_x86_64_linux_android="$TOOLCHAINS_DIR/android21-x86_64/bin/x86_64-linux-android21-clang"
-export CC_aarch64_linux_android="$TOOLCHAINS_DIR/android21-arm64/bin/aarch64-linux-android21-clang"
-export CC_armv7_linux_androideabi="$TOOLCHAINS_DIR/android21-arm/bin/armv7a-linux-androideabi21-clang"
-
-# Ensure the C cross-compilers are accessible to the libwg-go build
-export ANDROID_TOOLCHAIN_ROOT_arm="$TOOLCHAINS_DIR/android21-arm"
-export ANDROID_TOOLCHAIN_ROOT_x86="$TOOLCHAINS_DIR/android21-x86"
-export ANDROID_TOOLCHAIN_ROOT_arm64="$TOOLCHAINS_DIR/android21-arm64"
-export ANDROID_TOOLCHAIN_ROOT_x86_64="$TOOLCHAINS_DIR/android21-x86_64"
+export CC_i686_linux_android="$TOOLCHAIN_DIR/i686-linux-android21-clang"
+export CC_x86_64_linux_android="$TOOLCHAIN_DIR/x86_64-linux-android21-clang"
+export CC_aarch64_linux_android="$TOOLCHAIN_DIR/aarch64-linux-android21-clang"
+export CC_armv7_linux_androideabi="$TOOLCHAIN_DIR/armv7a-linux-androideabi21-clang"

--- a/android/fdroid-build/init.sh
+++ b/android/fdroid-build/init.sh
@@ -26,30 +26,5 @@ echo "0804bf02020dceaa8a7d7275ee79f7a142f1996bfd0c39216ccb405f93f994c0 go1.13.3.
 tar -xzvf go1.13.3.linux-amd64.tar.gz
 patch -p1 -f -N -r- -d "$HOME/go" < "$REPO_DIR/wireguard/libwg/goruntime-boottime-over-monotonic.diff"
 
-# Prepare standalone NDK toolchains
-mkdir "$TOOLCHAINS_DIR"
-for arch in arm arm64 x86 x86_64; do
-    case "$arch" in
-        "arm64")
-            android_lib_triple="aarch64-linux-android"
-            ;;
-        "x86_64")
-            android_lib_triple="x86_64-linux-android"
-            ;;
-        "arm")
-            android_lib_triple="arm-linux-androideabi"
-            ;;
-        "x86")
-            android_lib_triple="i686-linux-android"
-            ;;
-    esac
-
-    "$NDK_PATH/build/tools/make-standalone-toolchain.sh" --platform=android-21 --arch="$arch" --install-dir="$TOOLCHAINS_DIR/android21-$arch"
-
-    for file in crtbegin_dynamic.o crtend_android.o crtbegin_so.o crtend_so.o; do
-        ln -s "$TOOLCHAINS_DIR/android21-$arch/sysroot/usr/lib/$android_lib_triple/"{21/,}"$file"
-    done
-done
-
 # Configure Cargo for cross-compilation
 sed -e "s|{NDK_PATH}|$NDK_PATH|g" "$SCRIPT_DIR/cargo-config.toml.template" > "$HOME/.cargo/config"

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -11,9 +11,8 @@ NDK_GO_ARCH_MAP_arm64 := arm64
 NDK_GO_ARCH_MAP_mips := mipsx
 NDK_GO_ARCH_MAP_mips64 := mips64x
 
-CLANG_FLAGS := --target=$(ANDROID_LLVM_TRIPLE) --gcc-toolchain=$(ANDROID_TOOLCHAIN_ROOT) --sysroot=$(ANDROID_SYSROOT)
-export CGO_CFLAGS := $(CLANG_FLAGS) $(CFLAGS)
-export CGO_LDFLAGS := $(CLANG_FLAGS) $(LDFLAGS)
+export CGO_CFLAGS := $(CFLAGS)
+export CGO_LDFLAGS := $(LDFLAGS)
 export CC := $(ANDROID_C_COMPILER)
 export GOARCH := $(NDK_GO_ARCH_MAP_$(ANDROID_ARCH_NAME))
 export GOOS := android

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -14,47 +14,34 @@ for arch in arm arm64 x86_64 x86; do
     case "$arch" in
         "arm64")
             export ANDROID_LLVM_TRIPLE="aarch64-linux-android"
-            export ANDROID_LIB_TRIPLE="aarch64-linux-android"
             export RUST_TARGET_TRIPLE="aarch64-linux-android"
             export ANDROID_ABI="arm64-v8a"
             ;;
         "x86_64")
             export ANDROID_LLVM_TRIPLE="x86_64-linux-android"
-            export ANDROID_LIB_TRIPLE="x86_64-linux-android"
             export RUST_TARGET_TRIPLE="x86_64-linux-android"
             export ANDROID_ABI="x86_64"
             ;;
         "arm")
             export ANDROID_LLVM_TRIPLE="armv7a-linux-androideabi"
-            export ANDROID_LIB_TRIPLE="arm-linux-androideabi"
             export RUST_TARGET_TRIPLE="armv7-linux-androideabi"
             export ANDROID_ABI="armeabi-v7a"
             ;;
         "x86")
             export ANDROID_LLVM_TRIPLE="i686-linux-android"
-            export ANDROID_LIB_TRIPLE="i686-linux-android"
             export RUST_TARGET_TRIPLE="i686-linux-android"
             export ANDROID_ABI="x86"
             ;;
     esac
 
-    if which install-ndk-toolchain > /dev/null; then
-        eval "$(install-ndk-toolchain $arch)"
-    else
-        export ANDROID_TOOLCHAIN_ROOT="$(eval "echo \$ANDROID_TOOLCHAIN_ROOT_$arch")"
-        export ANDROID_SYSROOT="${ANDROID_TOOLCHAIN_ROOT}/sysroot"
-        export ANDROID_C_COMPILER="${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_LIB_TRIPLE}-clang"
-    fi
-
+    export ANDROID_C_COMPILER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/${ANDROID_LLVM_TRIPLE}21-clang"
     export ANDROID_ARCH_NAME=$arch
-    export PATH="$PATH:${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
     # Build Wireguard-Go
     echo $(pwd)
     make -f Android.mk clean
 
     export CFLAGS="-D__ANDROID_API__=21"
-    export LDFLAGS="-L${ANDROID_SYSROOT}/usr/lib/${ANDROID_LIB_TRIPLE}/21"
 
     make -f Android.mk
     # Copy build artifacts to `build/libs/$RUST_TARGET_TRIPLE` to be able to build `mullvad-jni`


### PR DESCRIPTION
Previously, the Android build process required setting up cross-compilation toolchains in separate directories to work correctly. This also required a few workarounds to make it compile successfully.

This PR changes that to use the prebuilt tools from the NDK, which simplifies the build process.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal change, not user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1904)
<!-- Reviewable:end -->
