### PR TITLE
Rework packet tunnel state and fix occasional hanging

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		582BB1B3229574F40055B6EF /* SettingsAccountCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582BB1B2229574F40055B6EF /* SettingsAccountCell.swift */; };
 		582BB1B52295780F0055B6EF /* AccountExpiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582BB1B42295780F0055B6EF /* AccountExpiry.swift */; };
 		5835B7CC233B76CB0096D79F /* TunnelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5835B7CB233B76CB0096D79F /* TunnelManager.swift */; };
+		583BC70724FE4DC500C9DE04 /* Optional+DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583BC70624FE4DC400C9DE04 /* Optional+DispatchQueue.swift */; };
+		583BC70824FE4DC500C9DE04 /* Optional+DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583BC70624FE4DC400C9DE04 /* Optional+DispatchQueue.swift */; };
 		5840250122B1124600E4CFEC /* IpAddress+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250022B1124600E4CFEC /* IpAddress+Codable.swift */; };
 		5840250222B1124600E4CFEC /* IpAddress+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250022B1124600E4CFEC /* IpAddress+Codable.swift */; };
 		5840250422B11AB700E4CFEC /* MullvadEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */; };
@@ -288,6 +290,7 @@
 		582BB1B2229574F40055B6EF /* SettingsAccountCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccountCell.swift; sourceTree = "<group>"; };
 		582BB1B42295780F0055B6EF /* AccountExpiry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExpiry.swift; sourceTree = "<group>"; };
 		5835B7CB233B76CB0096D79F /* TunnelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelManager.swift; sourceTree = "<group>"; };
+		583BC70624FE4DC400C9DE04 /* Optional+DispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+DispatchQueue.swift"; sourceTree = "<group>"; };
 		5840250022B1124600E4CFEC /* IpAddress+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IpAddress+Codable.swift"; sourceTree = "<group>"; };
 		5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadEndpoint.swift; sourceTree = "<group>"; };
 		5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelIpc.swift; sourceTree = "<group>"; };
@@ -612,6 +615,7 @@
 				58C6B35322BB87C4003C19AD /* WireguardPrivateKey.swift */,
 				58F3C098249B978C003E76BE /* x25519.c */,
 				58F3C097249B978C003E76BE /* x25519.h */,
+				583BC70624FE4DC400C9DE04 /* Optional+DispatchQueue.swift */,
 			);
 			path = MullvadVPN;
 			sourceTree = "<group>";
@@ -1002,6 +1006,7 @@
 				580EE22124B3240100F9D8A1 /* TransformOperationObserver.swift in Sources */,
 				582BB1AF229566420055B6EF /* SettingsCell.swift in Sources */,
 				5873884D239E6D7E00E96C4E /* EmbeddedViewContainerView.swift in Sources */,
+				583BC70724FE4DC500C9DE04 /* Optional+DispatchQueue.swift in Sources */,
 				58F3C0A4249CB069003E76BE /* HeaderBarView.swift in Sources */,
 				585FE2F124E1365400439C50 /* LogStreamer.swift in Sources */,
 				58B9EB132488ED2100095626 /* AlertPresenter.swift in Sources */,
@@ -1096,6 +1101,7 @@
 				581503A424D6F1EC00C9C50E /* ChainedError+Logger.swift in Sources */,
 				5815039824D6ECAE00C9C50E /* CustomFormatLogHandler.swift in Sources */,
 				5840250522B11AB700E4CFEC /* MullvadEndpoint.swift in Sources */,
+				583BC70824FE4DC500C9DE04 /* Optional+DispatchQueue.swift in Sources */,
 				58BFA5C722A7C97F00A6173D /* RelayCache.swift in Sources */,
 				580EE21024B322E700F9D8A1 /* TransformOperation.swift in Sources */,
 				58906DE02445C7A5002F0673 /* NEProviderStopReason+Debug.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -21,8 +21,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let simulatorTunnelProvider = SimulatorTunnelProviderHost()
     #endif
 
+    #if DEBUG
+    private let packetTunnelLogForwarder = LogStreamer<UTF8>(fileURLs: [ApplicationConfiguration.packetTunnelLogFileURL!])
+    #endif
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         initLoggingSystem(bundleIdentifier: Bundle.main.bundleIdentifier!)
+
+        #if DEBUG
+        let stdoutStream = TextFileOutputStream.standardOutputStream()
+        packetTunnelLogForwarder.start { (str) in
+            stdoutStream.write("\(str)\n")
+        }
+        #endif
 
         #if targetEnvironment(simulator)
         SimulatorTunnelProvider.shared.delegate = simulatorTunnelProvider

--- a/ios/MullvadVPN/ApplicationConfiguration.swift
+++ b/ios/MullvadVPN/ApplicationConfiguration.swift
@@ -16,16 +16,23 @@ class ApplicationConfiguration {
     /// The application identifier for the PacketTunnel extension
     static let packetTunnelExtensionIdentifier = "net.mullvad.MullvadVPN.PacketTunnel"
 
-    /// The application log files
-    static var logFileURLs: [URL] {
-        let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Self.securityGroupIdentifier)
-        let fileNames = ["net.mullvad.MullvadVPN", "net.mullvad.MullvadVPN.PacketTunnel"]
+    /// Container URL for security group
+    static var containerURL: URL? {
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Self.securityGroupIdentifier)
+    }
 
-        return fileNames.compactMap { (fileName) -> URL? in
-            return containerURL?
-                .appendingPathComponent("Logs", isDirectory: true)
-                .appendingPathComponent(fileName, isDirectory: false)
-                .appendingPathExtension("log")
-        }
+    /// The main application log file located in a shared container
+    static var mainApplicationLogFileURL: URL? {
+        return Self.containerURL?.appendingPathComponent("Logs/net.mullvad.MullvadVPN.log", isDirectory: false)
+    }
+
+    /// The packet tunnel log file located in a shared container
+    static var packetTunnelLogFileURL: URL? {
+        return Self.containerURL?.appendingPathComponent("Logs/net.mullvad.MullvadVPN.PacketTunnel.log", isDirectory: false)
+    }
+
+    /// All log files located in a shared container
+    static var logFileURLs: [URL] {
+        return [mainApplicationLogFileURL, packetTunnelLogFileURL].compactMap { $0 }
     }
 }

--- a/ios/MullvadVPN/AutomaticKeyRotationManager.swift
+++ b/ios/MullvadVPN/AutomaticKeyRotationManager.swift
@@ -69,6 +69,9 @@ class AutomaticKeyRotationManager {
     /// A variable backing the `eventHandler` public property
     private var _eventHandler: ((KeyRotationResult) -> Void)?
 
+    /// A dispatch queue used for broadcasting events
+    private let eventQueue: DispatchQueue?
+
     /// An event handler that's invoked when key rotation occurred
     var eventHandler: ((KeyRotationResult) -> Void)? {
         get {
@@ -83,11 +86,12 @@ class AutomaticKeyRotationManager {
         }
     }
 
-    init(persistentKeychainReference: Data) {
+    init(persistentKeychainReference: Data, eventQueue: DispatchQueue?) {
         self.persistentKeychainReference = persistentKeychainReference
+        self.eventQueue = eventQueue
     }
 
-    func startAutomaticRotation(completionHandler: @escaping () -> Void) {
+    func startAutomaticRotation(queue: DispatchQueue?, completionHandler: @escaping () -> Void) {
         dispatchQueue.async {
             guard !self.isAutomaticRotationEnabled else { return }
 
@@ -96,11 +100,11 @@ class AutomaticKeyRotationManager {
             self.isAutomaticRotationEnabled = true
             self.performKeyRotation()
 
-            completionHandler()
+            queue.performOnWrappedOrCurrentQueue(block: completionHandler)
         }
     }
 
-    func stopAutomaticRotation(completionHandler: @escaping () -> Void) {
+    func stopAutomaticRotation(queue: DispatchQueue?, completionHandler: @escaping () -> Void) {
         dispatchQueue.async {
             guard self.isAutomaticRotationEnabled else { return }
 
@@ -113,7 +117,7 @@ class AutomaticKeyRotationManager {
 
             self.timerSource?.cancel()
 
-            completionHandler()
+            queue.performOnWrappedOrCurrentQueue(block: completionHandler)
         }
     }
 
@@ -215,7 +219,9 @@ class AutomaticKeyRotationManager {
             if event.isNew {
                 logger.info("Finished private key rotation")
 
-                eventHandler?(event)
+                eventQueue.performOnWrappedOrCurrentQueue {
+                    self.eventHandler?(event)
+                }
             }
 
             if let rotationDate = Self.nextRotation(creationDate: event.creationDate) {

--- a/ios/MullvadVPN/AutomaticKeyRotationManager.swift
+++ b/ios/MullvadVPN/AutomaticKeyRotationManager.swift
@@ -93,12 +93,12 @@ class AutomaticKeyRotationManager {
 
     func startAutomaticRotation(queue: DispatchQueue?, completionHandler: @escaping () -> Void) {
         dispatchQueue.async {
-            guard !self.isAutomaticRotationEnabled else { return }
+            if !self.isAutomaticRotationEnabled {
+                self.logger.info("Start automatic key rotation")
 
-            self.logger.info("Start automatic key rotation")
-
-            self.isAutomaticRotationEnabled = true
-            self.performKeyRotation()
+                self.isAutomaticRotationEnabled = true
+                self.performKeyRotation()
+            }
 
             queue.performOnWrappedOrCurrentQueue(block: completionHandler)
         }
@@ -106,16 +106,16 @@ class AutomaticKeyRotationManager {
 
     func stopAutomaticRotation(queue: DispatchQueue?, completionHandler: @escaping () -> Void) {
         dispatchQueue.async {
-            guard self.isAutomaticRotationEnabled else { return }
+            if self.isAutomaticRotationEnabled {
+                self.logger.info("Stop automatic key rotation")
 
-            self.logger.info("Stop automatic key rotation")
+                self.isAutomaticRotationEnabled = false
 
-            self.isAutomaticRotationEnabled = false
+                self.dataTask?.cancel()
+                self.dataTask = nil
 
-            self.dataTask?.cancel()
-            self.dataTask = nil
-
-            self.timerSource?.cancel()
+                self.timerSource?.cancel()
+            }
 
             queue.performOnWrappedOrCurrentQueue(block: completionHandler)
         }

--- a/ios/MullvadVPN/ConnectViewController.swift
+++ b/ios/MullvadVPN/ConnectViewController.swift
@@ -123,7 +123,7 @@ class ConnectViewController: UIViewController, RootContainment, TunnelObserver,
 
     private func updateButtons() {
         switch tunnelState {
-        case .disconnected:
+        case .disconnected, .disconnecting:
             selectLocationButton.setTitle(NSLocalizedString("Select location", comment: ""), for: .normal)
             connectButton.setTitle(NSLocalizedString("Secure connection", comment: ""), for: .normal)
 
@@ -135,7 +135,7 @@ class ConnectViewController: UIViewController, RootContainment, TunnelObserver,
 
             setArrangedButtons([selectLocationButton, splitDisconnectButtonView])
 
-        case .connected, .reconnecting, .disconnecting:
+        case .connected, .reconnecting:
             selectLocationButton.setTitle(NSLocalizedString("Switch location", comment: ""), for: .normal)
             splitDisconnectButtonView.primaryButton.setTitle(NSLocalizedString("Disconnect", comment: ""), for: .normal)
 

--- a/ios/MullvadVPN/Optional+DispatchQueue.swift
+++ b/ios/MullvadVPN/Optional+DispatchQueue.swift
@@ -1,0 +1,22 @@
+//
+//  Optional+DispatchQueue.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 01/09/2020.
+//  Copyright © 2020 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension Optional where Wrapped == DispatchQueue {
+    /// Unwrap the `DispatchQueue` and perform the block on it, otherwise call the block
+    /// synchronously on the current queue when `Optional` is `.none`.
+    func performOnWrappedOrCurrentQueue(block: @escaping () -> Void) {
+        switch self {
+        case .some(let queue):
+            queue.async(execute: block)
+        case .none:
+            block()
+        }
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -84,10 +84,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 case .failure(let error):
                     self.logger.error(chainedError: error, message: "Failed to stop the tunnel")
                 }
-
-                completionHandler()
                 finish()
             }
+        }
+
+        operation.addDidFinishBlockObserver { (op) in
+            completionHandler()
         }
 
         exclusivityController.addOperation(operation, categories: [.exclusive])

--- a/ios/PacketTunnel/WireguardDevice.swift
+++ b/ios/PacketTunnel/WireguardDevice.swift
@@ -141,10 +141,12 @@ class WireguardDevice {
 
     // MARK: - Public methods
 
-    func start(configuration: WireguardConfiguration, completionHandler: @escaping (Result<(), Error>) -> Void) {
+    func start(queue: DispatchQueue?, configuration: WireguardConfiguration, completionHandler: @escaping (Result<(), Error>) -> Void) {
         workQueue.async {
             guard !self.isStarted else {
-                completionHandler(.failure(.alreadyStarted))
+                queue.performOnWrappedOrCurrentQueue {
+                    completionHandler(.failure(.alreadyStarted))
+                }
                 return
             }
 
@@ -160,15 +162,19 @@ class WireguardDevice {
 
                 self.startNetworkMonitor()
 
-                completionHandler(.success(()))
+                queue.performOnWrappedOrCurrentQueue {
+                    completionHandler(.success(()))
+                }
 
             case .failure(let error):
-                completionHandler(.failure(error))
+                queue.performOnWrappedOrCurrentQueue {
+                    completionHandler(.failure(error))
+                }
             }
         }
     }
 
-    func stop(completionHandler: @escaping (Result<(), Error>) -> Void) {
+    func stop(queue: DispatchQueue?, completionHandler: @escaping (Result<(), Error>) -> Void) {
         workQueue.async {
             if self.isStarted {
                 self.networkMonitor?.cancel()
@@ -177,14 +183,18 @@ class WireguardDevice {
                 self.stopWireguardBackend()
                 self.isStarted = false
 
-                completionHandler(.success(()))
+                queue.performOnWrappedOrCurrentQueue {
+                    completionHandler(.success(()))
+                }
             } else {
-                completionHandler(.failure(.notStarted))
+                queue.performOnWrappedOrCurrentQueue {
+                    completionHandler(.failure(.notStarted))
+                }
             }
         }
     }
 
-    func setConfiguration(_ newConfiguration: WireguardConfiguration, completionHandler: @escaping (Result<(), Error>) -> Void) {
+    func setConfiguration(_ newConfiguration: WireguardConfiguration, queue: DispatchQueue?, completionHandler: @escaping (Result<(), Error>) -> Void) {
         workQueue.async {
             if self.isStarted {
                 if let handle = self.wireguardHandle {
@@ -196,9 +206,13 @@ class WireguardDevice {
 
                 self.configuration = newConfiguration
 
-                completionHandler(.success(()))
+                queue.performOnWrappedOrCurrentQueue {
+                    completionHandler(.success(()))
+                }
             } else {
-                completionHandler(.failure(.notStarted))
+                queue.performOnWrappedOrCurrentQueue {
+                    completionHandler(.failure(.notStarted))
+                }
             }
         }
     }

--- a/ios/PacketTunnel/WireguardDevice.swift
+++ b/ios/PacketTunnel/WireguardDevice.swift
@@ -65,7 +65,7 @@ class WireguardDevice {
     /// A private queue used for Wireguard logging
     private static let loggingQueue = DispatchQueue(
         label: "net.mullvad.vpn.packet-tunnel.wireguard-device.global-logging-queue",
-        qos: .background
+        qos: .utility
     )
 
     /// A private queue used to synchronize access to `WireguardDevice` members


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Rework packet tunnel state management and fix the issue with the tunnel hanging during the call to set network settings.
1. Stream packet tunnel logs to stdout in the main process when in DEBUG. Makes it easier to observe what's happening in the tunnel without hooking up the packet tunnel process.
1. AsyncOperation: avoid locking the KVO calls to `willChangeValue` and `didChangeValue` to prevent the deadlock that happens when the base `Operation` class synchronously calls to `isFinished` in response to KVO notification while locking the current thread.  I have added another lock (`transactionLock`) to ensure that `start`, `finish` and `cancel` calls execute in one piece to ensure the state integrity.
1. AsyncOperation: Call `super.cancel()` to make sure that the base `Operation` is in the loop.
1. Add optional `queue: DispatchQueue?` to async calls that accept completion handler.
1. When disconnecting, make the UI appear as if the tunnel is already disconnected.
1. Move the call to `completionHandler` in `stopTunnel` until after the operation has finished. This way the tunnel is being released before the process quits on iOS 13.4.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2054)
<!-- Reviewable:end -->
