### PR TITLE
Remove spaces from account token before logging in

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -64,7 +64,7 @@ class AccountInput : LinearLayout {
 
     private val button = container.findViewById<ImageButton>(R.id.login_button).apply {
         setOnClickListener {
-            onLogin?.invoke(input.text.toString())
+            onLogin?.invoke(input.text.replace(Regex("[^0-9]"), ""))
         }
     }
 


### PR DESCRIPTION
Recently, the Login screen was updated to show the account number with spaces separating every four digits. However, this formatted string was still used directly as the account token when attempting to login. This meant that login would fail because the spaces were still in the account token. This PR fixes that by removing any non-digit characters from the input before using it as the account token.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not present in any released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2163)
<!-- Reviewable:end -->
