### PR TITLE
Fix crash if service connection is lost when opening the Split Tunneling settings screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Line wrap the file at 100 chars.                                              Th
   for a few seconds.
 - Fix the notification sometimes leaving the foreground and becoming dismissable even if the UI was
   still visible.
+- Fix crash if connection to service is lost while opening the Split Tunneling settings screen.
 
 #### Linux
 - Fix split tunneling rules preventing `systemd-resolved` from performing DNS lookups for excluded

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -60,6 +60,7 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
         private set
 
     lateinit var splitTunneling: SplitTunneling
+        private set
 
     override fun onNewServiceConnection(serviceConnection: ServiceConnection) {
         // This method is always either called first or after an `onNoServiceConnection`, so the

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnelingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnelingFragment.kt
@@ -3,7 +3,6 @@ package net.mullvad.mullvadvpn.ui
 import android.animation.Animator
 import android.animation.Animator.AnimatorListener
 import android.animation.ObjectAnimator
-import android.content.Context
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
@@ -51,12 +50,6 @@ class SplitTunnelingFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
     private lateinit var excludeApplications: View
     private lateinit var loadingSpinner: View
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        appListAdapter = AppListAdapter(context, splitTunneling)
-    }
-
     override fun onSafelyCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -69,6 +62,8 @@ class SplitTunnelingFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
         }
 
         titleController = CollapsibleTitleController(view, R.id.app_list)
+
+        appListAdapter = AppListAdapter(parentActivity, splitTunneling)
 
         view.findViewById<CustomRecyclerView>(R.id.app_list).apply {
             layoutManager = LinearLayoutManager(parentActivity)


### PR DESCRIPTION
A crash report indicated that the `splitTunneling` property was used before it was initialized in the `SplitTunnelingFragment`. The stack trace showed that this happened inside the `onAttach` method. The property should be initialized in the call to `super.onAttach`, _as long as the service connection is already available_. If it's not available, it doesn't get initialized, and that shouldn't be a problem since the super `ServiceDependentFragment` class should handle it gracefully by showing a temporary screen and then returning to the launch screen. However, the `SplitTunnelingFragment` tries to use the property out of one of the "safe" methods, so the super-class handling of the situation doesn't get a chance to execute because the code crashes before that happens.

This PR fixes that by delaying the initialization of the adapter so that it is only initialized inside a "safe" method, ensuring the `splitTunneling` property is initialized by then.

The PR also adds a missing `private` modifier to the property's setter for consistency with the other properties.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2136)
<!-- Reviewable:end -->
