### PR TITLE
Set account history button type to "button" to prevent submitting twice

### DIFF
--- a/gui/src/renderer/components/Login.tsx
+++ b/gui/src/renderer/components/Login.tsx
@@ -361,7 +361,7 @@ function AccountDropdownItem(props: IAccountDropdownItemProps) {
       <StyledAccountDropdownItem>
         <AriaControlGroup>
           <AriaControlled>
-            <StyledAccountDropdownItemButton id={props.label} onClick={handleSelect}>
+            <StyledAccountDropdownItemButton id={props.label} onClick={handleSelect} type="button">
               <StyledAccountDropdownItemButtonLabel>
                 {props.label}
               </StyledAccountDropdownItemButtonLabel>


### PR DESCRIPTION
When improving the accessibility the login form was converted to a `form` element which caused the account history items to submit the form in addition to the intended logic. This resulted in `login()` being called twice. This wasn't very noticeable but if the app was set to auto connect on login and that connection took more than a second **and** the user entered the settings view before the connection completed or the second login call timed out, the app redirected back to `/connect`. Adding `type="button"` makes sure that the history items don't submit the form.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2229)
<!-- Reviewable:end -->
