### PR TITLE
Fix quick-settings tile connect action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix Connect screen sometimes becoming unusually tall. This ended up causing the screen to be
   scrolled up and made the UI elements unable to be seen until the user scrolled down.
 - Fix app restarting itself after quitting.
+- Fix connect action from quick-settings tile or notification sometimes opening the UI instead of
+  connecting.
 
 
 ## [2020.5] - 2020-06-25

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -235,7 +235,7 @@ class MullvadVpnService : TalpidVpnService() {
         val connectionProxy = ConnectionProxy(this, daemon).apply {
             when (pendingAction) {
                 PendingAction.Connect -> {
-                    if (loggedIn) {
+                    if (settings.accountToken != null) {
                         connect()
                     } else {
                         openUi()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -42,7 +42,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var isStopping = false
     private var shouldStop = false
-    private var loggedIn = false
 
     private var startDaemonJob: Job? = null
 
@@ -54,15 +53,10 @@ class MullvadVpnService : TalpidVpnService() {
                 AccountExpiryNotification(this, daemon)
             }
 
-            accountNumberEvents = newInstance?.accountCache?.onAccountNumberChange
             accountExpiryEvents = newInstance?.accountCache?.onAccountExpiryChange
 
             serviceNotifier.notify(newInstance)
         }
-    }
-
-    private var accountNumberEvents by autoSubscribable<String?>(this, null) { accountNumber ->
-        loggedIn = accountNumber != null
     }
 
     private var accountExpiryEvents by autoSubscribable<DateTime?>(this, null) { expiry ->


### PR DESCRIPTION
Some recent change caused a bug, where starting the `MullvadVpnService` with a command to connect would only open the UI instead of actually connecting in the background. This happened because the service used an internal `loggedIn` flag to keep track if there was an account token set. However, when the service is started and requested to connect, the flag was checked before it had enough time to be initialed with the value from the initial settings, causing the service to think it wouldn't be able to connect because there is no account set. It would then open the UI so that the user could log in before connecting, but by the time the UI opened the flag would have been set but the connection would have been cancelled.

This PR fixes that by removing the flag and checking for the presence of the account token right after loading the initial settings.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1915)
<!-- Reviewable:end -->
