### PR TITLE
Update Kotlin plugin, compiler and library versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,8 +83,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:recyclerview-v7:28.0.0'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.21'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.10'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
     implementation 'joda-time:joda-time:2.10.2'
 }
 
@@ -101,7 +101,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.0'
         classpath 'com.github.triplet.gradle:play-publisher:2.7.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
     }
 }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -135,7 +135,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clipData = ClipData.newPlainText(clipboardLabel, accountToken)
 
-        clipboard.primaryClip = clipData
+        clipboard.setPrimaryClip(clipData)
 
         Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CopyableInformationView.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CopyableInformationView.kt
@@ -58,7 +58,7 @@ class CopyableInformationView : InformationView {
         val clipData = ClipData.newPlainText(clipboardLabel, information)
         val toastMessage = copiedToast ?: context.getString(R.string.copied_to_clipboard)
 
-        clipboard.primaryClip = clipData
+        clipboard.setPrimaryClip(clipData)
 
         Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
     }


### PR DESCRIPTION
This PR updates the Kotlin Gradle plugin (which consequently updates the Kotlin compiler version) and some Kotlin libraries. The only problem with the update was that some Java setter methods don't seem to map to automatic property names anymore, but a simple change fixed it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal change, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2160)
<!-- Reviewable:end -->
