### PR TITLE
Allow more device states with NM DNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - Make route monitor ignore loopback routes.
+- Increase NetworkManager device readiness timeout to 15 seconds.
 
 ### Fixed
 - Fix missing map animation after selecting a new location in the desktop app.
@@ -73,6 +74,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Handle statically added routes.
 - Stop reconnecting when using WireGuard and NetworkManager.
+- Apply DNS config quicker when managing DNS via NetworkManager.
+
 
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and


### PR DESCRIPTION
Seems like on a lot of Ubuntu 20.04 machines (and sister-distros), NM takes some time to get to the final `NM_DEVICE_STATE_ACTIVATED` state, even though any device state after [`NM_DEVICE_STATE_IP_CHECK`](https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMDeviceState) should mean that the device is ready for our DNS config. Since sometimes NM can also be slow to detect that a device is ready, I made a drastic choice to bump the timeout to 15 seconds and also now more states are considered to be OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2217)
<!-- Reviewable:end -->
