### PR TITLE
Add search domain to NM DNS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ Line wrap the file at 100 chars.                                              Th
   systemd-resolved directly to manage DNS.
 - Only use WireGuard kernel implementation if DNS isn't managed via NetworkManager.
 - Reset DNS config correctly when the tunnel monitor unexpectedly goes down.
+- Set search domains in NetworkManager's DNS configuration, resolving issues where NetworkManager
+  is used to manage DNS via systemd-resolved.
 
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -344,6 +344,7 @@ impl NetworkManager {
         settings.insert("method", Variant(Box::new("manual".to_string())));
         settings.insert("dns-priority", Variant(Box::new(DNS_FIRST_PRIORITY)));
         settings.insert("dns", Variant(Box::new(servers)));
+        settings.insert("dns-search", Variant(Box::new(vec!["~.".to_string()])));
     }
 
     fn fetch_device(&self, interface_name: &str) -> Result<dbus::Path<'static>> {


### PR DESCRIPTION
Setting the searhc domain key in the IP configs for NetworkManager makes NetworkManager capable to manage DNS via systemd-resolved again. To test this, you'd have to remove the systemd-resolved's check for being managed via NM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2255)
<!-- Reviewable:end -->
