### PR TITLE
Prefer netlink over NM to create a WireGuard device on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for custom DNS resolvers (CLI only).
 
 #### Linux
-- Use NetworkManager to create a WireGuard interface.
+- Optionally use NetworkManager to create WireGuard devices.
 - Add support for custom DNS resolvers (CLI only).
 
 #### macOS
@@ -82,6 +82,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix routing rules sometimes being duplicated.
 - When NetworkManager is managing /etc/resolv.conf but ultimately using systemd-resolved, use
   systemd-resolved directly to manage DNS.
+- Only use WireGuard kernel implementation if DNS isn't managed via NetworkManager.
 
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -364,6 +364,13 @@ echo "org.gradle.jvmargs=-Xmx4608M" >> ~/.gradle/gradle.properties
     * `"systemd"`: use systemd's `resolved` service through DBus
     * `"network-manager"`: use `NetworkManager` service through DBus
 
+* `TALPID_FORCE_USERSPACE_WIREGUARD` - Forces the daemon to use the userspace implementation of
+   WireGuard on Linux.
+
+* `TALPID_FORCE_NM_WIREGUARD` - Forces the daemon to use NetworkManager to create a WireGuard
+  device instead of relying on netlink. This is highly inadvisable currently, as NetworkManager is
+  exhibiting buggy behavior.
+
 
 ## Building and running the desktop Electron GUI app
 

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -152,5 +152,3 @@ pub fn will_use_nm() -> bool {
     crate::dns::imp::SystemdResolved::new().is_err()
         && crate::dns::imp::NetworkManager::new().is_ok()
 }
-
-

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -104,7 +104,15 @@ impl DnsMonitorHolder {
     fn with_detected_dns_manager() -> Result<Self> {
         SystemdResolved::new()
             .map(DnsMonitorHolder::SystemdResolved)
-            .or_else(|_| NetworkManager::new().map(DnsMonitorHolder::NetworkManager))
+            .or_else(|err| {
+                match err {
+                    systemd_resolved::Error::NoSystemdResolved(_) => (),
+                    other_error => {
+                        log::debug!("systemd-resolved is not being used because {}", other_error)
+                    }
+                }
+                NetworkManager::new().map(DnsMonitorHolder::NetworkManager)
+            })
             .or_else(|_| Resolvconf::new().map(DnsMonitorHolder::Resolvconf))
             .or_else(|_| StaticResolvConf::new().map(DnsMonitorHolder::StaticResolvConf))
             .map_err(|_| Error::NoDnsMonitor)
@@ -138,3 +146,11 @@ impl DnsMonitorHolder {
         Ok(())
     }
 }
+
+/// Returns true if DnsMonitor will use NetworkManager to manage DNS.
+pub fn will_use_nm() -> bool {
+    crate::dns::imp::SystemdResolved::new().is_err()
+        && crate::dns::imp::NetworkManager::new().is_ok()
+}
+
+

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -8,6 +8,9 @@ mod imp;
 #[path = "linux/mod.rs"]
 mod imp;
 
+#[cfg(target_os = "linux")]
+pub use imp::will_use_nm;
+
 #[cfg(windows)]
 #[path = "windows/mod.rs"]
 mod imp;

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
@@ -87,16 +87,6 @@ pub enum Error {
 
 const MULLVAD_INTERFACE_NAME: &str = "wg-mullvad";
 
-
-impl Error {
-    pub fn should_use_userspace(&self) -> bool {
-        match self {
-            Error::NetworkManager(nm_tunnel::Error::NMTooOld(_)) => true,
-            _ => false,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct Handle {
     pub wg_handle: WireguardConnection,


### PR DESCRIPTION
Since NM has issues with managing routes and not hanging forever, I've changed it so that NM will never be used to create a WireGuard device by default. To use NM, one would have to set environment variable `TALPID_FORCE_NM_WIREGUARD` to anything but `0`. The previous behavior would be to try and use NM first, and if NM fails to create a device, depending on the error, either try userspace or netlink to create a WireGuard device. Finally, if the daemon fails to create a device via netlink, it would fall back to the userspace implementation. The current behavior is changed so that at first the daemon will check if we can use a kernel implementation at all by checking if NM would manage DNS. If NM is managing DNS, the userspace implementation will be used. Otherwise, if `TALPID_FORCE_NM_WIREGUARD` is not set or is set to 0, the daemon will use netlink to create a device, otherwise NM will be used. Once NM is fixed, this logic can be reverted to what it was before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2246)
<!-- Reviewable:end -->
