### PR TITLE
Ignore untranslatable Android strings

### DIFF
--- a/android/src/main/res/values-da/strings.xml
+++ b/android/src/main/res/values-da/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Din e-mail (valgfrit)</string>
     <string name="user_message_hint">Beskriv dit problem</string>
     <string name="voucher_already_used">Kuponkode er allerede brugt.</string>
+    <string name="wg_key_url">https://mullvad.net/da/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Generer nøgle</string>
     <string name="wireguard_key">WireGuard-nøgle</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Ihre E-Mail-Adresse (optional)</string>
     <string name="user_message_hint">Beschreiben Sie Ihr Problem</string>
     <string name="voucher_already_used">Der Gutscheincode wurde bereits verwendet.</string>
+    <string name="wg_key_url">https://mullvad.net/de/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Schlüssel generieren</string>
     <string name="wireguard_key">WireGuard-Schlüssel</string>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Su correo electrónico (opcional)</string>
     <string name="user_message_hint">Describa el problema</string>
     <string name="voucher_already_used">El código del cupón ya se ha usado.</string>
+    <string name="wg_key_url">https://mullvad.net/es/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Generar clave</string>
     <string name="wireguard_key">Clave de WireGuard</string>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Sähköpostisi (valinnainen)</string>
     <string name="user_message_hint">Kuvaile ongelmaasi</string>
     <string name="voucher_already_used">Kuponkikoodi on jo käytetty.</string>
+    <string name="wg_key_url">https://mullvad.net/fi/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Luo avain</string>
     <string name="wireguard_key">WireGuard-avain</string>

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Votre e-mail (facultatif)</string>
     <string name="user_message_hint">Décrivez votre problème</string>
     <string name="voucher_already_used">Le code du bon a déjà été utilisé.</string>
+    <string name="wg_key_url">https://mullvad.net/fr/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Générer la clé</string>
     <string name="wireguard_key">Clé WireGuard</string>

--- a/android/src/main/res/values-it/strings.xml
+++ b/android/src/main/res/values-it/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">La tua e-mail (opzionale)</string>
     <string name="user_message_hint">Descrivi il tuo problema</string>
     <string name="voucher_already_used">Il codice voucher è già stato utilizzato.</string>
+    <string name="wg_key_url">https://mullvad.net/it/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Genera chiave</string>
     <string name="wireguard_key">Chiave WireGuard</string>

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">あなたのメールアドレス（任意）</string>
     <string name="user_message_hint">問題の内容をご説明ください</string>
     <string name="voucher_already_used">バウチャーコードはすでに使用されています。</string>
+    <string name="wg_key_url">https://mullvad.net/ja/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">鍵を生成</string>
     <string name="wireguard_key">WireGuard鍵</string>

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">이메일(선택 사항)</string>
     <string name="user_message_hint">문제 설명</string>
     <string name="voucher_already_used">이미 사용된 바우처 코드입니다.</string>
+    <string name="wg_key_url">https://mullvad.net/ko/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">키 생성</string>
     <string name="wireguard_key">WireGuard 키</string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">E-post (valgfritt)</string>
     <string name="user_message_hint">Beskriv problemet</string>
     <string name="voucher_already_used">Kupongkoden er allerede brukt.</string>
+    <string name="wg_key_url">https://mullvad.net/nb/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Generer nøkkel</string>
     <string name="wireguard_key">WireGuard-nøkkel</string>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Uw e-mailadres (optioneel)</string>
     <string name="user_message_hint">Beschrijf het probleem</string>
     <string name="voucher_already_used">Vouchercode is al gebruikt.</string>
+    <string name="wg_key_url">https://mullvad.net/nl/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Sleutel genereren</string>
     <string name="wireguard_key">WireGuard-sleutel</string>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Twój adres e-mail (opcjonalnie)</string>
     <string name="user_message_hint">Opisz problem</string>
     <string name="voucher_already_used">Kod z tego kuponu został już użyty.</string>
+    <string name="wg_key_url">https://mullvad.net/pl/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Wygeneruj klucz</string>
     <string name="wireguard_key">Klucz WireGuard</string>

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">O seu email (opcional)</string>
     <string name="user_message_hint">Descreva o seu problema</string>
     <string name="voucher_already_used">O código do voucher já foi utilizado.</string>
+    <string name="wg_key_url">https://mullvad.net/pt/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Gerar chave</string>
     <string name="wireguard_key">Chave WireGuard</string>

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Ваша электронная почта (необязательно)</string>
     <string name="user_message_hint">Опишите проблему</string>
     <string name="voucher_already_used">Этот код ваучера уже использовался.</string>
+    <string name="wg_key_url">https://mullvad.net/ru/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Сгенерировать ключ</string>
     <string name="wireguard_key">Ключ WireGuard</string>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">Din e-postadress (valfritt)</string>
     <string name="user_message_hint">Beskriv ditt problem</string>
     <string name="voucher_already_used">Kupongkoden har redan använts.</string>
+    <string name="wg_key_url">https://mullvad.net/sv/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Generera nyckel</string>
     <string name="wireguard_key">WireGuard-nyckel</string>

--- a/android/src/main/res/values-th/strings.xml
+++ b/android/src/main/res/values-th/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">อีเมลของคุณ (ไม่บังคับ)</string>
     <string name="user_message_hint">ระบุปัญหาของคุณ</string>
     <string name="voucher_already_used">รหัสบัตรกำนัลถูกใช้ไปแล้ว</string>
+    <string name="wg_key_url">https://mullvad.net/th/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">สร้างคีย์</string>
     <string name="wireguard_key">คีย์ WireGuard</string>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">E-posta adresiniz (isteğe bağlı)</string>
     <string name="user_message_hint">Sorununuzu açıklayın</string>
     <string name="voucher_already_used">Kupon kodu zaten kullanılmış.</string>
+    <string name="wg_key_url">https://mullvad.net/tr/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">Anahtar oluştur</string>
     <string name="wireguard_key">WireGuard anahtarı</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -97,6 +97,7 @@
     <string name="user_email_hint">您的電子郵件 (選填)</string>
     <string name="user_message_hint">描述您的問題</string>
     <string name="voucher_already_used">此憑證兌換碼已有人用過。</string>
+    <string name="wg_key_url">https://mullvad.net/zh-hant/account/ports</string>
     <string name="wireguard">WireGuard</string>
     <string name="wireguard_generate_key">產生金鑰</string>
     <string name="wireguard_key">WireGuard 金鑰</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -165,7 +165,7 @@
     <string name="enabled">Enabled</string>
     <string name="exclude_applications">Exclude applications</string>
     <string name="account_url">https://mullvad.net/en/account</string>
-    <string name="wg_key_url">https://mullvad.net/account/ports</string>
+    <string name="wg_key_url">https://mullvad.net/en/account/ports</string>
     <string name="create_account_url">https://mullvad.net/en/account/create</string>
     <string name="download_url">https://mullvad.net/en/download</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="connecting_to_daemon">Connecting to Mullvad system service...</string>
     <string name="login_title">Login</string>
     <string name="login_description">Enter your account number</string>
-    <string name="login_hint">0000 0000 0000 0000</string>
+    <string name="login_hint" translatable="false">0000 0000 0000 0000</string>
     <string name="logging_in_title">Logging in...</string>
     <string name="logging_in_description">Checking account number</string>
     <string name="logged_in_title">Logged in</string>
@@ -35,7 +35,7 @@
     <string name="buy_more_credit">Buy more credit</string>
     <string name="redeem_voucher">Redeem voucher</string>
     <string name="enter_voucher_code">Enter voucher code</string>
-    <string name="voucher_hint">XXXX-XXXX-XXXX-XXXX</string>
+    <string name="voucher_hint" translatable="false">XXXX-XXXX-XXXX-XXXX</string>
     <string name="redeem">Redeem</string>
     <string name="invalid_voucher">Voucher code is invalid.</string>
     <string name="voucher_already_used">Voucher code has already been used.</string>

--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -27,6 +27,10 @@ pub struct StringResource {
     /// The string resource ID.
     pub name: String,
 
+    /// If the string should be translated or not.
+    #[serde(default = "default_translatable")]
+    pub translatable: bool,
+
     /// The string value.
     #[serde(rename = "$value")]
     pub value: String,
@@ -97,7 +101,11 @@ impl StringResource {
             value.push_str(part);
         }
 
-        StringResource { name, value }
+        StringResource {
+            name,
+            translatable: true,
+            value,
+        }
     }
 
     /// Normalize the string value into a common format.
@@ -113,6 +121,10 @@ impl StringResource {
 
         self.value = value.into_owned();
     }
+}
+
+fn default_translatable() -> bool {
+    true
 }
 
 // Unfortunately, direct serialization to XML isn't working correctly.
@@ -131,10 +143,18 @@ impl Display for StringResources {
 
 impl Display for StringResource {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            r#"<string name="{}">{}</string>"#,
-            self.name, self.value
-        )
+        if self.translatable {
+            write!(
+                formatter,
+                r#"<string name="{}">{}</string>"#,
+                self.name, self.value
+            )
+        } else {
+            write!(
+                formatter,
+                r#"<string name="{}" translatable="false">{}</string>"#,
+                self.name, self.value
+            )
+        }
     }
 }

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
         serde_xml_rs::from_reader(strings_file).expect("Failed to read string resources file");
 
     string_resources.normalize();
+    string_resources.retain(|string| string.translatable);
 
     let mut known_urls = HashMap::with_capacity(string_resources.len());
     let mut known_strings = HashMap::with_capacity(string_resources.len());


### PR DESCRIPTION
Some strings aren't translatable. More specifically, the account number hint (`0000 0000 0000 0000`) and the voucher hint (similar but with `X`s) don't need to be translated. Android supports having string resources with a `translatable="false"` attribute. This PR adds that attribute and updates the translation conversion helper tool to ignore those string resources.

One URL was also updated to have a locale so that it can be translated instead of being marked as not translatable.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/1999)
<!-- Reviewable:end -->
