### PR TITLE
Avoid unnecessary rebuilds in build.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,11 +554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "futures"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -629,7 +624,6 @@ name = "futures-util"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3181,7 +3175,6 @@ dependencies = [
 "checksum fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 "checksum futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 "checksum futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"

--- a/build.sh
+++ b/build.sh
@@ -134,20 +134,20 @@ fi
 ################################################################################
 ./wireguard/build-wireguard-go.sh
 
+export MULLVAD_ADD_MANIFEST="1"
+
 echo "Building Rust code in release mode using $RUSTC_VERSION..."
 
+cargo +stable build $CARGO_ARGS --release
+
 if [[ ("$(uname -s)" == "Darwin") || ("$(uname -s)" == "Linux") ]]; then
-    pushd mullvad-cli
     mkdir -p "$SCRIPT_DIR/dist-assets/shell-completions"
     for sh in bash zsh fish; do
         echo "Generating shell completion script for $sh..."
-        cargo +stable run $CARGO_ARGS --release --features shell-completions -- \
-            shell-completions "$sh" "$SCRIPT_DIR/dist-assets/shell-completions/"
+        cargo +stable run --bin mullvad $CARGO_ARGS --release -- shell-completions "$sh" \
+            "$SCRIPT_DIR/dist-assets/shell-completions/"
     done
-    popd
 fi
-
-MULLVAD_ADD_MANIFEST="1" cargo +stable build $CARGO_ARGS --release
 
 ################################################################################
 # Other work to prepare the release.

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -7,10 +7,6 @@ license = "GPL-3.0"
 edition = "2018"
 publish = false
 
-[features]
-default = []
-shell-completions = []
-
 [[bin]]
 name = "mullvad"
 path = "src/main.rs"

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -57,7 +57,6 @@ async fn run() -> Result<()> {
     let commands = cmds::get_commands();
     let app = build_cli(&commands);
 
-    #[cfg(feature = "shell-completions")]
     let app = app.subcommand(
         clap::SubCommand::with_name("shell-completions")
             .about("Generates completion scripts for your shell")
@@ -71,12 +70,12 @@ async fn run() -> Result<()> {
                 clap::Arg::with_name("DIR")
                     .default_value("./")
                     .help("Output directory where the shell completions are written"),
-            ),
+            )
+            .setting(clap::AppSettings::Hidden),
     );
 
     let app_matches = app.get_matches();
     match app_matches.subcommand() {
-        #[cfg(feature = "shell-completions")]
         ("shell-completions", Some(sub_matches)) => {
             let shell = sub_matches
                 .value_of("SHELL")

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -12,7 +12,7 @@ atty = "0.2"
 cfg-if = "0.1"
 duct = "0.13"
 err-derive = "0.2.1"
-futures = { package = "futures", version = "0.3", features = [ "compat" ]}
+futures = "0.3"
 hex = "0.4"
 ipnetwork = "0.16"
 lazy_static = "1.0"
@@ -57,7 +57,6 @@ netlink-packet-route = "0.4"
 netlink-proto = "0.4"
 netlink-sys = "0.4"
 byteorder = "1"
-futures = { package = "futures", version = "0.3" }
 nftnl = { version = "0.5", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2.0", features = ["mnl-1-0-4"] }
 which = { version = "4.0", default-features = false }

--- a/update-relays.sh
+++ b/update-relays.sh
@@ -2,4 +2,5 @@
 
 echo "Updating relay list..."
 set -e
-cargo run -p mullvad-rpc --bin relay_list > dist-assets/relays.json
+
+cargo +stable run --bin relay_list --release > dist-assets/relays.json


### PR DESCRIPTION
Currently, `build.sh` builds all dependencies three times: Once when `cargo build` is run, once before the CLI is used to generate shell completions, and once before running the relay list updater.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2174)
<!-- Reviewable:end -->
