### PR TITLE
Fix crashes caused by a missing call to `Service.startForeground()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Line wrap the file at 100 chars.                                              Th
   settings tile.
 - Fix app starting by itself sometimes.
 - Fix apps not being excluded from the tunnel sometimes if auto-connect was enabled.
+- Fix crash that happened sometimes when closing the app or when requesting from the notification
+  or the quick-settings tile for the app to connect or disconnect.
 
 #### Windows
 - Fix log output encoding for Windows modules.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -92,7 +92,9 @@ class ForegroundNotificationManager(
         // on the foreground. With such request, when the service is started it must be placed on
         // the foreground with a call to startForeground before a timeout expires, otherwise Android
         // kills the app.
-        showOnForeground()
+        synchronized(this) {
+            showOnForeground()
+        }
 
         // Restore the notification to its correct state.
         updateNotification()
@@ -108,17 +110,19 @@ class ForegroundNotificationManager(
     }
 
     private fun updateNotification() {
-        if (shouldBeOnForeground != onForeground) {
-            if (shouldBeOnForeground) {
-                showOnForeground()
-            } else if (!shouldBeOnForeground) {
-                if (Build.VERSION.SDK_INT >= 24) {
-                    service.stopForeground(Service.STOP_FOREGROUND_DETACH)
-                } else {
-                    service.stopForeground(false)
-                }
+        synchronized(this) {
+            if (shouldBeOnForeground != onForeground) {
+                if (shouldBeOnForeground) {
+                    showOnForeground()
+                } else if (!shouldBeOnForeground) {
+                    if (Build.VERSION.SDK_INT >= 24) {
+                        service.stopForeground(Service.STOP_FOREGROUND_DETACH)
+                    } else {
+                        service.stopForeground(false)
+                    }
 
-                onForeground = false
+                    onForeground = false
+                }
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -114,7 +114,7 @@ class ForegroundNotificationManager(
             if (shouldBeOnForeground != onForeground) {
                 if (shouldBeOnForeground) {
                     showOnForeground()
-                } else if (!shouldBeOnForeground) {
+                } else {
                     if (Build.VERSION.SDK_INT >= 24) {
                         service.stopForeground(Service.STOP_FOREGROUND_DETACH)
                     } else {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -87,15 +87,30 @@ class ForegroundNotificationManager(
         tunnelStateNotification.visible = false
     }
 
+    fun acknowledgeStartForegroundService() {
+        // When sending start commands to the service, it is necessary to request the service to be
+        // on the foreground. With such request, when the service is started it must be placed on
+        // the foreground with a call to startForeground before a timeout expires, otherwise Android
+        // kills the app.
+        showOnForeground()
+
+        // Restore the notification to its correct state.
+        updateNotification()
+    }
+
+    private fun showOnForeground() {
+        service.startForeground(
+            TunnelStateNotification.NOTIFICATION_ID,
+            tunnelStateNotification.build()
+        )
+
+        onForeground = true
+    }
+
     private fun updateNotification() {
         if (shouldBeOnForeground != onForeground) {
             if (shouldBeOnForeground) {
-                service.startForeground(
-                    TunnelStateNotification.NOTIFICATION_ID,
-                    tunnelStateNotification.build()
-                )
-
-                onForeground = true
+                showOnForeground()
             } else if (!shouldBeOnForeground) {
                 if (Build.VERSION.SDK_INT >= 24) {
                     service.stopForeground(Service.STOP_FOREGROUND_DETACH)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -102,6 +102,8 @@ class MullvadVpnService : TalpidVpnService() {
         val startResult = super.onStartCommand(intent, flags, startId)
         var quitCommand = false
 
+        notificationManager.acknowledgeStartForegroundService()
+
         if (!keyguardManager.isDeviceLocked) {
             val action = intent?.action
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -94,6 +94,8 @@ class MullvadVpnService : TalpidVpnService() {
         notificationManager = ForegroundNotificationManager(this, serviceNotifier, keyguardManager)
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
+        notificationManager.acknowledgeStartForegroundService()
+
         setUp()
     }
 


### PR DESCRIPTION
On Android 8.0 and up, apps can only start services from the background if they request the service to be on the foreground. However, that means that the service must call `startForeground` as soon as it starts or receives a start command after already having started. Otherwise, Android kills the service for bad behavior after a timeout.

Previously the app would mostly work, since the service would spend most of the time in the foreground. However, removing the Quit button and changing the dismiss behavior increased the rate of crashes.

This PR fixes the issue by placing the foreground on the foreground for a moment every time the service is created or requested to start. After placing the notification there it just restores the notification to the correct behavior (either on the foreground or not).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2222)
<!-- Reviewable:end -->
