### PR TITLE
Tweak text sizes on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
@@ -28,7 +28,7 @@ class AccountCell : NavigateCell {
 
         setAllCaps(true)
         setTextColor(normalColor)
-        setTextSize(TypedValue.COMPLEX_UNIT_SP, 13.0f)
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.text_small))
         setTypeface(null, Typeface.BOLD)
 
         text = ""

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
@@ -32,7 +32,7 @@ class AppVersionCell : Cell {
         }
 
         setTextColor(context.getColor(R.color.white60))
-        setTextSize(TypedValue.COMPLEX_UNIT_SP, 13.0f)
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.text_small))
         setTypeface(null, Typeface.BOLD)
 
         text = ""

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
@@ -19,7 +19,7 @@ open class Cell : LinearLayout {
         setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
 
         setTextColor(context.getColor(R.color.white))
-        setTextSize(TypedValue.COMPLEX_UNIT_SP, 20.0f)
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.text_medium))
         setTypeface(null, Typeface.BOLD)
     }
 
@@ -34,7 +34,7 @@ open class Cell : LinearLayout {
                 setPadding(horizontalPadding, topPadding, horizontalPadding, 0)
 
                 setTextColor(context.getColor(R.color.white60))
-                setTextSize(TypedValue.COMPLEX_UNIT_SP, 13.0f)
+                setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.text_small))
             }
         }
 

--- a/android/src/main/res/layout/account_history_entry.xml
+++ b/android/src/main/res/layout/account_history_entry.xml
@@ -7,6 +7,6 @@
               android:layout_height="wrap_content"
               android:textColor="@color/blue"
               android:padding="10dip"
-              android:textSize="16dip"
+              android:textSize="@dimen/text_medium"
               android:textStyle="bold" />
 </LinearLayout>

--- a/android/src/main/res/layout/app_list_item.xml
+++ b/android/src/main/res/layout/app_list_item.xml
@@ -28,7 +28,7 @@
               android:layout_marginHorizontal="8dp"
               android:layout_marginVertical="16dp"
               android:textColor="@color/white"
-              android:textSize="16sp"
+              android:textSize="@dimen/text_medium"
               android:text="" />
     <net.mullvad.mullvadvpn.ui.widget.CellSwitch android:id="@+id/excluded"
                                                  android:layout_width="52dp"

--- a/android/src/main/res/layout/confirm_no_email.xml
+++ b/android/src/main/res/layout/confirm_no_email.xml
@@ -14,7 +14,7 @@
                   android:layout_weight="0"
                   android:layout_marginBottom="12dp"
                   android:textColor="@color/white80"
-                  android:textSize="16sp"
+                  android:textSize="@dimen/text_medium"
                   android:text="@string/confirm_no_email" />
         <Button android:id="@+id/send_button"
                 android:text="@string/send_anyway"

--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -53,7 +53,7 @@
                               android:layout_height="wrap_content"
                               android:layout_marginHorizontal="24dp"
                               android:textColor="@color/white"
-                              android:textSize="34sp"
+                              android:textSize="@dimen/text_large"
                               android:textStyle="bold"
                               android:text="" />
                     <TextView android:id="@+id/country"
@@ -61,7 +61,7 @@
                               android:layout_height="wrap_content"
                               android:layout_marginHorizontal="24dp"
                               android:textColor="@color/white"
-                              android:textSize="34sp"
+                              android:textSize="@dimen/text_large"
                               android:textStyle="bold"
                               android:text="" />
                     <LinearLayout android:id="@+id/tunnel_info"

--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -53,7 +53,7 @@
                               android:layout_height="wrap_content"
                               android:layout_marginHorizontal="24dp"
                               android:textColor="@color/white"
-                              android:textSize="@dimen/text_large"
+                              android:textSize="@dimen/text_huge"
                               android:textStyle="bold"
                               android:text="" />
                     <TextView android:id="@+id/country"
@@ -61,7 +61,7 @@
                               android:layout_height="wrap_content"
                               android:layout_marginHorizontal="24dp"
                               android:textColor="@color/white"
-                              android:textSize="@dimen/text_large"
+                              android:textSize="@dimen/text_huge"
                               android:textStyle="bold"
                               android:text="" />
                     <LinearLayout android:id="@+id/tunnel_info"

--- a/android/src/main/res/layout/connect.xml
+++ b/android/src/main/res/layout/connect.xml
@@ -44,7 +44,7 @@
                               android:layout_marginBottom="4dp"
                               android:layout_marginHorizontal="24dp"
                               android:textColor="@color/red"
-                              android:textSize="16sp"
+                              android:textSize="@dimen/text_medium"
                               android:textStyle="bold"
                               android:text="@string/unsecured_connection"
                               android:textAllCaps="true" />
@@ -80,7 +80,7 @@
                                       android:layout_width="wrap_content"
                                       android:layout_height="wrap_content"
                                       android:textColor="@color/white"
-                                      android:textSize="16sp"
+                                      android:textSize="@dimen/text_medium"
                                       android:textStyle="bold"
                                       android:text="" />
                             <ImageView android:id="@+id/chevron"
@@ -95,19 +95,19 @@
                                   android:layout_height="wrap_content"
                                   android:layout_marginTop="4dp"
                                   android:textColor="@color/white"
-                                  android:textSize="13sp"
+                                  android:textSize="@dimen/text_small"
                                   android:text="" />
                         <TextView android:id="@+id/in_address"
                                   android:layout_width="wrap_content"
                                   android:layout_height="wrap_content"
                                   android:textColor="@color/white"
-                                  android:textSize="13sp"
+                                  android:textSize="@dimen/text_small"
                                   android:text="" />
                         <TextView android:id="@+id/out_address"
                                   android:layout_width="wrap_content"
                                   android:layout_height="wrap_content"
                                   android:textColor="@color/white"
-                                  android:textSize="13sp"
+                                  android:textSize="@dimen/text_small"
                                   android:text="" />
                     </LinearLayout>
                 </LinearLayout>

--- a/android/src/main/res/layout/header_bar.xml
+++ b/android/src/main/res/layout/header_bar.xml
@@ -11,7 +11,7 @@
               android:layout_marginVertical="12dp"
               android:layout_weight="1"
               android:textColor="@color/white80"
-              android:textSize="24sp"
+              android:textSize="@dimen/text_big"
               android:textStyle="bold"
               android:text="@string/app_name"
               android:textAllCaps="true" />

--- a/android/src/main/res/layout/information_view.xml
+++ b/android/src/main/res/layout/information_view.xml
@@ -4,7 +4,7 @@
               android:layout_height="wrap_content"
               android:layout_marginBottom="9dp"
               android:textColor="@color/white60"
-              android:textSize="13sp"
+              android:textSize="@dimen/text_small"
               android:textStyle="bold"
               android:text="" />
     <FrameLayout android:layout_width="wrap_content"
@@ -13,7 +13,7 @@
                   android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:textColor="@color/white"
-                  android:textSize="16sp"
+                  android:textSize="@dimen/text_medium"
                   android:textStyle="bold"
                   android:text="" />
         <ProgressBar android:id="@+id/spinner"

--- a/android/src/main/res/layout/launch.xml
+++ b/android/src/main/res/layout/launch.xml
@@ -29,7 +29,7 @@
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:textColor="@color/white40"
-                  android:textSize="14sp"
+                  android:textSize="@dimen/text_small"
                   android:text="@string/connecting_to_daemon" />
     </LinearLayout>
 </FrameLayout>

--- a/android/src/main/res/layout/launch.xml
+++ b/android/src/main/res/layout/launch.xml
@@ -22,7 +22,7 @@
                   android:layout_height="wrap_content"
                   android:layout_marginBottom="4dp"
                   android:textColor="@color/white60"
-                  android:textSize="24sp"
+                  android:textSize="@dimen/text_big"
                   android:textStyle="bold"
                   android:text="@string/app_name"
                   android:textAllCaps="true" />

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -51,7 +51,7 @@
                       android:layout_marginBottom="4dp"
                       android:gravity="start"
                       android:textColor="@color/white"
-                      android:textSize="32sp"
+                      android:textSize="@dimen/text_huge"
                       android:textStyle="bold"
                       android:text="@string/login_title" />
             <TextView android:id="@+id/subtitle"
@@ -61,7 +61,7 @@
                       android:layout_marginBottom="10dp"
                       android:gravity="start"
                       android:textColor="@color/white80"
-                      android:textSize="13sp"
+                      android:textSize="@dimen/text_small"
                       android:text="@string/login_description" />
             <net.mullvad.mullvadvpn.ui.AccountInputContainer android:id="@+id/account_input_container"
                                                              android:layout_width="match_parent"
@@ -81,7 +81,7 @@
                           android:hint="@string/login_hint"
                           android:textColorHint="@color/blue40"
                           android:textColor="@color/blue"
-                          android:textSize="20sp"
+                          android:textSize="@dimen/text_medium_plus"
                           android:textStyle="bold" />
                 <ImageButton android:id="@+id/login_button"
                              android:layout_width="48dp"
@@ -114,7 +114,7 @@
                       android:layout_marginBottom="8dp"
                       android:gravity="start"
                       android:textColor="@color/white80"
-                      android:textSize="13sp"
+                      android:textSize="@dimen/text_small"
                       android:text="@string/dont_have_an_account" />
             <net.mullvad.mullvadvpn.ui.widget.Button android:id="@+id/create_account"
                                                      android:layout_width="match_parent"

--- a/android/src/main/res/layout/mtu_edit_text.xml
+++ b/android/src/main/res/layout/mtu_edit_text.xml
@@ -10,4 +10,4 @@
           android:hint="@string/hint_default"
           android:textColorHint="@color/white80"
           android:textColor="@color/white"
-          android:textSize="20sp" />
+          android:textSize="@dimen/text_medium_plus" />

--- a/android/src/main/res/layout/notification_banner.xml
+++ b/android/src/main/res/layout/notification_banner.xml
@@ -24,7 +24,7 @@
               android:layout_toLeftOf="@id/notification_icon"
               android:layout_toRightOf="@id/notification_status_container"
               android:layout_marginLeft="7dp"
-              android:textSize="13sp"
+              android:textSize="@dimen/text_small"
               android:textStyle="bold"
               android:text="@string/blocking_internet"
               android:textAllCaps="true" />
@@ -35,7 +35,7 @@
               android:layout_toLeftOf="@id/notification_icon"
               android:layout_alignLeft="@id/notification_title"
               android:layout_below="@id/notification_title"
-              android:textSize="13sp"
+              android:textSize="@dimen/text_small"
               android:textColor="@color/white60"
               android:text=""
               android:visibility="gone" />

--- a/android/src/main/res/layout/out_of_time.xml
+++ b/android/src/main/res/layout/out_of_time.xml
@@ -23,7 +23,7 @@
                       android:layout_height="wrap_content"
                       android:layout_marginHorizontal="24dp"
                       android:textColor="@color/white"
-                      android:textSize="32sp"
+                      android:textSize="@dimen/text_large"
                       android:textStyle="bold"
                       android:text="@string/out_of_time" />
             <TextView android:id="@+id/no_more_vpn_time_left"
@@ -33,7 +33,7 @@
                       android:layout_marginTop="8dp"
                       android:layout_marginBottom="11dp"
                       android:textColor="@color/white"
-                      android:textSize="13sp" />
+                      android:textSize="@dimen/text_small" />
             <Space android:layout_width="match_parent"
                    android:layout_height="0dp"
                    android:layout_weight="1" />

--- a/android/src/main/res/layout/out_of_time.xml
+++ b/android/src/main/res/layout/out_of_time.xml
@@ -23,7 +23,7 @@
                       android:layout_height="wrap_content"
                       android:layout_marginHorizontal="24dp"
                       android:textColor="@color/white"
-                      android:textSize="@dimen/text_large"
+                      android:textSize="@dimen/text_huge"
                       android:textStyle="bold"
                       android:text="@string/out_of_time" />
             <TextView android:id="@+id/no_more_vpn_time_left"

--- a/android/src/main/res/layout/problem_report.xml
+++ b/android/src/main/res/layout/problem_report.xml
@@ -125,7 +125,7 @@
                                   android:layout_height="wrap_content"
                                   android:layout_marginBottom="4dp"
                                   android:textColor="@color/white"
-                                  android:textSize="34sp"
+                                  android:textSize="@dimen/text_large"
                                   android:textStyle="bold"
                                   android:text="@string/sending" />
                         <TextView android:id="@+id/send_details"

--- a/android/src/main/res/layout/problem_report.xml
+++ b/android/src/main/res/layout/problem_report.xml
@@ -125,7 +125,7 @@
                                   android:layout_height="wrap_content"
                                   android:layout_marginBottom="4dp"
                                   android:textColor="@color/white"
-                                  android:textSize="@dimen/text_large"
+                                  android:textSize="@dimen/text_huge"
                                   android:textStyle="bold"
                                   android:text="@string/sending" />
                         <TextView android:id="@+id/send_details"

--- a/android/src/main/res/layout/problem_report.xml
+++ b/android/src/main/res/layout/problem_report.xml
@@ -55,7 +55,7 @@
                                   android:layout_marginBottom="24dp"
                                   android:layout_marginHorizontal="24dp"
                                   android:textColor="@color/white80"
-                                  android:textSize="13sp"
+                                  android:textSize="@dimen/text_small"
                                   android:text="@string/problem_report_description" />
                         <EditText android:id="@+id/user_email"
                                   android:layout_width="match_parent"
@@ -116,7 +116,7 @@
                                   android:layout_height="wrap_content"
                                   android:layout_marginBottom="4dp"
                                   android:textColor="@color/green"
-                                  android:textSize="16sp"
+                                  android:textSize="@dimen/text_medium"
                                   android:textStyle="bold"
                                   android:text="@string/secure_connection"
                                   android:textAllCaps="true" />
@@ -132,14 +132,14 @@
                                   android:layout_width="wrap_content"
                                   android:layout_height="wrap_content"
                                   android:textColor="@color/white60"
-                                  android:textSize="13sp"
+                                  android:textSize="@dimen/text_small"
                                   android:text="@string/sent_thanks"
                                   android:visibility="gone" />
                         <TextView android:id="@+id/response_message"
                                   android:layout_width="wrap_content"
                                   android:layout_height="wrap_content"
                                   android:textColor="@color/white60"
-                                  android:textSize="13sp"
+                                  android:textSize="@dimen/text_small"
                                   android:text="@string/sent_contact"
                                   android:visibility="gone" />
                         <Space android:layout_width="match_parent"

--- a/android/src/main/res/layout/redeem_voucher.xml
+++ b/android/src/main/res/layout/redeem_voucher.xml
@@ -15,7 +15,7 @@
                   android:layout_weight="0"
                   android:layout_marginBottom="12dp"
                   android:textColor="@color/white80"
-                  android:textSize="16sp"
+                  android:textSize="@dimen/text_medium"
                   android:text="@string/enter_voucher_code" />
         <EditText android:id="@+id/voucher_code"
                   android:layout_width="match_parent"
@@ -33,14 +33,14 @@
                   android:textAllCaps="true"
                   android:textColorHint="@color/blue40"
                   android:textColor="@color/blue"
-                  android:textSize="13sp"
+                  android:textSize="@dimen/text_small"
                   android:textStyle="bold" />
         <TextView android:id="@+id/error"
                   android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:layout_marginTop="8dp"
                   android:textColor="@color/red"
-                  android:textSize="13sp"
+                  android:textSize="@dimen/text_small"
                   android:textStyle="bold"
                   android:visibility="invisible" />
         <net.mullvad.mullvadvpn.ui.widget.Button android:id="@+id/redeem"

--- a/android/src/main/res/layout/relay_list_item.xml
+++ b/android/src/main/res/layout/relay_list_item.xml
@@ -27,7 +27,7 @@
               android:layout_marginHorizontal="8dp"
               android:layout_marginVertical="16dp"
               android:textColor="@color/white"
-              android:textSize="20sp"
+              android:textSize="@dimen/text_medium_plus"
               android:textStyle="bold"
               android:text="" />
     <ImageButton android:id="@+id/chevron"

--- a/android/src/main/res/layout/select_location_header.xml
+++ b/android/src/main/res/layout/select_location_header.xml
@@ -17,7 +17,7 @@
               android:layout_marginHorizontal="24dp"
               android:layout_marginBottom="24dp"
               android:textColor="@color/white60"
-              android:textSize="13sp"
+              android:textSize="@dimen/text_small"
               android:text="@string/select_location_description" />
     <ProgressBar android:id="@+id/loading_spinner"
                  android:layout_width="60dp"

--- a/android/src/main/res/layout/settings_back_button.xml
+++ b/android/src/main/res/layout/settings_back_button.xml
@@ -7,6 +7,6 @@
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:textColor="@color/white60"
-              android:textSize="13sp"
+              android:textSize="@dimen/text_small"
               android:textStyle="bold" />
 </merge>

--- a/android/src/main/res/layout/split_tunnelling_header.xml
+++ b/android/src/main/res/layout/split_tunnelling_header.xml
@@ -19,7 +19,7 @@
               android:paddingHorizontal="24dp"
               android:text="@string/split_tunnelling_description"
               android:textColor="@color/white60"
-              android:textSize="13sp" />
+              android:textSize="@dimen/text_small" />
     <net.mullvad.mullvadvpn.ui.widget.ToggleCell android:id="@+id/enabled"
                                                  android:layout_width="match_parent"
                                                  android:layout_height="wrap_content"
@@ -39,7 +39,7 @@
                   android:paddingHorizontal="8dp"
                   android:paddingVertical="17dp"
                   android:textColor="@color/white"
-                  android:textSize="20sp"
+                  android:textSize="@dimen/text_medium_plus"
                   android:textStyle="bold"
                   android:text="@string/exclude_applications" />
     </LinearLayout>

--- a/android/src/main/res/layout/welcome.xml
+++ b/android/src/main/res/layout/welcome.xml
@@ -18,7 +18,7 @@
                       android:layout_marginHorizontal="24dp"
                       android:layout_marginTop="24dp"
                       android:textColor="@color/white"
-                      android:textSize="32sp"
+                      android:textSize="@dimen/text_large"
                       android:textStyle="bold"
                       android:text="@string/congrats" />
             <TextView android:layout_width="wrap_content"
@@ -27,7 +27,7 @@
                       android:layout_marginTop="8dp"
                       android:layout_marginBottom="11dp"
                       android:textColor="@color/white"
-                      android:textSize="13sp"
+                      android:textSize="@dimen/text_small"
                       android:text="@string/here_is_your_account_number" />
             <TextView android:id="@+id/account_number"
                       android:layout_width="match_parent"
@@ -37,7 +37,7 @@
                       android:clickable="true"
                       android:background="?android:attr/selectableItemBackground"
                       android:textColor="@color/white"
-                      android:textSize="24sp"
+                      android:textSize="@dimen/text_big"
                       android:textStyle="bold"
                       android:text="" />
             <TextView android:id="@+id/pay_to_start_using"
@@ -46,7 +46,7 @@
                       android:layout_marginHorizontal="24dp"
                       android:layout_marginTop="11dp"
                       android:textColor="@color/white"
-                      android:textSize="13sp" />
+                      android:textSize="@dimen/text_small" />
             <Space android:layout_width="match_parent"
                    android:layout_height="0dp"
                    android:layout_weight="1" />

--- a/android/src/main/res/layout/welcome.xml
+++ b/android/src/main/res/layout/welcome.xml
@@ -18,7 +18,7 @@
                       android:layout_marginHorizontal="24dp"
                       android:layout_marginTop="24dp"
                       android:textColor="@color/white"
-                      android:textSize="@dimen/text_large"
+                      android:textSize="@dimen/text_huge"
                       android:textStyle="bold"
                       android:text="@string/congrats" />
             <TextView android:layout_width="wrap_content"

--- a/android/src/main/res/layout/wireguard_key.xml
+++ b/android/src/main/res/layout/wireguard_key.xml
@@ -70,7 +70,7 @@
                               android:layout_width="wrap_content"
                               android:layout_height="wrap_content"
                               android:textColor="@color/red"
-                              android:textSize="13sp"
+                              android:textSize="@dimen/text_small"
                               android:textStyle="bold"
                               android:visibility="gone" />
                     <ProgressBar android:id="@+id/verifying_key_spinner"

--- a/android/src/main/res/values/dimensions.xml
+++ b/android/src/main/res/values/dimensions.xml
@@ -24,4 +24,9 @@
     <dimen name="cell_footer_horizontal_padding">24dp</dimen>
     <dimen name="chevron_width">14dp</dimen>
     <dimen name="chevron_height">24dp</dimen>
+    <dimen name="text_small">13sp</dimen>
+    <dimen name="text_medium">16sp</dimen>
+    <dimen name="text_medium_plus">20sp</dimen>
+    <dimen name="text_big">24sp</dimen>
+    <dimen name="text_huge">32sp</dimen>
 </resources>

--- a/android/src/main/res/values/dimensions.xml
+++ b/android/src/main/res/values/dimensions.xml
@@ -26,7 +26,7 @@
     <dimen name="chevron_height">24dp</dimen>
     <dimen name="text_small">13sp</dimen>
     <dimen name="text_medium">16sp</dimen>
-    <dimen name="text_medium_plus">20sp</dimen>
+    <dimen name="text_medium_plus">18sp</dimen>
     <dimen name="text_big">24sp</dimen>
-    <dimen name="text_huge">32sp</dimen>
+    <dimen name="text_huge">30sp</dimen>
 </resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -11,7 +11,7 @@
         <item name="android:textCursorDrawable">@drawable/text_input_cursor</item>
         <item name="android:textColorHint">@color/blue40</item>
         <item name="android:textColor">@color/blue</item>
-        <item name="android:textSize">13sp</item>
+        <item name="android:textSize">@dimen/text_small</item>
     </style>
     <style name="Button"
            parent="Widget.AppCompat.Button.Borderless">
@@ -21,7 +21,7 @@
         <item name="android:paddingBottom">0dp</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">@color/white</item>
-        <item name="android:textSize">20sp</item>
+        <item name="android:textSize">@dimen/text_medium_plus</item>
         <item name="android:textStyle">bold</item>
     </style>
     <style name="GreenButton"
@@ -46,10 +46,10 @@
     </style>
     <style name="SettingsExpandedHeader"
            parent="SettingsHeader">
-        <item name="android:textSize">32sp</item>
+        <item name="android:textSize">@dimen/text_huge</item>
     </style>
     <style name="SettingsCollapsedHeader"
            parent="SettingsHeader">
-        <item name="android:textSize">16sp</item>
+        <item name="android:textSize">@dimen/text_medium</item>
     </style>
 </resources>


### PR DESCRIPTION
This PR consolidates the text sizes used on the Android UI, and tweaks them a little to look more like the desktop app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor and minor UI tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1962)
<!-- Reviewable:end -->
