### PR TITLE
Fix masquerade rule interfering with systemd-resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix inconsistent behavior of the quick-settings tile when logged out. It would sometimes enter the
   blocking state and sometimes open the UI for the user to login. Now it always opens the UI.
 
+#### Linux
+- Fix split tunneling rules preventing `systemd-resolved` from performing DNS lookups for excluded
+  processes.
+
 
 ## [2020.6-beta2] - 2020-08-27
 This release is for Android only.


### PR DESCRIPTION
Ideally the rule should apply only to the interface that currently provides internet access. This requires monitoring and updating the `masq` rule based on the best default route, so the solution would be somewhat involved. Making an exception for `lo` is sufficient in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2099)
<!-- Reviewable:end -->
