### PR TITLE
Make sure the app is marked with support TV devices

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
                   android:required="false" />
     <uses-feature android:name="android.hardware.faketouch"
                   android:required="false" />
+    <uses-feature android:name="android.hardware.screen.portrait"
+                  android:required="false" />
+    <uses-feature android:name="android.hardware.screen.landscape"
+                  android:required="false" />
     <application android:label="@string/app_name"
                  android:icon="@mipmap/ic_launcher"
                  android:roundIcon="@mipmap/ic_launcher"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,6 +4,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-feature android:name="android.hardware.touchscreen"
+                  android:required="false" />
+    <uses-feature android:name="android.hardware.faketouch"
+                  android:required="false" />
     <application android:label="@string/app_name"
                  android:icon="@mipmap/ic_launcher"
                  android:roundIcon="@mipmap/ic_launcher"


### PR DESCRIPTION
Previous PRs improved how the app is used on TV devices (#2177, #2193, #2195). However, users still can't install the app on TVs using Google Play. That's because the app was previously had an implicit requirement for some hardware features (namely, touch screen support and portrait screen orientation).

This PR changes that so that the app can be found on Google Play on Android TV devices (when the next version is released). To do so, the screen orientation requirement was marked as optional (for both orientations) and the touch screen requirement was also marked as optional (along with "faketouch", which would be better named as "touch-like" input, and which includes mouse input).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Previous changelog entries already describe improved TV support.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2196)
<!-- Reviewable:end -->
