### PR TITLE
Force JNI libraries to be compressed

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
                  android:icon="@mipmap/ic_launcher"
                  android:roundIcon="@mipmap/ic_launcher"
                  android:theme="@style/AppTheme"
+                 android:extractNativeLibs="true"
                  android:allowBackup="false"
                  tools:ignore="GoogleAppIndexingWarning">
         <activity android:name="net.mullvad.mullvadvpn.ui.MainActivity"


### PR DESCRIPTION
This PR disables a feature that was introduced on a newer Android Gradle plugin version that creates the release APK with uncompressed native binaries, causing it to have an increased size.

With the feature disabled, the final APKs should be smaller.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor change, mostly not user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1908)
<!-- Reviewable:end -->
