### PR TITLE
Reset DNS config if the tunnel monitor thread goes down

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -212,6 +212,7 @@ impl ConnectedState {
         match poll_result {
             Ok(Async::Ready(block_reason)) => {
                 if let Some(reason) = block_reason {
+                    Self::reset_dns(shared_values);
                     Self::reset_routes(shared_values);
                     return NewState(ErrorState::enter(shared_values, reason));
                 }


### PR DESCRIPTION
A tunnel close event is received if the tunnel monitor thread is shut down unexpectedly, for example if the virtual network adapter is missing on Windows. In case this happens, `ConnectedState::reset_dns` should be called to restore system DNS settings to their initial state, as is done elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2158)
<!-- Reviewable:end -->
