### PR TITLE
Fix screen title animation in Split Tunneling screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomItemAnimator.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomItemAnimator.kt
@@ -1,0 +1,37 @@
+package net.mullvad.mullvadvpn.ui.widget
+
+import android.support.v7.widget.DefaultItemAnimator
+import android.support.v7.widget.RecyclerView.ViewHolder
+import kotlin.math.round
+
+class CustomItemAnimator : DefaultItemAnimator() {
+    var onMove: ((Int, Int) -> Unit)? = null
+
+    override fun animateMove(
+        holder: ViewHolder,
+        fromX: Int,
+        fromY: Int,
+        toX: Int,
+        toY: Int
+    ): Boolean {
+        if (super.animateMove(holder, fromX, fromY, toX, toY)) {
+            var view = holder.itemView
+            var translationX = view.translationX
+            var translationY = view.translationY
+
+            view.animate().setUpdateListener { _ ->
+                val deltaX = round(translationX - view.translationX)
+                val deltaY = round(translationY - view.translationY)
+
+                onMove?.invoke(deltaX.toInt(), deltaY.toInt())
+
+                translationX -= deltaX
+                translationY -= deltaY
+            }
+
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
@@ -22,6 +22,10 @@ class CustomRecyclerView : RecyclerView, ListenableScrollableView {
     override fun onScrolled(horizontalDelta: Int, verticalDelta: Int) {
         super.onScrolled(horizontalDelta, verticalDelta)
 
+        dispatchScrollEvent(horizontalDelta, verticalDelta)
+    }
+
+    private fun dispatchScrollEvent(horizontalDelta: Int, verticalDelta: Int) {
         val oldHorizontalScrollOffset = horizontalScrollOffset
         val oldVerticalScrollOffset = verticalScrollOffset
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
@@ -19,6 +19,14 @@ class CustomRecyclerView : RecyclerView, ListenableScrollableView {
         super(context, attributes, defaultStyleAttribute) {
         }
 
+    init {
+        itemAnimator = CustomItemAnimator().apply {
+            onMove = { horizontalDelta, verticalDelta ->
+                dispatchScrollEvent(horizontalDelta, verticalDelta)
+            }
+        }
+    }
+
     override fun onScrolled(horizontalDelta: Int, verticalDelta: Int) {
         super.onScrolled(horizontalDelta, verticalDelta)
 


### PR DESCRIPTION
When the collapsing title animation [was implemented for `RecyclerView`s](https://github.com/mullvad/mullvadvpn-app/pull/1859), it had to work around the fact that `RecyclerView`s don't actually keep track of the absolute scroll position. It only sends delta scroll events. The solution then was to create a `CustomRecyclerView` sub-class that integrated the deltas in order to keep track of the absolute scroll position.

That worked well in almost all cases. The exception was when enabling the split tunneling feature (which populates a long list of apps), scrolling down a bit in order to shrink the title, and then disabling the feature again, causing the apps to be removed from the list. After removing the items, the list would relayout to fill the empty space, and would send no scroll events. Even worse, listening for the layout finished events also didn't tell if the view had scrolled or not (since it finished layout before moving the remaining items to their final position).

The root cause was that after the layout, the `RecyclerView` would schedule an animation to reposition the items, and that meant that it wouldn't actually consider that a scroll, and that the new position would only be available after a few hundred milliseconds.

This PR works around that issue by intercepting the animation before it is started, through a new `CustomItemAnimator` helper class, and adding an `AnimationUpdateListener` to intercepted animation. This is then used to dispatch the move events as scroll events to the `CustomRecyclerView` which then properly updates the absolute scroll offset.

The solution here is a minimal implementation to make things work with the current configuration of the app. It is likely that different usages will require further changes to the animation interception code (for example to handle replacing items with different `ViewHolder` types). For now at least, the original issue seems to be worked around.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI fix, no changes necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2206)
<!-- Reviewable:end -->
