### PR TITLE
Update confirm no email dialog to match the desktop app

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmNoEmailDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmNoEmailDialogFragment.kt
@@ -9,6 +9,7 @@ import android.support.v4.app.DialogFragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
 import android.widget.Button
 import kotlinx.coroutines.CompletableDeferred
 import net.mullvad.mullvadvpn.R
@@ -50,6 +51,12 @@ class ConfirmNoEmailDialogFragment : DialogFragment() {
         dialog.window?.setBackgroundDrawable(ColorDrawable(android.R.color.transparent))
 
         return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        dialog?.window?.setLayout(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
     }
 
     override fun onDismiss(dialogInterface: DialogInterface) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmNoEmailDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmNoEmailDialogFragment.kt
@@ -47,7 +47,7 @@ class ConfirmNoEmailDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)
 
-        dialog.window?.apply { setBackgroundDrawable(ColorDrawable(android.R.color.transparent)) }
+        dialog.window?.setBackgroundDrawable(ColorDrawable(android.R.color.transparent))
 
         return dialog
     }

--- a/android/src/main/res/layout/confirm_no_email.xml
+++ b/android/src/main/res/layout/confirm_no_email.xml
@@ -17,15 +17,15 @@
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:layout_weight="0"
-                  android:layout_marginBottom="12dp"
+                  android:layout_marginTop="16dp"
                   android:textColor="@color/white80"
                   android:textSize="@dimen/text_medium"
                   android:text="@string/confirm_no_email" />
         <Button android:id="@+id/send_button"
+                android:layout_marginVertical="@dimen/button_separation"
                 android:text="@string/send_anyway"
                 style="@style/RedButton" />
         <Button android:id="@+id/back_button"
-                android:layout_marginTop="16dp"
                 android:text="@string/back"
                 style="@style/BlueButton" />
     </LinearLayout>

--- a/android/src/main/res/layout/confirm_no_email.xml
+++ b/android/src/main/res/layout/confirm_no_email.xml
@@ -19,7 +19,7 @@
                   android:layout_weight="0"
                   android:layout_marginTop="16dp"
                   android:textColor="@color/white80"
-                  android:textSize="@dimen/text_medium"
+                  android:textSize="@dimen/text_small"
                   android:text="@string/confirm_no_email" />
         <Button android:id="@+id/send_button"
                 android:layout_marginVertical="@dimen/button_separation"

--- a/android/src/main/res/layout/confirm_no_email.xml
+++ b/android/src/main/res/layout/confirm_no_email.xml
@@ -9,6 +9,11 @@
                   android:orientation="vertical"
                   android:gravity="left"
                   android:elevation="2dp">
+        <ImageView android:layout_width="44dp"
+                   android:layout_height="44dp"
+                   android:layout_marginTop="8dp"
+                   android:layout_gravity="center"
+                   android:src="@drawable/icon_alert" />
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:layout_weight="0"


### PR DESCRIPTION
This PR updates the dialog for the user to confirm that they want to send a problem report without a way for support to contact them back. The dialog now matches the dialog on the desktop app.

The major change is that the dialog now occupies the full width of the devices (with a side margin) and has a warning image above the text.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Relatively minor UI tweak, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1990)
<!-- Reviewable:end -->
