### PR TITLE
Remove a use of wildcard imports in favor of importing used items

### DIFF
--- a/mullvad-daemon/src/exception_logging/unix.rs
+++ b/mullvad-daemon/src/exception_logging/unix.rs
@@ -1,7 +1,7 @@
 //! Installs signal handlers to catch critical program faults and logs them.
 
 use libc::{c_int, c_void, siginfo_t};
-use nix::sys::signal::*;
+use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
 
 use std::{convert::TryFrom, sync::Once};
 


### PR DESCRIPTION
I played around with some lints and somewhat unrelated to the lints I stumbled upon this code. Turned out it was not that many items we needed from this namespace, and I'm personally not a fan of wildcard imports. So I did this change. What do you think?

The main reason why I'm not a fan of wildcard imports is that when you see a type/function in code, you can't immediately trace where it comes from if it comes from a wildcard import. Wildcard imports can also bring in a bunch of traits without the reader noticing, these can affect the behaviour of any type and introduce new functionality. Too much magic for my taste.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2041)
<!-- Reviewable:end -->
