### PR TITLE
Replace connected-react-router with use of withRouter()

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -3089,26 +3089,6 @@
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
       "dev": true
     },
-    "connected-react-router": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.8.0.tgz",
-      "integrity": "sha512-E64/6krdJM3Ag3MMmh2nKPtMbH15s3JQDuaYJvOVXzu6MbHbDyIvuwLOyhQIuP4Om9zqEfZYiVyflROibSsONg==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        }
-      }
-    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",

--- a/gui/package.json
+++ b/gui/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.1.2",
     "argv-split": "^2.0.1",
-    "connected-react-router": "^6.8.0",
     "d3-geo": "^1.12.1",
     "electron-log": "^4.1.1",
     "gettext-parser": "^4.0.3",

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -1,12 +1,8 @@
-import {
-  ConnectedRouter,
-  push as pushHistory,
-  replace as replaceHistory,
-} from 'connected-react-router';
 import { ipcRenderer, shell, webFrame } from 'electron';
 import log from 'electron-log';
 import * as React from 'react';
 import { Provider } from 'react-redux';
+import { Router } from 'react-router';
 import { bindActionCreators } from 'redux';
 
 import ErrorBoundary from './components/ErrorBoundary';
@@ -77,20 +73,13 @@ const SUPPORTED_LOCALE_LIST = [
 
 export default class AppRenderer {
   private history = new History('/');
-  private reduxStore = configureStore(this.history);
+  private reduxStore = configureStore();
   private reduxActions = {
     account: bindActionCreators(accountActions, this.reduxStore.dispatch),
     connection: bindActionCreators(connectionActions, this.reduxStore.dispatch),
     settings: bindActionCreators(settingsActions, this.reduxStore.dispatch),
     version: bindActionCreators(versionActions, this.reduxStore.dispatch),
     userInterface: bindActionCreators(userInterfaceActions, this.reduxStore.dispatch),
-    history: bindActionCreators(
-      {
-        push: pushHistory,
-        replace: replaceHistory,
-      },
-      this.reduxStore.dispatch,
-    ),
   };
 
   private locale = 'en';
@@ -229,11 +218,11 @@ export default class AppRenderer {
     return (
       <AppContext.Provider value={{ app: this }}>
         <Provider store={this.reduxStore}>
-          <ConnectedRouter history={this.history}>
+          <Router history={this.history}>
             <ErrorBoundary>
               <AppRoutes />
             </ErrorBoundary>
-          </ConnectedRouter>
+          </Router>
         </Provider>
       </AppContext.Provider>
     );

--- a/gui/src/renderer/containers/AccountPage.tsx
+++ b/gui/src/renderer/containers/AccountPage.tsx
@@ -1,6 +1,5 @@
-import { goBack } from 'connected-react-router';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { links } from '../../config.json';
 import consumePromise from '../../shared/promise';
 import Account from '../components/Account';
@@ -14,17 +13,16 @@ const mapStateToProps = (state: IReduxState) => ({
   expiryLocale: state.userInterface.locale,
   isOffline: state.connection.isBlocked,
 });
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
-  const history = bindActionCreators({ goBack }, dispatch);
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   return {
     onLogout: () => {
       consumePromise(props.app.logout());
     },
     onClose: () => {
-      history.goBack();
+      props.history.goBack();
     },
     onBuyMore: () => props.app.openLinkWithAuth(links.purchase),
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(Account));
+export default withAppContext(withRouter(connect(mapStateToProps, mapDispatchToProps)(Account)));

--- a/gui/src/renderer/containers/AdvancedSettingsPage.tsx
+++ b/gui/src/renderer/containers/AdvancedSettingsPage.tsx
@@ -1,7 +1,6 @@
-import { goBack, push } from 'connected-react-router';
 import log from 'electron-log';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { BridgeState, RelayProtocol, TunnelProtocol } from '../../shared/daemon-rpc-types';
 import RelaySettingsBuilder from '../../shared/relay-settings-builder';
 import AdvancedSettings from '../components/AdvancedSettings';
@@ -51,11 +50,10 @@ const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) =>
   }
 };
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
-  const history = bindActionCreators({ push, goBack }, dispatch);
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   return {
     onClose: () => {
-      history.goBack();
+      props.history.goBack();
     },
     setOpenVpnRelayProtocolAndPort: async (protocol?: RelayProtocol, port?: number) => {
       const relayUpdate = RelaySettingsBuilder.normal()
@@ -154,9 +152,11 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
         log.error('Failed to update mtu value', e.message);
       }
     },
-    onViewWireguardKeys: () => history.push('/settings/advanced/wireguard-keys'),
-    onViewLinuxSplitTunneling: () => history.push('/settings/advanced/linux-split-tunneling'),
+    onViewWireguardKeys: () => props.history.push('/settings/advanced/wireguard-keys'),
+    onViewLinuxSplitTunneling: () => props.history.push('/settings/advanced/linux-split-tunneling'),
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(AdvancedSettings));
+export default withAppContext(
+  withRouter(connect(mapStateToProps, mapDispatchToProps)(AdvancedSettings)),
+);

--- a/gui/src/renderer/containers/ConnectPage.tsx
+++ b/gui/src/renderer/containers/ConnectPage.tsx
@@ -1,7 +1,6 @@
-import { push } from 'connected-react-router';
 import log from 'electron-log';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { sprintf } from 'sprintf-js';
 import { messages } from '../../shared/gettext';
 import Connect from '../components/Connect';
@@ -72,12 +71,10 @@ const mapStateToProps = (state: IReduxState) => {
   };
 };
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
-  const history = bindActionCreators({ push }, dispatch);
-
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   return {
     onSelectLocation: () => {
-      history.push('/select-location');
+      props.history.push('/select-location');
     },
     onConnect: async () => {
       try {
@@ -103,4 +100,4 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(Connect));
+export default withAppContext(withRouter(connect(mapStateToProps, mapDispatchToProps)(Connect)));

--- a/gui/src/renderer/containers/PreferencesPage.tsx
+++ b/gui/src/renderer/containers/PreferencesPage.tsx
@@ -1,7 +1,6 @@
-import { goBack } from 'connected-react-router';
 import log from 'electron-log';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import consumePromise from '../../shared/promise';
 import Preferences from '../components/Preferences';
 import withAppContext, { IAppContext } from '../context';
@@ -18,11 +17,10 @@ const mapStateToProps = (state: IReduxState) => ({
   startMinimized: state.settings.guiSettings.startMinimized,
 });
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
-  const history = bindActionCreators({ goBack }, dispatch);
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   return {
     onClose: () => {
-      history.goBack();
+      props.history.goBack();
     },
     setEnableSystemNotifications: (flag: boolean) => {
       props.app.setEnableSystemNotifications(flag);
@@ -53,4 +51,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(Preferences));
+export default withAppContext(
+  withRouter(connect(mapStateToProps, mapDispatchToProps)(Preferences)),
+);

--- a/gui/src/renderer/containers/SelectLanguagePage.tsx
+++ b/gui/src/renderer/containers/SelectLanguagePage.tsx
@@ -1,6 +1,5 @@
-import { goBack } from 'connected-react-router';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import SelectLanguage from '../components/SelectLanguage';
 import withAppContext, { IAppContext } from '../context';
 import { IReduxState, ReduxDispatch } from '../redux/store';
@@ -9,19 +8,19 @@ const mapStateToProps = (state: IReduxState) => ({
   preferredLocale: state.settings.guiSettings.preferredLocale,
 });
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
-  const history = bindActionCreators({ goBack }, dispatch);
-
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   return {
     preferredLocalesList: props.app.getPreferredLocaleList(),
     setPreferredLocale(locale: string) {
       props.app.setPreferredLocale(locale);
-      history.goBack();
+      props.history.goBack();
     },
     onClose() {
-      history.goBack();
+      props.history.goBack();
     },
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(SelectLanguage));
+export default withAppContext(
+  withRouter(connect(mapStateToProps, mapDispatchToProps)(SelectLanguage)),
+);

--- a/gui/src/renderer/containers/SelectLocationPage.tsx
+++ b/gui/src/renderer/containers/SelectLocationPage.tsx
@@ -1,6 +1,6 @@
-import { goBack } from 'connected-react-router';
 import log from 'electron-log';
 import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { bindActionCreators } from 'redux';
 import BridgeSettingsBuilder from '../../shared/bridge-settings-builder';
 import { LiftedConstraint, RelayLocation } from '../../shared/daemon-rpc-types';
@@ -40,18 +40,17 @@ const mapStateToProps = (state: IReduxState) => {
     allowBridgeSelection,
   };
 };
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
-  const history = bindActionCreators({ goBack }, dispatch);
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   const userInterface = bindActionCreators(userInterfaceActions, dispatch);
 
   return {
-    onClose: () => history.goBack(),
+    onClose: () => props.history.goBack(),
     onChangeLocationScope: (scope: LocationScope) => {
       userInterface.setLocationScope(scope);
     },
     onSelectExitLocation: async (relayLocation: RelayLocation) => {
       // dismiss the view first
-      history.goBack();
+      props.history.goBack();
 
       try {
         const relayUpdate = RelaySettingsBuilder.normal().location.fromRaw(relayLocation).build();
@@ -64,7 +63,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
     },
     onSelectBridgeLocation: async (bridgeLocation: RelayLocation) => {
       // dismiss the view first
-      history.goBack();
+      props.history.goBack();
 
       try {
         await props.app.updateBridgeSettings(
@@ -76,7 +75,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
     },
     onSelectClosestToExit: async () => {
       // dismiss the view first
-      history.goBack();
+      props.history.goBack();
 
       try {
         await props.app.updateBridgeSettings(new BridgeSettingsBuilder().location.any().build());
@@ -87,4 +86,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(SelectLocation));
+export default withAppContext(
+  withRouter(connect(mapStateToProps, mapDispatchToProps)(SelectLocation)),
+);

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -1,7 +1,6 @@
-import { goBack, push } from 'connected-react-router';
 import { remote, shell } from 'electron';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import Settings from '../components/Settings';
 import withAppContext, { IAppContext } from '../context';
 import { IReduxState, ReduxDispatch } from '../redux/store';
@@ -18,18 +17,17 @@ const mapStateToProps = (state: IReduxState, props: IAppContext) => ({
   upToDateVersion: state.version.suggestedUpgrade ? false : true,
   isOffline: state.connection.isBlocked,
 });
-const mapDispatchToProps = (dispatch: ReduxDispatch) => {
-  const history = bindActionCreators({ push, goBack }, dispatch);
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   return {
     onQuit: () => remote.app.quit(),
-    onClose: () => history.goBack(),
-    onViewSelectLanguage: () => history.push('/settings/language'),
-    onViewAccount: () => history.push('/settings/account'),
-    onViewSupport: () => history.push('/settings/support'),
-    onViewPreferences: () => history.push('/settings/preferences'),
-    onViewAdvancedSettings: () => history.push('/settings/advanced'),
+    onClose: () => props.history.goBack(),
+    onViewSelectLanguage: () => props.history.push('/settings/language'),
+    onViewAccount: () => props.history.push('/settings/account'),
+    onViewSupport: () => props.history.push('/settings/support'),
+    onViewPreferences: () => props.history.push('/settings/preferences'),
+    onViewAdvancedSettings: () => props.history.push('/settings/advanced'),
     onExternalLink: (url: string) => shell.openExternal(url),
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(Settings));
+export default withAppContext(withRouter(connect(mapStateToProps, mapDispatchToProps)(Settings)));

--- a/gui/src/renderer/containers/SupportPage.tsx
+++ b/gui/src/renderer/containers/SupportPage.tsx
@@ -1,6 +1,6 @@
-import { goBack } from 'connected-react-router';
 import { shell } from 'electron';
 import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { bindActionCreators } from 'redux';
 import Support from '../components/Support';
 import { collectProblemReport, sendProblemReport } from '../lib/problem-report';
@@ -15,13 +15,12 @@ const mapStateToProps = (state: IReduxState) => ({
   outdatedVersion: state.version.suggestedUpgrade ? true : false,
 });
 
-const mapDispatchToProps = (dispatch: ReduxDispatch) => {
+const mapDispatchToProps = (dispatch: ReduxDispatch, props: RouteComponentProps) => {
   const { saveReportForm, clearReportForm } = bindActionCreators(supportActions, dispatch);
-  const history = bindActionCreators({ goBack }, dispatch);
 
   return {
     onClose() {
-      history.goBack();
+      props.history.goBack();
     },
     viewLog(path: string) {
       shell.openItem(path);
@@ -34,4 +33,4 @@ const mapDispatchToProps = (dispatch: ReduxDispatch) => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Support);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Support));

--- a/gui/src/renderer/containers/WireguardKeysPage.tsx
+++ b/gui/src/renderer/containers/WireguardKeysPage.tsx
@@ -1,6 +1,5 @@
-import { goBack, push } from 'connected-react-router';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { links } from '../../config.json';
 import WireguardKeys from '../components/WireguardKeys';
 import withAppContext, { IAppContext } from '../context';
@@ -14,10 +13,9 @@ const mapStateToProps = (state: IReduxState) => ({
   tunnelState: state.connection.status,
   windowFocused: state.userInterface.windowFocused,
 });
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
-  const history = bindActionCreators({ push, goBack }, dispatch);
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
   return {
-    onClose: () => history.goBack(),
+    onClose: () => props.history.goBack(),
     onGenerateKey: () => props.app.generateWireguardKey(),
     onReplaceKey: (oldKey: IWgKey) => props.app.replaceWireguardKey(oldKey),
     onVerifyKey: (publicKey: IWgKey) => props.app.verifyWireguardKey(publicKey),
@@ -25,4 +23,6 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {
   };
 };
 
-export default withAppContext(connect(mapStateToProps, mapDispatchToProps)(WireguardKeys));
+export default withAppContext(
+  withRouter(connect(mapStateToProps, mapDispatchToProps)(WireguardKeys)),
+);

--- a/gui/src/renderer/redux/store.ts
+++ b/gui/src/renderer/redux/store.ts
@@ -1,5 +1,4 @@
-import { connectRouter, push, replace, routerMiddleware } from 'connected-react-router';
-import { applyMiddleware, combineReducers, compose, createStore, Dispatch } from 'redux';
+import { combineReducers, compose, createStore, Dispatch } from 'redux';
 
 import accountActions, { AccountAction } from './account/actions';
 import accountReducer, { IAccountReduxState } from './account/reducers';
@@ -13,8 +12,6 @@ import userInterfaceActions, { UserInterfaceAction } from './userinterface/actio
 import userInterfaceReducer, { IUserInterfaceReduxState } from './userinterface/reducers';
 import versionActions, { VersionAction } from './version/actions';
 import versionReducer, { IVersionReduxState } from './version/reducers';
-
-import History from '../lib/history';
 
 export interface IReduxState {
   account: IAccountReduxState;
@@ -35,7 +32,7 @@ export type ReduxAction =
 export type ReduxStore = ReturnType<typeof configureStore>;
 export type ReduxDispatch = Dispatch<ReduxAction>;
 
-export default function configureStore(routerHistory: History, initialState?: IReduxState) {
+export default function configureStore(initialState?: IReduxState) {
   const actionCreators = {
     ...accountActions,
     ...connectionActions,
@@ -43,8 +40,6 @@ export default function configureStore(routerHistory: History, initialState?: IR
     ...supportActions,
     ...versionActions,
     ...userInterfaceActions,
-    pushRoute: (route: string) => push(route),
-    replaceRoute: (route: string) => replace(route),
   };
 
   const reducers = {
@@ -54,7 +49,6 @@ export default function configureStore(routerHistory: History, initialState?: IR
     support: supportReducer,
     version: versionReducer,
     userInterface: userInterfaceReducer,
-    router: connectRouter(routerHistory),
   };
 
   const composeEnhancers: typeof compose = (() => {
@@ -66,8 +60,7 @@ export default function configureStore(routerHistory: History, initialState?: IR
     return compose;
   })();
 
-  const enhancer = composeEnhancers(applyMiddleware(routerMiddleware(routerHistory)));
-
+  const enhancer = composeEnhancers();
   const rootReducer = combineReducers(reducers);
 
   if (initialState) {


### PR DESCRIPTION
This PR removes the `connected-react-router` dependency since the same functionality can be achieved with the `withRouter` HOC.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2232)
<!-- Reviewable:end -->
