### PR TITLE
Convert Windows log sink input to UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Line wrap the file at 100 chars.                                              Th
   settings tile.
 - Fix app starting by itself sometimes.
 
+#### Windows
+- Fix log output encoding for Windows modules.
+
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and
   "Always require VPN" were disabled, the service would reset the firewall upon starting back up,

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -72,7 +72,7 @@ tun = "0.5"
 [target.'cfg(windows)'.dependencies]
 widestring = "0.4"
 winreg = { version = "0.7", features = ["transactions"] }
-winapi = { version = "0.3.6", features = ["handleapi", "ifdef", "libloaderapi", "netioapi", "synchapi", "winbase", "winuser"] }
+winapi = { version = "0.3.6", features = ["handleapi", "ifdef", "libloaderapi", "netioapi", "stringapiset", "synchapi", "winbase", "winuser"] }
 socket2 = "0.3"
 pnet_packet = "0.26"
 

--- a/talpid-core/src/logging/windows.rs
+++ b/talpid-core/src/logging/windows.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, c_void};
-use std::ffi::CStr;
+use std::{ffi::CStr, io, ptr};
+use winapi::um::{stringapiset::MultiByteToWideChar, winnls::CP_ACP};
 
 /// Logging callback type.
 pub type LogSink = extern "system" fn(level: log::Level, msg: *const c_char, context: *mut c_void);
@@ -17,7 +18,13 @@ pub extern "system" fn log_sink(level: log::Level, msg: *const c_char, context: 
             unsafe { CStr::from_ptr(context as *const _).to_string_lossy() }
         };
 
-        let managed_msg = unsafe { CStr::from_ptr(msg).to_string_lossy() };
+        let mb_string = unsafe { CStr::from_ptr(msg) };
+
+        let managed_msg = match multibyte_to_wide(mb_string, CP_ACP) {
+            Ok(wide_str) => String::from_utf16_lossy(&wide_str),
+            // Best effort:
+            Err(_) => mb_string.to_string_lossy().into_owned(),
+        };
 
         log::logger().log(
             &log::Record::builder()
@@ -27,4 +34,38 @@ pub extern "system" fn log_sink(level: log::Level, msg: *const c_char, context: 
                 .build(),
         );
     }
+}
+
+fn multibyte_to_wide(mb_string: &CStr, codepage: u32) -> Result<Vec<u16>, io::Error> {
+    if unsafe { *mb_string.as_ptr() } == 0 {
+        return Ok(vec![]);
+    }
+
+    let wc_size =
+        unsafe { MultiByteToWideChar(codepage, 0, mb_string.as_ptr(), -1, ptr::null_mut(), 0) };
+
+    if wc_size == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut wc_buffer = Vec::with_capacity(wc_size as usize);
+
+    let chars_written = unsafe {
+        MultiByteToWideChar(
+            codepage,
+            0,
+            mb_string.as_ptr(),
+            -1,
+            wc_buffer.as_mut_ptr(),
+            wc_size,
+        )
+    };
+
+    if chars_written == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    unsafe { wc_buffer.set_len((chars_written - 1) as usize) };
+
+    Ok(wc_buffer)
 }


### PR DESCRIPTION
Output from Windows modules to the daemon uses ANSI code pages, and is logged to `daemon.log`, which is in UTF-8. This sometimes results in garbled output. For example:

```
[2020-10-23 11:32:57.620][Connectivity monitor][INFO] Detailed interface logging
  Alias: Mobiln�t 13
  Description: Generic Mobile Broadband Adapter #13
```

This was fixed by converting the output to UTF-8. The output is now correct:

```
[2020-10-23 12:03:26.954][Connectivity monitor][INFO] Detailed interface logging
  Alias: Mobilnät 19
  Description: Generic Mobile Broadband Adapter #19
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2207)
<!-- Reviewable:end -->
