### PR TITLE
Fix linux install scripts

### DIFF
--- a/dist-assets/linux/after-remove.sh
+++ b/dist-assets/linux/after-remove.sh
@@ -2,14 +2,14 @@
 set -eu
 
 function remove_logs_and_cache {
-  rm -rf /var/log/mullvad-vpn/ || \
+  rm -r --interactive=never /var/log/mullvad-vpn/ || \
     echo "Failed to remove mullvad-vpn logs"
-  rm -rf /var/cache/mullvad-vpn/ || \
+  rm -r --interactive=never /var/cache/mullvad-vpn/ || \
     echo "Failed to remove mullvad-vpn cache"
 }
 
 function remove_config {
-  rm -rf /etc/mullvad-vpn || \
+  rm -r --interactive=never /etc/mullvad-vpn || \
     echo "Failed to remove mullvad-vpn config"
 }
 

--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -11,4 +11,4 @@ fi
 
 pkill -x "mullvad-gui" || true
 
-rm -f /var/cache/mullvad-vpn/relays.json || true
+rm -f /var/cache/mullvad-vpn/relays.json

--- a/dist-assets/linux/before-remove.sh
+++ b/dist-assets/linux/before-remove.sh
@@ -14,7 +14,7 @@ if [[ "$1" == "upgrade" ]]; then
     exit 0;
 fi
 
-mullvad account clear-history || echo "Failed to remove leftover WireGuard keys"
+/usr/bin/mullvad account clear-history || echo "Failed to remove leftover WireGuard keys"
 
 if which systemctl &> /dev/null; then
     # the user might've disabled or stopped the service themselves already


### PR DESCRIPTION
1. If the root user has something other than our CLI as the command `mullvad` these scripts would probably do strange things. So I updated it to use the full path. That's usually preferred to not rely on the environment happening to be correctly set up. For example, on my machine `/usr/local/bin` comes before `/usr/bin` in my root's `PATH`. So if the user created some random script `/usr/local/bin/mullvad` it would be executed instead.
2. The `-f` flag to `rm` suppresses all output and makes it always exit with exit code zero. As such, appending `|| true` or `|| echo "oh no"` does not do anything. Either we remove those or we remove `-f`. Here I kept the `|| echo {log the error}` and replaced `-f` with `--interactive=never` to ensure it would not get stuck on a prompt.

While testing this I noticed that `/opt/Mullvad VPN/` is not fully removed on uninstall. At least not on Fedora:
```
$ tree -a /opt/Mullvad\ VPN/
/opt/Mullvad VPN/
├── locales
├── resources
└── swiftshader
```

Might be worth fixing as well. But I'll leave that as a later task.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2073)
<!-- Reviewable:end -->
