### PR TITLE
Reconnect WireGuard tunnels after key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Show system notification when account has expired.
 - Add fish shell completions for the mullvad CLI.
+- Reconnect with a new key when WireGuard key is rotated automatically, previously the tunnel would
+  time out before reconnecting.
 
 ### Changed
 - Upgrade from Electron 7 to Electron 8.


### PR DESCRIPTION
I've added a daemon command to reconnect a WireGuard tunnel after receiving a new key. This should apply to both first time key regeneration and key rotation. I've done this by spawning a future on the RPC runtime. This can be changed once we migrate everything to new tokio. I've also changed the way the previous delayed reconnect works to use tokio instead of spawning a thread - this enables us to share the cancellation logic between both cases, as the circumstances where each would be used I believe are mutually exclusive. 

The cancellation of the delayed reconnection is issued when changes to the tunnel state are issued - technically this leaves a race condition where there reconnect might be issued as the tunnel state machine is already transitioning to a new state. This is fine as the reconnection command will only reconnect the tunnel if the target state indicates that the tunnel should be engaged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1928)
<!-- Reviewable:end -->
