### PR TITLE
Fix NM for IPv6 with OpenVPN

### DIFF
--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -215,7 +215,14 @@ impl NetworkManager {
             ipv6_settings.insert("route-metric", Variant(Box::new(0u32)));
             ipv6_settings.insert("routes", Variant(Box::new(device_routes6)));
             ipv6_settings.insert("route-data", Variant(Box::new(device_route6_data)));
-            ipv6_settings.insert("addresses", Variant(Box::new(device_addresses6)));
+            // if the link contains link local addresses, addresses shouldn't be reset
+            if ipv6_settings
+                .get("method")
+                .map(|method| method.as_str() != Some("link-local"))
+                .unwrap_or(true)
+            {
+                ipv6_settings.insert("addresses", Variant(Box::new(device_addresses6)));
+            }
         }
 
         let mut settings_backup =


### PR DESCRIPTION
The changes made to NM to get it to work with the kernel WireGuard implementation broke it for OpenVPN. If the address that's already set for an interface is local to the link, then it shouldn't be reset by NM - it will complain and return an error. So I changed the code to only append the IPv6 addresses to the config if the link does not have link local addresses. I did not bump the changelog because this bug hasn't been released yet.

Makes me think whether it'd be better to set the IP address as link local for WireGuard too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2061)
<!-- Reviewable:end -->
