### PR TITLE
Linux - parse loopback routes semi-correctly to count them and log less.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Line wrap the file at 100 chars.                                              Th
 - Reset DNS config correctly when the tunnel monitor unexpectedly goes down.
 - Set search domains in NetworkManager's DNS configuration, resolving issues where NetworkManager
   is used to manage DNS via systemd-resolved.
+- Parse routes more permissively and log parsing errors less verbosely.
 
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -782,16 +782,8 @@ impl RouteManagerImpl {
 
     // Tries to coax a Route out of a RouteMessage
     fn parse_route_message_inner(&self, msg: RouteMessage) -> Result<Option<Route>> {
-        let mut prefix = None;
-        let mut node_addr = None;
-        let mut device = None;
-        let mut metric = None;
-        let mut gateway: Option<IpAddr> = None;
-
-        let destination_length = msg.header.destination_prefix_length;
         let af_spec = msg.header.address_family;
-        let mut table_id = u32::from(msg.header.table);
-
+        let destination_length = msg.header.destination_prefix_length;
         let is_ipv4 = match af_spec as i32 {
             AF_INET => true,
             AF_INET6 => false,
@@ -801,7 +793,23 @@ impl RouteManagerImpl {
             }
         };
 
-        let mut is_loopback = false;
+
+        // By default, the prefix is unspecified.
+        let mut prefix = IpNetwork::new(
+            if is_ipv4 {
+                Ipv4Addr::UNSPECIFIED.into()
+            } else {
+                Ipv6Addr::UNSPECIFIED.into()
+            },
+            destination_length,
+        )
+        .map_err(Error::InvalidNetworkPrefix)?;
+        let mut node_addr = None;
+        let mut device = None;
+        let mut metric = None;
+        let mut gateway: Option<IpAddr> = None;
+
+        let mut table_id = u32::from(msg.header.table);
 
         for nla in msg.nlas.iter() {
             match nla {
@@ -811,7 +819,6 @@ impl RouteManagerImpl {
                             if !route_device.is_loopback() {
                                 device = Some(route_device);
                             } else {
-                                is_loopback = true;
                                 gateway = if is_ipv4 {
                                     Some(Ipv4Addr::LOCALHOST.into())
                                 } else {
@@ -830,12 +837,10 @@ impl RouteManagerImpl {
                 }
 
                 RouteNla::Destination(addr) => {
-                    prefix = Self::parse_ip(&addr)
-                        .and_then(|ip| {
-                            ipnetwork::IpNetwork::new(ip, destination_length)
-                                .map_err(Error::InvalidNetworkPrefix)
-                        })
-                        .map(Some)?;
+                    prefix = Self::parse_ip(&addr).and_then(|ip| {
+                        ipnetwork::IpNetwork::new(ip, destination_length)
+                            .map_err(Error::InvalidNetworkPrefix)
+                    })?;
                 }
 
                 // gateway NLAs indicate that this is actually a default route
@@ -866,7 +871,7 @@ impl RouteManagerImpl {
 
         Ok(Some(Route {
             node,
-            prefix: prefix.unwrap(),
+            prefix,
             metric,
             table_id,
         }))

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -73,6 +73,18 @@ pub enum Error {
     Shutdown,
 }
 
+impl Error {
+    /// Returns true only if it's a netlink error with a code ENETUNREACH
+    fn is_network_unreachable(&self) -> bool {
+        match self {
+            Error::NetlinkError(rtnetlink::Error::NetlinkError(err)) => {
+                err.code == -libc::ENETUNREACH
+            }
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct RequiredDefaultRoute {
     table_id: u32,
@@ -203,10 +215,33 @@ impl RouteManagerImpl {
 
         let mut main_routes = self.get_routes(None).await?.into_iter().collect::<Vec<_>>();
         main_routes.sort_by(|a, b| a.prefix.prefix().cmp(&b.prefix.prefix()));
+        main_routes.sort_by(|a, b| a.prefix.is_ipv4().cmp(&b.prefix.is_ipv4()));
 
         for mut route in main_routes {
             route.table_id = self.split_table_id;
-            self.add_route_direct(route).await?;
+            if let Err(err) = self.add_route_direct(route.clone()).await {
+                // If a rotue can't be added because parts of it's next-hop are unreachable, then
+                // a gateway route should be added first. Seemingly there's an ARP table per
+                // routing table, and a route that specifies both a gateway and an output interface
+                // depends on a route that instructs how to reach the gateway.
+                if err.is_network_unreachable() {
+                    match (route.device_only_route(), route.node.get_address()) {
+                        (Some(mut gateway_route), Some(address)) => {
+                            gateway_route.prefix =
+                                IpNetwork::new(address, if address.is_ipv4() { 32 } else { 128 })
+                                    .unwrap();
+                            let add_gateway_route = self.add_route_direct(gateway_route).await;
+                            let add_route_result = self.add_route_direct(route).await;
+                            if let Err(err) = add_gateway_route.and_then(|_| add_route_result) {
+                                log::error!("Failed to add route to split-routing table: {}", err);
+                            };
+                            continue;
+                        }
+                        _ => (),
+                    };
+                }
+                log::error!("Failed to add route to split-routing table: {}", err);
+            }
         }
         Ok(())
     }
@@ -869,12 +904,13 @@ impl RouteManagerImpl {
             device: device.map(|dev| dev.name.clone()),
         };
 
-        Ok(Some(Route {
+        let result = Ok(Some(Route {
             node,
             prefix,
             metric,
             table_id,
-        }))
+        }));
+        result
     }
 
     fn map_interface(msg: LinkMessage) -> Option<(u32, NetworkInterface)> {

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -40,6 +40,19 @@ impl Route {
         }
     }
 
+    /// Returns route that only contains the device node if a device node exists.
+    #[cfg(target_os = "linux")]
+    fn device_only_route(&self) -> Option<Self> {
+        if let Some(device) = self.node.get_device() {
+            Some(Self {
+                node: Node::device(device.to_string()),
+                ..self.clone()
+            })
+        } else {
+            None
+        }
+    }
+
     #[cfg(target_os = "linux")]
     fn table(mut self, new_id: u32) -> Self {
         self.table_id = new_id;

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -45,6 +45,11 @@ impl Route {
         self.table_id = new_id;
         self
     }
+
+    #[cfg(target_os = "linux")]
+    fn is_loopback(&self) -> bool {
+        self.node.ip.map(|ip| ip.is_loopback()).unwrap_or(false)
+    }
 }
 
 impl fmt::Display for Route {


### PR DESCRIPTION
Currently on every start of the daemon the route manager logs an entry for each loopback route it sees. To deal with this somewhat nicer, I've changed the route parsing code to just parse a loopback device as a route with a gateway via `127.0.0.1`, which can then be counted and filtered later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2245)
<!-- Reviewable:end -->
