### PR TITLE
Log better wg impl selection

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -180,7 +180,7 @@ impl WireguardMonitor {
         match self.tunnel.lock().expect("Tunnel lock poisoned").take() {
             Some(tunnel) => {
                 if let Err(e) = tunnel.stop() {
-                    log::error!("Failed to stop tunnel - {}", e);
+                    log::error!("{}", e.display_chain_with_msg("Failed to stop tunnel"));
                 }
             }
             None => {
@@ -250,7 +250,7 @@ impl CloseHandle {
     /// Closes a WireGuard tunnel
     pub fn close(&mut self) {
         if let Err(e) = self.chan.send(CloseMsg::Stop) {
-            log::trace!("Failed to send close message to wireguard tunnel - {}", e);
+            log::trace!("Failed to send close message to wireguard tunnel: {}", e);
         }
     }
 }
@@ -281,7 +281,7 @@ pub enum TunnelError {
     FatalStartWireguardError,
 
     /// Failed to tear down wireguard tunnel.
-    #[error(display = "Failed to stop wireguard tunnel - {}", status)]
+    #[error(display = "Failed to stop wireguard tunnel. Status: {}", status)]
     StopWireguardError {
         /// Returned error code
         status: i32,

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -132,12 +132,15 @@ impl WireguardMonitor {
         #[cfg(target_os = "linux")]
         match wireguard_kernel::KernelTunnel::new(route_manager.runtime_handle(), config) {
             Ok(tunnel) => {
+                log::debug!("Using kernel WireGuard implementation");
                 return Ok(Box::new(tunnel));
             }
-            Err(err) => {
+            Err(error) => {
                 log::error!(
-                    "Failed to setup kernel WireGuard device, falling back to userspace: {}",
-                    err
+                    "{}",
+                    error.display_chain_with_msg(
+                        "Failed to setup kernel WireGuard device, falling back to userspace"
+                    )
                 );
             }
         };


### PR DESCRIPTION
We want to make it simple to see from the logs which WireGuard implementation is actually used. So I add logging even in the case where the kernel one is used instead of staying silent. This makes it more explicit.

Also replaced some ` - ` delimiters and made them `: ` to be more consistent as well as used our `display_chain_with_msg` to print the entire chain and not just the top error.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2084)
<!-- Reviewable:end -->
