### PR TITLE
Add persistent firewall filters on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ Line wrap the file at 100 chars.                                              Th
   settings tile.
 - Fix app starting by itself sometimes.
 
+### Security
+#### Windows
+- Block all traffic received or sent before the BFE service and daemon service have started during
+  boot, if "Always require VPN" or auto-connect is enabled.
+
 
 ## [2020.6-beta3] - 2020-10-06
 This release is for desktop only.

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -640,6 +640,13 @@ where
             }
         }
 
+        // If auto-connect is enabled, block all traffic before shutting down to ensure
+        // that no traffic can leak during boot.
+        #[cfg(windows)]
+        if self.settings.auto_connect {
+            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
+        }
+
         self.finalize().await;
         Ok(())
     }

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -319,11 +319,11 @@ mod winfw {
     }
 
     #[allow(dead_code)]
-    #[repr(u8)]
+    #[repr(u32)]
     #[derive(Clone, Copy)]
     pub enum WinFwCleanupPolicy {
-        ContinueBlocking = 0u8,
-        ResetFirewall = 1u8,
+        ContinueBlocking = 0,
+        ResetFirewall = 1,
     }
 
     ffi_error!(InitializationResult, Error::Initialization);

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -100,7 +100,7 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 {
 	std::multimap<WfpObjectType, GUID> registry;
 
-	if (IdentityQualifier::IncludeDeprecated == qualifier)
+	if (IdentityQualifier::IncludeDeprecated == (qualifier & IdentityQualifier::IncludeDeprecated))
 	{
 		registry = DeprecatedIdentities();
 	}
@@ -147,6 +147,22 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Dns_PermitTunnel_Outbound_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Dns_PermitTunnel_Outbound_Ipv6()));
 
+	if (IdentityQualifier::IncludePersistent == (qualifier & IdentityQualifier::IncludePersistent))
+	{
+		registry.insert(std::make_pair(WfpObjectType::Provider, ProviderPersistent()));
+		registry.insert(std::make_pair(WfpObjectType::Sublayer, SublayerPersistent()));
+
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Boottime_BlockAll_Inbound_Ipv4()));
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Boottime_BlockAll_Outbound_Ipv4()));
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Boottime_BlockAll_Inbound_Ipv6()));
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Boottime_BlockAll_Outbound_Ipv6()));
+
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Persistent_BlockAll_Inbound_Ipv4()));
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Persistent_BlockAll_Outbound_Ipv4()));
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Persistent_BlockAll_Inbound_Ipv6()));
+		registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Persistent_BlockAll_Outbound_Ipv6()));
+	}
+
 	return registry;
 }
 
@@ -159,6 +175,20 @@ const GUID &MullvadGuids::Provider()
 		0xb9db,
 		0x43c0,
 		{ 0xb3, 0x43, 0xeb, 0x93, 0x65, 0xc7, 0xbd, 0xd2 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::ProviderPersistent()
+{
+	static const GUID g =
+	{
+		0x2bc5bc63,
+		0x80b0,
+		0x4119,
+		{ 0x86, 0xd3, 0x6a, 0xfe, 0x0d, 0xff, 0x2a, 0x26 }
 	};
 
 	return g;
@@ -187,6 +217,132 @@ const GUID &MullvadGuids::SublayerDns()
 		0xcca1,
 		0x4937,
 		{ 0xaa, 0xce, 0x51, 0x25, 0x6e, 0xf4, 0x81, 0xf3 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::SublayerPersistent()
+{
+	static const GUID g =
+	{
+		0x3c28881e,
+		0x8891,
+		0x4d61,
+		{ 0xb8, 0x7f, 0xf2, 0x72, 0x50, 0x2d, 0x10, 0x05 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Boottime_BlockAll_Outbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x5996aa42,
+		0x102b,
+		0x419f,
+		{ 0xad, 0x3d, 0x83, 0x5d, 0xb5, 0xb, 0x8b, 0x1 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Boottime_BlockAll_Inbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x6150b73d,
+		0x4dfa,
+		0x4c30,
+		{ 0x80, 0xeb, 0xe0, 0xee, 0x53, 0x51, 0x93, 0xda }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Boottime_BlockAll_Outbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0x139b8b26,
+		0x5037,
+		0x4929,
+		{ 0x92, 0x37, 0xe8, 0x73, 0xbd, 0xdd, 0x65, 0x1d }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Boottime_BlockAll_Inbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0x129927e2,
+		0x7a3a,
+		0x49bb,
+		{ 0xb9, 0x87, 0x36, 0x92, 0x56, 0x3a, 0x83, 0xf4 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Persistent_BlockAll_Outbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x79860c64,
+		0x9a5e,
+		0x48a3,
+		{ 0xb5, 0xf3, 0xd6, 0x4b, 0x41, 0x65, 0x9a, 0xa5 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Persistent_BlockAll_Inbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x9f177f14,
+		0xf090,
+		0x4fde,
+		{ 0x98, 0xf9, 0x84, 0x15, 0x31, 0x25, 0xa7, 0xc5 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Persistent_BlockAll_Outbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0xa9b72749,
+		0xb1c1,
+		0x4483,
+		{ 0xa3, 0x71, 0x90, 0xe1, 0x86, 0x68, 0x53, 0x2e }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Persistent_BlockAll_Inbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0x333e7e5c,
+		0x9293,
+		0x4bda,
+		{ 0x8b, 0x19, 0xb6, 0x70, 0x19, 0x1c, 0xc4, 0x7c }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -19,10 +19,12 @@ private:
 
 public:
 
-	enum class IdentityQualifier
+	enum class IdentityQualifier : uint32_t
 	{
-		IncludeDeprecated,
-		OnlyCurrent,
+		OnlyCurrent			= 0x00,
+		IncludeDeprecated	= 0x01,
+		IncludePersistent	= 0x02,
+		IncludeAll			= IncludeDeprecated | IncludePersistent,
 	};
 
 	static IdentityRegistry Registry(IdentityQualifier qualifier);
@@ -89,4 +91,31 @@ public:
 	static const GUID &Filter_Dns_PermitNonTunnel_Outbound_Ipv6();
 	static const GUID &Filter_Dns_PermitTunnel_Outbound_Ipv4();
 	static const GUID &Filter_Dns_PermitTunnel_Outbound_Ipv6();
+
+	//
+	// Persistent and boot-time filters
+	//
+
+	static const GUID &ProviderPersistent();
+	static const GUID &SublayerPersistent();
+
+	static const GUID &Filter_Boottime_BlockAll_Inbound_Ipv4();
+	static const GUID &Filter_Boottime_BlockAll_Outbound_Ipv4();
+	static const GUID &Filter_Boottime_BlockAll_Inbound_Ipv6();
+	static const GUID &Filter_Boottime_BlockAll_Outbound_Ipv6();
+
+	static const GUID &Filter_Persistent_BlockAll_Inbound_Ipv4();
+	static const GUID &Filter_Persistent_BlockAll_Outbound_Ipv4();
+	static const GUID &Filter_Persistent_BlockAll_Inbound_Ipv6();
+	static const GUID &Filter_Persistent_BlockAll_Outbound_Ipv6();
 };
+
+inline MullvadGuids::IdentityQualifier operator|(MullvadGuids::IdentityQualifier lhs, MullvadGuids::IdentityQualifier rhs)
+{
+	return static_cast<MullvadGuids::IdentityQualifier>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+inline MullvadGuids::IdentityQualifier operator&(MullvadGuids::IdentityQualifier lhs, MullvadGuids::IdentityQualifier rhs)
+{
+	return static_cast<MullvadGuids::IdentityQualifier>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}

--- a/windows/winfw/src/winfw/mullvadobjects.cpp
+++ b/windows/winfw/src/winfw/mullvadobjects.cpp
@@ -44,3 +44,33 @@ std::unique_ptr<wfp::SublayerBuilder> MullvadObjects::SublayerDns()
 
 	return builder;
 }
+
+//static
+std::unique_ptr<wfp::ProviderBuilder> MullvadObjects::ProviderPersistent()
+{
+	auto builder = std::make_unique<wfp::ProviderBuilder>();
+
+	(*builder)
+		.name(L"Mullvad VPN persistent")
+		.description(L"Mullvad VPN firewall integration")
+		.persistent()
+		.key(MullvadGuids::ProviderPersistent());
+
+	return builder;
+}
+
+//static
+std::unique_ptr<wfp::SublayerBuilder> MullvadObjects::SublayerPersistent()
+{
+	auto builder = std::make_unique<wfp::SublayerBuilder>();
+
+	(*builder)
+		.name(L"Mullvad VPN persistent")
+		.description(L"Filters that restrict traffic before WinFw is initialized")
+		.key(MullvadGuids::SublayerPersistent())
+		.provider(MullvadGuids::ProviderPersistent())
+		.persistent()
+		.weight(MAXUINT16);
+
+	return builder;
+}

--- a/windows/winfw/src/winfw/mullvadobjects.h
+++ b/windows/winfw/src/winfw/mullvadobjects.h
@@ -15,4 +15,7 @@ public:
 	static std::unique_ptr<wfp::ProviderBuilder> Provider();
 	static std::unique_ptr<wfp::SublayerBuilder> SublayerBaseline();
 	static std::unique_ptr<wfp::SublayerBuilder> SublayerDns();
+
+	static std::unique_ptr<wfp::ProviderBuilder> ProviderPersistent();
+	static std::unique_ptr<wfp::SublayerBuilder> SublayerPersistent();
 };

--- a/windows/winfw/src/winfw/objectpurger.cpp
+++ b/windows/winfw/src/winfw/objectpurger.cpp
@@ -29,7 +29,7 @@ ObjectPurger::RemovalFunctor ObjectPurger::GetRemoveFiltersFunctor()
 {
 	return [](wfp::FilterEngine &engine)
 	{
-		const auto registry = MullvadGuids::DetailedRegistry(MullvadGuids::IdentityQualifier::IncludeDeprecated);
+		const auto registry = MullvadGuids::DetailedRegistry(MullvadGuids::IdentityQualifier::IncludeAll);
 
 		// Resolve correct overload.
 		void (*deleter)(wfp::FilterEngine &, const GUID &) = wfp::ObjectDeleter::DeleteFilter;
@@ -40,6 +40,22 @@ ObjectPurger::RemovalFunctor ObjectPurger::GetRemoveFiltersFunctor()
 
 //static
 ObjectPurger::RemovalFunctor ObjectPurger::GetRemoveAllFunctor()
+{
+	return [](wfp::FilterEngine &engine)
+	{
+		const auto registry = MullvadGuids::DetailedRegistry(MullvadGuids::IdentityQualifier::IncludeAll);
+
+		// Resolve correct overload.
+		void(*deleter)(wfp::FilterEngine &, const GUID &) = wfp::ObjectDeleter::DeleteFilter;
+
+		RemoveRange(engine, deleter, registry.equal_range(WfpObjectType::Filter));
+		RemoveRange(engine, wfp::ObjectDeleter::DeleteSublayer, registry.equal_range(WfpObjectType::Sublayer));
+		RemoveRange(engine, wfp::ObjectDeleter::DeleteProvider, registry.equal_range(WfpObjectType::Provider));
+	};
+}
+
+//static
+ObjectPurger::RemovalFunctor ObjectPurger::GetRemoveNonPersistentFunctor()
 {
 	return [](wfp::FilterEngine &engine)
 	{

--- a/windows/winfw/src/winfw/objectpurger.h
+++ b/windows/winfw/src/winfw/objectpurger.h
@@ -15,6 +15,7 @@ public:
 
 	static RemovalFunctor GetRemoveFiltersFunctor();
 	static RemovalFunctor GetRemoveAllFunctor();
+	static RemovalFunctor GetRemoveNonPersistentFunctor();
 
 	static bool Execute(RemovalFunctor f);
 };

--- a/windows/winfw/src/winfw/rules/persistent/blockall.cpp
+++ b/windows/winfw/src/winfw/rules/persistent/blockall.cpp
@@ -1,0 +1,116 @@
+#include "stdafx.h"
+#include "blockall.h"
+#include <winfw/mullvadguids.h>
+#include <libwfp/filterbuilder.h>
+#include <libwfp/nullconditionbuilder.h>
+
+namespace rules::persistent
+{
+
+bool BlockAll::apply(IObjectInstaller &objectInstaller)
+{
+	wfp::FilterBuilder filterBuilder;
+
+	//
+	// Add boot-time filters (i.e., filters applied before BFE starts)
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Boottime_BlockAll_Outbound_Ipv4())
+		.name(L"Block all outbound connections (IPv4)")
+		.description(L"This filter is part of a rule that restricts inbound and outbound traffic")
+		.provider(MullvadGuids::ProviderPersistent())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
+		.sublayer(MullvadGuids::SublayerPersistent())
+		.weight(wfp::FilterBuilder::WeightClass::Max)
+		.boottime()
+		.block();
+
+	wfp::NullConditionBuilder nullConditionBuilder;
+
+	if (false == objectInstaller.addFilter(filterBuilder, nullConditionBuilder))
+	{
+		return false;
+	}
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Boottime_BlockAll_Inbound_Ipv4())
+		.name(L"Block all inbound connections (IPv4)")
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4);
+
+	if (false == objectInstaller.addFilter(filterBuilder, nullConditionBuilder))
+	{
+		return false;
+	}
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Boottime_BlockAll_Outbound_Ipv6())
+		.name(L"Block all outbound connections (IPv6)")
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+	if (false == objectInstaller.addFilter(filterBuilder, nullConditionBuilder))
+	{
+		return false;
+	}
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Boottime_BlockAll_Inbound_Ipv6())
+		.name(L"Block all inbound connections (IPv6)")
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+
+	if (false == objectInstaller.addFilter(filterBuilder, nullConditionBuilder))
+	{
+		return false;
+	}
+
+	//
+	// Add persistent filters (i.e., filters applied when BFE has started)
+	//
+
+	wfp::FilterBuilder persistentFilterBuilder;
+
+	persistentFilterBuilder
+		.key(MullvadGuids::Filter_Persistent_BlockAll_Outbound_Ipv4())
+		.name(L"Block all outbound connections (IPv4)")
+		.description(L"This filter is part of a rule that restricts inbound and outbound traffic")
+		.provider(MullvadGuids::ProviderPersistent())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
+		.sublayer(MullvadGuids::SublayerPersistent())
+		.weight(wfp::FilterBuilder::WeightClass::Max)
+		.persistent()
+		.block();
+
+	if (false == objectInstaller.addFilter(persistentFilterBuilder, nullConditionBuilder))
+	{
+		return false;
+	}
+
+	persistentFilterBuilder
+		.key(MullvadGuids::Filter_Persistent_BlockAll_Inbound_Ipv4())
+		.name(L"Block all inbound connections (IPv4)")
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4);
+
+	if (false == objectInstaller.addFilter(persistentFilterBuilder, nullConditionBuilder))
+	{
+		return false;
+	}
+
+	persistentFilterBuilder
+		.key(MullvadGuids::Filter_Persistent_BlockAll_Outbound_Ipv6())
+		.name(L"Block all outbound connections (IPv6)")
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+	if (false == objectInstaller.addFilter(persistentFilterBuilder, nullConditionBuilder))
+	{
+		return false;
+	}
+
+	persistentFilterBuilder
+		.key(MullvadGuids::Filter_Persistent_BlockAll_Inbound_Ipv6())
+		.name(L"Block all inbound connections (IPv6)")
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+
+	return objectInstaller.addFilter(persistentFilterBuilder, nullConditionBuilder);
+}
+
+}

--- a/windows/winfw/src/winfw/rules/persistent/blockall.h
+++ b/windows/winfw/src/winfw/rules/persistent/blockall.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <winfw/rules/ifirewallrule.h>
+
+namespace rules::persistent
+{
+
+class BlockAll : public IFirewallRule
+{
+public:
+
+	BlockAll() = default;
+	~BlockAll() = default;
+	
+	bool apply(IObjectInstaller &objectInstaller) override;
+};
+
+}

--- a/windows/winfw/src/winfw/sessioncontroller.cpp
+++ b/windows/winfw/src/winfw/sessioncontroller.cpp
@@ -60,7 +60,7 @@ bool CheckpointKeyToIndex(const std::vector<SessionRecord> &container, uint32_t 
 
 SessionController::SessionController(std::unique_ptr<wfp::FilterEngine> &&engine)
 	: m_engine(std::move(engine))
-	, m_identityRegistry(MullvadGuids::Registry(MullvadGuids::IdentityQualifier::OnlyCurrent))
+	, m_identityRegistry(MullvadGuids::Registry(MullvadGuids::IdentityQualifier::IncludePersistent))
 	, m_activeTransaction(false)
 {
 }

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -92,10 +92,12 @@ WinFw_InitializeBlocked(
 	void *logSinkContext
 );
 
-enum WINFW_CLEANUP_POLICY
+enum WINFW_CLEANUP_POLICY : uint32_t
 {
 	// Continue blocking if this happens to be the active policy
 	// otherwise reset the firewall.
+	// This adds persistent blocking filters that are active until
+	// WinFw is reinitialized.
 	WINFW_CLEANUP_POLICY_CONTINUE_BLOCKING = 0,
 
 	// Remove all objects that have been registered with WFP.

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="rules\dns\permitnontunnel.cpp" />
     <ClCompile Include="rules\dns\permittunnel.cpp" />
     <ClCompile Include="rules\multi\permitvpnrelay.cpp" />
+    <ClCompile Include="rules\persistent\blockall.cpp" />
     <ClCompile Include="rules\shared.cpp" />
     <ClCompile Include="sessioncontroller.cpp" />
     <ClCompile Include="sessionrecord.cpp" />
@@ -71,6 +72,7 @@
     <ClInclude Include="rules\dns\permitnontunnel.h" />
     <ClInclude Include="rules\dns\permittunnel.h" />
     <ClInclude Include="rules\multi\permitvpnrelay.h" />
+    <ClInclude Include="rules\persistent\blockall.h" />
     <ClInclude Include="rules\ports.h" />
     <ClInclude Include="rules\shared.h" />
     <ClInclude Include="wfpobjecttype.h" />

--- a/windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClCompile Include="rules\multi\permitvpnrelay.cpp">
       <Filter>rules\multi</Filter>
     </ClCompile>
+    <ClCompile Include="rules\persistent\blockall.cpp">
+      <Filter>rules\persistent</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -126,6 +129,9 @@
     <ClInclude Include="rules\multi\permitvpnrelay.h">
       <Filter>rules\multi</Filter>
     </ClInclude>
+    <ClInclude Include="rules\persistent\blockall.h">
+      <Filter>rules\persistent</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="rules">
@@ -139,6 +145,9 @@
     </Filter>
     <Filter Include="rules\multi">
       <UniqueIdentifier>{005cce7c-ed9d-4675-8e4f-759c9682b77e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rules\persistent">
+      <UniqueIdentifier>{d98577af-1119-4c3a-8a04-d24f461ee61c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
These changes cause the WinFw module to add persistent WFP filters when deinitialized with the "continue blocking" cleanup policy, and the daemon exits in a blocking state. This happens if "Always require VPN" is enabled, or if auto-connect is enabled.

Two sets of filters are required: Boot-time filters are used for blocking traffic before the BFE service has started. Persistent filters are used to block traffic after the BFE service has started, but before mullvad-daemon has started.

This prevents traffic leaks during boot when either "Always require VPN" or auto-connect is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2168)
<!-- Reviewable:end -->
