### PR TITLE
Fix split tunneling after restarting the app on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix rare crash that could happen when starting the background service.
 - Fix rare crash that happened with large text sizes and long location names on the main screen.
 - Fix UI not updating in split screen mode when the window is unfocused.
+- Fix split tunneling not being correctly configured after restarting the app.
 
 
 ## [2020.6-beta2] - 2020-08-27

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunneling.kt
@@ -27,7 +27,9 @@ class SplitTunneling(context: Context) {
         enabledChanged()
     }
 
-    var onChange: ((List<String>) -> Unit)? = null
+    var onChange by observable<((List<String>) -> Unit)?>(null) { _, _, _ ->
+        update()
+    }
 
     init {
         if (appListFile.exists()) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SplitTunneling.kt
@@ -32,6 +32,7 @@ class SplitTunneling(context: Context) {
     init {
         if (appListFile.exists()) {
             excludedApps.addAll(appListFile.readLines())
+            update()
         }
     }
 


### PR DESCRIPTION
Previously, split tunneling would stop working after the user restarts the app. This happened because the split tunneling configuration was properly loaded on start, but it didn't notify the listeners until another event happened. This PR fixes that by notifying the listener as soon as the list is first loaded, and when the listener is first configured.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2075)
<!-- Reviewable:end -->
