### PR TITLE
Fix IPC response serialisation on iOS < 13

### DIFF
--- a/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
@@ -65,7 +65,7 @@ class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
         }
     }
 
-    private func replyAppMessage<T: Encodable>(_ response: T, completionHandler: ((Data?) -> Void)?)
+    private func replyAppMessage<T: Codable>(_ response: T, completionHandler: ((Data?) -> Void)?)
     {
         switch PacketTunnelIpcHandler.encodeResponse(response: response) {
         case .success(let data):

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -337,7 +337,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - Private
 
-    private func replyAppMessage<T: Encodable>(
+    private func replyAppMessage<T: Codable>(
         _ result: Result<T, PacketTunnelProviderError>,
         completionHandler: ((Data?) -> Void)?) {
         let result = result.flatMap { (response) -> Result<Data, PacketTunnelProviderError> in


### PR DESCRIPTION
…mitive types without top level container

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

The JSON serialiser on iOS < 13 only supports arrays and objects as top-level elements. This PR wraps the IPC response in `PacketTunnelResponse<T>` generic container to satisfy such constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1994)
<!-- Reviewable:end -->
