### PR TITLE
Fix systemd-resolved DNS management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Line wrap the file at 100 chars.                                              Th
   connecting.
 - Fix notification sometimes not being dismissible.
 
+#### Linux
+- Fix `systemd-resolved` DNS management by not parsing `/etc/resolv.conf`.
+
 
 ## [2020.5] - 2020-06-25
 ### Added


### PR DESCRIPTION
Address some of the issues raised in #1952. The underlying issue is that the daemon would attempt to parse `/etc/resolv.conf` by a rather strict parser that would fail due to there being an unknown option being added to the file. The file is parsed to check if it contains the local resolver address  to address cases where the user might've changed the file. This behavior has been removed, but we should test this out more extensively to see what happens on older distributions. The DNS management has also been simplified with systemd-resolved by not using it when the stub `resolv.conf` file is not symlinked. This is because in case the _real_ `resolv.conf` file is being used, the glibc resolver will be used, and it will query the first 3 DNS servers listed in `resolv.conf` in order, switching over to the next one after a timeout - since the user usually has at least one other DNS server configured before they connect, there will always be a second of latency added to all DNS requests at best or they will always time out at worst, when connected to a tunnel. Thus, it's just easier to fall back to methods that will manage DNS in cruder ways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1968)
<!-- Reviewable:end -->
