### PR TITLE
Fix Windows firewall FFI calls

### DIFF
--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -151,16 +151,16 @@ impl Firewall {
         let mut relay_client: Vec<u16> = relay_client.as_os_str().encode_wide().collect();
         relay_client.push(0u16);
 
-        let pingable_hosts = if !pingable_hosts.is_empty() {
-            let pingable_addresses = pingable_hosts
-                .iter()
-                .map(|ip| Self::widestring_ip(*ip))
-                .collect::<Vec<_>>();
-            let pingable_address_ptrs = pingable_addresses
-                .iter()
-                .map(|ip| ip.as_ptr())
-                .collect::<Vec<_>>();
+        let pingable_addresses = pingable_hosts
+            .iter()
+            .map(|ip| Self::widestring_ip(*ip))
+            .collect::<Vec<_>>();
+        let pingable_address_ptrs = pingable_addresses
+            .iter()
+            .map(|ip| ip.as_ptr())
+            .collect::<Vec<_>>();
 
+        let pingable_hosts = if !pingable_address_ptrs.is_empty() {
             Some(WinFwPingableHosts {
                 interfaceAlias: ptr::null(),
                 addresses: pingable_address_ptrs.as_ptr(),


### PR DESCRIPTION
There was a lifetime issue in the FFI code for the Windows firewall - a struct was populated with pointers that were invalidated before the struct was used to call a FFI function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2013)
<!-- Reviewable:end -->
