### PR TITLE
Use the route manager to set up routes when using OpenVPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Use the API to fetch API IP addresses instead of DNS.
 - Remove WireGuard keys during uninstallation after the firewall is unlocked.
-- Set up routes for OpenVPN using the route manager instead of relying on OpenVPN.
 
 #### Android
 - Remove the Quit button.
@@ -56,6 +55,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Make route monitor ignore loopback routes.
 - Increase NetworkManager device readiness timeout to 15 seconds.
+- Set up routes for OpenVPN using the route manager instead of relying on OpenVPN.
 
 ### Fixed
 - Fix missing map animation after selecting a new location in the desktop app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Use the API to fetch API IP addresses instead of DNS.
 - Remove WireGuard keys during uninstallation after the firewall is unlocked.
+- Set up routes for OpenVPN using the route manager instead of relying on OpenVPN.
 
 #### Android
 - Remove the Quit button.

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -172,12 +172,6 @@ impl NetworkManager {
                 .get(NM_DEVICE, "Ip4Config")
                 .map_err(Error::Dbus)?;
 
-            let device_routes: Vec<Vec<u32>> = self
-                .dbus_connection
-                .with_path(NM_BUS, &device_ip4_config, RPC_TIMEOUT_MS)
-                .get(NM_IP4_CONFIG, "Routes")
-                .map_err(Error::Dbus)?;
-
             let device_route_data: Vec<HashMap<String, Variant<Box<dyn RefArg>>>> = self
                 .dbus_connection
                 .with_path(NM_BUS, &device_ip4_config, RPC_TIMEOUT_MS)
@@ -185,8 +179,8 @@ impl NetworkManager {
                 .map_err(Error::Dbus)?;
 
             ipv4_settings.insert("route-metric", Variant(Box::new(0u32)));
-            ipv4_settings.insert("routes", Variant(Box::new(device_routes)));
             ipv4_settings.insert("route-data", Variant(Box::new(device_route_data)));
+            ipv4_settings.remove("routes");
         }
 
         if let Some(ipv6_settings) = settings.get_mut("ipv6") {
@@ -201,13 +195,6 @@ impl NetworkManager {
                 .with_path(NM_BUS, &device_ip6_config, RPC_TIMEOUT_MS)
                 .get(NM_IP6_CONFIG, "Addresses")
                 .map_err(Error::Dbus)?;
-
-            let device_routes6: Vec<(Vec<u8>, u32, Vec<u8>, u32)> = self
-                .dbus_connection
-                .with_path(NM_BUS, &device_ip6_config, RPC_TIMEOUT_MS)
-                .get(NM_IP6_CONFIG, "Routes")
-                .map_err(Error::Dbus)?;
-
             let device_route6_data: Vec<HashMap<String, Variant<Box<dyn RefArg>>>> = self
                 .dbus_connection
                 .with_path(NM_BUS, &device_ip6_config, RPC_TIMEOUT_MS)
@@ -215,7 +202,7 @@ impl NetworkManager {
                 .map_err(Error::Dbus)?;
 
             ipv6_settings.insert("route-metric", Variant(Box::new(0u32)));
-            ipv6_settings.insert("routes", Variant(Box::new(device_routes6)));
+            ipv6_settings.remove("routes");
             ipv6_settings.insert("route-data", Variant(Box::new(device_route6_data)));
             // if the link contains link local addresses, addresses shouldn't be reset
             if ipv6_settings

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -231,6 +231,9 @@ impl OpenVpnCommand {
             args.push(OsString::from(mssfix.to_string()));
         }
 
+        #[cfg(target_os = "linux")]
+        args.push(OsString::from("--route-noexec"));
+
         if !self.enable_ipv6 {
             args.push(OsString::from("--pull-filter"));
             args.push(OsString::from("ignore"));

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -231,7 +231,6 @@ impl OpenVpnCommand {
             args.push(OsString::from(mssfix.to_string()));
         }
 
-        #[cfg(target_os = "linux")]
         args.push(OsString::from("--route-noexec"));
 
         if !self.enable_ipv6 {

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -42,6 +42,9 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
         "vpn_gateway",
         "1",
     ],
+    // The route manager is used to add the routes.
+    #[cfg(target_os = "linux")]
+    &["--route-noexec"],
 ];
 
 static ALLOWED_TLS1_2_CIPHERS: &[&str] = &[
@@ -230,8 +233,6 @@ impl OpenVpnCommand {
             args.push(OsString::from("--mssfix"));
             args.push(OsString::from(mssfix.to_string()));
         }
-
-        args.push(OsString::from("--route-noexec"));
 
         if !self.enable_ipv6 {
             args.push(OsString::from("--pull-filter"));

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -160,14 +160,9 @@ impl TunnelMonitor {
 
         match tunnel_parameters {
             #[cfg(not(target_os = "android"))]
-            TunnelParameters::OpenVpn(config) => Self::start_openvpn_tunnel(
-                &config,
-                log_file,
-                resource_dir,
-                on_event,
-                #[cfg(target_os = "linux")]
-                route_manager,
-            ),
+            TunnelParameters::OpenVpn(config) => {
+                Self::start_openvpn_tunnel(&config, log_file, resource_dir, on_event, route_manager)
+            }
             #[cfg(target_os = "android")]
             TunnelParameters::OpenVpn(_) => Err(Error::UnsupportedPlatform),
 
@@ -230,19 +225,13 @@ impl TunnelMonitor {
         log: Option<PathBuf>,
         resource_dir: &Path,
         on_event: L,
-        #[cfg(target_os = "linux")] route_manager: &mut RouteManager,
+        route_manager: &mut RouteManager,
     ) -> Result<Self>
     where
         L: Fn(TunnelEvent) + Send + Sync + 'static,
     {
-        let monitor = openvpn::OpenVpnMonitor::start(
-            on_event,
-            config,
-            log,
-            resource_dir,
-            #[cfg(target_os = "linux")]
-            route_manager,
-        )?;
+        let monitor =
+            openvpn::OpenVpnMonitor::start(on_event, config, log, resource_dir, route_manager)?;
         Ok(TunnelMonitor {
             monitor: InternalTunnelMonitor::OpenVpn(monitor),
         })

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -398,6 +398,8 @@ fn extract_routes(env: &HashMap<String, String>) -> Result<HashSet<RequiredRoute
     ));
     #[cfg(windows)]
     let tun_node6 = if tun_gateway_ip6.is_some() {
+        // The tapdrvr expects a special address here rather than a real gateway.
+        // See https://github.com/OpenVPN/openvpn/blob/23e11e591347080efa3b933beca7f620dd059d5c/src/openvpn/route.c#L2013
         routing::NetNode::from(routing::Node::new(
             "fe80::8"
                 .parse()

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -423,11 +423,14 @@ fn extract_routes(env: &HashMap<String, String>) -> Result<HashSet<RequiredRoute
     let ovpn_routes = parse_openvpn_dict_routes(env).map_err(Error::ParseRouteError)?;
 
     for route in ovpn_routes {
-        let node = match route.gateway {
-            _ if route.gateway == default_node_ip => routing::NetNode::DefaultNode,
-            _ if route.gateway == tun_gateway_ip => tun_node.clone(),
-            _ if Some(route.gateway) == tun_gateway_ip6 => tun_node6.clone(),
-            other => routing::NetNode::from(routing::Node::address(other)),
+        let node = if route.gateway == default_node_ip {
+            routing::NetNode::DefaultNode
+        } else if route.gateway == tun_gateway_ip {
+            tun_node.clone()
+        } else if Some(route.gateway) == tun_gateway_ip6 {
+            tun_node6.clone()
+        } else {
+            routing::NetNode::from(routing::Node::address(route.gateway))
         };
         routes.insert(RequiredRoute::new(route.network, node));
     }

--- a/talpid-core/src/tunnel/openvpn.rs
+++ b/talpid-core/src/tunnel/openvpn.rs
@@ -304,8 +304,15 @@ fn parse_openvpn_dict_routes(
     let mut routes4 = HashMap::<u32, HashMap<&str, &str>>::new();
     let mut routes6 = HashMap::new();
 
+    const NUM_EXPECTED_CAPTURES: usize = 4;
+
     for (key, value) in env.iter() {
         if let Some(captures) = ENV_ROUTE_ENTRY.captures(key) {
+            if captures.len() != NUM_EXPECTED_CAPTURES {
+                log::error!("Bug: unexpected number of captures");
+                continue;
+            }
+
             let route_index: u32 = captures[3].parse().unwrap();
             let property = captures.get(2).unwrap().as_str();
 


### PR DESCRIPTION
Previously, OpenVPN would create routes for us. Instead, we now simply take the routes it gives us and pass them to the route manager. This allows for more flexibility in setting up routing. The step after this is to use rule-based routing in order to reduce the amount of monitoring and parsing required on Linux.

Also, the virtual interface is now also able to switch from one physical interface to another better one (e.g. when switching off of Wi-Fi), as is already the case for WireGuard. This should prevent disconnects when the original interface goes down, although I haven't tested this.

Related PRs: #2231 #2115

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2254)
<!-- Reviewable:end -->
