### PR TITLE
Only use `setMetered` on newer Android versions

### DIFF
--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -1,6 +1,7 @@
 package net.mullvad.talpid
 
 import android.net.VpnService
+import android.os.Build
 import android.os.ParcelFileDescriptor
 import java.net.Inet4Address
 import java.net.Inet6Address
@@ -108,8 +109,11 @@ open class TalpidVpnService : VpnService() {
                 }
             }
 
+            if (Build.VERSION.SDK_INT >= 29) {
+                setMetered(false)
+            }
+
             setMtu(config.mtu)
-            setMetered(false)
             setBlocking(false)
         }
 


### PR DESCRIPTION
A recent PR introduced a call to the `setMetered` API to mark the VPN connection as not metered. Unfortunately, the `setMetered` API call is rather recent, and won't work on Android 9 and below.  This PR makes sure the function is only called on the Android versions that have the function.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not in any released version. No changelog entry needed.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2116)
<!-- Reviewable:end -->
