### PR TITLE
Switch to official rs-release crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,10 +2115,8 @@ dependencies = [
 [[package]]
 name = "rs-release"
 version = "0.1.7"
-source = "git+https://github.com/mullvad/rs-release?branch=snailquote-unescape#88b2afb04c3b2b1b76f27d8b8d48cd52facd292a"
-dependencies = [
- "snailquote",
-]
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a874cf4a0b9bc283edaa65d81d62368b84b1a8e56196e4885ca4701fd49972"
 
 [[package]]
 name = "rtnetlink"
@@ -2380,15 +2378,6 @@ name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
-
-[[package]]
-name = "snailquote"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3e2894a343234fb8a8653cf9d49ef6aea44e6581612ca311c91c4bd356dec4"
-dependencies = [
- "unicode_categories",
-]
 
 [[package]]
 name = "socket2"
@@ -3126,12 +3115,6 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unreachable"

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -27,7 +27,7 @@ duct = "0.13"
 
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rs-release = { git = "https://github.com/mullvad/rs-release", branch = "snailquote-unescape" }
+rs-release = "0.1.7"
 
 
 [target.'cfg(windows)'.build-dependencies]


### PR DESCRIPTION
This PR switches to the official `rs-release` crate. We have previously used a git dependency pointing to our fork of the crate with a fix that hasn't been merged into `rs-release` (https://github.com/JIghtuse/rs-release/pull/2).

Now we want to get rid of git dependencies and I've looked into how to solve this and came to the conclusion that the escaped strings shouldn't cause any issues. Additionally I haven't found any distributions which use escaped characters in the `NAME` or `VERSION` values, which are the ones that we use. I've looked in the latest versions of Ubuntu, Fedora, Debian and Linux Mint.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2215)
<!-- Reviewable:end -->
