### PR TITLE
Fix not saving scroll position before unmount

### DIFF
--- a/gui/src/renderer/components/NavigationBar.tsx
+++ b/gui/src/renderer/components/NavigationBar.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useContext, useLayoutEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import { colors } from '../../config.json';
@@ -136,7 +129,7 @@ export const NavigationScrollbars = React.forwardRef(function NavigationScrollba
     (state: IReduxState) => state.userInterface.scrollPosition[history.location.pathname],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const path = history.location.pathname;
 
     if (history.action === 'POP' && scrollPosition) {


### PR DESCRIPTION
It has turned out that there was breaking changes in React 17 that has affected our app. This is the only regression I've found and I've searched through the codebase for other similar usages and didn't find any. The regression that this PR fixes is that the app failed to save the scroll position when leaving a view due to the fact that `useEffect` clean up function is now called asynchronously.

React 17 upgrade PR: https://github.com/mullvad/mullvadvpn-app/pull/2247

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2263)
<!-- Reviewable:end -->
