### PR TITLE
Windows: Fix ExecToStack calls

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -747,6 +747,7 @@
 
 	# Discard return value
 	Pop $0
+	Pop $1
 
 	Sleep 5000
 
@@ -754,6 +755,7 @@
 
 	# Discard return value
 	Pop $0
+	Pop $1
 
 	Sleep 1000
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -726,6 +726,8 @@
 	${EndIf}
 	Pop $FullUninstall
 
+	log::Log "Running uninstaller for ${PRODUCT_NAME} ${VERSION}"
+
 	${If} $FullUninstall != 1
 		# Save the target tunnel state if we're upgrading
 		SetOutPath "$TEMP"
@@ -758,8 +760,6 @@
 	Pop $1
 
 	Sleep 1000
-
-	log::Log "Running uninstaller for ${PRODUCT_NAME} ${VERSION}"
 
 	${RemoveCLIFromEnvironPath}
 


### PR DESCRIPTION
Correct stack imbalance caused by insufficient popping in the NSIS uninstallation path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1939)
<!-- Reviewable:end -->
