### PR TITLE
Update target Android SDK to version 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ matrix:
       name: Android
       android:
         components:
-          - android-28
-          - build-tools-28.0.3
+          - android-29
+          - build-tools-29.0.3
       install:
         - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable --profile minimal -y
         - source $HOME/.cargo/env

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,13 +14,13 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.3'
 
     defaultConfig {
         applicationId "net.mullvad.mullvadvpn"
         minSdkVersion 24
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 20060001
         versionName "2020.6-beta1"
     }


### PR DESCRIPTION
Google will require app updates to be built targeting Android 10 (SDK level 29) starting on November. This PR updates the Android app's target SDK version from 28 to 29. It also updates the built tools version to version 29.0.3.

The Travis configuration file for the Android build was also updated to use the updated SDK and tools versions.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal change, not user visible.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
