### PR TITLE
Mark VPN connection as not metered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix app reopening after pressing the Quit button because app was running multiple tasks.
 - Fix inconsistent behavior of the quick-settings tile when logged out. It would sometimes enter the
   blocking state and sometimes open the UI for the user to login. Now it always opens the UI.
+- Mark the VPN connection as not metered, so that Android properly reports if the connection is or
+  isn't metered based solely on the underlying network, and not on the VPN connection.
 
 #### Linux
 - Fix split tunneling rules preventing `systemd-resolved` from performing DNS lookups for excluded

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -109,6 +109,7 @@ open class TalpidVpnService : VpnService() {
             }
 
             setMtu(config.mtu)
+            setMetered(false)
             setBlocking(false)
         }
 


### PR DESCRIPTION
Previously, the app didn't mark if the VPN connection was metered or not (i.e., charged by the amount of data transmitted). On recent Android versions, the default value is now set to `true`, which means some apps will behave differently while connected to the VPN server, in an attempt to reduce data charges.

This PR changes that so that the connection is marked as not metered. Since Mullvad does not charge per amount of data, it makes sense to mark the VPN connection as not metered. This has the effect of letting the underlying network decide if the connection is metered. If any of the transport layers is marked as metered, then the whole connection is marked as metered, otherwise it remains as not metered, and the behavior is as expected for the user.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2104)
<!-- Reviewable:end -->
