### PR TITLE
Fix format string in VoucherError

### DIFF
--- a/mullvad-types/src/account.rs
+++ b/mullvad-types/src/account.rs
@@ -42,7 +42,7 @@ pub enum VoucherError {
     /// Error code -100
     #[error(display = "Server internal error")]
     InternalError,
-    #[error(display = "Unknown error, _0")]
+    #[error(display = "Unknown error, {}", _0)]
     UnknownError(i64),
 }
 


### PR DESCRIPTION
A format string that's supposed to contain an error code only outputs `_0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1957)
<!-- Reviewable:end -->
