### PR TITLE
Format account number with spaces in the Login screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryAdapter.kt
@@ -5,8 +5,15 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.util.SegmentedTextFormatter
 
 class AccountHistoryAdapter : Adapter<AccountHistoryHolder>() {
+    private val formatter = SegmentedTextFormatter(' ').apply {
+        isValidInputCharacter = { character ->
+            '0' <= character && character <= '9'
+        }
+    }
+
     var accountHistory by observable(ArrayList<String>()) { _, _, _ ->
         notifyDataSetChanged()
     }
@@ -17,7 +24,7 @@ class AccountHistoryAdapter : Adapter<AccountHistoryHolder>() {
         val inflater = LayoutInflater.from(parentView.context)
         val view = inflater.inflate(R.layout.account_history_entry, parentView, false)
 
-        return AccountHistoryHolder(view).apply {
+        return AccountHistoryHolder(view, formatter).apply {
             onSelect = { account -> onSelectEntry?.invoke(account) }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryHolder.kt
@@ -5,12 +5,16 @@ import android.view.View
 import android.widget.TextView
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.util.SegmentedTextFormatter
 
-class AccountHistoryHolder(view: View) : ViewHolder(view) {
+class AccountHistoryHolder(
+    view: View,
+    private val formatter: SegmentedTextFormatter
+) : ViewHolder(view) {
     private val label: TextView = view.findViewById(R.id.label)
 
     var accountToken by observable("") { _, _, account ->
-        label.text = account
+        label.text = formatter.format(account)
     }
 
     var onSelect: ((String) -> Unit)? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -8,9 +8,9 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnFocusChangeListener
+import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.LinearLayout
-import android.widget.TextView
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.LoginState
@@ -42,7 +42,7 @@ class AccountInput : LinearLayout {
         }
     }
 
-    private val input = container.findViewById<TextView>(R.id.login_input).apply {
+    private val input = container.findViewById<EditText>(R.id.login_input).apply {
         addTextChangedListener(inputWatcher)
 
         onFocusChangeListener = OnFocusChangeListener { view, inputHasFocus ->
@@ -94,7 +94,7 @@ class AccountInput : LinearLayout {
     }
 
     fun loginWith(accountNumber: String) {
-        input.text = accountNumber
+        input.setText(accountNumber)
         onLogin?.invoke(accountNumber)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.LoginState
+import net.mullvad.mullvadvpn.util.SegmentedInputFormatter
 import net.mullvad.talpid.util.EventNotifier
 
 const val MIN_ACCOUNT_TOKEN_LENGTH = 10
@@ -53,6 +54,12 @@ class AccountInput : LinearLayout {
         // Manually initializing the `DigitsKeyListener` allows spaces to be used and still keeps
         // the input type as a number so that the correct software keyboard type is shown
         keyListener = DigitsKeyListener.getInstance("01234567890 ")
+
+        SegmentedInputFormatter(this, ' ').apply {
+            isValidInputCharacter = { character ->
+                '0' <= character && character <= '9'
+            }
+        }
     }
 
     private val button = container.findViewById<ImageButton>(R.id.login_button).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.ui.widget
 import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
+import android.text.method.DigitsKeyListener
 import android.text.style.MetricAffectingSpan
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -48,6 +49,10 @@ class AccountInput : LinearLayout {
         onFocusChangeListener = OnFocusChangeListener { view, inputHasFocus ->
             hasFocus = inputHasFocus && view.isEnabled
         }
+
+        // Manually initializing the `DigitsKeyListener` allows spaces to be used and still keeps
+        // the input type as a number so that the correct software keyboard type is shown
+        keyListener = DigitsKeyListener.getInstance("01234567890 ")
     }
 
     private val button = container.findViewById<ImageButton>(R.id.login_button).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedInputFormatter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedInputFormatter.kt
@@ -127,8 +127,8 @@ class SegmentedInputFormatter(val input: EditText, var separator: Char) : TextWa
     }
 
     private fun formatSeparator(input: Editable, index: Int): Boolean {
-        if (index < input.length && input[index] != '-') {
-            input.insert(index, "-")
+        if (index < input.length && input[index] != separator) {
+            input.insert(index, "$separator")
             return true
         } else {
             return false

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedTextFormatter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedTextFormatter.kt
@@ -1,0 +1,13 @@
+package net.mullvad.mullvadvpn.util
+
+class SegmentedTextFormatter(var separator: Char) {
+    var isValidInputCharacter: (Char) -> Boolean = { _ -> true }
+    var segmentSize = 4
+
+    fun format(string: String) = string
+        .asSequence()
+        .filter(isValidInputCharacter)
+        .chunked(segmentSize)
+        .map { segmentCharacters -> segmentCharacters.joinToString("") }
+        .joinToString("$separator")
+}

--- a/android/src/main/res/layout/account_input.xml
+++ b/android/src/main/res/layout/account_input.xml
@@ -1,12 +1,10 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
     <EditText android:id="@+id/login_input"
-              android:digits="0123456789"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:layout_weight="1"
               android:paddingHorizontal="12dp"
               android:background="@drawable/account_input_background"
-              android:inputType="number"
               android:singleLine="true"
               android:imeOptions="flagNoPersonalizedLearning"
               android:textCursorDrawable="@drawable/text_input_cursor"


### PR DESCRIPTION
This PR changes the Login screen so that the account number is shown with spaces separating every four digits. This is a minor UI tweak to improve readability and to make it more similar to the desktop app.

There was already a `SegmentedInputFormatter` helper class used in the Redeem Voucher dialog, and it was used for the account input widget. For the account history entries, a new and simpler `SegmentedTextFormatter` helper class was created.

Unfortunately, simply applying the `SegmentedInputFormatter` to the `AccountInput` widget didn't work initially. This was because setting the `digits` `TextView` attribute in the XML caused it to prohibit the space character from appearing in the widget. Adding a space character to that attribute value led the on-screen keyboard to change to not show numbers by default. The only solution found that allows spaces and that continues to show the digit on-screen keyboard was to manually instantiate a `DigitsKeyListener`.

The PR also includes a small bug-fix, where the `SegmentedInputFormatter` allowed the separator to change but in parts of it always assumed the separator to be a dash.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2141)
<!-- Reviewable:end -->
