### PR TITLE
Start tunnel state machine in appropriate state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for WireGuard's kernel module if it's loaded.
 
 ### Fixed
+- Stop resetting the firewall after an upgrade to not leak after an upgrade.
 
 #### Windows
 - Remove firewall filters (unblock internet access) when "Always require VPN" is enabled and the app

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -72,7 +72,7 @@ async fn reset_firewall() -> Result<(), Error> {
 
     let mut firewall = Firewall::new(FirewallArguments {
         initialize_blocked: false,
-        allow_lan: None,
+        allow_lan: true,
     })
     .map_err(Error::FirewallError)?;
 

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -186,7 +186,7 @@ pub struct FirewallArguments {
     /// Determines whether the firewall should atomically enter the blocked state during init.
     pub initialize_blocked: bool,
     /// This argument is required for the blocked state to configure the firewall correctly.
-    pub allow_lan: Option<bool>,
+    pub allow_lan: bool,
 }
 
 impl Firewall {

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -56,7 +56,7 @@ impl FirewallT for Firewall {
         let logging_context = b"WinFw\0".as_ptr();
 
         if args.initialize_blocked {
-            let cfg = &WinFwSettings::new(args.allow_lan.unwrap());
+            let cfg = &WinFwSettings::new(args.allow_lan);
             unsafe {
                 WinFw_InitializeBlocked(
                     WINFW_TIMEOUT_SECONDS,

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -10,7 +10,10 @@ use talpid_types::ErrorExt;
 pub struct DisconnectedState;
 
 impl DisconnectedState {
-    fn set_firewall_policy(shared_values: &mut SharedTunnelStateValues) {
+    fn set_firewall_policy(
+        shared_values: &mut SharedTunnelStateValues,
+        should_reset_firewall: bool,
+    ) {
         let result = if shared_values.block_when_disconnected {
             let policy = FirewallPolicy::Blocked {
                 allow_lan: shared_values.allow_lan,
@@ -20,11 +23,13 @@ impl DisconnectedState {
                     "Failed to apply blocking firewall policy for disconnected state",
                 )
             })
-        } else {
+        } else if should_reset_firewall {
             shared_values
                 .firewall
                 .reset_policy()
                 .map_err(|e| e.display_chain_with_msg("Failed to reset firewall policy"))
+        } else {
+            Ok(())
         };
         if let Err(error_chain) = result {
             log::error!("{}", error_chain);
@@ -33,11 +38,11 @@ impl DisconnectedState {
 }
 
 impl TunnelState for DisconnectedState {
-    type Bootstrap = ();
+    type Bootstrap = bool;
 
     fn enter(
         shared_values: &mut SharedTunnelStateValues,
-        _: Self::Bootstrap,
+        should_reset_firewall: Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
         #[cfg(target_os = "linux")]
         if let Err(error) = shared_values.route_manager.disable_exclusions_routes() {
@@ -46,7 +51,7 @@ impl TunnelState for DisconnectedState {
                 error.display_chain_with_msg("Failed to disable exclusions routes")
             );
         }
-        Self::set_firewall_policy(shared_values);
+        Self::set_firewall_policy(shared_values, should_reset_firewall);
         #[cfg(target_os = "android")]
         shared_values.tun_provider.close_tun();
 
@@ -72,14 +77,14 @@ impl TunnelState for DisconnectedState {
                         .set_allow_lan(allow_lan)
                         .expect("Failed to set allow LAN parameter");
 
-                    Self::set_firewall_policy(shared_values);
+                    Self::set_firewall_policy(shared_values, true);
                 }
                 SameState(self)
             }
             Ok(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 if shared_values.block_when_disconnected != block_when_disconnected {
                     shared_values.block_when_disconnected = block_when_disconnected;
-                    Self::set_firewall_policy(shared_values);
+                    Self::set_firewall_policy(shared_values, true);
                 }
                 SameState(self)
             }

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -125,7 +125,7 @@ impl DisconnectingState {
         }
 
         match self.after_disconnect {
-            AfterDisconnect::Nothing => DisconnectedState::enter(shared_values, ()),
+            AfterDisconnect::Nothing => DisconnectedState::enter(shared_values, true),
             AfterDisconnect::Block(cause) => ErrorState::enter(shared_values, cause),
             AfterDisconnect::Reconnect(retry_attempt) => {
                 ConnectingState::enter(shared_values, retry_attempt)

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -115,7 +115,7 @@ impl TunnelState for ErrorState {
             }
             Ok(TunnelCommand::Connect) => NewState(ConnectingState::enter(shared_values, 0)),
             Ok(TunnelCommand::Disconnect) | Err(_) => {
-                NewState(DisconnectedState::enter(shared_values, ()))
+                NewState(DisconnectedState::enter(shared_values, true))
             }
             Ok(TunnelCommand::Block(reason)) => NewState(ErrorState::enter(shared_values, reason)),
         }


### PR DESCRIPTION
Previously, after upgrading, there always existed a small leak window where the firewall was reset to a non-blocking state for a very brief period of time. There were two causes for this:
- the firewall was initialized to a non-blocking state unless the daemon was configured to block when disconnected
- the tunnel state machine would always start from a disconnected state which would always reset the firewall

The first problem is resolved by having the daemon specify the firewall arguments, using the cached target state and the _block when disconnected_ setting to deduce whether the firewall should be initialized to a blocked state.
The second is resolved by allowing to specify whether the tunnel state machine should start in the disconnected or connecting state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2058)
<!-- Reviewable:end -->
