### PR TITLE
Improve accessibility for inputs and modals

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -459,7 +459,8 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
           <AppButton.BlueButton key="back" onClick={this.hideConfirmBlockWhenDisconnectedAlert}>
             {messages.gettext('Back')}
           </AppButton.BlueButton>,
-        ]}>
+        ]}
+        close={this.hideConfirmBlockWhenDisconnectedAlert}>
         <ModalMessage>
           {messages.pgettext(
             'advanced-settings-view',

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -15,6 +15,7 @@ import {
   StyledTunnelProtocolContainer,
 } from './AdvancedSettingsStyles';
 import * as AppButton from './AppButton';
+import { AriaDescription, AriaInput, AriaInputGroup, AriaLabel } from './AriaInputGroup';
 import * as Cell from './Cell';
 import { Layout } from './Layout';
 import { ModalAlert, ModalAlertType, ModalContainer, ModalMessage } from './Modal';
@@ -169,182 +170,230 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                   </HeaderTitle>
                 </SettingsHeader>
 
-                <Cell.Container>
-                  <Cell.Label>
-                    {messages.pgettext('advanced-settings-view', 'Enable IPv6')}
-                  </Cell.Label>
-                  <Cell.Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {messages.pgettext(
-                      'advanced-settings-view',
-                      'Enable IPv6 communication through the tunnel.',
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
-
-                <Cell.Container>
-                  <Cell.Label>
-                    {messages.pgettext('advanced-settings-view', 'Always require VPN')}
-                  </Cell.Label>
-                  <Cell.Switch
-                    isOn={this.props.blockWhenDisconnected}
-                    onChange={this.setBlockWhenDisconnected}
-                  />
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {messages.pgettext(
-                      'advanced-settings-view',
-                      'If you disconnect or quit the app, this setting will block your internet.',
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
-
-                <StyledTunnelProtocolContainer>
-                  <StyledTunnelProtocolSelector
-                    title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
-                    values={this.tunnelProtocolItems(hasWireguardKey)}
-                    value={this.props.tunnelProtocol}
-                    onSelect={this.onSelectTunnelProtocol}
-                  />
-                  {!hasWireguardKey && (
-                    <StyledNoWireguardKeyErrorContainer>
-                      <StyledNoWireguardKeyError>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('advanced-settings-view', 'Enable IPv6')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        isOn={this.props.enableIpv6}
+                        onChange={this.props.setEnableIpv6}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
                         {messages.pgettext(
                           'advanced-settings-view',
-                          'To enable WireGuard, generate a key under the "WireGuard key" setting below.',
+                          'Enable IPv6 communication through the tunnel.',
                         )}
-                      </StyledNoWireguardKeyError>
-                    </StyledNoWireguardKeyErrorContainer>
-                  )}
-                </StyledTunnelProtocolContainer>
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('advanced-settings-view', 'Always require VPN')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        isOn={this.props.blockWhenDisconnected}
+                        onChange={this.setBlockWhenDisconnected}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'advanced-settings-view',
+                          'If you disconnect or quit the app, this setting will block your internet.',
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <StyledTunnelProtocolContainer>
+                    <StyledTunnelProtocolSelector
+                      title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
+                      values={this.tunnelProtocolItems(hasWireguardKey)}
+                      value={this.props.tunnelProtocol}
+                      onSelect={this.onSelectTunnelProtocol}
+                    />
+                    {!hasWireguardKey && (
+                      <StyledNoWireguardKeyErrorContainer>
+                        <AriaDescription>
+                          <StyledNoWireguardKeyError>
+                            {messages.pgettext(
+                              'advanced-settings-view',
+                              'To enable WireGuard, generate a key under the "WireGuard key" setting below.',
+                            )}
+                          </StyledNoWireguardKeyError>
+                        </AriaDescription>
+                      </StyledNoWireguardKeyErrorContainer>
+                    )}
+                  </StyledTunnelProtocolContainer>
+                </AriaInputGroup>
 
                 {this.props.tunnelProtocol !== 'wireguard' ? (
-                  <StyledSelectorContainer>
-                    <Selector
-                      title={messages.pgettext(
-                        'advanced-settings-view',
-                        'OpenVPN transport protocol',
-                      )}
-                      values={this.protocolItems}
-                      value={this.props.openvpn.protocol}
-                      onSelect={this.onSelectOpenvpnProtocol}
-                    />
-
-                    {this.props.openvpn.protocol ? (
+                  <AriaInputGroup>
+                    <StyledSelectorContainer>
                       <Selector
-                        title={sprintf(
-                          // TRANSLATORS: The title for the port selector section.
-                          // TRANSLATORS: Available placeholders:
-                          // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
-                          messages.pgettext('advanced-settings-view', 'OpenVPN %(portType)s port'),
-                          {
-                            portType: this.props.openvpn.protocol.toUpperCase(),
-                          },
+                        title={messages.pgettext(
+                          'advanced-settings-view',
+                          'OpenVPN transport protocol',
                         )}
-                        values={this.portItems[this.props.openvpn.protocol]}
-                        value={this.props.openvpn.port}
-                        onSelect={this.onSelectOpenVpnPort}
+                        values={this.protocolItems}
+                        value={this.props.openvpn.protocol}
+                        onSelect={this.onSelectOpenvpnProtocol}
                       />
-                    ) : undefined}
-                  </StyledSelectorContainer>
+
+                      {this.props.openvpn.protocol ? (
+                        <Selector
+                          title={sprintf(
+                            // TRANSLATORS: The title for the port selector section.
+                            // TRANSLATORS: Available placeholders:
+                            // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
+                            messages.pgettext(
+                              'advanced-settings-view',
+                              'OpenVPN %(portType)s port',
+                            ),
+                            {
+                              portType: this.props.openvpn.protocol.toUpperCase(),
+                            },
+                          )}
+                          values={this.portItems[this.props.openvpn.protocol]}
+                          value={this.props.openvpn.port}
+                          onSelect={this.onSelectOpenVpnPort}
+                        />
+                      ) : undefined}
+                    </StyledSelectorContainer>
+                  </AriaInputGroup>
                 ) : undefined}
 
                 {this.props.tunnelProtocol === 'wireguard' ? (
-                  <StyledSelectorContainer>
-                    <Selector
-                      // TRANSLATORS: The title for the shadowsocks bridge selector section.
-                      title={messages.pgettext('advanced-settings-view', 'WireGuard port')}
-                      values={this.wireguardPortItems}
-                      value={this.props.wireguard.port}
-                      onSelect={this.onSelectWireguardPort}
-                    />
-                  </StyledSelectorContainer>
+                  <AriaInputGroup>
+                    <StyledSelectorContainer>
+                      <Selector
+                        // TRANSLATORS: The title for the shadowsocks bridge selector section.
+                        title={messages.pgettext('advanced-settings-view', 'WireGuard port')}
+                        values={this.wireguardPortItems}
+                        value={this.props.wireguard.port}
+                        onSelect={this.onSelectWireguardPort}
+                      />
+                    </StyledSelectorContainer>
+                  </AriaInputGroup>
                 ) : undefined}
 
-                <Selector
-                  title={
-                    // TRANSLATORS: The title for the shadowsocks bridge selector section.
-                    messages.pgettext('advanced-settings-view', 'Bridge mode')
-                  }
-                  values={this.bridgeStateItems}
-                  value={this.props.bridgeState}
-                  onSelect={this.onSelectBridgeState}
-                />
+                <AriaInputGroup>
+                  <Selector
+                    title={
+                      // TRANSLATORS: The title for the shadowsocks bridge selector section.
+                      messages.pgettext('advanced-settings-view', 'Bridge mode')
+                    }
+                    values={this.bridgeStateItems}
+                    value={this.props.bridgeState}
+                    onSelect={this.onSelectBridgeState}
+                  />
+                </AriaInputGroup>
 
-                <Cell.Container>
-                  <Cell.Label>
-                    {messages.pgettext('advanced-settings-view', 'OpenVPN Mssfix')}
-                  </Cell.Label>
-                  <StyledInputFrame>
-                    <Cell.AutoSizingTextInput
-                      value={this.props.mssfix ? this.props.mssfix.toString() : ''}
-                      inputMode={'numeric'}
-                      maxLength={4}
-                      placeholder={messages.pgettext('advanced-settings-view', 'Default')}
-                      onSubmitValue={this.onMssfixSubmit}
-                      validateValue={AdvancedSettings.mssfixIsValid}
-                      submitOnBlur={true}
-                      modifyValue={AdvancedSettings.removeNonNumericCharacters}
-                    />
-                  </StyledInputFrame>
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {sprintf(
-                      // TRANSLATORS: The hint displayed below the Mssfix input field.
-                      // TRANSLATORS: Available placeholders:
-                      // TRANSLATORS: %(max)d - the maximum possible mssfix value
-                      // TRANSLATORS: %(min)d - the minimum possible mssfix value
-                      messages.pgettext(
-                        'advanced-settings-view',
-                        'Set OpenVPN MSS value. Valid range: %(min)d - %(max)d.',
-                      ),
-                      {
-                        min: MIN_MSSFIX_VALUE,
-                        max: MAX_MSSFIX_VALUE,
-                      },
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('advanced-settings-view', 'OpenVPN Mssfix')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <StyledInputFrame>
+                      <AriaInput>
+                        <Cell.AutoSizingTextInput
+                          value={this.props.mssfix ? this.props.mssfix.toString() : ''}
+                          inputMode={'numeric'}
+                          maxLength={4}
+                          placeholder={messages.pgettext('advanced-settings-view', 'Default')}
+                          onSubmitValue={this.onMssfixSubmit}
+                          validateValue={AdvancedSettings.mssfixIsValid}
+                          submitOnBlur={true}
+                          modifyValue={AdvancedSettings.removeNonNumericCharacters}
+                        />
+                      </AriaInput>
+                    </StyledInputFrame>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {sprintf(
+                          // TRANSLATORS: The hint displayed below the Mssfix input field.
+                          // TRANSLATORS: Available placeholders:
+                          // TRANSLATORS: %(max)d - the maximum possible mssfix value
+                          // TRANSLATORS: %(min)d - the minimum possible mssfix value
+                          messages.pgettext(
+                            'advanced-settings-view',
+                            'Set OpenVPN MSS value. Valid range: %(min)d - %(max)d.',
+                          ),
+                          {
+                            min: MIN_MSSFIX_VALUE,
+                            max: MAX_MSSFIX_VALUE,
+                          },
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
 
-                <Cell.Container>
-                  <Cell.Label>
-                    {messages.pgettext('advanced-settings-view', 'WireGuard MTU')}
-                  </Cell.Label>
-                  <StyledInputFrame>
-                    <Cell.AutoSizingTextInput
-                      value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
-                      inputMode={'numeric'}
-                      maxLength={4}
-                      placeholder={messages.pgettext('advanced-settings-view', 'Default')}
-                      onSubmitValue={this.onWireguardMtuSubmit}
-                      validateValue={AdvancedSettings.wireguarMtuIsValid}
-                      submitOnBlur={true}
-                      modifyValue={AdvancedSettings.removeNonNumericCharacters}
-                    />
-                  </StyledInputFrame>
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {sprintf(
-                      // TRANSLATORS: The hint displayed below the WireGuard MTU input field.
-                      // TRANSLATORS: Available placeholders:
-                      // TRANSLATORS: %(max)d - the maximum possible wireguard mtu value
-                      // TRANSLATORS: %(min)d - the minimum possible wireguard mtu value
-                      messages.pgettext(
-                        'advanced-settings-view',
-                        'Set WireGuard MTU value. Valid range: %(min)d - %(max)d.',
-                      ),
-                      {
-                        min: MIN_WIREGUARD_MTU_VALUE,
-                        max: MAX_WIREGUARD_MTU_VALUE,
-                      },
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('advanced-settings-view', 'WireGuard MTU')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <StyledInputFrame>
+                      <AriaInput>
+                        <Cell.AutoSizingTextInput
+                          value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
+                          inputMode={'numeric'}
+                          maxLength={4}
+                          placeholder={messages.pgettext('advanced-settings-view', 'Default')}
+                          onSubmitValue={this.onWireguardMtuSubmit}
+                          validateValue={AdvancedSettings.wireguarMtuIsValid}
+                          submitOnBlur={true}
+                          modifyValue={AdvancedSettings.removeNonNumericCharacters}
+                        />
+                      </AriaInput>
+                    </StyledInputFrame>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {sprintf(
+                          // TRANSLATORS: The hint displayed below the WireGuard MTU input field.
+                          // TRANSLATORS: Available placeholders:
+                          // TRANSLATORS: %(max)d - the maximum possible wireguard mtu value
+                          // TRANSLATORS: %(min)d - the minimum possible wireguard mtu value
+                          messages.pgettext(
+                            'advanced-settings-view',
+                            'Set WireGuard MTU value. Valid range: %(min)d - %(max)d.',
+                          ),
+                          {
+                            min: MIN_WIREGUARD_MTU_VALUE,
+                            max: MAX_WIREGUARD_MTU_VALUE,
+                          },
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
 
                 <StyledBottomCellGroup>
                   <Cell.CellButton onClick={this.props.onViewWireguardKeys}>

--- a/gui/src/renderer/components/AriaInputGroup.tsx
+++ b/gui/src/renderer/components/AriaInputGroup.tsx
@@ -1,0 +1,91 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+
+let groupCounter = 0;
+function getNewId() {
+  return groupCounter++;
+}
+
+interface IAriaInputContext {
+  inputId: string;
+  labelId?: string;
+  descriptionId?: string;
+  setHasLabel: (value: boolean) => void;
+  setHasDescription: (value: boolean) => void;
+}
+
+const missingAriaInputContextError = new Error('Missing AriaInputContext.Provider');
+const AriaInputContext = React.createContext<IAriaInputContext>({
+  get inputId(): string {
+    throw missingAriaInputContextError;
+  },
+  setHasLabel() {
+    throw missingAriaInputContextError;
+  },
+  setHasDescription() {
+    throw missingAriaInputContextError;
+  },
+});
+
+interface IAriaInputGroupProps {
+  children: React.ReactNode;
+}
+
+export function AriaInputGroup(props: IAriaInputGroupProps) {
+  const id = useMemo(getNewId, []);
+
+  const [hasLabel, setHasLabel] = useState(false);
+  const [hasDescription, setHasDescription] = useState(false);
+
+  const contextValue = {
+    inputId: `${id}-input`,
+    labelId: hasLabel ? `${id}-label` : undefined,
+    descriptionId: hasDescription ? `${id}-description` : undefined,
+    setHasLabel,
+    setHasDescription,
+  };
+
+  return (
+    <AriaInputContext.Provider value={contextValue}>{props.children}</AriaInputContext.Provider>
+  );
+}
+
+interface IAriaElementProps {
+  children: React.ReactElement;
+}
+
+export function AriaInput(props: IAriaElementProps) {
+  const { inputId, labelId, descriptionId } = useContext(AriaInputContext);
+
+  return React.cloneElement(props.children, {
+    id: inputId,
+    'aria-labelledby': labelId,
+    'aria-describedby': descriptionId,
+  });
+}
+
+export function AriaLabel(props: IAriaElementProps) {
+  const { inputId, labelId, setHasLabel } = useContext(AriaInputContext);
+
+  useEffect(() => {
+    setHasLabel(true);
+    return () => setHasLabel(false);
+  }, []);
+
+  return React.cloneElement(props.children, {
+    id: labelId,
+    htmlFor: inputId,
+  });
+}
+
+export function AriaDescription(props: IAriaElementProps) {
+  const { descriptionId, setHasDescription } = useContext(AriaInputContext);
+
+  useEffect(() => {
+    setHasDescription(true);
+    return () => setHasDescription(false);
+  }, []);
+
+  return React.cloneElement(props.children, {
+    id: descriptionId,
+  });
+}

--- a/gui/src/renderer/components/Cell.tsx
+++ b/gui/src/renderer/components/Cell.tsx
@@ -72,6 +72,11 @@ export function Label(props: React.HTMLAttributes<HTMLDivElement>) {
   return <StyledLabel disabled={disabled} {...props} />;
 }
 
+export function InputLabel(props: React.LabelHTMLAttributes<HTMLLabelElement>) {
+  const disabled = useContext(CellDisabledContext);
+  return <StyledLabel as="label" disabled={disabled} {...props} />;
+}
+
 export function SubText(props: React.HTMLAttributes<HTMLDivElement>) {
   const disabled = useContext(CellDisabledContext);
   return <StyledSubText disabled={disabled} {...props} />;
@@ -216,7 +221,7 @@ export function AutoSizingTextInput({ onChangeValue, ...otherProps }: IInputProp
       <StyledAutoSizingTextInputWrapper>
         <Input onChangeValue={onChangeValueWrapper} {...otherProps} />
       </StyledAutoSizingTextInputWrapper>
-      <StyledAutoSizingTextInputFiller className={otherProps.className}>
+      <StyledAutoSizingTextInputFiller className={otherProps.className} aria-hidden={true}>
         {value === '' ? otherProps.placeholder : value}
       </StyledAutoSizingTextInputFiller>
     </StyledAutoSizingTextInputContainer>

--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -194,7 +194,8 @@ export default class ExpiredAccountErrorView extends React.Component<
             onClick={this.onCloseBlockWhenDisconnectedInstructions}>
             {messages.gettext('Close')}
           </AppButton.BlueButton>,
-        ]}>
+        ]}
+        close={this.onCloseBlockWhenDisconnectedInstructions}>
         <ModalMessage>
           {messages.pgettext(
             'connect-view',

--- a/gui/src/renderer/components/LinuxSplitTunnelingSettings.tsx
+++ b/gui/src/renderer/components/LinuxSplitTunnelingSettings.tsx
@@ -274,6 +274,7 @@ function ApplicationRow(props: IApplicationRowProps) {
           iconColor={warningColor}
           message={warningMessage}
           buttons={warningDialogButtons}
+          close={hideWarningDialog}
         />
       )}
     </>

--- a/gui/src/renderer/components/Preferences.tsx
+++ b/gui/src/renderer/components/Preferences.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { messages } from '../../shared/gettext';
+import { AriaDescription, AriaInput, AriaInputGroup, AriaLabel } from './AriaInputGroup';
 import * as Cell from './Cell';
 import { Layout } from './Layout';
 import {
@@ -62,118 +63,181 @@ export default class Preferences extends React.Component<IProps> {
               </SettingsHeader>
 
               <StyledContent>
-                <Cell.Container>
-                  <Cell.Label>
-                    {messages.pgettext('preferences-view', 'Launch app on start-up')}
-                  </Cell.Label>
-                  <Cell.Switch isOn={this.props.autoStart} onChange={this.props.setAutoStart} />
-                </Cell.Container>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('preferences-view', 'Launch app on start-up')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch isOn={this.props.autoStart} onChange={this.props.setAutoStart} />
+                    </AriaInput>
+                  </Cell.Container>
+                </AriaInputGroup>
                 <StyledSeparator />
 
-                <Cell.Container>
-                  <Cell.Label>{messages.pgettext('preferences-view', 'Auto-connect')}</Cell.Label>
-                  <Cell.Switch isOn={this.props.autoConnect} onChange={this.props.setAutoConnect} />
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {messages.pgettext(
-                      'preferences-view',
-                      'Automatically connect to a server when the app launches.',
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
-
-                <Cell.Container>
-                  <Cell.Label>
-                    {messages.pgettext('preferences-view', 'Local network sharing')}
-                  </Cell.Label>
-                  <Cell.Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {messages.pgettext(
-                      'preferences-view',
-                      'Allows access to other devices on the same network for sharing, printing etc.',
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
-
-                <Cell.Container>
-                  <Cell.Label>{messages.pgettext('preferences-view', 'Notifications')}</Cell.Label>
-                  <Cell.Switch
-                    isOn={this.props.enableSystemNotifications}
-                    onChange={this.props.setEnableSystemNotifications}
-                  />
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {messages.pgettext(
-                      'preferences-view',
-                      'Enable or disable system notifications. The critical notifications will always be displayed.',
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
-
-                <Cell.Container>
-                  <Cell.Label>
-                    {messages.pgettext('preferences-view', 'Monochromatic tray icon')}
-                  </Cell.Label>
-                  <Cell.Switch
-                    isOn={this.props.monochromaticIcon}
-                    onChange={this.props.setMonochromaticIcon}
-                  />
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {messages.pgettext(
-                      'preferences-view',
-                      'Use a monochromatic tray icon instead of a colored one.',
-                    )}
-                  </Cell.FooterText>
-                </Cell.Footer>
-
-                {this.props.enableStartMinimizedToggle ? (
-                  <React.Fragment>
-                    <Cell.Container>
-                      <Cell.Label>
-                        {messages.pgettext('preferences-view', 'Start minimized')}
-                      </Cell.Label>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('preferences-view', 'Auto-connect')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
                       <Cell.Switch
-                        isOn={this.props.startMinimized}
-                        onChange={this.props.setStartMinimized}
+                        isOn={this.props.autoConnect}
+                        onChange={this.props.setAutoConnect}
                       />
-                    </Cell.Container>
-                    <Cell.Footer>
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
                       <Cell.FooterText>
                         {messages.pgettext(
                           'preferences-view',
-                          'Show only the tray icon when the app starts.',
+                          'Automatically connect to a server when the app launches.',
                         )}
                       </Cell.FooterText>
-                    </Cell.Footer>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('preferences-view', 'Local network sharing')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'preferences-view',
+                          'Allows access to other devices on the same network for sharing, printing etc.',
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('preferences-view', 'Notifications')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        isOn={this.props.enableSystemNotifications}
+                        onChange={this.props.setEnableSystemNotifications}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'preferences-view',
+                          'Enable or disable system notifications. The critical notifications will always be displayed.',
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('preferences-view', 'Monochromatic tray icon')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        isOn={this.props.monochromaticIcon}
+                        onChange={this.props.setMonochromaticIcon}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'preferences-view',
+                          'Use a monochromatic tray icon instead of a colored one.',
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                {this.props.enableStartMinimizedToggle ? (
+                  <React.Fragment>
+                    <AriaInputGroup>
+                      <Cell.Container>
+                        <AriaLabel>
+                          <Cell.InputLabel>
+                            {messages.pgettext('preferences-view', 'Start minimized')}
+                          </Cell.InputLabel>
+                        </AriaLabel>
+                        <AriaInput>
+                          <Cell.Switch
+                            isOn={this.props.startMinimized}
+                            onChange={this.props.setStartMinimized}
+                          />
+                        </AriaInput>
+                      </Cell.Container>
+                      <Cell.Footer>
+                        <AriaDescription>
+                          <Cell.FooterText>
+                            {messages.pgettext(
+                              'preferences-view',
+                              'Show only the tray icon when the app starts.',
+                            )}
+                          </Cell.FooterText>
+                        </AriaDescription>
+                      </Cell.Footer>
+                    </AriaInputGroup>
                   </React.Fragment>
                 ) : undefined}
 
-                <Cell.Container disabled={this.props.isBeta}>
-                  <Cell.Label>{messages.pgettext('preferences-view', 'Beta program')}</Cell.Label>
-                  <Cell.Switch
-                    isOn={this.props.showBetaReleases}
-                    onChange={this.props.setShowBetaReleases}
-                  />
-                </Cell.Container>
-                <Cell.Footer>
-                  <Cell.FooterText>
-                    {this.props.isBeta
-                      ? messages.pgettext(
-                          'preferences-view',
-                          'This option is unavailable while using a beta version.',
-                        )
-                      : messages.pgettext(
-                          'preferences-view',
-                          'Enable to get notified when new beta versions of the app are released.',
-                        )}
-                  </Cell.FooterText>
-                </Cell.Footer>
+                <AriaInputGroup>
+                  <Cell.Container disabled={this.props.isBeta}>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('preferences-view', 'Beta program')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        isOn={this.props.showBetaReleases}
+                        onChange={this.props.setShowBetaReleases}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {this.props.isBeta
+                          ? messages.pgettext(
+                              'preferences-view',
+                              'This option is unavailable while using a beta version.',
+                            )
+                          : messages.pgettext(
+                              'preferences-view',
+                              'Enable to get notified when new beta versions of the app are released.',
+                            )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
               </StyledContent>
             </NavigationScrollbars>
           </NavigationContainer>

--- a/gui/src/renderer/components/RedeemVoucher.tsx
+++ b/gui/src/renderer/components/RedeemVoucher.tsx
@@ -198,7 +198,8 @@ export function RedeemVoucherAlert(props: IRedeemVoucherAlertProps) {
         <AppButton.BlueButton key="cancel" disabled={cancelDisabled} onClick={props.onClose}>
           {messages.pgettext('redeem-voucher-alert', 'Cancel')}
         </AppButton.BlueButton>,
-      ]}>
+      ]}
+      close={props.onClose}>
       <StyledLabel>{messages.pgettext('redeem-voucher-alert', 'Enter voucher code')}</StyledLabel>
       <RedeemVoucherInput />
       <RedeemVoucherResponse />

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -252,6 +252,7 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
             {messages.gettext('Back')}
           </AppButton.BlueButton>,
         ]}
+        close={this.onCancelNoEmailDialog}
       />
     );
   }
@@ -286,6 +287,7 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
             {messages.gettext('Cancel')}
           </AppButton.BlueButton>,
         ]}
+        close={this.props.onClose}
       />
     );
   }

--- a/gui/src/renderer/components/Switch.tsx
+++ b/gui/src/renderer/components/Switch.tsx
@@ -83,6 +83,7 @@ export default class Switch extends React.PureComponent<IProps, IState> {
         ref={this.containerRef}
         onClick={this.handleClick}
         disabled={this.props.disabled ?? false}
+        aria-disabled={this.props.disabled ?? false}
         className={this.props.className}>
         <Knob
           disabled={this.props.disabled ?? false}

--- a/gui/src/renderer/components/Switch.tsx
+++ b/gui/src/renderer/components/Switch.tsx
@@ -3,6 +3,9 @@ import styled from 'styled-components';
 import { colors } from '../../config.json';
 
 interface IProps {
+  id?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
   isOn: boolean;
   onChange?: (isOn: boolean) => void;
   className?: string;
@@ -47,7 +50,7 @@ const Knob = styled.div({}, (props: { isOn: boolean; isPressed: boolean; disable
   };
 });
 
-export default class Switch extends React.Component<IProps, IState> {
+export default class Switch extends React.PureComponent<IProps, IState> {
   public state: IState = {
     isOn: this.props.isOn,
     isPressed: false,
@@ -58,14 +61,6 @@ export default class Switch extends React.Component<IProps, IState> {
   private isPanning = false;
   private startPos = 0;
   private changedDuringPan = false;
-
-  public shouldComponentUpdate(nextProps: IProps, nextState: IState) {
-    return (
-      nextState.isOn !== this.state.isOn ||
-      nextState.isPressed !== this.state.isPressed ||
-      nextProps.isOn !== this.props.isOn
-    );
-  }
 
   public componentDidUpdate(prevProps: IProps, _prevState: IState) {
     if (
@@ -80,8 +75,11 @@ export default class Switch extends React.Component<IProps, IState> {
   public render() {
     return (
       <SwitchContainer
+        id={this.props.id}
         role="checkbox"
-        aria-checked={this.state.isOn}
+        aria-labelledby={this.props['aria-labelledby']}
+        aria-describedby={this.props['aria-describedby']}
+        aria-checked={this.props.isOn}
         ref={this.containerRef}
         onClick={this.handleClick}
         disabled={this.props.disabled ?? false}


### PR DESCRIPTION
This PR:
* Makes input labels use the `<label>` tag
* Adds attributes to labels, inputs and descriptions (`id`, `for`, `aria-labelledby`, `aria-describedby`)
* Adds `aria-disabled` attribute to `Switch` to communicate whether or not it is disabled
* Makes it possible to close modal by pressing escape
* Prevents screenreaders from navigating to content behind modal
* (Random improvement): Replaces the use of `document.getElementById` in `ModalAlert` with a ref since there's now a context.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2117)
<!-- Reviewable:end -->
