### PR TITLE
Fix cell switch widget for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix connect action from quick-settings tile or notification sometimes opening the UI instead of
   connecting.
 - Fix notification sometimes not being dismissible.
+- Fix toggle switch sometimes getting stuck.
 
 #### Linux
 - Fix `systemd-resolved` DNS management by not parsing `/etc/resolv.conf`.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
@@ -56,6 +56,8 @@ class CellSwitch : LinearLayout {
     private val knobPosition: Float
         get() = knobView.translationX / knobMaxTranslation
 
+    private var animationIsReversed = false
+
     private val positionAnimation = ValueAnimator.ofFloat(0f, knobMaxTranslation).apply {
         addUpdateListener { animation ->
             knobView.translationX = animation.animatedValue as Float
@@ -213,12 +215,16 @@ class CellSwitch : LinearLayout {
 
         when (state) {
             State.ON -> {
+                animationIsReversed = false
                 colorAnimation.start()
                 positionAnimation.start()
             }
             State.OFF -> {
-                colorAnimation.reverse()
-                positionAnimation.reverse()
+                if (!animationIsReversed || !colorAnimation.isRunning()) {
+                    animationIsReversed = true
+                    colorAnimation.reverse()
+                    positionAnimation.reverse()
+                }
 
                 playTime = knobAnimationDuration - playTime
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
@@ -12,6 +12,7 @@ import android.view.Gravity
 import android.view.MotionEvent
 import android.widget.ImageView
 import android.widget.LinearLayout
+import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 
 class CellSwitch : LinearLayout {
@@ -20,14 +21,13 @@ class CellSwitch : LinearLayout {
         OFF
     }
 
-    var state = State.OFF
-        set(value) {
-            if (field != value) {
-                field = value
-                animateToState()
-                listener?.invoke(value)
-            }
+    var state by observable(State.OFF) { _, oldState, newState ->
+        animateToState()
+
+        if (oldState != newState) {
+            listener?.invoke(newState)
         }
+    }
 
     var listener: ((State) -> Unit)? = null
 

--- a/android/src/main/res/values/dimensions.xml
+++ b/android/src/main/res/values/dimensions.xml
@@ -9,11 +9,11 @@
     <dimen name="normal_button_height">44dp</dimen>
     <dimen name="tall_button_height">64dp</dimen>
     <dimen name="cell_switch_border_radius">16dp</dimen>
-    <dimen name="cell_switch_width">52dp</dimen>
-    <dimen name="cell_switch_height">32dp</dimen>
+    <dimen name="cell_switch_width">48dp</dimen>
+    <dimen name="cell_switch_height">30dp</dimen>
     <dimen name="cell_switch_knob_margin">4dp</dimen>
-    <dimen name="cell_switch_knob_max_translation">20dp</dimen>
-    <dimen name="cell_switch_knob_size">24dp</dimen>
+    <dimen name="cell_switch_knob_max_translation">18dp</dimen>
+    <dimen name="cell_switch_knob_size">22dp</dimen>
     <dimen name="settings_back_button_padding">12dp</dimen>
     <dimen name="cell_horizontal_padding">@dimen/side_margin</dimen>
     <dimen name="cell_inner_spacing">8dp</dimen>


### PR DESCRIPTION
Previously the cell switch widget used on Android could get stuck in an intermediate position. This would happen when a user manually drags the knob to a position that's not far enough from its initial position to cause a state change.

This PR fixes that by making sure to call the animation handler method every time the state is set (even if it is set to the same value). However, this led to an issue where the animation could start twice, and if it was reversed it would be reversed again restoring the default animation direction and ending up in the wrong state. The fix for this was to track if the animation was already running in a reversed state.

The PR also shrinks the widget size to better match the desktop component dimensions.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1981)
<!-- Reviewable:end -->
