### PR TITLE
Update build setup steps for Android in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,43 +144,47 @@ These instructions are for building the app for Android **under Linux**.
 sudo apt install zip default-jdk
 ```
 
-#### Download and install the SDK and NDK:
+#### Download and install the SDK
+
+The SDK should be placed in a separate directory, like for example `~/android` or `/opt/android`.
+This directory should be exported as the `$ANDROID_HOME` environment variable.
+
 ```bash
+cd /opt/android     # Or some other directory to place the Android SDK
+export ANDROID_HOME=$PWD
+
 wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
 unzip sdk-tools-linux-4333796.zip
 ./tools/bin/sdkmanager "platforms;android-28" "build-tools;28.0.3" "platform-tools"
-
-wget https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
-unzip android-ndk-r20-linux-x86_64.zip
-./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
-  --platform=android-21 \
-  --arch=arm64 \
-  --install-dir=$PWD/toolchains/android21-aarch64
-./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
-  --platform=android-21 \
-  --arch=arm \
-  --install-dir=$PWD/toolchains/android21-armv7
-./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
-  --platform=android-21 \
-  --arch=x86_64 \
-  --install-dir=$PWD/toolchains/android21-x86_64
-./android-ndk-r20/build/tools/make-standalone-toolchain.sh \
-  --platform=android-21 \
-  --arch=x86 \
-  --install-dir=$PWD/toolchains/android21-i686
 ```
 
-Set up the required environment variables:
+### Download and install the NDK
+
+The NDK should be placed in a separate directory, which can be inside the `$ANDROID_HOME` or in a
+completely separate path. The extracted directory must be exported as the `$ANDROID_NDK_HOME`
+environment variable.
+
+```bash
+cd "$ANDROID_HOME"  # Or some other directory to place the Android NDK
+wget https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
+unzip android-ndk-r20b-linux-x86_64.zip
+
+cd android-ndk-r20b
+export ANDROID_NDK_HOME="$PWD"
 ```
-export AR_aarch64_linux_android="$PWD/toolchains/android21-aarch64/bin/aarch64-linux-android-ar"
-export AR_armv7_linux_androideabi="$PWD/toolchains/android21-armv7/bin/arm-linux-androideabi-ar"
-export AR_x86_64_linux_android="$PWD/toolchains/android21-x86_64/bin/x86_64-linux-android-ar"
-export AR_i686_linux_android="$PWD/toolchains/android21-i686/bin/i686-linux-android-ar"
-export CC_aarch64_linux_android="$PWD/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang"
-export CC_armv7_linux_androideabi="$PWD/toolchains/android21-armv7/bin/armv7a-linux-androideabi21-clang"
-export CC_x86_64_linux_android="$PWD/toolchains/android21-x86_64/bin/x86_64-linux-android21-clang"
-export CC_i686_linux_android="$PWD/toolchains/android21-i686/bin/i686-linux-android21-clang"
-export ANDROID_HOME="$PWD"
+
+Some environment variables must also be exported so that some Rust dependencies can be
+cross-compiled correctly:
+```
+export NDK_TOOLCHAIN_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+export AR_aarch64_linux_android="$NDK_TOOLCHAIN_DIR/aarch64-linux-android-ar"
+export AR_armv7_linux_androideabi="$NDK_TOOLCHAIN_DIR/arm-linux-androideabi-ar"
+export AR_x86_64_linux_android="$NDK_TOOLCHAIN_DIR/x86_64-linux-android-ar"
+export AR_i686_linux_android="$NDK_TOOLCHAIN_DIR/i686-linux-android-ar"
+export CC_aarch64_linux_android="$NDK_TOOLCHAIN_DIR/aarch64-linux-android21-clang"
+export CC_armv7_linux_androideabi="$NDK_TOOLCHAIN_DIR/armv7a-linux-androideabi21-clang"
+export CC_x86_64_linux_android="$NDK_TOOLCHAIN_DIR/x86_64-linux-android21-clang"
+export CC_i686_linux_android="$NDK_TOOLCHAIN_DIR/i686-linux-android21-clang"
 ```
 
 #### Configuring Rust
@@ -200,20 +204,20 @@ you want as long as the `ANDROID_HOME` variable is set accordingly.
 Add to `~/.cargo/config`:
 ```
 [target.aarch64-linux-android]
-ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
-linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+ar = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+linker = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
 
 [target.armv7-linux-androideabi]
-ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar"
-linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang"
+ar = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar"
+linker = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang"
 
 [target.x86_64-linux-android]
-ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar"
-linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang"
+ar = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar"
+linker = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang"
 
 [target.i686-linux-android]
-ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"
-linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang"
+ar = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"
+linker = "/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang"
 ```
 
 #### Signing the release APK


### PR DESCRIPTION
This PR updates the README so that the build setup doesn't install standalone toolchains, since the Android app can now be built without them.

It also updates the recommended NDK version to `r20b`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Only changes the README.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1906)
<!-- Reviewable:end -->
