### PR TITLE
Migrate old uninstall registry key

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -585,7 +585,7 @@
 
 	# Application uninstall key
 	# Migrate 2018.(x<6) to current
-	registry::MoveKey "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\8fa2c331-e09e-5709-bc74-c59df61f0c7e" "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{${APP_GUID}}"
+	registry::MoveKey "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\8fa2c331-e09e-5709-bc74-c59df61f0c7e" "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APP_GUID}"
 
 	# Discard return value
 	Pop $0
@@ -593,7 +593,14 @@
 
 	# Application uninstall key
 	# Migrate 2018.6 through 2019.7 to current
-	registry::MoveKey "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Mullvad VPN" "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{${APP_GUID}}"
+	registry::MoveKey "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Mullvad VPN" "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APP_GUID}"
+
+	# Discard return value
+	Pop $0
+	Pop $0
+
+	# Migrate 2019.8 through 2020.5 to current
+	registry::MoveKey "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{${APP_GUID}}" "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APP_GUID}"
 
 	# Discard return value
 	Pop $0


### PR DESCRIPTION
electron-builder recently [reverted](https://github.com/electron-userland/electron-builder/pull/4443) where the NSIS install/uninstall information is stored. This causes upgrades from version 2020.5 of the app to fail.

As was done before, this PR simply moves the registry key in `customInit` to its new path, fixing upgrades from older versions. This does break downgrades, though. The app has to be fully uninstalled before an older version can be installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2023)
<!-- Reviewable:end -->
