### PR TITLE
Improve accessibility

### DIFF
--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -16,7 +16,7 @@ import AccountTokenLabel from './AccountTokenLabel';
 import * as AppButton from './AppButton';
 import { Layout } from './Layout';
 import { ModalContainer } from './Modal';
-import { BackBarItem, NavigationBar, NavigationItems } from './NavigationBar';
+import { BackBarItem, NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 
 import { AccountToken } from '../../shared/daemon-rpc-types';
@@ -45,6 +45,12 @@ export default class Account extends React.Component<IProps> {
                     messages.pgettext('navigation-bar', 'Settings')
                   }
                 </BackBarItem>
+                <TitleBarItem>
+                  {
+                    // TRANSLATORS: Title label in navigation bar
+                    messages.pgettext('account-view', 'Account')
+                  }
+                </TitleBarItem>
               </NavigationItems>
             </NavigationBar>
 

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -14,6 +14,7 @@ import {
 } from './AccountStyles';
 import AccountTokenLabel from './AccountTokenLabel';
 import * as AppButton from './AppButton';
+import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import { Layout } from './Layout';
 import { ModalContainer } from './Modal';
 import { BackBarItem, NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
@@ -81,10 +82,21 @@ export default class Account extends React.Component<IProps> {
                 <AppButton.BlockingButton
                   disabled={this.props.isOffline}
                   onClick={this.props.onBuyMore}>
-                  <StyledBuyCreditButton>
-                    <AppButton.Label>{messages.gettext('Buy more credit')}</AppButton.Label>
-                    <AppButton.Icon source="icon-extLink" height={16} width={16} />
-                  </StyledBuyCreditButton>
+                  <AriaDescriptionGroup>
+                    <AriaDescribed>
+                      <StyledBuyCreditButton>
+                        <AppButton.Label>{messages.gettext('Buy more credit')}</AppButton.Label>
+                        <AriaDescription>
+                          <AppButton.Icon
+                            source="icon-extLink"
+                            height={16}
+                            width={16}
+                            aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                          />
+                        </AriaDescription>
+                      </StyledBuyCreditButton>
+                    </AriaDescribed>
+                  </AriaDescriptionGroup>
                 </AppButton.BlockingButton>
 
                 <StyledRedeemVoucherButton />

--- a/gui/src/renderer/components/ErrorBoundary.tsx
+++ b/gui/src/renderer/components/ErrorBoundary.tsx
@@ -79,7 +79,7 @@ export default class ErrorBoundary extends React.Component<IProps, IState> {
             <StyledContainer>
               <Logo height={106} width={106} source="logo-icon" />
               <Title>{messages.pgettext('generic', 'MULLVAD VPN')}</Title>
-              <Subtitle>{reachBackMessage}</Subtitle>
+              <Subtitle role="alert">{reachBackMessage}</Subtitle>
             </StyledContainer>
           </Layout>
         </PlatformWindowContainer>

--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -6,6 +6,7 @@ import { AccountToken } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import { LoginState } from '../redux/account/reducers';
 import * as AppButton from './AppButton';
+import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import * as Cell from './Cell';
 import {
   StyledAccountTokenContainer,
@@ -168,10 +169,21 @@ export default class ExpiredAccountErrorView extends React.Component<
       <AppButton.BlockingButton
         disabled={this.getRecoveryAction() === RecoveryAction.disconnect}
         onClick={this.onOpenExternalPayment}>
-        <StyledBuyCreditButton>
-          <AppButton.Label>{buttonText}</AppButton.Label>
-          <AppButton.Icon source="icon-extLink" height={16} width={16} />
-        </StyledBuyCreditButton>
+        <AriaDescriptionGroup>
+          <AriaDescribed>
+            <StyledBuyCreditButton>
+              <AppButton.Label>{buttonText}</AppButton.Label>
+              <AriaDescription>
+                <AppButton.Icon
+                  source="icon-extLink"
+                  height={16}
+                  width={16}
+                  aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                />
+              </AriaDescription>
+            </StyledBuyCreditButton>
+          </AriaDescribed>
+        </AriaDescriptionGroup>
       </AppButton.BlockingButton>
     );
   }

--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -53,7 +53,7 @@ const BrandContainer = styled.div({
   alignItems: 'center',
 });
 
-const Title = styled.h1({
+const Title = styled.span({
   fontFamily: 'DINPro',
   fontSize: '24px',
   fontWeight: 900,

--- a/gui/src/renderer/components/Launch.tsx
+++ b/gui/src/renderer/components/Launch.tsx
@@ -45,7 +45,7 @@ export default function Launch() {
       <StyledContainer>
         <Logo height={106} width={106} source="logo-icon" />
         <Title>{messages.pgettext('generic', 'MULLVAD VPN')}</Title>
-        <Subtitle>
+        <Subtitle role="alert">
           {messages.pgettext('launch-view', 'Connecting to Mullvad system service...')}
         </Subtitle>
       </StyledContainer>

--- a/gui/src/renderer/components/NavigationBar.tsx
+++ b/gui/src/renderer/components/NavigationBar.tsx
@@ -136,7 +136,7 @@ const TitleBarItemContext = React.createContext({
   get titleContainerRef(): React.RefObject<HTMLDivElement> {
     throw Error('Missing TitleBarItemContext provider');
   },
-  get measuringTitleRef(): React.RefObject<HTMLSpanElement> {
+  get measuringTitleRef(): React.RefObject<HTMLHeadingElement> {
     throw Error('Missing TitleBarItemContext provider');
   },
 });
@@ -151,7 +151,7 @@ export const NavigationBar = function NavigationBarT(props: INavigationBarProps)
   const [titleAdjustment, setTitleAdjustment] = useState(0);
 
   const titleContainerRef = useRef() as React.RefObject<HTMLDivElement>;
-  const measuringTitleRef = useRef() as React.RefObject<HTMLSpanElement>;
+  const measuringTitleRef = useRef() as React.RefObject<HTMLHeadingElement>;
   const navigationBarRef = useRef() as React.RefObject<HTMLDivElement>;
 
   useLayoutEffect(() => {
@@ -215,10 +215,7 @@ export const TitleBarItem = React.memo(function TitleBarItemT(props: ITitleBarIt
 
   return (
     <StyledTitleBarItemContainer ref={titleContainerRef}>
-      <StyledTitleBarItemLabel
-        titleAdjustment={titleAdjustment}
-        visible={visible}
-        aria-hidden={!visible}>
+      <StyledTitleBarItemLabel titleAdjustment={titleAdjustment} visible={visible}>
         {props.children}
       </StyledTitleBarItemLabel>
 

--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -44,7 +44,7 @@ interface ITitleBarItemLabelProps {
   visible?: boolean;
 }
 
-export const StyledTitleBarItemLabel = styled.span({}, (props: ITitleBarItemLabelProps) => ({
+export const StyledTitleBarItemLabel = styled.h1({}, (props: ITitleBarItemLabelProps) => ({
   fontFamily: 'Open Sans',
   fontSize: '16px',
   fontWeight: 600,

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { colors, links } from '../../config.json';
 import { hasExpired, formatRemainingTime } from '../../shared/account-expiry';
 import { messages } from '../../shared/gettext';
+import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import * as Cell from './Cell';
 import { Layout } from './Layout';
 import {
@@ -176,15 +177,24 @@ export default class Settings extends React.Component<IProps> {
     }
 
     return (
-      <>
-        <Cell.CellButton disabled={this.props.isOffline} onClick={this.openDownloadLink}>
-          {icon}
-          <Cell.Label>{messages.pgettext('settings-view', 'App version')}</Cell.Label>
-          <Cell.SubText>{this.props.appVersion}</Cell.SubText>
-          <Cell.Icon height={16} width={16} source="icon-extLink" />
-        </Cell.CellButton>
+      <AriaDescriptionGroup>
+        <AriaDescribed>
+          <Cell.CellButton disabled={this.props.isOffline} onClick={this.openDownloadLink}>
+            {icon}
+            <Cell.Label>{messages.pgettext('settings-view', 'App version')}</Cell.Label>
+            <Cell.SubText>{this.props.appVersion}</Cell.SubText>
+            <AriaDescription>
+              <Cell.Icon
+                height={16}
+                width={16}
+                source="icon-extLink"
+                aria-label={messages.pgettext('accessibility', 'Opens externally')}
+              />
+            </AriaDescription>
+          </Cell.CellButton>
+        </AriaDescribed>
         {footer}
-      </>
+      </AriaDescriptionGroup>
     );
   }
 
@@ -201,15 +211,26 @@ export default class Settings extends React.Component<IProps> {
           <Cell.Icon height={12} width={7} source="icon-chevron" />
         </Cell.CellButton>
 
-        <Cell.CellButton disabled={this.props.isOffline} onClick={this.openFaqLink}>
-          <Cell.Label>
-            {
-              // TRANSLATORS: Link to the webpage
-              messages.pgettext('settings-view', 'FAQs & Guides')
-            }
-          </Cell.Label>
-          <Cell.Icon height={16} width={16} source="icon-extLink" />
-        </Cell.CellButton>
+        <AriaDescriptionGroup>
+          <AriaDescribed>
+            <Cell.CellButton disabled={this.props.isOffline} onClick={this.openFaqLink}>
+              <Cell.Label>
+                {
+                  // TRANSLATORS: Link to the webpage
+                  messages.pgettext('settings-view', 'FAQs & Guides')
+                }
+              </Cell.Label>
+              <AriaDescription>
+                <Cell.Icon
+                  height={16}
+                  width={16}
+                  source="icon-extLink"
+                  aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                />
+              </AriaDescription>
+            </Cell.CellButton>
+          </AriaDescribed>
+        </AriaDescriptionGroup>
 
         <Cell.CellButton onClick={this.props.onViewSelectLanguage}>
           <StyledCellIcon width={24} height={24} source="icon-language" />

--- a/gui/src/renderer/components/SettingsHeader.tsx
+++ b/gui/src/renderer/components/SettingsHeader.tsx
@@ -13,7 +13,7 @@ export const ContentWrapper = styled.div({
   },
 });
 
-export const HeaderTitle = styled.h1(bigText);
+export const HeaderTitle = styled.span(bigText);
 export const HeaderSubTitle = styled.span(smallText);
 
 interface ISettingsHeaderProps {

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -5,7 +5,7 @@ import * as AppButton from './AppButton';
 import ImageView from './ImageView';
 import { Layout } from './Layout';
 import { ModalAlert, ModalAlertType, ModalContainer } from './Modal';
-import { BackBarItem, NavigationBar, NavigationItems } from './NavigationBar';
+import { BackBarItem, NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderSubTitle, HeaderTitle } from './SettingsHeader';
 import {
   StyledBlueButton,
@@ -159,6 +159,12 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
                     messages.pgettext('navigation-bar', 'Settings')
                   }
                 </BackBarItem>
+                <TitleBarItem>
+                  {
+                    // TRANSLATORS: Title label in navigation bar
+                    messages.pgettext('support-view', 'Report a problem')
+                  }
+                </TitleBarItem>
               </NavigationItems>
             </NavigationBar>
             <StyledContentContainer>

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { links } from '../../config.json';
 import { messages } from '../../shared/gettext';
 import * as AppButton from './AppButton';
+import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import ImageView from './ImageView';
 import { Layout } from './Layout';
 import { ModalAlert, ModalAlertType, ModalContainer } from './Modal';
@@ -283,13 +284,25 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
         type={ModalAlertType.Warning}
         message={message}
         buttons={[
-          <AppButton.GreenButton
-            key="upgrade"
-            disabled={this.props.isOffline}
-            onClick={this.openDownloadLink}>
-            <AppButton.Label>{messages.pgettext('support-view', 'Upgrade app')}</AppButton.Label>
-            <AppButton.Icon height={16} width={16} source="icon-extLink" />
-          </AppButton.GreenButton>,
+          <AriaDescriptionGroup key="upgrade">
+            <AriaDescribed>
+              <AppButton.GreenButton
+                disabled={this.props.isOffline}
+                onClick={this.openDownloadLink}>
+                <AppButton.Label>
+                  {messages.pgettext('support-view', 'Upgrade app')}
+                </AppButton.Label>
+                <AriaDescription>
+                  <AppButton.Icon
+                    height={16}
+                    width={16}
+                    source="icon-extLink"
+                    aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                  />
+                </AriaDescription>
+              </AppButton.GreenButton>
+            </AriaDescribed>
+          </AriaDescriptionGroup>,
           <AppButton.RedButton key="proceed" onClick={this.acknowledgeOutdateVersion}>
             {messages.pgettext('support-view', 'Continue anyway')}
           </AppButton.RedButton>,
@@ -322,10 +335,23 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
           </StyledFormMessageRow>
         </StyledForm>
         <StyledFooter>
-          <StyledBlueButton onClick={this.onViewLog} disabled={this.state.disableActions}>
-            <AppButton.Label>{messages.pgettext('support-view', 'View app logs')}</AppButton.Label>
-            <AppButton.Icon source="icon-extLink" height={16} width={16} />
-          </StyledBlueButton>
+          <AriaDescriptionGroup>
+            <AriaDescribed>
+              <StyledBlueButton onClick={this.onViewLog} disabled={this.state.disableActions}>
+                <AppButton.Label>
+                  {messages.pgettext('support-view', 'View app logs')}
+                </AppButton.Label>
+                <AriaDescription>
+                  <AppButton.Icon
+                    source="icon-extLink"
+                    height={16}
+                    width={16}
+                    aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                  />
+                </AriaDescription>
+              </StyledBlueButton>
+            </AriaDescribed>
+          </AriaDescriptionGroup>
           <AppButton.GreenButton
             disabled={!this.validate() || this.state.disableActions}
             onClick={this.onSend}>

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { sprintf } from 'sprintf-js';
 import styled from 'styled-components';
 import { TunnelState } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
@@ -83,7 +84,12 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
     };
 
     const SelectedLocation = () => (
-      <SwitchLocationButton onClick={this.props.onSelectLocation}>
+      <SwitchLocationButton
+        onClick={this.props.onSelectLocation}
+        aria-label={sprintf(
+          messages.pgettext('accessibility', 'Select location. Current location is %(location)s'),
+          { location: this.props.selectedRelayName },
+        )}>
         <AppButton.Label>{this.props.selectedRelayName}</AppButton.Label>
         <SelectedLocationChevron height={12} width={7} source="icon-chevron" />
       </SwitchLocationButton>

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -6,6 +6,7 @@ import { TunnelState } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import { IWgKey, WgKeyState } from '../redux/settings/reducers';
 import * as AppButton from './AppButton';
+import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import ClipboardLabel from './ClipboardLabel';
 import ImageView from './ImageView';
 import { Layout } from './Layout';
@@ -145,12 +146,23 @@ export default class WireguardKeys extends React.Component<IProps, IState> {
                   <AppButton.BlockingButton
                     disabled={this.props.isOffline}
                     onClick={this.props.onVisitWebsiteKey}>
-                    <AppButton.BlueButton>
-                      <AppButton.Label>
-                        {messages.pgettext('wireguard-key-view', 'Manage keys')}
-                      </AppButton.Label>
-                      <AppButton.Icon source="icon-extLink" height={16} width={16} />
-                    </AppButton.BlueButton>
+                    <AriaDescriptionGroup>
+                      <AriaDescribed>
+                        <AppButton.BlueButton>
+                          <AppButton.Label>
+                            {messages.pgettext('wireguard-key-view', 'Manage keys')}
+                          </AppButton.Label>
+                          <AriaDescription>
+                            <AppButton.Icon
+                              source="icon-extLink"
+                              height={16}
+                              width={16}
+                              aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                            />
+                          </AriaDescription>
+                        </AppButton.BlueButton>
+                      </AriaDescribed>
+                    </AriaDescriptionGroup>
                   </AppButton.BlockingButton>
                 </StyledLastButtonRow>
               </StyledContent>

--- a/gui/src/renderer/lib/utilityHooks.ts
+++ b/gui/src/renderer/lib/utilityHooks.ts
@@ -1,0 +1,15 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export function useMounted() {
+  const mountedRef = useRef(false);
+  const isMounted = useCallback(() => mountedRef.current, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  return isMounted;
+}


### PR DESCRIPTION
This PR:
* Adds an `aria-label` to the select location button to better communicate it's function
* Adds the `alert` role to the text in `Launch` and `ErrorBoundary` to notify the user that something went wrong
* Makes `BlockingButton` use a context instead of cloning children to make it compatible with the `AriaGroup` components
* Adds `aria-label` to the `extLink` icon and add them as descriptions to their corresponding button to communicate that they'll open something externally
* Change which elements are used as headings. The navigation title is now always used as heading since it works well for all settings views to have one. If we were to use the "real" headings instead, we would have to specify it in each view containing one.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2134)
<!-- Reviewable:end -->
