### PR TITLE
Fix `NullPointerException` inside `MullvadTileService`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix the notification sometimes leaving the foreground and becoming dismissable even if the UI was
   still visible.
 - Fix crash if connection to service is lost while opening the Split Tunneling settings screen.
+- Fix rare crash that could occur when the tunnel state changes when showing or hiding the quick
+  settings tile.
 
 #### Linux
 - Fix split tunneling rules preventing `systemd-resolved` from performing DNS lookups for excluded

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -5,19 +5,18 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
+import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateListener
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
 class MullvadTileService : TileService() {
-    private var secured = false
-        set(value) {
-            if (field != value) {
-                field = value
-                updateTileState()
-            }
+    private var secured by observable(false) { _, wasSecured, isSecured ->
+        if (wasSecured != isSecured) {
+            updateTileState()
         }
+    }
 
     private lateinit var listener: TunnelStateListener
     private lateinit var securedIcon: Icon

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -75,7 +75,7 @@ class MullvadTileService : TileService() {
     }
 
     private fun updateTileState() {
-        qsTile.apply {
+        qsTile?.apply {
             if (secured) {
                 state = Tile.STATE_ACTIVE
                 icon = securedIcon

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -69,9 +69,9 @@ class MullvadTileService : TileService() {
     }
 
     override fun onStopListening() {
-        super.onStartListening()
-
         listener.onStateChange = null
+
+        super.onStartListening()
     }
 
     private fun updateTileState() {


### PR DESCRIPTION
There was a single crash report of a `NullPointerException` inside the `MullvadTileService`. This is pretty easy to avoid, and we simply add a `null` check in `qsTile?.apply`. However, the reason that `qsTile` was (or rather, `getQsTile()` returned) `null` is unknown.

The documentation only says that the returned tile is only valid between the `onStartListening()` and the `onStopListening()` callbacks. I changed the `super` call in `onStopListening()` to be in the end of the callback, just to make sure we use a more cautious interpretation of the documentation by not calling `getQsTile()` after calling `super.onStopListening()`. Still, looking at the code in AOSP it seems that changing the order shouldn't change anything.

Looking at the `TileService` code in AOSP, I couldn't find a reason for the `mTile` field to be `null`, except if there's an issue in Android and when binding to the internal service it fails to get the tile instance, or if the `getQsTile()` method is called too soon, which doesn't seem to be the case here.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2140)
<!-- Reviewable:end -->
