### PR TITLE
Wrap language selector in AriaInputGroup

### DIFF
--- a/gui/src/renderer/components/SelectLanguage.tsx
+++ b/gui/src/renderer/components/SelectLanguage.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 import { colors } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { AriaInputGroup } from './AriaGroup';
 import CustomScrollbars from './CustomScrollbars';
 import { Container, Layout } from './Layout';
 import {
@@ -85,13 +86,15 @@ export default class SelectLanguage extends React.Component<IProps, IState> {
                   {messages.pgettext('select-language-nav', 'Select language')}
                 </HeaderTitle>
               </SettingsHeader>
-              <StyledSelector
-                title=""
-                values={this.state.source}
-                value={this.props.preferredLocale}
-                onSelect={this.props.setPreferredLocale}
-                selectedCellRef={this.selectedCellRef}
-              />
+              <AriaInputGroup>
+                <StyledSelector
+                  title=""
+                  values={this.state.source}
+                  value={this.props.preferredLocale}
+                  onSelect={this.props.setPreferredLocale}
+                  selectedCellRef={this.selectedCellRef}
+                />
+              </AriaInputGroup>
             </StyledNavigationScrollbars>
           </NavigationContainer>
         </StyledContainer>


### PR DESCRIPTION
This PR fixes an error which caused the language selection view to show the error view. The issue was that `SelectLanguage` used `AriaGroup` components without the wrapping group. This PR adds the group component around the selector.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2132)
<!-- Reviewable:end -->
