### PR TITLE
New attempt to fix app restarting by itself when quitting

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -34,11 +34,13 @@ class MainActivity : FragmentActivity() {
 
     private val serviceConnectionManager = object : android.content.ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
+            android.util.Log.d("mullvad", "UI successfully connected to the service")
             val localBinder = binder as MullvadVpnService.LocalBinder
 
             service = localBinder
 
             localBinder.serviceNotifier.subscribe(this@MainActivity) { service ->
+                android.util.Log.d("mullvad", "UI connection to the service changed: $service")
                 serviceConnection?.onDestroy()
 
                 val newConnection = service?.let { safeService ->
@@ -55,6 +57,7 @@ class MainActivity : FragmentActivity() {
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
+            android.util.Log.d("mullvad", "UI lost the connection to the service")
             service?.serviceNotifier?.unsubscribe(this@MainActivity)
             serviceConnection = null
             serviceNotifier.notify(null)
@@ -79,6 +82,7 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onStart() {
+        android.util.Log.d("mullvad", "Starting main activity")
         super.onStart()
 
         val intent = Intent(this, MullvadVpnService::class.java)
@@ -97,6 +101,7 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onStop() {
+        android.util.Log.d("mullvad", "Stoping main activity")
         unbindService(serviceConnectionManager)
 
         super.onStop()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -89,6 +89,7 @@ class MainActivity : FragmentActivity() {
         super.onStart()
 
         if (!quitting) {
+            android.util.Log.d("mullvad", "Starting background service")
             val intent = Intent(this, MullvadVpnService::class.java)
 
             if (Build.VERSION.SDK_INT >= 26) {


### PR DESCRIPTION
The issue where trying to quit the app fails because it restarts by itself still seems to happen sometimes. The cause is still unknown, but there was a weird log sequence in a recent reproduction of the issue. Apparently `MainActivity.onStart` was called while the app was quitting (without a `MainActivity.onStop` call since the previous `MainActivity.onStart`). This might've been just some other weird issue, but in case it is related this PR changes the `onStart` method to not start the service if it knows the app is quitting.

The PR also adds extra log messages to the `MainActivity` in order to trace the connection between the service and the UI, since part of the issue might be one trying to start the other in a non-ending cycle.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **There's already a changelog entry for another fix attempt that hasn't been publicly released yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1983)
<!-- Reviewable:end -->
