### PR TITLE
Use a `RecyclerView` for the account history

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemDividerDecoration.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemDividerDecoration.kt
@@ -10,6 +10,7 @@ import kotlin.properties.Delegates.observable
 
 class ListItemDividerDecoration(context: Context) : ItemDecoration() {
     private var bottomOffset = 0
+    private var topOffset = 0
 
     var bottomOffsetId by observable<Int?>(null) { _, _, id ->
         if (id != null) {
@@ -19,7 +20,16 @@ class ListItemDividerDecoration(context: Context) : ItemDecoration() {
         }
     }
 
+    var topOffsetId by observable<Int?>(null) { _, _, id ->
+        if (id != null) {
+            topOffset = context.resources.getDimensionPixelSize(id)
+        } else {
+            topOffset = 0
+        }
+    }
+
     override fun getItemOffsets(offsets: Rect, view: View, parent: RecyclerView, state: State) {
         offsets.bottom = bottomOffset
+        offsets.top = topOffset
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemDividerDecoration.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemDividerDecoration.kt
@@ -8,7 +8,7 @@ import android.support.v7.widget.RecyclerView.State
 import android.view.View
 import net.mullvad.mullvadvpn.R
 
-class ListItemDividerDecoration(private val context: Context) : ItemDecoration() {
+class ListItemDividerDecoration(context: Context) : ItemDecoration() {
     private val dividerHeight = context.resources.getDimensionPixelSize(R.dimen.list_item_divider)
 
     override fun getItemOffsets(offsets: Rect, view: View, parent: RecyclerView, state: State) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemDividerDecoration.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemDividerDecoration.kt
@@ -6,12 +6,20 @@ import android.support.v7.widget.RecyclerView
 import android.support.v7.widget.RecyclerView.ItemDecoration
 import android.support.v7.widget.RecyclerView.State
 import android.view.View
-import net.mullvad.mullvadvpn.R
+import kotlin.properties.Delegates.observable
 
 class ListItemDividerDecoration(context: Context) : ItemDecoration() {
-    private val dividerHeight = context.resources.getDimensionPixelSize(R.dimen.list_item_divider)
+    private var bottomOffset = 0
+
+    var bottomOffsetId by observable<Int?>(null) { _, _, id ->
+        if (id != null) {
+            bottomOffset = context.resources.getDimensionPixelSize(id)
+        } else {
+            bottomOffset = 0
+        }
+    }
 
     override fun getItemOffsets(offsets: Rect, view: View, parent: RecyclerView, state: State) {
-        offsets.bottom = dividerHeight
+        offsets.bottom = bottomOffset
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -74,7 +74,11 @@ class SelectLocationFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
                 }
             }
 
-            addItemDecoration(ListItemDividerDecoration(parentActivity))
+            addItemDecoration(
+                ListItemDividerDecoration(parentActivity).apply {
+                    bottomOffsetId = R.dimen.list_item_divider
+                }
+            )
         }
 
         return view

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnelingFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SplitTunnelingFragment.kt
@@ -75,7 +75,11 @@ class SplitTunnelingFragment : ServiceDependentFragment(OnNoService.GoToLaunchSc
                 }
             }
 
-            addItemDecoration(ListItemDividerDecoration(parentActivity))
+            addItemDecoration(
+                ListItemDividerDecoration(parentActivity).apply {
+                    bottomOffsetId = R.dimen.list_item_divider
+                }
+            )
         }
 
         return view

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryAdapter.kt
@@ -1,0 +1,30 @@
+package net.mullvad.mullvadvpn.ui.widget
+
+import android.support.v7.widget.RecyclerView.Adapter
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.R
+
+class AccountHistoryAdapter : Adapter<AccountHistoryHolder>() {
+    var accountHistory by observable(ArrayList<String>()) { _, _, _ ->
+        notifyDataSetChanged()
+    }
+
+    var onSelectEntry: ((String) -> Unit)? = null
+
+    override fun onCreateViewHolder(parentView: ViewGroup, type: Int): AccountHistoryHolder {
+        val inflater = LayoutInflater.from(parentView.context)
+        val view = inflater.inflate(R.layout.account_history_entry, parentView, false)
+
+        return AccountHistoryHolder(view).apply {
+            onSelect = { account -> onSelectEntry?.invoke(account) }
+        }
+    }
+
+    override fun onBindViewHolder(holder: AccountHistoryHolder, position: Int) {
+        holder.accountToken = accountHistory[position]
+    }
+
+    override fun getItemCount() = accountHistory.size
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryHolder.kt
@@ -1,0 +1,23 @@
+package net.mullvad.mullvadvpn.ui.widget
+
+import android.support.v7.widget.RecyclerView.ViewHolder
+import android.view.View
+import android.widget.TextView
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.R
+
+class AccountHistoryHolder(view: View) : ViewHolder(view) {
+    private val label: TextView = view.findViewById(R.id.label)
+
+    var accountToken by observable("") { _, _, account ->
+        label.text = account
+    }
+
+    var onSelect: ((String) -> Unit)? = null
+
+    init {
+        view.setOnClickListener {
+            onSelect?.invoke(accountToken)
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -147,7 +147,7 @@ class AccountLogin : RelativeLayout {
                     ArrayAdapter(
                         context,
                         R.layout.account_history_entry,
-                        R.id.account_history_entry_text_view,
+                        R.id.label,
                         history
                     )
                 )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -14,6 +14,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.RelativeLayout
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.ui.ListItemDividerDecoration
 import net.mullvad.mullvadvpn.ui.LoginState
 import net.mullvad.mullvadvpn.ui.widget.AccountLoginBorder.BorderState
 
@@ -144,6 +145,12 @@ class AccountLogin : RelativeLayout {
         accountHistoryList.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = historyAdapter
+
+            addItemDecoration(
+                ListItemDividerDecoration(context).apply {
+                    topOffsetId = R.dimen.account_history_divider
+                }
+            )
         }
     }
 

--- a/android/src/main/res/drawable/account_history_list_divider.xml
+++ b/android/src/main/res/drawable/account_history_list_divider.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-       android:shape="rectangle">
-    <solid android:color="@color/darkBlue" />
-</shape>

--- a/android/src/main/res/layout/account_history_entry.xml
+++ b/android/src/main/res/layout/account_history_entry.xml
@@ -2,7 +2,7 @@
               android:layout_width="match_parent"
               android:layout_height="@dimen/account_history_entry_height"
               android:orientation="vertical">
-    <TextView android:id="@+id/account_history_entry_text_view"
+    <TextView android:id="@+id/label"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:background="@drawable/account_history_entry_background"

--- a/android/src/main/res/layout/account_login.xml
+++ b/android/src/main/res/layout/account_login.xml
@@ -9,9 +9,8 @@
                                                    android:layout_height="48dp"
                                                    android:layout_alignParentTop="true"
                                                    android:orientation="horizontal" />
-    <ListView android:id="@+id/history"
-              android:layout_width="fill_parent"
-              android:layout_height="wrap_content"
-              android:layout_below="@id/input"
-              android:dividerHeight="@dimen/account_history_divider" />
+    <android.support.v7.widget.RecyclerView android:id="@+id/history"
+                                            android:layout_width="match_parent"
+                                            android:layout_height="wrap_content"
+                                            android:layout_below="@id/input" />
 </merge>

--- a/android/src/main/res/layout/account_login.xml
+++ b/android/src/main/res/layout/account_login.xml
@@ -13,6 +13,5 @@
               android:layout_width="fill_parent"
               android:layout_height="wrap_content"
               android:layout_below="@id/input"
-              android:divider="@drawable/account_history_list_divider"
               android:dividerHeight="@dimen/account_history_divider" />
 </merge>


### PR DESCRIPTION
In order to add a remove button to each account history entry, more control over the entry views is needed. Therefore, this PR changes the account history to be stored in a `RecyclerView` instead of a `ListView`. This allows a custom adapter and view holder to be developed that can then have a custom button included in a future PR.

The change also simplifies the divider between the entries (and between the input and the list). The `ListItemDividerDecoration` was tweaked to allow the divider spacing to be in different places, and the other recycler views that use it were updated.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor with minimal UI changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2137)
<!-- Reviewable:end -->
