### PR TITLE
Remove verdict from masquerade rule

### DIFF
--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -325,7 +325,9 @@ impl<'a> PolicyBatch<'a> {
             rule.add_expr(&nft_expr!(cmp == split_tunnel::MARK));
 
             rule.add_expr(&nft_expr!(masquerade));
-            add_verdict(&mut rule, &Verdict::Accept);
+            if *ADD_COUNTERS {
+                rule.add_expr(&nft_expr!(counter));
+            }
             self.batch.add(&rule, nftnl::MsgType::Add);
         }
 


### PR DESCRIPTION
The `masquerade` rule is slightly off. It has an "accept" verdict, but this makes no sense. If you attempt to add the same rule using `nft`, you will see that it rejects this, because `masquerade` is supposed to be used in place of a verdict. It already functioned normally, so this fix is technically correct but it does not seem to matter in practice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2128)
<!-- Reviewable:end -->
