### PR TITLE
Fix login screen error message

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -23,7 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
-
+### Fixed
+- Fix regression where "Internal error" was displayed instead of server error (i.e too many 
+  WireGuard keys)
 
 ## [2020.4] - 2020-09-10
 ### Added
@@ -43,6 +45,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove the WireGuard key from the account inside the VPN tunnel during the log out, if VPN is
   active at that time. Before it would always remove it outside the tunnel.
 - Turn off WireGuard backend when there are no active network interfaces available. Saves battery.
+- Switch from JSON-RPC to REST communication protocol when talking to Mullvad API servers.
 
 
 ## [2020.3] - 2020-06-12

--- a/ios/MullvadVPN/DisplayChainedError.swift
+++ b/ios/MullvadVPN/DisplayChainedError.swift
@@ -16,7 +16,10 @@ extension RestError: DisplayChainedError {
     var errorChainDescription: String? {
         switch self {
         case .network(let urlError):
-            return urlError.localizedDescription
+            return String(
+                format: NSLocalizedString("Network error: %@", comment: ""),
+                urlError.localizedDescription
+            )
         case .server(let serverError):
             if let knownErrorDescription = serverError.errorDescription {
                 return knownErrorDescription

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -328,8 +328,30 @@ private extension LoginState {
             switch error {
             case .createAccount(let rpcError), .verifyAccount(let rpcError):
                 return rpcError.errorChainDescription ?? ""
-            case .tunnelConfiguration:
-                return NSLocalizedString("Internal error", comment: "")
+            case .tunnelConfiguration(let error):
+                if case .pushWireguardKey(let pushError) = error {
+                    switch pushError {
+                    case .network(let urlError):
+                        return String(
+                            format: NSLocalizedString("Network error: %@", comment: ""),
+                            urlError.localizedDescription
+                        )
+
+                    case .server(let serverError):
+                        var message = serverError.errorDescription ?? NSLocalizedString("Unknown server error.", comment: "")
+
+                        if let recoverySuggestion = serverError.recoverySuggestion {
+                            message.append("\n\(recoverySuggestion)")
+                        }
+
+                        return message
+
+                    case .encodePayload, .decodeErrorResponse, .decodeSuccessResponse:
+                        return NSLocalizedString("Internal error", comment: "")
+                    }
+                } else {
+                    return NSLocalizedString("Internal error", comment: "")
+                }
             }
 
         case .success(let method):

--- a/ios/MullvadVPN/MullvadRest.swift
+++ b/ios/MullvadVPN/MullvadRest.swift
@@ -51,9 +51,9 @@ struct ServerErrorResponse: LocalizedError, Decodable, RestResponse, Equatable {
     var errorDescription: String? {
         switch code {
         case Code.keyLimitReached.rawValue:
-            return NSLocalizedString("Too many public WireGuard keys", comment: "")
+            return NSLocalizedString("Too many WireGuard keys in use.", comment: "")
         case Code.invalidAccount.rawValue:
-            return NSLocalizedString("Invalid account", comment: "")
+            return NSLocalizedString("Invalid account.", comment: "")
         default:
             return nil
         }
@@ -62,7 +62,7 @@ struct ServerErrorResponse: LocalizedError, Decodable, RestResponse, Equatable {
     var recoverySuggestion: String? {
         switch code {
         case Code.keyLimitReached.rawValue:
-            return NSLocalizedString("Remove unused WireGuard keys", comment: "")
+            return NSLocalizedString("Please visit the website to revoke a key before login is possible.", comment: "")
         default:
             return nil
         }


### PR DESCRIPTION
… error (i.e too many WireGuard keys)

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- This PR fixes a regression where "Internal error" was displayed instead of server error (i.e too many WireGuard keys).
- Add missing CHANGELOG entry for a communication protocol transition from JSON-RPC -> REST (as per @faern's request)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2213)
<!-- Reviewable:end -->
