### PR TITLE
Work-around app being sideways on some TVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add button to remove account and WireGuard key from history in the login screen.
 - Improve navigation in the app using a keyboard, so that touchless devices (like TVs) can be used
   more smoothly.
+- Run app in landscape mode on TVs.
 
 ### Fixed
 - Fix missing map animation after selecting a new location in the desktop app.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
                   android:label="@string/app_name"
                   android:launchMode="singleTask"
                   android:configChanges="orientation|screenSize|screenLayout"
-                  android:screenOrientation="portrait"
+                  android:screenOrientation="sensorPortrait"
                   android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -1,8 +1,11 @@
 package net.mullvad.mullvadvpn.ui
 
 import android.app.Activity
+import android.app.UiModeManager
 import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -32,6 +35,12 @@ class MainActivity : FragmentActivity() {
     private var serviceConnection: ServiceConnection? = null
     private var shouldConnect = false
     private var visibleSecureScreens = HashSet<Fragment>()
+
+    private val deviceIsTv by lazy {
+        val uiModeManager = getSystemService(UI_MODE_SERVICE) as UiModeManager
+
+        uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
+    }
 
     private val serviceConnectionManager = object : android.content.ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
@@ -68,6 +77,10 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        if (deviceIsTv) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE)
+        }
+
         super.onCreate(savedInstanceState)
 
         problemReport.logDirectory.complete(filesDir)


### PR DESCRIPTION
The app was previously configured to only run on portrait mode. However this led to a problem on some TVs which instead of showing the app with black bars, it showed the app side-ways. This PR is an attempt to workaround that so that the app becomes usable.

The PR includes two changes. The first is to change the app from `portrait` mode to `sensorPortrait`, which allows the sensor to be used to determine if the app should rotate 180 degrees (i.e., so that it rotates if the device is used upside down).

The second change forces the mode to be `sensorLandscape` if the device is detected to be a TV.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2193)
<!-- Reviewable:end -->
