### PR TITLE
Make scrollbar update when content size changes

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -708,6 +708,12 @@
         "@types/react": "*"
       }
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.3.tgz",
+      "integrity": "sha512-3tGjLIDH8L57fWOfC7NVn/BbGQD7pXwbkk2+8Z4hK/S7kOIv1MUN4nkKjfx0qg4ctkukjzp3Bgr/Z+Hq5ZQZTQ==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.9.tgz",

--- a/gui/package.json
+++ b/gui/package.json
@@ -56,6 +56,7 @@
     "@types/react-redux": "^7.1.7",
     "@types/react-router": "^5.1.5",
     "@types/react-simple-maps": "^0.12.1",
+    "@types/resize-observer-browser": "^0.1.3",
     "@types/sinon": "^7.0.5",
     "@types/sprintf-js": "^1.1.2",
     "@types/styled-components": "^5.1.0",

--- a/gui/src/renderer/components/CustomScrollbars.tsx
+++ b/gui/src/renderer/components/CustomScrollbars.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
+import styled from 'styled-components';
 import { Scheduler } from '../../shared/scheduler';
+
+const ScrollableContent = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '100%',
+  height: 'max-content',
+});
 
 const AUTOHIDE_TIMEOUT = 1000;
 
@@ -54,9 +62,15 @@ export default class CustomScrollbars extends React.Component<IProps, IState> {
   };
 
   private scrollableRef = React.createRef<HTMLDivElement>();
+  private scrollableContentRef = React.createRef<HTMLDivElement>();
   private trackRef = React.createRef<HTMLDivElement>();
   private thumbRef = React.createRef<HTMLDivElement>();
   private autoHideScheduler = new Scheduler();
+
+  // Update scrollbar when content grows/shrinks.
+  private contentResizeObserver = new ResizeObserver(() => {
+    this.updateScrollbarsHelper({ size: true });
+  });
 
   public scrollToTop() {
     const scrollable = this.scrollableRef.current;
@@ -134,6 +148,10 @@ export default class CustomScrollbars extends React.Component<IProps, IState> {
     if (this.props.autoHide) {
       this.startAutoHide();
     }
+
+    if (this.scrollableContentRef.current) {
+      this.contentResizeObserver.observe(this.scrollableContentRef.current);
+    }
   }
 
   public shouldComponentUpdate(nextProps: IProps, nextState: IState) {
@@ -160,6 +178,10 @@ export default class CustomScrollbars extends React.Component<IProps, IState> {
     document.removeEventListener('mousemove', this.handleMouseMove);
     document.removeEventListener('mouseup', this.handleMouseUp);
     document.removeEventListener('mousedown', this.handleMouseDown);
+
+    if (this.scrollableContentRef.current) {
+      this.contentResizeObserver.unobserve(this.scrollableContentRef.current);
+    }
   }
 
   public componentDidUpdate() {
@@ -201,7 +223,7 @@ export default class CustomScrollbars extends React.Component<IProps, IState> {
           style={{ overflow: 'auto', flex: fillContainer ? '1' : undefined }}
           onScroll={this.onScroll}
           ref={this.scrollableRef}>
-          {children}
+          <ScrollableContent ref={this.scrollableContentRef}>{children}</ScrollableContent>
         </div>
       </div>
     );

--- a/gui/src/renderer/components/WireguardKeysStyles.tsx
+++ b/gui/src/renderer/components/WireguardKeysStyles.tsx
@@ -15,7 +15,7 @@ export const StyledContainer = styled(Container)({
 export const StyledContent = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  minHeight: '100%',
+  flex: 1,
 });
 
 export const StyledMessages = styled.div({


### PR DESCRIPTION
This PR adds a `ResizeObserver` to listen to height changes of the content in `CustomScrollbars`. Previously the scrollbar length and position didn't update when the content changed, e.g. when expanding/collapsing countries or cities in the location picker, or when the split tunneling view finished loading the installed apps. With this PR the scrollbar is updated on every height change.

![4](https://user-images.githubusercontent.com/3668602/92635164-aea18c00-f2d5-11ea-970f-53cae8d6daf2.gif)
![3](https://user-images.githubusercontent.com/3668602/92635097-9598db00-f2d5-11ea-89f4-42d0aa387385.gif)

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2095)
<!-- Reviewable:end -->
