### PR TITLE
Speed up host resolution for local custom DNS

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -71,7 +71,7 @@ tun = "0.5"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "0.4"
-winreg = "0.7"
+winreg = { version = "0.7", features = ["transactions"] }
 winapi = { version = "0.3.6", features = ["handleapi", "ifdef", "libloaderapi", "netioapi", "synchapi", "winbase", "winuser"] }
 socket2 = "0.3"
 pnet_packet = "0.26"

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -167,6 +167,7 @@ fn set_dns_cache_policy_inner(transaction: &Transaction, servers: &[IpAddr]) -> 
     let (policy_config, _) =
         dns_cache_parameters.create_subkey_transacted(policy_path, transaction)?;
 
+    // Enable only the "Generic DNS server" option
     policy_config.set_value("ConfigOptions", &0x08u32)?;
     let server_list: Vec<String> = servers.iter().map(|server| server.to_string()).collect();
     policy_config.set_value("GenericDNSServers", &server_list.join(";"))?;


### PR DESCRIPTION
On Windows 10, the interface with the lowest metric is preferred for DNS resolution. When looking up hostnames using `getaddrinfo`, it will block until it has received a response from this interface (or times out after several seconds). It then uses responses from other interfaces as a fallback.

The metric also influences route priority. The metric of the tunnel interface is intentionally set to 1 in order for the default route belonging to the virtual adapter to always be preferred. This causes a huge lag because the tunnel interface is not allowed to request anything from local resolvers.

This was fixed by setting the DNS servers to use in the dnscache policy, which overrides the preference for a lower metric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2203)
<!-- Reviewable:end -->
