### PR TITLE
Load JNI library sooner to try to avoid crashes when starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Use gRPC for communication between frontends and the backend instead of JSON-RPC.
 
+### Fixed
+#### Android
+- Fix possible crash when starting the app, caused by trying to use JNI functions before the library
+  is loaded.
+
 
 ## [2020.6-beta1] - 2020-08-20
 ### Added

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -28,6 +28,10 @@ class MullvadVpnService : TalpidVpnService() {
 
         val KEY_CONNECT_ACTION = "net.mullvad.mullvadvpn.connect_action"
         val KEY_DISCONNECT_ACTION = "net.mullvad.mullvadvpn.disconnect_action"
+
+        init {
+            System.loadLibrary("mullvad_jni")
+        }
     }
 
     private enum class PendingAction {


### PR DESCRIPTION
The recently released `2020.6-beta1` version of the Android app is showing an unusually high number of crashes caused by `UnsatisfiedLinkError`. They seem to happen when calling `TalpidVpnService.defaultTunConfig`, which seems to indicate it's failing when trying to call a JNI method. One possible explanation is that the `TalpidVpnService` is calling the method before the `mullvad-jni` library is loaded (because it seems to be loaded only when the daemon is starting).

This PR tries to fix that by loading the JNI library sooner. It is now also requested to be loaded when the `MullvadVpnService` class is loaded.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2015)
<!-- Reviewable:end -->
