### PR TITLE
Fix Swift compiler segfault in release build

### DIFF
--- a/ios/MullvadVPN/Operations/AssociatedValue.swift
+++ b/ios/MullvadVPN/Operations/AssociatedValue.swift
@@ -16,7 +16,7 @@ final class AssociatedValue<T>: NSObject {
     }
 
     class func get(object: Any, key: UnsafeRawPointer) -> T? {
-        let container = objc_getAssociatedObject(object, key) as? Self
+        let container = objc_getAssociatedObject(object, key) as? AssociatedValue<T>
         return container?.value
     }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes a segfault in swiftc. Somehow Swift is not able to infer `Self` in the context of class method of generic `AssociatedValue<T>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1980)
<!-- Reviewable:end -->
