### PR TITLE
Fix crash when Selecting Location

### DIFF
--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -519,6 +519,7 @@ impl RelaySettingsUpdate {
 #[serde(default)]
 pub struct RelayConstraintsUpdate {
     pub location: Option<Constraint<LocationConstraint>>,
+    #[cfg_attr(target_os = "android", jnix(default))]
     pub provider: Option<Constraint<Provider>>,
     #[cfg_attr(target_os = "android", jnix(default))]
     pub tunnel_protocol: Option<Constraint<TunnelType>>,


### PR DESCRIPTION
A previous PR marked a field related to the relay provider as to be skipped by `jnix` because it's not used yet on Android, but I managed to miss another type that also had the field. This PR also marks that field in order to prevent a crash when changing the relay constraints.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any released version, so no changelog is necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2034)
<!-- Reviewable:end -->
