### PR TITLE
Require Travis jobs for beta Rust to succeed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,8 +159,6 @@ matrix:
 
   allow_failures:
     - name: Desktop Frontend, Windows
-    - name: Daemon, Linux - beta Rust
-    - name: Daemon, Windows - beta Rust
 
 notifications:
   email:


### PR DESCRIPTION
It looks like the Travis jobs "Daemon, Windows - beta Rust" and "Daemon, Linux - beta Rust" has been succeeding for the last 27 days. They have been reenabled in this PR.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1998)
<!-- Reviewable:end -->
