### PR TITLE
Fix page margin in SettingsHeader

### DIFF
--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -41,6 +41,6 @@ export default {
     lineHeight: 20,
     color: colors.red,
     marginTop: 12,
-    paddingHorizontal: 20,
+    paddingHorizontal: 22,
   }),
 };

--- a/gui/src/renderer/components/SettingsHeader.tsx
+++ b/gui/src/renderer/components/SettingsHeader.tsx
@@ -4,7 +4,7 @@ import { bigText, smallText } from './common-styles';
 
 export const Container = styled.div({
   flex: 0,
-  padding: '2px 20px 20px',
+  padding: '2px 22px 20px',
 });
 
 export const ContentWrapper = styled.div({


### PR DESCRIPTION
This PR changes the horizontal margin of `SettingsHeader` to `22px` from `20px` which was left there by mistake.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1973)
<!-- Reviewable:end -->
