### PR TITLE
Linux - sort routes by prefix length before application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Add support for custom DNS resolvers (CLI only).
 
+#### Linux
+- Use NetworkManager to create a WireGuard interface.
+
 ### Changed
 - Use the API to fetch API IP addresses instead of DNS.
 - Remove WireGuard keys during uninstallation after the firewall is unlocked.
@@ -57,6 +60,10 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix log output encoding for Windows modules.
+
+#### Linux
+- Handle statically added routes.
+- Stop reconnecting when using WireGuard and NetworkManager.
 
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -196,7 +196,9 @@ impl RouteManagerImpl {
     async fn initialize_exclusions_routes(&mut self) -> Result<()> {
         self.purge_exclusions_routes().await?;
 
-        let main_routes = self.get_routes(None).await?;
+        let mut main_routes = self.get_routes(None).await?.into_iter().collect::<Vec<_>>();
+        main_routes.sort_by(|a, b| a.prefix.prefix().cmp(&b.prefix.prefix()));
+
         for mut route in main_routes {
             route.table_id = self.split_table_id;
             self.add_route_direct(route).await?;


### PR DESCRIPTION
Up until now, when initializing the split tunneling routing table, the routes were being added in arbitrary order. Since routes can have dependencies, route application can fail if the routes are being set in the wrong order. This seems to happen often when the routes are set manually via `ip route add ...`. The solution is to sort the routes by prefix length so that the more specific routes are always applied first. 

In an unrelated note, I updated the changelog for both this issue and the issue with NM and periodic disconnection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2211)
<!-- Reviewable:end -->
