### PR TITLE
Make addresses use one line each

### DIFF
--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -60,6 +60,11 @@ const Caption = styled(Text)({
   marginRight: '8px',
 });
 
+const IpAddresses = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
 const Header = styled.div({
   display: 'flex',
   alignItems: 'center',
@@ -100,10 +105,10 @@ export default class ConnectionPanel extends React.Component<IProps> {
             {outAddress && (outAddress.ipv4 || outAddress.ipv6) && (
               <Row>
                 <Caption>{messages.pgettext('connection-info', 'Out')}</Caption>
-                <div>
+                <IpAddresses>
                   {outAddress.ipv4 && <Text>{outAddress.ipv4}</Text>}
                   {outAddress.ipv6 && <Text>{outAddress.ipv6}</Text>}
-                </div>
+                </IpAddresses>
               </Row>
             )}
           </React.Fragment>


### PR DESCRIPTION
This PR fixes a graphical issue where the ipv4 and ipv6 addresses where places on the same line. This changes it to on line each.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2022)
<!-- Reviewable:end -->
