### PR TITLE
Allow build[-apk].sh to work even when release tag does not exist

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -47,7 +47,7 @@ if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
     fi
 fi
 
-product_version_commit_hash=$(git rev-parse android/$PRODUCT_VERSION^{commit})
+product_version_commit_hash=$(git rev-parse android/$PRODUCT_VERSION^{commit} || echo "")
 current_head_commit_hash=$(git rev-parse HEAD^{commit})
 if [[ "$BUILD_TYPE" == "debug" || $product_version_commit_hash != $current_head_commit_hash ]]; then
     PRODUCT_VERSION="${PRODUCT_VERSION}-dev-${current_head_commit_hash:0:6}"

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ else
     export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 
-product_version_commit_hash=$(git rev-parse $PRODUCT_VERSION^{commit})
+product_version_commit_hash=$(git rev-parse $PRODUCT_VERSION^{commit} || echo "")
 current_head_commit_hash=$(git rev-parse HEAD^{commit})
 if [[ "$BUILD_MODE" == "dev" || $product_version_commit_hash != $current_head_commit_hash ]]; then
     PRODUCT_VERSION="$PRODUCT_VERSION-dev-${current_head_commit_hash:0:6}"


### PR DESCRIPTION
Follow up on #2085. Currently it crashes when trying to build and the version metadata files has a version that there is no tag for. this should not really ever happen in the real world. But during this transition period that will be true. And also, better to cover an edge case than crash.

`git rev-parse HEAD` should never fail. `HEAD` does always exist. But some arbitrary tag might not exist.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2088)
<!-- Reviewable:end -->
