### PR TITLE
Fix typo in `occurred`

### DIFF
--- a/gui/locales/da/messages.po
+++ b/gui/locales/da/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Indløs kupon"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "En fejl opstod."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/de/messages.po
+++ b/gui/locales/de/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Gutschein einlösen"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Ein Fehler ist aufgetreten."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/es/messages.po
+++ b/gui/locales/es/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Canjear cupón"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Se produjo un error."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/fi/messages.po
+++ b/gui/locales/fi/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Lunasta kuponki"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Ilmeni virhe."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/fr/messages.po
+++ b/gui/locales/fr/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Échangez un bon"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Une erreur est survenue."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/it/messages.po
+++ b/gui/locales/it/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Riscatta voucher"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Si è verificato un errore."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/ja/messages.po
+++ b/gui/locales/ja/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "バウチャーを使用する"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "エラー発生。"
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/ko/messages.po
+++ b/gui/locales/ko/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "바우처 사용"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "오류가 발생했습니다."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -618,7 +618,7 @@ msgid "Redeem voucher"
 msgstr ""
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr ""
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/nb/messages.po
+++ b/gui/locales/nb/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Løs inn kupong"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Det oppstod en feil."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/nl/messages.po
+++ b/gui/locales/nl/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Voucher inwisselen"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Er is een fout opgetreden."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/pl/messages.po
+++ b/gui/locales/pl/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Zrealizuj kupon"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Wystąpił błąd."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/pt/messages.po
+++ b/gui/locales/pt/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Reclamar voucher"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Ocorreu um erro."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/ru/messages.po
+++ b/gui/locales/ru/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Погасить ваучер"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Произошла ошибка."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/sv/messages.po
+++ b/gui/locales/sv/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Lös in kupong"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Ett fel har inträffat."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/th/messages.po
+++ b/gui/locales/th/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "แลกบัตรกำนัล"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "เกิดข้อผิดพลาดขึ้น"
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/tr/messages.po
+++ b/gui/locales/tr/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "Kuponu kullan"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "Bir hata oluştu."
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/zh-CN/messages.po
+++ b/gui/locales/zh-CN/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "兑换优惠券"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "出错了。"
 
 msgctxt "redeem-voucher-view"

--- a/gui/locales/zh-TW/messages.po
+++ b/gui/locales/zh-TW/messages.po
@@ -628,7 +628,7 @@ msgid "Redeem voucher"
 msgstr "兌換憑證"
 
 msgctxt "redeem-voucher-view"
-msgid "An error occured."
+msgid "An error occurred."
 msgstr "發生錯誤了。"
 
 msgctxt "redeem-voucher-view"

--- a/gui/src/renderer/components/RedeemVoucher.tsx
+++ b/gui/src/renderer/components/RedeemVoucher.tsx
@@ -163,7 +163,7 @@ export function RedeemVoucherResponse() {
       case 'error':
         return (
           <StyledErrorResponse>
-            {messages.pgettext('redeem-voucher-view', 'An error occured.')}
+            {messages.pgettext('redeem-voucher-view', 'An error occurred.')}
           </StyledErrorResponse>
         );
     }


### PR DESCRIPTION
This PR fixes a typo with the word `occurred` in the Redeem Voucher screen. This also led to changing the `msgid` to the respective translations.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI change.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1919)
<!-- Reviewable:end -->
