### PR TITLE
Don't log absence of systemd-resolved as an error

### DIFF
--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -98,8 +98,12 @@ impl SystemdResolved {
             Ok(systemd_resolved)
         })();
 
-        if let Err(err) = &result {
-            log::error!("systemd-resolved is not being used because: {}", err);
+        match &result {
+            Err(Error::NoSystemdResolved(_)) => (),
+            Err(error) => {
+                log::error!("systemd-resolved is not being used because: {}", error);
+            }
+            Ok(_) => (),
         }
 
 


### PR DESCRIPTION
Currently, if systemd-resolved is not available, this is logged:
```
[ERROR] systemd-resolved is not being used because: Systemd resolved not detected
```
This is not an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2240)
<!-- Reviewable:end -->
