### PR TITLE
Move Docker images to Quay.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ matrix:
         # --privileged is required because nightly cargo uses statx instead of stat, and that
         # syscall is so new that it's not on the docker whitelist yet.
         # https://github.com/rust-lang/rust/issues/65662
-        - docker run -d --privileged --name mvd-build -v $(pwd):/travis -w /travis  mullvadvpn/mullvadvpn-app-build:latest tail -f /dev/null
+        - docker run -d --privileged --name mvd-build -v $(pwd):/travis -w /travis  quay.io/mullvad/mullvadvpn-app-build:latest tail -f /dev/null
         - docker ps
       script:
         - docker exec -t mvd-build bash ci/ci-rust-script.sh nightly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To build the image:
-# docker build . -t mullvadvpn/mullvadvpn-app-build
-# To push the image to our docker hub:
-# docker push mullvadvpn/mullvadvpn-app-build
+# docker build . -t quay.io/mullvad/mullvadvpn-app-build
+# To push the image to Quay.io:
+# docker push quay.io/mullvad/mullvadvpn-app-build
 FROM debian:stable@sha256:75f7d0590b45561bfa443abad0b3e0f86e2811b1fc176f786cd30eb078d1846f
 RUN apt update -y
 RUN apt install build-essential \

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -97,7 +97,7 @@ function build_android {
         docker run --rm \
             -v "$(pwd)/../":/workspace \
             --entrypoint "/workspace/wireguard/libwg/build-android.sh" \
-            mullvadvpn/mullvad-android-app-build@sha256:$docker_image_hash
+            quay.io/mullvad/mullvad-android-app-build@sha256:$docker_image_hash
     else
         ./libwg/build-android.sh
     fi


### PR DESCRIPTION
This PR removes references to DockerHub for Docker images. The image hashes remain the same, but the tag is changed to reflect the new URL.

﻿Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2244)
<!-- Reviewable:end -->
