### PR TITLE
Import plural translations into Android

### DIFF
--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -234,3 +234,17 @@ impl PluralResources {
         }
     }
 }
+
+impl PluralResource {
+    /// Create a plural resource representation.
+    ///
+    /// The resource has a name, used as the identifier, and a list of items. Each item contains
+    /// the message and the quantity it should be used for.
+    pub fn new(name: String, values: impl Iterator<Item = (PluralQuantity, String)>) -> Self {
+        let items = values
+            .map(|(quantity, string)| PluralVariant { quantity, string })
+            .collect();
+
+        PluralResource { name, items }
+    }
+}

--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -225,3 +225,12 @@ impl IntoIterator for PluralResources {
         self.entries.into_iter()
     }
 }
+
+impl PluralResources {
+    /// Create an empty list of plural resources.
+    pub fn new() -> Self {
+        PluralResources {
+            entries: Vec::new(),
+        }
+    }
+}

--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -193,7 +193,7 @@ pub struct PluralVariant {
 }
 
 /// A valid quantity for a plural variant.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PluralQuantity {
     Zero,

--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -248,3 +248,52 @@ impl PluralResource {
         PluralResource { name, items }
     }
 }
+
+impl Display for PluralResources {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        writeln!(formatter, r#"<?xml version="1.0" encoding="utf-8"?>"#)?;
+        writeln!(formatter, "<resources>")?;
+
+        for entry in &self.entries {
+            write!(formatter, "{}", entry)?;
+        }
+
+        writeln!(formatter, "</resources>")
+    }
+}
+
+impl Display for PluralResource {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        writeln!(formatter, r#"    <plurals name="{}">"#, self.name)?;
+
+        for item in &self.items {
+            writeln!(formatter, "        {}", item)?;
+        }
+
+        writeln!(formatter, "    </plurals>")
+    }
+}
+
+impl Display for PluralVariant {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            r#"<item quantity="{}">{}</item>"#,
+            self.quantity, self.string
+        )
+    }
+}
+
+impl Display for PluralQuantity {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        let quantity = match self {
+            PluralQuantity::Zero => "zero",
+            PluralQuantity::One => "one",
+            PluralQuantity::Few => "few",
+            PluralQuantity::Many => "many",
+            PluralQuantity::Other => "other",
+        };
+
+        write!(formatter, "{}", quantity)
+    }
+}

--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -198,6 +198,8 @@ pub struct PluralVariant {
 pub enum PluralQuantity {
     Zero,
     One,
+    Few,
+    Many,
     Other,
 }
 

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -11,6 +11,11 @@ lazy_static! {
     static ref PARAMETERS: Regex = Regex::new(r"%\([^)]*\)").unwrap();
 }
 
+/// A parsed gettext translation file.
+pub struct Translation {
+    entries: Vec<MsgEntry>,
+}
+
 /// A message entry in a gettext translation file.
 #[derive(Clone, Debug)]
 pub struct MsgEntry {
@@ -28,6 +33,15 @@ pub enum MsgValue {
     },
 }
 
+impl IntoIterator for Translation {
+    type Item = MsgEntry;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
+    }
+}
+
 impl From<String> for MsgValue {
     fn from(string: String) -> Self {
         MsgValue::Invariant(string)
@@ -38,7 +52,7 @@ impl From<String> for MsgValue {
 ///
 /// The messages are normalized into a common format so that they can be compared to Android string
 /// resource entries.
-pub fn load_file(file_path: impl AsRef<Path>) -> Vec<MsgEntry> {
+pub fn load_file(file_path: impl AsRef<Path>) -> Translation {
     let mut entries = Vec::new();
     let mut current_id = None;
     let file = BufReader::new(File::open(file_path).expect("Failed to open gettext file"));
@@ -62,7 +76,7 @@ pub fn load_file(file_path: impl AsRef<Path>) -> Vec<MsgEntry> {
         }
     }
 
-    entries
+    Translation { entries }
 }
 
 /// Append message entries to a translation file.

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -46,6 +46,23 @@ pub enum MsgValue {
     },
 }
 
+/// A helper macro to match a string to various prefix and suffix combinations.
+macro_rules! match_str {
+    (
+        ( $string:expr )
+        $( [$start:expr, $middle:ident, $end:expr] => $body:tt )*
+        _ => $else:expr $(,)*
+    ) => {
+        $(
+            if let Some($middle) = parse_line($string, $start, $end) {
+                $body
+            } else
+        )* {
+            $else
+        }
+    };
+}
+
 impl Translation {
     /// Load message entries from a gettext translation file.
     ///

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -72,6 +72,26 @@ impl Translation {
     /// The only metadata that is parsed from the file is the "Plural-Form" header. It is assumed
     /// that the header value is one of some hard-coded values, so if new languages that have new
     /// plurals are added, the code will have to be updated.
+    ///
+    /// An gettext translation file has the format in the example below:
+    ///
+    /// ```
+    /// # The start of the file can contain empty entries to include some header with meta
+    /// # information. Below is the header indicating the plural format.
+    /// msgid ""
+    /// msgstr ""
+    /// "Plural-Forms: nplurals=2; plural=(n != 1);"
+    ///
+    /// # Simple translated messages
+    /// msgid "Message in original language"
+    /// msgstr "Mesaĝo en tradukita lingvo"
+    ///
+    /// # Plural translated messages (with two forms)
+    /// msgid "One translated message"
+    /// msgid_plural "%d translated messages"
+    /// msgstr[0] "Unu tradukita mesaĝo"
+    /// msgstr[1] "%d tradukitaj mesaĝoj"
+    /// ```
     pub fn from_file(file_path: impl AsRef<Path>) -> Self {
         let mut parsing_header = false;
         let mut entries = Vec::new();

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -1,8 +1,10 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::{
+    collections::BTreeMap,
     fs::{File, OpenOptions},
     io::{self, BufRead, BufReader, BufWriter, Write},
+    mem,
     path::Path,
 };
 
@@ -41,6 +43,8 @@ impl Translation {
     pub fn from_file(file_path: impl AsRef<Path>) -> Self {
         let mut entries = Vec::new();
         let mut current_id = None;
+        let mut current_plural_id = None;
+        let mut variants = BTreeMap::new();
         let file = BufReader::new(File::open(file_path).expect("Failed to open gettext file"));
 
         for line in file.lines() {
@@ -49,16 +53,48 @@ impl Translation {
 
             if let Some(msg_id) = parse_line(line, "msgid \"", "\"") {
                 current_id = Some(normalize(msg_id));
-            } else {
-                if let Some(translation) = parse_line(line, "msgstr \"", "\"") {
-                    if let Some(id) = current_id.take() {
-                        let value = MsgValue::from(normalize(translation));
+            } else if let Some(translation) = parse_line(line, "msgstr \"", "\"") {
+                if let Some(id) = current_id.take() {
+                    let value = MsgValue::from(normalize(translation));
 
-                        entries.push(MsgEntry { id, value });
-                    }
+                    entries.push(MsgEntry { id, value });
                 }
 
                 current_id = None;
+                current_plural_id = None;
+            } else if let Some(plural_id) = parse_line(line, "msgid_plural \"", "\"") {
+                current_plural_id = Some(normalize(plural_id));
+            } else if let Some(plural_translation) = parse_line(line, "msgstr[", "\"") {
+                let variant_id_end = plural_translation
+                    .chars()
+                    .position(|character| character == ']')
+                    .expect("Invalid plural msgstr");
+                let variant_id: usize = plural_translation[..variant_id_end]
+                    .parse()
+                    .expect("Invalid variant index");
+                let variant_msg = parse_line(&plural_translation[variant_id_end..], "] \"", "")
+                    .expect("Invalid plural msgstr");
+
+                variants.insert(variant_id, normalize(variant_msg));
+            } else {
+                if let Some(plural_id) = current_plural_id.take() {
+                    let id = current_id.take().expect("Missing msgid for plural message");
+                    let values = mem::replace(&mut variants, BTreeMap::new())
+                        .into_iter()
+                        .enumerate()
+                        .inspect(|(index, (variant_id, _))| {
+                            assert_eq!(index, variant_id, "Unexpected variant ID for plural msgstr")
+                        })
+                        .map(|(_, (_, value))| value)
+                        .collect();
+                    let value = MsgValue::Plural { plural_id, values };
+
+                    entries.push(MsgEntry { id, value });
+                }
+
+                current_id = None;
+                current_plural_id = None;
+                variants.clear();
             }
         }
 

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -85,61 +85,71 @@ impl Translation {
             let line = line.expect("Failed to read from gettext file");
             let line = line.trim();
 
-            if let Some(msg_id) = parse_line(line, "msgid \"", "\"") {
-                current_id = Some(normalize(msg_id));
-            } else if let Some(translation) = parse_line(line, "msgstr \"", "\"") {
-                if let Some(id) = current_id.take() {
-                    let value = MsgValue::from(normalize(translation));
-
-                    parsing_header = id.is_empty() && translation.is_empty();
-
-                    entries.push(MsgEntry { id, value });
+            match_str! { (line)
+                ["msgid \"", msg_id, "\""] => {
+                    current_id = Some(normalize(msg_id));
                 }
+                ["msgstr \"", translation, "\""] => {
+                    if let Some(id) = current_id.take() {
+                        let value = MsgValue::from(normalize(translation));
 
-                current_id = None;
-                current_plural_id = None;
-            } else if let Some(plural_id) = parse_line(line, "msgid_plural \"", "\"") {
-                current_plural_id = Some(normalize(plural_id));
-                parsing_header = false;
-            } else if let Some(plural_translation) = parse_line(line, "msgstr[", "\"") {
-                let variant_id_end = plural_translation
-                    .chars()
-                    .position(|character| character == ']')
-                    .expect("Invalid plural msgstr");
-                let variant_id: usize = plural_translation[..variant_id_end]
-                    .parse()
-                    .expect("Invalid variant index");
-                let variant_msg = parse_line(&plural_translation[variant_id_end..], "] \"", "")
-                    .expect("Invalid plural msgstr");
+                        parsing_header = id.is_empty() && translation.is_empty();
 
-                variants.insert(variant_id, normalize(variant_msg));
-                parsing_header = false;
-            } else if let Some(header) = parse_line(line, "\"", "\\n\"") {
-                if parsing_header {
-                    if let Some(plural_formula) = parse_line(header, "Plural-Forms: ", ";") {
-                        plural_form = Some(PluralForm::from_formula(plural_formula));
+                        entries.push(MsgEntry { id, value });
+                    }
+
+                    current_id = None;
+                    current_plural_id = None;
+                }
+                ["msgid_plural \"", plural_id, "\""] => {
+                    current_plural_id = Some(normalize(plural_id));
+                    parsing_header = false;
+                }
+                ["msgstr[", plural_translation, "\""] => {
+                    let variant_id_end = plural_translation
+                        .chars()
+                        .position(|character| character == ']')
+                        .expect("Invalid plural msgstr");
+                    let variant_id: usize = plural_translation[..variant_id_end]
+                        .parse()
+                        .expect("Invalid variant index");
+                    let variant_msg = parse_line(&plural_translation[variant_id_end..], "] \"", "")
+                        .expect("Invalid plural msgstr");
+
+                    variants.insert(variant_id, normalize(variant_msg));
+                    parsing_header = false;
+                }
+                ["\"", header, "\\n\""] => {
+                    if parsing_header {
+                        if let Some(plural_formula) = parse_line(header, "Plural-Forms: ", ";") {
+                            plural_form = Some(PluralForm::from_formula(plural_formula));
+                        }
                     }
                 }
-            } else {
-                if let Some(plural_id) = current_plural_id.take() {
-                    let id = current_id.take().expect("Missing msgid for plural message");
-                    let values = mem::replace(&mut variants, BTreeMap::new())
-                        .into_iter()
-                        .enumerate()
-                        .inspect(|(index, (variant_id, _))| {
-                            assert_eq!(index, variant_id, "Unexpected variant ID for plural msgstr")
-                        })
-                        .map(|(_, (_, value))| value)
-                        .collect();
-                    let value = MsgValue::Plural { plural_id, values };
+                _ => {
+                    if let Some(plural_id) = current_plural_id.take() {
+                        let id = current_id.take().expect("Missing msgid for plural message");
+                        let values = mem::replace(&mut variants, BTreeMap::new())
+                            .into_iter()
+                            .enumerate()
+                            .inspect(|(index, (variant_id, _))| {
+                                assert_eq!(
+                                    index, variant_id,
+                                    "Unexpected variant ID for plural msgstr"
+                                )
+                            })
+                            .map(|(_, (_, value))| value)
+                            .collect();
+                        let value = MsgValue::Plural { plural_id, values };
 
-                    entries.push(MsgEntry { id, value });
+                        entries.push(MsgEntry { id, value });
+                    }
+
+                    current_id = None;
+                    current_plural_id = None;
+                    variants.clear();
+                    parsing_header = false;
                 }
-
-                current_id = None;
-                current_plural_id = None;
-                variants.clear();
-                parsing_header = false;
             }
         }
 

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -18,6 +18,16 @@ pub struct Translation {
     entries: Vec<MsgEntry>,
 }
 
+/// Known plural forms.
+#[derive(Clone, Copy, Debug)]
+pub enum PluralForm {
+    Single,
+    SingularForOne,
+    SingularForZeroAndOne,
+    Polish,
+    Russian,
+}
+
 /// A message entry in a gettext translation file.
 #[derive(Clone, Debug)]
 pub struct MsgEntry {
@@ -108,6 +118,28 @@ impl IntoIterator for Translation {
 
     fn into_iter(self) -> Self::IntoIter {
         self.entries.into_iter()
+    }
+}
+
+impl PluralForm {
+    /// Obtain an instance based on a known plural formula.
+    ///
+    /// Plural variants need to be obtained using a formula. However, some locales have known
+    /// formulas, so they can be represented as a known plural form. This constructor can return a
+    /// plural form based on the formulas that are known to be used in the project.
+    pub fn from_formula(formula: &str) -> Self {
+        match formula {
+            "nplurals=1; plural=0" => PluralForm::Single,
+            "nplurals=2; plural=(n != 1)" => PluralForm::SingularForOne,
+            "nplurals=2; plural=(n > 1)" => PluralForm::SingularForZeroAndOne,
+            "nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3)" => {
+                PluralForm::Polish
+            }
+            "nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3))" => {
+                PluralForm::Russian
+            }
+            other => panic!("Unknown plural formula: {}", other),
+        }
     }
 }
 

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -224,6 +224,24 @@ fn generate_translations(
     missing_translations.retain(|translation, _| known_strings.contains_key(translation));
 }
 
+/// Converts a gettext plural form into the plural quantities used by Android.
+///
+/// Returns an iterator that can be zipped with the gettext plural variants to produce the Android
+/// plural string items.
+fn android_plural_quantities_from_gettext_plural_form(
+    plural_form: gettext::PluralForm,
+) -> impl Iterator<Item = android::PluralQuantity> + Clone {
+    use android::PluralQuantity::*;
+    use gettext::PluralForm;
+
+    match plural_form {
+        PluralForm::Single => vec![Other],
+        PluralForm::SingularForOne | PluralForm::SingularForZeroAndOne => vec![One, Other],
+        PluralForm::Polish | PluralForm::Russian => vec![One, Few, Many, Other],
+    }
+    .into_iter()
+}
+
 /// Tries to map a translation locale to a locale used on the Mullvad website.
 ///
 /// The mapping is trivial if no region is specified. Otherwise the region code must be manually

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -188,7 +188,7 @@ fn generate_translations(
     locale: &str,
     known_urls: HashMap<String, String>,
     mut known_strings: HashMap<String, String>,
-    translations: Vec<gettext::MsgEntry>,
+    translations: gettext::Translation,
     output_path: impl AsRef<Path>,
     missing_translations: &mut HashMap<String, String>,
 ) {

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
             locale,
             known_urls.clone(),
             known_strings.clone(),
-            gettext::load_file(&locale_file),
+            gettext::Translation::from_file(&locale_file),
             destination_dir.join("strings.xml"),
             &mut missing_translations,
         );


### PR DESCRIPTION
Previously, the translation converter helper tool would only load Android plural resources and append them as missing translations to the template file (`gui/locales/messages.pot`). This PR updates the tool so that it can properly read the plural messages from each translation file and then convert them and write them out as Android plural resources XML files.

Since different locales have different pluralization rules, this is a bit tricky. On Android, the options available to translators is rather limited, since the messages must specify the plural quantity based on five options (`zero`, `one`, `few`, `many` and `other`) while gettext allows a general formula than can produce an unlimited number of strings to use. To make the conversion possible, only known formulas are parsed from the translation file header. They are then used to map to Android's plural scheme.

The manually implemented parser in the `Translation::from_file` method became more complex, since now it must load not only message entries, but also the plural form header and the plural entries. It might be interesting to rewrite the parser using some library in the future, to make it more maintainable. But that should probably be left for a separate PR if needed.

The normal messages have a simple pattern of a `msgid` line followed by `msgstr` line. However, the header has the same pattern, but with an empty ID and value, and then a list of "header" strings follow. The parser keeps track if it entered a header area to see if it can find the plural form header. The plural entries are similar to the normal message entries, but the ID is followed by a `msgid_plural` line, and then a series of `msgstr[X]` lines to create an array with the plural items. These array values are collected into a `BTreeMap`, so that they can be sorted and then are later easily zipped together with their respective Android plural quantity.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tool update, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2107)
<!-- Reviewable:end -->
