### PR TITLE
Update the Android route manager

### DIFF
--- a/talpid-core/src/routing/android.rs
+++ b/talpid-core/src/routing/android.rs
@@ -23,9 +23,15 @@ impl RouteManagerImpl {
     ) -> Result<(), Error> {
         let mut manage_rx = manage_rx.fuse();
         while let Some(command) = manage_rx.next().await {
-            if let RouteManagerCommand::Shutdown(tx) = command {
-                tx.send(()).map_err(|()| Error)?;
-                break;
+            match command {
+                RouteManagerCommand::Shutdown(tx) => {
+                    tx.send(()).map_err(|()| Error)?;
+                    break;
+                }
+                RouteManagerCommand::AddRoutes(_routes, tx) => {
+                    let _ = tx.send(Ok(()));
+                }
+                RouteManagerCommand::ClearRoutes => (),
             }
         }
         Ok(())

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -88,7 +88,6 @@ impl WireguardMonitor {
             .set_tunnel_link(&iface_name)
             .map_err(Error::SetupRoutingError)?;
 
-        #[cfg(not(target_os = "android"))]
         route_manager
             .add_routes(Self::get_routes(&iface_name, &config))
             .map_err(Error::SetupRoutingError)?;


### PR DESCRIPTION
Some recent changes to the route monitor would cause methods to return errors if the underlying implementation didn't send back a correct response. The Android route manager essentially does nothing, but it should stlil respond. This was fixed.

Related: #2256, https://github.com/mullvad/mullvadvpn-app/commit/86170137bf1bc141b7bcff5e952121ac8784fb8c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2260)
<!-- Reviewable:end -->
