### PR TITLE
Support custom DNS on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - Use NetworkManager to create a WireGuard interface.
+- Add support for custom DNS resolvers (CLI only).
 
 ### Changed
 - Use the API to fetch API IP addresses instead of DNS.

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -63,7 +63,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         Box::new(Disconnect),
         Box::new(Reconnect),
         Box::new(Lan),
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "linux"))]
         Box::new(CustomDns),
         Box::new(Relay),
         Box::new(Reset),

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -26,7 +26,7 @@ use futures::{
 };
 use log::{debug, error, info, warn};
 use mullvad_rpc::AccountsProxy;
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "linux"))]
 use mullvad_types::settings::DnsOptions;
 use mullvad_types::{
     account::{AccountData, AccountToken, VoucherSubmission},
@@ -43,7 +43,7 @@ use mullvad_types::{
     wireguard::KeygenEvent,
 };
 use settings::SettingsPersister;
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "linux"))]
 use std::net::IpAddr;
 #[cfg(not(target_os = "android"))]
 use std::path::Path;
@@ -197,7 +197,7 @@ pub enum DaemonCommand {
     /// Set if IPv6 should be enabled in the tunnel
     SetEnableIpv6(oneshot::Sender<()>, bool),
     /// Set custom DNS servers to use instead of passing requests to the gateway
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     SetDnsOptions(oneshot::Sender<()>, DnsOptions),
     /// Set MTU for wireguard tunnels
     SetWireguardMtu(oneshot::Sender<()>, Option<u16>),
@@ -582,7 +582,7 @@ where
         let tunnel_command_tx = tunnel_state_machine::spawn(
             settings.allow_lan,
             settings.block_when_disconnected,
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             Self::get_custom_resolvers(&settings.tunnel_options.dns_options),
             tunnel_parameters_generator,
             log_dir,
@@ -636,7 +636,7 @@ where
         Ok(daemon)
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     fn get_custom_resolvers(dns_options: &DnsOptions) -> Option<Vec<IpAddr>> {
         if dns_options.custom {
             Some(dns_options.addresses.clone())
@@ -1056,7 +1056,7 @@ where
             }
             SetBridgeState(tx, bridge_state) => self.on_set_bridge_state(tx, bridge_state),
             SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6),
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             SetDnsOptions(tx, dns_servers) => self.on_set_dns_options(tx, dns_servers),
             SetWireguardMtu(tx, mtu) => self.on_set_wireguard_mtu(tx, mtu),
             SetWireguardRotationInterval(tx, interval) => {
@@ -1696,7 +1696,7 @@ where
         }
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     fn on_set_dns_options(&mut self, tx: oneshot::Sender<()>, dns_options: DnsOptions) {
         let save_result = self.settings.set_dns_options(dns_options.clone());
         match save_result {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -6,7 +6,7 @@ use mullvad_management_interface::{
 };
 use mullvad_paths;
 use mullvad_rpc::{rest::Error as RestError, StatusCode};
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "linux"))]
 use mullvad_types::settings::DnsOptions;
 use mullvad_types::{
     account::AccountToken,
@@ -410,7 +410,7 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(|_| Status::internal("internal error"))
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     async fn set_dns_options(&self, request: Request<types::DnsOptions>) -> ServiceResult<()> {
         let options = request.into_inner();
         log::debug!(
@@ -441,7 +441,7 @@ impl ManagementService for ManagementServiceImpl {
             .map(Response::new)
             .map_err(|_| Status::internal("internal error"))
     }
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, target_os = "linux")))]
     async fn set_dns_options(&self, _: Request<types::DnsOptions>) -> ServiceResult<()> {
         Ok(Response::new(()))
     }
@@ -1179,7 +1179,7 @@ fn convert_tunnel_options(options: &TunnelOptions) -> types::TunnelOptions {
         generic: Some(types::tunnel_options::GenericOptions {
             enable_ipv6: options.generic.enable_ipv6,
         }),
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "linux"))]
         dns_options: Some(types::DnsOptions {
             custom: options.dns_options.custom,
             addresses: options
@@ -1189,7 +1189,7 @@ fn convert_tunnel_options(options: &TunnelOptions) -> types::TunnelOptions {
                 .map(|addr| addr.to_string())
                 .collect(),
         }),
-        #[cfg(not(windows))]
+        #[cfg(not(any(windows, target_os = "linux")))]
         dns_options: None,
     }
 }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -1,5 +1,5 @@
 use log::{debug, error, info};
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "linux"))]
 use mullvad_types::settings::DnsOptions;
 use mullvad_types::{
     relay_constraints::{BridgeSettings, BridgeState, RelaySettingsUpdate},
@@ -212,7 +212,7 @@ impl SettingsPersister {
         self.update(should_save)
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     pub fn set_dns_options(&mut self, options: DnsOptions) -> Result<bool, Error> {
         let should_save =
             Self::update_field(&mut self.settings.tunnel_options.dns_options, options);

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -7,7 +7,7 @@ use jnix::IntoJava;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use serde_json;
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "linux"))]
 use std::net::IpAddr;
 use talpid_types::net::{openvpn, wireguard, GenericTunnelOptions};
 
@@ -167,12 +167,12 @@ pub struct TunnelOptions {
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub generic: GenericTunnelOptions,
     /// Custom DNS options.
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     pub dns_options: DnsOptions,
 }
 
 /// Custom DNS config
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "linux"))]
 #[serde(default)]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct DnsOptions {
@@ -194,7 +194,7 @@ impl Default for TunnelOptions {
                 // Enable IPv6 be default on Android
                 enable_ipv6: cfg!(target_os = "android"),
             },
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             dns_options: DnsOptions::default(),
         }
     }

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -471,6 +471,7 @@ impl<'a> PolicyBatch<'a> {
                 peer_endpoint,
                 tunnel,
                 allow_lan,
+                dns_servers,
                 use_fwmark,
             } => {
                 self.add_allow_endpoint_rules(peer_endpoint, *use_fwmark);

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -112,7 +112,7 @@ pub enum FirewallPolicy {
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
         /// Servers that are allowed to respond to DNS requests.
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "linux"))]
         dns_servers: Vec<IpAddr>,
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -67,6 +67,10 @@ lazy_static! {
         Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 1, 3),
     ];
     static ref ROUTER_SOLICITATION_OUT_DST_ADDR: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 2);
+    static ref LOOPBACK_NETS: [IpNetwork; 2] = [
+        IpNetwork::V4(ipnetwork::Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 0), 8).unwrap()),
+        IpNetwork::V6(ipnetwork::Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 128).unwrap()),
+    ];
 }
 #[cfg(all(unix, not(target_os = "android")))]
 const DHCPV4_SERVER_PORT: u16 = 67;

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -78,7 +78,7 @@ impl ConnectedState {
 
     #[allow(unused_variables)]
     fn get_dns_servers(&self, shared_values: &SharedTunnelStateValues) -> Vec<IpAddr> {
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "linux"))]
         if let Some(ref servers) = shared_values.custom_dns {
             servers.clone()
         } else {
@@ -89,7 +89,7 @@ impl ConnectedState {
             };
             dns_ips
         }
-        #[cfg(not(windows))]
+        #[cfg(not(any(windows, target_os = "linux")))]
         {
             let mut dns_ips = vec![];
             dns_ips.push(self.metadata.ipv4_gateway.into());
@@ -105,7 +105,7 @@ impl ConnectedState {
             peer_endpoint: self.tunnel_parameters.get_next_hop_endpoint(),
             tunnel: self.metadata.clone(),
             allow_lan: shared_values.allow_lan,
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             dns_servers: self.get_dns_servers(shared_values),
             #[cfg(windows)]
             relay_client: TunnelMonitor::get_relay_client(
@@ -182,7 +182,7 @@ impl ConnectedState {
                     }
                 }
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 if shared_values.custom_dns != servers {
                     shared_values.custom_dns = servers;

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -227,7 +227,7 @@ impl ConnectingState {
                     }
                 }
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -82,7 +82,7 @@ impl TunnelState for DisconnectedState {
                 }
                 SameState(self.into())
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -32,7 +32,7 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Nothing
                 }
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "linux"))]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Nothing
@@ -54,7 +54,7 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Block(reason)
                 }
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "linux"))]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Block(reason)
@@ -81,7 +81,7 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "linux"))]
                 Some(TunnelCommand::CustomDns(servers)) => {
                     shared_values.custom_dns = servers;
                     AfterDisconnect::Reconnect(retry_attempt)

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -102,7 +102,7 @@ impl TunnelState for ErrorState {
                     SameState(self.into())
                 }
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             Some(TunnelCommand::CustomDns(servers)) => {
                 shared_values.custom_dns = servers;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -24,7 +24,7 @@ use futures::{
     channel::{mpsc, oneshot},
     stream, StreamExt,
 };
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "linux"))]
 use std::net::IpAddr;
 use std::{
     collections::HashSet,
@@ -76,7 +76,7 @@ pub enum Error {
 pub async fn spawn(
     allow_lan: bool,
     block_when_disconnected: bool,
-    #[cfg(windows)] custom_dns: Option<Vec<IpAddr>>,
+    #[cfg(any(windows, target_os = "linux"))] custom_dns: Option<Vec<IpAddr>>,
     tunnel_parameters_generator: impl TunnelParametersGenerator,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
@@ -112,7 +112,7 @@ pub async fn spawn(
             allow_lan,
             block_when_disconnected,
             is_offline,
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             custom_dns,
             tunnel_parameters_generator,
             tun_provider,
@@ -153,7 +153,7 @@ pub enum TunnelCommand {
     /// Enable or disable LAN access in the firewall.
     AllowLan(bool),
     /// Set custom DNS servers to use.
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     CustomDns(Option<Vec<IpAddr>>),
     /// Enable or disable the block_when_disconnected feature.
     BlockWhenDisconnected(bool),
@@ -192,7 +192,7 @@ impl TunnelStateMachine {
         allow_lan: bool,
         block_when_disconnected: bool,
         is_offline: bool,
-        #[cfg(windows)] custom_dns: Option<Vec<IpAddr>>,
+        #[cfg(any(windows, target_os = "linux"))] custom_dns: Option<Vec<IpAddr>>,
         tunnel_parameters_generator: impl TunnelParametersGenerator,
         tun_provider: TunProvider,
         log_dir: Option<PathBuf>,
@@ -217,7 +217,7 @@ impl TunnelStateMachine {
             allow_lan,
             block_when_disconnected,
             is_offline,
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "linux"))]
             custom_dns,
             tunnel_parameters_generator: Box::new(tunnel_parameters_generator),
             tun_provider,
@@ -289,7 +289,7 @@ struct SharedTunnelStateValues {
     /// True when the computer is known to be offline.
     is_offline: bool,
     /// Custom DNS servers to use.
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     custom_dns: Option<Vec<IpAddr>>,
     /// The generator of new `TunnelParameter`s
     tunnel_parameters_generator: Box<dyn TunnelParametersGenerator>,


### PR DESCRIPTION
Allow custom DNS resolvers to be used on Linux. For addresses in private IP ranges, DNS requests are permitted by the firewall on all non-tunnel interfaces. For other addresses, requests are only allowed on the tunnel interface.

Related PRs: #2205, #2188

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2210)
<!-- Reviewable:end -->
