### PR TITLE
Remove unused MISSING_ARGUMENT constant and document remaining constants

### DIFF
--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -92,8 +92,8 @@ impl From<Result<VoucherSubmission, daemon_interface::Error>> for VoucherSubmiss
             Ok(submission) => VoucherSubmissionResult::Ok(submission),
             Err(daemon_interface::Error::RpcError(RestError::ApiError(_, code))) => {
                 match code.as_str() {
-                    "INVALID_VOUCHER" => VoucherSubmissionResult::InvalidVoucher,
-                    "VOUCHER_USED" => VoucherSubmissionResult::VoucherAlreadyUsed,
+                    mullvad_rpc::INVALID_VOUCHER => VoucherSubmissionResult::InvalidVoucher,
+                    mullvad_rpc::VOUCHER_USED => VoucherSubmissionResult::VoucherAlreadyUsed,
                     _ => VoucherSubmissionResult::RpcError,
                 }
             }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -29,6 +29,11 @@ mod relay_list;
 pub use hyper::StatusCode;
 pub use relay_list::RelayListProxy;
 
+/// Error code returned by the Mullvad API if the voucher has alreaby been used.
+pub const VOUCHER_USED: &str = "VOUCHER_USED";
+
+/// Error code returned by the Mullvad API if the voucher code is invalid.
+pub const INVALID_VOUCHER: &str = "INVALID_VOUCHER";
 
 const API_HOST: &str = "api.mullvad.net";
 pub const API_IP_CACHE_FILENAME: &str = "api-ip-address.txt";
@@ -124,9 +129,6 @@ struct AccountResponse {
     token: AccountToken,
     expires: DateTime<Utc>,
 }
-pub const VOUCHER_USED: &str = "VOUCHER_USED";
-pub const INVALID_VOUCHER: &str = "INVALID_VOUCHER";
-pub const MISSING_ARGUMENT: &str = "MISSING_ARGUMENT";
 
 impl AccountsProxy {
     pub fn new(handle: rest::MullvadRestHandle) -> Self {


### PR DESCRIPTION
I could not find any usage for the `MISSING_ARGUMENT` constant. So I removed it. I moved the other constants to the top of the file, where constants are usually defined, and gave them documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2047)
<!-- Reviewable:end -->
