### PR TITLE
Create an `ExponentialBackoff` helper class

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/ExponentialBackoff.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/ExponentialBackoff.kt
@@ -1,0 +1,52 @@
+package net.mullvad.mullvadvpn.util
+
+// Calculates a series of delays that increase exponentially.
+//
+// The delays follow the formula:
+//
+// (base ^ retryAttempt) * scale
+//
+// but it is never larger than the specified cap value.
+class ExponentialBackoff : Iterator<Long> {
+    private var unscaledValue = 1L
+    private var current = 1L
+
+    var iteration = 1
+        private set
+
+    var base = 2L
+    var scale = 1000L
+    var cap = Long.MAX_VALUE
+    var count: Int? = null
+
+    override fun hasNext(): Boolean {
+        val maxIterations = count
+
+        if (maxIterations != null) {
+            return iteration < maxIterations
+        } else {
+            return true
+        }
+    }
+
+    override fun next(): Long {
+        iteration += 1
+
+        if (current >= cap) {
+            return cap
+        } else {
+            val value = current
+
+            unscaledValue *= base
+            current = Math.min(cap, scale * unscaledValue)
+
+            return value
+        }
+    }
+
+    fun reset() {
+        unscaledValue = 1L
+        current = 1L
+        iteration = 1
+    }
+}


### PR DESCRIPTION
This PR creates an `ExponentialBackoff` helper class so that the logic that was originally in the `AccountCache` can be reused in the future when retrying to connect to Google's billing server. The class is implemented as an `Iterator`, meaning you can just use the `next()` method to get ever increasing delays, until the specified maximum delay. The scale factor was added because the exponential part is usually calculated in seconds, but must be scaled to milliseconds before being used.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2154)
<!-- Reviewable:end -->
