### PR TITLE
Remove In/Out address string resource parameters

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
@@ -104,17 +104,14 @@ class LocationInfo(val parentView: View, val context: Context) {
 
     private fun showInAddress(endpoint: Endpoint?) {
         if (endpoint != null) {
-            val transportProtocol = when (endpoint.protocol) {
+            val host = endpoint.address.address.hostAddress
+            val port = endpoint.address.port
+            val protocol = when (endpoint.protocol) {
                 TransportProtocol.Tcp -> context.getString(R.string.tcp)
                 TransportProtocol.Udp -> context.getString(R.string.udp)
             }
 
-            inAddress.text = context.getString(
-                R.string.in_address,
-                endpoint.address.address.hostAddress,
-                endpoint.address.port,
-                transportProtocol
-            )
+            inAddress.text = context.getString(R.string.in_address) + "  $host:$port $protocol"
         } else {
             inAddress.text = ""
         }
@@ -136,7 +133,7 @@ class LocationInfo(val parentView: View, val context: Context) {
                 ipAddress = "${ipv4.hostAddress} / ${ipv6.hostAddress}"
             }
 
-            outAddress.text = context.getString(R.string.out_address, ipAddress)
+            outAddress.text = context.getString(R.string.out_address) + "  $ipAddress"
         } else {
             outAddress.text = ""
         }

--- a/android/src/main/res/values-da/strings.xml
+++ b/android/src/main/res/values-da/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Du skal muligvis vende tilbage til appens hovedskærm og klikke på Afbryd forbindelse, før du prøver igen. Bare rolig, de angivne oplysninger bliver ikke slettet fra formularen.</string>
     <string name="here_is_your_account_number">Her er dit kontonummer. Gem det!</string>
     <string name="hint_default">Default (Standardværdi)</string>
+    <string name="in_address">Ind</string>
     <string name="invalid_voucher">Kuponkode er ugyldig.</string>
     <string name="is_offline">Denne enhed er offline, ingen tunneler kan etableres</string>
     <string name="local_network_sharing">Lokal netværksdeling</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Log ind</string>
     <string name="no_wireguard_key">Gyldig WireGuard-nøgle mangler. Administrer nøgler under Avancerede indstillinger.</string>
     <string name="not_blocking_internet">DU LÆKKER MÅSKE NETVÆRKSTRAFIK</string>
+    <string name="out_address">Ud</string>
     <string name="out_of_time">Tid udløbet</string>
     <string name="paid_until">Betalt indtil</string>
     <string name="pay_to_start_using">For at begynde at bruge appen skal du først føje tid til din konto.</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Möglicherweise müssen Sie zum Hauptbildschirm der App zurückgehen und auf Trennen klicken, bevor Sie es erneut versuchen. Keine Sorge, die eingegebenen Informationen bleiben im Formular gespeichert.</string>
     <string name="here_is_your_account_number">Hier ist Ihre Kundennummer. Verlieren Sie sie nicht!</string>
     <string name="hint_default">Standard</string>
+    <string name="in_address">Eingehend</string>
     <string name="invalid_voucher">Der Gutscheincode ist ungültig.</string>
     <string name="is_offline">Diese Gerät ist offline, es können keine Tunnel aufgebaut werden</string>
     <string name="local_network_sharing">Teilen im lokalen Netzwerk</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Anmelden</string>
     <string name="no_wireguard_key">Gültiger WireGuard-Schlüssel fehlt. Sie können Ihre Schlüssel in den erweiterten Einstellungen verwalten.</string>
     <string name="not_blocking_internet">IHR NETZVERKEHR KÖNNTE UNSICHER SEIN</string>
+    <string name="out_address">Ausgehend</string>
     <string name="out_of_time">Zeit abgelaufen</string>
     <string name="paid_until">Bezahlt bis</string>
     <string name="pay_to_start_using">Um mit der Nutzung dieser App zu beginnen, müssen Sie erst einmal Zeit zu Ihrem Konto hinzufügen.</string>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Para volver a intentarlo, puede que necesite volver a la pantalla principal de la aplicación y hacer clic en Desconectar. No se preocupe, la información que ha especificado permanecerá en el formulario.</string>
     <string name="here_is_your_account_number">Este es un número de cuenta. ¡Guárdelo bien!</string>
     <string name="hint_default">Predeterminado</string>
+    <string name="in_address">Entrada</string>
     <string name="invalid_voucher">El código del cupón no es válido.</string>
     <string name="is_offline">Este dispositivo no está conectado, no puede establecerse ningún túnel</string>
     <string name="local_network_sharing">Uso compartido de la red local</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Iniciar sesión</string>
     <string name="no_wireguard_key">Falta una clave de WireGuard válida. Administre las claves en la Configuración avanzada.</string>
     <string name="not_blocking_internet">PUEDE QUE SE ESTÉ FILTRANDO SU TRÁFICO DE RED</string>
+    <string name="out_address">Salida</string>
     <string name="out_of_time">Tiempo agotado</string>
     <string name="paid_until">Pagado hasta</string>
     <string name="pay_to_start_using">Para empezar a usar la aplicación, primero necesita agregar tiempo a su cuenta.</string>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Ennen kuin yrität uudelleen sinun on ehkä palattava sovelluksen päänäytölle ja napsautettava yhteyden katkaisua. Älä huoli, syöttämäsi tiedot säilyvät lomakkeella.</string>
     <string name="here_is_your_account_number">Tässä tulee tilisi numero. Laita se talteen!</string>
     <string name="hint_default">Oletus</string>
+    <string name="in_address">Saapuva</string>
     <string name="invalid_voucher">Kuponkikoodi ei kelpaa.</string>
     <string name="is_offline">Tämä laite ei ole yhdistetty verkkoon. Tunneleita ei voida luoda.</string>
     <string name="local_network_sharing">Paikallisen verkon jakaminen</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Kirjaudu sisään</string>
     <string name="no_wireguard_key">Validi WireGuard-avain puuttuu. Hallinnoi avaimia lisäasetuksissa.</string>
     <string name="not_blocking_internet">VERKKOLIIKENTEESI SAATTAA VUOTAA</string>
+    <string name="out_address">Lähtevä</string>
     <string name="out_of_time">Ei käyttöaikaa</string>
     <string name="paid_until">Maksu ennen</string>
     <string name="pay_to_start_using">Voit aloittaa sovelluksen käyttämisen lisäämällä ensin aikaa tilillesi.</string>

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Vous allez peut-être devoir retourner à l\'écran principal de l\'application pour cliquer sur Déconnexion avant de réessayer. Ne vous inquiétez pas, les informations saisies resteront dans le formulaire.</string>
     <string name="here_is_your_account_number">Voici votre numéro de compte. Gardez-le !</string>
     <string name="hint_default">Par défaut</string>
+    <string name="in_address">Entrante</string>
     <string name="invalid_voucher">Le code du bon n\'est pas valide.</string>
     <string name="is_offline">Cet appareil est hors ligne. Aucun tunnel ne peut être établi</string>
     <string name="local_network_sharing">Partage réseau local</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Connexion</string>
     <string name="no_wireguard_key">Une clé wireguard valide manque. Gérez les clés dans les paramètre avancés.</string>
     <string name="not_blocking_internet">VOUS POURRIEZ AVOIR DES FUITES DE TRAFIC RÉSEAU</string>
+    <string name="out_address">Sortante</string>
     <string name="out_of_time">Plus de temps</string>
     <string name="paid_until">Payé jusqu\'au</string>
     <string name="pay_to_start_using">Pour commencer à utiliser l\'application, vous devez d\'abord ajouter du temps à votre compte.</string>

--- a/android/src/main/res/values-it/strings.xml
+++ b/android/src/main/res/values-it/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Prima di riprovare, potresti dover tornare alla schermata principale dell\'app e fare clic su Disconnetti. Non preoccuparti: le informazioni inserite rimarranno nel modulo.</string>
     <string name="here_is_your_account_number">Ecco il tuo numero di account. Salvalo!</string>
     <string name="hint_default">Predefinito</string>
+    <string name="in_address">Ricezione</string>
     <string name="invalid_voucher">Il codice voucher non è valido.</string>
     <string name="is_offline">Il dispositivo è offline. Impossibile stabilire tunnel</string>
     <string name="local_network_sharing">Condivisione rete locale</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Accedi</string>
     <string name="no_wireguard_key">Manca una chiave WireGuard valida. Gestisci le chiavi da Impostazioni avanzate.</string>
     <string name="not_blocking_internet">POSSIBILI PERDITE NEL TRAFFICO DI RETE</string>
+    <string name="out_address">Invio</string>
     <string name="out_of_time">Scaduto</string>
     <string name="paid_until">Pagato fino al</string>
     <string name="pay_to_start_using">Per iniziare a utilizzare l\'app, devi prima aggiungere tempo al tuo account.</string>

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">再試行する前に、アプリのメイン画面に戻って「接続解除」をクリックする必要があるかもしれません。すでにフォームに入力された情報が失われることはありませんので、ご安心ください。</string>
     <string name="here_is_your_account_number">これがあなたのアカウント番号です。保存してください！</string>
     <string name="hint_default">デフォルト</string>
+    <string name="in_address">内側</string>
     <string name="invalid_voucher">バウチャーコードが無効です。</string>
     <string name="is_offline">このデバイスはオフラインであるため、トンネルを作成できません。</string>
     <string name="local_network_sharing">ローカルネットワーク共有</string>
@@ -54,6 +55,7 @@
     <string name="login_title">ログイン</string>
     <string name="no_wireguard_key">有効なWireGuard鍵が見つかりません。詳細設定で鍵を管理してください。</string>
     <string name="not_blocking_internet">ネットワーク通信が漏洩している可能性があります。</string>
+    <string name="out_address">外側</string>
     <string name="out_of_time">時間切れ</string>
     <string name="paid_until">次の日時まで支払い済み</string>
     <string name="pay_to_start_using">アプリを使い始めるには、まずはアカウントに時間を追加する必要があります。</string>

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">다시 시도하기 전에 앱의 메인 화면으로 돌아가서 연결 끊기를 클릭해야 할 수도 있습니다. 입력한 정보는 양식에서 그대로 유지됩니다.</string>
     <string name="here_is_your_account_number">계정 번호는 다음과 같습니다. 저장하세요!</string>
     <string name="hint_default">기본값</string>
+    <string name="in_address">인</string>
     <string name="invalid_voucher">유효하지 않은 바우처 코드입니다.</string>
     <string name="is_offline">장치가 오프라인 상태이며, 터널을 설정할 수 없습니다</string>
     <string name="local_network_sharing">로컬 네트워크 공유</string>
@@ -54,6 +55,7 @@
     <string name="login_title">로그인</string>
     <string name="no_wireguard_key">유효한 WireGuard 키가 없습니다. 고급 설정에서 키를 관리하세요.</string>
     <string name="not_blocking_internet">네트워크 트래픽이 유출될 수 있음</string>
+    <string name="out_address">아웃</string>
     <string name="out_of_time">시간 초과</string>
     <string name="paid_until">유효 기간</string>
     <string name="pay_to_start_using">앱 사용을 시작하려면, 먼저 계정에 시간을 추가해야 합니다.</string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Du må gå tilbake til hovedskjermen til appen og trykke på \\\"Koble fra\\\" før du kan prøve på nytt. Men det er ingen grunn til bekymring, informasjonen du har skrevet i skjemaet blir ikke borte.</string>
     <string name="here_is_your_account_number">Dette er kontonummeret ditt. Ta vare på det!</string>
     <string name="hint_default">Standard</string>
+    <string name="in_address">Inngående</string>
     <string name="invalid_voucher">Ugyldig kupongkode.</string>
     <string name="is_offline">Enheten er frakoblet. Ingen tunneler kan opprettes</string>
     <string name="local_network_sharing">Deling over lokalt nettverk</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Logg inn</string>
     <string name="no_wireguard_key">Det mangler en gyldig WireGuard-nøkkel. Du kan behandle nøklene under avanserte innstillinger.</string>
     <string name="not_blocking_internet">DET KAN VÆRE EN NETTVERKSLEKKASJE HOS DEG</string>
+    <string name="out_address">Utgående</string>
     <string name="out_of_time">Tiden har utløpt</string>
     <string name="paid_until">Betalt fram til</string>
     <string name="pay_to_start_using">For å starte bruken av appen, må du først legge til tid til kontoen.</string>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Voordat u het opnieuw probeert, keert u eventueel terug naar het hoofdscherm van de app en klikt u op Verbinding verbreken. Geen zorgen, de ingevoerde informatie blijft in het formulier staan.</string>
     <string name="here_is_your_account_number">Hier is uw accountnummer. Sla het op!</string>
     <string name="hint_default">Standaard</string>
+    <string name="in_address">In</string>
     <string name="invalid_voucher">Vouchercode is ongeldig.</string>
     <string name="is_offline">Dit toestel is offline, er kunnen geen tunnels worden gemaakt</string>
     <string name="local_network_sharing">Delen op lokaal netwerk</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Aanmelden</string>
     <string name="no_wireguard_key">Geldige WireGuard-sleutel ontbreekt. Beheer sleutels onder Geavanceerde instellingen.</string>
     <string name="not_blocking_internet">U LEKT MOGELIJK NETWERKVERKEER</string>
+    <string name="out_address">Uit</string>
     <string name="out_of_time">Geen tijd meer</string>
     <string name="paid_until">Betaald tot</string>
     <string name="pay_to_start_using">Om de app te gebruiken, moet u eerst tijd toevoegen aan uw account.</string>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Być może przed ponowną próbą trzeba będzie wrócić do głównego ekranu aplikacji i kliknąć przycisk Rozłącz. Nie martw się, wprowadzone informacje pozostaną w formularzu.</string>
     <string name="here_is_your_account_number">Oto Twój numer konta. Zachowaj go!</string>
     <string name="hint_default">Domyślnie</string>
+    <string name="in_address">Wejście</string>
     <string name="invalid_voucher">Nieprawidłowy kod kuponu.</string>
     <string name="is_offline">To urządzenie jest offline, nie można ustanowić tuneli</string>
     <string name="local_network_sharing">Udostępnianie sieci lokalnej</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Logowanie</string>
     <string name="no_wireguard_key">Brak prawidłowego klucza WireGuard. Zarządzaj kluczami w obszarze Ustawienia zaawansowane.</string>
     <string name="not_blocking_internet">TWÓJ RUCH SIECIOWY MOŻE WYCIEKAĆ</string>
+    <string name="out_address">Wyjście</string>
     <string name="out_of_time">Koniec czasu</string>
     <string name="paid_until">Płatne do</string>
     <string name="pay_to_start_using">Aby rozpocząć korzystanie z aplikacji, musisz najpierw dodać czas do swojego konta.</string>

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Pode ter de voltar ao ecrã principal da app e clicar em Desligar antes de tentar novamente. Não se preocupe, a informação que introduziu permanecerá no formulário.</string>
     <string name="here_is_your_account_number">Aqui tem o seu número de conta. Guarde-o!</string>
     <string name="hint_default">Padrão</string>
+    <string name="in_address">Entrada</string>
     <string name="invalid_voucher">Código do voucher inválido.</string>
     <string name="is_offline">Este dispositivo está offline, não foi possível configurar túneis</string>
     <string name="local_network_sharing">Partilha de rede local</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Iniciar sessão</string>
     <string name="no_wireguard_key">Chave WireGuard válida em falta. Faça a gestão das chaves em Definições Avançadas.</string>
     <string name="not_blocking_internet">PODERÁ ESTAR A PERDER TRÁFEGO DE REDE</string>
+    <string name="out_address">Saída</string>
     <string name="out_of_time">Sem tempo</string>
     <string name="paid_until">Pago até</string>
     <string name="pay_to_start_using">Para começar a utilizar a aplicação, primeiro tem de adicionar tempo à sua conta.</string>

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Прежде чем повторить попытку, может понадобиться вернуться на главный экран приложения и нажать «Отключить». Не волнуйтесь: введенные в форму данные сохранятся.</string>
     <string name="here_is_your_account_number">Вот номер вашей учетной записи. Сохраните его!</string>
     <string name="hint_default">По умолчанию</string>
+    <string name="in_address">Вход</string>
     <string name="invalid_voucher">Код ваучера недействителен.</string>
     <string name="is_offline">Устройство вне сети, установить подключение к туннелям невозможно</string>
     <string name="local_network_sharing">Обмен данными в локальной сети</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Вход</string>
     <string name="no_wireguard_key">Не найден корректный ключ WireGuard. Управлять ключами можно в разделе «Дополнительные настройки».</string>
     <string name="not_blocking_internet">ВОЗМОЖНА УТЕЧКА СЕТЕВОГО ТРАФИКА</string>
+    <string name="out_address">Выход</string>
     <string name="out_of_time">Закончилось время</string>
     <string name="paid_until">Оплачено до</string>
     <string name="pay_to_start_using">Чтобы пользоваться приложением, нужно добавить время на учетную запись.</string>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Du kan behöva gå tillbaka till appens huvudskärm och klicka på Koppla från innan du försöker igen. Oroa dig inte, den information du angett i formuläret kommer att bli kvar där.</string>
     <string name="here_is_your_account_number">Här är ditt kontonummer. Spara det!</string>
     <string name="hint_default">Standard</string>
+    <string name="in_address">In</string>
     <string name="invalid_voucher">Kupongkoden är ogiltig.</string>
     <string name="is_offline">Denna enhet är frånkopplad, inga tunnlar kan skapas</string>
     <string name="local_network_sharing">Lokal nätverksdelning</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Logga in</string>
     <string name="no_wireguard_key">Giltig WireGuard-nyckel saknas. Hantera nycklar i avancerade inställningar.</string>
     <string name="not_blocking_internet">DU KANSKE HAR LÄCKAGE I NÄTVERKSTRAFIKEN</string>
+    <string name="out_address">Ut</string>
     <string name="out_of_time">Ingen tid kvar</string>
     <string name="paid_until">Betalat till</string>
     <string name="pay_to_start_using">Om du vill börja använda appen måste du först lägga till tid i ditt konto.</string>

--- a/android/src/main/res/values-th/strings.xml
+++ b/android/src/main/res/values-th/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">คุณอาจจำเป็นต้องย้อนกลับไปที่หน้าจอหลักของแอป และคลิกตัดการเชื่อมต่อ ก่อนที่จะลองใหม่อีกครั้ง และไม่ต้องกังวลไป เพราะข้อมูลที่คุณป้อนไว้จะยังคงอยู่ในแบบฟอร์มเหมือนเดิม</string>
     <string name="here_is_your_account_number">นี่คือหมายเลขบัญชีของคุณ จดบันทึกไว้ด้วยนะ!</string>
     <string name="hint_default">ค่าเริ่มต้น</string>
+    <string name="in_address">เข้า</string>
     <string name="invalid_voucher">รหัสบัตรกำนัลไม่ถูกต้อง</string>
     <string name="is_offline">อุปกรณ์ออฟไลน์อยู่ในขณะนี้ ไม่สามารถสร้างช่องทางการเชื่อมต่อได้</string>
     <string name="local_network_sharing">การแชร์ในเครือข่ายท้องถิ่น</string>
@@ -54,6 +55,7 @@
     <string name="login_title">เข้าสู่ระบบ</string>
     <string name="no_wireguard_key">ไม่มีคีย์ WireGuard ที่ถูกต้อง โปรดจัดการคีย์ภายใต้ส่วนการตั้งค่าขั้นสูง</string>
     <string name="not_blocking_internet">คุณอาจมีการรับส่งข้อมูลทางเครือข่ายที่รั่วไหลอยู่ในขณะนี้</string>
+    <string name="out_address">ออก</string>
     <string name="out_of_time">หมดเวลา</string>
     <string name="paid_until">ชำระเงินแล้วจนถึง</string>
     <string name="pay_to_start_using">คุณจำเป็นต้องเพิ่มเวลาไปยังบัญชีของคุณก่อน เพื่อที่จะเริ่มใช้งานแอป</string>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">Yeniden denemeden önce uygulamanın ana ekranına dönüp Bağlantıyı Kes\'e tıklamanız gerekebilir. Endişelenmeyin, girdiğiniz bilgiler formda kalacaktır.</string>
     <string name="here_is_your_account_number">İşte hesap numaranız. Kaydedin!</string>
     <string name="hint_default">Varsayılan</string>
+    <string name="in_address">Giriş</string>
     <string name="invalid_voucher">Kupon kodu geçersiz.</string>
     <string name="is_offline">Bu cihaz çevrimdışı, tünel oluşturulamaz</string>
     <string name="local_network_sharing">Yerel ağ paylaşımı</string>
@@ -54,6 +55,7 @@
     <string name="login_title">Oturum Aç</string>
     <string name="no_wireguard_key">Geçerli WireGuard anahtarı eksik. Gelişmiş ayarlardan anahtarları yönetin.</string>
     <string name="not_blocking_internet">AĞ TRAFİĞİNİZDE SIZINTI OLABİLİR</string>
+    <string name="out_address">Çıkış</string>
     <string name="out_of_time">Süre doldu</string>
     <string name="paid_until">Şu tarihe kadar ödendi:</string>
     <string name="pay_to_start_using">Uygulamayı kullanmaya başlamak için önce hesabınıza süre eklemeniz gerekir.</string>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -38,6 +38,7 @@
     <string name="failed_to_send_details">在重试之前，您需要返回应用的主屏幕并点击“断开连接”。别担心，您输入的信息将保留在窗体中。</string>
     <string name="here_is_your_account_number">以下是您的帐号。请妥善保存！</string>
     <string name="hint_default">默认</string>
+    <string name="in_address">内部</string>
     <string name="invalid_voucher">该优惠券码无效。</string>
     <string name="is_offline">此设备已离线，无法建立隧道</string>
     <string name="local_network_sharing">本地网络共享</string>
@@ -51,6 +52,7 @@
     <string name="login_title">登录</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 密钥。在“高级”设置下管理密钥。</string>
     <string name="not_blocking_internet">您的网络流量可能在泄露</string>
+    <string name="out_address">外部</string>
     <string name="out_of_time">已没有时间</string>
     <string name="paid_until">到期时间</string>
     <string name="pay_to_start_using">要开始使用本应用，您首先需要向帐户中充入时间。</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -41,6 +41,7 @@
     <string name="failed_to_send_details">在重試之前，您可能需要返回應用程式的主畫面，然後按一下「中斷連線」。請不用擔心，您輸入的資訊將保留在表單中。</string>
     <string name="here_is_your_account_number">以下是您的帳號。請妥善保管！</string>
     <string name="hint_default">預設</string>
+    <string name="in_address">入境</string>
     <string name="invalid_voucher">憑證兌換碼無效。</string>
     <string name="is_offline">此裝置目前離線中，無法建立通道</string>
     <string name="local_network_sharing">本機網路分享</string>
@@ -54,6 +55,7 @@
     <string name="login_title">登入</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 金鑰。在「進階」設定下管理金鑰。</string>
     <string name="not_blocking_internet">您的網路流量可能正在洩露</string>
+    <string name="out_address">出境</string>
     <string name="out_of_time">逾時</string>
     <string name="paid_until">支付至</string>
     <string name="pay_to_start_using">需先在帳戶中加時，才能開始使用本應用程式。</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -106,8 +106,8 @@
     <string name="wireguard">WireGuard</string>
     <string name="tcp">TCP</string>
     <string name="udp">UDP</string>
-    <string name="in_address">In %1$s:%2$d %3$s</string>
-    <string name="out_address">Out %1$s</string>
+    <string name="in_address">In</string>
+    <string name="out_address">Out</string>
     <string name="blocking_internet">Blocking internet</string>
     <string name="not_blocking_internet">YOU MIGHT BE LEAKING NETWORK TRAFFIC</string>
     <string name="failed_to_block_internet">Failed to block all network traffic. Please


### PR DESCRIPTION
The Android app would previously use string formatting parameters to create the endpoint information strings in the Connect screen. That was different from the desktop app, which used separate elements for the label and the value. This meant that the translation for the string resource couldn't be used.

This PR removes the formatting parameters and manually adds the parameters to the end of the string, so that the string resource can have a translation imported from the desktop app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1997)
<!-- Reviewable:end -->
