### PR TITLE
Remove unnecessary vector from mullvad-exclude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,9 +1053,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libdbus-sys"
@@ -1274,7 +1274,7 @@ dependencies = [
  "mullvad-paths",
  "mullvad-rpc",
  "mullvad-types",
- "nix 0.18.0",
+ "nix 0.19.0",
  "parking_lot 0.11.0",
  "rand",
  "regex",
@@ -1296,7 +1296,7 @@ name = "mullvad-exclude"
 version = "2020.6.0"
 dependencies = [
  "err-derive",
- "nix 0.18.0",
+ "nix 0.19.0",
  "talpid-types",
 ]
 
@@ -1316,7 +1316,7 @@ dependencies = [
  "mullvad-problem-report",
  "mullvad-rpc",
  "mullvad-types",
- "nix 0.18.0",
+ "nix 0.19.0",
  "rand",
  "talpid-core",
  "talpid-types",
@@ -1558,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "85db2feff6bf70ebc3a4793191517d5f0331100a2f10f9bf93b5e5214f32b7b7"
 dependencies = [
  "bitflags 1.2.1",
  "cc",
@@ -2565,7 +2565,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nftnl",
- "nix 0.18.0",
+ "nix 0.19.0",
  "notify",
  "openvpn-plugin",
  "os_pipe",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -41,7 +41,7 @@ android_logger = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-nix = "0.18"
+nix = "0.19"
 simple-signal = "1.1"
 
 [target.'cfg(windows)'.dependencies]

--- a/mullvad-exclude/Cargo.toml
+++ b/mullvad-exclude/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = "0.18"
+nix = "0.19"
 err-derive = "0.2.1"
 talpid-types = { path = "../talpid-types" }

--- a/mullvad-exclude/src/main.rs
+++ b/mullvad-exclude/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     convert::Infallible,
     env,
     error::Error as StdError,
-    ffi::{CStr, CString, NulError},
+    ffi::{CString, NulError},
     fs,
     io::{self, BufWriter, Write},
     os::unix::ffi::OsStrExt,
@@ -81,7 +81,6 @@ fn run() -> Result<Infallible, Error> {
         .map(|arg| CString::new(arg.as_bytes()))
         .collect::<Result<Vec<CString>, NulError>>()
         .map_err(Error::ArgumentNulError)?;
-    let args: Vec<&CStr> = args.iter().map(|arg| &**arg).collect();
 
     let cgroup_dir = find_net_cls_mount()
         .map_err(Error::FindNetClsController)?

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -18,7 +18,7 @@ jnix = { version = "0.2.3", features = ["derive"] }
 lazy_static = "1"
 log = "0.4"
 log-panics = "2"
-nix = "0.18"
+nix = "0.19"
 rand = "0.7"
 tokio = "0.2"
 

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -38,7 +38,7 @@ tonic = "0.3.1"
 prost = "0.6"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.18"
+nix = "0.19"
 
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
Upgrade `nix`. `execvp` no longer forces you to pass `&[&CStr]` to it, so a tiny improvement was made in `mullvad-exclude`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2191)
<!-- Reviewable:end -->
