### PR TITLE
Android split tunnelling behavior

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
@@ -6,9 +6,13 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.service.SplitTunnelling
 import net.mullvad.mullvadvpn.util.JobTracker
 
-class AppListAdapter(context: Context) : Adapter<AppListItemHolder>() {
+class AppListAdapter(
+    context: Context,
+    private val splitTunnelling: SplitTunnelling
+) : Adapter<AppListItemHolder>() {
     private val appList = ArrayList<AppInfo>()
     private val jobTracker = JobTracker()
     private val packageManager = context.packageManager
@@ -41,7 +45,7 @@ class AppListAdapter(context: Context) : Adapter<AppListItemHolder>() {
         val inflater = LayoutInflater.from(parentView.context)
         val view = inflater.inflate(R.layout.app_list_item, parentView, false)
 
-        return AppListItemHolder(packageManager, jobTracker, view)
+        return AppListItemHolder(splitTunnelling, packageManager, jobTracker, view)
     }
 
     override fun onBindViewHolder(holder: AppListItemHolder, position: Int) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
@@ -8,10 +8,12 @@ import android.widget.ImageView
 import android.widget.TextView
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.service.SplitTunnelling
 import net.mullvad.mullvadvpn.ui.CellSwitch
 import net.mullvad.mullvadvpn.util.JobTracker
 
 class AppListItemHolder(
+    private val splitTunnelling: SplitTunnelling,
     private val packageManager: PackageManager,
     private val jobTracker: JobTracker,
     view: View
@@ -32,6 +34,12 @@ class AppListItemHolder(
             } else {
                 hideIcon()
                 loadIcon(info)
+            }
+
+            if (splitTunnelling.isAppExcluded(info.info.packageName)) {
+                excluded.forcefullySetState(CellSwitch.State.ON)
+            } else {
+                excluded.forcefullySetState(CellSwitch.State.OFF)
             }
         } else {
             name.text = ""

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
@@ -51,6 +51,15 @@ class AppListItemHolder(
         view.setOnClickListener {
             excluded.toggle()
         }
+
+        excluded.listener = { state ->
+            appInfo?.info?.packageName?.let { app ->
+                when (state) {
+                    CellSwitch.State.ON -> splitTunnelling.excludeApp(app)
+                    CellSwitch.State.OFF -> splitTunnelling.includeApp(app)
+                }
+            }
+        }
     }
 
     private fun hideIcon() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -242,7 +242,17 @@ class MullvadVpnService : TalpidVpnService() {
             pendingAction = null
         }
 
-        instance = ServiceInstance(daemon, connectionProxy, connectivityListener, settingsListener)
+        val splitTunnelling = SplitTunnelling().apply {
+            onChange = { excludedApps -> disallowedApps = excludedApps }
+        }
+
+        instance = ServiceInstance(
+            daemon,
+            connectionProxy,
+            connectivityListener,
+            settingsListener,
+            splitTunnelling
+        )
     }
 
     private fun stop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -243,7 +243,11 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
         val splitTunnelling = SplitTunnelling().apply {
-            onChange = { excludedApps -> disallowedApps = excludedApps }
+            onChange = { excludedApps ->
+                disallowedApps = excludedApps
+                markTunAsStale()
+                connectionProxy.reconnect()
+            }
         }
 
         instance = ServiceInstance(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -6,7 +6,8 @@ class ServiceInstance(
     val daemon: MullvadDaemon,
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,
-    val settingsListener: SettingsListener
+    val settingsListener: SettingsListener,
+    val splitTunnelling: SplitTunnelling
 ) {
     val accountCache = AccountCache(daemon, settingsListener)
     val keyStatusListener = KeyStatusListener(daemon)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunnelling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunnelling.kt
@@ -1,0 +1,33 @@
+package net.mullvad.mullvadvpn.service
+
+import kotlin.properties.Delegates.observable
+
+class SplitTunnelling {
+    private val excludedApps = HashSet<String>()
+
+    val excludedAppList
+        get() = if (enabled) {
+            excludedApps.toList()
+        } else {
+            emptyList()
+        }
+
+    var enabled by observable(false) { _, _, _ -> update() }
+    var onChange: ((List<String>) -> Unit)? = null
+
+    fun isAppExcluded(appPackageName: String) = excludedApps.contains(appPackageName)
+
+    fun excludeApp(appPackageName: String) {
+        excludedApps.add(appPackageName)
+        update()
+    }
+
+    fun includeApp(appPackageName: String) {
+        excludedApps.remove(appPackageName)
+        update()
+    }
+
+    private fun update() {
+        onChange?.invoke(excludedAppList)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -12,6 +12,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val keyStatusListener = service.keyStatusListener
     val locationInfoCache = service.locationInfoCache
     val settingsListener = service.settingsListener
+    val splitTunnelling = service.splitTunnelling
 
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -13,6 +13,7 @@ import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SettingsListener
+import net.mullvad.mullvadvpn.service.SplitTunnelling
 import net.mullvad.talpid.ConnectivityListener
 
 abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceAwareFragment() {
@@ -58,6 +59,8 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
     lateinit var settingsListener: SettingsListener
         private set
 
+    lateinit var splitTunnelling: SplitTunnelling
+
     override fun onNewServiceConnection(serviceConnection: ServiceConnection) {
         // This method is always either called first or after an `onNoServiceConnection`, so the
         // initialization of the fields doesn't have to be synchronized
@@ -70,6 +73,7 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
         locationInfoCache = serviceConnection.locationInfoCache
         relayListListener = serviceConnection.relayListListener
         settingsListener = serviceConnection.settingsListener
+        splitTunnelling = serviceConnection.splitTunnelling
 
         synchronized(this) {
             when (state) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
@@ -52,7 +52,7 @@ class SplitTunnellingFragment : ServiceDependentFragment(OnNoService.GoToLaunchS
     override fun onAttach(context: Context) {
         super.onAttach(context)
 
-        appListAdapter = AppListAdapter(context)
+        appListAdapter = AppListAdapter(context, splitTunnelling)
     }
 
     override fun onSafelyCreateView(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
@@ -133,10 +133,12 @@ class SplitTunnellingFragment : ServiceDependentFragment(OnNoService.GoToLaunchS
 
         excludeApplications.visibility = View.VISIBLE
         excludeApplicationsFadeOut.reverse()
+        splitTunnelling.enabled = true
     }
 
     private fun disable() {
         appListAdapter.enabled = false
+        splitTunnelling.enabled = false
         excludeApplicationsFadeOut.start()
     }
 

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -17,6 +17,8 @@ open class TalpidVpnService : VpnService() {
 
     private var currentTunConfig = defaultTunConfig()
 
+    protected var disallowedApps: List<String>? = null
+
     val connectivityListener = ConnectivityListener()
 
     override fun onCreate() {
@@ -90,6 +92,12 @@ open class TalpidVpnService : VpnService() {
 
             for (route in config.routes) {
                 addRoute(route.address, route.prefixLength.toInt())
+            }
+
+            disallowedApps?.let { apps ->
+                for (app in apps) {
+                    addDisallowedApplication(app)
+                }
             }
 
             setMtu(config.mtu)

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -16,6 +16,7 @@ open class TalpidVpnService : VpnService() {
     }
 
     private var currentTunConfig = defaultTunConfig()
+    private var tunIsStale = false
 
     protected var disallowedApps: List<String>? = null
 
@@ -33,13 +34,14 @@ open class TalpidVpnService : VpnService() {
         synchronized(this) {
             val tunDevice = activeTunDevice
 
-            if (config == currentTunConfig && tunDevice != null) {
+            if (config == currentTunConfig && tunDevice != null && !tunIsStale) {
                 return tunDevice
             } else {
                 val newTunDevice = createTun(config)
 
                 currentTunConfig = config
                 activeTunDevice = newTunDevice
+                tunIsStale = false
 
                 return newTunDevice
             }
@@ -72,6 +74,12 @@ open class TalpidVpnService : VpnService() {
     fun closeTun() {
         synchronized(this) {
             activeTunDevice = null
+        }
+    }
+
+    fun markTunAsStale() {
+        synchronized(this) {
+            tunIsStale = true
         }
     }
 


### PR DESCRIPTION
This PR continues the implementation of split tunnelling on Android. This PR implements the actual split tunnelling configuration to make it work. The only missing part is persisting the configuration, which will be done in the next PR.

A `SplitTunnelling` helper class was added to be used by the UI to configure split tunnelling. It can enable or disable the feature as a whole, and add and remove apps that are excluded from the tunnel. Every time these settings change, the list of excluded apps in `TalpidVpnService` is updated, the tunnel is marked as stale and a reconnect is requested. This forces the tun device to be recreated with the updated exclusion list.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Changelog entry will be added in the next PR.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1936)
<!-- Reviewable:end -->
