### PR TITLE
Allow expanding locations with one relay on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
@@ -53,6 +53,4 @@ class RelayCity(
             return 1
         }
     }
-
-    fun getRelayCount(): Int = relays.size
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
@@ -16,7 +16,7 @@ class RelayCity(
         get() = relays.any { relay -> relay.active }
 
     override val hasChildren
-        get() = relays.size > 0
+        get() = !relays.isEmpty()
 
     override val visibleChildCount: Int
         get() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCity.kt
@@ -16,7 +16,7 @@ class RelayCity(
         get() = relays.any { relay -> relay.active }
 
     override val hasChildren
-        get() = relays.size > 1
+        get() = relays.size > 0
 
     override val visibleChildCount: Int
         get() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
@@ -15,7 +15,7 @@ class RelayCountry(
         get() = cities.any { city -> city.active }
 
     override val hasChildren
-        get() = getRelayCount() > 1
+        get() = getRelayCount() > 0
 
     override val visibleChildCount: Int
         get() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
@@ -15,7 +15,7 @@ class RelayCountry(
         get() = cities.any { city -> city.active }
 
     override val hasChildren
-        get() = getRelayCount() > 0
+        get() = !cities.isEmpty()
 
     override val visibleChildCount: Int
         get() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/relaylist/RelayCountry.kt
@@ -50,6 +50,4 @@ class RelayCountry(
 
         return GetItemResult.Count(itemCount)
     }
-
-    fun getRelayCount(): Int = cities.map { city -> city.getRelayCount() }.sum()
 }


### PR DESCRIPTION
Previously the Select Location screen would not show child items for locations that had only one relay. However, that might lead to some UX issues, where the user can't see what city is available in a country, and can't select a single server if more are added later without having to change the constraint again.

This PR changes that so that all locations with at least one relay can be fully expanded.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak, but if a changelog entry is necessary, we can add one for all platforms later when they are updated.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2142)
<!-- Reviewable:end -->
