### PR TITLE
Prevent override of CustomScrollbar className prop

### DIFF
--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -32,7 +32,7 @@ export default {
     marginBottom: 20,
   }),
   advanced_settings__wgkeys_cell: Styles.createViewStyle({
-    marginBottom: 20,
+    marginBottom: 22,
   }),
   advanced_settings__wg_no_key: Styles.createTextStyle({
     fontFamily: 'Open Sans',

--- a/gui/src/renderer/components/CustomScrollbars.tsx
+++ b/gui/src/renderer/components/CustomScrollbars.tsx
@@ -176,6 +176,7 @@ export default class CustomScrollbars extends React.Component<IProps, IState> {
       onScroll: _onScroll,
       fillContainer,
       children,
+      className,
       ...otherProps
     } = this.props;
     const showScrollbars = this.state.canScroll && this.state.showScrollIndicators;
@@ -185,9 +186,10 @@ export default class CustomScrollbars extends React.Component<IProps, IState> {
     const thumbWideClass = this.state.isWide ? ' custom-scrollbars__thumb--wide' : '';
     const trackClass =
       showScrollbars && this.state.showTrack ? ' custom-scrollbars__track--visible' : '';
+    const classNames = className ? `${className} custom-scrollbars` : 'custom-scrollbars';
 
     return (
-      <div {...otherProps} className="custom-scrollbars">
+      <div {...otherProps} className={classNames}>
         <div className={`custom-scrollbars__track ${trackClass}`} ref={this.trackRef} />
         <div
           className={`custom-scrollbars__thumb ${thumbWideClass} ${thumbActiveClass} ${thumbAnimationClass}`}

--- a/gui/src/renderer/components/PreferencesStyles.tsx
+++ b/gui/src/renderer/components/PreferencesStyles.tsx
@@ -13,6 +13,7 @@ export default {
   preferences__content: Styles.createViewStyle({
     flexDirection: 'column',
     flex: 1,
+    marginBottom: 2,
   }),
   preferences__separator: Styles.createViewStyle({
     height: 1,


### PR DESCRIPTION
This PR fixes an issue where some screens didn't fill the viewport due to the `className` prop in `CustomScrollbars` being overridden.

This PR also changes the page bottom margin to `22px` in `Settings` and `AdvancedSettings`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1979)
<!-- Reviewable:end -->
