### PR TITLE
Use TunnelType instead of TunnelProtocol

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -9,11 +9,13 @@ use std::{
 use mullvad_types::{
     relay_constraints::{
         Constraint, OpenVpnConstraints, RelayConstraintsUpdate, RelaySettingsUpdate,
-        TunnelProtocol, WireguardConstraints,
+        WireguardConstraints,
     },
     ConnectionConfig, CustomTunnelEndpoint,
 };
-use talpid_types::net::{all_of_the_internet, openvpn, wireguard, Endpoint, TransportProtocol};
+use talpid_types::net::{
+    all_of_the_internet, openvpn, wireguard, Endpoint, TransportProtocol, TunnelType,
+};
 
 pub struct Relay;
 
@@ -318,8 +320,8 @@ impl Relay {
 
     fn set_tunnel_protocol(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let tunnel_protocol = match matches.value_of("tunnel protocol").unwrap() {
-            "wireguard" => Constraint::Only(TunnelProtocol::Wireguard),
-            "openvpn" => Constraint::Only(TunnelProtocol::OpenVpn),
+            "wireguard" => Constraint::Only(TunnelType::Wireguard),
+            "openvpn" => Constraint::Only(TunnelType::OpenVpn),
             "any" => Constraint::Any,
             _ => unreachable!(),
         };

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -3,13 +3,13 @@ use crate::{
     custom_tunnel::CustomTunnelEndpoint,
     relay_constraints::{
         BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
-        OpenVpnConstraints, RelaySettings as NewRelaySettings, TunnelProtocol,
-        WireguardConstraints,
+        OpenVpnConstraints, RelaySettings as NewRelaySettings, WireguardConstraints,
     },
     settings::TunnelOptions,
 };
 use serde::{Deserialize, Serialize};
 use std::io::Read;
+use talpid_types::net::TunnelType;
 
 
 /// Mullvad daemon settings.
@@ -95,7 +95,7 @@ fn migrate_relay_settings(relay_settings: RelaySettings) -> NewRelaySettings {
                 }
                 Constraint::Only(TunnelConstraints::Wireguard(constraints)) => {
                     new_constraints.wireguard_constraints = constraints;
-                    new_constraints.tunnel_protocol = Constraint::Only(TunnelProtocol::Wireguard);
+                    new_constraints.tunnel_protocol = Constraint::Only(TunnelType::Wireguard);
                 }
             };
             crate::relay_constraints::RelaySettings::Normal(new_constraints)


### PR DESCRIPTION
Whilst working on key rotation, I came to notice that `talpid-types::net::TunnelType` is identical to `mullvad-types::relay_constraints::TunnelProtocol`.  I've changed the daemon to use `talpid-types;:net::TunnelType` everywhere instead. Nothing seems to be broken, but feel free to dismiss this PR if this a change that is not needed.

I've smoke-tested and settings can still be loaded as is, and the GUI deserializes the settings all the same.