### PR TITLE
Fix relay update timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Line wrap the file at 100 chars.                                              Th
 - Show a warning in the CLI if the provided location constraints don't match any known relay.
 
 ### Fixed
+- Fix high CPU usage in 2020.6-beta1. This was due to an incorrectly initialized stream in the
+  relay list updater.
+
 #### Android
 - Fix possible crash when starting the app, caused by trying to use JNI functions before the library
   is loaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix high CPU usage in 2020.6-beta1. This was due to an incorrectly initialized stream in the
   relay list updater.
+- Fix the relay list not being updated in 2020.6-beta1 after the daemon has started.
 
 #### Android
 - Fix possible crash when starting the app, caused by trying to use JNI functions before the library

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -807,11 +807,9 @@ impl RelayListUpdater {
     }
 
     async fn run(mut self, mut cmd_rx: mpsc::Receiver<()>) {
+        let mut check_interval = tokio02::time::interval(UPDATE_CHECK_INTERVAL).fuse();
+        let mut download_future = Box::pin(Fuse::terminated());
         loop {
-            let mut check_interval = tokio02::time::interval(UPDATE_CHECK_INTERVAL).fuse();
-            let mut download_future = Box::pin(Fuse::terminated());
-
-
             futures::select! {
                 _check_update = check_interval.next() => {
                     if !download_future.is_terminated() && self.should_update() {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -812,7 +812,7 @@ impl RelayListUpdater {
         loop {
             futures::select! {
                 _check_update = check_interval.next() => {
-                    if !download_future.is_terminated() && self.should_update() {
+                    if download_future.is_terminated() && self.should_update() {
                         download_future = Box::pin(Self::download_relay_list(self.rpc_client.clone()).fuse());
                         self.earliest_next_try = Instant::now() + UPDATE_INTERVAL;
                     }


### PR DESCRIPTION
Introduced by commit `753164546`:

```
        loop {
            let mut check_interval = tokio02::time::interval(UPDATE_CHECK_INTERVAL).fuse();
            let mut download_future = Box::pin(Fuse::terminated());
            futures::select! {
                _check_update = check_interval.next() => {
                    if !download_future.is_terminated() && self.should_update() {
                        download_future = Box::pin(Self::download_relay_list(self.rpc_client.clone()).fuse());
                        self.earliest_next_try = Instant::now() + UPDATE_INTERVAL;
                    }
                },
            ...
```

Since `check_interval` is assigned inside the loop, it is resolved every time this loops. (The first tick completes immediately.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2025)
<!-- Reviewable:end -->
