### PR TITLE
Fix navigation on login screen

### DIFF
--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -13,6 +13,7 @@
                   android:nextFocusForward="@id/login_input"
                   android:nextFocusDown="@id/login_input"
                   android:descendantFocusability="beforeDescendants">
+        <requestFocus />
         <net.mullvad.mullvadvpn.ui.widget.HeaderBar android:id="@+id/header_bar"
                                                     android:layout_width="match_parent"
                                                     android:layout_height="wrap_content" />

--- a/android/src/main/res/layout/login.xml
+++ b/android/src/main/res/layout/login.xml
@@ -10,6 +10,8 @@
                   android:orientation="vertical"
                   android:focusable="true"
                   android:focusableInTouchMode="true"
+                  android:nextFocusForward="@id/login_input"
+                  android:nextFocusDown="@id/login_input"
                   android:descendantFocusability="beforeDescendants">
         <net.mullvad.mullvadvpn.ui.widget.HeaderBar android:id="@+id/header_bar"
                                                     android:layout_width="match_parent"


### PR DESCRIPTION
[Previously](https://github.com/mullvad/mullvadvpn-app/pull/2177), the app got improved keyboard navigation in order to better support TVs. However, the login screen had a bug where it wouldn't focus the account input area when using the navigation arrow keys. It would only work with the tab key, which isn't available on most TV remotes.

This PR fixes that by making sure that pressing down when the background is focused moves the focus to the account input box. To improve the UX a little bit the app now starts with the background focused, so one press of the down key should allow the user to enter the account number.

I didn't automatically focus the account input area because on devices with no hardware keyboards it pops up the soft-keyboard which ends up hiding the "Create Account" button.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not in any released version yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2195)
<!-- Reviewable:end -->
