### PR TITLE
Remove repeated strings resources on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -39,8 +39,8 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
             tunnelState = this@OutOfTimeFragment.tunnelState
         }
 
-        view.findViewById<TextView>(R.id.no_more_vpn_time_left).text =
-            parentActivity.getString(R.string.no_more_vpn_time_left) + " " +
+        view.findViewById<TextView>(R.id.account_credit_has_expired).text =
+            parentActivity.getString(R.string.account_credit_has_expired) + " " +
             parentActivity.getString(R.string.add_time_to_account)
 
         disconnectButton = view.findViewById<Button>(R.id.disconnect).apply {

--- a/android/src/main/res/layout/out_of_time.xml
+++ b/android/src/main/res/layout/out_of_time.xml
@@ -26,7 +26,7 @@
                       android:textSize="@dimen/text_huge"
                       android:textStyle="bold"
                       android:text="@string/out_of_time" />
-            <TextView android:id="@+id/no_more_vpn_time_left"
+            <TextView android:id="@+id/account_credit_has_expired"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
                       android:layout_marginHorizontal="@dimen/side_margin"

--- a/android/src/main/res/values-da/strings.xml
+++ b/android/src/main/res/values-da/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Konto oprettet</string>
+    <string name="account_credit_has_expired">Du har ikke mere VPN-tid tilbage på denne konto.</string>
     <string name="account_number">Kontonummer</string>
     <string name="account_url">https://mullvad.net/da/account</string>
     <string name="add_time_to_account">Køb enten kredit på vores hjemmeside, eller indløs en kupon.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Ugyldigt kontonummer</string>
     <string name="login_fail_title">Login mislykkedes</string>
     <string name="login_title">Log ind</string>
-    <string name="no_more_vpn_time_left">Du har ikke mere VPN-tid tilbage på denne konto.</string>
     <string name="no_wireguard_key">Gyldig WireGuard-nøgle mangler. Administrer nøgler under Avancerede indstillinger.</string>
     <string name="not_blocking_internet">DU LÆKKER MÅSKE NETVÆRKSTRAFIK</string>
     <string name="out_of_time">Tid udløbet</string>
     <string name="paid_until">Betalt indtil</string>
     <string name="pay_to_start_using">For at begynde at bruge appen skal du først føje tid til din konto.</string>
     <string name="problem_report_description">For at vi bedre kan hjælpe dig, bedes du vedhæfte din apps logfil til denne meddelelse. Dine data vil forblive sikre og private, da de anonymiseres, før de sendes via en krypteret kanal.</string>
+    <string name="public_key">Offentlig nøgle</string>
     <string name="quit">Luk app</string>
     <string name="reconnecting">Genopretter forbindelse</string>
     <string name="redeem">Indløs</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Administrer nøgler</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">Indstil WireGuard MTU-værdi. Gyldigt interval: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Offentlig nøgle</string>
     <string name="wireguard_replace_key">Regenerer nøgle</string>
     <string name="wireguard_verify_key">Bekræft nøgle</string>
 </resources>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Konto erstellt</string>
+    <string name="account_credit_has_expired">Sie haben keine VPN-Zeit mehr auf diesem Konto.</string>
     <string name="account_number">Kontonummer</string>
     <string name="account_url">https://mullvad.net/de/account</string>
     <string name="add_time_to_account">Kaufen Sie entweder Guthaben über unsere Seite oder lösen Sie einen Gutschein ein.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Ungültige Kontonummer</string>
     <string name="login_fail_title">Anmeldung fehlgeschlagen</string>
     <string name="login_title">Anmelden</string>
-    <string name="no_more_vpn_time_left">Sie haben keine VPN-Zeit mehr auf diesem Konto.</string>
     <string name="no_wireguard_key">Gültiger WireGuard-Schlüssel fehlt. Sie können Ihre Schlüssel in den erweiterten Einstellungen verwalten.</string>
     <string name="not_blocking_internet">IHR NETZVERKEHR KÖNNTE UNSICHER SEIN</string>
     <string name="out_of_time">Zeit abgelaufen</string>
     <string name="paid_until">Bezahlt bis</string>
     <string name="pay_to_start_using">Um mit der Nutzung dieser App zu beginnen, müssen Sie erst einmal Zeit zu Ihrem Konto hinzufügen.</string>
     <string name="problem_report_description">Damit wir Ihnen besser helfen können, wird die Protokolldatei Ihrer App an diese Nachricht angehängt. Ihre Daten bleiben sicher und privat, da sie vor dem Senden über einen verschlüsselten Kanal anonymisiert werden.</string>
+    <string name="public_key">Öffentlicher Schlüssel</string>
     <string name="quit">App beenden</string>
     <string name="reconnecting">Wiederherstellen der Verbindung</string>
     <string name="redeem">Einlösen</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Schlüssel verwalten</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">WireGuard MTU-Wert einstellen. Gültiger Bereich: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Öffentlicher Schlüssel</string>
     <string name="wireguard_replace_key">Schlüssel neu generieren</string>
     <string name="wireguard_verify_key">Schlüssel verifizieren</string>
 </resources>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Cuenta creada</string>
+    <string name="account_credit_has_expired">No queda tiempo de uso de VPN en la cuenta.</string>
     <string name="account_number">Número de cuenta</string>
     <string name="account_url">https://mullvad.net/es/account</string>
     <string name="add_time_to_account">Compre crédito en nuestro sitio web o canjee un cupón.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Número de cuenta no válido</string>
     <string name="login_fail_title">Error de inicio de sesión</string>
     <string name="login_title">Iniciar sesión</string>
-    <string name="no_more_vpn_time_left">No queda tiempo de uso de VPN en la cuenta.</string>
     <string name="no_wireguard_key">Falta una clave de WireGuard válida. Administre las claves en la Configuración avanzada.</string>
     <string name="not_blocking_internet">PUEDE QUE SE ESTÉ FILTRANDO SU TRÁFICO DE RED</string>
     <string name="out_of_time">Tiempo agotado</string>
     <string name="paid_until">Pagado hasta</string>
     <string name="pay_to_start_using">Para empezar a usar la aplicación, primero necesita agregar tiempo a su cuenta.</string>
     <string name="problem_report_description">Para ayudarle de una forma más eficiente, se adjuntará el archivo de registro de la aplicación a este mensaje. Sus datos permanecerán protegidos y privados, ya que se anonimizan antes de enviarse a través de un canal cifrado.</string>
+    <string name="public_key">Clave pública</string>
     <string name="quit">Salir de la aplicación</string>
     <string name="reconnecting">Volviendo a establecer la conexión</string>
     <string name="redeem">Canjear</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Administrar claves</string>
     <string name="wireguard_mtu">MTU de WireGuard</string>
     <string name="wireguard_mtu_footer">Establezca el valor de MTU de WireGuard. Intervalo válido: %1$d-%2$d.</string>
-    <string name="wireguard_public_key">Clave pública</string>
     <string name="wireguard_replace_key">Volver a generar clave</string>
     <string name="wireguard_verify_key">Verificar clave</string>
 </resources>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Tili luotu</string>
+    <string name="account_credit_has_expired">Sinulla ei ole enempää VPN-aikaa jäljellä tällä tilillä.</string>
     <string name="account_number">Tilin numero</string>
     <string name="account_url">https://mullvad.net/fi/account</string>
     <string name="add_time_to_account">Osta käyttöaikaa verkkosivustoltamme tai lunasta kuponki.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Virheellinen tilin numero</string>
     <string name="login_fail_title">Sisäänkirjautuminen epäonnistui</string>
     <string name="login_title">Kirjaudu sisään</string>
-    <string name="no_more_vpn_time_left">Sinulla ei ole enempää VPN-aikaa jäljellä tällä tilillä.</string>
     <string name="no_wireguard_key">Validi WireGuard-avain puuttuu. Hallinnoi avaimia lisäasetuksissa.</string>
     <string name="not_blocking_internet">VERKKOLIIKENTEESI SAATTAA VUOTAA</string>
     <string name="out_of_time">Ei käyttöaikaa</string>
     <string name="paid_until">Maksu ennen</string>
     <string name="pay_to_start_using">Voit aloittaa sovelluksen käyttämisen lisäämällä ensin aikaa tilillesi.</string>
     <string name="problem_report_description">Jotta voimme olla avuksi parhaamme mukaan, sovelluksesi lokitiedosto liitetään tähän viestiin. Tietosi pysyvät suojattuina ja yksityisinä, ja ne anonymisoidaan salatun kanavan kautta ennen lähetystä.</string>
+    <string name="public_key">Julkinen avain</string>
     <string name="quit">Lopeta</string>
     <string name="reconnecting">Yhdistetään uudelleen</string>
     <string name="redeem">Lunasta</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Hallitse avaimia</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">Aseta WireGuardin MTU-arvo väliltä %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Julkinen avain</string>
     <string name="wireguard_replace_key">Luo uusi avain</string>
     <string name="wireguard_verify_key">Todenna avain</string>
 </resources>

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Compte créé</string>
+    <string name="account_credit_has_expired">Vous n\'avez plus de temps de VPN sur ce compte.</string>
     <string name="account_number">Numéro de compte</string>
     <string name="account_url">https://mullvad.net/fr/account</string>
     <string name="add_time_to_account">Achetez du crédit sur notre site web ou échangez un bon.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Numéro de compte non valide</string>
     <string name="login_fail_title">Échec de la connexion</string>
     <string name="login_title">Connexion</string>
-    <string name="no_more_vpn_time_left">Vous n\'avez plus de temps de VPN sur ce compte.</string>
     <string name="no_wireguard_key">Une clé wireguard valide manque. Gérez les clés dans les paramètre avancés.</string>
     <string name="not_blocking_internet">VOUS POURRIEZ AVOIR DES FUITES DE TRAFIC RÉSEAU</string>
     <string name="out_of_time">Plus de temps</string>
     <string name="paid_until">Payé jusqu\'au</string>
     <string name="pay_to_start_using">Pour commencer à utiliser l\'application, vous devez d\'abord ajouter du temps à votre compte.</string>
     <string name="problem_report_description">Pour mieux vous aider, le fichier journal de l\'application est joint à ce message. Vos données restent privées et en sécurité dans la mesure où elles sont rendues anonymes avant d\'être envoyées via un canal chiffré.</string>
+    <string name="public_key">Clé publique</string>
     <string name="quit">Quitter l\'application</string>
     <string name="reconnecting">Reconnexion</string>
     <string name="redeem">Échanger</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Gérer les clés</string>
     <string name="wireguard_mtu">MTU WireGuard</string>
     <string name="wireguard_mtu_footer">Définir la valeur MTU WireGuard. Plage valide : %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Clé publique</string>
     <string name="wireguard_replace_key">Regénérer la clé</string>
     <string name="wireguard_verify_key">Vérifier la clé</string>
 </resources>

--- a/android/src/main/res/values-it/strings.xml
+++ b/android/src/main/res/values-it/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Account creato</string>
+    <string name="account_credit_has_expired">Hai esaurito il tempo VPN su questo account.</string>
     <string name="account_number">Numero di account</string>
     <string name="account_url">https://mullvad.net/it/account</string>
     <string name="add_time_to_account">Acquista credito sul nostro sito web o riscatta un voucher.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Numero di account non valido</string>
     <string name="login_fail_title">Accesso non riuscito</string>
     <string name="login_title">Accedi</string>
-    <string name="no_more_vpn_time_left">Hai esaurito il tempo VPN su questo account.</string>
     <string name="no_wireguard_key">Manca una chiave WireGuard valida. Gestisci le chiavi da Impostazioni avanzate.</string>
     <string name="not_blocking_internet">POSSIBILI PERDITE NEL TRAFFICO DI RETE</string>
     <string name="out_of_time">Scaduto</string>
     <string name="paid_until">Pagato fino al</string>
     <string name="pay_to_start_using">Per iniziare a utilizzare l\'app, devi prima aggiungere tempo al tuo account.</string>
     <string name="problem_report_description">Per aiutarti in modo più efficace, il file di registro della tua app sarà allegato a questo messaggio. I tuoi dati rimarranno protetti e privati, e saranno anonimizzati prima di essere inviati tramite un canale crittografato.</string>
+    <string name="public_key">Chiave pubblica</string>
     <string name="quit">Esci dall\'app</string>
     <string name="reconnecting">Riconnessione</string>
     <string name="redeem">Riscatta</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Gestisci chiavi</string>
     <string name="wireguard_mtu">MTU WireGuard</string>
     <string name="wireguard_mtu_footer">Imposta il valore MTU WireGuard. Intervallo valido: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Chiave pubblica</string>
     <string name="wireguard_replace_key">Rigenera chiave</string>
     <string name="wireguard_verify_key">Verifica chiave</string>
 </resources>

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">アカウントを作成しました</string>
+    <string name="account_credit_has_expired">このアカウントには、もう残っているVPN時間がありません。</string>
     <string name="account_number">アカウント番号</string>
     <string name="account_url">https://mullvad.net/ja/account</string>
     <string name="add_time_to_account">当社ウェブサイトでクレジットを購入するか、バウチャーを使用してください。</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">アカウント番号が正しくありません</string>
     <string name="login_fail_title">ログインに失敗しました</string>
     <string name="login_title">ログイン</string>
-    <string name="no_more_vpn_time_left">このアカウントには、もう残っているVPN時間がありません。</string>
     <string name="no_wireguard_key">有効なWireGuard鍵が見つかりません。詳細設定で鍵を管理してください。</string>
     <string name="not_blocking_internet">ネットワーク通信が漏洩している可能性があります。</string>
     <string name="out_of_time">時間切れ</string>
     <string name="paid_until">次の日時まで支払い済み</string>
     <string name="pay_to_start_using">アプリを使い始めるには、まずはアカウントに時間を追加する必要があります。</string>
     <string name="problem_report_description">さらに効率よく問題解決を支援するため、お使いのアプリのログファイルをこのメッセージに添付します。個人データは匿名化された後に暗号化されたチャネルで送信されるため、その安全性は維持され、公開されることはありません。</string>
+    <string name="public_key">公開鍵</string>
     <string name="quit">アプリを終了する</string>
     <string name="reconnecting">再接続中</string>
     <string name="redeem">使用する</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">鍵を管理</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">WireGuard MTU の値を設定します。有効範囲：%1$d ～ %2$d</string>
-    <string name="wireguard_public_key">公開鍵</string>
     <string name="wireguard_replace_key">鍵を生成</string>
     <string name="wireguard_verify_key">鍵を検証</string>
 </resources>

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">계정 생성됨</string>
+    <string name="account_credit_has_expired">이 계정에 더 이상 VPN 시간이 없습니다.</string>
     <string name="account_number">계정 번호</string>
     <string name="account_url">https://mullvad.net/ko/account</string>
     <string name="add_time_to_account">웹 사이트에서 크레딧을 구매하거나 바우처를 사용하세요.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">유효하지 않은 계정 번호</string>
     <string name="login_fail_title">로그인 실패</string>
     <string name="login_title">로그인</string>
-    <string name="no_more_vpn_time_left">이 계정에 더 이상 VPN 시간이 없습니다.</string>
     <string name="no_wireguard_key">유효한 WireGuard 키가 없습니다. 고급 설정에서 키를 관리하세요.</string>
     <string name="not_blocking_internet">네트워크 트래픽이 유출될 수 있음</string>
     <string name="out_of_time">시간 초과</string>
     <string name="paid_until">유효 기간</string>
     <string name="pay_to_start_using">앱 사용을 시작하려면, 먼저 계정에 시간을 추가해야 합니다.</string>
     <string name="problem_report_description">효과적인 문제 해결을 위해 앱의 로그 파일이 이 메시지에 첨부됩니다. 사용자 데이터는 암호화된 채널을 통해 전송되기 전에 익명 처리되므로 안전하고 비공개로 유지됩니다.</string>
+    <string name="public_key">공개 키</string>
     <string name="quit">앱 종료</string>
     <string name="reconnecting">다시 연결 중</string>
     <string name="redeem">사용</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">키 관리</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">WireGuard MTU 값을 설정하세요. 유효 범위: %1$d ~ %2$d.</string>
-    <string name="wireguard_public_key">공개 키</string>
     <string name="wireguard_replace_key">키 다시 생성</string>
     <string name="wireguard_verify_key">키 확인</string>
 </resources>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Konto opprettet</string>
+    <string name="account_credit_has_expired">Du har ikke mer VPN-tid igjen på kontoen.</string>
     <string name="account_number">Kontonummer</string>
     <string name="account_url">https://mullvad.net/nb/account</string>
     <string name="add_time_to_account">Du kan enten kjøpe kreditt på nettsiden vår eller løse inn en kupong.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Ugyldig kontonummer</string>
     <string name="login_fail_title">Kunne ikke logge inn</string>
     <string name="login_title">Logg inn</string>
-    <string name="no_more_vpn_time_left">Du har ikke mer VPN-tid igjen på kontoen.</string>
     <string name="no_wireguard_key">Det mangler en gyldig WireGuard-nøkkel. Du kan behandle nøklene under avanserte innstillinger.</string>
     <string name="not_blocking_internet">DET KAN VÆRE EN NETTVERKSLEKKASJE HOS DEG</string>
     <string name="out_of_time">Tiden har utløpt</string>
     <string name="paid_until">Betalt fram til</string>
     <string name="pay_to_start_using">For å starte bruken av appen, må du først legge til tid til kontoen.</string>
     <string name="problem_report_description">For å kunne gi deg god nok hjelp vil loggfilen til appen ligge som vedlegg til meldingen. All data forblir beskyttet og privat gjennom anonymisering før det sendes gjennom en kryptert kanal.</string>
+    <string name="public_key">Offentlig nøkkel</string>
     <string name="quit">Lukk app</string>
     <string name="reconnecting">Kobler til på nytt</string>
     <string name="redeem">Løs inn</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Behandle nøkler</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">Angi WireGuard MTU-verdi. Verdiområde: %1$d-%2$d.</string>
-    <string name="wireguard_public_key">Offentlig nøkkel</string>
     <string name="wireguard_replace_key">Generer nøkkel på nytt</string>
     <string name="wireguard_verify_key">Bekreft nøkkel</string>
 </resources>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Account aangemaakt</string>
+    <string name="account_credit_has_expired">U hebt geen VPN-tijd meer op dit account.</string>
     <string name="account_number">Accountnummer</string>
     <string name="account_url">https://mullvad.net/nl/account</string>
     <string name="add_time_to_account">Koop krediet op onze website of wissel een voucher in.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Ongeldig accountnummer</string>
     <string name="login_fail_title">Aanmelden mislukt</string>
     <string name="login_title">Aanmelden</string>
-    <string name="no_more_vpn_time_left">U hebt geen VPN-tijd meer op dit account.</string>
     <string name="no_wireguard_key">Geldige WireGuard-sleutel ontbreekt. Beheer sleutels onder Geavanceerde instellingen.</string>
     <string name="not_blocking_internet">U LEKT MOGELIJK NETWERKVERKEER</string>
     <string name="out_of_time">Geen tijd meer</string>
     <string name="paid_until">Betaald tot</string>
     <string name="pay_to_start_using">Om de app te gebruiken, moet u eerst tijd toevoegen aan uw account.</string>
     <string name="problem_report_description">Het logboekbestand van uw app wordt aan dit bericht gekoppeld zodat we u beter kunnen helpen. Uw gegevens blijven veilig en privé, omdat ze worden geanonimiseerd voordat ze over een versleuteld kanaal worden verzonden.</string>
+    <string name="public_key">Openbare sleutel</string>
     <string name="quit">App afsluiten</string>
     <string name="reconnecting">Opnieuw verbinden</string>
     <string name="redeem">Inwisselen</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Sleutels beheren</string>
     <string name="wireguard_mtu">WireGuard-MTU</string>
     <string name="wireguard_mtu_footer">Stel de WireGuard MTU-waarde in. Geldig bereik: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Openbare sleutel</string>
     <string name="wireguard_replace_key">Sleutel opnieuw genereren</string>
     <string name="wireguard_verify_key">Sleutel verifiëren</string>
 </resources>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Utworzono konto</string>
+    <string name="account_credit_has_expired">Na tym koncie nie masz już czasu VPN.</string>
     <string name="account_number">Numer konta</string>
     <string name="account_url">https://mullvad.net/pl/account</string>
     <string name="add_time_to_account">Doładuj w naszej witrynie internetowej lub zrealizuj kupon.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Nieprawidłowy numer konta</string>
     <string name="login_fail_title">Błąd logowania</string>
     <string name="login_title">Logowanie</string>
-    <string name="no_more_vpn_time_left">Na tym koncie nie masz już czasu VPN.</string>
     <string name="no_wireguard_key">Brak prawidłowego klucza WireGuard. Zarządzaj kluczami w obszarze Ustawienia zaawansowane.</string>
     <string name="not_blocking_internet">TWÓJ RUCH SIECIOWY MOŻE WYCIEKAĆ</string>
     <string name="out_of_time">Koniec czasu</string>
     <string name="paid_until">Płatne do</string>
     <string name="pay_to_start_using">Aby rozpocząć korzystanie z aplikacji, musisz najpierw dodać czas do swojego konta.</string>
     <string name="problem_report_description">Aby pomóc Ci skuteczniej, do tej wiadomości dołączony zostanie plik dzienników aplikacji. Twoje dane pozostaną bezpieczne i prywatne, ponieważ przed wysłaniem zaszyfrowanym kanałem zostają one zanonimizowane.</string>
+    <string name="public_key">Klucz publiczny</string>
     <string name="quit">Zamknij aplikację</string>
     <string name="reconnecting">Ponowne łączenie</string>
     <string name="redeem">Zrealizuj</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Zarządzaj kluczami</string>
     <string name="wireguard_mtu">MTU WireGuard</string>
     <string name="wireguard_mtu_footer">Ustaw wartość MTU WireGuard. Prawidłowy zakres: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Klucz publiczny</string>
     <string name="wireguard_replace_key">Ponownie wygeneruj klucz</string>
     <string name="wireguard_verify_key">Zweryfikuj klucz</string>
 </resources>

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Conta criada</string>
+    <string name="account_credit_has_expired">Não tem mais Tempo de VPN restante nesta conta.</string>
     <string name="account_number">Número de conta</string>
     <string name="account_url">https://mullvad.net/pt/account</string>
     <string name="add_time_to_account">Compre crédito no nosso sítio da web ou reclame um voucher.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Número de conta inválido</string>
     <string name="login_fail_title">Erro ao iniciar sessão</string>
     <string name="login_title">Iniciar sessão</string>
-    <string name="no_more_vpn_time_left">Não tem mais Tempo de VPN restante nesta conta.</string>
     <string name="no_wireguard_key">Chave WireGuard válida em falta. Faça a gestão das chaves em Definições Avançadas.</string>
     <string name="not_blocking_internet">PODERÁ ESTAR A PERDER TRÁFEGO DE REDE</string>
     <string name="out_of_time">Sem tempo</string>
     <string name="paid_until">Pago até</string>
     <string name="pay_to_start_using">Para começar a utilizar a aplicação, primeiro tem de adicionar tempo à sua conta.</string>
     <string name="problem_report_description">Para o ajudarmos de forma mais eficaz, o ficheiro de registo da sua aplicação será anexado a esta mensagem. Os seus dados permanecerão seguros e privados, pois são tornados anónimos antes de serem enviados através de um canal encriptado.</string>
+    <string name="public_key">Chave pública</string>
     <string name="quit">Sair da app</string>
     <string name="reconnecting">A religar</string>
     <string name="redeem">Reclamar</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Gerir chaves</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">Definir o valor WireGuard MTU. Intervalo válido: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Chave pública</string>
     <string name="wireguard_replace_key">Voltar a gerar chave</string>
     <string name="wireguard_verify_key">Verificar chave</string>
 </resources>

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Учетная запись создана</string>
+    <string name="account_credit_has_expired">На этой учетной записи времени VPN не осталось.</string>
     <string name="account_number">Номер учетной записи</string>
     <string name="account_url">https://mullvad.net/ru/account</string>
     <string name="add_time_to_account">Пополните баланс у нас на сайте или погасите ваучер.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Недействительный номер учетной записи</string>
     <string name="login_fail_title">Ошибка входа</string>
     <string name="login_title">Вход</string>
-    <string name="no_more_vpn_time_left">На этой учетной записи времени VPN не осталось.</string>
     <string name="no_wireguard_key">Не найден корректный ключ WireGuard. Управлять ключами можно в разделе «Дополнительные настройки».</string>
     <string name="not_blocking_internet">ВОЗМОЖНА УТЕЧКА СЕТЕВОГО ТРАФИКА</string>
     <string name="out_of_time">Закончилось время</string>
     <string name="paid_until">Оплачено до</string>
     <string name="pay_to_start_using">Чтобы пользоваться приложением, нужно добавить время на учетную запись.</string>
     <string name="problem_report_description">Чтобы помощь была эффективнее, к этому сообщению будет прикреплен файл журнала из приложения. Ваши данные останутся защищенными и конфиденциальными: они обезличиваются и отправляются по зашифрованному каналу.</string>
+    <string name="public_key">Открытый ключ</string>
     <string name="quit">Выйти из приложения</string>
     <string name="reconnecting">Идет переподключение</string>
     <string name="redeem">Погасить</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Управление ключами</string>
     <string name="wireguard_mtu">MTU для WireGuard</string>
     <string name="wireguard_mtu_footer">Установить значение MTU для WireGuard. Диапазон значений: %1$d–%2$d.</string>
-    <string name="wireguard_public_key">Открытый ключ</string>
     <string name="wireguard_replace_key">Повторно сгенерировать ключ</string>
     <string name="wireguard_verify_key">Проверка ключа</string>
 </resources>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Kontot har skapats</string>
+    <string name="account_credit_has_expired">Du har ingen VPN-tid kvar på det här kontot.</string>
     <string name="account_number">Kontonummer</string>
     <string name="account_url">https://mullvad.net/sv/account</string>
     <string name="add_time_to_account">Du kan antingen köpa kredit på vår webbplats eller lösa in en kupong.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Ogiltigt kontonummer</string>
     <string name="login_fail_title">Inloggningen misslyckades</string>
     <string name="login_title">Logga in</string>
-    <string name="no_more_vpn_time_left">Du har ingen VPN-tid kvar på det här kontot.</string>
     <string name="no_wireguard_key">Giltig WireGuard-nyckel saknas. Hantera nycklar i avancerade inställningar.</string>
     <string name="not_blocking_internet">DU KANSKE HAR LÄCKAGE I NÄTVERKSTRAFIKEN</string>
     <string name="out_of_time">Ingen tid kvar</string>
     <string name="paid_until">Betalat till</string>
     <string name="pay_to_start_using">Om du vill börja använda appen måste du först lägga till tid i ditt konto.</string>
     <string name="problem_report_description">För att hjälpa dig mer effektivt kommer appens loggfil att bifogas i detta meddelande. Dina uppgifter förblir säkra och privata, eftersom de anonymiseras innan de skickas över en krypterad kanal.</string>
+    <string name="public_key">Offentlig nyckel</string>
     <string name="quit">Avsluta appen</string>
     <string name="reconnecting">Återansluter</string>
     <string name="redeem">Lös in</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Hantera nycklar</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">Ange WireGuard MTU-värde. Giltigt intervall: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Offentlig nyckel</string>
     <string name="wireguard_replace_key">Generera om nyckel</string>
     <string name="wireguard_verify_key">Verifiera nyckel</string>
 </resources>

--- a/android/src/main/res/values-th/strings.xml
+++ b/android/src/main/res/values-th/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">สร้างบัญชีแล้ว</string>
+    <string name="account_credit_has_expired">คุณไม่มีเวลาใช้งาน VPN เหลืออยู่ในบัญชีนี้แล้ว</string>
     <string name="account_number">หมายเลขบัญชี</string>
     <string name="account_url">https://mullvad.net/th/account</string>
     <string name="add_time_to_account">ซื้อเครดิตบนเว็บไซต์ของเรา หรือแลกรับบัตรกำนัล</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">หมายเลขบัญชีไม่ถูกต้อง</string>
     <string name="login_fail_title">การเข้าสู่ระบบล้มเหลว</string>
     <string name="login_title">เข้าสู่ระบบ</string>
-    <string name="no_more_vpn_time_left">คุณไม่มีเวลาใช้งาน VPN เหลืออยู่ในบัญชีนี้แล้ว</string>
     <string name="no_wireguard_key">ไม่มีคีย์ WireGuard ที่ถูกต้อง โปรดจัดการคีย์ภายใต้ส่วนการตั้งค่าขั้นสูง</string>
     <string name="not_blocking_internet">คุณอาจมีการรับส่งข้อมูลทางเครือข่ายที่รั่วไหลอยู่ในขณะนี้</string>
     <string name="out_of_time">หมดเวลา</string>
     <string name="paid_until">ชำระเงินแล้วจนถึง</string>
     <string name="pay_to_start_using">คุณจำเป็นต้องเพิ่มเวลาไปยังบัญชีของคุณก่อน เพื่อที่จะเริ่มใช้งานแอป</string>
     <string name="problem_report_description">ไฟล์บันทึกในแอปของคุณจะแนบไปกับข้อความนี้ เพื่อที่เราจะสามารถช่วยเหลือคุณได้อย่างมีประสิทธิภาพมากขึ้น ข้อมูลของคุณจะยังคงมีความปลอดภัยและเป็นส่วนตัว เพราะจะไม่มีการระบุตัวตนก่อนส่งข้อมูลผ่านช่องทางที่มีการเข้ารหัส</string>
+    <string name="public_key">คีย์สาธารณะ</string>
     <string name="quit">ออกจากแอป</string>
     <string name="reconnecting">กำลังเชื่อมต่อใหม่</string>
     <string name="redeem">แลกรับ</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">จัดการคีย์</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">ตั้งค่า WireGuard MTU ช่วงที่ใช้ได้: %1$d - %2$d</string>
-    <string name="wireguard_public_key">คีย์สาธารณะ</string>
     <string name="wireguard_replace_key">สร้างคีย์ใหม่</string>
     <string name="wireguard_verify_key">ตรวจสอบคีย์</string>
 </resources>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">Hesap oluşturuldu</string>
+    <string name="account_credit_has_expired">Bu hesap için artık VPN süreniz kalmadı.</string>
     <string name="account_number">Hesap Kimliği</string>
     <string name="account_url">https://mullvad.net/tr/account</string>
     <string name="add_time_to_account">Web sitemizden kredi satın alın veya kupon kullanın.</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">Geçersiz hesap numarası</string>
     <string name="login_fail_title">Oturum açma başarısız</string>
     <string name="login_title">Oturum Aç</string>
-    <string name="no_more_vpn_time_left">Bu hesap için artık VPN süreniz kalmadı.</string>
     <string name="no_wireguard_key">Geçerli WireGuard anahtarı eksik. Gelişmiş ayarlardan anahtarları yönetin.</string>
     <string name="not_blocking_internet">AĞ TRAFİĞİNİZDE SIZINTI OLABİLİR</string>
     <string name="out_of_time">Süre doldu</string>
     <string name="paid_until">Şu tarihe kadar ödendi:</string>
     <string name="pay_to_start_using">Uygulamayı kullanmaya başlamak için önce hesabınıza süre eklemeniz gerekir.</string>
     <string name="problem_report_description">Size daha etkin bir şekilde yardımcı olmak için uygulamanızın günlük dosyası bu mesaja eklenecektir. Verileriniz şifrelenmiş bir kanal üzerinden gönderilmeden önce anonimleştirildiği için güvenli ve gizli kalacaktır.</string>
+    <string name="public_key">Genel anahtar</string>
     <string name="quit">Uygulamadan çık</string>
     <string name="reconnecting">Yeniden Bağlanılıyor</string>
     <string name="redeem">Kullan</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">Anahtarları yönet</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">WireGuard MTU değerini ayarlayın. Geçerli aralık: %1$d - %2$d.</string>
-    <string name="wireguard_public_key">Genel anahtar</string>
     <string name="wireguard_replace_key">Yeniden anahtar oluştur</string>
     <string name="wireguard_verify_key">Anahtarı doğrula</string>
 </resources>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">已创建帐户</string>
+    <string name="account_credit_has_expired">此帐户没有更多的 VPN 时间了。</string>
     <string name="account_number">帐号</string>
     <string name="add_time_to_account">在我们的网站上购买额度或兑换优惠券。</string>
     <string name="allow_lan_footer">允许访问同一个网络上的其他设备以进行共享和打印等。</string>
@@ -48,13 +49,13 @@
     <string name="login_fail_description">帐号无效</string>
     <string name="login_fail_title">登录失败</string>
     <string name="login_title">登录</string>
-    <string name="no_more_vpn_time_left">此帐户没有更多的 VPN 时间了。</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 密钥。在“高级”设置下管理密钥。</string>
     <string name="not_blocking_internet">您的网络流量可能在泄露</string>
     <string name="out_of_time">已没有时间</string>
     <string name="paid_until">到期时间</string>
     <string name="pay_to_start_using">要开始使用本应用，您首先需要向帐户中充入时间。</string>
     <string name="problem_report_description">为了更有效地帮助您，您应用的日志文件将附加到此消息。您的数据将保持安全和私密，因为所有数据在发送之前都将通过加密通道进行匿名处理。</string>
+    <string name="public_key">公钥</string>
     <string name="quit">退出应用</string>
     <string name="reconnecting">正在重新连接</string>
     <string name="redeem">兑换</string>
@@ -103,7 +104,6 @@
     <string name="wireguard_manage_keys">管理密钥</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">设置 WireGuard MTU 值。有效范围：%1$d - %2$d。</string>
-    <string name="wireguard_public_key">公钥</string>
     <string name="wireguard_replace_key">重新生成密钥</string>
     <string name="wireguard_verify_key">验证密钥</string>
 </resources>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_created">已建立帳戶</string>
+    <string name="account_credit_has_expired">您這個帳戶已經沒有剩餘的 VPN 時間了。</string>
     <string name="account_number">帳戶編號</string>
     <string name="account_url">https://mullvad.net/zh-hant/account</string>
     <string name="add_time_to_account">在我們網站上購買點數或兌換憑證。</string>
@@ -51,13 +52,13 @@
     <string name="login_fail_description">帳號無效</string>
     <string name="login_fail_title">登入失敗</string>
     <string name="login_title">登入</string>
-    <string name="no_more_vpn_time_left">您這個帳戶已經沒有剩餘的 VPN 時間了。</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 金鑰。在「進階」設定下管理金鑰。</string>
     <string name="not_blocking_internet">您的網路流量可能正在洩露</string>
     <string name="out_of_time">逾時</string>
     <string name="paid_until">支付至</string>
     <string name="pay_to_start_using">需先在帳戶中加時，才能開始使用本應用程式。</string>
     <string name="problem_report_description">為了更有效協助您，會將應用程式的日誌檔將附加到此郵件。您的資料會保持安全和私密性，因為這些資料會先經過匿名處理，再透過加密通道傳送。</string>
+    <string name="public_key">公開金鑰</string>
     <string name="quit">退出應用程式</string>
     <string name="reconnecting">正在重新連線</string>
     <string name="redeem">兌換</string>
@@ -106,7 +107,6 @@
     <string name="wireguard_manage_keys">管理金鑰</string>
     <string name="wireguard_mtu">WireGuard MTU</string>
     <string name="wireguard_mtu_footer">設定 WireGuard MTU 值。有效範圍：%1$d - %2$d。</string>
-    <string name="wireguard_public_key">公開金鑰</string>
     <string name="wireguard_replace_key">重新產生金鑰</string>
     <string name="wireguard_verify_key">驗證金鑰</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -158,7 +158,7 @@
     <string name="wireguard_key_valid">Key is valid</string>
     <string name="wireguard_key_invalid">Key is invalid</string>
     <string name="wireguard_key_verification_failure">Key verification failed</string>
-    <string name="wireguard_public_key">Public key</string>
+    <string name="wireguard_public_key">WireGuard public key</string>
     <string name="copied_wireguard_public_key">Copied WireGuard public key to clipboard</string>
     <string name="split_tunnelling">Split tunnelling</string>
     <string name="split_tunnelling_description">Split tunnelling makes it possible to select which

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -49,7 +49,6 @@
     <string name="account_credit_has_expired">You have no more VPN time left on this
     account.</string>
     <string name="out_of_time">Out of time</string>
-    <string name="no_more_vpn_time_left">You have no more VPN time left on this account.</string>
     <string name="add_time_to_account">Either buy credit on our website or redeem a
     voucher.</string>
     <string name="settings_preferences">Preferences</string>

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -38,14 +38,26 @@ fn main() {
 
     string_resources.normalize();
 
-    let (known_urls, known_strings): (HashMap<_, _>, _) = string_resources
-        .into_iter()
-        .map(|string| {
-            let android_id = string.name;
+    let mut known_urls = HashMap::with_capacity(string_resources.len());
+    let mut known_strings = HashMap::with_capacity(string_resources.len());
 
-            (string.value, android_id)
-        })
-        .partition(|(string_value, _)| string_value.starts_with("https://mullvad.net/en/"));
+    for string in string_resources {
+        let destination = if string.value.starts_with("https://mullvad.net/en/") {
+            &mut known_urls
+        } else {
+            &mut known_strings
+        };
+
+        if destination
+            .insert(string.value.clone(), string.name)
+            .is_some()
+        {
+            panic!(
+                "String {:?} has more than one Android resource ID",
+                string.value
+            );
+        }
+    }
 
     let mut missing_translations = known_strings.clone();
 


### PR DESCRIPTION
Some string resources on Android had more than one ID, which meant that translations didn't work for them. This PR updates the translation conversion tool to report such issues, and fixes the two issues that were previously present.

One of the strings was repeated because one variant was used in the UI and another was used as meta-data for the clipboard. The meta-data for the clipboard was updated to be clearer.

The other string was repeated due to a refactor which split a long string in two and created a new resource for the first part instead of reusing the previously existing resource.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. *Minor UI tweak, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1996)
<!-- Reviewable:end -->
