### PR TITLE
Fix build.sh for android tags

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -47,9 +47,10 @@ if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
     fi
 fi
 
-if [[ "$BUILD_TYPE" == "debug" || "$(git describe)" != "$PRODUCT_VERSION" ]]; then
-    GIT_COMMIT="$(git rev-parse HEAD | head -c 6)"
-    PRODUCT_VERSION="${PRODUCT_VERSION}-dev-${GIT_COMMIT}"
+product_version_commit_hash=$(git rev-parse android/$PRODUCT_VERSION^{commit})
+current_head_commit_hash=$(git rev-parse HEAD^{commit})
+if [[ "$BUILD_TYPE" == "debug" || $product_version_commit_hash != $current_head_commit_hash ]]; then
+    PRODUCT_VERSION="${PRODUCT_VERSION}-dev-${current_head_commit_hash:0:6}"
     echo "Modifying product version to $PRODUCT_VERSION"
 else
     echo "Removing old Rust build artifacts"
@@ -57,6 +58,7 @@ else
     CARGO_ARGS+=" --locked"
 fi
 
+echo "Building Mullvad VPN $PRODUCT_VERSION for Android"
 pushd "$SCRIPT_DIR/android"
 
 # Fallback to the system-wide gradle command if the gradlew script is removed.

--- a/build.sh
+++ b/build.sh
@@ -62,9 +62,10 @@ else
     export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 
-if [[ "$BUILD_MODE" == "dev" || $(git describe) != "$PRODUCT_VERSION" ]]; then
-    GIT_COMMIT=$(git rev-parse HEAD | head -c 6)
-    PRODUCT_VERSION="$PRODUCT_VERSION-dev-$GIT_COMMIT"
+product_version_commit_hash=$(git rev-parse $PRODUCT_VERSION^{commit})
+current_head_commit_hash=$(git rev-parse HEAD^{commit})
+if [[ "$BUILD_MODE" == "dev" || $product_version_commit_hash != $current_head_commit_hash ]]; then
+    PRODUCT_VERSION="$PRODUCT_VERSION-dev-${current_head_commit_hash:0:6}"
     echo "Modifying product version to $PRODUCT_VERSION"
 
     echo "Disabling Apple notarization (macOs only) of installer in this dev build"


### PR DESCRIPTION
`git describe` did not work very well any more when we might have two tags on the same commit. It could return the wrong one and the build scripts failed to realize it was a release build.

My change involves using `$PRODUCT_VERSION` (the version we think we are building) and checking what commit hash the corresponding release tag is on. We then get the commit hash for `HEAD`. If they are equal, it means this should be a release build for that `$PRODUCT_VERSION`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2085)
<!-- Reviewable:end -->
