### PR TITLE
Fix fish completions location on linux

### DIFF
--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -132,7 +132,8 @@ const config = {
       distAssets('shell-completions/mullvad.bash') +
         '=/usr/share/bash-completion/completions/mullvad',
       distAssets('shell-completions/_mullvad') + '=/usr/local/share/zsh/site-functions/_mullvad',
-      distAssets('shell-completions/mullvad.fish') + '=/usr/share/fish/vendor_completions.d',
+      distAssets('shell-completions/mullvad.fish') +
+        '=/usr/share/fish/vendor_completions.d/mullvad.fish',
     ],
     afterInstall: distAssets('linux/after-install.sh'),
     afterRemove: distAssets('linux/after-remove.sh'),
@@ -157,7 +158,8 @@ const config = {
       distAssets('shell-completions/mullvad.bash') +
         '=/usr/share/bash-completion/completions/mullvad',
       distAssets('shell-completions/_mullvad') + '=/usr/share/zsh/site-functions/_mullvad',
-      distAssets('shell-completions/mullvad.fish') + '=/usr/share/fish/vendor_completions.d',
+      distAssets('shell-completions/mullvad.fish') +
+        '=/usr/share/fish/vendor_completions.d/mullvad.fish',
     ],
     afterInstall: distAssets('linux/after-install.sh'),
     afterRemove: distAssets('linux/after-remove.sh'),


### PR DESCRIPTION
This PR moves the fish completions into `vendor_completions.d` instead of trying to replace it. This solves the following error message during install:
```
Unpacking mullvad-vpn (2020.5.0-dev-e906ab) over (2020.5.0) ...
dpkg: error processing archive /home/oskar/mullvadvpn-app/dist/MullvadVPN-2020.
5-dev-e906ab_amd64.deb (--unpack):
 trying to overwrite directory '/usr/share/fish/vendor_completions.d' in packag e fwupd 1.3.9-4ubuntu0.1 with nondirectory
 dpkg-deb: error: paste subprocess was killed by signal (Broken pipe)
```

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1926)
<!-- Reviewable:end -->
