### PR TITLE
Fix initial scroll to selected item in language selector

### DIFF
--- a/gui/src/renderer/components/SelectLanguage.tsx
+++ b/gui/src/renderer/components/SelectLanguage.tsx
@@ -80,7 +80,7 @@ export default class SelectLanguage extends React.Component<IProps, IState> {
               </NavigationItems>
             </NavigationBar>
 
-            <StyledNavigationScrollbars>
+            <StyledNavigationScrollbars ref={this.scrollView}>
               <SettingsHeader>
                 <HeaderTitle>
                   {messages.pgettext('select-language-nav', 'Select language')}


### PR DESCRIPTION
This PR fixes the non-working automatic scroll to the selected language in the language selector.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2220)
<!-- Reviewable:end -->
