### PR TITLE
Remove trailing separator after updating selection

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedInputFormatter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/SegmentedInputFormatter.kt
@@ -36,13 +36,13 @@ class SegmentedInputFormatter(val input: EditText, var separator: Char) : TextWa
 
         if (isValidInput(string)) {
             editing = false
-            maybeUpdateSelection()
+            maybeUpdateSelection(text)
         } else {
             formatInput(text)
         }
     }
 
-    private fun maybeUpdateSelection() {
+    private fun maybeUpdateSelection(text: Editable) {
         if (removing) {
             var start = input.selectionStart
             var end = input.selectionEnd
@@ -60,6 +60,13 @@ class SegmentedInputFormatter(val input: EditText, var separator: Char) : TextWa
 
             if (changed) {
                 input.setSelection(start, end)
+
+                if (start == end && end == text.length - 1) {
+                    // The cursor was previously at the last character, and now after the character
+                    // was removed it has been moved to before the separator. It's best now to
+                    // remove the unnecessary trailing separator
+                    text.delete(text.length - 1, text.length)
+                }
             }
         }
     }


### PR DESCRIPTION
Previously, a trailing separator was sometimes left in the input when entering a voucher code. This happened after entering a voucher code and pressing backspace repeatedly until it removed a character right before a separator. The logic in `SegmentedInputFormatter` would then try to help the user by placing the cursor before the previous character, skipping the separator. This meant that the separator would be left there.

It should be left there if it's not the last character, but otherwise it's best if it is removed. This PR removes it if it is the last character.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI fix, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2201)
<!-- Reviewable:end -->
