### PR TITLE
Prefer systemd-resolved over NM if it's working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Line wrap the file at 100 chars.                                              Th
 - Stop reconnecting when using WireGuard and NetworkManager.
 - Apply DNS config quicker when managing DNS via NetworkManager.
 - Fix routing rules sometimes being duplicated.
+- When NetworkManager is managing /etc/resolv.conf but ultimately using systemd-resolved, use
+  systemd-resolved directly to manage DNS.
 
 
 ### Security

--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -94,16 +94,19 @@ impl SystemdResolved {
             };
 
             systemd_resolved.ensure_resolved_exists()?;
-            Self::ensure_resolv_conf_is_resolved_symlink()?;
+            if !super::network_manager::is_nm_managing_via_resolved(
+                &systemd_resolved.dbus_connection,
+            ) {
+                Self::ensure_resolv_conf_is_resolved_symlink()?;
+            }
             Ok(systemd_resolved)
         })();
 
         match &result {
-            Err(Error::NoSystemdResolved(_)) => (),
+            Ok(_) | Err(Error::NoSystemdResolved(_)) => (),
             Err(error) => {
                 log::error!("systemd-resolved is not being used because: {}", error);
             }
-            Ok(_) => (),
         }
 
 


### PR DESCRIPTION
Originally, there were issues with NetworkManager not being able to set DNS servers per interface when it's managing DNS via systemd-resolved. Unfortunately, it fails silently and, worse still, there are users who have a config where `/etc/resolv.conf` is managed via NetworkManager but actual DNS management is done via systemd-resolved. In such a config, the daemon would fall back to using NetworkManager and it would fail silently. Whilst technically, NM is buggy here, the changes here would make the daemon prefer systemd-resolved over NM in a case where `/etc/resolv.conf` is still managed by NetworkManager yet DNS is actually managed via systemd-resolved's local resolver. This is achieved by verifying if NM is managing `/etc/resolv.conf` and relying on systemd-resolved when verifiying if the daemon should use systemd-resolved to apply our DNS config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2241)
<!-- Reviewable:end -->
