### PR TITLE
Fix skipped map pan/zoom animation when switching location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add button to remove account and WireGuard key from history in the login screen.
 
 ### Fixed
+- Fix missing map animation after selecting a new location in the desktop app.
+
 #### Android
 - Fix connect action button sometimes showing itself as "Cancel" instead of "Secure my connection"
   for a few seconds.


### PR DESCRIPTION
This PR adds a custom `ZoomableGroup` component which doesn't contain the issue where the map zooms and pans to the initial location. As a result the other workaround can be removed and therefore both the initial transition issue and the missing transition issue caused by the first workaround is fixed.

The `ZoomableGroup` implementation can be removed when this issue has been solved:
https://github.com/zcreativelabs/react-simple-maps/issues/228

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2185)
<!-- Reviewable:end -->
