### PR TITLE
Make map marker size consistent and animate changes

### DIFF
--- a/gui/src/renderer/components/SvgMap.tsx
+++ b/gui/src/renderer/components/SvgMap.tsx
@@ -36,11 +36,13 @@ const zoomableGroupStyle = {
   transition: `transform ${MOVE_SPEED}ms ease-out`,
 };
 
-const markerStyle = mergeRsmStyle({
-  default: {
+function getMarkerImageStyle(zoom: number) {
+  return {
+    width: '60px',
+    transform: `translate(${-30 / zoom}px, ${-30 / zoom}px) scale(${1 / zoom})`,
     transition: `transform ${MOVE_SPEED}ms ease-out`,
-  },
-});
+  };
+}
 
 const geographyStyle = mergeRsmStyle({
   default: {
@@ -219,6 +221,12 @@ function SvgMap(props: IProps) {
   const enableTransitionScheduler = useScheduler();
   useEffect(() => enableTransitionScheduler.schedule(() => setEnableTransition(true)), []);
 
+  const markerStyle = useMemo(
+    () => mergeRsmStyle({ default: { display: props.showMarker ? undefined : 'none' } }),
+    [props.showMarker],
+  );
+  const markerImageStyle = useMemo(() => getMarkerImageStyle(zoomLevel), [zoomLevel]);
+
   return (
     <ComposableMap
       width={width}
@@ -257,18 +265,9 @@ function SvgMap(props: IProps) {
             ));
           }}
         </Geographies>
-        {
-          // disable CSS transition when moving between locations
-          // by using the different "key"
-          props.showMarker && (
-            <Marker
-              key={`user-location-${center.join('-')}`}
-              coordinates={center}
-              style={markerStyle}>
-              <image x="-6" y="-6" width="12" xlinkHref={props.markerImagePath} />
-            </Marker>
-          )
-        }
+        <Marker coordinates={center} style={markerStyle}>
+          <image style={markerImageStyle} xlinkHref={props.markerImagePath} />
+        </Marker>
       </ZoomableGroup>
     </ComposableMap>
   );


### PR DESCRIPTION
This PR:
* Makes the map marker the same size when it is disconnected as when it's connected, this issue was introduced when upgrading `react-simple-maps`.
* Adds a transition to the size change. The size and offset is added to the image inside the marker to allow it to transition without the whole marker transitioning when switching location.

![output](https://user-images.githubusercontent.com/3668602/94405330-addf7580-0170-11eb-8982-519b3265bf8c.gif)

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2150)
<!-- Reviewable:end -->
