### PR TITLE
Add provider constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add CLI command to set the location constraint via `mullvad relay set relay HOSTNAME`.
 - Add a provider relay constraint, which restricts relay selection to a given hosting provider.
-- Include hosting providers in the CLI for `mullvad relay list`.
+- Include hosting providers in the CLI for `mullvad relay list` and `mullvad bridge list`.
 
 ### Changed
 - Use gRPC for communication between frontends and the backend instead of JSON-RPC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add CLI command to set the location constraint via `mullvad relay set relay HOSTNAME`.
+- Add a provider relay constraint, which restricts relay selection to a given hosting provider.
 
 ### Changed
 - Use gRPC for communication between frontends and the backend instead of JSON-RPC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add CLI command to set the location constraint via `mullvad relay set relay HOSTNAME`.
 - Add a provider relay constraint, which restricts relay selection to a given hosting provider.
+- Include hosting providers in the CLI for `mullvad relay list`.
 
 ### Changed
 - Use gRPC for communication between frontends and the backend instead of JSON-RPC.

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -444,7 +444,10 @@ impl Bridge {
                     city.name, city.code, city.latitude, city.longitude
                 );
                 for relay in &city.relays {
-                    println!("\t\t{} ({})", relay.hostname, relay.ipv4_addr_in);
+                    println!(
+                        "\t\t{} ({}) - hosted by {}",
+                        relay.hostname, relay.ipv4_addr_in, relay.provider
+                    );
                 }
             }
             println!();

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -4,7 +4,7 @@ use clap::value_t;
 use mullvad_management_interface::types::{
     bridge_settings::{Type as BridgeSettingsType, *},
     bridge_state::State as BridgeStateType,
-    BridgeSettings, BridgeState,
+    BridgeSettings, BridgeState, RelayLocation,
 };
 use talpid_types::net::openvpn::SHADOWSOCKS_CIPHERS;
 
@@ -45,6 +45,18 @@ fn create_bridge_set_subcommand() -> clap::App<'static, 'static> {
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(create_set_state_subcommand())
         .subcommand(create_set_custom_settings_subcommand())
+        .subcommand(
+            clap::SubCommand::with_name("provider")
+                .about(
+                    "Set a hosting provider to select bridge relays from. The 'list' \
+                        command shows the available relays and their providers.",
+                )
+                .arg(
+                    clap::Arg::with_name("provider")
+                        .help("The hosting provider to use, or 'any' for no preference.")
+                        .required(true),
+                ),
+        )
         .subcommand(location::get_subcommand().about(
             "Set country or city to select bridge relays from. Use the 'list' \
              command to show available alternatives.",
@@ -155,6 +167,9 @@ impl Bridge {
             ("location", Some(location_matches)) => {
                 Self::handle_set_bridge_location(location_matches).await
             }
+            ("provider", Some(provider_matches)) => {
+                Self::handle_set_bridge_provider(provider_matches).await
+            }
             ("custom", Some(custom_matches)) => {
                 Self::handle_bridge_set_custom_settings(custom_matches).await
             }
@@ -175,8 +190,9 @@ impl Bridge {
             }
             BridgeSettingsType::Normal(constraints) => {
                 println!(
-                    "Bridge constraints - {}",
-                    location::format_location(constraints.location.as_ref())
+                    "Bridge constraints - {}, {}",
+                    location::format_location(constraints.location.as_ref()),
+                    location::format_provider(constraints.provider.as_ref())
                 );
             }
         };
@@ -184,12 +200,52 @@ impl Bridge {
     }
 
     async fn handle_set_bridge_location(matches: &clap::ArgMatches<'_>) -> Result<()> {
-        let constraints = location::get_constraint(matches);
+        Self::update_bridge_settings(Some(location::get_constraint(matches)), None).await
+    }
+
+    async fn handle_set_bridge_provider(matches: &clap::ArgMatches<'_>) -> Result<()> {
+        let new_provider =
+            value_t!(matches.value_of("provider"), String).unwrap_or_else(|e| e.exit());
+        let new_provider = if new_provider == "any" {
+            "".to_string()
+        } else {
+            new_provider
+        };
+
+        Self::update_bridge_settings(None, Some(new_provider)).await
+    }
+
+    async fn update_bridge_settings(
+        location: Option<RelayLocation>,
+        provider: Option<String>,
+    ) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
+        let settings = rpc.get_settings(()).await?.into_inner();
+
+        let bridge_settings = settings.bridge_settings.unwrap();
+        let constraints = match bridge_settings.r#type.unwrap() {
+            BridgeSettingsType::Normal(mut constraints) => {
+                if let Some(new_location) = location {
+                    constraints.location = Some(new_location);
+                }
+                if let Some(new_provider) = provider {
+                    constraints.provider = new_provider;
+                }
+                constraints
+            }
+            _ => {
+                let location = location.unwrap_or_default();
+                let provider = provider.unwrap_or_default();
+
+                BridgeConstraints {
+                    location: Some(location),
+                    provider,
+                }
+            }
+        };
+
         rpc.set_bridge_settings(BridgeSettings {
-            r#type: Some(BridgeSettingsType::Normal(BridgeConstraints {
-                location: Some(constraints),
-            })),
+            r#type: Some(BridgeSettingsType::Normal(constraints)),
         })
         .await?;
         Ok(())

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -621,8 +621,8 @@ impl Relay {
                         _ => unreachable!("Bug in relay filtering earlier on"),
                     };
                     println!(
-                        "\t\t{} ({}) - {}",
-                        relay.hostname, relay.ipv4_addr_in, support_msg
+                        "\t\t{} ({}) - {}, hosted by {}",
+                        relay.hostname, relay.ipv4_addr_in, support_msg, relay.provider
                     );
                 }
             }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -9,7 +9,7 @@ use std::{
 use mullvad_management_interface::types::{
     connection_config::{self, OpenvpnConfig, WireguardConfig},
     relay_settings, relay_settings_update, ConnectionConfig, CustomRelaySettings,
-    NormalRelaySettingsUpdate, OpenvpnConstraints, RelayListCountry, RelayLocation,
+    NormalRelaySettingsUpdate, OpenvpnConstraints, ProviderUpdate, RelayListCountry, RelayLocation,
     RelaySettingsUpdate, TransportProtocol, TransportProtocolConstraint, TunnelType,
     TunnelTypeConstraint, TunnelTypeUpdate, WireguardConstraints,
 };
@@ -127,6 +127,16 @@ impl Command for Relay {
                             ),
                     )
                     .subcommand(
+                        clap::SubCommand::with_name("provider")
+                            .about("Set a hosting provider to select relays from. The 'list' \
+                                   command shows the available relays and their providers.")
+                            .arg(
+                                clap::Arg::with_name("provider")
+                                .help("The hosting provider to use, or 'any' for no preference.")
+                                .required(true)
+                            )
+                    )
+                    .subcommand(
                         clap::SubCommand::with_name("tunnel")
                             .about("Set individual tunnel constraints")
                             .arg(
@@ -195,6 +205,8 @@ impl Relay {
             self.set_location(location_matches).await
         } else if let Some(relay_matches) = matches.subcommand_matches("relay") {
             self.set_relay(relay_matches).await
+        } else if let Some(provider_matches) = matches.subcommand_matches("provider") {
+            self.set_provider(provider_matches).await
         } else if let Some(tunnel_matches) = matches.subcommand_matches("tunnel") {
             self.set_tunnel(tunnel_matches).await
         } else if let Some(tunnel_matches) = matches.subcommand_matches("tunnel-protocol") {
@@ -426,6 +438,26 @@ impl Relay {
         .await
     }
 
+    async fn set_provider(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+        let provider = value_t!(matches.value_of("provider"), String).unwrap_or_else(|e| e.exit());
+
+        self.update_constraints(RelaySettingsUpdate {
+            r#type: Some(relay_settings_update::Type::Normal(
+                NormalRelaySettingsUpdate {
+                    provider: Some(ProviderUpdate {
+                        provider: if provider == "any" {
+                            "".to_string()
+                        } else {
+                            provider
+                        },
+                    }),
+                    ..Default::default()
+                },
+            )),
+        })
+        .await
+    }
+
     async fn set_tunnel(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let vpn_protocol = matches.value_of("vpn protocol").unwrap();
         let port = parse_port_constraint(matches.value_of("port").unwrap())?;
@@ -507,27 +539,30 @@ impl Relay {
             relay_settings::Endpoint::Normal(settings) => match settings.tunnel_type {
                 None => {
                     println!(
-                        "Any tunnel protocol with OpenVPN over {} and WireGuard over {} in {}",
+                        "Any tunnel protocol with OpenVPN over {} and WireGuard over {} in {} using {}",
                         Self::format_openvpn_constraints(settings.openvpn_constraints.as_ref()),
                         Self::format_wireguard_constraints(settings.wireguard_constraints.as_ref()),
-                        location::format_location(settings.location.as_ref())
+                        location::format_location(settings.location.as_ref()),
+                        location::format_provider(settings.provider.as_ref())
                     );
                 }
                 Some(constraint) => match TunnelType::from_i32(constraint.tunnel_type).unwrap() {
                     TunnelType::Wireguard => {
                         println!(
-                            "WireGuard over {} in {}",
+                            "WireGuard over {} in {} using {}",
                             Self::format_wireguard_constraints(
                                 settings.wireguard_constraints.as_ref()
                             ),
-                            location::format_location(settings.location.as_ref())
+                            location::format_location(settings.location.as_ref()),
+                            location::format_provider(settings.provider.as_ref())
                         );
                     }
                     TunnelType::Openvpn => {
                         println!(
-                            "OpenVPN over {} in {}",
+                            "OpenVPN over {} in {} using {}",
                             Self::format_openvpn_constraints(settings.openvpn_constraints.as_ref()),
-                            location::format_location(settings.location.as_ref())
+                            location::format_location(settings.location.as_ref()),
+                            location::format_provider(settings.provider.as_ref())
                         );
                     }
                 },

--- a/mullvad-cli/src/location.rs
+++ b/mullvad-cli/src/location.rs
@@ -73,6 +73,14 @@ pub fn format_location(location: Option<&RelayLocation>) -> String {
     "any location".to_string()
 }
 
+pub fn format_provider(provider: &str) -> String {
+    if !provider.is_empty() {
+        format!("provider {}", provider)
+    } else {
+        "any provider".to_string()
+    }
+}
+
 fn country_code_validator(code: String) -> std::result::Result<(), String> {
     if code.len() == 2 || code == "any" {
         Ok(())

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -857,6 +857,7 @@ where
                     BridgeSettings::Normal(settings) => {
                         let bridge_constraints = InternalBridgeConstraints {
                             location: settings.location.clone(),
+                            provider: settings.provider.clone(),
                             // FIXME: This is temporary while talpid-core only supports TCP proxies
                             transport_protocol: Constraint::Only(TransportProtocol::Tcp),
                         };

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -967,6 +967,13 @@ fn convert_relay_settings_update(
 
             Ok(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
                 location,
+                provider: settings.provider.map(|provider_update| {
+                    if !provider_update.provider.is_empty() {
+                        Constraint::Only(provider_update.provider.clone())
+                    } else {
+                        Constraint::Any
+                    }
+                }),
                 tunnel_protocol,
                 wireguard_constraints: settings.wireguard_constraints.map(|constraints| {
                     WireguardConstraints {
@@ -1005,6 +1012,10 @@ fn convert_relay_settings(settings: &RelaySettings) -> types::RelaySettings {
         RelaySettings::Normal(constraints) => {
             relay_settings::Endpoint::Normal(types::NormalRelaySettings {
                 location: convert_location_constraint(&constraints.location),
+                provider: match &constraints.provider {
+                    Constraint::Any => "".to_string(),
+                    Constraint::Only(ref provider) => provider.clone(),
+                },
                 tunnel_type: match constraints.tunnel_protocol {
                     Constraint::Any => None,
                     Constraint::Only(TunnelType::Wireguard) => Some(types::TunnelType::Wireguard),

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -12,7 +12,7 @@ use mullvad_types::{
     location::GeoIpLocation,
     relay_constraints::{
         BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
-        OpenVpnConstraints, RelayConstraintsUpdate, RelaySettings, RelaySettingsUpdate,
+        OpenVpnConstraints, Provider, RelayConstraintsUpdate, RelaySettings, RelaySettingsUpdate,
         WireguardConstraints,
     },
     relay_list::{Relay, RelayList, RelayListCountry},
@@ -271,14 +271,16 @@ impl ManagementService for ManagementServiceImpl {
 
         let settings = match settings {
             BridgeSettingType::Normal(constraints) => {
-                let constraint = match constraints.location {
+                let location = match constraints.location {
                     None => Constraint::Any,
                     Some(location) => convert_proto_location(location),
                 };
+                let provider = match constraints.provider.as_ref() {
+                    "" => Constraint::Any,
+                    provider => Constraint::Only(String::from(provider)),
+                };
 
-                BridgeSettings::Normal(BridgeConstraints {
-                    location: constraint,
-                })
+                BridgeSettings::Normal(BridgeConstraints { location, provider })
             }
             BridgeSettingType::Local(proxy_settings) => {
                 let peer = proxy_settings
@@ -1012,10 +1014,7 @@ fn convert_relay_settings(settings: &RelaySettings) -> types::RelaySettings {
         RelaySettings::Normal(constraints) => {
             relay_settings::Endpoint::Normal(types::NormalRelaySettings {
                 location: convert_location_constraint(&constraints.location),
-                provider: match &constraints.provider {
-                    Constraint::Any => "".to_string(),
-                    Constraint::Only(ref provider) => provider.clone(),
-                },
+                provider: convert_provider_constraint(&constraints.provider),
                 tunnel_type: match constraints.tunnel_protocol {
                     Constraint::Any => None,
                     Constraint::Only(TunnelType::Wireguard) => Some(types::TunnelType::Wireguard),
@@ -1110,6 +1109,7 @@ fn convert_bridge_settings(settings: &BridgeSettings) -> types::BridgeSettings {
         BridgeSettings::Normal(constraints) => {
             BridgeSettingType::Normal(types::bridge_settings::BridgeConstraints {
                 location: convert_location_constraint(&constraints.location),
+                provider: convert_provider_constraint(&constraints.provider),
             })
         }
         BridgeSettings::Custom(proxy_settings) => match proxy_settings {
@@ -1194,6 +1194,13 @@ fn convert_location_constraint(
             hostname: hostname.to_string(),
         },
     })
+}
+
+fn convert_provider_constraint(provider: &Constraint<Provider>) -> String {
+    match provider.as_ref() {
+        Constraint::Any => "".to_string(),
+        Constraint::Only(ref provider) => provider.to_string(),
+    }
 }
 
 fn convert_bridge_state(state: &BridgeState) -> types::BridgeState {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -543,6 +543,9 @@ impl RelaySelector {
         if !constraints.location.matches(relay) {
             return None;
         }
+        if !constraints.provider.matches_eq(&relay.provider) {
+            return None;
+        }
 
         let mut filtered_relay = relay.clone();
         filtered_relay

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -270,17 +270,23 @@ message TunnelTypeConstraint {
 
 message NormalRelaySettings {
 	RelayLocation location = 1;
-	TunnelTypeConstraint tunnel_type = 2;
-	WireguardConstraints wireguard_constraints = 3;
-	OpenvpnConstraints openvpn_constraints = 4;
+	string provider = 2;
+	TunnelTypeConstraint tunnel_type = 3;
+	WireguardConstraints wireguard_constraints = 4;
+	OpenvpnConstraints openvpn_constraints = 5;
 }
 
 // Constraints are only updated for fields that are provided
 message NormalRelaySettingsUpdate {
 	RelayLocation location = 1;
-	TunnelTypeUpdate tunnel_type = 2;
-	WireguardConstraints wireguard_constraints = 3;
-	OpenvpnConstraints openvpn_constraints = 4;
+	ProviderUpdate provider = 2;
+	TunnelTypeUpdate tunnel_type = 3;
+	WireguardConstraints wireguard_constraints = 4;
+	OpenvpnConstraints openvpn_constraints = 5;
+}
+
+message ProviderUpdate {
+	string provider = 1;
 }
 
 message TunnelTypeUpdate {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -201,6 +201,7 @@ message AccountHistory {
 message BridgeSettings {
 	message BridgeConstraints {
 		RelayLocation location = 1;
+		string provider = 2;
 	}
 
 	message LocalProxySettings {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -425,10 +425,12 @@ pub enum BridgeSettings {
 
 
 /// Limits the set of bridge servers to use in `mullvad-daemon`.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
 #[serde(rename_all = "snake_case")]
 pub struct BridgeConstraints {
     pub location: Constraint<LocationConstraint>,
+    pub provider: Constraint<Provider>,
 }
 
 impl fmt::Display for BridgeConstraints {
@@ -466,6 +468,7 @@ impl fmt::Display for BridgeState {
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InternalBridgeConstraints {
     pub location: Constraint<LocationConstraint>,
+    pub provider: Constraint<Provider>,
     pub transport_protocol: Constraint<TransportProtocol>,
 }
 

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -40,9 +40,7 @@ impl Default for Settings {
                 location: Constraint::Only(LocationConstraint::Country("se".to_owned())),
                 tunnel: Constraint::Any,
             }),
-            bridge_settings: BridgeSettings::Normal(BridgeConstraints {
-                location: Constraint::Any,
-            }),
+            bridge_settings: BridgeSettings::Normal(BridgeConstraints::default()),
             bridge_state: BridgeState::Auto,
             allow_lan: false,
             block_when_disconnected: false,

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -63,9 +63,7 @@ impl Default for Settings {
                 location: Constraint::Only(LocationConstraint::Country("se".to_owned())),
                 ..Default::default()
             }),
-            bridge_settings: BridgeSettings::Normal(BridgeConstraints {
-                location: Constraint::Any,
-            }),
+            bridge_settings: BridgeSettings::Normal(BridgeConstraints::default()),
             bridge_state: BridgeState::Auto,
             allow_lan: false,
             block_when_disconnected: false,


### PR DESCRIPTION
These changes introduce a constraint to restrict the relay selector to choosing servers matching a given hosting provider. These CLI commands were added:

`mullvad relay set provider <provider>`
`mullvad bridge set provider <provider>`

`mullvad relay list` and `mullvad bridge list` were also updated to include the hosting provider of each server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2018)
<!-- Reviewable:end -->
