### PR TITLE
Fix crash when removing selected text in Redeem Voucher dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix possible crash when starting the app, caused by trying to use JNI functions before the library
   is loaded.
+- Fix crash when selecting the whole text entered for the voucher code and then deleting it in the
+  Redeem Voucher dialog.
 
 
 ## [2020.6-beta1] - 2020-08-20

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedInputFormatter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedInputFormatter.kt
@@ -48,12 +48,12 @@ class SegmentedInputFormatter(val input: EditText, var separator: Char) : TextWa
             var end = input.selectionEnd
             var changed = false
 
-            if (start % separatorSkipCount == 0) {
+            if (start % separatorSkipCount == 0 && start > 0) {
                 start -= 1
                 changed = true
             }
 
-            if (end % separatorSkipCount == 0) {
+            if (end % separatorSkipCount == 0 && end > 0) {
                 end -= 1
                 changed = true
             }


### PR DESCRIPTION
Some crashes have been seen for a while in the Redeem Voucher dialog. The log always shows that it is caused by having an out-of-bounds value when updating the text selection. However, the logs didn't actually show the value that caused it, so the way to reproduce it was unknown.

Today I managed to reproduce the error by selecting the whole text and deleting it. The cause was that the new selection was `0..0`, and the separator handling code tried to update the selection to `-1..-1`. This PR fixes the issue but not updating the selection boundary if it's at the start of the string.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2016)
<!-- Reviewable:end -->
