### PR TITLE
Improve timestamp formatting in the CLI

### DIFF
--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -153,7 +153,9 @@ impl Account {
     }
 
     fn format_expiry(expiry: &Timestamp) -> String {
-        chrono::NaiveDateTime::from_timestamp(expiry.seconds, expiry.nanos as u32).to_string()
+        let ndt = chrono::NaiveDateTime::from_timestamp(expiry.seconds, expiry.nanos as u32);
+        let utc = chrono::DateTime::<chrono::Utc>::from_utc(ndt, chrono::Utc);
+        utc.with_timezone(&chrono::Local).to_string()
     }
 
     async fn clear_history(&self) -> Result<()> {

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -317,6 +317,8 @@ impl Tunnel {
     }
 
     fn format_key_timestamp(timestamp: &Timestamp) -> String {
-        chrono::NaiveDateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32).to_string()
+        let ndt = chrono::NaiveDateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32);
+        let utc = chrono::DateTime::<chrono::Utc>::from_utc(ndt, chrono::Utc);
+        utc.with_timezone(&chrono::Local).to_string()
     }
 }


### PR DESCRIPTION
Timestamps were being shown in UTC without any time zone info. Use local time instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2143)
<!-- Reviewable:end -->
