### PR TITLE
Create `AccountInput` widget

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInput.kt
@@ -49,7 +49,7 @@ class AccountInput(val parentView: View, context: Context) {
         }
 
     val container: AccountInputContainer = parentView.findViewById(R.id.account_input_container)
-    val input: TextView = parentView.findViewById(R.id.account_input)
+    val input: TextView = parentView.findViewById(R.id.login_input)
     val button: ImageButton = parentView.findViewById(R.id.login_button)
     val accountHistoryList: ListView = parentView.findViewById(R.id.account_history_list)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -15,9 +15,6 @@ import net.mullvad.mullvadvpn.ui.AccountInputContainer.BorderState
 import net.mullvad.mullvadvpn.ui.widget.AccountInput
 
 class AccountInputController(val parentView: View, context: Context) {
-    private val disabledBackgroundColor = context.getColor(R.color.white20)
-    private val enabledBackgroundColor = context.getColor(R.color.white)
-
     private var inputHasFocus by observable(false) { _, _, hasFocus ->
         updateBorder()
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -16,7 +16,7 @@ import net.mullvad.mullvadvpn.ui.AccountInputContainer.BorderState
 
 const val MIN_ACCOUNT_TOKEN_LENGTH = 10
 
-class AccountInput(val parentView: View, context: Context) {
+class AccountInputController(val parentView: View, context: Context) {
     private val disabledBackgroundColor = context.getColor(R.color.white20)
     private val disabledTextColor = context.getColor(R.color.white)
     private val enabledBackgroundColor = context.getColor(R.color.white)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -18,18 +18,16 @@ class AccountInputController(val parentView: View, context: Context) {
         }
     }
 
-    private var usingErrorColor by observable(false) { _, _, _ ->
-        updateBorder()
-    }
-
     var state: LoginState by observable(LoginState.Initial) { _, _, newState ->
         input.loginState = newState
+
+        updateBorder()
 
         when (newState) {
             LoginState.Initial -> {}
             LoginState.InProgress -> loggingInState()
             LoginState.Success -> successState()
-            LoginState.Failure -> failureState()
+            LoginState.Failure -> {}
         }
     }
 
@@ -42,7 +40,9 @@ class AccountInputController(val parentView: View, context: Context) {
         }
 
         onTextChanged.subscribe(this) { _ ->
-            leaveErrorState()
+            if (state == LoginState.Failure) {
+                state = LoginState.Initial
+            }
         }
     }
 
@@ -79,10 +79,6 @@ class AccountInputController(val parentView: View, context: Context) {
         container.visibility = View.INVISIBLE
     }
 
-    private fun failureState() {
-        usingErrorColor = true
-    }
-
     private fun updateAccountHistory() {
         accountHistory?.let { history ->
             accountHistoryList.apply {
@@ -110,19 +106,12 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     private fun updateBorder() {
-        if (usingErrorColor) {
+        if (state == LoginState.Failure) {
             container.borderState = BorderState.ERROR
         } else if (inputHasFocus) {
             container.borderState = BorderState.FOCUSED
         } else {
             container.borderState = BorderState.UNFOCUSED
-        }
-    }
-
-    private fun leaveErrorState() {
-        if (usingErrorColor) {
-            input.loginState = LoginState.Initial
-            usingErrorColor = false
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.ListView
-import android.widget.TextView
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.AccountInputContainer.BorderState
@@ -24,7 +23,7 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     var state: LoginState by observable(LoginState.Initial) { _, _, newState ->
-        newInput.loginState = newState
+        input.loginState = newState
 
         when (newState) {
             LoginState.Initial -> {}
@@ -35,10 +34,9 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     val container: AccountInputContainer = parentView.findViewById(R.id.account_input_container)
-    val input: TextView = parentView.findViewById(R.id.login_input)
     val accountHistoryList: ListView = parentView.findViewById(R.id.account_history_list)
 
-    val newInput = parentView.findViewById<AccountInput>(R.id.account_input).apply {
+    val input = parentView.findViewById<AccountInput>(R.id.account_input).apply {
         onFocusChanged.subscribe(this) { hasFocus ->
             inputHasFocus = hasFocus
         }
@@ -65,12 +63,12 @@ class AccountInputController(val parentView: View, context: Context) {
         }
 
     var onLogin: ((String) -> Unit)?
-        get() = newInput.onLogin
-        set(value) { newInput.onLogin = value }
+        get() = input.onLogin
+        set(value) { input.onLogin = value }
 
     fun onDestroy() {
-        newInput.onFocusChanged.unsubscribe(this)
-        newInput.onTextChanged.unsubscribe(this)
+        input.onFocusChanged.unsubscribe(this)
+        input.onTextChanged.unsubscribe(this)
     }
 
     private fun loggingInState() {
@@ -98,7 +96,7 @@ class AccountInputController(val parentView: View, context: Context) {
                 )
 
                 setOnItemClickListener { _, _, idx, _ ->
-                    newInput.loginWith(history[idx])
+                    input.loginWith(history[idx])
                     accountHistoryList.visibility = View.GONE
                 }
             }
@@ -123,7 +121,7 @@ class AccountInputController(val parentView: View, context: Context) {
 
     private fun leaveErrorState() {
         if (usingErrorColor) {
-            newInput.loginState = LoginState.Initial
+            input.loginState = LoginState.Initial
             usingErrorColor = false
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -71,12 +71,11 @@ class AccountInputController(val parentView: View, context: Context) {
             }
         }
 
-    var onLogin: ((String) -> Unit)? = null
+    var onLogin: ((String) -> Unit)?
+        get() = newInput.onLogin
+        set(value) { newInput.onLogin = value }
 
     init {
-        button.setOnClickListener {
-            onLogin?.invoke(input.text.toString())
-        }
         setButtonEnabled(false)
 
         input.apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -70,8 +70,6 @@ class AccountInputController(val parentView: View, context: Context) {
         input.apply {
             addTextChangedListener(InputWatcher())
         }
-
-        container.setOnClickListener { shouldShowAccountHistory = true }
     }
 
     fun onDestroy() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -8,7 +8,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnTouchListener
 import android.widget.ArrayAdapter
-import android.widget.ImageButton
 import android.widget.ListView
 import android.widget.TextView
 import kotlin.properties.Delegates.observable
@@ -50,7 +49,6 @@ class AccountInputController(val parentView: View, context: Context) {
 
     val container: AccountInputContainer = parentView.findViewById(R.id.account_input_container)
     val input: TextView = parentView.findViewById(R.id.login_input)
-    val button: ImageButton = parentView.findViewById(R.id.login_button)
     val accountHistoryList: ListView = parentView.findViewById(R.id.account_history_list)
 
     val newInput = parentView.findViewById<AccountInput>(R.id.account_input)
@@ -93,8 +91,6 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     private fun initialState() {
-        button.visibility = View.VISIBLE
-
         input.apply {
             setTextColor(enabledTextColor)
             setEnabled(true)
@@ -103,8 +99,6 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     private fun loggingInState() {
-        button.visibility = View.GONE
-
         input.apply {
             setTextColor(disabledTextColor)
             setEnabled(false)
@@ -115,14 +109,11 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     private fun successState() {
-        button.visibility = View.GONE
         input.visibility = View.GONE
         container.visibility = View.INVISIBLE
     }
 
     private fun failureState() {
-        button.visibility = View.VISIBLE
-
         input.apply {
             findFocus()
             setTextColor(errorTextColor)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -16,10 +16,7 @@ import net.mullvad.mullvadvpn.ui.widget.AccountInput
 
 class AccountInputController(val parentView: View, context: Context) {
     private val disabledBackgroundColor = context.getColor(R.color.white20)
-    private val disabledTextColor = context.getColor(R.color.white)
     private val enabledBackgroundColor = context.getColor(R.color.white)
-    private val enabledTextColor = context.getColor(R.color.blue)
-    private val errorTextColor = context.getColor(R.color.red)
 
     private var inputHasFocus by observable(false) { _, _, hasFocus ->
         updateBorder()
@@ -37,7 +34,7 @@ class AccountInputController(val parentView: View, context: Context) {
         newInput.loginState = newState
 
         when (newState) {
-            LoginState.Initial -> initialState()
+            LoginState.Initial -> {}
             LoginState.InProgress -> loggingInState()
             LoginState.Success -> successState()
             LoginState.Failure -> failureState()
@@ -87,37 +84,15 @@ class AccountInputController(val parentView: View, context: Context) {
         container.setOnClickListener { shouldShowAccountHistory = true }
     }
 
-    private fun initialState() {
-        input.apply {
-            setTextColor(enabledTextColor)
-            setEnabled(true)
-            visibility = View.VISIBLE
-        }
-    }
-
     private fun loggingInState() {
-        input.apply {
-            setTextColor(disabledTextColor)
-            setEnabled(false)
-            visibility = View.VISIBLE
-            clearFocus()
-        }
         accountHistoryList.visibility = View.INVISIBLE
     }
 
     private fun successState() {
-        input.visibility = View.GONE
         container.visibility = View.INVISIBLE
     }
 
     private fun failureState() {
-        input.apply {
-            findFocus()
-            setTextColor(errorTextColor)
-            setEnabled(true)
-            visibility = View.VISIBLE
-        }
-
         usingErrorColor = true
     }
 
@@ -162,7 +137,7 @@ class AccountInputController(val parentView: View, context: Context) {
 
     private fun leaveErrorState() {
         if (usingErrorColor) {
-            input.setTextColor(enabledTextColor)
+            newInput.loginState = LoginState.Initial
             usingErrorColor = false
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -76,8 +76,6 @@ class AccountInputController(val parentView: View, context: Context) {
         set(value) { newInput.onLogin = value }
 
     init {
-        setButtonEnabled(false)
-
         input.apply {
             addTextChangedListener(InputWatcher())
             setOnTouchListener(
@@ -95,7 +93,6 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     private fun initialState() {
-        setButtonEnabled(input.text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
         button.visibility = View.VISIBLE
 
         input.apply {
@@ -106,7 +103,6 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     private fun loggingInState() {
-        setButtonEnabled(false)
         button.visibility = View.GONE
 
         input.apply {
@@ -119,14 +115,12 @@ class AccountInputController(val parentView: View, context: Context) {
     }
 
     private fun successState() {
-        setButtonEnabled(false)
         button.visibility = View.GONE
         input.visibility = View.GONE
         container.visibility = View.INVISIBLE
     }
 
     private fun failureState() {
-        setButtonEnabled(false)
         button.visibility = View.VISIBLE
 
         input.apply {
@@ -137,16 +131,6 @@ class AccountInputController(val parentView: View, context: Context) {
         }
 
         usingErrorColor = true
-    }
-
-    private fun setButtonEnabled(enabled: Boolean) {
-        button.apply {
-            if (enabled != isEnabled()) {
-                setEnabled(enabled)
-                setClickable(enabled)
-                setFocusable(enabled)
-            }
-        }
     }
 
     private fun updateAccountHistory() {
@@ -209,7 +193,7 @@ class AccountInputController(val parentView: View, context: Context) {
         override fun afterTextChanged(text: Editable) {
             inputHasFocus = true
             removeFormattingSpans(text)
-            setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
+            newInput.setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
             leaveErrorState()
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -1,8 +1,6 @@
 package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.ListView
@@ -44,6 +42,10 @@ class AccountInputController(val parentView: View, context: Context) {
         onFocusChanged.subscribe(this) { hasFocus ->
             inputHasFocus = hasFocus
         }
+
+        onTextChanged.subscribe(this) { _ ->
+            leaveErrorState()
+        }
     }
 
     var accountHistory: ArrayList<String>? = null
@@ -66,14 +68,9 @@ class AccountInputController(val parentView: View, context: Context) {
         get() = newInput.onLogin
         set(value) { newInput.onLogin = value }
 
-    init {
-        input.apply {
-            addTextChangedListener(InputWatcher())
-        }
-    }
-
     fun onDestroy() {
         newInput.onFocusChanged.unsubscribe(this)
+        newInput.onTextChanged.unsubscribe(this)
     }
 
     private fun loggingInState() {
@@ -128,16 +125,6 @@ class AccountInputController(val parentView: View, context: Context) {
         if (usingErrorColor) {
             newInput.loginState = LoginState.Initial
             usingErrorColor = false
-        }
-    }
-
-    inner class InputWatcher : TextWatcher {
-        override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {}
-
-        override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {}
-
-        override fun afterTextChanged(text: Editable) {
-            leaveErrorState()
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -11,6 +11,7 @@ import android.widget.ArrayAdapter
 import android.widget.ImageButton
 import android.widget.ListView
 import android.widget.TextView
+import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.AccountInputContainer.BorderState
 
@@ -23,30 +24,26 @@ class AccountInputController(val parentView: View, context: Context) {
     private val enabledTextColor = context.getColor(R.color.blue)
     private val errorTextColor = context.getColor(R.color.red)
 
-    private var inputHasFocus = false
-        set(value) {
-            field = value
-            updateBorder()
-            if (value == true) {
-                shouldShowAccountHistory = true
-            }
-        }
+    private var inputHasFocus by observable(false) { _, _, hasFocus ->
+        updateBorder()
 
-    private var usingErrorColor = false
-        set(value) {
-            field = value
-            updateBorder()
+        if (hasFocus) {
+            shouldShowAccountHistory = true
         }
+    }
 
-    var state = LoginState.Initial
-        set(value) {
-            when (value) {
-                LoginState.Initial -> initialState()
-                LoginState.InProgress -> loggingInState()
-                LoginState.Success -> successState()
-                LoginState.Failure -> failureState()
-            }
+    private var usingErrorColor by observable(false) { _, _, _ ->
+        updateBorder()
+    }
+
+    var state by observable(LoginState.Initial) { _, _, newState ->
+        when (newState) {
+            LoginState.Initial -> initialState()
+            LoginState.InProgress -> loggingInState()
+            LoginState.Success -> successState()
+            LoginState.Failure -> failureState()
         }
+    }
 
     val container: AccountInputContainer = parentView.findViewById(R.id.account_input_container)
     val input: TextView = parentView.findViewById(R.id.login_input)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -3,7 +3,6 @@ package net.mullvad.mullvadvpn.ui
 import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
-import android.text.style.MetricAffectingSpan
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnTouchListener
@@ -14,8 +13,6 @@ import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.AccountInputContainer.BorderState
 import net.mullvad.mullvadvpn.ui.widget.AccountInput
-
-const val MIN_ACCOUNT_TOKEN_LENGTH = 10
 
 class AccountInputController(val parentView: View, context: Context) {
     private val disabledBackgroundColor = context.getColor(R.color.white20)
@@ -170,12 +167,6 @@ class AccountInputController(val parentView: View, context: Context) {
         }
     }
 
-    private fun removeFormattingSpans(text: Editable) {
-        for (span in text.getSpans(0, text.length, MetricAffectingSpan::class.java)) {
-            text.removeSpan(span)
-        }
-    }
-
     inner class InputWatcher : TextWatcher {
         override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {}
 
@@ -183,8 +174,6 @@ class AccountInputController(val parentView: View, context: Context) {
 
         override fun afterTextChanged(text: Editable) {
             inputHasFocus = true
-            removeFormattingSpans(text)
-            newInput.setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
             leaveErrorState()
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -106,11 +106,8 @@ class AccountInputController(val parentView: View, context: Context) {
                 )
 
                 setOnItemClickListener { _, _, idx, _ ->
-                    val accountNumber = history[idx]
-
-                    input.setText(accountNumber)
+                    newInput.loginWith(history[idx])
                     accountHistoryList.visibility = View.GONE
-                    onLogin?.invoke(accountNumber)
                 }
             }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -3,9 +3,7 @@ package net.mullvad.mullvadvpn.ui
 import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.MotionEvent
 import android.view.View
-import android.view.View.OnTouchListener
 import android.widget.ArrayAdapter
 import android.widget.ListView
 import android.widget.TextView
@@ -42,7 +40,11 @@ class AccountInputController(val parentView: View, context: Context) {
     val input: TextView = parentView.findViewById(R.id.login_input)
     val accountHistoryList: ListView = parentView.findViewById(R.id.account_history_list)
 
-    val newInput = parentView.findViewById<AccountInput>(R.id.account_input)
+    val newInput = parentView.findViewById<AccountInput>(R.id.account_input).apply {
+        onFocusChanged.subscribe(this) { hasFocus ->
+            inputHasFocus = hasFocus
+        }
+    }
 
     var accountHistory: ArrayList<String>? = null
         set(value) {
@@ -67,18 +69,13 @@ class AccountInputController(val parentView: View, context: Context) {
     init {
         input.apply {
             addTextChangedListener(InputWatcher())
-            setOnTouchListener(
-                OnTouchListener {
-                    _, event ->
-                    if (MotionEvent.ACTION_UP == event.getAction()) {
-                        shouldShowAccountHistory = true
-                    }
-                    false
-                }
-            )
         }
 
         container.setOnClickListener { shouldShowAccountHistory = true }
+    }
+
+    fun onDestroy() {
+        newInput.onFocusChanged.unsubscribe(this)
     }
 
     private fun loggingInState() {
@@ -142,7 +139,6 @@ class AccountInputController(val parentView: View, context: Context) {
         override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {}
 
         override fun afterTextChanged(text: Editable) {
-            inputHasFocus = true
             leaveErrorState()
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountInputController.kt
@@ -14,6 +14,7 @@ import android.widget.TextView
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.AccountInputContainer.BorderState
+import net.mullvad.mullvadvpn.ui.widget.AccountInput
 
 const val MIN_ACCOUNT_TOKEN_LENGTH = 10
 
@@ -36,7 +37,9 @@ class AccountInputController(val parentView: View, context: Context) {
         updateBorder()
     }
 
-    var state by observable(LoginState.Initial) { _, _, newState ->
+    var state: LoginState by observable(LoginState.Initial) { _, _, newState ->
+        newInput.loginState = newState
+
         when (newState) {
             LoginState.Initial -> initialState()
             LoginState.InProgress -> loggingInState()
@@ -49,6 +52,8 @@ class AccountInputController(val parentView: View, context: Context) {
     val input: TextView = parentView.findViewById(R.id.login_input)
     val button: ImageButton = parentView.findViewById(R.id.login_button)
     val accountHistoryList: ListView = parentView.findViewById(R.id.account_history_list)
+
+    val newInput = parentView.findViewById<AccountInput>(R.id.account_input)
 
     var accountHistory: ArrayList<String>? = null
         set(value) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -28,7 +28,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var loggingInStatus: View
     private lateinit var loggedInStatus: View
     private lateinit var loginFailStatus: View
-    private lateinit var accountInput: AccountInput
+    private lateinit var accountInput: AccountInputController
     private lateinit var scrollArea: ScrollView
 
     private val loggedIn = CompletableDeferred<LoginResult>()
@@ -46,7 +46,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         loggedInStatus = view.findViewById(R.id.logged_in_status)
         loginFailStatus = view.findViewById(R.id.login_fail_status)
 
-        accountInput = AccountInput(view, parentActivity)
+        accountInput = AccountInputController(view, parentActivity)
         accountInput.onLogin = { accountToken -> login(accountToken) }
 
         view.findViewById<Button>(R.id.create_account)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -81,6 +81,11 @@ class AccountInput : LinearLayout {
         setButtonEnabled(false)
     }
 
+    fun loginWith(accountNumber: String) {
+        input.text = accountNumber
+        onLogin?.invoke(accountNumber)
+    }
+
     private fun initialState() {
         input.apply {
             setTextColor(enabledTextColor)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.ui.LoginState
 
 class AccountInput : LinearLayout {
     private val container =
@@ -13,6 +14,8 @@ class AccountInput : LinearLayout {
 
             inflater.inflate(R.layout.account_input, this)
         }
+
+    var loginState = LoginState.Initial
 
     constructor(context: Context) : super(context) {}
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -7,12 +7,14 @@ import android.text.style.MetricAffectingSpan
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.OnFocusChangeListener
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.LoginState
+import net.mullvad.talpid.util.EventNotifier
 
 const val MIN_ACCOUNT_TOKEN_LENGTH = 10
 
@@ -41,6 +43,10 @@ class AccountInput : LinearLayout {
 
     private val input = container.findViewById<TextView>(R.id.login_input).apply {
         addTextChangedListener(inputWatcher)
+
+        onFocusChangeListener = OnFocusChangeListener { view, inputHasFocus ->
+            hasFocus = inputHasFocus && view.isEnabled
+        }
     }
 
     private val button = container.findViewById<ImageButton>(R.id.login_button).apply {
@@ -48,6 +54,9 @@ class AccountInput : LinearLayout {
             onLogin?.invoke(input.text.toString())
         }
     }
+
+    val onFocusChanged = EventNotifier(false)
+    private var hasFocus by onFocusChanged.notifiable()
 
     var loginState by observable(LoginState.Initial) { _, _, state ->
         when (state) {
@@ -90,6 +99,7 @@ class AccountInput : LinearLayout {
         input.apply {
             setTextColor(enabledTextColor)
             setEnabled(true)
+            setFocusableInTouchMode(true)
             visibility = View.VISIBLE
         }
 
@@ -101,8 +111,8 @@ class AccountInput : LinearLayout {
         input.apply {
             setTextColor(disabledTextColor)
             setEnabled(false)
+            setFocusable(false)
             visibility = View.VISIBLE
-            clearFocus()
         }
 
         button.visibility = View.GONE
@@ -121,10 +131,11 @@ class AccountInput : LinearLayout {
         setButtonEnabled(false)
 
         input.apply {
-            findFocus()
             setTextColor(errorTextColor)
             setEnabled(true)
+            setFocusableInTouchMode(true)
             visibility = View.VISIBLE
+            requestFocus()
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -3,7 +3,9 @@ package net.mullvad.mullvadvpn.ui.widget
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.widget.ImageButton
 import android.widget.LinearLayout
+import android.widget.TextView
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.LoginState
 
@@ -15,7 +17,17 @@ class AccountInput : LinearLayout {
             inflater.inflate(R.layout.account_input, this)
         }
 
+    private val input = container.findViewById<TextView>(R.id.login_input)
+
+    private val button = container.findViewById<ImageButton>(R.id.login_button).apply {
+        setOnClickListener {
+            onLogin?.invoke(input.text.toString())
+        }
+    }
+
     var loginState = LoginState.Initial
+
+    var onLogin: ((String) -> Unit)? = null
 
     constructor(context: Context) : super(context) {}
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.ui.widget
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.View
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -61,18 +62,22 @@ class AccountInput : LinearLayout {
     }
 
     private fun initialState() {
+        button.visibility = View.VISIBLE
         setButtonEnabled(input.text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
     }
 
     private fun loggingInState() {
+        button.visibility = View.GONE
         setButtonEnabled(false)
     }
 
     private fun successState() {
+        button.visibility = View.GONE
         setButtonEnabled(false)
     }
 
     private fun failureState() {
+        button.visibility = View.VISIBLE
         setButtonEnabled(false)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -38,6 +38,7 @@ class AccountInput : LinearLayout {
         override fun afterTextChanged(text: Editable) {
             removeFormattingSpans(text)
             setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
+            onTextChanged.notify(Unit)
         }
     }
 
@@ -57,6 +58,8 @@ class AccountInput : LinearLayout {
 
     val onFocusChanged = EventNotifier(false)
     private var hasFocus by onFocusChanged.notifiable()
+
+    val onTextChanged = EventNotifier(Unit)
 
     var loginState by observable(LoginState.Initial) { _, _, state ->
         when (state) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -6,8 +6,11 @@ import android.view.LayoutInflater
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
+import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.LoginState
+
+const val MIN_ACCOUNT_TOKEN_LENGTH = 10
 
 class AccountInput : LinearLayout {
     private val container =
@@ -25,7 +28,14 @@ class AccountInput : LinearLayout {
         }
     }
 
-    var loginState = LoginState.Initial
+    var loginState by observable(LoginState.Initial) { _, _, state ->
+        when (state) {
+            LoginState.Initial -> initialState()
+            LoginState.InProgress -> loggingInState()
+            LoginState.Success -> successState()
+            LoginState.Failure -> failureState()
+        }
+    }
 
     var onLogin: ((String) -> Unit)? = null
 
@@ -46,5 +56,33 @@ class AccountInput : LinearLayout {
 
     init {
         orientation = HORIZONTAL
+
+        setButtonEnabled(false)
+    }
+
+    private fun initialState() {
+        setButtonEnabled(input.text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
+    }
+
+    private fun loggingInState() {
+        setButtonEnabled(false)
+    }
+
+    private fun successState() {
+        setButtonEnabled(false)
+    }
+
+    private fun failureState() {
+        setButtonEnabled(false)
+    }
+
+    /*private*/ fun setButtonEnabled(enabled: Boolean) {
+        button.apply {
+            if (enabled != isEnabled()) {
+                setEnabled(enabled)
+                setClickable(enabled)
+                setFocusable(enabled)
+            }
+        }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -1,6 +1,9 @@
 package net.mullvad.mullvadvpn.ui.widget
 
 import android.content.Context
+import android.text.Editable
+import android.text.TextWatcher
+import android.text.style.MetricAffectingSpan
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
@@ -21,7 +24,20 @@ class AccountInput : LinearLayout {
             inflater.inflate(R.layout.account_input, this)
         }
 
-    private val input = container.findViewById<TextView>(R.id.login_input)
+    private val inputWatcher = object : TextWatcher {
+        override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {}
+
+        override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {}
+
+        override fun afterTextChanged(text: Editable) {
+            removeFormattingSpans(text)
+            setButtonEnabled(text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
+        }
+    }
+
+    private val input = container.findViewById<TextView>(R.id.login_input).apply {
+        addTextChangedListener(inputWatcher)
+    }
 
     private val button = container.findViewById<ImageButton>(R.id.login_button).apply {
         setOnClickListener {
@@ -81,13 +97,19 @@ class AccountInput : LinearLayout {
         setButtonEnabled(false)
     }
 
-    /*private*/ fun setButtonEnabled(enabled: Boolean) {
+    private fun setButtonEnabled(enabled: Boolean) {
         button.apply {
             if (enabled != isEnabled()) {
                 setEnabled(enabled)
                 setClickable(enabled)
                 setFocusable(enabled)
             }
+        }
+    }
+
+    private fun removeFormattingSpans(text: Editable) {
+        for (span in text.getSpans(0, text.length, MetricAffectingSpan::class.java)) {
+            text.removeSpan(span)
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -17,6 +17,10 @@ import net.mullvad.mullvadvpn.ui.LoginState
 const val MIN_ACCOUNT_TOKEN_LENGTH = 10
 
 class AccountInput : LinearLayout {
+    private val disabledTextColor = context.getColor(R.color.white)
+    private val enabledTextColor = context.getColor(R.color.blue)
+    private val errorTextColor = context.getColor(R.color.red)
+
     private val container =
         context.getSystemService(Context.LAYOUT_INFLATER_SERVICE).let { service ->
             val inflater = service as LayoutInflater
@@ -78,11 +82,24 @@ class AccountInput : LinearLayout {
     }
 
     private fun initialState() {
+        input.apply {
+            setTextColor(enabledTextColor)
+            setEnabled(true)
+            visibility = View.VISIBLE
+        }
+
         button.visibility = View.VISIBLE
         setButtonEnabled(input.text.length >= MIN_ACCOUNT_TOKEN_LENGTH)
     }
 
     private fun loggingInState() {
+        input.apply {
+            setTextColor(disabledTextColor)
+            setEnabled(false)
+            visibility = View.VISIBLE
+            clearFocus()
+        }
+
         button.visibility = View.GONE
         setButtonEnabled(false)
     }
@@ -90,11 +107,20 @@ class AccountInput : LinearLayout {
     private fun successState() {
         button.visibility = View.GONE
         setButtonEnabled(false)
+
+        input.visibility = View.GONE
     }
 
     private fun failureState() {
         button.visibility = View.VISIBLE
         setButtonEnabled(false)
+
+        input.apply {
+            findFocus()
+            setTextColor(errorTextColor)
+            setEnabled(true)
+            visibility = View.VISIBLE
+        }
     }
 
     private fun setButtonEnabled(enabled: Boolean) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -1,0 +1,35 @@
+package net.mullvad.mullvadvpn.ui.widget
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import net.mullvad.mullvadvpn.R
+
+class AccountInput : LinearLayout {
+    private val container =
+        context.getSystemService(Context.LAYOUT_INFLATER_SERVICE).let { service ->
+            val inflater = service as LayoutInflater
+
+            inflater.inflate(R.layout.account_input, this)
+        }
+
+    constructor(context: Context) : super(context) {}
+
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+
+    constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
+        super(context, attributes, defaultStyleAttribute) {}
+
+    constructor(
+        context: Context,
+        attributes: AttributeSet,
+        defaultStyleAttribute: Int,
+        defaultStyleResource: Int
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {
+    }
+
+    init {
+        orientation = HORIZONTAL
+    }
+}

--- a/android/src/main/res/layout/account_input.xml
+++ b/android/src/main/res/layout/account_input.xml
@@ -1,0 +1,24 @@
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+    <EditText android:id="@+id/account_input"
+              android:digits="0123456789"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:layout_weight="1"
+              android:paddingHorizontal="12dp"
+              android:background="@drawable/account_input_background"
+              android:inputType="number"
+              android:singleLine="true"
+              android:imeOptions="flagNoPersonalizedLearning"
+              android:textCursorDrawable="@drawable/text_input_cursor"
+              android:hint="@string/login_hint"
+              android:textColorHint="@color/blue40"
+              android:textColor="@color/blue"
+              android:textSize="@dimen/text_medium_plus"
+              android:textStyle="bold" />
+    <ImageButton android:id="@+id/login_button"
+                 android:layout_width="48dp"
+                 android:layout_height="match_parent"
+                 android:layout_weight="0"
+                 android:background="@drawable/login_button_background"
+                 android:src="@drawable/login_button_arrow" />
+</merge>

--- a/android/src/main/res/layout/account_input.xml
+++ b/android/src/main/res/layout/account_input.xml
@@ -1,5 +1,5 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
-    <EditText android:id="@+id/account_input"
+    <EditText android:id="@+id/login_input"
               android:digits="0123456789"
               android:layout_width="match_parent"
               android:layout_height="match_parent"

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -67,7 +67,8 @@
             <net.mullvad.mullvadvpn.ui.AccountInputContainer android:id="@+id/account_input_container"
                                                              android:layout_width="match_parent"
                                                              android:layout_height="48dp">
-                <net.mullvad.mullvadvpn.ui.widget.AccountInput android:layout_width="match_parent"
+                <net.mullvad.mullvadvpn.ui.widget.AccountInput android:id="@+id/account_input"
+                                                               android:layout_width="match_parent"
                                                                android:layout_height="48dp"
                                                                android:layout_alignParentTop="true"
                                                                android:orientation="horizontal" />

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -67,33 +67,10 @@
             <net.mullvad.mullvadvpn.ui.AccountInputContainer android:id="@+id/account_input_container"
                                                              android:layout_width="match_parent"
                                                              android:layout_height="48dp">
-                <LinearLayout android:layout_width="match_parent"
-                              android:layout_height="48dp"
-                              android:layout_alignParentTop="true"
-                              android:orientation="horizontal">
-                    <EditText android:id="@+id/account_input"
-                              android:digits="0123456789"
-                              android:layout_width="match_parent"
-                              android:layout_height="match_parent"
-                              android:layout_weight="1"
-                              android:paddingHorizontal="12dp"
-                              android:background="@drawable/account_input_background"
-                              android:inputType="number"
-                              android:singleLine="true"
-                              android:imeOptions="flagNoPersonalizedLearning"
-                              android:textCursorDrawable="@drawable/text_input_cursor"
-                              android:hint="@string/login_hint"
-                              android:textColorHint="@color/blue40"
-                              android:textColor="@color/blue"
-                              android:textSize="@dimen/text_medium_plus"
-                              android:textStyle="bold" />
-                    <ImageButton android:id="@+id/login_button"
-                                 android:layout_width="48dp"
-                                 android:layout_height="match_parent"
-                                 android:layout_weight="0"
-                                 android:background="@drawable/login_button_background"
-                                 android:src="@drawable/login_button_arrow" />
-                </LinearLayout>
+                <net.mullvad.mullvadvpn.ui.widget.AccountInput android:layout_width="match_parent"
+                                                               android:layout_height="48dp"
+                                                               android:layout_alignParentTop="true"
+                                                               android:orientation="horizontal" />
             </net.mullvad.mullvadvpn.ui.AccountInputContainer>
             <ListView android:id="@+id/account_history_list"
                       android:layout_width="fill_parent"


### PR DESCRIPTION
The previous `AccountInput` class became a little too complex and hard to change, so this PR lays some groundwork for future changes. It renames the old class into `AccountInputController`, which better fits its purpose. A new `AccountInput` class was created, but it acts as a custom widget and can be used in the XML layout files.

Most of the functionality remained the same, except that touch event were replaced by focus events, which are now properly handled. Previously, the input view had a few focus bugs. First, it would keep focused while disabled which would prevent the history from opening up after a login failure. And second, it didn't properly request focus when login failed, and the `findFocus()` call that was there was used incorrectly. With this now properly handled, the border should now behave more similarly to the desktop app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2056)
<!-- Reviewable:end -->
