### PR TITLE
Fix race conditions during initialization of `ConnectionProxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Line wrap the file at 100 chars.                                              Th
 - Remove firewall filters (unblock internet access) when "Always require VPN" is enabled and the app
   is uninstalled.
 
+#### Android
+- Fix rare crash that could happen when starting the background service.
+
 
 ## [2020.6-beta2] - 2020-08-27
 This release is for Android only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -22,7 +22,6 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
     private var activeAction: Job? = null
     private var resetAnticipatedStateJob: Job? = null
 
-    private val fetchInitialStateJob = fetchInitialState()
     private val initialState: TunnelState = TunnelState.Disconnected()
 
     var onStateChange = EventNotifier(initialState)
@@ -33,6 +32,8 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
         private set
     var uiState by onUiStateChange.notifiable()
         private set
+
+    private val fetchInitialStateJob = fetchInitialState()
 
     init {
         daemon.onTunnelStateChange = { newState ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -25,8 +25,8 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
     private val fetchInitialStateJob = fetchInitialState()
     private val initialState: TunnelState = TunnelState.Disconnected()
 
-    var onUiStateChange = EventNotifier(initialState)
     var onStateChange = EventNotifier(initialState)
+    var onUiStateChange = EventNotifier(initialState)
     var vpnPermission = CompletableDeferred<Boolean>()
 
     var state = initialState

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -32,9 +32,7 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
     var state = initialState
         private set(value) {
             field = value
-            resetAnticipatedStateJob?.cancel()
             onStateChange.notify(value)
-            uiState = value
         }
 
     var uiState = initialState
@@ -46,7 +44,9 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
     init {
         daemon.onTunnelStateChange = { newState ->
             synchronized(this) {
+                resetAnticipatedStateJob?.cancel()
                 state = newState
+                uiState = newState
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -29,17 +29,10 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
     var onUiStateChange = EventNotifier(initialState)
     var vpnPermission = CompletableDeferred<Boolean>()
 
-    var state = initialState
-        private set(value) {
-            field = value
-            onStateChange.notify(value)
-        }
-
-    var uiState = initialState
-        private set(value) {
-            field = value
-            onUiStateChange.notify(value)
-        }
+    var state by onStateChange.notifiable()
+        private set
+    var uiState by onUiStateChange.notifiable()
+        private set
 
     init {
         daemon.onTunnelStateChange = { newState ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -25,6 +25,10 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
     private val fetchInitialStateJob = fetchInitialState()
     private val initialState: TunnelState = TunnelState.Disconnected()
 
+    var onUiStateChange = EventNotifier(initialState)
+    var onStateChange = EventNotifier(initialState)
+    var vpnPermission = CompletableDeferred<Boolean>()
+
     var state = initialState
         private set(value) {
             field = value
@@ -38,10 +42,6 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
             field = value
             onUiStateChange.notify(value)
         }
-
-    var onUiStateChange = EventNotifier(uiState)
-    var onStateChange = EventNotifier(state)
-    var vpnPermission = CompletableDeferred<Boolean>()
 
     init {
         daemon.onTunnelStateChange = { newState ->


### PR DESCRIPTION
There was a single report with a crash happening when the `ConnectionProxy` was initialized. Through the stack trace it was possible to see that there was a `NullPointerException` while fetching the initial state. If fetching the state was quick enough, it would try to notify the tunnel state listeners before the notifiers had been initialized.

This PR fixes that issue by changing the initialization order. It also refactors the state properties to use the delegate provided by the notifiers.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2059)
<!-- Reviewable:end -->
