### PR TITLE
Fix conditions to anticipate reconnecting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Line wrap the file at 100 chars.                                              Th
   blocking state and sometimes open the UI for the user to login. Now it always opens the UI.
 - Mark the VPN connection as not metered, so that Android properly reports if the connection is or
   isn't metered based solely on the underlying network, and not on the VPN connection.
+- Fix connect action button sometimes showing itself as "Cancel" instead of "Secure my connection"
+  for a few seconds.
 
 #### Linux
 - Fix split tunneling rules preventing `systemd-resolved` from performing DNS lookups for excluded


### PR DESCRIPTION
When a reconnect is requested in the Kotlin side, the `ConnectionProxy` will attempt to "anticipate" the reconnecting state. That means that it will notify any UI state listeners to update to the reconnecting state _before_ the actual reconnecting state is received from the Rust side. This is done to improve the responsiveness of the UI so that the user feels a reaction to the command as soon as possible.

Previously, the reconnecting state would be incorrectly anticipated in a few cases. Most notably, when the tunnel was disconnected. This became apparent with the introduction of the split tunneling feature, because every change to the split tunneling configuration requested a reconnect, and the Rust side would correctly ignore the request if the target state was unsecured. This meant that when the split tunneling configuration changed (when for example it was first loaded from persistent storage), it would reconnect the tunnel and the `ConnectionProxy` would incorrectly anticipate the reconnect if the tunnel was disconnected, so parts of the UI would update incorrectly, and then return to the correct state after a few seconds.

This PR updates the conditions used to determine when the reconnect state should be anticipated to prevent incorrect UI updates.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2121)
<!-- Reviewable:end -->
