### PR TITLE
Change font weight to normal in list item labels

### DIFF
--- a/gui/src/renderer/components/CityRow.tsx
+++ b/gui/src/renderer/components/CityRow.tsx
@@ -35,6 +35,9 @@ const StyledChevronButton = styled(ChevronButton)({
 });
 
 const Label = styled(Cell.Label)({
+  fontFamily: 'Open Sans',
+  fontWeight: 'normal',
+  fontSize: '16px',
   '[disabled] &': {
     color: colors.white20,
   },

--- a/gui/src/renderer/components/CountryRow.tsx
+++ b/gui/src/renderer/components/CountryRow.tsx
@@ -42,6 +42,9 @@ const StyledChevronButton = styled(ChevronButton)({
 });
 
 const Label = styled(Cell.Label)({
+  fontFamily: 'Open Sans',
+  fontWeight: 'normal',
+  fontSize: '16px',
   '[disabled] &': {
     color: colors.white20,
   },

--- a/gui/src/renderer/components/LinuxSplitTunnelingSettings.tsx
+++ b/gui/src/renderer/components/LinuxSplitTunnelingSettings.tsx
@@ -64,7 +64,9 @@ const StyledIcon = styled(Cell.UntintedIcon)(disabledApplication, {
 });
 
 const StyledCellLabel = styled(Cell.Label)(disabledApplication, {
+  fontFamily: 'Open Sans',
   fontWeight: 'normal',
+  fontSize: '16px',
 });
 
 const StyledIconPlaceholder = styled.div({

--- a/gui/src/renderer/components/RelayRow.tsx
+++ b/gui/src/renderer/components/RelayRow.tsx
@@ -21,6 +21,9 @@ const Button = styled(Cell.CellButton)((props: { selected: boolean }) => ({
 }));
 
 const Label = styled(Cell.Label)({
+  fontFamily: 'Open Sans',
+  fontWeight: 'normal',
+  fontSize: '16px',
   '[disabled] &': {
     color: colors.white20,
   },

--- a/gui/src/renderer/components/Selector.tsx
+++ b/gui/src/renderer/components/Selector.tsx
@@ -58,6 +58,12 @@ const StyledCellIcon = styled(Cell.Icon)((props: { visible: boolean }) => ({
   marginRight: '8px',
 }));
 
+const StyledLabel = styled(Cell.Label)({
+  fontFamily: 'Open Sans',
+  fontWeight: 'normal',
+  fontSize: '16px',
+});
+
 interface ISelectorCellProps<T> {
   value: T;
   selected: boolean;
@@ -80,7 +86,7 @@ export class SelectorCell<T> extends React.Component<ISelectorCellProps<T>> {
           height={24}
           tintColor={colors.white}
         />
-        <Cell.Label>{this.props.children}</Cell.Label>
+        <StyledLabel>{this.props.children}</StyledLabel>
       </Cell.CellButton>
     );
   }


### PR DESCRIPTION
This PR changes the font weight to "normal" in list item labels such as countries/cities/relays in `SelectLocation`, items in `Selector` and items in the the language selector.

![Screen Shot 2020-08-18 at 16 32 25](https://user-images.githubusercontent.com/3668602/90528738-439be400-e173-11ea-9c17-d0335d93d633.png)
![Screen Shot 2020-08-18 at 16 32 04](https://user-images.githubusercontent.com/3668602/90528729-426ab700-e173-11ea-97e1-a72fafcb0edf.png)

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1989)
<!-- Reviewable:end -->
