### PR TITLE
Bundle relays with the app

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## Generated assets
+Assets/relays.json
+
 ## Build generated
 build/
 DerivedData/

--- a/ios/BuildInstructions.md
+++ b/ios/BuildInstructions.md
@@ -147,6 +147,15 @@ xcrun altool --store-password-in-keychain-item <KEYCHAIN_ITEM_NAME> \
 
 [Apple ID website]: https://appleid.apple.com/account/manage
 
+# Install Xcode project dependencies
+
+Xcode project uses a pre-build action to bundle the relay list with the app, which depends on `jq`. 
+You can install it with `brew install jq`. See [jq website] for more installation options.
+
+[jq website]: https://stedolan.github.io/jq/download/
+
+The log output is saved to `ios/prebuild.log`.
+
 # Automated build and deployment
 
 Build script does not bump the build number, so make sure to do that manually and commit to repo:

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -150,6 +150,8 @@
 		58C6B36122C0EC82003C19AD /* AnyIPEndpoint+DNS64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C6B36022C0EC82003C19AD /* AnyIPEndpoint+DNS64.swift */; };
 		58C6B36522C10596003C19AD /* AnyIPEndpoint+Wireguard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C6B36422C10596003C19AD /* AnyIPEndpoint+Wireguard.swift */; };
 		58C6B36722C106FC003C19AD /* WireguardCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C6B36622C106FC003C19AD /* WireguardCommand.swift */; };
+		58CC40EF24A601900019D96E /* ObserverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CC40EE24A601900019D96E /* ObserverList.swift */; };
+		58CC40F024A602780019D96E /* ObserverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CC40EE24A601900019D96E /* ObserverList.swift */; };
 		58CCA010224249A1004F3011 /* ConnectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA00F224249A1004F3011 /* ConnectViewController.swift */; };
 		58CCA01222424D11004F3011 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA01122424D11004F3011 /* SettingsViewController.swift */; };
 		58CCA0162242560B004F3011 /* UIColor+Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA0152242560B004F3011 /* UIColor+Palette.swift */; };
@@ -170,6 +172,8 @@
 		58F3C0962492617E003E76BE /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E973DD24850EB600096F90 /* AsyncOperation.swift */; };
 		58F3C0A2249CA1E0003E76BE /* HeaderBarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 58F3C0A1249CA1E0003E76BE /* HeaderBarView.xib */; };
 		58F3C0A4249CB069003E76BE /* HeaderBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3C0A3249CB069003E76BE /* HeaderBarView.swift */; };
+		58F3C0A624A50157003E76BE /* relays.json in Resources */ = {isa = PBXBuildFile; fileRef = 58F3C0A524A50155003E76BE /* relays.json */; };
+		58F3C0A724A50C02003E76BE /* relays.json in Resources */ = {isa = PBXBuildFile; fileRef = 58F3C0A524A50155003E76BE /* relays.json */; };
 		58F840AF2464382C0044E708 /* KeychainItemRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840AE2464382C0044E708 /* KeychainItemRevision.swift */; };
 		58F840B02464382C0044E708 /* KeychainItemRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840AE2464382C0044E708 /* KeychainItemRevision.swift */; };
 		58F840B22464491D0044E708 /* ChainedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840B12464491D0044E708 /* ChainedError.swift */; };
@@ -325,6 +329,7 @@
 		58C6B36022C0EC82003C19AD /* AnyIPEndpoint+DNS64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyIPEndpoint+DNS64.swift"; sourceTree = "<group>"; };
 		58C6B36422C10596003C19AD /* AnyIPEndpoint+Wireguard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyIPEndpoint+Wireguard.swift"; sourceTree = "<group>"; };
 		58C6B36622C106FC003C19AD /* WireguardCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireguardCommand.swift; sourceTree = "<group>"; };
+		58CC40EE24A601900019D96E /* ObserverList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverList.swift; sourceTree = "<group>"; };
 		58CCA00F224249A1004F3011 /* ConnectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectViewController.swift; sourceTree = "<group>"; };
 		58CCA01122424D11004F3011 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		58CCA0152242560B004F3011 /* UIColor+Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Palette.swift"; sourceTree = "<group>"; };
@@ -352,6 +357,7 @@
 		58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerActivityIndicatorView.swift; sourceTree = "<group>"; };
 		58F3C0A1249CA1E0003E76BE /* HeaderBarView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeaderBarView.xib; sourceTree = "<group>"; };
 		58F3C0A3249CB069003E76BE /* HeaderBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBarView.swift; sourceTree = "<group>"; };
+		58F3C0A524A50155003E76BE /* relays.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = relays.json; sourceTree = "<group>"; };
 		58F840AE2464382C0044E708 /* KeychainItemRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItemRevision.swift; sourceTree = "<group>"; };
 		58F840B12464491D0044E708 /* ChainedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainedError.swift; sourceTree = "<group>"; };
 		58FAEDEB245059F000CB0F5B /* KeychainAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAttributes.swift; sourceTree = "<group>"; };
@@ -509,7 +515,6 @@
 				5840250022B1124600E4CFEC /* IpAddress+Codable.swift */,
 				58C6B34E22BB7AC0003C19AD /* IPAddressRange.swift */,
 				58561C98239A5D1500BD6B5E /* IPEndpoint.swift */,
-				58ADDB3B227B1BD200FAFEA7 /* JsonRpc.swift */,
 				58FAEDF6245088E100CB0F5B /* Keychain.swift */,
 				58FAEDEB245059F000CB0F5B /* KeychainAttributes.swift */,
 				58FAEE0024533A9C00CB0F5B /* KeychainClass.swift */,
@@ -530,8 +535,10 @@
 				588AE72E2362001F009F9F2E /* MutuallyExclusive.swift */,
 				58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */,
 				5811DE4F239014550011EB53 /* NEVPNStatus+Debug.swift */,
+				58CC40EE24A601900019D96E /* ObserverList.swift */,
 				580EE1FF24B3218800F9D8A1 /* Operations */,
 				5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */,
+				58ADDB3B227B1BD200FAFEA7 /* JsonRpc.swift */,
 				58BFA5C522A7C97F00A6173D /* RelayCache.swift */,
 				58781CC822AE7CA8009B9D8E /* RelayConstraints.swift */,
 				5888AD88227B18C40051EB06 /* RelayList.swift */,
@@ -608,6 +615,14 @@
 				58ECD29123F178FD004298B6 /* Screenshots.xcconfig */,
 			);
 			path = Configurations;
+			sourceTree = "<group>";
+		};
+		58F3C0A824A50C0E003E76BE /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				58F3C0A524A50155003E76BE /* relays.json */,
+			);
+			path = Assets;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -782,6 +797,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				58F3C0A2249CA1E0003E76BE /* HeaderBarView.xib in Resources */,
+				58F3C0A624A50157003E76BE /* relays.json in Resources */,
 				58CE5E6E224146210008646E /* LaunchScreen.storyboard in Resources */,
 				58CE5E6B224146210008646E /* Assets.xcassets in Resources */,
 				58CE5E69224146200008646E /* Main.storyboard in Resources */,
@@ -792,6 +808,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				58F3C0A724A50C02003E76BE /* relays.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -914,6 +931,7 @@
 				5845F83A236C6A7200B2D93C /* AutoDisposableSink.swift in Sources */,
 				5840250422B11AB700E4CFEC /* MullvadEndpoint.swift in Sources */,
 				58FD5BEC2420F58A00112C88 /* SKPaymentQueuePublisher.swift in Sources */,
+				58CC40EF24A601900019D96E /* ObserverList.swift in Sources */,
 				58CCA01822426713004F3011 /* AccountViewController.swift in Sources */,
 				5868585524054096000B8131 /* AppButton.swift in Sources */,
 				5845F842236CBACD00B2D93C /* PacketTunnelIpc.swift in Sources */,
@@ -1011,6 +1029,7 @@
 				5860F1EB23AA4CF300CEA666 /* Logging.swift in Sources */,
 				5860F1C223A785C600CEA666 /* WireguardDevice.swift in Sources */,
 				580EE21624B3231200F9D8A1 /* OperationBlockObserver.swift in Sources */,
+				58CC40F024A602780019D96E /* ObserverList.swift in Sources */,
 				58C6B35522BB87C4003C19AD /* WireguardPrivateKey.swift in Sources */,
 				58FAEE0424533AC000CB0F5B /* KeychainClass.swift in Sources */,
 				58AEEF6C2344A49D00C9BBD5 /* TunnelConfigurationManager.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
+++ b/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1130"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "exec &gt; $PROJECT_DIR/prebuild.log 2&gt;&amp;1&#10;&#10;$PROJECT_DIR/update-relays.sh&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "58CE5E5F224146200008646E"
+                     BuildableName = "MullvadVPN.app"
+                     BlueprintName = "MullvadVPN"
+                     ReferencedContainer = "container:MullvadVPN.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ios/MullvadVPN/MullvadRpc.swift
+++ b/ios/MullvadVPN/MullvadRpc.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import Network
-import Combine
 
 /// API server URL
 private let kMullvadAPIURL = URL(string: "https://api.mullvad.net/rpc/")!
@@ -73,7 +72,7 @@ class MullvadRpc {
     }
 
     /// An error type emitted by `MullvadRpc`
-    enum Error: Swift.Error {
+    enum Error: ChainedError {
         /// A network communication error
         case network(URLError)
 
@@ -86,19 +85,19 @@ class MullvadRpc {
         /// An error occured when encoding the JSON request
         case encoding(Swift.Error)
 
-        var localizedDescription: String {
+        var errorDescription: String? {
             switch self {
-            case .network(let urlError):
-                return "Network error: \(urlError.localizedDescription)"
+            case .network:
+                return "Network error"
 
-            case .server(let serverError):
-                return "Server error: \(serverError.localizedDescription)"
+            case .server:
+                return "Server error"
 
-            case .encoding(let encodingError):
-                return "Encoding error: \(encodingError.localizedDescription)"
+            case .encoding:
+                return "Encoding error"
 
-            case .decoding(let decodingError):
-                return "Decoding error: \(decodingError.localizedDescription)"
+            case .decoding:
+                return "Decoding error"
             }
         }
     }
@@ -108,106 +107,7 @@ class MullvadRpc {
         return MullvadRpc(session: URLSession(configuration: .ephemeral))
     }
 
-    init(session: URLSession) {
-        self.session = session
-    }
-
-    func createAccount() -> AnyPublisher<String, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "create_account", params: [])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    func getRelayList() -> AnyPublisher<RelayList, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "relay_list_v3", params: [])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    func getAccountExpiry(accountToken: String) -> AnyPublisher<Date, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "get_expiry", params: [AnyEncodable(accountToken)])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    func pushWireguardKey(accountToken: String, publicKey: Data) -> AnyPublisher<WireguardAssociatedAddresses, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "push_wg_key", params: [
-            AnyEncodable(accountToken),
-            AnyEncodable(publicKey)
-        ])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    func replaceWireguardKey(accountToken: String, oldPublicKey: Data, newPublicKey: Data) -> AnyPublisher<WireguardAssociatedAddresses, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "replace_wg_key", params: [
-            AnyEncodable(accountToken),
-            AnyEncodable(oldPublicKey),
-            AnyEncodable(newPublicKey)
-        ])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    func checkWireguardKey(accountToken: String, publicKey: Data) -> AnyPublisher<Bool, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "check_wg_key", params: [
-            AnyEncodable(accountToken),
-            AnyEncodable(publicKey)
-        ])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    func removeWireguardKey(accountToken: String, publicKey: Data) -> AnyPublisher<Bool, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "remove_wg_key", params: [
-            AnyEncodable(accountToken),
-            AnyEncodable(publicKey)
-        ])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    func sendAppStoreReceipt(accountToken: String, receiptData: Data) -> AnyPublisher<SendAppStoreReceiptResponse, MullvadRpc.Error> {
-        let request = JsonRpcRequest(method: "apple_payment", params: [
-            AnyEncodable(accountToken),
-            AnyEncodable(receiptData)
-        ])
-
-        return makeDataTaskPublisher(request: request)
-    }
-
-    private func makeDataTaskPublisher<T: Decodable>(request: JsonRpcRequest) -> AnyPublisher<T, MullvadRpc.Error> {
-        return Just(request)
-            .encode(encoder: Self.makeJSONEncoder())
-            .mapError { MullvadRpc.Error.encoding($0) }
-            .map { Self.makeURLRequest(httpBody: $0) }
-            .flatMap {
-                self.session.dataTaskPublisher(for: $0)
-                    .mapError { MullvadRpc.Error.network($0) }
-                    .flatMap { (data, httpResponse) in
-                        Just(data)
-                            .decode(type: JsonRpcResponse<T, ResponseCode>.self, decoder: Self.makeJSONDecoder())
-                            .mapError { MullvadRpc.Error.decoding($0) }
-                            .flatMap { (serverResponse) in
-                                // unwrap JsonRpcResponse.result
-                                serverResponse.result
-                                    .mapError { MullvadRpc.Error.server($0) }
-                                    .publisher
-                            }
-                }
-        }.eraseToAnyPublisher()
-    }
-
-    private static func makeURLRequest(httpBody: Data) -> URLRequest {
-        var request = URLRequest(url: kMullvadAPIURL, cachePolicy: .useProtocolCachePolicy, timeoutInterval: kNetworkTimeout)
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpMethod = "POST"
-        request.httpBody = httpBody
-
-        return request
-    }
-
-    private static func makeJSONEncoder() -> JSONEncoder {
+    class func makeJSONEncoder() -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         encoder.dateEncodingStrategy = .iso8601
@@ -215,12 +115,88 @@ class MullvadRpc {
         return encoder
     }
 
-    private static func makeJSONDecoder() -> JSONDecoder {
+    class func makeJSONDecoder() -> JSONDecoder {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         decoder.dateDecodingStrategy = .iso8601
         decoder.dataDecodingStrategy = .base64
         return decoder
+    }
+
+    init(session: URLSession) {
+        self.session = session
+    }
+
+    func createAccount() -> MullvadRpc.Request<String> {
+        let request = JsonRpcRequest(method: "create_account", params: [])
+
+        return MullvadRpc.Request(session: session, request: request)
+    }
+
+    func getRelayList() -> MullvadRpc.Request<RelayList> {
+        let request = JsonRpcRequest(method: "relay_list_v3", params: [])
+
+        return MullvadRpc.Request(session: session, request: request)
+    }
+
+    func getAccountExpiry(accountToken: String) -> MullvadRpc.Request<Date> {
+        let request = JsonRpcRequest(method: "get_expiry", params: [AnyEncodable(accountToken)])
+
+        return MullvadRpc.Request(session: session, request: request)
+    }
+
+    func getAccountExpiry(request: MullvadRpc.Request<Date>? = nil) -> MullvadRpc.Operation<Date> {
+        return MullvadRpc.Operation(request: request)
+    }
+
+    func pushWireguardKey(accountToken: String, publicKey: Data) -> MullvadRpc.Request<WireguardAssociatedAddresses> {
+        let request = JsonRpcRequest(method: "push_wg_key", params: [
+            AnyEncodable(accountToken),
+            AnyEncodable(publicKey)
+        ])
+
+        return MullvadRpc.Request(session: session, request: request)
+    }
+
+    func replaceWireguardKey(accountToken: String, oldPublicKey: Data, newPublicKey: Data) -> MullvadRpc.Request<WireguardAssociatedAddresses> {
+        let request = JsonRpcRequest(method: "replace_wg_key", params: [
+            AnyEncodable(accountToken),
+            AnyEncodable(oldPublicKey),
+            AnyEncodable(newPublicKey)
+        ])
+
+        return MullvadRpc.Request(session: session, request: request)
+    }
+
+    func checkWireguardKey(accountToken: String, publicKey: Data) -> MullvadRpc.Request<Bool> {
+        let request = JsonRpcRequest(method: "check_wg_key", params: [
+            AnyEncodable(accountToken),
+            AnyEncodable(publicKey)
+        ])
+
+        return MullvadRpc.Request(session: session, request: request)
+    }
+
+    func checkWireguardKey(request: MullvadRpc.Request<Bool>? = nil) -> MullvadRpc.Operation<Bool> {
+        return MullvadRpc.Operation(request: request)
+    }
+
+    func removeWireguardKey(accountToken: String, publicKey: Data) -> MullvadRpc.Request<Bool> {
+        let request = JsonRpcRequest(method: "remove_wg_key", params: [
+            AnyEncodable(accountToken),
+            AnyEncodable(publicKey)
+        ])
+
+        return MullvadRpc.Request(session: session, request: request)
+    }
+
+    func sendAppStoreReceipt(accountToken: String, receiptData: Data) -> MullvadRpc.Request<SendAppStoreReceiptResponse> {
+        let request = JsonRpcRequest(method: "apple_payment", params: [
+            AnyEncodable(accountToken),
+            AnyEncodable(receiptData)
+        ])
+
+        return MullvadRpc.Request(session: session, request: request)
     }
 }
 
@@ -249,6 +225,123 @@ extension JsonRpcResponseError: LocalizedError
 
         default:
             return nil
+        }
+    }
+}
+
+
+extension MullvadRpc {
+
+    class Request<Response: Decodable> {
+        typealias RequestCompletionHandler = (Result<Response, MullvadRpc.Error>) -> Void
+
+        private let session: URLSession
+        private let request: JsonRpcRequest
+
+        private let lock = NSLock()
+        private var urlSessionTask: URLSessionTask?
+
+        fileprivate init(session: URLSession, request: JsonRpcRequest) {
+            self.session = session
+            self.request = request
+        }
+
+        func start(completionHandler: @escaping RequestCompletionHandler) {
+            lock.withCriticalBlock {
+                assert(self.urlSessionTask == nil)
+
+                switch makeURLRequest() {
+                case .success(let urlRequest):
+                    let task = session.dataTask(with: urlRequest) { (responseData, urlResponse, error) in
+                        switch (responseData, error) {
+                        case (.some(let data), .none):
+                            completionHandler(Self.decodeResponse(data))
+
+                        case (.none, .some(let urlError as URLError)):
+                            completionHandler(.failure(.network(urlError)))
+
+                        default:
+                            fatalError()
+                        }
+                    }
+                    self.urlSessionTask = task
+                    task.resume()
+
+                case .failure(let error):
+                    completionHandler(.failure(error))
+                }
+            }
+        }
+
+        func cancel() {
+            lock.withCriticalBlock {
+                self.urlSessionTask?.cancel()
+            }
+        }
+
+        func operation() -> MullvadRpc.Operation<Response> {
+            return MullvadRpc.Operation(request: self)
+        }
+
+        private func makeURLRequest() -> Result<URLRequest, MullvadRpc.Error> {
+            do {
+                let data = try MullvadRpc.makeJSONEncoder().encode(request)
+
+                return .success(Self.makeURLRequest(httpBody: data))
+            } catch {
+                return .failure(.encoding(error))
+            }
+        }
+
+        private static func decodeResponse(_ responseData: Data) -> Result<Response, MullvadRpc.Error> {
+            do {
+                let serverResponse = try MullvadRpc.makeJSONDecoder()
+                    .decode(JsonRpcResponse<Response, MullvadRpc.ResponseCode>.self, from: responseData)
+
+                // unwrap JsonRpcResponse.result
+                return serverResponse.result
+                    .mapError { .server($0) }
+            } catch {
+                return .failure(.decoding(error))
+            }
+        }
+
+        private static func makeURLRequest(httpBody: Data) -> URLRequest {
+            var request = URLRequest(
+                url: kMullvadAPIURL,
+                cachePolicy: .useProtocolCachePolicy,
+                timeoutInterval: kNetworkTimeout
+            )
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpMethod = "POST"
+            request.httpBody = httpBody
+
+            return request
+        }
+    }
+
+    class Operation<Response>: AsyncOperation, InputOperation, OutputOperation where Response: Decodable {
+        typealias Input = Request<Response>
+        typealias Output = Result<Response, MullvadRpc.Error>
+
+        init(request: Input? = nil) {
+            super.init()
+            self.input = request
+        }
+
+        override func main() {
+            guard let request = self.input else {
+                self.finish()
+                return
+            }
+
+            request.start { [weak self] (result) in
+                self?.finish(with: result)
+            }
+        }
+
+        override func operationDidCancel() {
+            input?.cancel()
         }
     }
 }

--- a/ios/MullvadVPN/ObserverList.swift
+++ b/ios/MullvadVPN/ObserverList.swift
@@ -1,0 +1,53 @@
+//
+//  ObserverList.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 26/06/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+protocol WeakObserverBox: Equatable {
+    associatedtype Wrapped
+
+    var inner: Wrapped? { get }
+}
+
+class ObserverList<T: WeakObserverBox> {
+    private let lock = NSRecursiveLock()
+    private var observers = [T]()
+
+    func append(_ observer: T) {
+        lock.withCriticalBlock {
+            if !self.observers.contains(observer) {
+                self.observers.append(observer)
+            }
+        }
+    }
+
+    func remove(_ observer: T) {
+        lock.withCriticalBlock {
+            self.observers.removeAll { $0 == observer }
+        }
+    }
+
+    func forEach(_ body: (T) -> Void) {
+        lock.withCriticalBlock {
+            var discardObservers = [T]()
+            self.observers.forEach { (boxedObserver) in
+                body(boxedObserver)
+
+                if boxedObserver.inner == nil {
+                    discardObservers.append(boxedObserver)
+                }
+            }
+
+            if !discardObservers.isEmpty {
+                self.observers.removeAll { (observer) -> Bool in
+                    return discardObservers.contains(observer)
+                }
+            }
+        }
+    }
+}

--- a/ios/MullvadVPN/RelayList.swift
+++ b/ios/MullvadVPN/RelayList.swift
@@ -50,6 +50,15 @@ struct RelayList: Codable {
 
 extension RelayList {
 
+    /// Returns the total number of relays
+    var numRelays: Int {
+        return countries.reduce(0) { (accum, country) -> Int in
+            return country.cities.reduce(accum, { (accum, city) -> Int in
+                return accum + city.relays.count
+            })
+        }
+    }
+
     /// Returns an alphabetically sorted `RelayList`
     func sorted() -> Self {
         let lexicalComparator = { (a: String, b: String) -> Bool in

--- a/ios/update-relays.sh
+++ b/ios/update-relays.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$PROJECT_DIR" ]; then
+  echo "This script is intended to be executed by Xcode"
+  exit 1
+fi
+
+RELAYS_FILE="$PROJECT_DIR/Assets/relays.json"
+
+if [ $CONFIGURATION == "Release" ]; then
+  echo "Remove relays file"
+  rm "$RELAYS_FILE" || true
+fi
+
+if [ ! -f "$RELAYS_FILE" ]; then
+  echo "Download relays file"
+  curl https://api.mullvad.net/rpc/ \
+    -d '{"jsonrpc": "2.0", "id": "0", "method": "relay_list_v3"}' \
+    --header "Content-Type: application/json" | jq -c .result > "$RELAYS_FILE"
+fi


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. "Un-combine" `MullvadRpc` and adds `MullvadRpc.Request` along with `MullvadRpc.Operation` both of which can be used depending on the preferred way of executing tasks, but ultimately `MullvadRpc.Request` runs the network requests.
1. "Un-combine" `RelayCache`
1. Add observation support to `RelayCache` to be able to pick up events when relays are being updated. In the future, the GUI app will only update relays once when started while the majority of work will be done by the tunnel. Nevertheless in future PRs SelectLocation controller will listen to updates and react accordingly, just in case if the initial load takes longer than expected once the app started.
1. Add `ObserverList` implementation that maintains weak references to its observers. The weak references are nulled once the observer drops. This is very convenient especially in the UI when controllers act as observes.
1. Add `update-relays.sh` script to pull the relays from RPC. The script is called from `pre-build` action by `xcodebuild`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1905)
<!-- Reviewable:end -->
