### PR TITLE
Fix Travis builds after skipping use of the route manager on Android

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -2,17 +2,19 @@ use self::config::Config;
 #[cfg(not(windows))]
 use super::tun_provider;
 use super::{tun_provider::TunProvider, TunnelEvent, TunnelMetadata};
-use crate::routing::{self, RequiredRoute};
+use crate::routing;
 #[cfg(target_os = "linux")]
 use lazy_static::lazy_static;
 #[cfg(target_os = "linux")]
 use std::env;
 use std::{
-    collections::HashSet,
     path::Path,
     sync::{mpsc, Arc, Mutex},
 };
 use talpid_types::ErrorExt;
+
+#[cfg(not(target_os = "android"))]
+use {crate::routing::RequiredRoute, std::collections::HashSet};
 
 /// WireGuard config data-types
 pub mod config;
@@ -245,6 +247,7 @@ impl WireguardMonitor {
             })
     }
 
+    #[cfg(not(target_os = "android"))]
     fn get_routes(iface_name: &str, config: &Config) -> HashSet<RequiredRoute> {
         let node = routing::Node::device(iface_name.to_string());
         let mut routes: HashSet<RequiredRoute> = Self::get_tunnel_routes(config)


### PR DESCRIPTION
A [previous PR](https://github.com/mullvad/mullvadvpn-app/pull/2256) fixed a bug on Android where the tunnel wouldn't start correctly because of the use of the dummy route manager implementation. However, Travis CI builds weren't working at the time and I missed that there was unused code still getting compiled in.

This PR fixes the CI builds so that the unused method is compiled out.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2262)
<!-- Reviewable:end -->
