### PR TITLE
Replace "Enabled" with "Enable" in Split Tunneling

### DIFF
--- a/android/src/main/res/layout/split_tunneling_header.xml
+++ b/android/src/main/res/layout/split_tunneling_header.xml
@@ -24,7 +24,7 @@
                                                  android:layout_width="match_parent"
                                                  android:layout_height="wrap_content"
                                                  android:layout_marginTop="@dimen/vertical_space"
-                                                 mullvad:text="@string/enabled" />
+                                                 mullvad:text="@string/enable" />
     <LinearLayout android:id="@+id/exclude_applications"
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -162,7 +162,7 @@
     <string name="split_tunneling">Split tunneling</string>
     <string name="split_tunneling_description">Split tunneling makes it possible to select which
     applications should not be routed through the VPN tunnel.</string>
-    <string name="enabled">Enabled</string>
+    <string name="enable">Enable</string>
     <string name="exclude_applications">Exclude applications</string>
     <string name="account_url">https://mullvad.net/en/account</string>
     <string name="wg_key_url">https://mullvad.net/en/account/ports</string>


### PR DESCRIPTION
This is a minor UI message tweak to make the Android app more consistent with the desktop app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2251)
<!-- Reviewable:end -->
