### PR TITLE
Implement persistence of split-tunnelling configuration on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Line wrap the file at 100 chars.                                              Th
 - Reconnect with a new key when WireGuard key is rotated automatically, previously the tunnel would
   time out before reconnecting.
 
+#### Android
+- Add split-tunnelling, allowing apps to be configured to be excluded from the tunnel.
+
 ### Changed
 - Upgrade from Electron 7 to Electron 8.
 - Change version string parsing to never suggest the user to upgrade to an older version.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
@@ -35,7 +35,7 @@ class AppListAdapter(
 
     init {
         jobTracker.newBackgroundJob("populateAppList") {
-            populateAppList(context)
+            populateAppList()
         }
     }
 
@@ -52,7 +52,7 @@ class AppListAdapter(
         holder.appInfo = appList.get(position)
     }
 
-    private fun populateAppList(context: Context) {
+    private fun populateAppList() {
         val applications = packageManager
             .getInstalledApplications(0)
             .filter { info -> info.packageName != thisPackageName }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -242,7 +242,7 @@ class MullvadVpnService : TalpidVpnService() {
             pendingAction = null
         }
 
-        val splitTunnelling = SplitTunnelling().apply {
+        val splitTunnelling = SplitTunnelling(this).apply {
             onChange = { excludedApps ->
                 disallowedApps = excludedApps
                 markTunAsStale()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunnelling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunnelling.kt
@@ -1,12 +1,14 @@
 package net.mullvad.mullvadvpn.service
 
 import android.content.Context
+import java.io.File
 import kotlin.properties.Delegates.observable
 
 private const val SHARED_PREFERENCES = "split_tunnelling"
 private const val KEY_ENABLED = "enabled"
 
 class SplitTunnelling(context: Context) {
+    private val appListFile = File(context.filesDir, "split-tunnelling.txt")
     private val excludedApps = HashSet<String>()
     private val preferences = context.getSharedPreferences(SHARED_PREFERENCES, Context.MODE_PRIVATE)
 
@@ -23,6 +25,12 @@ class SplitTunnelling(context: Context) {
 
     var onChange: ((List<String>) -> Unit)? = null
 
+    init {
+        if (appListFile.exists()) {
+            excludedApps.addAll(appListFile.readLines())
+        }
+    }
+
     fun isAppExcluded(appPackageName: String) = excludedApps.contains(appPackageName)
 
     fun excludeApp(appPackageName: String) {
@@ -33,6 +41,10 @@ class SplitTunnelling(context: Context) {
     fun includeApp(appPackageName: String) {
         excludedApps.remove(appPackageName)
         update()
+    }
+
+    fun persist() {
+        appListFile.writeText(excludedApps.joinToString(separator = "\n"))
     }
 
     private fun enabledChanged() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
@@ -110,8 +110,15 @@ class SplitTunnellingFragment : ServiceDependentFragment(OnNoService.GoToLaunchS
                 setDuration(200)
             }
 
+        if (configureSpinner()) {
+            jobTracker.newUiJob("enableAdapter") {
+                loadingSpinner.visibility = View.GONE
+                appListAdapter.enabled = true
+            }
+        }
+
         enabledToggle = header.findViewById<CellSwitch>(R.id.enabled_toggle).apply {
-            if (appListAdapter.enabled) {
+            if (splitTunnelling.enabled) {
                 forcefullySetState(CellSwitch.State.ON)
             } else {
                 forcefullySetState(CellSwitch.State.OFF)
@@ -131,27 +138,30 @@ class SplitTunnellingFragment : ServiceDependentFragment(OnNoService.GoToLaunchS
     }
 
     private fun enable() {
-        appListAdapter.apply {
-            if (!isListReady) {
-                enabled = false
-                showLoadingSpinner()
-                onListReady = {
-                    hideLoadingSpinner()
-                }
-            } else {
-                enabled = true
-            }
-        }
-
+        splitTunnelling.enabled = true
+        appListAdapter.enabled = configureSpinner()
         excludeApplications.visibility = View.VISIBLE
         excludeApplicationsFadeOut.reverse()
-        splitTunnelling.enabled = true
     }
 
     private fun disable() {
-        appListAdapter.enabled = false
         splitTunnelling.enabled = false
+        appListAdapter.enabled = false
         excludeApplicationsFadeOut.start()
+    }
+
+    private fun configureSpinner(): Boolean {
+        if (splitTunnelling.enabled && !appListAdapter.isListReady) {
+            showLoadingSpinner()
+
+            appListAdapter.onListReady = {
+                hideLoadingSpinner()
+            }
+
+            return false
+        } else {
+            return splitTunnelling.enabled
+        }
     }
 
     private fun showLoadingSpinner() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
@@ -105,6 +105,12 @@ class SplitTunnellingFragment : ServiceDependentFragment(OnNoService.GoToLaunchS
             }
 
         enabledToggle = header.findViewById<CellSwitch>(R.id.enabled_toggle).apply {
+            if (appListAdapter.enabled) {
+                forcefullySetState(CellSwitch.State.ON)
+            } else {
+                forcefullySetState(CellSwitch.State.OFF)
+            }
+
             listener = { toggleState ->
                 when (toggleState) {
                     CellSwitch.State.ON -> enable()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
@@ -84,6 +84,12 @@ class SplitTunnellingFragment : ServiceDependentFragment(OnNoService.GoToLaunchS
         return view
     }
 
+    override fun onSafelyPause() {
+        jobTracker.newBackgroundJob("persistExcludedApps") {
+            splitTunnelling.persist()
+        }
+    }
+
     override fun onSafelyDestroyView() {
         titleController.onDestroy()
     }


### PR DESCRIPTION
This PR completes the split-tunnelling feature implementation on Android by adding persistence to the configuration. Whether the feature is enabled or not is stored as a shared preference, and the list of apps that are excluded from tunnel is stored in a separate text file. The configuration is persisted every time the user leaves the split tunnelling settings screen.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1938)
<!-- Reviewable:end -->
