### PR TITLE
Quit when notification is dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash if connection to service is lost while opening the Split Tunneling settings screen.
 - Fix rare crash that could occur when the tunnel state changes when showing or hiding the quick
   settings tile.
+- Fix app starting by itself sometimes.
 
 #### Linux
 - Fix split tunneling rules preventing `systemd-resolved` from performing DNS lookups for excluded

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
             <intent-filter>
                 <action android:name="net.mullvad.mullvadvpn.disconnect_action" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="net.mullvad.mullvadvpn.quit_action" />
+            </intent-filter>
         </service>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadTileService"
                  android:label="@string/app_name"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -46,13 +46,14 @@ class ForegroundNotificationManager(
 
     private var loggedIn by observable(false) { _, _, _ -> updateNotificationAction() }
 
-    private var onForeground = false
-
     private val tunnelState
         get() = tunnelStateEvents?.latestEvent ?: TunnelState.Disconnected()
 
     private val shouldBeOnForeground
         get() = lockedToForeground || !(tunnelState is TunnelState.Disconnected)
+
+    var onForeground = false
+        private set
 
     var lockedToForeground by observable(false) { _, _, _ -> updateNotification() }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -28,6 +28,7 @@ class MullvadVpnService : TalpidVpnService() {
 
         val KEY_CONNECT_ACTION = "net.mullvad.mullvadvpn.connect_action"
         val KEY_DISCONNECT_ACTION = "net.mullvad.mullvadvpn.disconnect_action"
+        val KEY_QUIT_ACTION = "net.mullvad.mullvadvpn.quit_action"
 
         init {
             System.loadLibrary("mullvad_jni")
@@ -99,6 +100,7 @@ class MullvadVpnService : TalpidVpnService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "Starting service")
         val startResult = super.onStartCommand(intent, flags, startId)
+        var quitCommand = false
 
         if (!keyguardManager.isDeviceLocked) {
             val action = intent?.action
@@ -107,10 +109,13 @@ class MullvadVpnService : TalpidVpnService() {
                 pendingAction = PendingAction.Connect
             } else if (action == KEY_DISCONNECT_ACTION) {
                 pendingAction = PendingAction.Disconnect
+            } else if (action == KEY_QUIT_ACTION && !notificationManager.onForeground) {
+                quitCommand = true
+                stop()
             }
         }
 
-        if (shouldStop) {
+        if (shouldStop && !quitCommand) {
             shouldStop = false
 
             if (isStopping) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -37,26 +37,36 @@ class NotificationChannel(
         }
     }
 
-    fun buildNotification(intent: PendingIntent, title: String): Notification {
-        return buildNotification(intent, title, emptyList())
+    fun buildNotification(
+        intent: PendingIntent,
+        title: String,
+        deleteIntent: PendingIntent? = null
+    ): Notification {
+        return buildNotification(intent, title, emptyList(), deleteIntent)
     }
 
-    fun buildNotification(intent: PendingIntent, title: Int): Notification {
-        return buildNotification(intent, title, emptyList())
+    fun buildNotification(
+        intent: PendingIntent,
+        title: Int,
+        deleteIntent: PendingIntent? = null
+    ): Notification {
+        return buildNotification(intent, title, emptyList(), deleteIntent)
     }
 
     fun buildNotification(
         pendingIntent: PendingIntent,
         title: Int,
-        actions: List<NotificationCompat.Action>
+        actions: List<NotificationCompat.Action>,
+        deleteIntent: PendingIntent? = null
     ): Notification {
-        return buildNotification(pendingIntent, context.getString(title), actions)
+        return buildNotification(pendingIntent, context.getString(title), actions, deleteIntent)
     }
 
     fun buildNotification(
         pendingIntent: PendingIntent,
         title: String,
-        actions: List<NotificationCompat.Action>
+        actions: List<NotificationCompat.Action>,
+        deleteIntent: PendingIntent? = null
     ): Notification {
         val builder = NotificationCompat.Builder(context, id)
             .setSmallIcon(R.drawable.small_logo_black)
@@ -66,6 +76,10 @@ class NotificationChannel(
 
         for (action in actions) {
             builder.addAction(action)
+        }
+
+        deleteIntent?.let { intent ->
+            builder.setDeleteIntent(intent)
         }
 
         return builder.build()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -10,6 +10,7 @@ import android.support.v4.app.NotificationCompat
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.service.MullvadVpnService
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
@@ -90,13 +91,15 @@ class TunnelStateNotification(val context: Context) {
         val pendingIntent =
             PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
+        val deleteIntent = buildDeleteIntent()
+
         val actions = if (showAction) {
             listOf(buildAction())
         } else {
             emptyList()
         }
 
-        return channel.buildNotification(pendingIntent, notificationText, actions)
+        return channel.buildNotification(pendingIntent, notificationText, actions, deleteIntent)
     }
 
     private fun buildAction(): NotificationCompat.Action {
@@ -113,5 +116,16 @@ class TunnelStateNotification(val context: Context) {
         }
 
         return NotificationCompat.Action(action.icon, label, pendingIntent)
+    }
+
+    private fun buildDeleteIntent(): PendingIntent {
+        val intent = Intent(MullvadVpnService.KEY_QUIT_ACTION).setPackage("net.mullvad.mullvadvpn")
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT
+
+        if (Build.VERSION.SDK_INT >= 26) {
+            return PendingIntent.getForegroundService(context, 1, intent, flags)
+        } else {
+            return PendingIntent.getService(context, 1, intent, flags)
+        }
     }
 }


### PR DESCRIPTION
There have been a few reports of the app starting by itself (and connecting to the tunnel) when it's not supposed to (for example, after disconnecting while having the auto-connect setting enabled). The cause is still unknown, but this PR is an attempt to prevent this from happening by stopping the background service when the notification is dismissed. By stopping the service, there should be no way for it to start unless the user opens the app again.

Dismissing the notification is only possible if the notification is not on the foreground and the screen is unlocked, which means that it can only be dismissed while disconnected, the screen is unlocked and the tunnel is disconnected.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2164)
<!-- Reviewable:end -->
