### PR TITLE
Fix crash leaving Select Location screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Line wrap the file at 100 chars.                                              Th
   Redeem Voucher dialog.
 - Show "Exclude applications" header if needed when entering the "Split tunneling" screen.
 - Fix check for update versions and check for support for current version.
+- Fix crash that could happen when leaving the Select Location screen.
 
 
 ## [2020.6-beta1] - 2020-08-20

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -122,8 +122,7 @@ class SelectLocationFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
         relayListListener.onRelayListChange = null
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
+    override fun onSafelyDestroyView() {
         titleController.onDestroy()
     }
 


### PR DESCRIPTION
The `SelectLocationFragment` was overriding the incorrect view destructor from the `ServiceDependentFragment` base class. This led to two crashes being reported in the Play store. This PR fixes the code to override the correct destructor.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2021)
<!-- Reviewable:end -->
