### PR TITLE
Use netlink to add and remove the fwmark rule

### DIFF
--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -263,7 +263,9 @@ impl RouteManagerImpl {
             Ok(mut response) => {
                 while let Some(message) = response.next().await {
                     if let NetlinkPayload::Error(error) = message.payload {
-                        log::warn!("Failed to delete routing policy: {}", error);
+                        if error.to_io().kind() != io::ErrorKind::NotFound {
+                            log::warn!("Failed to delete routing policy: {}", error);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Currently the Linux routing module executes `ip rule ...` to add and remove the rule that directs marked packets to the `mullvad_exclusions` table. This refactoring accomplishes this using netlink messages, consistent with the rest of the module.

Another improvement can be made by not setting up the table using `/etc/iproute2/rt_tables`, which would remove the dependency on `iproute2`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2126)
<!-- Reviewable:end -->
