### PR TITLE
Support custom DNS servers on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add `--wait` flag to `connect`, `disconnect` and `reconnect` CLI subcommands to make the CLI wait
   for the target state to be reached before exiting.
 
+#### Windows
+- Add support for custom DNS resolvers (CLI only).
+
 ### Changed
 - Use the API to fetch API IP addresses instead of DNS.
 - Remove WireGuard keys during uninstallation after the firewall is unlocked.

--- a/docs/security.md
+++ b/docs/security.md
@@ -156,8 +156,11 @@ stays active until the user requests a disconnect, quit, server change, change o
 that affects the tunnel or until the tunnel goes down unexpectedly.
 
 In this state, all traffic in both directions over the tunnel interface is allowed. Minus DNS
-requests (TCP and UDP destination port 53) not to a gateway IP on the tunnel interface.
-Meaning we can *only* request DNS inside the tunnel and *only* from the relay server itself.
+requests (TCP and UDP destination port 53) not to a gateway IP on the tunnel interface or
+one of the defined custom DNS servers.
+We can *only* request DNS inside the tunnel and *only* from the relay server itself,
+unless one or more custom DNS servers are provided. If custom servers are specified, DNS requests
+can only be made to them.
 
 This state allows traffic on all interfaces to and from the IP+port+protocol combination that
 the tunnel runs over. See the [connecting] state for details on this rule.
@@ -237,11 +240,10 @@ Since an invalid or missing DNS response prevents the user from going where they
 it is important that it works and gives correct replies, from an anti-censorship point of view.
 Poisoned DNS replies is a very common way of censoring the network in many places.
 
-With the above as background, the app makes sure that every DNS request from the device goes
-inside the VPN tunnel and to exactly one place, the VPN relay server the device is currently
-connected to. That ensures the request reaches the Mullvad infrastructure and does so safely
-(encrypted). From there the Mullvad servers are responsible for delivering a correct and
-uncensored reply.
+By default, the app makes sure that every DNS request from the device goes inside the VPN tunnel
+and only to the VPN relay server that the device is currently connected to. If custom DNS servers
+are provided, requests are always made inside the tunnel unless the address belongs to a private
+address range (such as 192.168.0.0/16) or a loopback address.
 
 The above holds during the [connected] state. In the [disconnected]
 state the app does nothing with DNS, meaning the default one is used, probably from the ISP.

--- a/mullvad-cli/src/cmds/custom_dns.rs
+++ b/mullvad-cli/src/cmds/custom_dns.rs
@@ -1,0 +1,74 @@
+use crate::{new_rpc_client, Command, Result};
+use mullvad_management_interface::types;
+
+pub struct CustomDns;
+
+#[mullvad_management_interface::async_trait]
+impl Command for CustomDns {
+    fn name(&self) -> &'static str {
+        "custom-dns"
+    }
+
+    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
+        clap::SubCommand::with_name(self.name())
+            .about("Configure custom DNS servers to use when connected")
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+            .subcommand(
+                clap::SubCommand::with_name("set")
+                    .about("Change custom DNS setting")
+                    .arg(
+                        clap::Arg::with_name("servers")
+                            .multiple(true)
+                            .required(false),
+                    ),
+            )
+            .subcommand(
+                clap::SubCommand::with_name("get").about("Display the current custom DNS setting"),
+            )
+    }
+
+    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+        if let Some(set_matches) = matches.subcommand_matches("set") {
+            self.set(set_matches.values_of_lossy("servers")).await
+        } else if let Some(_matches) = matches.subcommand_matches("get") {
+            self.get().await
+        } else {
+            unreachable!("No custom-dns command given");
+        }
+    }
+}
+
+impl CustomDns {
+    async fn set(&self, servers: Option<Vec<String>>) -> Result<()> {
+        let mut rpc = new_rpc_client().await?;
+        rpc.set_custom_dns(types::CustomDns {
+            addresses: servers.unwrap_or_default(),
+        })
+        .await?;
+        println!("Updated custom DNS settings");
+        Ok(())
+    }
+
+    async fn get(&self) -> Result<()> {
+        let mut rpc = new_rpc_client().await?;
+        let custom_dns = rpc
+            .get_settings(())
+            .await?
+            .into_inner()
+            .tunnel_options
+            .unwrap()
+            .generic
+            .unwrap()
+            .custom_dns;
+        match custom_dns {
+            None => println!("No DNS servers are configured"),
+            Some(types::CustomDns { addresses }) => {
+                println!("Custom DNS servers:");
+                for server in &addresses {
+                    println!("\t{}", server);
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -25,6 +25,9 @@ pub use self::disconnect::Disconnect;
 mod lan;
 pub use self::lan::Lan;
 
+mod custom_dns;
+pub use self::custom_dns::CustomDns;
+
 mod reconnect;
 pub use self::reconnect::Reconnect;
 
@@ -60,6 +63,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         Box::new(Disconnect),
         Box::new(Reconnect),
         Box::new(Lan),
+        Box::new(CustomDns),
         Box::new(Relay),
         Box::new(Reset),
         #[cfg(target_os = "linux")]

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -63,6 +63,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         Box::new(Disconnect),
         Box::new(Reconnect),
         Box::new(Lan),
+        #[cfg(windows)]
         Box::new(CustomDns),
         Box::new(Relay),
         Box::new(Reset),

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -576,6 +576,7 @@ where
         let tunnel_command_tx = tunnel_state_machine::spawn(
             settings.allow_lan,
             settings.block_when_disconnected,
+            settings.tunnel_options.generic.custom_dns.clone(),
             tunnel_parameters_generator,
             log_dir,
             resource_dir,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -48,6 +48,7 @@ use std::{
     io,
     marker::PhantomData,
     mem,
+    net::IpAddr,
     path::PathBuf,
     sync::{mpsc as sync_mpsc, Arc, Weak},
     time::Duration,
@@ -192,6 +193,8 @@ pub enum DaemonCommand {
     SetBridgeState(oneshot::Sender<Result<(), settings::Error>>, BridgeState),
     /// Set if IPv6 should be enabled in the tunnel
     SetEnableIpv6(oneshot::Sender<()>, bool),
+    /// Set custom DNS servers to use instead of passing requests to the gateway
+    SetCustomDns(oneshot::Sender<()>, Option<Vec<IpAddr>>),
     /// Set MTU for wireguard tunnels
     SetWireguardMtu(oneshot::Sender<()>, Option<u16>),
     /// Set automatic key rotation interval for wireguard tunnels
@@ -1040,6 +1043,7 @@ where
             }
             SetBridgeState(tx, bridge_state) => self.on_set_bridge_state(tx, bridge_state),
             SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6),
+            SetCustomDns(tx, dns_servers) => self.on_set_custom_dns(tx, dns_servers),
             SetWireguardMtu(tx, mtu) => self.on_set_wireguard_mtu(tx, mtu),
             SetWireguardRotationInterval(tx, interval) => {
                 self.on_set_wireguard_rotation_interval(tx, interval).await
@@ -1672,6 +1676,21 @@ where
                         .notify_settings(self.settings.to_settings());
                     info!("Initiating tunnel restart because the enable IPv6 setting changed");
                     self.reconnect_tunnel();
+                }
+            }
+            Err(e) => error!("{}", e.display_chain_with_msg("Unable to save settings")),
+        }
+    }
+
+    fn on_set_custom_dns(&mut self, tx: oneshot::Sender<()>, servers: Option<Vec<IpAddr>>) {
+        let save_result = self.settings.set_custom_dns(servers.clone());
+        match save_result {
+            Ok(settings_changed) => {
+                Self::oneshot_send(tx, (), "set_custom_dns response");
+                if settings_changed {
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
+                    self.send_tunnel_command(TunnelCommand::CustomDns(servers));
                 }
             }
             Err(e) => error!("{}", e.display_chain_with_msg("Unable to save settings")),

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -408,6 +408,33 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(|_| Status::internal("internal error"))
     }
 
+    async fn set_custom_dns(&self, request: Request<types::CustomDns>) -> ServiceResult<()> {
+        let servers = request.into_inner();
+        log::debug!("set_custom_dns({:?})", servers.addresses);
+
+        let mut servers_ip = vec![];
+        for server in servers.addresses.into_iter() {
+            if let Ok(addr) = server.parse() {
+                servers_ip.push(addr);
+            } else {
+                let err_msg = format!("failed to parse IP address: {}", server);
+                return Err(Status::invalid_argument(err_msg));
+            }
+        }
+
+        let servers_ip = if !servers_ip.is_empty() {
+            Some(servers_ip)
+        } else {
+            None
+        };
+
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::SetCustomDns(tx, servers_ip))?;
+        rx.await
+            .map(Response::new)
+            .map_err(|_| Status::internal("internal error"))
+    }
+
     // Account management
     //
 
@@ -1140,6 +1167,13 @@ fn convert_tunnel_options(options: &TunnelOptions) -> types::TunnelOptions {
         }),
         generic: Some(types::tunnel_options::GenericOptions {
             enable_ipv6: options.generic.enable_ipv6,
+            custom_dns: options
+                .generic
+                .custom_dns
+                .as_ref()
+                .map(|addresses| types::CustomDns {
+                    addresses: addresses.iter().map(|addr| addr.to_string()).collect(),
+                }),
         }),
     }
 }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -3,10 +3,11 @@ use mullvad_types::{
     relay_constraints::{BridgeSettings, BridgeState, RelaySettingsUpdate},
     settings::Settings,
 };
+#[cfg(windows)]
+use std::net::IpAddr;
 use std::{
     fs::{self, File},
     io,
-    net::IpAddr,
     ops::Deref,
     path::{Path, PathBuf},
 };
@@ -211,6 +212,7 @@ impl SettingsPersister {
         self.update(should_save)
     }
 
+    #[cfg(windows)]
     pub fn set_custom_dns(&mut self, servers: Option<Vec<IpAddr>>) -> Result<bool, Error> {
         let should_save = Self::update_field(
             &mut self.settings.tunnel_options.generic.custom_dns,

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -6,6 +6,7 @@ use mullvad_types::{
 use std::{
     fs::{self, File},
     io,
+    net::IpAddr,
     ops::Deref,
     path::{Path, PathBuf},
 };
@@ -206,6 +207,14 @@ impl SettingsPersister {
         let should_save = Self::update_field(
             &mut self.settings.tunnel_options.generic.enable_ipv6,
             enable_ipv6,
+        );
+        self.update(should_save)
+    }
+
+    pub fn set_custom_dns(&mut self, servers: Option<Vec<IpAddr>>) -> Result<bool, Error> {
+        let should_save = Self::update_field(
+            &mut self.settings.tunnel_options.generic.custom_dns,
+            servers,
         );
         self.update(should_save)
     }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -39,6 +39,7 @@ service ManagementService {
 	rpc SetOpenvpnMssfix(google.protobuf.UInt32Value) returns (google.protobuf.Empty) {}
 	rpc SetWireguardMtu(google.protobuf.UInt32Value) returns (google.protobuf.Empty) {}
 	rpc SetEnableIpv6(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
+	rpc SetCustomDns(CustomDns) returns (google.protobuf.Empty) {}
 
 	// Account management
 	rpc CreateNewAccount(google.protobuf.Empty) returns (google.protobuf.StringValue) {}
@@ -359,11 +360,16 @@ message TunnelOptions {
 	}
 	message GenericOptions {
 		bool enable_ipv6 = 1;
+		CustomDns custom_dns = 2;
 	}
 
 	OpenvpnOptions openvpn = 1;
 	WireguardOptions wireguard = 2;
 	GenericOptions generic = 3;
+}
+
+message CustomDns {
+	repeated string addresses = 1;
 }
 
 message PublicKey {

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -177,6 +177,7 @@ impl Default for TunnelOptions {
             generic: GenericTunnelOptions {
                 // Enable IPv6 be default on Android
                 enable_ipv6: cfg!(target_os = "android"),
+                custom_dns: None,
             },
         }
     }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -177,6 +177,7 @@ impl Default for TunnelOptions {
             generic: GenericTunnelOptions {
                 // Enable IPv6 be default on Android
                 enable_ipv6: cfg!(target_os = "android"),
+                #[cfg(windows)]
                 custom_dns: None,
             },
         }

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -112,6 +112,7 @@ pub enum FirewallPolicy {
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
         /// Servers that are allowed to respond to DNS requests.
+        #[cfg(windows)]
         dns_servers: Vec<IpAddr>,
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -111,6 +111,8 @@ pub enum FirewallPolicy {
         tunnel: crate::tunnel::TunnelMetadata,
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
+        /// Servers that are allowed to respond to DNS requests.
+        dns_servers: Vec<IpAddr>,
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]
         relay_client: PathBuf,

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -99,10 +99,11 @@ impl FirewallT for Firewall {
                 peer_endpoint,
                 tunnel,
                 allow_lan,
+                dns_servers,
                 relay_client,
             } => {
                 let cfg = &WinFwSettings::new(allow_lan);
-                self.set_connected_state(&peer_endpoint, &cfg, &tunnel, &relay_client)
+                self.set_connected_state(&peer_endpoint, &cfg, &tunnel, &dns_servers, &relay_client)
             }
             FirewallPolicy::Blocked { allow_lan } => {
                 let cfg = &WinFwSettings::new(allow_lan);
@@ -192,6 +193,7 @@ impl Firewall {
         endpoint: &Endpoint,
         winfw_settings: &WinFwSettings,
         tunnel_metadata: &crate::tunnel::TunnelMetadata,
+        dns_servers: &[IpAddr],
         relay_client: &Path,
     ) -> Result<(), Error> {
         trace!("Applying 'connected' firewall policy");

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -91,9 +91,16 @@ impl ConnectedState {
     }
 
     fn set_dns(&self, shared_values: &mut SharedTunnelStateValues) -> Result<(), BoxedError> {
-        let mut dns_ips = vec![self.metadata.ipv4_gateway.into()];
-        if let Some(ipv6_gateway) = self.metadata.ipv6_gateway {
-            dns_ips.push(ipv6_gateway.into());
+        let mut default_dns = vec![];
+
+        let dns_ips = if let Some(ref servers) = shared_values.custom_dns {
+            servers
+        } else {
+            default_dns.push(self.metadata.ipv4_gateway.into());
+            if let Some(ipv6_gateway) = self.metadata.ipv6_gateway {
+                default_dns.push(ipv6_gateway.into());
+            };
+            &default_dns
         };
 
         shared_values

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -227,6 +227,7 @@ impl ConnectingState {
                     }
                 }
             }
+            #[cfg(windows)]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -227,6 +227,10 @@ impl ConnectingState {
                     }
                 }
             }
+            Some(TunnelCommand::CustomDns(servers)) => {
+                shared_values.custom_dns = servers;
+                SameState(self.into())
+            }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 shared_values.block_when_disconnected = block_when_disconnected;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -82,6 +82,7 @@ impl TunnelState for DisconnectedState {
                 }
                 SameState(self.into())
             }
+            #[cfg(windows)]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -82,6 +82,10 @@ impl TunnelState for DisconnectedState {
                 }
                 SameState(self.into())
             }
+            Some(TunnelCommand::CustomDns(servers)) => {
+                shared_values.custom_dns = servers;
+                SameState(self.into())
+            }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 if shared_values.block_when_disconnected != block_when_disconnected {
                     shared_values.block_when_disconnected = block_when_disconnected;

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -32,6 +32,7 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Nothing
                 }
+                #[cfg(windows)]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Nothing
@@ -53,6 +54,7 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Block(reason)
                 }
+                #[cfg(windows)]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Block(reason)
@@ -79,6 +81,7 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
+                #[cfg(windows)]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Reconnect(retry_attempt)

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -32,6 +32,10 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Nothing
                 }
+                Some(TunnelCommand::CustomDns(servers)) => {
+                    shared_values.custom_dns = servers;
+                    AfterDisconnect::Nothing
+                }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                     shared_values.block_when_disconnected = block_when_disconnected;
                     AfterDisconnect::Nothing
@@ -47,6 +51,10 @@ impl DisconnectingState {
             AfterDisconnect::Block(reason) => match command {
                 Some(TunnelCommand::AllowLan(allow_lan)) => {
                     let _ = shared_values.set_allow_lan(allow_lan);
+                    AfterDisconnect::Block(reason)
+                }
+                Some(TunnelCommand::CustomDns(servers)) => {
+                    shared_values.custom_dns = servers;
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
@@ -69,6 +77,10 @@ impl DisconnectingState {
             AfterDisconnect::Reconnect(retry_attempt) => match command {
                 Some(TunnelCommand::AllowLan(allow_lan)) => {
                     let _ = shared_values.set_allow_lan(allow_lan);
+                    AfterDisconnect::Reconnect(retry_attempt)
+                }
+                Some(TunnelCommand::CustomDns(servers)) => {
+                    shared_values.custom_dns = servers;
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -102,6 +102,7 @@ impl TunnelState for ErrorState {
                     SameState(self.into())
                 }
             }
+            #[cfg(windows)]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -102,6 +102,10 @@ impl TunnelState for ErrorState {
                     SameState(self.into())
                 }
             }
+            Some(TunnelCommand::CustomDns(servers)) => {
+                shared_values.custom_dns = servers;
+                SameState(self.into())
+            }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 shared_values.block_when_disconnected = block_when_disconnected;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -27,6 +27,7 @@ use futures::{
 use std::{
     collections::HashSet,
     io,
+    net::IpAddr,
     path::{Path, PathBuf},
     sync::{mpsc as sync_mpsc, Arc},
 };
@@ -74,6 +75,7 @@ pub enum Error {
 pub async fn spawn(
     allow_lan: bool,
     block_when_disconnected: bool,
+    custom_dns: Option<Vec<IpAddr>>,
     tunnel_parameters_generator: impl TunnelParametersGenerator,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
@@ -109,6 +111,7 @@ pub async fn spawn(
             allow_lan,
             block_when_disconnected,
             is_offline,
+            custom_dns,
             tunnel_parameters_generator,
             tun_provider,
             log_dir,
@@ -184,6 +187,7 @@ impl TunnelStateMachine {
         allow_lan: bool,
         block_when_disconnected: bool,
         is_offline: bool,
+        custom_dns: Option<Vec<IpAddr>>,
         tunnel_parameters_generator: impl TunnelParametersGenerator,
         tun_provider: TunProvider,
         log_dir: Option<PathBuf>,
@@ -208,6 +212,7 @@ impl TunnelStateMachine {
             allow_lan,
             block_when_disconnected,
             is_offline,
+            custom_dns,
             tunnel_parameters_generator: Box::new(tunnel_parameters_generator),
             tun_provider,
             log_dir,
@@ -277,6 +282,8 @@ struct SharedTunnelStateValues {
     block_when_disconnected: bool,
     /// True when the computer is known to be offline.
     is_offline: bool,
+    /// Custom DNS servers to use.
+    custom_dns: Option<Vec<IpAddr>>,
     /// The generator of new `TunnelParameter`s
     tunnel_parameters_generator: Box<dyn TunnelParametersGenerator>,
     /// The provider of tunnel devices.

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -150,6 +150,8 @@ pub async fn spawn(
 pub enum TunnelCommand {
     /// Enable or disable LAN access in the firewall.
     AllowLan(bool),
+    /// Set custom DNS servers to use.
+    CustomDns(Option<Vec<IpAddr>>),
     /// Enable or disable the block_when_disconnected feature.
     BlockWhenDisconnected(bool),
     /// Notify the state machine of the connectivity of the device.

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -24,10 +24,11 @@ use futures::{
     channel::{mpsc, oneshot},
     stream, StreamExt,
 };
+#[cfg(windows)]
+use std::net::IpAddr;
 use std::{
     collections::HashSet,
     io,
-    net::IpAddr,
     path::{Path, PathBuf},
     sync::{mpsc as sync_mpsc, Arc},
 };
@@ -75,7 +76,7 @@ pub enum Error {
 pub async fn spawn(
     allow_lan: bool,
     block_when_disconnected: bool,
-    custom_dns: Option<Vec<IpAddr>>,
+    #[cfg(windows)] custom_dns: Option<Vec<IpAddr>>,
     tunnel_parameters_generator: impl TunnelParametersGenerator,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
@@ -111,6 +112,7 @@ pub async fn spawn(
             allow_lan,
             block_when_disconnected,
             is_offline,
+            #[cfg(windows)]
             custom_dns,
             tunnel_parameters_generator,
             tun_provider,
@@ -151,6 +153,7 @@ pub enum TunnelCommand {
     /// Enable or disable LAN access in the firewall.
     AllowLan(bool),
     /// Set custom DNS servers to use.
+    #[cfg(windows)]
     CustomDns(Option<Vec<IpAddr>>),
     /// Enable or disable the block_when_disconnected feature.
     BlockWhenDisconnected(bool),
@@ -189,7 +192,7 @@ impl TunnelStateMachine {
         allow_lan: bool,
         block_when_disconnected: bool,
         is_offline: bool,
-        custom_dns: Option<Vec<IpAddr>>,
+        #[cfg(windows)] custom_dns: Option<Vec<IpAddr>>,
         tunnel_parameters_generator: impl TunnelParametersGenerator,
         tun_provider: TunProvider,
         log_dir: Option<PathBuf>,
@@ -214,6 +217,7 @@ impl TunnelStateMachine {
             allow_lan,
             block_when_disconnected,
             is_offline,
+            #[cfg(windows)]
             custom_dns,
             tunnel_parameters_generator: Box::new(tunnel_parameters_generator),
             tun_provider,
@@ -285,6 +289,7 @@ struct SharedTunnelStateValues {
     /// True when the computer is known to be offline.
     is_offline: bool,
     /// Custom DNS servers to use.
+    #[cfg(windows)]
     custom_dns: Option<Vec<IpAddr>>,
     /// The generator of new `TunnelParameter`s
     tunnel_parameters_generator: Box<dyn TunnelParametersGenerator>,

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -203,6 +203,8 @@ pub struct GenericTunnelOptions {
     /// Enable configuration of IPv6 on the tunnel interface, allowing IPv6 communication to be
     /// forwarded through the tunnel.
     pub enable_ipv6: bool,
+    /// Custom DNS servers to use.
+    pub custom_dns: Option<Vec<IpAddr>>,
 }
 
 /// Returns a vector of IP networks representing all of the internet, 0.0.0.0/0.

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -204,6 +204,7 @@ pub struct GenericTunnelOptions {
     /// forwarded through the tunnel.
     pub enable_ipv6: bool,
     /// Custom DNS servers to use.
+    #[cfg(windows)]
     pub custom_dns: Option<Vec<IpAddr>>,
 }
 

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -43,7 +43,8 @@ public:
 		const WinFwRelay &relay,
 		const std::wstring &relayClient,
 		const std::wstring &tunnelInterfaceAlias,
-		const std::vector<wfp::IpAddress> &tunnelDnsServers
+		const std::vector<wfp::IpAddress> &tunnelDnsServers,
+		const std::vector<wfp::IpAddress> &nonTunnelDnsServers
 	);
 
 	bool applyPolicyBlocked(const WinFwSettings &settings);

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -7,6 +7,7 @@
 #include "libwfp/ipnetwork.h"
 #include <windows.h>
 #include <libcommon/error.h>
+#include <libcommon/string.h>
 #include <optional>
 
 namespace
@@ -387,6 +388,31 @@ WinFw_ApplyPolicyConnected(
 		{
 			auto ip = wfp::IpAddress(dnsServers[i]);
 			addToDnsCollection(ip.type() == wfp::IpAddress::Type::Ipv4 ? v4GatewayIp : v6GatewayIp, std::move(ip));
+		}
+
+		if (nullptr != g_logSink)
+		{
+			std::stringstream ss;
+			ss << "Non-tunnel DNS servers: ";
+			for (size_t i = 0; i < nonTunnelDnsServers.size(); i++) {
+				if (i > 0)
+				{
+					ss << ", ";
+				}
+				ss << common::string::ToAnsi(nonTunnelDnsServers[i].toString());
+			}
+			g_logSink(MULLVAD_LOG_LEVEL_DEBUG, ss.str().c_str(), g_logSinkContext);
+
+			ss.str(std::string());
+			ss << "Tunnel DNS servers: ";
+			for (size_t i = 0; i < tunnelDnsServers.size(); i++) {
+				if (i > 0)
+				{
+					ss << ", ";
+				}
+				ss << common::string::ToAnsi(tunnelDnsServers[i].toString());
+			}
+			g_logSink(MULLVAD_LOG_LEVEL_DEBUG, ss.str().c_str(), g_logSinkContext);
 		}
 
 		return g_fwContext->applyPolicyConnected(

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -167,14 +167,15 @@ WinFw_ApplyPolicyConnecting(
 // - What is specified by settings
 // - Communication with the relay server
 // - Non-DNS traffic inside the VPN tunnel
-// - DNS requests inside the VPN tunnel, to the specified DNS server
+// - DNS requests inside the VPN tunnel to any specified remote DNS server
+// - DNS requests outside the VPN tunnel to any specified local DNS servers
 //
 // Parameters:
 //
 // tunnelInterfaceAlias:
 //   Friendly name of VPN tunnel interface
-// v4DnsHost/v6DnsHost:
-//   String encoded IP address of DNS to use inside tunnel
+// dnsServers:
+//   Array of string-encoded IP addresses of DNS servers to use
 //
 extern "C"
 WINFW_LINKAGE
@@ -185,8 +186,10 @@ WinFw_ApplyPolicyConnected(
 	const WinFwRelay *relay,
 	const wchar_t *relayClient,
 	const wchar_t *tunnelInterfaceAlias,
-	const wchar_t *v4DnsHost,
-	const wchar_t *v6DnsHost
+	const wchar_t *v4Gateway,
+	const wchar_t *v6Gateway,
+	const wchar_t **dnsServers,
+	size_t numDnsServers
 );
 
 //


### PR DESCRIPTION
This allows users to use DNS servers other than those provided by the relay server. One or more addresses can be set. For each address, the following applies:

* If an IP address is in a private network, non-tunnel interfaces are allowed by the firewall to send and receive DNS traffic to that address. However, the interfaces must be configured by the user to do so.

* For other IP addresses, the daemon configures the tunnel interface correctly to use the provided addresses. `WinFw` will allow traffic to pass to/from those addresses, and on that interface only. Due to hijacking, this currently has no effect.

Servers can be set or retrieved in the CLI as follows:
```
mullvad custom-dns set [addresses...]
mullvad custom-dns get
```

If `mullvad custom-dns set` is run without any arguments, the DNS server will be set to the gateway of the tunnel interface (i.e., the default setting).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2188)
<!-- Reviewable:end -->
