### PR TITLE
Use the `AccountCache` to keep track of the account history

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -22,6 +22,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
 
     val onAccountNumberChange = EventNotifier<String?>(null)
     val onAccountExpiryChange = EventNotifier<DateTime?>(null)
+    val onAccountHistoryChange = EventNotifier<ArrayList<String>>(ArrayList())
 
     var newlyCreatedAccount = false
         private set
@@ -30,6 +31,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
 
     private var accountNumber by onAccountNumberChange.notifiable()
     private var accountExpiry by onAccountExpiryChange.notifiable()
+    private var accountHistory by onAccountHistoryChange.notifiable()
 
     private var createdAccountExpiry: DateTime? = null
     private var oldAccountExpiry: DateTime? = null
@@ -93,6 +95,12 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
         jobTracker.cancelAllJobs()
     }
 
+    private fun fetchAccountHistory() {
+        jobTracker.newBackgroundJob("fetchHistory") {
+            accountHistory = daemon.getAccountHistory()
+        }
+    }
+
     private fun markAccountAsNotNew() {
         newlyCreatedAccount = false
         createdAccountExpiry = null
@@ -104,6 +112,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
             accountNumber = newAccountNumber
 
             fetchAccountExpiry()
+            fetchAccountHistory()
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -59,7 +59,6 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             accountLogin.clearFocus()
         }
 
-        fetchHistory()
         scrollToShow(accountLogin)
 
         return view
@@ -74,11 +73,16 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             }
         }
 
-        fetchHistory()
+        accountCache.onAccountHistoryChange.subscribe(this) { history ->
+            jobTracker.newUiJob("updateHistory") {
+                accountLogin.accountHistory = history
+            }
+        }
     }
 
     override fun onSafelyStop() {
         jobTracker.cancelJob("advanceToNextScreen")
+        accountCache.onAccountHistoryChange.unsubscribe(this)
     }
 
     private fun scrollToShow(view: View) {
@@ -123,14 +127,6 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         scrollToShow(loggingInStatus)
 
         performLogin(accountToken)
-    }
-
-    private fun fetchHistory() {
-        jobTracker.newUiJob("fetchHistory") {
-            accountLogin.accountHistory = jobTracker.runOnBackground() {
-                daemon.getAccountHistory()
-            }
-        }
     }
 
     private fun performLogin(accountToken: String) {


### PR DESCRIPTION
Before adding the functionality to remove entries from the account history, I thought it was best to centralize where the account history was managed. This PR then moves the account history fetching and notification into the `AccountCache` class, which also knows if the account changed so it can re-fetch the history at the appropriate time.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2135)
<!-- Reviewable:end -->
