### PR TITLE
Purge WFP filters upon a full uninstall when always-require-vpn is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ This release is for Android only.
 - Fix crash that could happen when leaving the Select Location screen.
 - Don't show out-of-time notification for newly created accounts.
 
+#### Windows
+- Remove firewall filters (unblock internet access) when "Always require VPN" is enabled and the app
+  is uninstalled.
+
 
 ## [2020.6-beta1] - 2020-08-20
 This release is for Android only.

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -771,13 +771,11 @@
 		Pop $1
 	${EndIf}
 
-	nsExec::ExecToStack '"$SYSDIR\sc.exe" stop mullvadvpn'
+	nsExec::ExecToStack '"$SYSDIR\net.exe" stop mullvadvpn'
 
 	# Discard return value
 	Pop $0
 	Pop $1
-
-	Sleep 5000
 
 	nsExec::ExecToStack '"$SYSDIR\sc.exe" delete mullvadvpn'
 


### PR DESCRIPTION
When always-require-vpn is enabled, the WFP filters should be cleared upon a full uninstall. Currently they're not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2039)
<!-- Reviewable:end -->
