### PR TITLE
Remember scroll position when navigating back

### DIFF
--- a/gui/src/renderer/lib/utilityHooks.ts
+++ b/gui/src/renderer/lib/utilityHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 export function useMounted() {
   const mountedRef = useRef(false);
@@ -12,4 +12,16 @@ export function useMounted() {
   }, []);
 
   return isMounted;
+}
+
+export function useCombinedRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> {
+  return useCallback((element: T | null) => refs.forEach((ref) => assignToRef(element, ref)), []);
+}
+
+function assignToRef<T>(element: T | null, ref?: React.Ref<T>) {
+  if (typeof ref === 'function') {
+    ref(element);
+  } else if (ref && element) {
+    (ref as React.MutableRefObject<T>).current = element;
+  }
 }

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -24,12 +24,25 @@ export interface ISetWindowFocusedAction {
   focused: boolean;
 }
 
+export interface IAddScrollPosition {
+  type: 'ADD_SCROLL_POSITION';
+  path: string;
+  scrollPosition: [number, number];
+}
+
+export interface IRemoveScrollPosition {
+  type: 'REMOVE_SCROLL_POSITION';
+  path: string;
+}
+
 export type UserInterfaceAction =
   | IUpdateLocaleAction
   | IUpdateWindowArrowPositionAction
   | IUpdateConnectionInfoOpenAction
   | ISetLocationScopeAction
-  | ISetWindowFocusedAction;
+  | ISetWindowFocusedAction
+  | IAddScrollPosition
+  | IRemoveScrollPosition;
 
 function updateLocale(locale: string): IUpdateLocaleAction {
   return {
@@ -65,10 +78,27 @@ function setWindowFocused(focused: boolean): ISetWindowFocusedAction {
   };
 }
 
+function addScrollPosition(path: string, scrollPosition: [number, number]): IAddScrollPosition {
+  return {
+    type: 'ADD_SCROLL_POSITION',
+    path,
+    scrollPosition,
+  };
+}
+
+function removeScrollPosition(path: string): IRemoveScrollPosition {
+  return {
+    type: 'REMOVE_SCROLL_POSITION',
+    path,
+  };
+}
+
 export default {
   updateLocale,
   updateWindowArrowPosition,
   toggleConnectionPanel,
   setLocationScope,
   setWindowFocused,
+  addScrollPosition,
+  removeScrollPosition,
 };

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -11,6 +11,7 @@ export interface IUserInterfaceReduxState {
   connectionPanelVisible: boolean;
   locationScope: LocationScope;
   windowFocused: boolean;
+  scrollPosition: Record<string, [number, number]>;
 }
 
 const initialState: IUserInterfaceReduxState = {
@@ -18,6 +19,7 @@ const initialState: IUserInterfaceReduxState = {
   connectionPanelVisible: false,
   locationScope: LocationScope.relay,
   windowFocused: false,
+  scrollPosition: {},
 };
 
 export default function (
@@ -39,6 +41,18 @@ export default function (
 
     case 'SET_WINDOW_FOCUSED':
       return { ...state, windowFocused: action.focused };
+
+    case 'ADD_SCROLL_POSITION':
+      return {
+        ...state,
+        scrollPosition: { ...state.scrollPosition, [action.path]: action.scrollPosition },
+      };
+
+    case 'REMOVE_SCROLL_POSITION': {
+      const scrollPosition = { ...state.scrollPosition };
+      delete scrollPosition[action.path];
+      return { ...state, scrollPosition };
+    }
 
     default:
       return state;


### PR DESCRIPTION
This PR makes the app remember the scroll position when navigating to reset the scroll position to the correct location when navigating backwards.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2179)
<!-- Reviewable:end -->
