### PR TITLE
Refactor `ConnectivityListener` to remove deprecation warnings

### DIFF
--- a/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -52,7 +52,7 @@ class ConnectivityListener {
         connectivityManager.registerNetworkCallback(request, callback)
     }
 
-    fun unregister(context: Context) {
+    fun unregister() {
         connectivityManager.unregisterNetworkCallback(callback)
     }
 

--- a/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager.NetworkCallback
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import kotlin.properties.Delegates.observable
 import net.mullvad.talpid.util.EventNotifier
 
 class ConnectivityListener {
@@ -33,16 +34,13 @@ class ConnectivityListener {
 
     val connectivityNotifier = EventNotifier(false)
 
-    var isConnected = false
-        private set(value) {
-            field = value
-
-            if (senderAddress != 0L) {
-                notifyConnectivityChange(value, senderAddress)
-            }
-
-            connectivityNotifier.notify(value)
+    var isConnected by observable(false) { _, _, value ->
+        if (senderAddress != 0L) {
+            notifyConnectivityChange(value, senderAddress)
         }
+
+        connectivityNotifier.notify(value)
+    }
 
     var senderAddress = 0L
 

--- a/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -34,12 +34,14 @@ class ConnectivityListener {
 
     val connectivityNotifier = EventNotifier(false)
 
-    var isConnected by observable(false) { _, _, value ->
-        if (senderAddress != 0L) {
-            notifyConnectivityChange(value, senderAddress)
-        }
+    var isConnected by observable(false) { _, oldValue, newValue ->
+        if (newValue != oldValue) {
+            if (senderAddress != 0L) {
+                notifyConnectivityChange(newValue, senderAddress)
+            }
 
-        connectivityNotifier.notify(value)
+            connectivityNotifier.notify(newValue)
+        }
     }
 
     var senderAddress = 0L

--- a/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -15,18 +15,12 @@ class ConnectivityListener {
     private val callback = object : NetworkCallback() {
         override fun onAvailable(network: Network) {
             availableNetworks.add(network)
-
-            if (!isConnected) {
-                isConnected = true
-            }
+            isConnected = true
         }
 
         override fun onLost(network: Network) {
             availableNetworks.remove(network)
-
-            if (isConnected && availableNetworks.isEmpty()) {
-                isConnected = false
-            }
+            isConnected = !availableNetworks.isEmpty()
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -28,7 +28,7 @@ open class TalpidVpnService : VpnService() {
     }
 
     override fun onDestroy() {
-        connectivityListener.unregister(this)
+        connectivityListener.unregister()
     }
 
     fun getTun(config: TunConfig): Int {


### PR DESCRIPTION
The previous `ConnectivityListener` listened for connection change intents to determine the current connectivity. This is working well, but the API has been deprecated for a while, which led to multiple warnings being emitted when compiling. This PR rewrites the `ConnectivityListener` to use a newer `NetworkCallback` API which should be more efficient.

The new callback is called whenever a network that satisfies the specified criteria (in the `NetworkRequest` instance) becomes available or is lost. The class then keeps a set of available networks and determines if connectivity is available or not based on if the set is empty or not.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2138)
<!-- Reviewable:end -->
