### PR TITLE
Fix warning about unregocnized DOM element prop in AppButton

### DIFF
--- a/gui/src/renderer/components/AppButton.tsx
+++ b/gui/src/renderer/components/AppButton.tsx
@@ -47,7 +47,7 @@ export interface IProps extends React.HTMLAttributes<HTMLButtonElement> {
 }
 
 const BaseButton = React.memo(function BaseButtonT(props: IProps) {
-  const { children, ...otherProps } = props;
+  const { children, textOffset, ...otherProps } = props;
 
   const [textAdjustment, setTextAdjustment] = useState(0);
   const buttonRef = useRef() as React.RefObject<HTMLButtonElement>;
@@ -66,8 +66,7 @@ const BaseButton = React.memo(function BaseButtonT(props: IProps) {
       const trailingSpace = buttonRect.width - (leftDiff + textRect.width);
 
       // calculate text adjustment
-      const textOffset = props.textOffset ?? 0;
-      const textAdjustment = leftDiff - trailingSpace - textOffset;
+      const textAdjustment = leftDiff - trailingSpace - (textOffset ?? 0);
 
       // re-render the view with the new text adjustment if it changed
       setTextAdjustment(textAdjustment);


### PR DESCRIPTION
The prop `textOffset` is passed to `SimpleButton` which passes it the `button` element causing React to log a warning. This doesn't affect behaviour of the button and the warning is only logged in development mode. This PR fixes this by not passing `textOffset` to `SimpleButton`.

The `textOffset` prop is only used in `MultiButton` which is only used for the disconnect/reconnect buttons.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2187)
<!-- Reviewable:end -->
