### PR TITLE
Don't show out-of-time notification for new accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Line wrap the file at 100 chars.                                              Th
 - Show "Exclude applications" header if needed when entering the "Split tunneling" screen.
 - Fix check for update versions and check for support for current version.
 - Fix crash that could happen when leaving the Select Location screen.
+- Don't show out-of-time notification for newly created accounts.
 
 
 ## [2020.6-beta1] - 2020-08-20


### PR DESCRIPTION
Previously, the app would always show a notification when the account time ran out or was close to running out. The previous version (2020.6-beta1) changed that to not show the notification for newly created accounts in order to improve the user experience. However, that change had a bug in it. The account would be marked as not new as soon as the service could read the account expiry time. Since the "Welcome" screen checks for a new expiry every 15 seconds, the notification would reappear after 15 seconds or so.

This PR fixes the issue by only marking the account as not new after the expiry changes from the initial value. In order to do this, the first valid expiry value for the newly created account is stored and used to compare future account expiry values. This "cached" value is reset whenever the new account flag is changed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2004)
<!-- Reviewable:end -->
