### PR TITLE
Kill Electron app before upgrade on Linux

### DIFF
--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -9,4 +9,6 @@ if which systemctl &> /dev/null; then
     fi
 fi
 
+pkill -x "mullvad-gui" || true
+
 rm -f /var/cache/mullvad-vpn/relays.json || true


### PR DESCRIPTION
Kill Electron app before upgrade on Linux. Without this an old version of the app will continue to run after the upgrade which might result in issues when communicating with the newer daemon.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2024)
<!-- Reviewable:end -->
