### PR TITLE
Disable NetworkManager's connectivity check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Optionally use NetworkManager to create WireGuard devices.
 - Add support for custom DNS resolvers (CLI only).
+- Disable NetworkManager's connectivity check before applying firewall rules to avoid triggerring
+  NetworkManager's [bug](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/312#note_453724)
 
 #### macOS
 - Add support for custom DNS resolvers (CLI only).

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -64,6 +64,14 @@ impl super::DnsMonitorT for DnsMonitor {
         }
         Ok(())
     }
+
+    fn dbus_connection(&self) -> Option<&dbus::ffidisp::Connection> {
+        match &self.inner {
+            Some(DnsMonitorHolder::NetworkManager(nm)) => Some(&nm.dbus_connection),
+            Some(DnsMonitorHolder::SystemdResolved(sdr)) => Some(&sdr.dbus_connection),
+            _ => None,
+        }
+    }
 }
 
 pub enum DnsMonitorHolder {

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -77,7 +77,7 @@ lazy_static! {
 }
 
 pub struct NetworkManager {
-    dbus_connection: Connection,
+    pub dbus_connection: Connection,
     device: Option<String>,
     settings_backup: Option<HashMap<String, HashMap<String, Variant<Box<dyn RefArg>>>>>,
 }

--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -79,7 +79,7 @@ lazy_static! {
 }
 
 pub struct SystemdResolved {
-    dbus_connection: Connection,
+    pub dbus_connection: Connection,
     interface_link: Option<(String, dbus::Path<'static>)>,
 }
 

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -53,6 +53,11 @@ impl DnsMonitor {
         log::info!("Resetting DNS");
         self.inner.reset()
     }
+
+    #[cfg(target_os="linux")]
+    fn dbus_connection(&self) -> Option<&dbus::ffidisp::Connection> {
+        self.inner.dbus_connection()
+    }
 }
 
 trait DnsMonitorT: Sized {
@@ -63,4 +68,7 @@ trait DnsMonitorT: Sized {
     fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<(), Self::Error>;
 
     fn reset(&mut self) -> Result<(), Self::Error>;
+
+    #[cfg(target_os="linux")]
+    fn dbus_connection(&self) -> Option<&dbus::ffidisp::Connection>;
 }

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -54,8 +54,9 @@ impl DnsMonitor {
         self.inner.reset()
     }
 
-    #[cfg(target_os="linux")]
-    fn dbus_connection(&self) -> Option<&dbus::ffidisp::Connection> {
+    /// Expose an existing DBus connection if one already exists.
+    #[cfg(target_os = "linux")]
+    pub fn dbus_connection(&self) -> Option<&dbus::ffidisp::Connection> {
         self.inner.dbus_connection()
     }
 }
@@ -69,6 +70,6 @@ trait DnsMonitorT: Sized {
 
     fn reset(&mut self) -> Result<(), Self::Error>;
 
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     fn dbus_connection(&self) -> Option<&dbus::ffidisp::Connection>;
 }

--- a/talpid-core/src/linux.rs
+++ b/talpid-core/src/linux.rs
@@ -28,3 +28,47 @@ pub enum IfaceIndexLookupError {
 
 // b"mole" is [ 0x6d, 0x6f 0x6c, 0x65 ]
 pub const TUNNEL_FW_MARK: u32 = 0x6d6f6c65;
+
+pub mod network_manager {
+    use dbus::ffidisp::{stdintf::*, Connection};
+
+    const NM_BUS: &str = "org.freedesktop.NetworkManager";
+    const NM_TOP_OBJECT: &str = "org.freedesktop.NetworkManager";
+    const NM_OBJECT_PATH: &str = "/org/freedesktop/NetworkManager";
+    const CONNECTIVITY_CHECK_KEY: &str = "ConnectivityCheckEnabled";
+    const RPC_TIMEOUT_MS: i32 = 1500;
+
+    /// Ensures NetworkManager's connectivity check is disabled and returns the connectivity check
+    /// previous state. Returns true only if the connectivity check was enabled and is now
+    /// disabled. Disabling the connectivity check should be done before a firewall is applied
+    /// due to the fact that blocking DNS requests can make it hang:
+    /// https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/404
+    pub fn nm_disable_connectivity_check(connection: &Connection) -> Option<bool> {
+        let nm_manager = connection.with_path(NM_BUS, NM_OBJECT_PATH, RPC_TIMEOUT_MS);
+        match nm_manager.get(NM_TOP_OBJECT, CONNECTIVITY_CHECK_KEY) {
+            Ok(true) => {
+                if let Err(err) = nm_manager.set(NM_TOP_OBJECT, CONNECTIVITY_CHECK_KEY, false) {
+                    log::error!(
+                        "Failed to disable NetworkManager connectivity check: {}",
+                        err
+                    );
+                    Some(false)
+                } else {
+                    Some(true)
+                }
+            }
+            Ok(false) => Some(false),
+            Err(_) => None,
+        }
+    }
+
+    /// Enabled NetworkManager's connectivity check. Fails silently.
+    pub fn nm_enable_connectivity_check(connection: &Connection) {
+        if let Err(err) = connection
+            .with_path(NM_BUS, NM_OBJECT_PATH, RPC_TIMEOUT_MS)
+            .set(NM_TOP_OBJECT, CONNECTIVITY_CHECK_KEY, true)
+        {
+            log::error!("Failed to reset NetworkManager connectivity check: {}", err);
+        }
+    }
+}

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -53,6 +53,9 @@ impl ConnectingState {
         shared_values: &mut SharedTunnelStateValues,
         params: &TunnelParameters,
     ) -> Result<(), FirewallPolicyError> {
+        #[cfg(target_os = "linux")]
+        shared_values.disable_connectivity_check();
+
         let peer_endpoint = params.get_next_hop_endpoint();
 
         let policy = FirewallPolicy::Connecting {

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -52,6 +52,8 @@ impl TunnelState for DisconnectedState {
             );
         }
         Self::set_firewall_policy(shared_values, should_reset_firewall);
+        #[cfg(target_os = "linux")]
+        shared_values.reset_connectivity_check();
         #[cfg(target_os = "android")]
         shared_values.tun_provider.close_tun();
 

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -23,6 +23,9 @@ impl ErrorState {
             allow_lan: shared_values.allow_lan,
         };
 
+        #[cfg(target_os = "linux")]
+        shared_values.disable_connectivity_check();
+
         shared_values
             .firewall
             .apply_policy(policy)
@@ -121,6 +124,8 @@ impl TunnelState for ErrorState {
             }
             Some(TunnelCommand::Connect) => NewState(ConnectingState::enter(shared_values, 0)),
             Some(TunnelCommand::Disconnect) | None => {
+                #[cfg(target_os = "linux")]
+                shared_values.reset_connectivity_check();
                 NewState(DisconnectedState::enter(shared_values, true))
             }
             Some(TunnelCommand::Block(reason)) => {


### PR DESCRIPTION
It seems that NetworkManager can hang if it can't do it's connectivity check - which can often be induced by applying our firewall rules. As such, I've changed the tunnel state machine to disable the connectivity check before applying the firewall rules, and restoring it afterwards. No effort is made to track the flag that enables the connectivity check - the user may enable it after the rules have been applied - I don't believe we should do anything about that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2249)
<!-- Reviewable:end -->
