### PR TITLE
Append plural messages from the Android app to the gettext messages template

### DIFF
--- a/android/src/main/res/values/plurals.xml
+++ b/android/src/main/res/values/plurals.xml
@@ -1,14 +1,14 @@
 <resources>
     <plurals name="years_left">
-        <item quantity="one">%d year left</item>
+        <item quantity="one">1 year left</item>
         <item quantity="other">%d years left</item>
     </plurals>
     <plurals name="months_left">
-        <item quantity="one">%d month left</item>
+        <item quantity="one">1 month left</item>
         <item quantity="other">%d months left</item>
     </plurals>
     <plurals name="days_left">
-        <item quantity="one">%d day left</item>
+        <item quantity="one">1 day left</item>
         <item quantity="other">%d days left</item>
     </plurals>
     <plurals name="minutes_ago">

--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -158,3 +158,68 @@ impl Display for StringResource {
         }
     }
 }
+
+/// Contents of an Android plurals resources file.
+///
+/// This type can be created directly deserializing the `plurals.xml` file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PluralResources {
+    #[serde(rename = "plurals")]
+    entries: Vec<PluralResource>,
+}
+
+/// An entry in an Android plurals resources file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PluralResource {
+    /// The plural resource ID.
+    pub name: String,
+
+    /// The items of the plural resource, one for each quantity variant.
+    #[serde(rename = "item")]
+    pub items: Vec<PluralVariant>,
+}
+
+/// A string resource for a specific quantity.
+///
+/// This is part of a plural resource.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PluralVariant {
+    /// The quantity for this variant to be used.
+    pub quantity: PluralQuantity,
+
+    /// The string value
+    #[serde(rename = "$value")]
+    pub string: String,
+}
+
+/// A valid quantity for a plural variant.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluralQuantity {
+    Zero,
+    One,
+    Other,
+}
+
+impl Deref for PluralResources {
+    type Target = Vec<PluralResource>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entries
+    }
+}
+
+impl DerefMut for PluralResources {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entries
+    }
+}
+
+impl IntoIterator for PluralResources {
+    type Item = PluralResource;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
+    }
+}

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -96,19 +96,19 @@ fn main() {
 
     if !missing_translations.is_empty() {
         println!("Appending missing translations to template file:");
-    }
 
-    gettext::append_to_template(
-        locale_dir.join("messages.pot"),
-        missing_translations
-            .into_iter()
-            .inspect(|(missing_translation, id)| println!("  {}: {}", id, missing_translation))
-            .map(|(id, _)| gettext::MsgEntry {
-                id,
-                value: String::new(),
-            }),
-    )
-    .expect("Failed to append missing translations to message template file");
+        gettext::append_to_template(
+            locale_dir.join("messages.pot"),
+            missing_translations
+                .into_iter()
+                .inspect(|(missing_translation, id)| println!("  {}: {}", id, missing_translation))
+                .map(|(id, _)| gettext::MsgEntry {
+                    id,
+                    value: String::new(),
+                }),
+        )
+        .expect("Failed to append missing translations to message template file");
+    }
 }
 
 /// Determines the localized value resources directory name based on a locale specification.

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -16,6 +16,13 @@
 //! order when only named parameters are used, and Android strings only supported numbered
 //! parameters.
 //!
+//! Android's plural resources aren't currently translated, but this tool will convert them to
+//! gettext message templates and append them to the message template file. It's important to note
+//! that the first quantity item for a plural will be used as the `msgid`, so it shouldn't
+//! have any parameters. The last quantity item for a plural will be used as the `msgid_plural`,
+//! and it can contain parameters. This assumes a plural resource will have at least two items.
+//! While it would still work with a single item, this is an unlikely case for a plural resource.
+//!
 //! Note that this conversion procedure is very raw and likely very brittle, so while it works for
 //! most cases, it is important to keep in mind that this is just a helper tool and manual steps are
 //! likely to be needed from time to time.

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -153,11 +153,13 @@ fn generate_translations(
     let mut localized_resource = android::StringResources::new();
 
     for translation in translations {
-        if let Some(android_key) = known_strings.remove(&translation.id) {
-            localized_resource.push(android::StringResource::new(
-                android_key,
-                &translation.value,
-            ));
+        if let gettext::MsgValue::Invariant(translation_value) = translation.value {
+            if let Some(android_key) = known_strings.remove(&translation.id) {
+                localized_resource.push(android::StringResource::new(
+                    android_key,
+                    &translation_value,
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
The Android app uses a few plural string resources to handle relative time. The desktop app uses the `moment` library to handle that appropriately with localization. That means that the Android app can't import the necessary relative time plural strings from the desktop app. The solution in this PR is to append the Android plurals to the desktop app's gettext localization messages template file so that they can be sent for translation later on.

The helper translation conversion tool was updated to be able to parse Android plural resource files and to be able to represent and write gettext plural messages. The tool can then just read the Android plural resources and append their gettext plural message templates to the messages template file.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes, no changelog entry needed.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2005)
<!-- Reviewable:end -->
