### PR TITLE
Clean up installer.exe copy in AppData

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -655,12 +655,12 @@
 	#
 	# The electron-builder NSIS logic, that runs before 'customInstall' is activated,
 	# makes a copy of the installer file:
-	# C:\Users\%CURRENTUSER%\AppData\Roaming\${PRODUCT_NAME}\__installer.exe
+	# C:\Users\%CURRENTUSER%\AppData\Local\mullvad-vpn-updater\installer.exe
 	#
-	# Let's undo this and remove the entire "Mullvad" folder under "Roaming".
+	# Let's undo this and remove the entire folder in AppData.
 	#
 	SetShellVarContext current
-	RMDir /r "$APPDATA\${PRODUCT_NAME}"
+	RMDir /r "$LOCALAPPDATA\mullvad-vpn-updater"
 
 	${RemoveRelayCache}
 	


### PR DESCRIPTION
The installer (due to `electron-builder`) dumps a copy of itself in `%LOCALAPPDATA%\mullvad-vpn-updater`. This file is not being removed by the uninstaller, and is only used for automatic updates. So it should be deleted during the installation. Ideally it would be fixed by patching upstream so that the file isn't copied in the first place, but this patch will do until the issue is fixed in `electron-builder`.

Related issue: https://github.com/electron-userland/electron-builder/issues/3831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2155)
<!-- Reviewable:end -->
