### PR TITLE
Update `prepare_release.sh` to support Android specific tags

### DIFF
--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -5,12 +5,39 @@
 
 set -eu
 
-if [[ "$#" != "1" ]]; then
-    echo "Please give the release version as the first and only argument to this script."
+PRODUCT_VERSION=""
+ANDROID="false"
+DESKTOP="false"
+
+for argument in "$@"; do
+    case "$argument" in
+        "--android")
+            ANDROID="true"
+            ;;
+        "--desktop")
+            DESKTOP="true"
+            ;;
+        -*)
+            echo "Unknown option \"$argument\""
+            exit 1
+            ;;
+        *)
+            PRODUCT_VERSION="$argument"
+            ;;
+    esac
+done
+
+if [ -z "$PRODUCT_VERSION" ]; then
+    echo "Please give the release version as an argument to this script."
     echo "For example: '2018.1-beta3' for a beta release, or '2018.6' for a stable one."
     exit 1
 fi
-PRODUCT_VERSION=$1
+
+if [[ "$ANDROID" != "true" && "$DESKTOP" != "true" ]]; then
+    echo "Please specify if the release is for the desktop app and/or for Android app."
+    echo "For example: --android --desktop"
+    exit 1
+fi
 
 if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
     echo "Dirty working directory! Will not accept that for an official release."
@@ -51,7 +78,13 @@ git commit -S -m "Updating version in package files" \
     dist-assets/windows/version.h
 
 echo "Tagging current git commit with release tag $PRODUCT_VERSION..."
-git tag -s $PRODUCT_VERSION -m $PRODUCT_VERSION
+
+if [[ "$ANDROID" == "true" ]]; then
+    git tag -s "android/$PRODUCT_VERSION" -m "android/$PRODUCT_VERSION"
+fi
+if [[ "$DESKTOP" == "true" ]]; then
+    git tag -s $PRODUCT_VERSION -m $PRODUCT_VERSION
+fi
 
 ./version-metadata.sh delete-backup
 

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -79,11 +79,15 @@ git commit -S -m "Updating version in package files" \
 
 echo "Tagging current git commit with release tag $PRODUCT_VERSION..."
 
+NEW_TAGS=""
+
 if [[ "$ANDROID" == "true" ]]; then
     git tag -s "android/$PRODUCT_VERSION" -m "android/$PRODUCT_VERSION"
+    NEW_TAGS+=" android/$PRODUCT_VERSION"
 fi
 if [[ "$DESKTOP" == "true" ]]; then
     git tag -s $PRODUCT_VERSION -m $PRODUCT_VERSION
+    NEW_TAGS+=" $PRODUCT_VERSION"
 fi
 
 ./version-metadata.sh delete-backup
@@ -92,5 +96,5 @@ echo "================================================="
 echo "| DONE preparing for a release!                 |"
 echo "|    Now push the tag created by this script    |"
 echo "|    after you have verified it is correct:     |"
-echo "|        $ git push origin $PRODUCT_VERSION     |"
+echo "|        $ git push origin$NEW_TAGS"
 echo "================================================="

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -44,7 +44,7 @@ if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
     exit 1
 fi
 
-if [[ $(grep $PRODUCT_VERSION CHANGELOG.md) == "" ]]; then
+if [[ $(grep "^## \\[$PRODUCT_VERSION\\] - " CHANGELOG.md) == "" ]]; then
     echo "It looks like you did not add $PRODUCT_VERSION to the changelog?"
     echo "Please make sure the changelog is up to date and correct before you proceed."
     exit 1


### PR DESCRIPTION
Currently a single tag is used to represent releases for both the Android and the desktop app. Unfortunately, this makes it confusing to understand which platform the release is for when only one of them has a release. Therefore there was an agreement to improve the situation by adding an Android specific tag for versions that have a release for that platform, and use the previous tag format for desktop releases.

Note that this doesn't change that the versioning is still the same, i.e., both platforms follow the same version evolution, but each platform can have a release for that version or not.

This PR updates the `./prepare_release.sh` script to support the new tag scheme. Now either on or both of the flags `--android` and `--desktop` _must_ be specified for the script to tag the commit with the appropriate tags. The final message was also updated to list out which tags were added in the hint to push the tags. (The last column marker was removed since it was rarely properly aligned).

The PR also includes a small fix to the regular expression that checks for the version being released in the changelog. Previously it was possible to add a `2020.8-beta1` section and make a `2020.8` release without adding the `2020.8` section. The regular expression is now more strict, but it still ignores whatever comes after the separating hyphen `-` (which so far has only been the release date).

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2082)
<!-- Reviewable:end -->
