### PR TITLE
Fix mullvad-tests crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,14 +1563,21 @@ dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "mullvad-ipc-client 0.1.0",
  "mullvad-paths 0.1.0",
+ "mullvad-rpc 0.1.0",
  "mullvad-types 0.1.0",
  "notify 4.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "openvpn-plugin 0.3.0 (git+https://github.com/mullvad/openvpn-plugin-rs?branch=auth-failed-event)",
+ "parity-tokio-ipc 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "talpid-ipc 0.1.0",
  "talpid-types 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -14,6 +14,7 @@ integration-tests = []
 duct = "0.13"
 mullvad-ipc-client = { path = "../mullvad-ipc-client" }
 mullvad-paths = { path = "../mullvad-paths" }
+mullvad-rpc = { path = "../mullvad-rpc" }
 mullvad-types = { path = "../mullvad-types" }
 notify = "4.0"
 openvpn-plugin = { git = "https://github.com/mullvad/openvpn-plugin-rs", branch = "auth-failed-event", features = ["serde"] }
@@ -23,9 +24,17 @@ tempfile = "3.0"
 jsonrpc-client-core = { git = "https://github.com/mullvad/jsonrpc-client-rs", rev = "68aac55b" }
 jsonrpc-client-ipc = { git = "https://github.com/mullvad/jsonrpc-client-rs", rev = "68aac55b" }
 jsonrpc-client-pubsub = { git = "https://github.com/mullvad/jsonrpc-client-rs", rev = "68aac55b" }
-tokio = "0.1"
-tokio-timer = "0.1"
 futures = "0.1.23"
+tokio01 = { package = "tokio", version = "0.1" }
+tokio-timer = "0.1"
+tokio = { version = "0.2", features =  [ "io-util", "process", "rt-core", "rt-threaded", "stream", "fs"] }
+tonic = "0.2"
+tower = "0.3"
+prost = "0.6"
+parity-tokio-ipc = "0.7"
+
+[build-dependencies]
+tonic-build = { version = "0.2", default-features = false, features = ["transport", "prost"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/mullvad-tests/build.rs
+++ b/mullvad-tests/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    const OPENVPN_PROTO_FILE: &str = "../talpid-openvpn-plugin/proto/openvpn_plugin.proto";
+    tonic_build::compile_protos(OPENVPN_PROTO_FILE).unwrap();
+    println!("cargo:rerun-if-changed={}", OPENVPN_PROTO_FILE);
+}

--- a/mullvad-tests/tests/startup.rs
+++ b/mullvad-tests/tests/startup.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "integration-tests")]
 
 use mullvad_tests::DaemonRunner;
-use talpid_types::tunnel::TunnelStateTransition;
+use mullvad_types::states::TunnelState;
 
 #[test]
 fn starts_in_disconnected_state() {
@@ -10,5 +10,5 @@ fn starts_in_disconnected_state() {
 
     let state = rpc_client.get_state().expect("Failed to read daemon state");
 
-    assert_eq!(state, TunnelStateTransition::Disconnected);
+    assert_eq!(state, TunnelState::Disconnected);
 }

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -66,7 +66,7 @@ pub struct AmIMullvad {
 }
 
 /// GeoIP information exposed from the daemon to frontends.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct GeoIpLocation {

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -18,7 +18,7 @@ pub enum TargetState {
 }
 
 /// Represents the state the client tunnel is in.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "state", content = "details")]
 #[cfg_attr(target_os = "android", derive(IntoJava))]


### PR DESCRIPTION
Running `./integration_tests.sh` failed for a few reasons:
* The relay list was downloaded when the daemon was started, replacing the fake list.
* The relay list format had changed.
* `talpid-openvpn-plugin` hosts a gRPC server, but `mullvad-tests` tried to connect using JSON-RPC.
* Other types had changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1953)
<!-- Reviewable:end -->
