### PR TITLE
Improve how background service knows if the UI is visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Line wrap the file at 100 chars.                                              Th
   isn't metered based solely on the underlying network, and not on the VPN connection.
 - Fix connect action button sometimes showing itself as "Cancel" instead of "Secure my connection"
   for a few seconds.
+- Fix the notification sometimes leaving the foreground and becoming dismissable even if the UI was
+  still visible.
 
 #### Linux
 - Fix split tunneling rules preventing `systemd-resolved` from performing DNS lookups for excluded

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -77,8 +77,12 @@ class MullvadVpnService : TalpidVpnService() {
         }
     }
 
-    private var isBound by observable(false) { _, _, isBound ->
-        notificationManager.lockedToForeground = isBound
+    private var isBound: Boolean by observable(false) { _, _, isBound ->
+        notificationManager.lockedToForeground = isUiVisible or isBound
+    }
+
+    private var isUiVisible: Boolean by observable(false) { _, _, isUiVisible ->
+        notificationManager.lockedToForeground = isUiVisible or isBound
     }
 
     override fun onCreate() {
@@ -160,6 +164,10 @@ class MullvadVpnService : TalpidVpnService() {
     inner class LocalBinder : Binder() {
         val serviceNotifier
             get() = this@MullvadVpnService.serviceNotifier
+
+        var isUiVisible
+            get() = this@MullvadVpnService.isUiVisible
+            set(value) { this@MullvadVpnService.isUiVisible = value }
     }
 
     private fun setUp() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -27,6 +27,7 @@ class MainActivity : FragmentActivity() {
     val problemReport = MullvadProblemReport()
     val serviceNotifier = EventNotifier<ServiceConnection?>(null)
 
+    private var isUiVisible = false
     private var service: MullvadVpnService.LocalBinder? = null
     private var serviceConnection: ServiceConnection? = null
     private var shouldConnect = false
@@ -38,6 +39,8 @@ class MainActivity : FragmentActivity() {
             val localBinder = binder as MullvadVpnService.LocalBinder
 
             service = localBinder
+
+            localBinder.isUiVisible = isUiVisible
 
             localBinder.serviceNotifier.subscribe(this@MainActivity) { service ->
                 android.util.Log.d("mullvad", "UI connection to the service changed: $service")
@@ -85,6 +88,8 @@ class MainActivity : FragmentActivity() {
         android.util.Log.d("mullvad", "Starting main activity")
         super.onStart()
 
+        isUiVisible = true
+
         val intent = Intent(this, MullvadVpnService::class.java)
 
         if (Build.VERSION.SDK_INT >= 26) {
@@ -94,6 +99,7 @@ class MainActivity : FragmentActivity() {
         }
 
         bindService(intent, serviceConnectionManager, 0)
+        service?.isUiVisible = true
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
@@ -102,6 +108,8 @@ class MainActivity : FragmentActivity() {
 
     override fun onStop() {
         android.util.Log.d("mullvad", "Stoping main activity")
+        isUiVisible = false
+        service?.isUiVisible = false
         unbindService(serviceConnectionManager)
 
         super.onStop()


### PR DESCRIPTION
Previously, the app used the `onBind` and `onUnbind` callbacks to determine if the UI was visible, since the UI connected to the service when it started and disconnected when it stopped. However, Android sometimes disconnects the UI from service and reconnects it when needed transparently, which makes the logic incorrect sometimes. An example is when the UI is open, the notification drawer is pulled down and the app's notification is used to connect and then disconnect the tunnel. Afterwards, the service thinks the UI is no longer visible and this can be seen because the notification can be dismissed away while the UI is visible.

This PR adds a `isUiVisible` flag to the `MullvadVpnService` which is set when the UI becomes visible and unset when it disappears. The logic to determine if the notification is dismissible or not is if the UI is visible or if there is an active connection to the service (which could come from the somewhere else).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2124)
<!-- Reviewable:end -->
