### PR TITLE
Stop the connectivity monitor after ping times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Line wrap the file at 100 chars.                                              Th
 - Upgrade Wintun from 0.7 to 0.8.1.
 
 ### Fixed
+- Fix connectivity monitor for WireGuard not disconnecting from a relay when connectivity is lost.
+
 #### Windows
 - Fix window flickering by disabling window animations.
 

--- a/talpid-core/src/ping_monitor/mod.rs
+++ b/talpid-core/src/ping_monitor/mod.rs
@@ -7,4 +7,18 @@ mod imp;
 #[path = "win.rs"]
 mod imp;
 
-pub use imp::{Error, Pinger};
+pub use imp::Error;
+
+pub trait Pinger: Send {
+    /// Sends an ICMP packet
+    fn send_icmp(&mut self) -> Result<(), Error>;
+    /// Clears all resources used by the pinger.
+    fn reset(&mut self) {}
+}
+
+pub fn new_pinger(
+    addr: std::net::Ipv4Addr,
+    interface_name: String,
+) -> Result<Box<dyn Pinger>, Error> {
+    Ok(Box::new(imp::Pinger::new(addr, interface_name)?))
+}

--- a/talpid-core/src/ping_monitor/win.rs
+++ b/talpid-core/src/ping_monitor/win.rs
@@ -60,13 +60,6 @@ impl Pinger {
         })
     }
 
-    pub fn send_icmp(&mut self) -> Result<()> {
-        let dest = SocketAddr::new(IpAddr::from(self.addr), 0);
-        let request = self.next_ping_request();
-        self.send_ping_request(&request, dest)
-    }
-
-
     fn send_ping_request(
         &mut self,
         request: &EchoRequestPacket<'static>,
@@ -115,5 +108,13 @@ impl Pinger {
         let seq = self.seq;
         self.seq += 1;
         seq
+    }
+}
+
+impl super::Pinger for Pinger {
+    fn send_icmp(&mut self) -> Result<()> {
+        let dest = SocketAddr::new(IpAddr::from(self.addr), 0);
+        let request = self.next_ping_request();
+        self.send_ping_request(&request, dest)
     }
 }


### PR DESCRIPTION
I've left a horrible bug where the WireGuard connectivity monitor won't disconnect from a relay once connectivity has been lost. The fix is rather simple.

I've also added some tests which require some invasive refactoring. Ideally, we'd be able to mock the OS timers and sleeps to test this robustly, but that is not the case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1920)
<!-- Reviewable:end -->
