### PR TITLE
Don't show account time expired notification for new accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add exponential backoff to relay list downloader.
 - Display the original block reason in the non-blocking error state, and why applying the blocking
   policy failed.
+- Don't show account time expired notification for newly created accounts.
 
 #### Android
 - Show a system notification when the account time will soon run out.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -36,6 +36,16 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
         }
     }
 
+    fun createNewAccount(): String? {
+        return daemon.createNewAccount()
+    }
+
+    fun login(account: String) {
+        if (account != accountNumber) {
+            daemon.setAccount(account)
+        }
+    }
+
     fun fetchAccountExpiry() {
         synchronized(this) {
             accountNumber?.let { account ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -23,6 +23,9 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
     val onAccountNumberChange = EventNotifier<String?>(null)
     val onAccountExpiryChange = EventNotifier<DateTime?>(null)
 
+    var newlyCreatedAccount = false
+        private set
+
     private val jobTracker = JobTracker()
 
     private var accountNumber by onAccountNumberChange.notifiable()
@@ -37,11 +40,14 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
     }
 
     fun createNewAccount(): String? {
+        newlyCreatedAccount = true
+
         return daemon.createNewAccount()
     }
 
     fun login(account: String) {
         if (account != accountNumber) {
+            newlyCreatedAccount = false
             daemon.setAccount(account)
         }
     }
@@ -109,6 +115,10 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
             if (newAccountExpiry != oldAccountExpiry || retryAttempt >= MAX_INVALIDATED_RETRIES) {
                 accountExpiry = newAccountExpiry
                 oldAccountExpiry = null
+
+                if (accountExpiry != null) {
+                    newlyCreatedAccount = false
+                }
 
                 return true
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -19,8 +19,6 @@ import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
 import net.mullvad.talpid.util.EventNotifier
-import net.mullvad.talpid.util.autoSubscribable
-import org.joda.time.DateTime
 
 private const val RELAYS_FILE = "relays.json"
 
@@ -49,23 +47,17 @@ class MullvadVpnService : TalpidVpnService() {
         if (newInstance != oldInstance) {
             oldInstance?.onDestroy()
 
-            accountExpiryNotification = newInstance?.daemon?.let { daemon ->
-                AccountExpiryNotification(this, daemon)
+            accountExpiryNotification = newInstance?.let { instance ->
+                AccountExpiryNotification(this, instance.daemon, instance.accountCache)
             }
-
-            accountExpiryEvents = newInstance?.accountCache?.onAccountExpiryChange
 
             serviceNotifier.notify(newInstance)
         }
     }
 
-    private var accountExpiryEvents by autoSubscribable<DateTime?>(this, null) { expiry ->
-        accountExpiryNotification?.accountExpiry = expiry
-    }
-
     private var accountExpiryNotification
     by observable<AccountExpiryNotification?>(null) { _, oldNotification, _ ->
-        oldNotification?.accountExpiry = null
+        oldNotification?.onDestroy()
     }
 
     private lateinit var keyguardManager: KeyguardManager

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -58,9 +58,10 @@ class AccountExpiryNotification(
 
     private suspend fun update(accountExpiry: DateTime?) {
         val remainingTime = accountExpiry?.let { expiry -> Duration(DateTime.now(), expiry) }
+        val closeToExpire = remainingTime?.isShorterThan(REMAINING_TIME_FOR_REMINDERS) ?: false
 
-        if (remainingTime != null && remainingTime.isShorterThan(REMAINING_TIME_FOR_REMINDERS)) {
-            val notification = build(accountExpiry, remainingTime)
+        if (closeToExpire && !accountCache.newlyCreatedAccount) {
+            val notification = build(accountExpiry!!, remainingTime!!)
 
             channel.notificationManager.notify(NOTIFICATION_ID, notification)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -95,7 +95,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         scrollToShow(loggingInStatus)
 
         val accountToken = jobTracker.runOnBackground {
-            daemon.createNewAccount()
+            accountCache.createNewAccount()
         }
 
         if (accountToken == null) {
@@ -135,7 +135,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
                 when (accountDataResult) {
                     is GetAccountDataResult.Ok -> {
-                        daemon.setAccount(accountToken)
+                        accountCache.login(accountToken)
 
                         val expiryString = accountDataResult.accountData.expiry
                         val expiry = DateTime.parse(expiryString, AccountCache.EXPIRY_FORMAT)
@@ -147,7 +147,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
                         }
                     }
                     is GetAccountDataResult.RpcError -> {
-                        daemon.setAccount(accountToken)
+                        accountCache.login(accountToken)
                         LoginResult.ExistingAccountWithTime
                     }
                     else -> null


### PR DESCRIPTION
Previously, when a user creates a new account a notification would appear saying that the account time had expired. Since the account is new, that's rather obvious and the notification is unhelpful (if not confusing). This PR changes the app to not show the notification after creating an account.

Because the notification is handled by the service, it had no knowledge of whether the current account is new or not. The UI needed a way to tell the service that it was creating an account. There are a few options on how to do this, but I ended up choosing the simplest one, using the `AccountCache` as a proxy between the UI and the service. It already serves that purpose when providing to the UI the account number and the expiration, and now it also provides to the service if the UI requested a new account to be created.

The `AccountExpiryNotification` controller was then updated to use the `AccountCache` to determine if it should show or hide the notification.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1982)
<!-- Reviewable:end -->
