### PR TITLE
Fix infinite recursion in `Default` implementation for `RelayConstraints`

### DIFF
--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -185,6 +185,7 @@ impl RelaySettings {
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct RelayConstraints {
     pub location: Constraint<LocationConstraint>,
+    #[cfg_attr(target_os = "android", jnix(skip))]
     pub provider: Constraint<Provider>,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub tunnel_protocol: Constraint<TunnelType>,

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -199,7 +199,10 @@ impl Default for RelayConstraints {
     fn default() -> Self {
         RelayConstraints {
             tunnel_protocol: Constraint::Only(TunnelType::Wireguard),
-            ..Default::default()
+            location: Constraint::default(),
+            provider: Constraint::default(),
+            wireguard_constraints: WireguardConstraints::default(),
+            openvpn_constraints: OpenVpnConstraints::default(),
         }
     }
 }


### PR DESCRIPTION
This PR removes an infinite recursion in the implementation of `Default` for the `RelayConstraints` type. Unfortunately, that means that each field must be manually specified.

The PR also marks the `provider` field as to be skipped during the conversion to the Java `RelayConstraints` class because there is no equivalent field there yet.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not present in any released version, so no changelog entry is necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2032)
<!-- Reviewable:end -->
