### PR TITLE
Improve order of translation instructions

### DIFF
--- a/gui/locales/README.md
+++ b/gui/locales/README.md
@@ -45,6 +45,11 @@ This is a folder with gettext translations for Mullvad VPN app.
 Run `npm run update-translations` to extract the new translations from the source
 code. Use `crowdin.sh upload` to submit them to Crowdin.
 
+#### Android translations
+
+The Android app uses translation strings stored in a different format, but which can be generated
+from the translations in this directory. For more information, see [here](../../android/README.md).
+
 ### relay-locations.pot
 
 To update the countries and cities you have to run the geo data scripts. Follow the instructions
@@ -77,8 +82,3 @@ command:
 ```
 CROWDIN_API_KEY=$YOUR_CROWDIN_KEY ./gui/scripts/crowdin.sh download
 ```
-
-## Android translations
-
-The Android app uses translation strings stored in a different format, but which can be generated
-from the translations in this directory. For more information, see [here](../../android/README.md).

--- a/gui/locales/README.md
+++ b/gui/locales/README.md
@@ -43,7 +43,7 @@ This is a folder with gettext translations for Mullvad VPN app.
 ### messages.pot
 
 Run `npm run update-translations` to extract the new translations from the source
-code. Use `crowdin.sh upload` to submit them to Crowdin.
+code.
 
 #### Android translations
 

--- a/gui/locales/README.md
+++ b/gui/locales/README.md
@@ -53,7 +53,7 @@ from the translations in this directory. For more information, see [here](../../
 ### relay-locations.pot
 
 To update the countries and cities you have to run the geo data scripts. Follow the instructions
-in `gui/scripts/README.md`.
+in [`gui/scripts/README.md`](../scripts/README.md).
 
 ## Uploading translations template to Crowdin
 


### PR DESCRIPTION
This PR moves the reference to the translation generation instructions for Android to the `messages.pot` section in `gui/locales/README.md` to prevent that they are forgotten when preparing a release.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2227)
<!-- Reviewable:end -->
