### PR TITLE
Use netlink for connectivity checking

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -152,7 +152,7 @@ impl WireguardMonitor {
     ) -> Result<Box<dyn Tunnel>> {
         #[cfg(target_os = "linux")]
         if !*FORCE_USERSPACE_WIREGUARD {
-            match network_manager::NetworkManager::new(config) {
+            match network_manager::NetworkManager::new(route_manager.runtime_handle(), config) {
                 Ok(tunnel) => {
                     log::debug!("Using NetworkManager to use kernel WireGuard implementation");
                     return Ok(Box::new(tunnel));

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
@@ -19,7 +19,7 @@ use tokio::stream::StreamExt;
 
 mod parsers;
 
-mod wg_message;
+pub mod wg_message;
 use wg_message::{DeviceMessage, DeviceNla, PeerNla};
 mod nl_message;
 use nl_message::{ControlNla, NetlinkControlMessage};
@@ -209,7 +209,7 @@ impl Tunnel for KernelTunnel {
 
 #[derive(Debug)]
 pub struct Handle {
-    wg_handle: WireguardConnection,
+    pub wg_handle: WireguardConnection,
     route_handle: rtnetlink::Handle,
     wg_abort_handle: AbortHandle,
     route_abort_handle: AbortHandle,
@@ -370,7 +370,7 @@ impl Drop for Handle {
 }
 
 #[derive(Debug, Clone)]
-struct WireguardConnection {
+pub struct WireguardConnection {
     connection: ConnectionHandle<DeviceMessage>,
     message_type: u16,
 }

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
@@ -1,4 +1,4 @@
-use super::{stats::Stats, Config, Tunnel, TunnelError};
+use super::{Config, Tunnel, TunnelError};
 use futures::future::{abortable, AbortHandle};
 use netlink_packet_core::{constants::*, NetlinkDeserializable};
 use netlink_packet_route::{
@@ -20,9 +20,14 @@ use tokio::stream::StreamExt;
 mod parsers;
 
 pub mod wg_message;
-use wg_message::{DeviceMessage, DeviceNla, PeerNla};
-mod nl_message;
+use wg_message::{DeviceMessage, DeviceNla};
+pub mod nl_message;
 use nl_message::{ControlNla, NetlinkControlMessage};
+
+pub mod netlink_tunnel;
+pub use netlink_tunnel::NetlinkTunnel;
+pub mod nm_tunnel;
+pub use nm_tunnel::NetworkManagerTunnel;
 
 
 #[derive(err_derive::Error, Debug)]
@@ -75,137 +80,22 @@ pub enum Error {
 
     #[error(display = "Failed to delete device")]
     DeleteDeviceError(#[error(source)] rtnetlink::Error),
-}
 
-pub struct KernelTunnel {
-    interface_index: u32,
-    netlink_connections: Handle,
-    tokio_handle: tokio::runtime::Handle,
+    #[error(display = "NetworkManager error")]
+    NetworkManager(#[error(source)] nm_tunnel::Error),
 }
 
 const MULLVAD_INTERFACE_NAME: &str = "wg-mullvad";
 
-impl KernelTunnel {
-    pub fn new(tokio_handle: tokio::runtime::Handle, config: &Config) -> Result<Self, Error> {
-        tokio_handle.clone().block_on(async {
-            let mut netlink_connections = Handle::connect().await?;
-            let interface_index = netlink_connections
-                .create_device(MULLVAD_INTERFACE_NAME.to_string(), config.mtu as u32)
-                .await?;
 
-            let mut tunnel = Self {
-                interface_index,
-                netlink_connections,
-                tokio_handle,
-            };
-
-            if let Err(err) = tunnel.setup(config).await {
-                if let Err(teardown_err) = tunnel
-                    .netlink_connections
-                    .delete_device(interface_index)
-                    .await
-                {
-                    log::error!(
-                        "Failed to tear down WireGuard interface after failing to apply config: {}",
-                        teardown_err
-                    );
-                }
-                return Err(err);
-            }
-
-
-            Ok(tunnel)
-        })
-    }
-
-    async fn setup(&mut self, config: &Config) -> Result<(), Error> {
-        self.netlink_connections
-            .wg_handle
-            .set_config(self.interface_index, config)
-            .await?;
-
-        for tunnel_ip in config.tunnel.addresses.iter() {
-            self.netlink_connections
-                .set_ip_address(self.interface_index, *tunnel_ip)
-                .await?;
-        }
-
-        Ok(())
-    }
-}
-
-impl Tunnel for KernelTunnel {
-    fn get_interface_name(&self) -> String {
-        let mut wg = self.netlink_connections.wg_handle.clone();
-        let result = self.tokio_handle.block_on(async move {
-            let device = wg.get_by_index(self.interface_index).await?;
-            for nla in device.nlas {
-                if let DeviceNla::IfName(name) = nla {
-                    return Ok(name);
-                }
-            }
-            return Err(Error::Truncated);
-        });
-
-        match result {
-            Ok(name) => name.to_string_lossy().to_string(),
-            Err(err) => {
-                log::error!("Failed to deduce interface name at runtime, will attempt to use the default name. {}", err);
-                MULLVAD_INTERFACE_NAME.to_string()
-            }
+impl Error {
+    pub fn should_use_userspace(&self) -> bool {
+        match self {
+            Error::NetworkManager(nm_tunnel::Error::NMTooOld(_)) => true,
+            _ => false,
         }
     }
-
-    fn stop(self: Box<Self>) -> std::result::Result<(), TunnelError> {
-        let Self {
-            mut netlink_connections,
-            interface_index,
-            tokio_handle,
-        } = *self;
-        tokio_handle.block_on(async move {
-            if let Err(err) = netlink_connections.delete_device(interface_index).await {
-                log::error!("Failed to remove WireGuard device - {}", err);
-                Err(TunnelError::FatalStartWireguardError)
-            } else {
-                Ok(())
-            }
-        })
-    }
-
-    fn get_tunnel_stats(&self) -> std::result::Result<Stats, TunnelError> {
-        let mut wg = self.netlink_connections.wg_handle.clone();
-        let interface_index = self.interface_index;
-        let result = self.tokio_handle.block_on(async move {
-            let device = wg.get_by_index(interface_index).await.map_err(|err| {
-                log::error!("Failed to fetch WireGuard device config: {}", err);
-                TunnelError::GetConfigError
-            })?;
-
-            // iterate over device attributes
-            let mut tx_bytes = 0;
-            let mut rx_bytes = 0;
-            for nla in device.nlas {
-                if let DeviceNla::Peers(peers) = nla {
-                    // iterate over all peer attributes
-                    let peer_iter = peers.iter().map(|peer| peer.0.as_slice()).flatten();
-
-                    for peer_nla in peer_iter {
-                        match peer_nla {
-                            PeerNla::TxBytes(bytes) => tx_bytes += *bytes,
-                            PeerNla::RxBytes(bytes) => rx_bytes += *bytes,
-                            _ => continue,
-                        };
-                    }
-                }
-            }
-
-            Ok(Stats { tx_bytes, rx_bytes })
-        });
-
-        result
-    }
 }
-
 
 #[derive(Debug)]
 pub struct Handle {

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
@@ -1,0 +1,113 @@
+use super::{
+    super::stats::Stats, wg_message::DeviceNla, Config, Error, Handle, Tunnel, TunnelError,
+    MULLVAD_INTERFACE_NAME,
+};
+
+
+pub struct NetlinkTunnel {
+    interface_index: u32,
+    netlink_connections: Handle,
+    tokio_handle: tokio::runtime::Handle,
+}
+
+impl NetlinkTunnel {
+    pub fn new(tokio_handle: tokio::runtime::Handle, config: &Config) -> Result<Self, Error> {
+        tokio_handle.clone().block_on(async {
+            let mut netlink_connections = Handle::connect().await?;
+            let interface_index = netlink_connections
+                .create_device(MULLVAD_INTERFACE_NAME.to_string(), config.mtu as u32)
+                .await?;
+
+            let mut tunnel = Self {
+                interface_index,
+                netlink_connections,
+                tokio_handle,
+            };
+
+            if let Err(err) = tunnel.setup(config).await {
+                if let Err(teardown_err) = tunnel
+                    .netlink_connections
+                    .delete_device(interface_index)
+                    .await
+                {
+                    log::error!(
+                        "Failed to tear down WireGuard interface after failing to apply config: {}",
+                        teardown_err
+                    );
+                }
+                return Err(err);
+            }
+
+
+            Ok(tunnel)
+        })
+    }
+
+    async fn setup(&mut self, config: &Config) -> Result<(), Error> {
+        self.netlink_connections
+            .wg_handle
+            .set_config(self.interface_index, config)
+            .await?;
+
+        for tunnel_ip in config.tunnel.addresses.iter() {
+            self.netlink_connections
+                .set_ip_address(self.interface_index, *tunnel_ip)
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Tunnel for NetlinkTunnel {
+    fn get_interface_name(&self) -> String {
+        let mut wg = self.netlink_connections.wg_handle.clone();
+        let result = self.tokio_handle.block_on(async move {
+            let device = wg.get_by_index(self.interface_index).await?;
+            for nla in device.nlas {
+                if let DeviceNla::IfName(name) = nla {
+                    return Ok(name);
+                }
+            }
+            return Err(Error::Truncated);
+        });
+
+        match result {
+            Ok(name) => name.to_string_lossy().to_string(),
+            Err(err) => {
+                log::error!("Failed to deduce interface name at runtime, will attempt to use the default name. {}", err);
+                MULLVAD_INTERFACE_NAME.to_string()
+            }
+        }
+    }
+
+    fn stop(self: Box<Self>) -> std::result::Result<(), TunnelError> {
+        let Self {
+            mut netlink_connections,
+            interface_index,
+            tokio_handle,
+        } = *self;
+        tokio_handle.block_on(async move {
+            if let Err(err) = netlink_connections.delete_device(interface_index).await {
+                log::error!("Failed to remove WireGuard device - {}", err);
+                Err(TunnelError::FatalStartWireguardError)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn get_tunnel_stats(&self) -> std::result::Result<Stats, TunnelError> {
+        let mut wg = self.netlink_connections.wg_handle.clone();
+        let interface_index = self.interface_index;
+        let result = self.tokio_handle.block_on(async move {
+            let device = wg.get_by_index(interface_index).await.map_err(|err| {
+                log::error!("Failed to fetch WireGuard device config: {}", err);
+                TunnelError::GetConfigError
+            })?;
+            Ok(Stats::parse_device_message(&device))
+        });
+
+        result
+    }
+}


### PR DESCRIPTION
One of the connectivity checker implementations uses D-Bus to check whether any traffic has been sent or received on the tunnel interface. This is preferentially used when setting up the kernel implementation of the WG tunnel.

At least one user has found that these D-Bus requests may time out and cause disconnects (apparently randomly). It isn't clear why this occurs, but it is possible that the time out is simply too ruthless on some slow systems. There should be no harm in giving the request more time to obtain the information. That is what this PR does.

```
[talpid_core::tunnel::wireguard::network_manager][ERROR] Failed to read tunnel stats from NM: "Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken."
[talpid_core::tunnel::wireguard][ERROR] Error: Connectivity monitor failed
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2238)
<!-- Reviewable:end -->
