### PR TITLE
Set hostname constraint directly in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add CLI command to set the location constraint via `mullvad relay set relay HOSTNAME`.
+
 ### Changed
 - Use gRPC for communication between frontends and the backend instead of JSON-RPC.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Changed
 - Use gRPC for communication between frontends and the backend instead of JSON-RPC.
+- Show a warning in the CLI if the provided location constraints don't match any known relay.
 
 ### Fixed
 #### Android

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -374,6 +374,8 @@ impl Relay {
         let mut found = false;
 
         if !location_constraint.country.is_empty() {
+            // TODO: `mullvad_types::relay_constraints::LocationConstraint::matches(&relay)`
+            //       could be used to guarantee consistency with the daemon.
             let countries = Self::get_filtered_relays().await?;
             for country in &countries {
                 if country.code != location_constraint.country {


### PR DESCRIPTION
As the title says. The command is `mullvad relay set relay <hostname>`. This can make setting the location constraints more convenient.

Additionally, output a warning if a relay in cannot be found when using `mullvad relay set location ...`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2009)
<!-- Reviewable:end -->
