### PR TITLE
Add support for custom DNS server on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,9 +999,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jnix"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354ae923ca4df982181ae2cd77eb4214f8c11d11d0c0cd8606c9347ac2abc57"
+checksum = "1c610361550ad147bf2d7ddf71b67035706759ebf6f503cc6cbe4a581004de8a"
 dependencies = [
  "jni",
  "jnix-macros",
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "jnix-macros"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78132fe420156f13b30518fcda9449b0ab8ae3b5584e8a1c53ce390fe770b44"
+checksum = "13e87ff0edc1c5199f084e3175e9a3f5ee2bb56035403b685d0ec8edd5157250"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/DnsOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/DnsOptions.kt
@@ -1,0 +1,6 @@
+package net.mullvad.mullvadvpn.model
+
+import java.net.InetAddress
+import java.util.ArrayList
+
+data class DnsOptions(val custom: Boolean, val addresses: ArrayList<InetAddress>)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelOptions.kt
@@ -2,4 +2,4 @@ package net.mullvad.mullvadvpn.model
 
 import net.mullvad.talpid.net.wireguard.TunnelOptions as WireguardTunnelOptions
 
-data class TunnelOptions(val wireguard: WireguardTunnelOptions)
+data class TunnelOptions(val wireguard: WireguardTunnelOptions, val dnsOptions: DnsOptions)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -1,0 +1,68 @@
+package net.mullvad.mullvadvpn.service
+
+import java.net.InetAddress
+import java.util.ArrayList
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.model.DnsOptions
+import net.mullvad.talpid.util.EventNotifier
+
+class CustomDns(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
+    private var enabled by observable(false) { _, oldValue, newValue ->
+        if (oldValue != newValue) {
+            onEnabledChanged.notify(newValue)
+        }
+    }
+
+    private var dnsServers by observable<ArrayList<InetAddress>>(ArrayList()) { _, _, servers ->
+        onDnsServersChanged.notify(servers.toList())
+    }
+
+    val onEnabledChanged = EventNotifier(false)
+    val onDnsServersChanged = EventNotifier<List<InetAddress>>(emptyList())
+
+    init {
+        settingsListener.dnsOptionsNotifier.subscribe(this) { dnsOptions ->
+            enabled = dnsOptions.custom
+            dnsServers = ArrayList(dnsOptions.addresses)
+        }
+    }
+
+    fun onDestroy() {
+        settingsListener.dnsOptionsNotifier.unsubscribe(this)
+    }
+
+    fun enable() {
+        synchronized(this) {
+            changeDnsOptions(true, dnsServers)
+        }
+    }
+
+    fun disable() {
+        synchronized(this) {
+            changeDnsOptions(false, dnsServers)
+        }
+    }
+
+    fun addDnsServer(server: InetAddress) {
+        synchronized(this) {
+            if (!dnsServers.contains(server)) {
+                dnsServers.add(server)
+                changeDnsOptions(enabled, dnsServers)
+            }
+        }
+    }
+
+    fun removeDnsServer(server: InetAddress) {
+        synchronized(this) {
+            if (dnsServers.remove(server)) {
+                changeDnsOptions(enabled, dnsServers)
+            }
+        }
+    }
+
+    private fun changeDnsOptions(enable: Boolean, dnsServers: ArrayList<InetAddress>) {
+        val options = DnsOptions(enable, dnsServers)
+
+        daemon.setDnsOptions(options)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service
 
 import net.mullvad.mullvadvpn.model.AppVersionInfo
+import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.model.KeygenEvent
@@ -106,6 +107,10 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         setAutoConnect(daemonInterfaceAddress, autoConnect)
     }
 
+    fun setDnsOptions(dnsOptions: DnsOptions) {
+        setDnsOptions(daemonInterfaceAddress, dnsOptions)
+    }
+
     fun setWireguardMtu(wireguardMtu: Int?) {
         setWireguardMtu(daemonInterfaceAddress, wireguardMtu)
     }
@@ -158,6 +163,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     private external fun setAccount(daemonInterfaceAddress: Long, accountToken: String?)
     private external fun setAllowLan(daemonInterfaceAddress: Long, allowLan: Boolean)
     private external fun setAutoConnect(daemonInterfaceAddress: Long, alwaysOn: Boolean)
+    private external fun setDnsOptions(daemonInterfaceAddress: Long, dnsOptions: DnsOptions)
     private external fun setWireguardMtu(daemonInterfaceAddress: Long, wireguardMtu: Int?)
     private external fun shutdown(daemonInterfaceAddress: Long)
     private external fun submitVoucher(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -226,6 +226,7 @@ class MullvadVpnService : TalpidVpnService() {
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
         val settingsListener = SettingsListener(daemon, settings)
         val connectionProxy = ConnectionProxy(this, daemon)
+        val customDns = CustomDns(daemon, settingsListener)
         val splitTunneling = splitTunneling.await()
 
         splitTunneling.onChange = { excludedApps ->
@@ -241,6 +242,7 @@ class MullvadVpnService : TalpidVpnService() {
                 daemon,
                 connectionProxy,
                 connectivityListener,
+                customDns,
                 settingsListener,
                 splitTunneling
             )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -6,6 +6,7 @@ class ServiceInstance(
     val daemon: MullvadDaemon,
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,
+    val customDns: CustomDns,
     val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
@@ -16,6 +17,7 @@ class ServiceInstance(
     fun onDestroy() {
         accountCache.onDestroy()
         connectionProxy.onDestroy()
+        customDns.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -14,6 +14,7 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
     private val settingsNotifier: EventNotifier<Settings> = EventNotifier(settings)
 
     val accountNumberNotifier = EventNotifier(initialSettings.accountToken)
+    val dnsOptionsNotifier = EventNotifier(initialSettings.tunnelOptions.dnsOptions)
 
     var onRelaySettingsChange: ((RelaySettings?) -> Unit)? = null
         set(value) {
@@ -48,6 +49,10 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
         synchronized(this) {
             if (settings.accountToken != newSettings.accountToken) {
                 accountNumberNotifier.notify(newSettings.accountToken)
+            }
+
+            if (settings.tunnelOptions.dnsOptions != newSettings.tunnelOptions.dnsOptions) {
+                dnsOptionsNotifier.notify(newSettings.tunnelOptions.dnsOptions)
             }
 
             if (settings.relaySettings != newSettings.relaySettings) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -9,6 +9,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val accountCache = service.accountCache
     val connectionProxy = service.connectionProxy
     val connectivityListener = service.connectivityListener
+    val customDns = service.customDns
     val keyStatusListener = service.keyStatusListener
     val locationInfoCache = service.locationInfoCache
     val settingsListener = service.settingsListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -9,6 +9,7 @@ import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.ConnectionProxy
+import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
@@ -44,6 +45,9 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
     lateinit var connectivityListener: ConnectivityListener
         private set
 
+    lateinit var customDns: CustomDns
+        private set
+
     lateinit var daemon: MullvadDaemon
         private set
 
@@ -69,6 +73,7 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
         appVersionInfoCache = serviceConnection.appVersionInfoCache
         connectionProxy = serviceConnection.connectionProxy
         connectivityListener = serviceConnection.connectivityListener
+        customDns = serviceConnection.customDns
         daemon = serviceConnection.daemon
         keyStatusListener = serviceConnection.keyStatusListener
         locationInfoCache = serviceConnection.locationInfoCache

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -194,7 +194,6 @@ pub enum DaemonCommand {
     /// Set if IPv6 should be enabled in the tunnel
     SetEnableIpv6(oneshot::Sender<()>, bool),
     /// Set custom DNS servers to use instead of passing requests to the gateway
-    #[cfg(not(target_os = "android"))]
     SetDnsOptions(oneshot::Sender<()>, DnsOptions),
     /// Set MTU for wireguard tunnels
     SetWireguardMtu(oneshot::Sender<()>, Option<u16>),
@@ -1052,7 +1051,6 @@ where
             }
             SetBridgeState(tx, bridge_state) => self.on_set_bridge_state(tx, bridge_state),
             SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6),
-            #[cfg(not(target_os = "android"))]
             SetDnsOptions(tx, dns_servers) => self.on_set_dns_options(tx, dns_servers),
             SetWireguardMtu(tx, mtu) => self.on_set_wireguard_mtu(tx, mtu),
             SetWireguardRotationInterval(tx, interval) => {
@@ -1692,7 +1690,6 @@ where
         }
     }
 
-    #[cfg(not(target_os = "android"))]
     fn on_set_dns_options(&mut self, tx: oneshot::Sender<()>, dns_options: DnsOptions) {
         let save_result = self.settings.set_dns_options(dns_options.clone());
         match save_result {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -26,8 +26,6 @@ use futures::{
 };
 use log::{debug, error, info, warn};
 use mullvad_rpc::AccountsProxy;
-#[cfg(not(target_os = "android"))]
-use mullvad_types::settings::DnsOptions;
 use mullvad_types::{
     account::{AccountData, AccountToken, VoucherSubmission},
     endpoint::MullvadEndpoint,
@@ -37,14 +35,12 @@ use mullvad_types::{
         RelaySettingsUpdate,
     },
     relay_list::{Relay, RelayList},
-    settings::Settings,
+    settings::{DnsOptions, Settings},
     states::{TargetState, TunnelState},
     version::{AppVersion, AppVersionInfo},
     wireguard::KeygenEvent,
 };
 use settings::SettingsPersister;
-#[cfg(not(target_os = "android"))]
-use std::net::IpAddr;
 #[cfg(not(target_os = "android"))]
 use std::path::Path;
 use std::{
@@ -52,6 +48,7 @@ use std::{
     io,
     marker::PhantomData,
     mem,
+    net::IpAddr,
     path::PathBuf,
     sync::{mpsc as sync_mpsc, Arc, Weak},
     time::Duration,
@@ -583,7 +580,6 @@ where
         let tunnel_command_tx = tunnel_state_machine::spawn(
             settings.allow_lan,
             settings.block_when_disconnected,
-            #[cfg(not(target_os = "android"))]
             Self::get_custom_resolvers(&settings.tunnel_options.dns_options),
             tunnel_parameters_generator,
             log_dir,
@@ -637,7 +633,6 @@ where
         Ok(daemon)
     }
 
-    #[cfg(not(target_os = "android"))]
     fn get_custom_resolvers(dns_options: &DnsOptions) -> Option<Vec<IpAddr>> {
         if dns_options.custom {
             Some(dns_options.addresses.clone())

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -1,9 +1,7 @@
 use log::{debug, error, info};
-#[cfg(not(target_os = "android"))]
-use mullvad_types::settings::DnsOptions;
 use mullvad_types::{
     relay_constraints::{BridgeSettings, BridgeState, RelaySettingsUpdate},
-    settings::Settings,
+    settings::{DnsOptions, Settings},
 };
 use std::{
     fs::{self, File},
@@ -212,7 +210,6 @@ impl SettingsPersister {
         self.update(should_save)
     }
 
-    #[cfg(not(target_os = "android"))]
     pub fn set_dns_options(&mut self, options: DnsOptions) -> Result<bool, Error> {
         let should_save =
             Self::update_field(&mut self.settings.tunnel_options.dns_options, options);

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -14,7 +14,7 @@ crate_type = ["cdylib"]
 err-derive = "0.2.1"
 futures = "0.3"
 ipnetwork = "0.16"
-jnix = { version = "0.2.3", features = ["derive"] }
+jnix = { version = "0.3", features = ["derive"] }
 lazy_static = "1"
 log = "0.4"
 log-panics = "2"

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -7,6 +7,7 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/mullvadvpn/model/AppVersionInfo",
     "net/mullvad/mullvadvpn/model/Constraint$Any",
     "net/mullvad/mullvadvpn/model/Constraint$Only",
+    "net/mullvad/mullvadvpn/model/DnsOptions",
     "net/mullvad/mullvadvpn/model/GeoIpLocation",
     "net/mullvad/mullvadvpn/model/GetAccountDataResult$Ok",
     "net/mullvad/mullvadvpn/model/GetAccountDataResult$InvalidAccount",

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -5,7 +5,7 @@ use mullvad_types::{
     location::GeoIpLocation,
     relay_constraints::RelaySettingsUpdate,
     relay_list::RelayList,
-    settings::Settings,
+    settings::{DnsOptions, Settings},
     states::{TargetState, TunnelState},
     version::AppVersionInfo,
     wireguard::{self, KeygenEvent},
@@ -198,6 +198,14 @@ impl DaemonInterface {
         let (tx, rx) = oneshot::channel();
 
         self.send_command(DaemonCommand::SetAutoConnect(tx, auto_connect))?;
+
+        block_on(rx).map_err(|_| Error::NoResponse)
+    }
+
+    pub fn set_dns_options(&self, dns_options: DnsOptions) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(DaemonCommand::SetDnsOptions(tx, dns_options))?;
 
         block_on(rx).map_err(|_| Error::NoResponse)
     }

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -20,4 +20,4 @@ serde_json = "1.0"
 talpid-types = { path = "../talpid-types" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.2.3", features = ["derive"] }
+jnix = { version = "0.3", features = ["derive"] }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -3,7 +3,7 @@ use crate::relay_constraints::{
     RelayConstraints, RelaySettings, RelaySettingsUpdate,
 };
 #[cfg(target_os = "android")]
-use jnix::IntoJava;
+use jnix::{FromJava, IntoJava};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -172,7 +172,7 @@ pub struct TunnelOptions {
 /// Custom DNS config
 #[serde(default)]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-#[cfg_attr(target_os = "android", derive(IntoJava))]
+#[cfg_attr(target_os = "android", derive(FromJava, IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct DnsOptions {
     /// Whether to use the addresses in `custom_dns`.

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -166,7 +166,6 @@ pub struct TunnelOptions {
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub generic: GenericTunnelOptions,
     /// Custom DNS options.
-    #[cfg(not(target_os = "android"))]
     pub dns_options: DnsOptions,
 }
 

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -7,7 +7,6 @@ use jnix::IntoJava;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use serde_json;
-#[cfg(not(target_os = "android"))]
 use std::net::IpAddr;
 use talpid_types::net::{openvpn, wireguard, GenericTunnelOptions};
 
@@ -172,9 +171,10 @@ pub struct TunnelOptions {
 }
 
 /// Custom DNS config
-#[cfg(not(target_os = "android"))]
 #[serde(default)]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[cfg_attr(target_os = "android", derive(IntoJava))]
+#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct DnsOptions {
     /// Whether to use the addresses in `custom_dns`.
     pub custom: bool,
@@ -194,7 +194,6 @@ impl Default for TunnelOptions {
                 // Enable IPv6 be default on Android
                 enable_ipv6: cfg!(target_os = "android"),
             },
-            #[cfg(not(target_os = "android"))]
             dns_options: DnsOptions::default(),
         }
     }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -42,7 +42,7 @@ nix = "0.19"
 
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.2.3", features = ["derive"] }
+jnix = { version = "0.3", features = ["derive"] }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/talpid-core/src/tunnel/tun_provider/android/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/android/mod.rs
@@ -60,11 +60,16 @@ pub struct AndroidTunProvider {
     object: GlobalRef,
     last_tun_config: TunConfig,
     allow_lan: bool,
+    custom_dns_servers: Option<Vec<IpAddr>>,
 }
 
 impl AndroidTunProvider {
     /// Create a new AndroidTunProvider interfacing with Android's VpnService.
-    pub fn new(context: AndroidContext, allow_lan: bool) -> Self {
+    pub fn new(
+        context: AndroidContext,
+        allow_lan: bool,
+        custom_dns_servers: Option<Vec<IpAddr>>,
+    ) -> Self {
         let env = JnixEnv::from(
             context
                 .jvm
@@ -79,12 +84,22 @@ impl AndroidTunProvider {
             object: context.vpn_service,
             last_tun_config: TunConfig::default(),
             allow_lan,
+            custom_dns_servers,
         }
     }
 
     pub fn set_allow_lan(&mut self, allow_lan: bool) -> Result<(), Error> {
         if self.allow_lan != allow_lan {
             self.allow_lan = allow_lan;
+            self.recreate_tun_if_open()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn set_custom_dns_servers(&mut self, servers: Option<Vec<IpAddr>>) -> Result<(), Error> {
+        if self.custom_dns_servers != servers {
+            self.custom_dns_servers = servers;
             self.recreate_tun_if_open()?;
         }
 
@@ -213,6 +228,11 @@ impl AndroidTunProvider {
     }
 
     fn prepare_tun_config(&self, config: &mut TunConfig) {
+        self.prepare_tun_config_for_allow_lan(config);
+        self.prepare_tun_config_for_custom_dns(config);
+    }
+
+    fn prepare_tun_config_for_allow_lan(&self, config: &mut TunConfig) {
         if self.allow_lan {
             let (required_ipv4_routes, required_ipv6_routes) = config
                 .required_routes
@@ -250,6 +270,12 @@ impl AndroidTunProvider {
                 .collect();
 
             config.routes = routes;
+        }
+    }
+
+    fn prepare_tun_config_for_custom_dns(&self, config: &mut TunConfig) {
+        if let Some(custom_dns_servers) = self.custom_dns_servers.clone() {
+            config.dns_servers = custom_dns_servers;
         }
     }
 

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -193,26 +193,35 @@ impl ConnectedState {
                 }
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                if shared_values.set_custom_dns(servers) {
-                    if let Err(error) = self.set_firewall_policy(shared_values) {
-                        return self.disconnect(
-                            shared_values,
-                            AfterDisconnect::Block(ErrorStateCause::SetFirewallPolicyError(error)),
-                        );
-                    }
-
-                    match self.set_dns(shared_values) {
-                        Ok(()) => SameState(self.into()),
-                        Err(error) => {
-                            log::error!("{}", error.display_chain_with_msg("Failed to set DNS"));
-                            self.disconnect(
+                match shared_values.set_custom_dns(servers) {
+                    Ok(true) => {
+                        if let Err(error) = self.set_firewall_policy(shared_values) {
+                            return self.disconnect(
                                 shared_values,
-                                AfterDisconnect::Block(ErrorStateCause::SetDnsError),
-                            )
+                                AfterDisconnect::Block(ErrorStateCause::SetFirewallPolicyError(
+                                    error,
+                                )),
+                            );
+                        }
+
+                        match self.set_dns(shared_values) {
+                            Ok(()) => SameState(self.into()),
+                            Err(error) => {
+                                log::error!(
+                                    "{}",
+                                    error.display_chain_with_msg("Failed to set DNS")
+                                );
+                                self.disconnect(
+                                    shared_values,
+                                    AfterDisconnect::Block(ErrorStateCause::SetDnsError),
+                                )
+                            }
                         }
                     }
-                } else {
-                    SameState(self.into())
+                    Ok(false) => SameState(self.into()),
+                    Err(error_cause) => {
+                        self.disconnect(shared_values, AfterDisconnect::Block(error_cause))
+                    }
                 }
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -192,7 +192,6 @@ impl ConnectedState {
                     }
                 }
             }
-            #[cfg(not(target_os = "android"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 if shared_values.custom_dns != servers {
                     shared_values.custom_dns = servers;

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -193,9 +193,7 @@ impl ConnectedState {
                 }
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                if shared_values.custom_dns != servers {
-                    shared_values.custom_dns = servers;
-
+                if shared_values.set_custom_dns(servers) {
                     if let Err(error) = self.set_firewall_policy(shared_values) {
                         return self.disconnect(
                             shared_values,

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -205,6 +205,9 @@ impl ConnectedState {
                         }
 
                         match self.set_dns(shared_values) {
+                            #[cfg(target_os = "android")]
+                            Ok(()) => self.disconnect(shared_values, AfterDisconnect::Reconnect(0)),
+                            #[cfg(not(target_os = "android"))]
                             Ok(()) => SameState(self.into()),
                             Err(error) => {
                                 log::error!(

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -236,10 +236,11 @@ impl ConnectingState {
                 }
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                if let Err(error_cause) = shared_values.set_custom_dns(servers) {
-                    self.disconnect(shared_values, AfterDisconnect::Block(error_cause))
-                } else {
-                    SameState(self.into())
+                match shared_values.set_custom_dns(servers) {
+                    #[cfg(target_os = "android")]
+                    Ok(true) => self.disconnect(shared_values, AfterDisconnect::Reconnect(0)),
+                    Ok(_) => SameState(self.into()),
+                    Err(cause) => self.disconnect(shared_values, AfterDisconnect::Block(cause)),
                 }
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -236,7 +236,7 @@ impl ConnectingState {
                 }
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                shared_values.custom_dns = servers;
+                shared_values.set_custom_dns(servers);
                 SameState(self.into())
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -236,8 +236,11 @@ impl ConnectingState {
                 }
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                shared_values.set_custom_dns(servers);
-                SameState(self.into())
+                if let Err(error_cause) = shared_values.set_custom_dns(servers) {
+                    self.disconnect(shared_values, AfterDisconnect::Block(error_cause))
+                } else {
+                    SameState(self.into())
+                }
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 shared_values.block_when_disconnected = block_when_disconnected;

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -235,7 +235,6 @@ impl ConnectingState {
                     }
                 }
             }
-            #[cfg(not(target_os = "android"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -78,7 +78,11 @@ impl TunnelState for DisconnectedState {
                 SameState(self.into())
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                shared_values.set_custom_dns(servers);
+                // Same situation as allow LAN above.
+                shared_values
+                    .set_custom_dns(servers)
+                    .expect("Failed to reconnect after changing custom DNS servers");
+
                 SameState(self.into())
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -78,7 +78,7 @@ impl TunnelState for DisconnectedState {
                 SameState(self.into())
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                shared_values.custom_dns = servers;
+                shared_values.set_custom_dns(servers);
                 SameState(self.into())
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -77,7 +77,6 @@ impl TunnelState for DisconnectedState {
                 }
                 SameState(self.into())
             }
-            #[cfg(not(target_os = "android"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -33,7 +33,7 @@ impl DisconnectingState {
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {
-                    shared_values.custom_dns = servers;
+                    shared_values.set_custom_dns(servers);
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
@@ -54,7 +54,7 @@ impl DisconnectingState {
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {
-                    shared_values.custom_dns = servers;
+                    shared_values.set_custom_dns(servers);
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
@@ -80,7 +80,7 @@ impl DisconnectingState {
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {
-                    shared_values.custom_dns = servers;
+                    shared_values.set_custom_dns(servers);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -33,7 +33,7 @@ impl DisconnectingState {
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {
-                    shared_values.set_custom_dns(servers);
+                    let _ = shared_values.set_custom_dns(servers);
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
@@ -54,7 +54,7 @@ impl DisconnectingState {
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {
-                    shared_values.set_custom_dns(servers);
+                    let _ = shared_values.set_custom_dns(servers);
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
@@ -80,7 +80,7 @@ impl DisconnectingState {
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {
-                    shared_values.set_custom_dns(servers);
+                    let _ = shared_values.set_custom_dns(servers);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -32,7 +32,6 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Nothing
                 }
-                #[cfg(not(target_os = "android"))]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Nothing
@@ -54,7 +53,6 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Block(reason)
                 }
-                #[cfg(not(target_os = "android"))]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Block(reason)
@@ -81,7 +79,6 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
-                #[cfg(not(target_os = "android"))]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Reconnect(retry_attempt)

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -105,7 +105,6 @@ impl TunnelState for ErrorState {
                     SameState(self.into())
                 }
             }
-            #[cfg(not(target_os = "android"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -106,8 +106,11 @@ impl TunnelState for ErrorState {
                 }
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                shared_values.set_custom_dns(servers);
-                SameState(self.into())
+                if let Err(error_state_cause) = shared_values.set_custom_dns(servers) {
+                    NewState(Self::enter(shared_values, error_state_cause))
+                } else {
+                    SameState(self.into())
+                }
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 shared_values.block_when_disconnected = block_when_disconnected;

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -106,7 +106,7 @@ impl TunnelState for ErrorState {
                 }
             }
             Some(TunnelCommand::CustomDns(servers)) => {
-                shared_values.custom_dns = servers;
+                shared_values.set_custom_dns(servers);
                 SameState(self.into())
             }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -100,6 +100,8 @@ pub async fn spawn(
         android_context,
         #[cfg(target_os = "android")]
         allow_lan,
+        #[cfg(target_os = "android")]
+        custom_dns.clone(),
     );
 
     let runtime = tokio::runtime::Handle::current();

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -23,11 +23,10 @@ use futures::{
     channel::{mpsc, oneshot},
     stream, StreamExt,
 };
-#[cfg(not(target_os = "android"))]
-use std::net::IpAddr;
 use std::{
     collections::HashSet,
     io,
+    net::IpAddr,
     path::{Path, PathBuf},
     sync::{mpsc as sync_mpsc, Arc},
 };
@@ -75,7 +74,7 @@ pub enum Error {
 pub async fn spawn(
     allow_lan: bool,
     block_when_disconnected: bool,
-    #[cfg(not(target_os = "android"))] custom_dns: Option<Vec<IpAddr>>,
+    custom_dns: Option<Vec<IpAddr>>,
     tunnel_parameters_generator: impl TunnelParametersGenerator,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
@@ -112,7 +111,6 @@ pub async fn spawn(
             allow_lan,
             block_when_disconnected,
             is_offline,
-            #[cfg(not(target_os = "android"))]
             custom_dns,
             tunnel_parameters_generator,
             tun_provider,
@@ -193,7 +191,7 @@ impl TunnelStateMachine {
         allow_lan: bool,
         block_when_disconnected: bool,
         is_offline: bool,
-        #[cfg(not(target_os = "android"))] custom_dns: Option<Vec<IpAddr>>,
+        custom_dns: Option<Vec<IpAddr>>,
         tunnel_parameters_generator: impl TunnelParametersGenerator,
         tun_provider: TunProvider,
         log_dir: Option<PathBuf>,

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -151,7 +151,6 @@ pub enum TunnelCommand {
     /// Enable or disable LAN access in the firewall.
     AllowLan(bool),
     /// Set custom DNS servers to use.
-    #[cfg(not(target_os = "android"))]
     CustomDns(Option<Vec<IpAddr>>),
     /// Enable or disable the block_when_disconnected feature.
     BlockWhenDisconnected(bool),
@@ -216,7 +215,6 @@ impl TunnelStateMachine {
             allow_lan,
             block_when_disconnected,
             is_offline,
-            #[cfg(not(target_os = "android"))]
             custom_dns,
             tunnel_parameters_generator: Box::new(tunnel_parameters_generator),
             tun_provider,
@@ -290,7 +288,6 @@ struct SharedTunnelStateValues {
     /// True when the computer is known to be offline.
     is_offline: bool,
     /// Custom DNS servers to use.
-    #[cfg(not(target_os = "android"))]
     custom_dns: Option<Vec<IpAddr>>,
     /// The generator of new `TunnelParameter`s
     tunnel_parameters_generator: Box<dyn TunnelParametersGenerator>,

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -328,6 +328,15 @@ impl SharedTunnelStateValues {
         Ok(())
     }
 
+    pub fn set_custom_dns(&mut self, custom_dns: Option<Vec<IpAddr>>) -> bool {
+        if self.custom_dns != custom_dns {
+            self.custom_dns = custom_dns;
+            true
+        } else {
+            false
+        }
+    }
+
     /// NetworkManager's connectivity check can get hung when DNS requests fail, thus the TSM
     /// should always disable it before applying firewall rules. The connectivity check should be
     /// reset whenever the firewall is cleared.

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -16,4 +16,4 @@ rand = "0.7"
 err-derive = "0.2.1"
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.2.3", features = ["derive"] }
+jnix = { version = "0.3", features = ["derive"] }


### PR DESCRIPTION
By default the app uses the DNS servers provided by the relay server. However, some users prefer to use custom DNS servers. This PR implements that and adds an initial entry in the Advanced Settings screen to configure the custom DNS server address. If left unspecified, the app falls back to using the DNS servers provided by the relay.

The current implementation is very simplified, supporting a single custom DNS server address. It is persisted as a shared preference, and how it is used to configure the tunnel is similar to how split-tunneling is implemented. When the setting is changed, the tun device is marked as stale and a reconnection is requested. When creating the tun device, `TalpidVpnService` will pass the DNS servers provided by the relay server to a `prepareDnsServers` method. This method is overloaded by the `MullvadVpnService` in order to replace them with the custom DNS server address if it is set.

As part of the UI changes, since the current UI to configure the custom DNS server address is very similar to the UI to configure the WireGuard MTU value, the `MtuCell` was split in two. The functionality that is common to both the custom DNS UI and the MTU UI was placed in a new `InputCell` widget class. The `MtuClass` then becomes a specialization of the `InputCell` class, and a new `CustomDnsCell` class was created that follows the same approach.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2096)
<!-- Reviewable:end -->
