### PR TITLE
Ignore loopback routes on Linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,12 @@ Line wrap the file at 100 chars.                                              Th
   more smoothly.
 - Run app in landscape mode on TVs.
 
+#### Linux
+- Make route monitor ignore loopback routes.
+
 ### Fixed
 - Fix missing map animation after selecting a new location in the desktop app.
+- Fix crash on older kernels which report a default route through the loopback interface.
 
 #### Android
 - Fix connect action button sometimes showing itself as "Cancel" instead of "Secure my connection"


### PR DESCRIPTION
On some older kernels, I've seen netlink report routes which seemingly route 0.0.0.0/0 through the loopback interface. This is bonkers and makes no sense. The changes I have here would just ignore such routes when parsing them. Another, not as destructive change, would be to parse them as is - if there is no destination NLA, just assume a default route and add it as such, and filter it out later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2218)
<!-- Reviewable:end -->
