### PR TITLE
Improve notification timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 - Change version string parsing to never suggest the user to upgrade to an older version.
 - Make connectivity checker more resilient to suspension.
 - Make uninstaller on desktop platforms attempt to remove WireGuard keys from accounts.
+- Make important notifications not timeout on macOS and remain in the notification list on Linux.
 
 #### Android
 - Show a system notification when the account time will soon run out.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -84,6 +84,7 @@ type AccountVerification = { status: 'verified' } | { status: 'deferred'; error:
 
 class ApplicationMain {
   private notificationController = new NotificationController({
+    openApp: () => this.windowController?.show(),
     openLink: (url: string, withAuth?: boolean) => this.openLink(url, withAuth),
     isWindowVisible: () => this.windowController?.isVisible() ?? false,
     areSystemNotificationsEnabled: () => this.guiSettings.enableSystemNotifications,

--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -98,7 +98,9 @@ export default class NotificationController {
       this.addPendingNotification(notification);
       notification.show();
 
-      setTimeout(() => notification.close(), 4000);
+      if (!systemNotification.critical) {
+        setTimeout(() => notification.close(), 4000);
+      }
 
       return notification;
     } else {
@@ -112,6 +114,7 @@ export default class NotificationController {
       body: systemNotification.message,
       silent: true,
       icon: this.notificationIcon,
+      timeoutType: systemNotification.critical ? 'never' : 'default',
     });
 
     if (systemNotification.action) {

--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -16,6 +16,7 @@ import {
 import consumePromise from '../shared/promise';
 
 interface NotificationControllerDelegate {
+  openApp(): void;
   openLink(url: string, withAuth?: boolean): Promise<void>;
   isWindowVisible(): boolean;
   areSystemNotificationsEnabled(): boolean;
@@ -114,9 +115,17 @@ export default class NotificationController {
     });
 
     if (systemNotification.action) {
-      const { withAuth, url } = systemNotification.action;
       notification.on('click', () => {
-        consumePromise(this.notificationControllerDelegate.openLink(url, withAuth));
+        consumePromise(
+          this.notificationControllerDelegate.openLink(
+            systemNotification.action!.url,
+            systemNotification.action!.withAuth,
+          ),
+        );
+      });
+    } else {
+      notification.on('click', () => {
+        this.notificationControllerDelegate.openApp();
       });
     }
 

--- a/gui/src/shared/notifications/account-expired.ts
+++ b/gui/src/shared/notifications/account-expired.ts
@@ -28,7 +28,12 @@ export class AccountExpiredNotificationProvider implements SystemNotificationPro
       ),
       critical: true,
       presentOnce: { value: true, name: this.constructor.name },
-      action: { type: 'open-url', url: links.purchase, withAuth: true },
+      action: {
+        type: 'open-url',
+        url: links.purchase,
+        withAuth: true,
+        text: messages.pgettext('notifications', 'Buy more'),
+      },
     };
   }
 }

--- a/gui/src/shared/notifications/close-to-account-expiry.ts
+++ b/gui/src/shared/notifications/close-to-account-expiry.ts
@@ -41,7 +41,12 @@ export class CloseToAccountExpiryNotificationProvider
     return {
       message,
       critical: true,
-      action: { type: 'open-url', url: links.purchase, withAuth: true },
+      action: {
+        type: 'open-url',
+        url: links.purchase,
+        withAuth: true,
+        text: messages.pgettext('notifications', 'Buy more'),
+      },
     };
   }
 

--- a/gui/src/shared/notifications/notification.ts
+++ b/gui/src/shared/notifications/notification.ts
@@ -1,4 +1,9 @@
-export type NotificationAction = { type: 'open-url'; url: string; withAuth?: boolean };
+export type NotificationAction = {
+  type: 'open-url';
+  url: string;
+  text?: string;
+  withAuth?: boolean;
+};
 
 export type InAppNotificationIndicatorType = 'success' | 'warning' | 'error';
 

--- a/gui/src/shared/notifications/unsupported-version.ts
+++ b/gui/src/shared/notifications/unsupported-version.ts
@@ -27,7 +27,11 @@ export class UnsupportedVersionNotificationProvider
     return {
       message,
       critical: true,
-      action: { type: 'open-url', url: links.download },
+      action: {
+        type: 'open-url',
+        url: links.download,
+        text: messages.pgettext('notifications', 'Upgrade'),
+      },
       presentOnce: { value: true, name: this.constructor.name },
       suppressInDevelopment: true,
     };


### PR DESCRIPTION
This PR changes the behavior notifications to:
* Not close critical notifications after 4s
* Show a button for actions in macOS instead of making the whole notification clickable
* Clicking on notifications that doesn't have an action (or all on macOS) opens the app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1930)
<!-- Reviewable:end -->
