### PR TITLE
Start key rotation after initial key is created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Stop resetting the firewall after an upgrade to not leak after an upgrade.
+- Start key rotation when WireGuard key is first created.
 
 #### Windows
 - Remove firewall filters (unblock internet access) when "Always require VPN" is enabled and the app

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -24,6 +24,8 @@ use talpid_types::ErrorExt;
 const DEFAULT_AUTOMATIC_KEY_ROTATION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 /// How long to wait before reattempting to rotate keys on failure
 const AUTOMATIC_ROTATION_RETRY_DELAY: Duration = Duration::from_secs(60 * 15);
+/// How long to wait before starting the first key rotation.
+const ROTATION_START_DELAY: Duration = Duration::from_secs(60 * 3);
 /// How often to check whether the key has expired.
 /// A short interval is used in case the computer is ever suspended.
 const KEY_CHECK_INTERVAL: Duration = Duration::from_secs(60);
@@ -337,7 +339,7 @@ impl KeyManager {
         account_token: AccountToken,
     ) {
         let mut interval = tokio::time::interval_at(
-            (Instant::now() + AUTOMATIC_ROTATION_RETRY_DELAY).into(),
+            (Instant::now() + ROTATION_START_DELAY).into(),
             AUTOMATIC_ROTATION_RETRY_DELAY,
         );
 

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -375,7 +375,7 @@ impl KeyManager {
         self.stop_automatic_rotation();
 
         if self.auto_rotation_interval == Duration::new(0, 0) {
-            // disabled
+            log::debug!("Not running key rotation because it's disabled");
             return;
         }
 

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -150,7 +150,11 @@ impl KeyManager {
 
 
     /// Generate a new private key asynchronously. The new keys will be sent to the daemon channel.
-    pub async fn generate_key_async(&mut self, account: AccountToken, timeout: Option<Duration>) {
+    pub async fn spawn_key_generation_task(
+        &mut self,
+        account: AccountToken,
+        timeout: Option<Duration>,
+    ) {
         self.reset();
         let private_key = PrivateKey::new_from_random();
 


### PR DESCRIPTION
When a new account is set, and a key is generated, the daemon previously didn't start the key rotation timer. The effect is that if a new user never reboots, the key would not be rotated indefinitely. I've changed the daemon so that whenever a new key event is received and the current account has no key, the key rotation would be started. The reason for not starting the key rotation whenever a new key is created is because the key rotation will almost always be started already.

The last commit here is a small refactoring to simplify the code for key rotation/generation. This is purely optional and I can drop it, since we're so close to a release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2149)
<!-- Reviewable:end -->
