### PR TITLE
Fix WireGuard not connecting if IPv6 is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix window flickering by disabling window animations.
+- Fix WireGuard not connecting if IPv6 is disabled in the adapter or OS. `libwg` would time out
+  waiting for an IPv6 interface to become available.
 
 #### Android
 - Fix Connect screen sometimes becoming unusually tall. This ended up causing the screen to be

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -10,8 +10,6 @@ use std::{
 #[cfg(not(target_os = "android"))]
 use talpid_types::net::openvpn as openvpn_types;
 use talpid_types::net::{wireguard as wireguard_types, TunnelParameters};
-#[cfg(target_os = "windows")]
-use talpid_types::ErrorExt;
 
 #[cfg(target_os = "android")]
 pub use self::tun_provider::TunConfig;
@@ -241,22 +239,10 @@ impl TunnelMonitor {
         let options = tunnel_parameters.get_generic_options();
 
         #[cfg(target_os = "windows")]
-        match tunnel_parameters {
-            TunnelParameters::OpenVpn(..) => {
-                if options.enable_ipv6 {
-                    try_enabling_ipv6(tunnel_parameters)
-                } else {
-                    Ok(())
-                }
-            }
-            TunnelParameters::Wireguard(..) => {
-                // WireGuard always waits on an IPv6 interface,
-                // even if it's not in use
-                if let Err(e) = try_enabling_ipv6(tunnel_parameters) {
-                    log::error!("{}", e.display_chain_with_msg("Failed to enable IPv6"));
-                }
-                Ok(())
-            }
+        if options.enable_ipv6 {
+            try_enabling_ipv6(tunnel_parameters)
+        } else {
+            Ok(())
         }
 
         #[cfg(not(target_os = "windows"))]

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -126,9 +126,12 @@ impl WgGoTunnel {
             .map(LoggingContext)
             .map_err(TunnelError::LoggingError)?;
 
-        let wait_on_ipv6 = config.ipv6_gateway.is_some() ||
-            config.tunnel.addresses.iter().any(|ip| ip.is_ipv6()) ||
-            config.peers.iter().any(|config| config.allowed_ips.iter().any(|ip| ip.is_ipv6()));
+        let wait_on_ipv6 = config.ipv6_gateway.is_some()
+            || config.tunnel.addresses.iter().any(|ip| ip.is_ipv6())
+            || config
+                .peers
+                .iter()
+                .any(|config| config.allowed_ips.iter().any(|ip| ip.is_ipv6()));
 
         let handle = unsafe {
             wgTurnOn(


### PR DESCRIPTION
Effectively, only wait on the IPv6 interface when IPv6 is enabled in the settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1941)
<!-- Reviewable:end -->
