### PR TITLE
Only show bridge servers in location entry list

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -750,7 +750,9 @@ class ApplicationMain {
           cities: country.cities
             .map((city) => ({
               ...city,
-              relays: city.relays.filter((relay) => relay.bridges),
+              relays: city.relays.filter(
+                (relay) => relay.bridges && relay.bridges.shadowsocks.length > 0,
+              ),
             }))
             .filter((city) => city.relays.length > 0),
         }))


### PR DESCRIPTION
My guess is that the switch to gRPC changed `relay.bridges` from being undefined to `{ shadowsocks: [] }` if the current relay isn't a bridge server and therefore the previous logic here fails.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2027)
<!-- Reviewable:end -->
