### PR TITLE
Improve Linux split tunneling dialog messages

### DIFF
--- a/gui/src/renderer/components/LinuxSplitTunnelingSettings.tsx
+++ b/gui/src/renderer/components/LinuxSplitTunnelingSettings.tsx
@@ -220,7 +220,7 @@ function ApplicationRow(props: IApplicationRowProps) {
     ? sprintf(
         messages.pgettext(
           'split-tunneling-view',
-          '%(applicationName)s is problematic and cannot be excluded from the VPN tunnel.',
+          '%(applicationName)s is problematic and can’t be excluded from the VPN tunnel.',
         ),
         {
           applicationName: props.application.name,
@@ -229,7 +229,7 @@ function ApplicationRow(props: IApplicationRowProps) {
     : sprintf(
         messages.pgettext(
           'split-tunneling-view',
-          '%(applicationName)s is problematic and might not be excluded from the VPN tunnel. Try closing all existing instances of %(applicationName)s before starting it from here.',
+          'If it’s already running, close %(applicationName)s before launching it from here. Otherwise it might not be excluded from the VPN tunnel.',
         ),
         {
           applicationName: props.application.name,


### PR DESCRIPTION
This PR changes the dialog messages in the Linux split tunneling view.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2053)
<!-- Reviewable:end -->
