### PR TITLE
Keep key information up to date

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -403,6 +403,8 @@ class ApplicationMain {
         break;
     }
 
+    this.installGenericFocusHandlers(windowController);
+
     if (this.shouldShowWindowOnStart() || process.env.NODE_ENV === 'development') {
       windowController.show();
     }
@@ -1580,6 +1582,15 @@ class ApplicationMain {
         closeEvent.preventDefault();
         windowController.hide();
       }
+    });
+  }
+
+  private installGenericFocusHandlers(windowController: WindowController) {
+    windowController.window.on('focus', () => {
+      IpcMainEventChannel.windowFocus.notify(windowController.webContents, true);
+    });
+    windowController.window.on('blur', () => {
+      IpcMainEventChannel.windowFocus.notify(windowController.webContents, false);
     });
   }
 

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -188,6 +188,10 @@ export default class AppRenderer {
       this.reduxActions.settings.setWireguardKeygenEvent(event);
     });
 
+    IpcRendererEventChannel.windowFocus.listen((focus: boolean) => {
+      this.reduxActions.userInterface.setWindowFocused(focus);
+    });
+
     // Request the initial state from the main process
     const initialState = IpcRendererEventChannel.state.get();
 

--- a/gui/src/renderer/containers/WireguardKeysPage.tsx
+++ b/gui/src/renderer/containers/WireguardKeysPage.tsx
@@ -12,6 +12,7 @@ const mapStateToProps = (state: IReduxState) => ({
   isOffline: state.connection.isBlocked,
   locale: state.userInterface.locale,
   tunnelState: state.connection.status,
+  windowFocused: state.userInterface.windowFocused,
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   const history = bindActionCreators({ push, goBack }, dispatch);

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -19,11 +19,17 @@ export interface ISetLocationScopeAction {
   scope: LocationScope;
 }
 
+export interface ISetWindowFocusedAction {
+  type: 'SET_WINDOW_FOCUSED';
+  focused: boolean;
+}
+
 export type UserInterfaceAction =
   | IUpdateLocaleAction
   | IUpdateWindowArrowPositionAction
   | IUpdateConnectionInfoOpenAction
-  | ISetLocationScopeAction;
+  | ISetLocationScopeAction
+  | ISetWindowFocusedAction;
 
 function updateLocale(locale: string): IUpdateLocaleAction {
   return {
@@ -52,9 +58,17 @@ function setLocationScope(scope: LocationScope): ISetLocationScopeAction {
   };
 }
 
+function setWindowFocused(focused: boolean): ISetWindowFocusedAction {
+  return {
+    type: 'SET_WINDOW_FOCUSED',
+    focused,
+  };
+}
+
 export default {
   updateLocale,
   updateWindowArrowPosition,
   toggleConnectionPanel,
   setLocationScope,
+  setWindowFocused,
 };

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -10,12 +10,14 @@ export interface IUserInterfaceReduxState {
   arrowPosition?: number;
   connectionPanelVisible: boolean;
   locationScope: LocationScope;
+  windowFocused: boolean;
 }
 
 const initialState: IUserInterfaceReduxState = {
   locale: 'en',
   connectionPanelVisible: false,
   locationScope: LocationScope.relay,
+  windowFocused: false,
 };
 
 export default function (
@@ -34,6 +36,9 @@ export default function (
 
     case 'SET_LOCATION_SCOPE':
       return { ...state, locationScope: action.scope };
+
+    case 'SET_WINDOW_FOCUSED':
+      return { ...state, windowFocused: action.focused };
 
     default:
       return state;

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -168,6 +168,7 @@ interface ISplitTunnelingHandlers {
 
 const LOCALE_CHANGED = 'locale-changed';
 const WINDOW_SHAPE_CHANGED = 'window-shape-changed';
+const WINDOW_FOCUS_CHANGED = 'window-focus';
 
 const DAEMON_CONNECTED = 'daemon-connected';
 const DAEMON_DISCONNECTED = 'daemon-disconnected';
@@ -242,6 +243,10 @@ export class IpcRendererEventChannel {
 
   public static windowShape: IReceiver<IWindowShapeParameters> = {
     listen: listen(WINDOW_SHAPE_CHANGED),
+  };
+
+  public static windowFocus: IReceiver<boolean> = {
+    listen: listen(WINDOW_FOCUS_CHANGED),
   };
 
   public static daemonConnected: IReceiver<void> = {
@@ -344,6 +349,10 @@ export class IpcMainEventChannel {
 
   public static windowShape: ISender<IWindowShapeParameters> = {
     notify: sender(WINDOW_SHAPE_CHANGED),
+  };
+
+  public static windowFocus: ISender<boolean> = {
+    notify: sender(WINDOW_FOCUS_CHANGED),
   };
 
   public static daemonConnected: ISenderVoid = {


### PR DESCRIPTION
This PR makes sure that the "Key generated" value is up to date by:
* Updating the value when the app is opened if the `WireguardKeys` view is the current view
* Every minute as long as the view is visible

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2144)
<!-- Reviewable:end -->
