### PR TITLE
Update Android strings to better match desktop strings

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
@@ -39,6 +40,10 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
         }
 
         headerBar = HeaderBar(view, parentActivity)
+
+        view.findViewById<TextView>(R.id.no_more_vpn_time_left).text =
+            parentActivity.getString(R.string.no_more_vpn_time_left) + " " +
+            parentActivity.getString(R.string.add_time_to_account)
 
         disconnectButton = view.findViewById<Button>(R.id.disconnect).apply {
             setOnClickAction("disconnect", jobTracker) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
@@ -1,10 +1,15 @@
 package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
+import android.graphics.Typeface
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.text.Editable
+import android.text.Spannable
+import android.text.SpannableStringBuilder
 import android.text.TextWatcher
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -47,7 +52,6 @@ class ProblemReportFragment : Fragment() {
     private lateinit var sendStatusLabel: TextView
     private lateinit var sendDetailsLabel: TextView
     private lateinit var responseMessageLabel: TextView
-    private lateinit var responseEmailLabel: TextView
 
     private lateinit var editMessageButton: Button
     private lateinit var tryAgainButton: Button
@@ -87,7 +91,6 @@ class ProblemReportFragment : Fragment() {
         sendStatusLabel = view.findViewById<TextView>(R.id.send_status)
         sendDetailsLabel = view.findViewById<TextView>(R.id.send_details)
         responseMessageLabel = view.findViewById<TextView>(R.id.response_message)
-        responseEmailLabel = view.findViewById<TextView>(R.id.response_email)
 
         editMessageButton = view.findViewById<Button>(R.id.edit_message_button)
         tryAgainButton = view.findViewById<Button>(R.id.try_again_button)
@@ -193,7 +196,6 @@ class ProblemReportFragment : Fragment() {
         sendStatusLabel.visibility = View.VISIBLE
         sendDetailsLabel.visibility = View.GONE
         responseMessageLabel.visibility = View.GONE
-        responseEmailLabel.visibility = View.GONE
 
         sendStatusLabel.setText(R.string.sending)
 
@@ -209,17 +211,34 @@ class ProblemReportFragment : Fragment() {
         sendDetailsLabel.visibility = View.VISIBLE
 
         if (!userEmail.isEmpty()) {
-            responseMessageLabel.visibility = View.VISIBLE
-            responseEmailLabel.visibility = View.VISIBLE
-            responseEmailLabel.text = userEmail
-
-            showingEmail = true
+            showResponseMessage(userEmail)
         }
 
         sendStatusLabel.setText(R.string.sent)
         sendDetailsLabel.setText(R.string.sent_thanks)
 
         scrollArea.scrollTo(0, titleController.fullCollapseScrollOffset.toInt())
+    }
+
+    private fun showResponseMessage(userEmail: String) {
+        val responseMessageTemplate = parentActivity.getString(R.string.sent_contact)
+        val responseMessage = parentActivity.getString(R.string.sent_contact, userEmail)
+
+        val emailStart = responseMessageTemplate.indexOf('%')
+        val emailEndFromStringEnd = responseMessageTemplate.length - (emailStart + 4)
+        val emailEnd = responseMessage.length - emailEndFromStringEnd
+
+        val boldStyle = StyleSpan(Typeface.BOLD)
+        val colorStyle = ForegroundColorSpan(parentActivity.getColor(R.color.white))
+
+        responseMessageLabel.text = SpannableStringBuilder(responseMessage).apply {
+            setSpan(boldStyle, emailStart, emailEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            setSpan(colorStyle, emailStart, emailEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        responseMessageLabel.visibility = View.VISIBLE
+
+        showingEmail = true
     }
 
     private fun showErrorScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -35,6 +35,10 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             setOnClickListener { copyAccountTokenToClipboard() }
         }
 
+        view.findViewById<TextView>(R.id.pay_to_start_using).text =
+            parentActivity.getString(R.string.pay_to_start_using) + " " +
+            parentActivity.getString(R.string.add_time_to_account)
+
         view.findViewById<UrlButton>(R.id.buy_credit).apply {
             prepare(daemon, jobTracker)
         }

--- a/android/src/main/res/layout/out_of_time.xml
+++ b/android/src/main/res/layout/out_of_time.xml
@@ -55,14 +55,14 @@
                       android:textSize="32sp"
                       android:textStyle="bold"
                       android:text="@string/out_of_time" />
-            <TextView android:layout_width="wrap_content"
+            <TextView android:id="@+id/no_more_vpn_time_left"
+                      android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
                       android:layout_marginHorizontal="24dp"
                       android:layout_marginTop="8dp"
                       android:layout_marginBottom="11dp"
                       android:textColor="@color/white"
-                      android:textSize="13sp"
-                      android:text="@string/no_more_vpn_time_left" />
+                      android:textSize="13sp" />
             <Space android:layout_width="match_parent"
                    android:layout_height="0dp"
                    android:layout_weight="1" />

--- a/android/src/main/res/layout/problem_report.xml
+++ b/android/src/main/res/layout/problem_report.xml
@@ -142,13 +142,6 @@
                                   android:textSize="13sp"
                                   android:text="@string/sent_contact"
                                   android:visibility="gone" />
-                        <TextView android:id="@+id/response_email"
-                                  android:layout_width="wrap_content"
-                                  android:layout_height="wrap_content"
-                                  android:textColor="@color/white"
-                                  android:textSize="13sp"
-                                  android:textStyle="bold"
-                                  android:visibility="gone" />
                         <Space android:layout_width="match_parent"
                                android:layout_height="0dp"
                                android:layout_weight="1" />

--- a/android/src/main/res/layout/welcome.xml
+++ b/android/src/main/res/layout/welcome.xml
@@ -69,13 +69,13 @@
                       android:textSize="24sp"
                       android:textStyle="bold"
                       android:text="" />
-            <TextView android:layout_width="wrap_content"
+            <TextView android:id="@+id/pay_to_start_using"
+                      android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
                       android:layout_marginHorizontal="24dp"
                       android:layout_marginTop="11dp"
                       android:textColor="@color/white"
-                      android:textSize="13sp"
-                      android:text="@string/pay_to_start_using" />
+                      android:textSize="13sp" />
             <Space android:layout_width="match_parent"
                    android:layout_height="0dp"
                    android:layout_weight="1" />

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -94,11 +94,11 @@
     the form.</string>
     <string name="edit_message">Edit message</string>
     <string name="try_again">Try again</string>
-    <string name="unsecured_connection">Unsecured connection</string>
-    <string name="creating_secure_connection">Creating secure connection</string>
-    <string name="secure_connection">Secure connection</string>
-    <string name="blocked_connection">Blocked connection</string>
-    <string name="error_state">Failed to secure connection</string>
+    <string name="unsecured_connection">UNSECURED CONNECTION</string>
+    <string name="creating_secure_connection">CREATING SECURE CONNECTION</string>
+    <string name="secure_connection">SECURE CONNECTION</string>
+    <string name="blocked_connection">BLOCKED CONNECTION</string>
+    <string name="error_state">FAILED TO SECURE CONNECTION</string>
     <string name="connect">Secure my connection</string>
     <string name="cancel">Cancel</string>
     <string name="disconnect">Disconnect</string>
@@ -110,7 +110,7 @@
     <string name="in_address">In %1$s:%2$d %3$s</string>
     <string name="out_address">Out %1$s</string>
     <string name="blocking_internet">Blocking internet</string>
-    <string name="not_blocking_internet">You might be leaking network traffic</string>
+    <string name="not_blocking_internet">YOU MIGHT BE LEAKING NETWORK TRAFFIC</string>
     <string name="failed_to_block_internet">Failed to block all network traffic. Please
     troubleshoot or report the problem to us.</string>
     <string name="auth_failed">Account authentication failed.</string>
@@ -133,10 +133,10 @@
     <string name="wireguard_error">WireGuard error</string>
     <string name="too_many_keys">Too many WireGuard keys registered to account</string>
     <string name="failed_to_generate_key">Failed to generate a key</string>
-    <string name="update_available">Update available</string>
+    <string name="update_available">UPDATE AVAILABLE</string>
     <string name="update_available_description">Install Mullvad VPN (%1$s) to stay up to
     date</string>
-    <string name="unsupported_version">Unsupported version</string>
+    <string name="unsupported_version">UNSUPPORTED VERSION</string>
     <string name="unsupported_version_description">You are running an unsupported app version.
     Please upgrade to %1$s now to ensure your security</string>
     <string name="unsupported_version_without_upgrade">You are running an unsupported app

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -151,7 +151,6 @@
     <string name="wireguard_generate_key">Generate key</string>
     <string name="wireguard_replace_key">Regenerate key</string>
     <string name="wireguard_manage_keys">Manage keys</string>
-    <string name="wireguard_key_age">Key generated on</string>
     <string name="wireguard_key_reconnecting">Reconnecting with new WireGuard key...</string>
     <string name="wireguard_key_blocked_state_message">Unable to manage keys while in a blocked
     state</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -17,14 +17,14 @@
     <string name="login_title">Login</string>
     <string name="login_description">Enter your account number</string>
     <string name="login_hint">0000 0000 0000 0000</string>
-    <string name="logging_in_title">Logging in</string>
+    <string name="logging_in_title">Logging in...</string>
     <string name="logging_in_description">Checking account number</string>
-    <string name="logged_in_title">Login successful</string>
+    <string name="logged_in_title">Logged in</string>
     <string name="login_fail_title">Login failed</string>
-    <string name="login_fail_description">Invalid account number, try again</string>
+    <string name="login_fail_description">Invalid account number</string>
     <string name="dont_have_an_account">Don\'t have an account number?</string>
     <string name="create_account">Create account</string>
-    <string name="creating_new_account">Creating new account</string>
+    <string name="creating_new_account">Creating account...</string>
     <string name="failed_to_create_account">Failed to create account</string>
     <string name="account_created">Account created</string>
     <string name="congrats">Congrats!</string>
@@ -57,7 +57,7 @@
     <string name="app_version">App version</string>
     <string name="update_available_footer">Update available, download to remain safe.</string>
     <string name="report_a_problem">Report a problem</string>
-    <string name="quit">Quit</string>
+    <string name="quit">Quit app</string>
     <string name="account_number">Account number</string>
     <string name="mullvad_account_number">Mullvad account number</string>
     <string name="copied_mullvad_account_number">Copied Mullvad account number to
@@ -124,14 +124,15 @@
     <string name="no_matching_relay">No relay server matches the current settings</string>
     <string name="no_matching_bridge_relay">No bridge relay server matches the current
     settings</string>
-    <string name="no_wireguard_key">No WireGuard key set</string>
+    <string name="no_wireguard_key">Valid WireGuard key is missing. Manage keys under Advanced
+    settings.</string>
     <string name="custom_tunnel_host_resolution_error">Failed to resolve the hostname of custom
     server</string>
     <string name="is_offline">This device is offline, no tunnels can be established</string>
     <string name="tap_adapter_problem">TAP adapter error</string>
     <string name="wireguard_error">WireGuard error</string>
     <string name="too_many_keys">Too many WireGuard keys registered to account</string>
-    <string name="failed_to_generate_key">Failed to generate WireGuard key</string>
+    <string name="failed_to_generate_key">Failed to generate a key</string>
     <string name="update_available">Update available</string>
     <string name="update_available_description">Install Mullvad VPN (%1$s) to stay up to
     date</string>
@@ -143,7 +144,7 @@
     <string name="account_credit_expires_soon">Account credit expires soon</string>
     <string name="select_location">Select location</string>
     <string name="select_location_description">While connected, your real location is masked with a
-    private and secure location in the selected region</string>
+    private and secure location in the selected region.</string>
     <string name="wireguard_key">WireGuard key</string>
     <string name="public_key">Public key</string>
     <string name="wireguard_key_generated">Key generated</string>
@@ -157,7 +158,7 @@
     <string name="wireguard_key_valid">Key is valid</string>
     <string name="wireguard_key_invalid">Key is invalid</string>
     <string name="wireguard_key_verification_failure">Key verification failed</string>
-    <string name="wireguard_public_key">WireGuard public key</string>
+    <string name="wireguard_public_key">Public key</string>
     <string name="copied_wireguard_public_key">Copied WireGuard public key to clipboard</string>
     <string name="split_tunnelling">Split tunnelling</string>
     <string name="split_tunnelling_description">Split tunnelling makes it possible to select which

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="congrats">Congrats!</string>
     <string name="here_is_your_account_number">Here\'s your account number. Save it!</string>
     <string name="pay_to_start_using">To start using the app, you first need to add time to your
-    account. Either buy credit on our website or redeem a voucher.</string>
+    account.</string>
     <string name="buy_credit">Buy credit</string>
     <string name="buy_more_credit">Buy more credit</string>
     <string name="redeem_voucher">Redeem voucher</string>
@@ -49,8 +49,9 @@
     <string name="account_credit_has_expired">You have no more VPN time left on this
     account.</string>
     <string name="out_of_time">Out of time</string>
-    <string name="no_more_vpn_time_left">You have no more VPN time left on this account. Either buy
-    credit on our website or redeem a voucher.</string>
+    <string name="no_more_vpn_time_left">You have no more VPN time left on this account.</string>
+    <string name="add_time_to_account">Either buy credit on our website or redeem a
+    voucher.</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_advanced">Advanced</string>
     <string name="app_version">App version</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
     <string name="send_anyway">Send anyway</string>
     <string name="back">Back</string>
     <string name="sent_thanks">Thanks! We will look into this.</string>
-    <string name="sent_contact">If needed we will contact you on</string>
+    <string name="sent_contact">If needed we will contact you on %1$s</string>
     <string name="failed_to_send_details">You may need to go back to the app\'s main screen and
     click Disconnect before trying again. Don\'t worry, the information you entered will remain in
     the form.</string>


### PR DESCRIPTION
This PR changes some Android strings so that they can be matched with their equivalents in the desktop app. Some of them contain minor wording changes, some became capitalized, and some had to have their display code changed so that the format parameters also match the desktop version.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1958)
<!-- Reviewable:end -->
