### PR TITLE
Fix settings close button not clickable

### DIFF
--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -36,6 +36,7 @@ export const StyledTitleBarItemContainer = styled.div({
   minWidth: 0,
   flexDirection: 'column',
   justifyContent: 'center',
+  overflow: 'hidden',
 });
 
 interface ITitleBarItemLabelProps {


### PR DESCRIPTION
This PR fixes an issue where the settings close button wasn't clickable when there was no title.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2076)
<!-- Reviewable:end -->
