### PR TITLE
Fix notification not becoming dismissible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix app restarting itself after quitting.
 - Fix connect action from quick-settings tile or notification sometimes opening the UI instead of
   connecting.
+- Fix notification sometimes not being dismissible.
 
 
 ## [2020.5] - 2020-06-25

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -18,11 +18,11 @@ class EventNotifier<T>(private val initialValue: T) {
 
     fun notify(event: T) {
         synchronized(this) {
+            latestEvent = event
+
             for (listener in listeners.values) {
                 listener(event)
             }
-
-            latestEvent = event
         }
     }
 


### PR DESCRIPTION
Sometimes the Android notification would stay in the foreground when it shouldn't. This happened because the notification manager would use tunnel state events to update the foreground status in an unexpected way. Instead of using the tunnel state provided by the callback, it would manually get the state through the `EventNotifier.latestEvent` property. This is because it would call a common `updateNotification` method, that is also called in scenarios that aren't tunnel state changes. To be able to use the tunnel state in different scenarios, the decision was made to query the tunnel state stored in the `EventNotifier` instead of storing the tunnel state in the `ForegroundNotificationManager` class.

This eventually led to a bug, since the `EventNotifier` would only update the `latestEvent` property after notifying all the observers of the change. This meant that when the tunnel state changes, the `ForegroundNotificationManager.updateNotification` would actually base its decisions on the previous tunnel state, and not the most recent tunnel state.

This PR fixes the `EventNotifier` to set the `latestEvent` property _before_ notifying all the observers.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1916)
<!-- Reviewable:end -->
