### PR TITLE
Fix Android cell widget UI

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
@@ -18,7 +18,7 @@ open class Cell : LinearLayout {
         setPadding(0, verticalPadding, rightPadding, verticalPadding)
 
         setTextColor(context.getColor(R.color.white))
-        setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.text_medium))
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.text_medium_plus))
         setTypeface(null, Typeface.BOLD)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
@@ -40,6 +40,7 @@ open class Cell : LinearLayout {
     protected var cell: LinearLayout = this
         set(value) {
             field = value.apply {
+                val height = resources.getDimensionPixelSize(R.dimen.cell_height)
                 val leftPadding = resources.getDimensionPixelSize(R.dimen.cell_left_padding)
                 val rightPadding = resources.getDimensionPixelSize(R.dimen.cell_right_padding)
 
@@ -47,6 +48,7 @@ open class Cell : LinearLayout {
                 isClickable = true
                 gravity = Gravity.CENTER
                 orientation = HORIZONTAL
+                minimumHeight = height
 
                 setBackgroundResource(R.drawable.cell_button_background)
                 setPadding(leftPadding, 0, rightPadding, 0)

--- a/android/src/main/res/values/dimensions.xml
+++ b/android/src/main/res/values/dimensions.xml
@@ -10,6 +10,7 @@
     <dimen name="account_history_entry_height">48dp</dimen>
     <dimen name="edit_text_corner_radius">4dp</dimen>
     <dimen name="button_height">44dp</dimen>
+    <dimen name="cell_height">52dp</dimen>
     <dimen name="cell_switch_border_radius">16dp</dimen>
     <dimen name="cell_switch_width">48dp</dimen>
     <dimen name="cell_switch_height">30dp</dimen>


### PR DESCRIPTION
While implementing the custom DNS UI, I realized that something was odd. The new UI elements seemed larger than the elements that were already present. After talking to Matilda about it, I realized that I made a mistake when I scaled down the UI dimensions following the desktop changes a few months ago. This PR fixes a few more noticeable issues, but o more thorough check should be done in the future comparing all screens to the source-of-truth.

In this PR, the text size of the label in the cell widget is fixed, as well as establishing a minimum height for the cell widget. The height is still allowed to grow (even though that might cause a few inconsistencies) because some languages have long text that end up spanning more than one line.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **UI tweak, no changelog necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2236)
<!-- Reviewable:end -->
