### PR TITLE
Enable alwaysOnTop on Windows to ensure app is placed above other apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix log output encoding for Windows modules.
+- Fix app not appearing on top in some situations when pressing the tray icon.
 
 #### Linux
 - Handle statically added routes.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1370,6 +1370,10 @@ class ApplicationMain {
         // setup window flags to mimic an overlay window
         return new BrowserWindow({
           ...options,
+          // Due to a bug in Electron the app is sometimes placed behind other apps when opened.
+          // Setting alwaysOnTop to true ensures that the app is placed on top. Electron issue:
+          // https://github.com/electron/electron/issues/25915
+          alwaysOnTop: true,
           transparent: true,
           skipTaskbar: true,
         });


### PR DESCRIPTION
The app isn't placed on top if the tray icon is pressed while the start menu is open. Additionally the focus events become broken until the user clicks on the app window, more specifically there's no `blur` event if the user focuses another application before clicking the app window.

This PR adds the `alwaysOnTop` flag to the `BrowserWindow` to ensure it's always placed on top. It doesn't fix the focus issue which is a bug in Electron: https://github.com/electron/electron/issues/25915

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2212)
<!-- Reviewable:end -->
