### PR TITLE
Generalize the route manager channel

### DIFF
--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -17,8 +17,7 @@ use netlink_packet_route::rtnl::constants::RT_TABLE_MAIN;
 
 pub use imp::{Error, RouteManager};
 
-#[cfg(target_os = "linux")]
-pub use imp::RouteManagerCommand;
+pub use imp::RouteManagerHandle;
 
 /// A netowrk route with a specific network node, destinaiton and an optional metric.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]

--- a/talpid-core/src/routing/windows.rs
+++ b/talpid-core/src/routing/windows.rs
@@ -22,18 +22,23 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct RouteManager {
     callback_handles: Vec<winnet::WinNetCallbackHandle>,
     is_stopped: bool,
+    runtime: tokio::runtime::Handle,
 }
 
 impl RouteManager {
     /// Creates a new route manager that will apply the provided routes and ensure they exist until
     /// it's stopped.
-    pub fn new(required_routes: HashSet<RequiredRoute>) -> Result<Self> {
+    pub fn new(
+        runtime: tokio::runtime::Handle,
+        required_routes: HashSet<RequiredRoute>,
+    ) -> Result<Self> {
         if !winnet::activate_routing_manager() {
             return Err(Error::FailedToStartManager);
         }
         let manager = Self {
             callback_handles: vec![],
             is_stopped: false,
+            runtime,
         };
         manager.add_routes(required_routes)?;
         Ok(manager)

--- a/talpid-core/src/routing/windows.rs
+++ b/talpid-core/src/routing/windows.rs
@@ -1,5 +1,12 @@
 use super::NetNode;
 use crate::{routing::RequiredRoute, winnet};
+use futures::{
+    channel::{
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        oneshot,
+    },
+    StreamExt,
+};
 use std::collections::HashSet;
 
 /// Windows routing errors.
@@ -14,6 +21,9 @@ pub enum Error {
     /// Failure to clear routes
     #[error(display = "Failed to clear applied routes")]
     ClearRoutesFailed,
+    /// Attempt to use route manager that has been dropped
+    #[error(display = "Cannot send message to route manager since it is down")]
+    RouteManagerDown,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -21,8 +31,32 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Manages routes by calling into WinNet
 pub struct RouteManager {
     callback_handles: Vec<winnet::WinNetCallbackHandle>,
-    is_stopped: bool,
     runtime: tokio::runtime::Handle,
+    manage_tx: Option<UnboundedSender<RouteManagerCommand>>,
+}
+
+/// Handle to a route manager.
+#[derive(Clone)]
+pub struct RouteManagerHandle {
+    runtime: tokio::runtime::Handle,
+    tx: UnboundedSender<RouteManagerCommand>,
+}
+
+impl RouteManagerHandle {
+    /// Applies the given routes while the route manager is running.
+    pub fn add_routes(&self, routes: HashSet<RequiredRoute>) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .unbounded_send(RouteManagerCommand::AddRoutes(routes, response_tx))
+            .map_err(|_| Error::RouteManagerDown)?;
+        self.runtime.block_on(response_rx).unwrap()
+    }
+}
+
+#[derive(Debug)]
+pub enum RouteManagerCommand {
+    AddRoutes(HashSet<RequiredRoute>, oneshot::Sender<Result<()>>),
+    Shutdown,
 }
 
 impl RouteManager {
@@ -35,13 +69,61 @@ impl RouteManager {
         if !winnet::activate_routing_manager() {
             return Err(Error::FailedToStartManager);
         }
+        let (manage_tx, manage_rx) = mpsc::unbounded();
         let manager = Self {
             callback_handles: vec![],
-            is_stopped: false,
-            runtime,
+            runtime: runtime.clone(),
+            manage_tx: Some(manage_tx),
         };
         manager.add_routes(required_routes)?;
+        runtime.spawn(RouteManager::listen(manage_rx));
+
         Ok(manager)
+    }
+
+    /// Retrieve a sender directly to the command channel.
+    pub fn handle(&self) -> Result<RouteManagerHandle> {
+        if let Some(tx) = &self.manage_tx {
+            Ok(RouteManagerHandle {
+                runtime: self.runtime.clone(),
+                tx: tx.clone(),
+            })
+        } else {
+            Err(Error::RouteManagerDown)
+        }
+    }
+
+    async fn listen(mut manage_rx: UnboundedReceiver<RouteManagerCommand>) {
+        while let Some(command) = manage_rx.next().await {
+            match command {
+                RouteManagerCommand::AddRoutes(routes, tx) => {
+                    let routes: Vec<_> = routes
+                        .iter()
+                        .map(|route| {
+                            let destination = winnet::WinNetIpNetwork::from(route.prefix);
+                            match &route.node {
+                                NetNode::DefaultNode => {
+                                    winnet::WinNetRoute::through_default_node(destination)
+                                }
+                                NetNode::RealNode(node) => winnet::WinNetRoute::new(
+                                    winnet::WinNetNode::from(node),
+                                    destination,
+                                ),
+                            }
+                        })
+                        .collect();
+
+                    if winnet::routing_manager_add_routes(&routes) {
+                        let _ = tx.send(Ok(()));
+                    } else {
+                        let _ = tx.send(Err(Error::AddRoutesFailed));
+                    }
+                }
+                RouteManagerCommand::Shutdown => {
+                    break;
+                }
+            }
+        }
     }
 
     /// Sets a callback that is called whenever the default route changes.
@@ -51,7 +133,7 @@ impl RouteManager {
         callback: Option<winnet::DefaultRouteChangedCallback>,
         context: T,
     ) {
-        if self.is_stopped {
+        if self.manage_tx.is_none() {
             return;
         }
 
@@ -76,32 +158,29 @@ impl RouteManager {
     /// Stops the routing manager and invalidates the route manager - no new default route callbacks
     /// can be added
     pub fn stop(&mut self) {
-        if !self.is_stopped {
+        if let Some(tx) = self.manage_tx.take() {
+            if tx.unbounded_send(RouteManagerCommand::Shutdown).is_err() {
+                log::error!("RouteManager channel already down or thread panicked");
+            }
+
             self.callback_handles.clear();
             winnet::deactivate_routing_manager();
-            self.is_stopped = true;
         }
     }
 
     /// Applies the given routes until [`RouteManager::stop`] is called.
     pub fn add_routes(&self, routes: HashSet<RequiredRoute>) -> Result<()> {
-        let routes: Vec<_> = routes
-            .iter()
-            .map(|route| {
-                let destination = winnet::WinNetIpNetwork::from(route.prefix);
-                match &route.node {
-                    NetNode::DefaultNode => winnet::WinNetRoute::through_default_node(destination),
-                    NetNode::RealNode(node) => {
-                        winnet::WinNetRoute::new(winnet::WinNetNode::from(node), destination)
-                    }
-                }
-            })
-            .collect();
-
-        if winnet::routing_manager_add_routes(&routes) {
-            Ok(())
+        if let Some(tx) = &self.manage_tx {
+            let (result_tx, result_rx) = oneshot::channel();
+            if tx
+                .unbounded_send(RouteManagerCommand::AddRoutes(routes, result_tx))
+                .is_err()
+            {
+                return Err(Error::RouteManagerDown);
+            }
+            self.runtime.block_on(result_rx).unwrap()
         } else {
-            Err(Error::AddRoutesFailed)
+            Err(Error::RouteManagerDown)
         }
     }
 

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -109,6 +109,7 @@ pub async fn spawn(
     let (startup_result_tx, startup_result_rx) = sync_mpsc::channel();
     std::thread::spawn(move || {
         let state_machine = TunnelStateMachine::new(
+            runtime.clone(),
             allow_lan,
             block_when_disconnected,
             is_offline,
@@ -189,6 +190,7 @@ struct TunnelStateMachine {
 
 impl TunnelStateMachine {
     fn new(
+        runtime: tokio::runtime::Handle,
         allow_lan: bool,
         block_when_disconnected: bool,
         is_offline: bool,
@@ -209,7 +211,7 @@ impl TunnelStateMachine {
         let firewall = Firewall::new(args).map_err(Error::InitFirewallError)?;
         let dns_monitor = DnsMonitor::new(cache_dir).map_err(Error::InitDnsMonitorError)?;
         let route_manager =
-            RouteManager::new(HashSet::new()).map_err(Error::InitRouteManagerError)?;
+            RouteManager::new(runtime, HashSet::new()).map_err(Error::InitRouteManagerError)?;
         let mut shared_values = SharedTunnelStateValues {
             firewall,
             dns_monitor,


### PR DESCRIPTION
On Linux, a channel can already be used to communicate with the route manager across different threads. This has been generalized to all OSes and abstracted behind a type `RouteManagerHandle`. It is a prerequisite for manually setting up routes in the OpenVPN tunnel monitor, which is part of a refactoring to rely less on route monitoring.

### Other changes
* No longer spawn a separate new runtime on Linux for the route manager.
* Don't rely on executors from `futures` while handling events from OpenVPN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2231)
<!-- Reviewable:end -->
