### PR TITLE
Workaround for Linux tray context menu action delay

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1433,16 +1433,18 @@ class ApplicationMain {
         label: this.getLinuxContextMenuActionButtonLabel(),
         click: () => {
           if (this.tunnelState.state === 'disconnected') {
-            consumePromise(this.daemonRpc.connectTunnel());
+            // Workaround: gRPC calls are sometimes delayed by a few seconds and setImmediate
+            // mitigates this. https://github.com/grpc/grpc-node/issues/882
+            setImmediate(() => consumePromise(this.daemonRpc.connectTunnel()));
           } else {
-            consumePromise(this.daemonRpc.disconnectTunnel());
+            setImmediate(() => consumePromise(this.daemonRpc.disconnectTunnel()));
           }
         },
       },
       {
         label: messages.gettext('Reconnect'),
         enabled: this.tunnelState.state === 'connected' || this.tunnelState.state === 'connecting',
-        click: () => consumePromise(this.daemonRpc.reconnectTunnel()),
+        click: () => setImmediate(() => consumePromise(this.daemonRpc.reconnectTunnel())),
       },
     ];
 


### PR DESCRIPTION
This PR adds a workaround for the delay when pressing a context menu action, as suggested in this gRPC-js issue https://github.com/grpc/grpc-node/issues/882.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2112)
<!-- Reviewable:end -->
