### PR TITLE
Update "Report a Problem" screen UI on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
@@ -208,16 +208,28 @@ class ProblemReportFragment : Fragment() {
 
         sentSuccessfullyIcon.visibility = View.VISIBLE
         sendStatusLabel.visibility = View.VISIBLE
-        sendDetailsLabel.visibility = View.VISIBLE
 
         if (!userEmail.isEmpty()) {
             showResponseMessage(userEmail)
         }
 
+        showThanksMessage()
         sendStatusLabel.setText(R.string.sent)
-        sendDetailsLabel.setText(R.string.sent_thanks)
 
         scrollArea.scrollTo(0, titleController.fullCollapseScrollOffset.toInt())
+    }
+
+    private fun showThanksMessage() {
+        val thanks = parentActivity.getString(R.string.sent_thanks)
+        val weWillLookIntoThis = parentActivity.getString(R.string.we_will_look_into_this)
+
+        val colorStyle = ForegroundColorSpan(parentActivity.getColor(R.color.green))
+
+        sendDetailsLabel.text = SpannableStringBuilder("$thanks $weWillLookIntoThis").apply {
+            setSpan(colorStyle, 0, thanks.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        sendDetailsLabel.visibility = View.VISIBLE
     }
 
     private fun showResponseMessage(userEmail: String) {

--- a/android/src/main/res/layout/problem_report.xml
+++ b/android/src/main/res/layout/problem_report.xml
@@ -114,14 +114,6 @@
                                        android:src="@drawable/icon_fail"
                                        android:visibility="gone" />
                         </FrameLayout>
-                        <TextView android:layout_width="wrap_content"
-                                  android:layout_height="wrap_content"
-                                  android:layout_marginBottom="4dp"
-                                  android:textColor="@color/green"
-                                  android:textSize="@dimen/text_medium"
-                                  android:textStyle="bold"
-                                  android:text="@string/secure_connection"
-                                  android:textAllCaps="true" />
                         <TextView android:id="@+id/send_status"
                                   android:layout_width="wrap_content"
                                   android:layout_height="wrap_content"

--- a/android/src/main/res/values-da/strings.xml
+++ b/android/src/main/res/values-da/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Sender...</string>
     <string name="sent">Sendt</string>
     <string name="sent_contact">Hvis det er nødvendigt, kontakter vi dig via %1$s</string>
-    <string name="sent_thanks">Tak! Vi vil undersøge det nærmere.</string>
     <string name="set_dns_error">Kunne ikke indstille system-DNS-serveren</string>
     <string name="set_firewall_policy_error">Kunne ikke anvende firewall-regler. Enheden er muligvis ikke sikret</string>
     <string name="settings">Indstillinger</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Wird gesendet...</string>
     <string name="sent">Gesendet</string>
     <string name="sent_contact">Bei Bedarf werden wir Sie unter %1$s kontaktieren</string>
-    <string name="sent_thanks">Danke! Wir werden uns darum kümmern.</string>
     <string name="set_dns_error">Fehler beim Festlegen des System-DNS-Servers</string>
     <string name="set_firewall_policy_error">Fehler beim Anwenden der Firewall-Regeln. Das Gerät ist derzeit möglicherweise ungesichert</string>
     <string name="settings">Einstellungen</string>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Enviando…</string>
     <string name="sent">Enviado</string>
     <string name="sent_contact">Si es necesario, le enviaremos un mensaje a la dirección %1$s</string>
-    <string name="sent_thanks">¡Gracias! Le echaremos un vistazo.</string>
     <string name="set_dns_error">No se pudo establecer el servidor DNS del sistema</string>
     <string name="set_firewall_policy_error">Error al aplicar las reglas del firewall. Puede que el dispositivo no esté protegido actualmente</string>
     <string name="settings">Configuración</string>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Lähetetään...</string>
     <string name="sent">Lähetetty</string>
     <string name="sent_contact">Tarvittaessa otamme sinuun yhteyttä osoitteeseen %1$s</string>
-    <string name="sent_thanks">Kiitos! Tutkimme asiaa.</string>
     <string name="set_dns_error">Järjestelmän DNS-palvelimen asetus epäonnistui</string>
     <string name="set_firewall_policy_error">Palomuurisääntöjä ei voitu ottaa käyttöön. Laite ei välttämättä ole suojattu.</string>
     <string name="settings">Asetukset</string>

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Envoi...</string>
     <string name="sent">Envoyé</string>
     <string name="sent_contact">Si nécessaire, nous vous contacterons sur %1$s</string>
-    <string name="sent_thanks">Merci ! Nous allons nous pencher dessus.</string>
     <string name="set_dns_error">Échec de la configuration du serveur DNS système</string>
     <string name="set_firewall_policy_error">Échec de l\'application des règles du pare-feu. L\'appareil est potentiellement non sécurisé à l\'heure actuelle</string>
     <string name="settings">Paramètres</string>

--- a/android/src/main/res/values-it/strings.xml
+++ b/android/src/main/res/values-it/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Invio...</string>
     <string name="sent">Inviato</string>
     <string name="sent_contact">Se necessario, ti contatteremo all\'indirizzo %1$s</string>
-    <string name="sent_thanks">Grazie! Verificheremo.</string>
     <string name="set_dns_error">Impossibile impostare il server DNS di sistema</string>
     <string name="set_firewall_policy_error">Impossibile applicare le regole firewall. Il dispositivo potrebbe essere non protetto</string>
     <string name="settings">Impostazioni</string>

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">送信中...</string>
     <string name="sent">送信済み</string>
     <string name="sent_contact">必要に応じて %1$s までご連絡いたします</string>
-    <string name="sent_thanks">ありがとうございます！この問題を調査いたします。</string>
     <string name="set_dns_error">システムの DNS サーバーの設定に失敗しました</string>
     <string name="set_firewall_policy_error">ファイヤーウォール規則の適用に失敗しました。現在、デバイスがセキュリティ保護されていない可能性があります。</string>
     <string name="settings">設定</string>

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">전송 중...</string>
     <string name="sent">전송 완료</string>
     <string name="sent_contact">필요하면 %1$s(으)로 연락드리겠습니다</string>
-    <string name="sent_thanks">감사합니다! 조사해보겠습니다.</string>
     <string name="set_dns_error">시스템 DNS 서버를 설정하지 못했습니다.</string>
     <string name="set_firewall_policy_error">방화벽 규칙을 적용하지 못했습니다. 장치가 현재 안전하지 않을 수 있습니다.</string>
     <string name="settings">설정</string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Sender ...</string>
     <string name="sent">Sendt</string>
     <string name="sent_contact">Vi vil kontakte deg på %1$s ved behov</string>
-    <string name="sent_thanks">Takk! Dette skal vi følge opp.</string>
     <string name="set_dns_error">Kunne ikke angi systemets DNS-server</string>
     <string name="set_firewall_policy_error">Kunne ikke anvende brannmurregler. Enheten kan være usikker</string>
     <string name="settings">Innstillinger</string>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Verzenden...</string>
     <string name="sent">Verzonden</string>
     <string name="sent_contact">Indien nodig nemen we u contact op via %1$s</string>
-    <string name="sent_thanks">Bedankt! We gaan het bekijken.</string>
     <string name="set_dns_error">Instellen van DNS-server van systeem is mislukt</string>
     <string name="set_firewall_policy_error">Toepassen van firewallregels is mislukt. Het toestel is nu mogelijk niet beveiligd</string>
     <string name="settings">Instellingen</string>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Wysyłanie...</string>
     <string name="sent">Wysłano</string>
     <string name="sent_contact">W razie potrzeby skontaktujemy się z Tobą pod adresem %1$s</string>
-    <string name="sent_thanks">Dziękujemy! Sprawdzimy to.</string>
     <string name="set_dns_error">Niepowodzenie ustawienia systemowego serwera DNS</string>
     <string name="set_firewall_policy_error">Błąd stosowania reguł zapory. Urządzenie może być obecnie niezabezpieczone</string>
     <string name="settings">Ustawienia</string>

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">A enviar...</string>
     <string name="sent">Enviado</string>
     <string name="sent_contact">Se necessário, iremos contactá-lo através de %1$s</string>
-    <string name="sent_thanks">Obrigado! Vamos analisar esta situação.</string>
     <string name="set_dns_error">Erro ao definir o servidor de sistema DNS</string>
     <string name="set_firewall_policy_error">Erro ao aplicar as regras da firewall. O dispositivo pode estar atualmente inseguro</string>
     <string name="settings">Definições</string>

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Идет отправка...</string>
     <string name="sent">Отправлено</string>
     <string name="sent_contact">При необходимости мы свяжемся с вами по адресу %1$s</string>
-    <string name="sent_thanks">Спасибо! Мы рассмотрим эту проблему.</string>
     <string name="set_dns_error">Не удалось установить системный DNS-сервер</string>
     <string name="set_firewall_policy_error">Не удалось применить правила брандмауэра. Сейчас устройство может быть не защищено</string>
     <string name="settings">Настройки</string>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Skicka...</string>
     <string name="sent">Skickat</string>
     <string name="sent_contact">Om det behövs kontaktar vi dig på %1$s</string>
-    <string name="sent_thanks">Tack! Vi kommer att undersöka detta.</string>
     <string name="set_dns_error">Det gick inte att ange systemets DNS-server</string>
     <string name="set_firewall_policy_error">Det gick inte att tillämpa brandväggsregler. Enheten kan för närvarande vara osäker</string>
     <string name="settings">Inställningar</string>

--- a/android/src/main/res/values-th/strings.xml
+++ b/android/src/main/res/values-th/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">กำลังส่ง...</string>
     <string name="sent">ส่ง</string>
     <string name="sent_contact">เราจะติดต่อคุณทาง %1$s หากจำเป็น</string>
-    <string name="sent_thanks">ขอบคุณมาก! เราจะตรวจสอบปัญหานี้</string>
     <string name="set_dns_error">ไม่สามารถตั้งค่าเซิร์ฟเวอร์ DNS ของระบบได้</string>
     <string name="set_firewall_policy_error">ไม่สามารถปรับใช้งานกฎของไฟร์วอลล์ได้ อุปกรณ์อาจไม่มีความปลอดภัยในขณะนี้</string>
     <string name="settings">การตั้งค่า</string>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">Gönderiliyor...</string>
     <string name="sent">Gönderildi</string>
     <string name="sent_contact">Gerektiğinde sizinle %1$s adresinden iletişime geçeceğiz</string>
-    <string name="sent_thanks">Teşekkürler! Bunu araştıracağız.</string>
     <string name="set_dns_error">Sistem DNS sunucusu belirlenemiyor</string>
     <string name="set_firewall_policy_error">Güvenlik duvarı kuralları uygulanamıyor. Cihaz şu an korumasız olabilir</string>
     <string name="settings">Ayarlar</string>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -71,7 +71,6 @@
     <string name="sending">正在发送…</string>
     <string name="sent">已发送</string>
     <string name="sent_contact">如果需要，我们将通过 %1$s 与您联系</string>
-    <string name="sent_thanks">谢谢！我们将对此进行调查。</string>
     <string name="set_dns_error">无法设置系统 DNS 服务器</string>
     <string name="set_firewall_policy_error">无法应用防火墙规则。设备当前可能不会受到保护</string>
     <string name="settings">设置</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -74,7 +74,6 @@
     <string name="sending">傳送中...</string>
     <string name="sent">已傳送</string>
     <string name="sent_contact">如有需要，我們將以 %1$s 與您聯繫</string>
-    <string name="sent_thanks">謝謝！我們會對此進行調查。</string>
     <string name="set_dns_error">無法設定系統 DNS 伺服器</string>
     <string name="set_firewall_policy_error">無法套用防火牆規則。裝置目前可能不安全</string>
     <string name="settings">設定</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -85,7 +85,8 @@
     address.</string>
     <string name="send_anyway">Send anyway</string>
     <string name="back">Back</string>
-    <string name="sent_thanks">Thanks! We will look into this.</string>
+    <string name="sent_thanks">Thanks!</string>
+    <string name="we_will_look_into_this">We will look into this.</string>
     <string name="sent_contact">If needed we will contact you on %1$s</string>
     <string name="failed_to_send_details">You may need to go back to the app\'s main screen and
     click Disconnect before trying again. Don\'t worry, the information you entered will remain in


### PR DESCRIPTION
This PR updates the "Report a Problem" screen on Android to match the new UI specification. The "Secure Connection" subtitle was removed and the the "Thanks!" part of the message shown after a successful send is now green. However, due to the need to split the message in two parts, the translations entries are no longer valid and were removed. They will match the translation entries on the desktop once they are updated, so the conversion should be simple using the translation converter tool.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Small UI tweak, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2165)
<!-- Reviewable:end -->
