### PR TITLE
Fix exclude applications header not shown when entering "Split Tunneling" screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Line wrap the file at 100 chars.                                              Th
   is loaded.
 - Fix crash when selecting the whole text entered for the voucher code and then deleting it in the
   Redeem Voucher dialog.
+- Show "Exclude applications" header if needed when entering the "Split tunneling" screen.
 
 
 ## [2020.6-beta1] - 2020-08-20

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnellingFragment.kt
@@ -119,6 +119,12 @@ class SplitTunnellingFragment : ServiceDependentFragment(OnNoService.GoToLaunchS
             }
         }
 
+        if (splitTunnelling.enabled) {
+            jobTracker.newUiJob("showExcludedApplications") {
+                excludeApplications.visibility = View.VISIBLE
+            }
+        }
+
         enabledToggle = header.findViewById<ToggleCell>(R.id.enabled).apply {
             if (splitTunnelling.enabled) {
                 forcefullySetState(CellSwitch.State.ON)


### PR DESCRIPTION
Previously, entering the "Split Tunneling" screen with split tunneling enabled wouldn't show the "Exclude applications" header. It would only appear after disabling and enabling split tunneling again. This happened because the "Exclude applications" header wasn't set up when the `ListView` header view was set-up . This PR fixes that by scheduling the header to be made visible if needed when setting up the `ListView` header.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2006)
<!-- Reviewable:end -->
