### PR TITLE
Fix title collapse animation hook

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomItemAnimator.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomItemAnimator.kt
@@ -1,10 +1,13 @@
 package net.mullvad.mullvadvpn.ui.widget
 
 import android.support.v7.widget.DefaultItemAnimator
+import android.support.v7.widget.RecyclerView.LayoutManager
 import android.support.v7.widget.RecyclerView.ViewHolder
 import kotlin.math.round
 
 class CustomItemAnimator : DefaultItemAnimator() {
+    var layoutManager: LayoutManager? = null
+
     var onMove: ((Int, Int) -> Unit)? = null
 
     override fun animateMove(
@@ -16,17 +19,20 @@ class CustomItemAnimator : DefaultItemAnimator() {
     ): Boolean {
         if (super.animateMove(holder, fromX, fromY, toX, toY)) {
             var view = holder.itemView
-            var translationX = view.translationX
-            var translationY = view.translationY
 
-            view.animate().setUpdateListener { _ ->
-                val deltaX = round(translationX - view.translationX)
-                val deltaY = round(translationY - view.translationY)
+            if (view == layoutManager?.getChildAt(0)) {
+                var translationX = view.translationX
+                var translationY = view.translationY
 
-                onMove?.invoke(deltaX.toInt(), deltaY.toInt())
+                view.animate().setUpdateListener { _ ->
+                    val deltaX = round(translationX - view.translationX)
+                    val deltaY = round(translationY - view.translationY)
 
-                translationX -= deltaX
-                translationY -= deltaY
+                    onMove?.invoke(deltaX.toInt(), deltaY.toInt())
+
+                    translationX -= deltaX
+                    translationY -= deltaY
+                }
             }
 
             return true

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
@@ -2,10 +2,13 @@ package net.mullvad.mullvadvpn.ui.widget
 
 import android.content.Context
 import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.RecyclerView.LayoutManager
 import android.util.AttributeSet
 import net.mullvad.mullvadvpn.util.ListenableScrollableView
 
 class CustomRecyclerView : RecyclerView, ListenableScrollableView {
+    private val customItemAnimator = CustomItemAnimator()
+
     override var horizontalScrollOffset = 0
     override var verticalScrollOffset = 0
 
@@ -20,11 +23,17 @@ class CustomRecyclerView : RecyclerView, ListenableScrollableView {
         }
 
     init {
-        itemAnimator = CustomItemAnimator().apply {
+        itemAnimator = customItemAnimator.apply {
             onMove = { horizontalDelta, verticalDelta ->
                 dispatchScrollEvent(horizontalDelta, verticalDelta)
             }
         }
+    }
+
+    override fun setLayoutManager(layoutManager: LayoutManager?) {
+        super.setLayoutManager(layoutManager)
+
+        customItemAnimator.layoutManager = layoutManager
     }
 
     override fun onScrolled(horizontalDelta: Int, verticalDelta: Int) {


### PR DESCRIPTION
[Previously](https://github.com/mullvad/mullvadvpn-app/pull/2206), a workaround was implemented to listen for item animations in the `RecyclerView` in order to detect animations that should be treated as scroll events. However, the PR intercepted animations on all items. This led to a bug that was discovered while implementing the new custom DNS UI, where an item animation causes the title to collapse when it shouldn't.

This PR fixes that issue by only treating animations of the first visible item as animations that should be treated as scroll events.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2258)
<!-- Reviewable:end -->
