### PR TITLE
Deny all Rust warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
             ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
             linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
       before_script:
-        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens"
+        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens --deny unconditional_recursion"
         - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar
         - export CC_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang
         - source env.sh aarch64-linux-android

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
             ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
             linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
       before_script:
-        - export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens --deny unconditional_recursion"
+        - export RUSTFLAGS="--deny warnings"
         - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar
         - export CC_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang
         - source env.sh aarch64-linux-android

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN_CHANNEL=$1
-export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens --deny unconditional_recursion"
+export RUSTFLAGS="--deny warnings"
 
 source env.sh
 

--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN_CHANNEL=$1
-export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens"
+export RUSTFLAGS="--deny unused_imports --deny dead_code --deny unused_mut --deny unused_variables --deny unused_parens --deny unconditional_recursion"
 
 source env.sh
 


### PR DESCRIPTION
Previously we had some deprecation warnings we could not easily get rid of. We have now gotten rid of those. And we hit a new bad problem due to a warning we did not catch:
```
warning: function cannot return without recursing                                                                                                            
   --> mullvad-types/src/relay_constraints.rs:199:5
    |                                                                                                                                                        
199 |     fn default() -> Self {      
    |     ^^^^^^^^^^^^^^^^^^^^ cannot return without recursing                                                                                               
...                               
202 |             ..Default::default()                                                                                                                       
    |               ------------------ recursive call site
    |                                                                                                                                                        
    = note: `#[warn(unconditional_recursion)]` on by default                                                                 
    = help: a `loop` may express intention better if this is on purpose                                                                                      
```

So we want to catch warnings better. Since we don't have any warnings on master, let's just deny all warnings for now and see if it seems doable!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2031)
<!-- Reviewable:end -->
