### PR TITLE
Fix version update checks on release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash when selecting the whole text entered for the voucher code and then deleting it in the
   Redeem Voucher dialog.
 - Show "Exclude applications" header if needed when entering the "Split tunneling" screen.
+- Fix check for update versions and check for support for current version.
 
 
 ## [2020.6-beta1] - 2020-08-20

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -224,6 +224,7 @@ impl VersionUpdater {
 
         // If this is a dev build ,there's no need to pester the API for version checks.
         if *IS_DEV_BUILD {
+            log::warn!("Not checking for updates because this is a development build");
             while let Some(_) = rx.next().await {}
             return;
         }

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -25,7 +25,7 @@ lazy_static::lazy_static! {
     static ref STABLE_REGEX: Regex = Regex::new(r"^(\d{4})\.(\d+)$").unwrap();
     static ref BETA_REGEX: Regex = Regex::new(r"^(\d{4})\.(\d+)-beta(\d+)$").unwrap();
     static ref APP_VERSION: Option<AppVersion> = AppVersion::from_str(PRODUCT_VERSION);
-    static ref IS_DEV_BUILD: bool = APP_VERSION.is_some();
+    static ref IS_DEV_BUILD: bool = APP_VERSION.is_none();
 }
 
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -312,7 +312,7 @@ pub fn load_cache(cache_dir: &Path) -> AppVersionInfo {
             );
             // If we don't have a cache, start out with sane defaults.
             AppVersionInfo {
-                supported: *IS_DEV_BUILD,
+                supported: !*IS_DEV_BUILD,
                 latest_stable: PRODUCT_VERSION.to_owned(),
                 latest_beta: PRODUCT_VERSION.to_owned(),
                 suggested_upgrade: None,


### PR DESCRIPTION
The newly release Android version wasn't performing any checks for new version updates or if the current version is still supported. This happened because the globaly `IS_DEV_BUILD` flag was initialized to the incorrect value.

This PR fixes that, and also makes it so that all development builds are marked as unsupported. A log message was also added so that if a similar issue occurs in the future, it is easier to narrow the root cause.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2019)
<!-- Reviewable:end -->
