### PR TITLE
Show app version in settings when failing to connect to daemon

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -540,6 +540,12 @@ class ApplicationMain {
     } else {
       log.info('Disconnected from the daemon');
     }
+
+    // Set GUI version info if it hasn't already been done. Only happens if the app starts without a
+    // connection to the daemon.
+    if (this.currentVersion.gui === '') {
+      this.setDaemonVersion('');
+    }
   };
 
   private connectToDaemon() {


### PR DESCRIPTION
Currently the app version in settings is empty if the frontend fails to connect to the daemon. This PR fixes that by sending the version information to the renderer when frontend fails to connect to the daemon if it hasn't already been done.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2216)
<!-- Reviewable:end -->
