### PR TITLE
Update UI even when window doesn't have focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix rare crash that could happen when starting the background service.
 - Fix rare crash that happened with large text sizes and long location names on the main screen.
+- Fix UI not updating in split screen mode when the window is unfocused.
 
 
 ## [2020.6-beta2] - 2020-08-27

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -85,7 +85,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         return view
     }
 
-    override fun onSafelyResume() {
+    override fun onSafelyStart() {
         accountCache.onAccountNumberChange.subscribe(this) { accountNumber ->
             jobTracker.newUiJob("updateAccountNumber") {
                 accountNumberView.information = accountNumber
@@ -112,7 +112,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         accountCache.onAccountNumberChange.unsubscribe(this)
         accountCache.onAccountExpiryChange.unsubscribe(this)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -76,7 +76,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         return view
     }
 
-    override fun onSafelyResume() {
+    override fun onSafelyStart() {
         locationInfo.isTunnelInfoExpanded = isTunnelInfoExpanded
 
         notificationBanner.onResume()
@@ -109,7 +109,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         locationInfoCache.onNewLocation = null
         relayListListener.onRelayListChange = null
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
@@ -28,18 +28,18 @@ class LaunchFragment : ServiceAwareFragment() {
         return view
     }
 
-    override fun onResume() {
-        super.onResume()
+    override fun onStart() {
+        super.onStart()
 
         jobTracker.newUiJob("advanceToNextScreen") {
             advanceToNextScreen()
         }
     }
 
-    override fun onPause() {
+    override fun onStop() {
         jobTracker.cancelJob("advanceToNextScreen")
 
-        super.onPause()
+        super.onStop()
     }
 
     private suspend fun advanceToNextScreen() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -60,7 +60,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         return view
     }
 
-    override fun onSafelyResume() {
+    override fun onSafelyStart() {
         jobTracker.newUiJob("advanceToNextScreen") {
             when (loggedIn.await()) {
                 LoginResult.ExistingAccountWithTime -> openNextScreen(ConnectFragment())
@@ -72,7 +72,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         fetchHistory()
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         jobTracker.cancelJob("advanceToNextScreen")
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -68,7 +68,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
         return view
     }
 
-    override fun onSafelyResume() {
+    override fun onSafelyStart() {
         accountCache.onAccountExpiryChange.subscribe(this) { expiry ->
             checkExpiry(expiry)
         }
@@ -81,7 +81,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
         }
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         accountCache.onAccountExpiryChange.unsubscribe(this)
         jobTracker.cancelJob("pollAccountData")
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -80,7 +80,7 @@ class SelectLocationFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
         return view
     }
 
-    override fun onSafelyResume() {
+    override fun onSafelyStart() {
         // If the relay list is immediately available, setting the listener will cause it to be
         // called right away, while the state is still Initializing. In that case we can skip
         // showing the spinner animation and go directly to the Visible state.
@@ -118,7 +118,7 @@ class SelectLocationFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
         }
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         relayListListener.onRelayListChange = null
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -77,14 +77,14 @@ class SettingsFragment : ServiceAwareFragment() {
         return view
     }
 
-    override fun onResume() {
-        super.onResume()
+    override fun onStart() {
+        super.onStart()
 
         configureListeners()
         active = true
     }
 
-    override fun onPause() {
+    override fun onStop() {
         active = false
         versionInfoCache?.onUpdate = null
 
@@ -93,7 +93,7 @@ class SettingsFragment : ServiceAwareFragment() {
             onAccountExpiryChange.unsubscribe(this@SettingsFragment)
         }
 
-        super.onPause()
+        super.onStop()
     }
 
     override fun onDestroyView() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnelingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnelingFragment.kt
@@ -86,7 +86,7 @@ class SplitTunnelingFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
         return view
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         jobTracker.newBackgroundJob("persistExcludedApps") {
             splitTunneling.persist()
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -54,7 +54,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         return view
     }
 
-    override fun onSafelyResume() {
+    override fun onSafelyStart() {
         accountCache.onAccountNumberChange.subscribe(this) { account ->
             updateAccountNumber(account)
         }
@@ -71,7 +71,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         accountCache.onAccountNumberChange.unsubscribe(this)
         accountCache.onAccountExpiryChange.unsubscribe(this)
         jobTracker.cancelJob("pollAccountData")

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -141,7 +141,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         return view
     }
 
-    override fun onSafelyResume() {
+    override fun onSafelyStart() {
         connectionProxy.onUiStateChange.subscribe(this) { uiState ->
             jobTracker.newUiJob("tunnelStateUpdate") {
                 synchronized(this@WireguardKeyFragment) {
@@ -169,7 +169,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         actionState = ActionState.Idle(false)
     }
 
-    override fun onSafelyPause() {
+    override fun onSafelyStop() {
         connectionProxy.onUiStateChange.unsubscribe(this)
         keyStatusListener.onKeyStatusChange.unsubscribe(this)
 


### PR DESCRIPTION
I've been overly conservative regarding the fragment lifecycles. They always wait for the window to gain focus before they start updating. This works for most cases, but it fails to work on split-screen mode when the user is using another app (i.e., our app's window loses focus). This becomes more apparent with configuration changes (like changing the text size in the accessibility options), where the app would return to the launch screen and wait until it receives focus again.

This PR changes all fragments to use `onStart`/`onStop` instead of `onResume`/`onPause`. This improves the situation in split screen mode with little impact on normal usage.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2063)
<!-- Reviewable:end -->
