### PR TITLE
Prevent duplicate fwmark rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Line wrap the file at 100 chars.                                              Th
 - Handle statically added routes.
 - Stop reconnecting when using WireGuard and NetworkManager.
 - Apply DNS config quicker when managing DNS via NetworkManager.
+- Fix routing rules sometimes being duplicated.
 
 
 ### Security


### PR DESCRIPTION
`RouteManager::enable_exclusions_routes` is called when entering the connecting state, but `NLM_F_REPLACE` is ignored when the rule is added, causing duplicate rules to be added if it is called multiple times.

This may occur if connecting fails, for example, and the daemon attempts to reconnect. In this case, the disconnected state is not entered before the connecting state is entered again, and so `RouteManager::disable_exclusions_routes` is not called in between.

This should not cause any serious issues, but it does clutter the routing rules list seen with `ip rule`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2224)
<!-- Reviewable:end -->
