### PR TITLE
Fix return value for WinFw_Deinitialize

### DIFF
--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -189,7 +189,7 @@ WinFw_Deinitialize(WINFW_CLEANUP_POLICY cleanupPolicy)
 		return true;
 	}
 
-	return WinFw_Reset();
+	return WINFW_POLICY_STATUS_SUCCESS == WinFw_Reset();
 }
 
 WINFW_LINKAGE


### PR DESCRIPTION
`WinFw_Deinitialize()` incorrectly returned `false` even if it succeeded (and vice versa).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2037)
<!-- Reviewable:end -->
