### PR TITLE
Reset focus on navigation and other accessibility improvements

### DIFF
--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -6,6 +6,7 @@ import NotificationArea from '../components/NotificationArea';
 import { AuthFailureKind, parseAuthFailure } from '../../shared/auth-failure';
 import { LoginState } from '../redux/account/reducers';
 import { IConnectionReduxState } from '../redux/connection/reducers';
+import { FocusFallback } from './Focus';
 import { Brand, HeaderBarStyle, HeaderBarSettingsButton } from './HeaderBar';
 import ImageView from './ImageView';
 import { Container, Header, Layout } from './Layout';
@@ -89,7 +90,9 @@ export default class Connect extends React.Component<IProps, IState> {
       <ModalContainer>
         <Layout>
           <Header barStyle={this.headerBarStyle()}>
-            <Brand />
+            <FocusFallback>
+              <Brand />
+            </FocusFallback>
             <HeaderBarSettingsButton />
           </Header>
           <StyledContainer>

--- a/gui/src/renderer/components/Focus.tsx
+++ b/gui/src/renderer/components/Focus.tsx
@@ -1,0 +1,63 @@
+import path from 'path';
+import React, { useImperativeHandle, useState } from 'react';
+import { useLocation } from 'react-router';
+import { sprintf } from 'sprintf-js';
+import styled from 'styled-components';
+import { messages } from '../../shared/gettext';
+
+const PageChangeAnnouncer = styled.div({
+  width: 0,
+  height: 0,
+  overflow: 'hidden',
+});
+
+export interface IFocusHandle {
+  resetFocus(): void;
+}
+
+interface IFocusProps {
+  children?: React.ReactElement;
+}
+
+function Focus(props: IFocusProps, ref: React.Ref<IFocusHandle>) {
+  const location = useLocation();
+  const [title, setTitle] = useState<string>();
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      resetFocus: () => {
+        const pageName = path.basename(location.pathname);
+        const titleElement = document.getElementsByTagName('h1')[0];
+        const titleContent = titleElement?.textContent ?? pageName;
+        setTitle(titleContent);
+
+        const focusElement = titleElement ?? document.getElementsByTagName('header')[0];
+        if (focusElement) {
+          focusElement.setAttribute('tabindex', '-1');
+          focusElement.focus();
+        }
+      },
+    }),
+    [location.pathname],
+  );
+
+  return (
+    <>
+      {title && (
+        <PageChangeAnnouncer aria-live="polite">
+          {
+            // TRANSLATORS: This string is used to notify users of screenreaders that the view has
+            // TRANSLATORS: changed, usually as a result of pressing a navigation button.
+            // TRANSLATORS: Available placeholders:
+            // TRANSLATORS: %(title)s - page title
+            sprintf(messages.pgettext('accessibility', '%(title)s, View loaded'), { title })
+          }
+        </PageChangeAnnouncer>
+      )}
+      {props.children}
+    </>
+  );
+}
+
+export default React.memo(React.forwardRef(Focus));

--- a/gui/src/renderer/components/Focus.tsx
+++ b/gui/src/renderer/components/Focus.tsx
@@ -5,6 +5,8 @@ import { sprintf } from 'sprintf-js';
 import styled from 'styled-components';
 import { messages } from '../../shared/gettext';
 
+const FOCUS_FALLBACK_CLASS = 'focus-fallback';
+
 const PageChangeAnnouncer = styled.div({
   width: 0,
   height: 0,
@@ -32,7 +34,8 @@ function Focus(props: IFocusProps, ref: React.Ref<IFocusHandle>) {
         const titleContent = titleElement?.textContent ?? pageName;
         setTitle(titleContent);
 
-        const focusElement = titleElement ?? document.getElementsByTagName('header')[0];
+        const focusElement =
+          titleElement ?? document.getElementsByClassName(FOCUS_FALLBACK_CLASS)[0];
         if (focusElement) {
           focusElement.setAttribute('tabindex', '-1');
           focusElement.focus();
@@ -61,3 +64,13 @@ function Focus(props: IFocusProps, ref: React.Ref<IFocusHandle>) {
 }
 
 export default React.memo(React.forwardRef(Focus));
+
+interface IFocusFallbackProps {
+  children: React.ReactElement;
+}
+
+export function FocusFallback(props: IFocusFallbackProps) {
+  return React.cloneElement(props.children, {
+    className: `${props.children.props.className} ${FOCUS_FALLBACK_CLASS}`,
+  });
+}

--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -66,9 +66,9 @@ const Logo = styled(ImageView)({
   margin: '4px 0 3px',
 });
 
-export function Brand() {
+export function Brand(props: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <BrandContainer>
+    <BrandContainer {...props}>
       <Logo width={44} height={44} source="logo-icon" />
       <Title>{messages.pgettext('generic', 'MULLVAD VPN')}</Title>
     </BrandContainer>

--- a/gui/src/renderer/components/ImageView.tsx
+++ b/gui/src/renderer/components/ImageView.tsx
@@ -53,9 +53,10 @@ export default function ImageView(props: IImageViewProps) {
       </ImageMask>
     );
   } else {
+    const { source: _source, width, height, ...otherProps } = props;
     return (
-      <Wrapper onClick={props.onClick} className={props.className}>
-        <img src={url} width={props.width} height={props.height} aria-hidden={true} />
+      <Wrapper {...otherProps}>
+        <img src={url} width={width} height={height} aria-hidden={true} />
       </Wrapper>
     );
   }

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -66,7 +66,7 @@ export default function NotificationArea(props: IProps) {
       return (
         <NotificationBanner className={props.className} visible>
           <NotificationIndicator type={notification.indicator} />
-          <NotificationContent role="alert" aria-live="polite">
+          <NotificationContent role="status" aria-live="polite">
             <NotificationTitle>{notification.title}</NotificationTitle>
             <NotificationSubtitle>{notification.subtitle}</NotificationSubtitle>
           </NotificationContent>

--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -66,7 +66,7 @@ export default function NotificationArea(props: IProps) {
       return (
         <NotificationBanner className={props.className} visible>
           <NotificationIndicator type={notification.indicator} />
-          <NotificationContent role="alert" aria-live="assertive">
+          <NotificationContent role="alert" aria-live="polite">
             <NotificationTitle>{notification.title}</NotificationTitle>
             <NotificationSubtitle>{notification.subtitle}</NotificationSubtitle>
           </NotificationContent>

--- a/gui/src/renderer/components/SecuredLabel.tsx
+++ b/gui/src/renderer/components/SecuredLabel.tsx
@@ -30,7 +30,7 @@ interface ISecuredLabelProps {
 
 export default function SecuredLabel(props: ISecuredLabelProps) {
   return (
-    <StyledSecuredLabel {...props} role="alert" aria-live="polite">
+    <StyledSecuredLabel {...props} role="status" aria-live="polite">
       {getLabelText(props.displayStyle)}
     </StyledSecuredLabel>
   );

--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -16,6 +16,7 @@ interface ITransitionQueueItem {
 
 interface IProps extends ITransitionGroupProps {
   children: TransitioningView;
+  onTransitionEnd: () => void;
 }
 
 interface IItemStyle {
@@ -192,6 +193,7 @@ export default class TransitionContainer extends React.Component<IProps, IState>
 
   private finishCycling() {
     this.isCycling = false;
+    this.props.onTransitionEnd();
   }
 
   private continueCycling = () => {

--- a/gui/src/renderer/routes.tsx
+++ b/gui/src/renderer/routes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Route, RouteComponentProps, Switch, withRouter } from 'react-router';
 import Launch from './components/Launch';
+import Focus, { IFocusHandle } from './components/Focus';
 import LinuxSplitTunnelingSettings from './components/LinuxSplitTunnelingSettings';
 import TransitionContainer, { TransitionView } from './components/TransitionContainer';
 import AccountPage from './containers/AccountPage';
@@ -23,6 +24,8 @@ interface IAppRoutesState {
 
 class AppRoutes extends React.Component<RouteComponentProps, IAppRoutesState> {
   private unobserveHistory?: () => void;
+
+  private focusRef = React.createRef<IFocusHandle>();
 
   constructor(props: RouteComponentProps) {
     super(props);
@@ -58,35 +61,41 @@ class AppRoutes extends React.Component<RouteComponentProps, IAppRoutesState> {
 
     return (
       <PlatformWindowContainer>
-        <TransitionContainer {...transitionProps}>
-          <TransitionView viewId={location.key || ''}>
-            <Switch key={location.key} location={location}>
-              <Route exact={true} path="/" component={Launch} />
-              <Route exact={true} path="/login" component={LoginPage} />
-              <Route exact={true} path="/connect" component={ConnectPage} />
-              <Route exact={true} path="/settings" component={SettingsPage} />
-              <Route exact={true} path="/settings/language" component={SelectLanguagePage} />
-              <Route exact={true} path="/settings/account" component={AccountPage} />
-              <Route exact={true} path="/settings/preferences" component={PreferencesPage} />
-              <Route exact={true} path="/settings/advanced" component={AdvancedSettingsPage} />
-              <Route
-                exact={true}
-                path="/settings/advanced/wireguard-keys"
-                component={WireguardKeysPage}
-              />
-              <Route
-                exact={true}
-                path="/settings/advanced/linux-split-tunneling"
-                component={LinuxSplitTunnelingSettings}
-              />
-              <Route exact={true} path="/settings/support" component={SupportPage} />
-              <Route exact={true} path="/select-location" component={SelectLocationPage} />
-            </Switch>
-          </TransitionView>
-        </TransitionContainer>
+        <Focus ref={this.focusRef}>
+          <TransitionContainer onTransitionEnd={this.onNavigation} {...transitionProps}>
+            <TransitionView viewId={location.key || ''}>
+              <Switch key={location.key} location={location}>
+                <Route exact={true} path="/" component={Launch} />
+                <Route exact={true} path="/login" component={LoginPage} />
+                <Route exact={true} path="/connect" component={ConnectPage} />
+                <Route exact={true} path="/settings" component={SettingsPage} />
+                <Route exact={true} path="/settings/language" component={SelectLanguagePage} />
+                <Route exact={true} path="/settings/account" component={AccountPage} />
+                <Route exact={true} path="/settings/preferences" component={PreferencesPage} />
+                <Route exact={true} path="/settings/advanced" component={AdvancedSettingsPage} />
+                <Route
+                  exact={true}
+                  path="/settings/advanced/wireguard-keys"
+                  component={WireguardKeysPage}
+                />
+                <Route
+                  exact={true}
+                  path="/settings/advanced/linux-split-tunneling"
+                  component={LinuxSplitTunnelingSettings}
+                />
+                <Route exact={true} path="/settings/support" component={SupportPage} />
+                <Route exact={true} path="/select-location" component={SelectLocationPage} />
+              </Switch>
+            </TransitionView>
+          </TransitionContainer>
+        </Focus>
       </PlatformWindowContainer>
     );
   }
+
+  private onNavigation = () => {
+    this.focusRef.current?.resetFocus();
+  };
 }
 
 const AppRoutesWithRouter = withRouter(AppRoutes);


### PR DESCRIPTION
This PR:
* Resets focus on navigation to either the first header or some fallback element
* Announces navigation with an invisible `div` that has the `aria-live` argument set
* Restores focus when closing a modal
* Makes notification area polite since that seems more correct
* Change `role` to `status` for `NotificationArea` and `SecuredLabel` since `alert` should be used for errors.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2148)
<!-- Reviewable:end -->
