### PR TITLE
Make NM WireGuard tunnel work on older NM versions

### DIFF
--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -222,7 +222,11 @@ impl NetworkManager {
             // if the link contains link local addresses, addresses shouldn't be reset
             if ipv6_settings
                 .get("method")
-                .map(|method| method.as_str() != Some("link-local"))
+                .map(|method| {
+                    // if IPv6 isn't enabled, IPv6 method will be set to "ignore", in which case we
+                    // shouldn't reapply any config for ipv6
+                    method.as_str() != Some("link-local") && method.as_str() != Some("ignore")
+                })
                 .unwrap_or(true)
             {
                 ipv6_settings.insert("addresses", Variant(Box::new(device_addresses6)));

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -158,24 +158,29 @@ impl WireguardMonitor {
                     return Ok(Box::new(tunnel));
                 }
                 Err(err) => {
+                    if !err.should_use_userspace() {
+                        match wireguard_kernel::KernelTunnel::new(
+                            route_manager.runtime_handle(),
+                            config,
+                        ) {
+                            Ok(tunnel) => {
+                                log::debug!("Using kernel WireGuard implementation");
+                                return Ok(Box::new(tunnel));
+                            }
+                            Err(error) => {
+                                log::error!(
+                                    "{}",
+                                    error.display_chain_with_msg(
+                                        "Failed to setup kernel WireGuard device, falling back to userspace"
+                                    )
+                                );
+                            }
+                        };
+                    }
                     log::debug!(
                         "{}",
                         err.display_chain_with_msg(
                             "Failed to create a WireGuard device via NetworkManager"
-                        )
-                    );
-                }
-            };
-            match wireguard_kernel::KernelTunnel::new(route_manager.runtime_handle(), config) {
-                Ok(tunnel) => {
-                    log::debug!("Using kernel WireGuard implementation");
-                    return Ok(Box::new(tunnel));
-                }
-                Err(error) => {
-                    log::error!(
-                        "{}",
-                        error.display_chain_with_msg(
-                            "Failed to setup kernel WireGuard device, falling back to userspace"
                         )
                     );
                 }


### PR DESCRIPTION
Earlier, I made some changes to allow creating a WireGuard interface via NetworkManager. This code works, but improvements could be made to make it work with older NetworkManager versions - `AddConnection2` is only available as of NM 1.20, whereas WireGuard is supported as of version `1.16`.  So firstly, the NetworkManager WireGuard tunnel implementation checks if the NetworkManager that's available is new enough, then it attempts to apply the config, first via `AddConnection2`, and if that fails since that method doesn't exist, via `AddConnectionUnsaved`. There were also issues with IPv6 config when applying our DNS config via NM, which are resolved by checking what method is set for `ipv6` management.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2219)
<!-- Reviewable:end -->
