### PR TITLE
Use single task for app to prevent quitting from not closing the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix rare crash that happened with large text sizes and long location names on the main screen.
 - Fix UI not updating in split screen mode when the window is unfocused.
 - Fix split tunneling not being correctly configured after restarting the app.
+- Fix app reopening after pressing the Quit button because app was running multiple tasks.
 
 
 ## [2020.6-beta2] - 2020-08-27

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
                  tools:ignore="GoogleAppIndexingWarning">
         <activity android:name="net.mullvad.mullvadvpn.ui.MainActivity"
                   android:label="@string/app_name"
+                  android:launchMode="singleTask"
                   android:configChanges="orientation|screenSize|screenLayout"
                   android:screenOrientation="portrait"
                   android:windowSoftInputMode="adjustPan">

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -169,6 +169,7 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
             } else {
                 val activityIntent = Intent(context, MainActivity::class.java).apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     putExtra(MainActivity.KEY_SHOULD_CONNECT, true)
                 }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -282,6 +282,7 @@ class MullvadVpnService : TalpidVpnService() {
     private fun openUi() {
         val intent = Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
 
         startActivity(intent)


### PR DESCRIPTION
Previously, it was possible to make the Quit button not work by spawning more than one task with the `MainActivity`. One way to do this was by:

1. Logging out
2. Quitting the app
3. Trying to connect using the Quick-Settings tile, which would then open the login screen
4. Returning to the home screen
5. Opening the app from the launcher
6. Trying to Quit, which would then close the app but appear to reopen it right away.

This PR fixes that by marking the `MainActivity` as a single task, so that when opening the UI any previous instances are closed. The PR also takes a further precaution by requesting to clean the task stack when opening the UI, so that it will go to the intended screen without creating a weird navigation path for the back button.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2090)
<!-- Reviewable:end -->
