### PR TITLE
Fix inconsistent quick settings tile behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix UI not updating in split screen mode when the window is unfocused.
 - Fix split tunneling not being correctly configured after restarting the app.
 - Fix app reopening after pressing the Quit button because app was running multiple tasks.
+- Fix inconsistent behavior of the quick-settings tile when logged out. It would sometimes enter the
+  blocking state and sometimes open the UI for the user to login. Now it always opens the UI.
 
 
 ## [2020.6-beta2] - 2020-08-27

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -68,20 +68,14 @@ class MullvadVpnService : TalpidVpnService() {
     private lateinit var notificationManager: ForegroundNotificationManager
     private lateinit var tunnelStateUpdater: TunnelStateUpdater
 
-    private var pendingAction: PendingAction? = null
-        set(value) {
-            field = value
-
-            instance?.connectionProxy?.let { activeConnectionProxy ->
-                when (value) {
-                    PendingAction.Connect -> activeConnectionProxy.connect()
-                    PendingAction.Disconnect -> activeConnectionProxy.disconnect()
-                    null -> {}
-                }
-
-                field = null
-            }
+    private var pendingAction by observable<PendingAction?>(null) { _, _, action ->
+        instance?.let { activeInstance ->
+            handlePendingAction(
+                activeInstance.connectionProxy,
+                activeInstance.settingsListener.settings
+            )
         }
+    }
 
     private var isBound by observable(false) { _, _, isBound ->
         notificationManager.lockedToForeground = isBound

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -270,7 +270,7 @@ class MullvadVpnService : TalpidVpnService() {
                 }
             }
             PendingAction.Disconnect -> connectionProxy.disconnect()
-            null -> {}
+            null -> return
         }
 
         pendingAction = null


### PR DESCRIPTION
Previously, the quick settings tile would have an inconsistent behavior when there was no account set. If the service was already running, pressing the tile would make the daemon enter the blocked state. If it wasn't running, it would be started but the UI would be opened so that the user could log in first.

This PR makes the behavior consistent by always opening the UI if the user is logged out.

Unfortunately, on my test device there is still a small difference. For some unknown reason, Android will take a few seconds (3-5) to start the UI if the service is already running. I couldn't figure out what could cause this. The closest I came was with removing the `singleTask` configuration on the activity, which reduced the lag to less than one second. However, that would reintroduce the failure to quit bug, so I decided to leave it as is.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2092)
<!-- Reviewable:end -->
