### PR TITLE
Improve handling of firewall errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Upgrade Wintun from 0.7 to 0.8.1.
+- Display causes of firewall errors in the GUI.
 
 #### Linux
 - Allow users to specify `net_cls` controller mountpoint via `TALPID_NET_CLS_MOUNT_DIR`. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Line wrap the file at 100 chars.                                              Th
 - Make uninstaller on desktop platforms attempt to remove WireGuard keys from accounts.
 - Make important notifications not timeout on macOS and remain in the notification list on Linux.
 - Add exponential backoff to relay list downloader.
+- Display the original block reason in the non-blocking error state, and why applying the blocking
+  policy failed.
 
 #### Android
 - Show a system notification when the account time will soon run out.

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -264,12 +264,23 @@ const tunnelStateSchema = oneOf(
         object({
           reason: enumeration(
             'ipv6_unavailable',
-            'set_firewall_policy_error',
             'set_dns_error',
             'start_tunnel_error',
             'is_offline',
             'tap_adapter_problem',
           ),
+        }),
+        object({
+          reason: enumeration('set_firewall_policy_error'),
+          details: object({
+            reason: enumeration('generic', 'locked'),
+            details: maybe(
+              object({
+                name: string,
+                pid: number,
+              }),
+            ),
+          }),
         }),
         object({
           reason: enumeration('auth_failed'),

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -259,7 +259,17 @@ const tunnelStateSchema = oneOf(
   object({
     state: enumeration('error'),
     details: object({
-      is_blocking: boolean,
+      block_failure: maybe(
+        object({
+          reason: enumeration('generic', 'locked'),
+          details: maybe(
+            object({
+              name: string,
+              pid: number,
+            }),
+          ),
+        }),
+      ),
       cause: oneOf(
         object({
           reason: enumeration(

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -863,7 +863,7 @@ class ApplicationMain {
         return 'securing';
 
       case 'error':
-        if (tunnelState.details.isBlocking) {
+        if (!tunnelState.details.blockFailure) {
           return 'securing';
         } else {
           return 'unsecured';

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -634,7 +634,7 @@ export default class AppRenderer {
         break;
 
       case 'error':
-        actions.updateBlockState(tunnelState.details.isBlocking);
+        actions.updateBlockState(!tunnelState.details.blockFailure);
         break;
     }
   }

--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -169,7 +169,7 @@ export default class Connect extends React.Component<IProps, IState> {
       case 'connected':
         return HeaderBarStyle.success;
       case 'error':
-        return status.details.isBlocking ? HeaderBarStyle.success : HeaderBarStyle.error;
+        return !status.details.blockFailure ? HeaderBarStyle.success : HeaderBarStyle.error;
       case 'disconnecting':
         switch (status.details) {
           case 'block':
@@ -223,7 +223,7 @@ export default class Connect extends React.Component<IProps, IState> {
       case 'connected':
         return MarkerStyle.secure;
       case 'error':
-        return status.details.isBlocking ? MarkerStyle.secure : MarkerStyle.unsecure;
+        return !status.details.blockFailure ? MarkerStyle.secure : MarkerStyle.unsecure;
       case 'disconnected':
         return MarkerStyle.unsecure;
       case 'disconnecting':

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -176,7 +176,7 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
       case 'error':
         if (
           this.props.tunnelState.state === 'error' &&
-          !this.props.tunnelState.details.isBlocking
+          this.props.tunnelState.details.blockFailure
         ) {
           return (
             <Wrapper>

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -15,6 +15,16 @@ export interface ILocation {
   bridgeHostname?: string;
 }
 
+export type FirewallPolicyError =
+  | { reason: 'generic' }
+  | {
+      reason: 'locked';
+      details?: {
+        name: string;
+        pid: number;
+      };
+    };
+
 export type TunnelParameterError =
   | 'no_matching_relay'
   | 'no_matching_bridge_relay'
@@ -25,12 +35,12 @@ export type ErrorStateCause =
   | {
       reason:
         | 'ipv6_unavailable'
-        | 'set_firewall_policy_error'
         | 'set_dns_error'
         | 'start_tunnel_error'
         | 'is_offline'
         | 'tap_adapter_problem';
     }
+  | { reason: 'set_firewall_policy_error'; details: FirewallPolicyError }
   | { reason: 'tunnel_parameter_error'; details: TunnelParameterError }
   | { reason: 'auth_failed'; details?: string };
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -112,7 +112,7 @@ export type TunnelState =
   | { state: 'error'; details: IErrorState };
 
 export interface IErrorState {
-  isBlocking: boolean;
+  blockFailure?: FirewallPolicyError;
   cause: ErrorStateCause;
 }
 

--- a/gui/src/shared/notifications/error.ts
+++ b/gui/src/shared/notifications/error.ts
@@ -97,10 +97,22 @@ function getInAppNotificationSubtitle(tunnelState: { state: 'error'; details: IE
             extraMessage = messages.pgettext('in-app-notifications', 'Your kernel may be outdated');
             break;
           case 'win32':
-            extraMessage = messages.pgettext(
-              'in-app-notifications',
-              'This might be caused by third party security software',
-            );
+            switch (blockReason.details.reason) {
+              case 'locked':
+                if (blockReason.details.details) {
+                  // TODO: Check if this message is ok
+                  extraMessage = `${messages.pgettext(
+                    'in-app-notifications',
+                    'An application prevented the policy from being set',
+                  )}: ${blockReason.details.details.name}`;
+                } else {
+                  extraMessage = messages.pgettext(
+                    'in-app-notifications',
+                    'This might be caused by third party security software',
+                  );
+                }
+                break;
+            }
             break;
         }
         return `${messages.pgettext(

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -120,8 +120,11 @@ fn print_blocked_reason(reason: &ErrorStateCause) {
             println!("Blocked: {}", AuthFailed::from(auth_failure_str));
         }
         #[cfg(target_os = "linux")]
-        ErrorStateCause::SetFirewallPolicyError => {
-            println!("Blocked: {}", ErrorStateCause::SetFirewallPolicyError);
+        ErrorStateCause::SetFirewallPolicyError(error) => {
+            println!(
+                "Blocked: {}",
+                ErrorStateCause::SetFirewallPolicyError(error.clone())
+            );
             println!("Your kernel might be terribly out of date or missing nftables");
         }
         other => println!("Blocked: {}", other),

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::firewall::FirewallPolicy;
 use futures01::{sync::mpsc, Stream};
 use talpid_types::{
-    tunnel::{self as talpid_tunnel, ErrorStateCause},
+    tunnel::{self as talpid_tunnel, ErrorStateCause, FirewallPolicyError},
     ErrorExt,
 };
 
@@ -16,23 +16,29 @@ pub struct ErrorState {
 
 impl ErrorState {
     /// Returns true if firewall policy was applied successfully
-    fn set_firewall_policy(shared_values: &mut SharedTunnelStateValues) -> bool {
+    fn set_firewall_policy(
+        shared_values: &mut SharedTunnelStateValues,
+    ) -> Result<(), FirewallPolicyError> {
         let policy = FirewallPolicy::Blocked {
             allow_lan: shared_values.allow_lan,
         };
 
-        match shared_values.firewall.apply_policy(policy) {
-            Ok(()) => true,
-            Err(error) => {
+        shared_values
+            .firewall
+            .apply_policy(policy)
+            .map_err(|error| {
                 log::error!(
                     "{}",
                     error.display_chain_with_msg(
                         "Failed to apply firewall policy for blocked state"
                     )
                 );
-                false
-            }
-        }
+                match error {
+                    #[cfg(windows)]
+                    crate::firewall::Error::ApplyingBlockedPolicy(policy_error) => policy_error,
+                    _ => FirewallPolicyError::Generic,
+                }
+            })
     }
 
     /// Returns true if a new tunnel device was successfully created.
@@ -61,9 +67,12 @@ impl TunnelState for ErrorState {
         block_reason: Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
         #[cfg(not(target_os = "android"))]
-        let is_blocking = Self::set_firewall_policy(shared_values);
+        let (block_reason, is_blocking) = match Self::set_firewall_policy(shared_values) {
+            Ok(()) => (block_reason, true),
+            Err(error) => (ErrorStateCause::SetFirewallPolicyError(error), false),
+        };
         #[cfg(target_os = "android")]
-        let is_blocking = Self::create_blocking_tun(shared_values);
+        let (block_reason, is_blocking) = (block_reason, Self::create_blocking_tun(shared_values));
         (
             TunnelStateWrapper::from(ErrorState {
                 block_reason: block_reason.clone(),
@@ -84,7 +93,7 @@ impl TunnelState for ErrorState {
                 if let Err(error_state_cause) = shared_values.set_allow_lan(allow_lan) {
                     NewState(Self::enter(shared_values, error_state_cause))
                 } else {
-                    Self::set_firewall_policy(shared_values);
+                    let _ = Self::set_firewall_policy(shared_values);
                     SameState(self)
                 }
             }

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -132,6 +132,13 @@ typedef struct tag_PingableHosts
 }
 PingableHosts;
 
+enum WINFW_POLICY_STATUS
+{
+	WINFW_POLICY_STATUS_SUCCESS = 0,
+	WINFW_POLICY_STATUS_GENERAL_FAILURE = 1,
+	WINFW_POLICY_STATUS_LOCK_TIMEOUT = 2,
+};
+
 //
 // ApplyPolicyConnecting:
 //
@@ -142,7 +149,7 @@ PingableHosts;
 //
 extern "C"
 WINFW_LINKAGE
-bool
+WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
@@ -169,7 +176,7 @@ WinFw_ApplyPolicyConnecting(
 //
 extern "C"
 WINFW_LINKAGE
-bool
+WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyConnected(
 	const WinFwSettings *settings,
@@ -188,7 +195,7 @@ WinFw_ApplyPolicyConnected(
 //
 extern "C"
 WINFW_LINKAGE
-bool
+WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyBlocked(
 	const WinFwSettings *settings
@@ -201,6 +208,6 @@ WinFw_ApplyPolicyBlocked(
 //
 extern "C"
 WINFW_LINKAGE
-bool
+WINFW_POLICY_STATUS
 WINFW_API
 WinFw_Reset();


### PR DESCRIPTION
This makes a couple of improvements to firewall error handling:
* Detect whether the firewall failed due to being unable to acquire the transaction lock on Windows. Usually this is due to third-party software, so this will allow the backend to pass the process (PID, and application name) responsible to the GUI and display it. (The detection is not yet implemented.)
* If blocking fails in the error state, display the cause in the GUI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1959)
<!-- Reviewable:end -->
