### PR TITLE
Don't add routes with `RouteManager` on Android

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -88,6 +88,7 @@ impl WireguardMonitor {
             .set_tunnel_link(&iface_name)
             .map_err(Error::SetupRoutingError)?;
 
+        #[cfg(not(target_os = "android"))]
         route_manager
             .add_routes(Self::get_routes(&iface_name, &config))
             .map_err(Error::SetupRoutingError)?;


### PR DESCRIPTION
The previous state of the `master` branch would fail to connect the tunnel on Android, and the log would say that the error was in the `RouteManager`. On Android, there is no need to use the `RouteManager` so this PR provides a quick fix that avoids the call that adds the routes using the `RouteManager` instance.

In the future, it might be a good idea to revisit the `RouteManager` code itself and see if it can be compiled out on Android.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not present in any released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2256)
<!-- Reviewable:end -->
