### PR TITLE
Build all Rust code on nighly, since the blocker (jsonrpc) is gone

### DIFF
--- a/ci/ci-rust-script.sh
+++ b/ci/ci-rust-script.sh
@@ -36,12 +36,8 @@ esac
 # On Windows, it relies on having msbuild.exe in your path.
 ./wireguard/build-wireguard-go.sh
 
-# FIXME: Becaues of our old jsonrpc dependency our Rust code won't build
-# on latest nightly.
-if [ "${RUST_TOOLCHAIN_CHANNEL}" != "nightly" ]; then
-  time cargo build --locked --verbose
-  time cargo test --locked --verbose
-fi
+time cargo build --locked --verbose
+time cargo test --locked --verbose
 
 if [[ "${RUST_TOOLCHAIN_CHANNEL}" == "nightly" && "$(uname -s)" == "Linux" ]]; then
   rustfmt --version;


### PR DESCRIPTION
The jsonrpc stuff is finally gone. According to this fixme comment that was the only thing stopping us from building on nightly. And I tested now, it works to build on nightly. So let's run the full CI there as before, fewer special cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2033)
<!-- Reviewable:end -->
