### PR TITLE
Don't manage DNS via systemd-resolved in NM module

### DIFF
--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -40,7 +40,7 @@ pub enum Error {
     #[error(display = "Failed to match the returned D-Bus object with expected type")]
     MatchDBusTypeError(#[error(source)] dbus::arg::TypeMismatchError),
 
-    #[error(display = "DNS is managed by systemd-resolved - NM can't enforce DNS globally")]
+    #[error(display = "DNS is managed by systemd-resolved")]
     SystemdResolved,
 
     #[error(display = "Failed to find obtain devices from network manager")]
@@ -122,6 +122,8 @@ impl NetworkManager {
             .map_err(Error::Dbus)?;
 
         match dns_mode.as_ref() {
+            // If systemd-resolved manages DNS, then our config is ignored
+            "systemd-resolved" => return Err(Error::SystemdResolved),
             // If NetworkManager isn't managing DNS for us, it's useless.
             "none" => return Err(Error::NetworkManagerNotManagingDns),
             _ => (),


### PR DESCRIPTION
We generally fall back on NM if systemd-resolved cannot be used. In this case, if NM manages DNS via systemd-resolved, the configuration that is set on the connection is apparently ignored. Solve this by returning an error and falling back on the static resolver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2237)
<!-- Reviewable:end -->
