### PR TITLE
Add actions to Linux tray context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 #### Linux
 - Add support for WireGuard's kernel module if it's loaded.
+- Add tray context menu with actions.
+
+### Changed
+- Open and focus app when opened from context menu instead of toggling the window.
 
 ### Fixed
 - Stop resetting the firewall after an upgrade to not leak after an upgrade.

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -97,19 +97,19 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
 
     const Disconnect = (props: React.ComponentProps<typeof AppButton.RedTransparentButton>) => (
       <AppButton.RedTransparentButton onClick={this.props.onDisconnect} {...props}>
-        {messages.pgettext('tunnel-control', 'Disconnect')}
+        {messages.gettext('Disconnect')}
       </AppButton.RedTransparentButton>
     );
 
     const Cancel = (props: React.ComponentProps<typeof AppButton.RedTransparentButton>) => (
       <AppButton.RedTransparentButton onClick={this.props.onDisconnect} {...props}>
-        {messages.pgettext('tunnel-control', 'Cancel')}
+        {messages.gettext('Cancel')}
       </AppButton.RedTransparentButton>
     );
 
     const Dismiss = (props: React.ComponentProps<typeof AppButton.RedTransparentButton>) => (
       <AppButton.RedTransparentButton onClick={this.props.onDisconnect} {...props}>
-        {messages.pgettext('tunnel-control', 'Dismiss')}
+        {messages.gettext('Dismiss')}
       </AppButton.RedTransparentButton>
     );
 

--- a/gui/src/shared/localization-contexts.ts
+++ b/gui/src/shared/localization-contexts.ts
@@ -28,4 +28,5 @@ export type LocalizationContexts =
   | 'split-tunneling-view'
   | 'split-tunneling-nav'
   | 'support-view'
-  | 'select-language-nav';
+  | 'select-language-nav'
+  | 'tray-icon-context-menu';


### PR DESCRIPTION
This PR adds actions to the context menu displayed when clicking on the tray icon in some desktop environments. Since we have to have a context menu we want to make the most of it. To keep the old behavior in desktop environments that support listening on tray icon click, a list of DEs supporting it is used to decide the behavior.

In addition to adding actions to the context menu, this PR changes the behavior when clicking the tray icon (or "Open Mullvad VPN" in the context menu) to always showing and focusing the app. This was changed since the toggle behavior was a bit confusing when the app was open but hidden behind some other window. Now it will always be placed on top of other windows. Hiding the app will still be possible by pressing the "x" window icon.

![image](https://user-images.githubusercontent.com/3668602/92455657-42823380-f1c2-11ea-93d4-dd5ebdff5f56.png)
![image](https://user-images.githubusercontent.com/3668602/92455683-4910ab00-f1c2-11ea-8f11-77332638c94f.png)

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2086)
<!-- Reviewable:end -->
