### PR TITLE
Enable account view on insufficient funds

### DIFF
--- a/ios/MullvadVPN/ConnectViewController.swift
+++ b/ios/MullvadVPN/ConnectViewController.swift
@@ -54,7 +54,7 @@ class ConnectViewController: UIViewController, RootContainment, TunnelObserver,
         }
     }
 
-    private var showedAccountView = true
+    private var showedAccountView = false
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
…count has insufficient funds

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

I forgot to undo the change that suppressed the account view from appearing when account has insufficient funds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2066)
<!-- Reviewable:end -->
