### PR TITLE
Fix apps not being excluded sometimes when starting with Auto-Connect enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix rare crash that could occur when the tunnel state changes when showing or hiding the quick
   settings tile.
 - Fix app starting by itself sometimes.
+- Fix apps not being excluded from the tunnel sometimes if auto-connect was enabled.
 
 #### Windows
 - Fix log output encoding for Windows modules.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -114,7 +114,7 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
                 is TunnelState.Disconnecting -> {
                     when (currentState.actionAfterDisconnect) {
                         ActionAfterDisconnect.Nothing -> false
-                        ActionAfterDisconnect.Reconnect -> false
+                        ActionAfterDisconnect.Reconnect -> true
                         ActionAfterDisconnect.Block -> true
                     }
                 }


### PR DESCRIPTION
Previously, sometimes the app would start with Auto-Connect enabled and connect automatically before the list of excluded apps was loaded from persistent storage. After loading is complete, the `SplitTunneling` class notifies the listener (`MullvadVpnService`) which then requests a reconnect.

However, if the reconnect is requested while the app is already reconnecting, the reconnect command wouldn't get sent to the daemon. That meant that the tunnel wouldn't be recreated to exclude the loaded apps, which led to the bug.

This PR fixes that by allowing the reconnect command to be sent to the daemon even if it is already reconnecting.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2223)
<!-- Reviewable:end -->
