### PR TITLE
Always succeed in resetting the DNS config if the tunnel interface is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Line wrap the file at 100 chars.                                              Th
 - When NetworkManager is managing /etc/resolv.conf but ultimately using systemd-resolved, use
   systemd-resolved directly to manage DNS.
 - Only use WireGuard kernel implementation if DNS isn't managed via NetworkManager.
-
+- Reset DNS config correctly when the tunnel monitor unexpectedly goes down.
 
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and

--- a/talpid-core/src/dns/linux/resolvconf.rs
+++ b/talpid-core/src/dns/linux/resolvconf.rs
@@ -106,7 +106,7 @@ impl Resolvconf {
         let mut result = Ok(());
 
         for record_name in self.record_names.drain() {
-            let output = duct::cmd!(&self.resolvconf, "-d", &record_name)
+            let output = duct::cmd!(&self.resolvconf, "-d", &record_name, "-f")
                 .stderr_capture()
                 .unchecked()
                 .run()

--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -242,8 +242,8 @@ impl SystemdResolved {
             Ok(mut reply) => reply.as_result().map(|_| ()),
             Err(error) => {
                 if error.name() == Some("org.freedesktop.DBus.Error.UnknownObject") {
-                    log::info!(
-                        "Not reseting DNS of interface {} because it no longer exists",
+                    log::trace!(
+                        "Not resetting DNS of interface {} because it no longer exists",
                         interface_name
                     );
                     Ok(())

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -48,6 +48,7 @@ impl DnsMonitor {
     }
 
     /// Reset system DNS settings to what it was before being set by this instance.
+    /// This succeeds if the interface does not exist.
     pub fn reset(&mut self) -> Result<(), Error> {
         log::info!("Resetting DNS");
         self.inner.reset()


### PR DESCRIPTION
In some cases when resetting the DNS config, the tunnel interface is already down. This must be done regardless, because some implementations of the DNS monitor modify a global state (e.g., on Windows and macOS, or when using a static resolv.conf). At the moment, two implementations may return an error if an interface cannot be found. This PR updates them to always treat this as an expected case and not log an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2243)
<!-- Reviewable:end -->
