### PR TITLE
Ignore deprecation warning in clap macro invocation

### DIFF
--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -64,9 +64,8 @@ lazy_static::lazy_static! {
 }
 
 fn create_app() -> App<'static, 'static> {
-    let app = App::new(crate_name!())
+    let mut app = App::new(crate_name!())
         .version(version::PRODUCT_VERSION)
-        .author(crate_authors!(", "))
         .about(crate_description!())
         .after_help(ENV_DESC.as_str())
         .arg(
@@ -84,10 +83,15 @@ fn create_app() -> App<'static, 'static> {
             Arg::with_name("disable_stdout_timestamps")
                 .long("disable-stdout-timestamps")
                 .help("Don't log timestamps when logging to stdout, useful when running as a systemd service")
-            );
+        );
+    // A workaround since clap 2 will not fix the deprecation warnings in this macro.
+    #[allow(deprecated)]
+    {
+        app = app.author(crate_authors!(", "));
+    }
 
     if cfg!(windows) {
-        app.arg(
+        app = app.arg(
             Arg::with_name("run_as_service")
                 .long("run-as-service")
                 .help("Run as a system service. On Windows this option must be used when running a system service"),
@@ -96,7 +100,6 @@ fn create_app() -> App<'static, 'static> {
                 .long("register-service")
                 .help("Register itself as a system service"),
         )
-    } else {
-        app
     }
+    app
 }


### PR DESCRIPTION
Maybe about time to get rid of the annoying:
```
warning: use of deprecated item 'std::sync::ONCE_INIT': the `new` function is now preferred

  --> mullvad-daemon/src/cli.rs:69:17
   |
69 |         .author(crate_authors!(", "))
   |                 ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

I have realized that `clap` will never fix the warning. Simply because that would bump the MSRV, and `clap 2` has apparently stated that it should remain at 1.24 :man_shrugging:  :( (https://github.com/clap-rs/clap/pull/1988)

So I rearranged the code a little bit in order to be able to stick an `#[allow(deprecated)]` on the problematic code, but just as little of it as possible.

We use the same macro in `mullvad-cli`. But for some reason that does not emit any warning during regular build, so I did not touch it. I don't know why and I did not spend any time on figuring it out either.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1910)
<!-- Reviewable:end -->
