### PR TITLE
Run mullvad-setup prepare-restart in preinstall script instead of postinstall

### DIFF
--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -51,8 +51,6 @@ EOM
 ZSH_COMPLETIONS_DIR="/usr/local/share/zsh/site-functions/"
 FISH_COMPLETIONS_DIR="/usr/local/share/fish/vendor_completions.d/"
 
-"$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" prepare-restart || true
-
 pkill -x "Mullvad VPN" || echo "Unable to kill GUI, not running?"
 sleep 1
 

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -3,6 +3,7 @@
 set -eux
 
 LOG_DIR=/var/log/mullvad-vpn
+INSTALL_DIR=$2
 
 mkdir -p $LOG_DIR
 chmod 755 $LOG_DIR
@@ -76,4 +77,12 @@ if [ -d "$OLD_CACHE_DIR" ]; then
     rm -rf "$OLD_CACHE_DIR"
 fi
 
-rm -f "$NEW_CACHE_DIR/relays.json" || true
+# Remove the existing relay list.
+# There is a risk that it's incompatible with the format this version wants
+rm "$NEW_CACHE_DIR/relays.json" || true
+
+# Notify the running daemon that we are going to kill it and replace it with a newer version.
+# This will make the daemon save it's state to a file and then lock the firewall to prevent
+# leaks during the upgrade.
+"$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" prepare-restart || \
+    echo "Failed to send 'prepare-restart' command to old mullvad-daemon"

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -545,13 +545,19 @@ where
                 .map_err(Error::ReadCachedTargetState),
             Err(e) => {
                 if e.kind() == io::ErrorKind::NotFound {
+                    debug!("No cached target state to load");
                     Ok(None)
                 } else {
                     Err(Error::OpenCachedTargetState(e))
                 }
             }
         }?;
-        if cached_target_state.is_some() {
+        if let Some(cached_target_state) = &cached_target_state {
+            info!(
+                "Loaded cached target state \"{}\" from {}",
+                cached_target_state,
+                target_cache.display()
+            );
             let _ = fs::remove_file(target_cache).map_err(|e| {
                 error!("Cannot delete target tunnel state cache: {}", e);
             });
@@ -586,7 +592,6 @@ where
                 info!("Automatically connecting since auto-connect is turned on");
                 TargetState::Secured
             } else {
-                info!("Restoring cached target state");
                 cached_target_state.unwrap_or(TargetState::Unsecured)
             }
         } else {

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -2,6 +2,7 @@ use crate::location::GeoIpLocation;
 #[cfg(target_os = "android")]
 use jnix::IntoJava;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use talpid_types::{
     net::TunnelEndpoint,
     tunnel::{ActionAfterDisconnect, ErrorState},
@@ -15,6 +16,15 @@ use talpid_types::{
 pub enum TargetState {
     Unsecured,
     Secured,
+}
+
+impl fmt::Display for TargetState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TargetState::Unsecured => "Unsecured".fmt(f),
+            TargetState::Secured => "Secured".fmt(f),
+        }
+    }
 }
 
 /// Represents the state the client tunnel is in.


### PR DESCRIPTION
Fixes a leak during upgrade due to mullvad-setup no longer being compatible with old daemon

Not mentioned in changelog as a fix, since upgrading between any existing versions does not have this leak. It's only from any existing release to anything after the gRPC migration that causes the leak.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2036)
<!-- Reviewable:end -->
