### PR TITLE
Unix reset firewall on uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for WireGuard's kernel module if it's loaded.
 - Add tray context menu with actions.
 - Improve accessibility in the desktop app.
+- Reset firewall when uninstalling.
+
+#### MacOS
+- Reset firewall whe uninstalling.
 
 ### Changed
 - Open and focus app when opened from context menu instead of toggling the window.

--- a/dist-assets/linux/before-remove.sh
+++ b/dist-assets/linux/before-remove.sh
@@ -24,3 +24,5 @@ elif /sbin/init --version | grep upstart &> /dev/null; then
     stop mullvad-daemon
     rm -f /etc/init/mullvad-daemon.conf
 fi
+
+/opt/Mullvad\ VPN/resources/mullvad-setup reset-firewall || true

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -20,6 +20,9 @@ DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"
 sudo launchctl unload -w "$DAEMON_PLIST_PATH"
 sudo rm -f "$DAEMON_PLIST_PATH"
 
+echo "Resetting firewall"
+sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup reset-firewall
+
 echo "Removing zsh shell completion symlink ..."
 sudo rm -f /usr/local/share/zsh/site-functions/_mullvad
 


### PR DESCRIPTION
When uninstalling, the Linux and MacOS uninstallers did not reset the firewall. This would leave the host without internet access if the user had enabled the _always require VPN_ setting. I've changed the uninstaller scripts for both Linux and MacOS to execute `mullvad-setup reset-firewall` after the daemon has been stopped. I've tested this on MacOS and Debian.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2152)
<!-- Reviewable:end -->
