### PR TITLE
Add option to make the CLI wait for the target state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Improve accessibility in the desktop app.
+- Add `--wait` flag to `connect`, `disconnect` and `reconnect` CLI subcommands to make the CLI wait
+  for the target state to be reached before exiting.
 
 ### Changed
 - Use the API to fetch API IP addresses instead of DNS.

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -1,5 +1,6 @@
-use crate::{new_rpc_client, Command, Result};
-use talpid_types::ErrorExt;
+use crate::{format, new_rpc_client, state, Command, Error, Result};
+use futures::StreamExt;
+use mullvad_management_interface::types::tunnel_state::State;
 
 pub struct Connect;
 
@@ -12,13 +13,38 @@ impl Command for Connect {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Command the client to start establishing a VPN tunnel")
+            .arg(
+                clap::Arg::with_name("wait")
+                    .long("wait")
+                    .short("w")
+                    .help("Wait until connected before exiting"),
+            )
     }
 
-    async fn run(&self, _: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
-        if let Err(e) = rpc.connect_tunnel(()).await {
-            eprintln!("{}", e.display_chain());
+
+        let receiver_option = if matches.is_present("wait") {
+            Some(state::state_listen(rpc.clone()))
+        } else {
+            None
+        };
+
+        if rpc.connect_tunnel(()).await?.into_inner() {
+            if let Some(mut receiver) = receiver_option {
+                while let Some(state) = receiver.next().await {
+                    let state = state?;
+                    format::print_state(&state);
+                    match state.state.unwrap() {
+                        State::Connected(_) => return Ok(()),
+                        State::Error(_) => return Err(Error::CommandFailed("connect")),
+                        _ => {}
+                    }
+                }
+                return Err(Error::StatusListenerFailed);
+            }
         }
+
         Ok(())
     }
 }

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -1,4 +1,6 @@
-use crate::{new_rpc_client, Command, Result};
+use crate::{format, new_rpc_client, state, Command, Error, Result};
+use futures::StreamExt;
+use mullvad_management_interface::types::tunnel_state::State::Disconnected;
 
 pub struct Disconnect;
 
@@ -11,11 +13,37 @@ impl Command for Disconnect {
     fn clap_subcommand(&self) -> clap::App<'static, 'static> {
         clap::SubCommand::with_name(self.name())
             .about("Command the client to disconnect the VPN tunnel")
+            .arg(
+                clap::Arg::with_name("wait")
+                    .long("wait")
+                    .short("w")
+                    .help("Wait until disconnected before exiting"),
+            )
     }
 
-    async fn run(&self, _: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
-        rpc.disconnect_tunnel(()).await?;
+
+        let receiver_option = if matches.is_present("wait") {
+            Some(state::state_listen(rpc.clone()))
+        } else {
+            None
+        };
+
+        if rpc.disconnect_tunnel(()).await?.into_inner() {
+            if let Some(mut receiver) = receiver_option {
+                while let Some(state) = receiver.next().await {
+                    let state = state?;
+                    format::print_state(&state);
+                    match state.state.unwrap() {
+                        Disconnected(_) => return Ok(()),
+                        _ => {}
+                    }
+                }
+                return Err(Error::StatusListenerFailed);
+            }
+        }
+
         Ok(())
     }
 }

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -1,4 +1,14 @@
-use mullvad_management_interface::types::KeygenEvent;
+use mullvad_management_interface::types::{
+    error_state::{
+        firewall_policy_error::ErrorType as FirewallPolicyErrorType, Cause as ErrorStateCause,
+        FirewallPolicyError, GenerationError,
+    },
+    tunnel_state,
+    tunnel_state::State::*,
+    ErrorState, KeygenEvent, ProxyType, TransportProtocol, TunnelEndpoint, TunnelState, TunnelType,
+};
+use mullvad_types::auth_failed::AuthFailed;
+use std::fmt::Write;
 
 pub fn print_keygen_event(key_event: &KeygenEvent) {
     use mullvad_management_interface::types::keygen_event::KeygenEvent as EventType;
@@ -16,5 +26,155 @@ pub fn print_keygen_event(key_event: &KeygenEvent) {
         EventType::GenerationFailure => {
             println!("Failed to generate new WireGuard key");
         }
+    }
+}
+
+pub fn print_state(state: &TunnelState) {
+    print!("Tunnel status: ");
+    match state.state.as_ref().unwrap() {
+        Error(error) => print_error_state(error.error_state.as_ref().unwrap()),
+        Connected(tunnel_state::Connected { relay_info }) => {
+            let endpoint = relay_info
+                .as_ref()
+                .unwrap()
+                .tunnel_endpoint
+                .as_ref()
+                .unwrap();
+            println!("Connected to {}", format_endpoint(&endpoint));
+        }
+        Connecting(tunnel_state::Connecting { relay_info }) => {
+            let endpoint = relay_info
+                .as_ref()
+                .unwrap()
+                .tunnel_endpoint
+                .as_ref()
+                .unwrap();
+            println!("Connecting to {}...", format_endpoint(&endpoint));
+        }
+        Disconnected(_) => println!("Disconnected"),
+        Disconnecting(_) => println!("Disconnecting..."),
+    }
+}
+
+fn format_endpoint(endpoint: &TunnelEndpoint) -> String {
+    let mut out = format!(
+        "{} {} over {}",
+        match TunnelType::from_i32(endpoint.tunnel_type).expect("unknown tunnel protocol") {
+            TunnelType::Wireguard => "WireGuard",
+            TunnelType::Openvpn => "OpenVPN",
+        },
+        endpoint.address,
+        format_protocol(
+            TransportProtocol::from_i32(endpoint.protocol).expect("unknown transport protocol")
+        ),
+    );
+
+    if let Some(ref proxy) = endpoint.proxy {
+        write!(
+            &mut out,
+            " via {} {} over {}",
+            match ProxyType::from_i32(proxy.proxy_type).expect("unknown proxy type") {
+                ProxyType::Shadowsocks => "Shadowsocks",
+                ProxyType::Custom => "custom bridge",
+            },
+            proxy.address,
+            format_protocol(
+                TransportProtocol::from_i32(proxy.protocol).expect("unknown transport protocol")
+            ),
+        )
+        .unwrap();
+    }
+
+    out
+}
+
+fn print_error_state(error_state: &ErrorState) {
+    if error_state.blocking_error.is_some() {
+        eprintln!("Mullvad daemon failed to setup firewall rules!");
+        eprintln!("Deamon cannot block traffic from flowing, non-local traffic will leak");
+    }
+
+    match ErrorStateCause::from_i32(error_state.cause) {
+        Some(ErrorStateCause::AuthFailed) => {
+            println!(
+                "Blocked: {}",
+                AuthFailed::from(error_state.auth_fail_reason.as_ref())
+            );
+        }
+        #[cfg(target_os = "linux")]
+        Some(ErrorStateCause::SetFirewallPolicyError) => {
+            println!("Blocked: {}", error_state_to_string(error_state));
+            println!("Your kernel might be terribly out of date or missing nftables");
+        }
+        _ => println!("Blocked: {}", error_state_to_string(error_state)),
+    }
+}
+
+fn error_state_to_string(error_state: &ErrorState) -> String {
+    use ErrorStateCause::*;
+
+    let error_str = match ErrorStateCause::from_i32(error_state.cause).expect("unknown error cause")
+    {
+        AuthFailed => {
+            return if error_state.auth_fail_reason.is_empty() {
+                "Authentication with remote server failed".to_string()
+            } else {
+                format!(
+                    "Authentication with remote server failed: {}",
+                    error_state.auth_fail_reason
+                )
+            };
+        }
+        Ipv6Unavailable => "Failed to configure IPv6 because it's disabled in the platform",
+        SetFirewallPolicyError => {
+            return policy_error_to_string(error_state.policy_error.as_ref().unwrap())
+        }
+        SetDnsError => "Failed to set system DNS server",
+        StartTunnelError => "Failed to start connection to remote server",
+        TunnelParameterError => {
+            return format!(
+                "Failure to generate tunnel parameters: {}",
+                tunnel_parameter_error_to_string(error_state.parameter_error)
+            );
+        }
+        IsOffline => "This device is offline, no tunnels can be established",
+        TapAdapterProblem => "A problem with the TAP adapter has been detected",
+        #[cfg(target_os = "android")]
+        VpnPermissionDenied => "The Android VPN permission was denied when creating the tunnel",
+        #[cfg(not(target_os = "android"))]
+        _ => unreachable!("unknown error cause"),
+    };
+
+    error_str.to_string()
+}
+
+fn tunnel_parameter_error_to_string(parameter_error: i32) -> &'static str {
+    match GenerationError::from_i32(parameter_error).expect("unknown generation error") {
+        GenerationError::NoMatchingRelay => "Failure to select a matching tunnel relay",
+        GenerationError::NoMatchingBridgeRelay => "Failure to select a matching bridge relay",
+        GenerationError::NoWireguardKey => "No wireguard key available",
+        GenerationError::CustomTunnelHostResolutionError => {
+            "Can't resolve hostname for custom tunnel host"
+        }
+    }
+}
+
+fn policy_error_to_string(policy_error: &FirewallPolicyError) -> String {
+    let cause = match FirewallPolicyErrorType::from_i32(policy_error.r#type)
+        .expect("unknown policy error")
+    {
+        FirewallPolicyErrorType::Generic => return "Failed to set firewall policy".to_string(),
+        FirewallPolicyErrorType::Locked => format!(
+            "An application prevented the firewall policy from being set: {} (pid {})",
+            policy_error.lock_name, policy_error.lock_pid
+        ),
+    };
+    format!("Failed to set firewall policy: {}", cause)
+}
+
+fn format_protocol(protocol: TransportProtocol) -> &'static str {
+    match protocol {
+        TransportProtocol::Udp => "UDP",
+        TransportProtocol::Tcp => "TCP",
     }
 }

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -10,6 +10,7 @@ pub use mullvad_management_interface::{self, new_rpc_client};
 mod cmds;
 mod format;
 mod location;
+mod state;
 
 pub const BIN_NAME: &str = "mullvad";
 pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
@@ -33,6 +34,9 @@ pub enum Error {
 
     #[error(display = "Command failed: {}", _0)]
     CommandFailed(&'static str),
+
+    #[error(display = "Failed to listen for status updates")]
+    StatusListenerFailed,
 }
 
 #[tokio::main]

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// The given command is not correct in some way
     #[error(display = "Invalid command: {}", _0)]
     InvalidCommand(&'static str),
+
+    #[error(display = "Command failed: {}", _0)]
+    CommandFailed(&'static str),
 }
 
 #[tokio::main]

--- a/mullvad-cli/src/state.rs
+++ b/mullvad-cli/src/state.rs
@@ -1,0 +1,41 @@
+use crate::{Error, Result};
+use futures::{
+    channel::{mpsc, mpsc::Receiver},
+    SinkExt,
+};
+use mullvad_management_interface::{
+    types::{daemon_event::Event as EventType, TunnelState},
+    ManagementServiceClient,
+};
+
+// Spawns a new task that listens for tunnel state changes and forwards it through the returned
+// channel. Panics if called from outside of the Tokio runtime.
+pub fn state_listen(mut rpc: ManagementServiceClient) -> Receiver<Result<TunnelState>> {
+    let (mut sender, receiver) = mpsc::channel::<Result<TunnelState>>(1);
+    tokio::spawn(async move {
+        match rpc.events_listen(()).await {
+            Ok(events) => {
+                let mut events = events.into_inner();
+                loop {
+                    let forward = match events.message().await {
+                        Ok(Some(event)) => match event.event.unwrap() {
+                            EventType::TunnelState(new_state) => Ok(new_state),
+                            _ => continue,
+                        },
+                        Ok(None) => break,
+                        Err(status) => Err(Error::GrpcClientError(status)),
+                    };
+
+                    if let Err(_) = sender.send(forward).await {
+                        break;
+                    }
+                }
+            }
+            Err(status) => {
+                let _ = sender.send(Err(Error::GrpcClientError(status))).await;
+            }
+        }
+    });
+
+    receiver
+}

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -42,7 +42,7 @@ impl DaemonInterface {
 
         self.send_command(DaemonCommand::SetTargetState(tx, TargetState::Secured))?;
 
-        block_on(rx).map_err(|_| Error::NoResponse)
+        block_on(rx).map(|_| ()).map_err(|_| Error::NoResponse)
     }
 
     pub fn create_new_account(&self) -> Result<String> {
@@ -60,7 +60,7 @@ impl DaemonInterface {
 
         self.send_command(DaemonCommand::SetTargetState(tx, TargetState::Unsecured))?;
 
-        block_on(rx).map_err(|_| Error::NoResponse)
+        block_on(rx).map(|_| ()).map_err(|_| Error::NoResponse)
     }
 
     pub fn generate_wireguard_key(&self) -> Result<KeygenEvent> {
@@ -148,7 +148,9 @@ impl DaemonInterface {
     }
 
     pub fn reconnect(&self) -> Result<()> {
-        self.send_command(DaemonCommand::Reconnect)?;
+        let (tx, _) = oneshot::channel();
+
+        self.send_command(DaemonCommand::Reconnect(tx))?;
 
         Ok(())
     }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -8,9 +8,9 @@ import "google/protobuf/wrappers.proto";
 
 service ManagementService {
 	// Control and get tunnel state
-	rpc ConnectTunnel(google.protobuf.Empty) returns (google.protobuf.Empty) {}
-	rpc DisconnectTunnel(google.protobuf.Empty) returns (google.protobuf.Empty) {}
-	rpc ReconnectTunnel(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+	rpc ConnectTunnel(google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
+	rpc DisconnectTunnel(google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
+	rpc ReconnectTunnel(google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
 	rpc GetTunnelState(google.protobuf.Empty) returns (TunnelState) {}
 
 	// Control the daemon and receive events


### PR DESCRIPTION
This PR adds an argument (`--wait`) to the `connect`, `disconnect` and `reconnect` CLI commands which keeps the CLI running until the target state is reached. This will make it possible to run commands in sequence in a bash script, useful for automated testing for example.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2156)
<!-- Reviewable:end -->
