### PR TITLE
Add unpin window setting on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 - Navigate back to the main view when escape is pressed.
 - Add support for custom DNS resolvers.
 
+#### Windows
+- Add setting that unpins the window from the tray icon to let the user move it around freely.
+
 #### Linux
 - Optionally use NetworkManager to create WireGuard devices.
 - Disable NetworkManager's connectivity check before applying firewall rules to avoid triggerring

--- a/gui/src/main/gui-settings.ts
+++ b/gui/src/main/gui-settings.ts
@@ -10,6 +10,7 @@ const settingsSchema = {
   enableSystemNotifications: 'boolean',
   monochromaticIcon: 'boolean',
   startMinimized: 'boolean',
+  unpinnedWindow: 'boolean',
 };
 
 const defaultSettings: IGuiSettingsState = {
@@ -18,6 +19,7 @@ const defaultSettings: IGuiSettingsState = {
   enableSystemNotifications: true,
   monochromaticIcon: false,
   startMinimized: false,
+  unpinnedWindow: process.platform !== 'win32' && process.platform !== 'darwin',
 };
 
 export default class GuiSettings {
@@ -63,6 +65,14 @@ export default class GuiSettings {
 
   get startMinimized(): boolean {
     return this.stateValue.startMinimized;
+  }
+
+  set unpinnedWindow(newValue: boolean) {
+    this.changeStateAndNotify({ ...this.stateValue, unpinnedWindow: newValue });
+  }
+
+  get unpinnedWindow(): boolean {
+    return this.stateValue.unpinnedWindow;
   }
 
   public onChange?: (newState: IGuiSettingsState, oldState: IGuiSettingsState) => void;

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -133,6 +133,7 @@ class AttachedToTrayWindowPositioning implements IWindowPositioning {
 export default class WindowController {
   private width: number;
   private height: number;
+  private windowValue: BrowserWindow;
   private webContentsValue: WebContents;
   private windowPositioning: IWindowPositioning;
   private isWindowReady = false;
@@ -145,18 +146,33 @@ export default class WindowController {
     return this.webContentsValue;
   }
 
-  constructor(private windowValue: BrowserWindow, tray: Tray) {
+  constructor(windowValue: BrowserWindow, private tray: Tray, unpinnedWindow: boolean) {
     const [width, height] = windowValue.getSize();
     this.width = width;
     this.height = height;
+    this.windowValue = windowValue;
     this.webContentsValue = windowValue.webContents;
-    this.windowPositioning =
-      process.platform === 'linux'
-        ? new StandaloneWindowPositioning()
-        : new AttachedToTrayWindowPositioning(tray);
+    this.windowPositioning = unpinnedWindow
+      ? new StandaloneWindowPositioning()
+      : new AttachedToTrayWindowPositioning(tray);
 
     this.installDisplayMetricsHandler();
     this.installWindowReadyHandlers();
+  }
+
+  public replaceWindow(window: BrowserWindow, unpinnedWindow: boolean) {
+    this.window.removeAllListeners();
+    this.window.destroy();
+
+    this.windowValue = window;
+    this.webContentsValue = window.webContents;
+
+    this.windowPositioning = unpinnedWindow
+      ? new StandaloneWindowPositioning()
+      : new AttachedToTrayWindowPositioning(this.tray);
+
+    this.updatePosition();
+    this.notifyUpdateWindowShape();
   }
 
   public show(whenReady = true) {

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -208,11 +208,26 @@ export default class WindowController {
   private showImmediately() {
     const window = this.windowValue;
 
-    this.updatePosition();
-    this.notifyUpdateWindowShape();
+    // When running with unpinned window on Windows there's a bug that causes the app to become
+    // wider if opened from minimized if the updated position is set before the window is opened.
+    // Unfortunately the order can't always be changed since this would cause the Window to "jump"
+    // in other scenarios.
+    if (
+      process.platform === 'win32' &&
+      this.windowPositioning instanceof StandaloneWindowPositioning
+    ) {
+      window.show();
+      window.focus();
 
-    window.show();
-    window.focus();
+      this.updatePosition();
+      this.notifyUpdateWindowShape();
+    } else {
+      this.updatePosition();
+      this.notifyUpdateWindowShape();
+
+      window.show();
+      window.focus();
+    }
   }
 
   private updatePosition() {

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -386,6 +386,10 @@ export default class AppRenderer {
     IpcRendererEventChannel.guiSettings.setMonochromaticIcon(monochromaticIcon);
   }
 
+  public setUnpinnedWindow(unpinnedWindow: boolean) {
+    IpcRendererEventChannel.guiSettings.setUnpinnedWindow(unpinnedWindow);
+  }
+
   public async verifyWireguardKey(publicKey: IWgKey) {
     const actions = this.reduxActions;
     actions.settings.verifyWireguardKey(publicKey);

--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 import { colors } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { IReduxState } from '../redux/store';
 import ImageView from './ImageView';
 
 export enum HeaderBarStyle {
@@ -19,9 +21,14 @@ const headerBarStyleColorMap = {
   [HeaderBarStyle.success]: colors.green,
 };
 
-const HeaderBarContainer = styled.header({}, (props: { barStyle?: HeaderBarStyle }) => ({
+interface IHeaderBarContainerProps {
+  barStyle?: HeaderBarStyle;
+  unpinnedWindow: boolean;
+}
+
+const HeaderBarContainer = styled.header({}, (props: IHeaderBarContainerProps) => ({
   padding: '12px 16px',
-  paddingTop: process.platform === 'darwin' ? '24px' : '12px',
+  paddingTop: process.platform === 'darwin' && !props.unpinnedWindow ? '24px' : '12px',
   backgroundColor: headerBarStyleColorMap[props.barStyle ?? HeaderBarStyle.default],
 }));
 
@@ -40,8 +47,15 @@ interface IHeaderBarProps {
 }
 
 export default function HeaderBar(props: IHeaderBarProps) {
+  const unpinnedWindow = useSelector(
+    (state: IReduxState) => state.settings.guiSettings.unpinnedWindow,
+  );
+
   return (
-    <HeaderBarContainer barStyle={props.barStyle} className={props.className}>
+    <HeaderBarContainer
+      barStyle={props.barStyle}
+      className={props.className}
+      unpinnedWindow={unpinnedWindow}>
       <HeaderBarContent>{props.children}</HeaderBarContent>
     </HeaderBarContainer>
   );

--- a/gui/src/renderer/components/NavigationBar.tsx
+++ b/gui/src/renderer/components/NavigationBar.tsx
@@ -178,6 +178,9 @@ interface INavigationBarProps {
 
 export const NavigationBar = function NavigationBarT(props: INavigationBarProps) {
   const { showsBarSeparator, showsBarTitle } = useContext(NavigationScrollContext);
+  const unpinnedWindow = useSelector(
+    (state: IReduxState) => state.settings.guiSettings.unpinnedWindow,
+  );
   const [titleAdjustment, setTitleAdjustment] = useState(0);
 
   const titleContainerRef = useRef() as React.RefObject<HTMLDivElement>;
@@ -217,7 +220,7 @@ export const NavigationBar = function NavigationBarT(props: INavigationBarProps)
   });
 
   return (
-    <StyledNavigationBar>
+    <StyledNavigationBar unpinnedWindow={unpinnedWindow}>
       <StyledNavigationBarWrapper ref={navigationBarRef}>
         <TitleBarItemContext.Provider
           value={{
@@ -266,7 +269,10 @@ interface ICloseBarItemProps {
 export function CloseBarItem(props: ICloseBarItemProps) {
   // Use the arrow down icon on Linux, to avoid confusion with the close button in the window
   // title bar.
-  const iconName = process.platform === 'linux' ? 'icon-close-down' : 'icon-close';
+  const unpinnedWindow = useSelector(
+    (state: IReduxState) => state.settings.guiSettings.unpinnedWindow,
+  );
+  const iconName = unpinnedWindow ? 'icon-close-down' : 'icon-close';
   return (
     <StyledCloseBarItemButton aria-label={messages.gettext('Close')} onClick={props.action}>
       <StyledCloseBarItemIcon

--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -17,11 +17,11 @@ export const StyledNavigationItems = styled.div({
   flexDirection: 'row',
 });
 
-export const StyledNavigationBar = styled.nav({
+export const StyledNavigationBar = styled.nav((props: { unpinnedWindow: boolean }) => ({
   flex: 0,
   padding: '12px',
-  paddingTop: process.platform === 'darwin' ? '24px' : '12px',
-});
+  paddingTop: process.platform === 'darwin' && !props.unpinnedWindow ? '24px' : '12px',
+}));
 
 export const StyledNavigationBarWrapper = styled.div({
   display: 'flex',

--- a/gui/src/renderer/components/PlatformWindow.tsx
+++ b/gui/src/renderer/components/PlatformWindow.tsx
@@ -2,12 +2,17 @@ import styled from 'styled-components';
 
 const ARROW_WIDTH = 30;
 
-export default styled.div({}, ({ arrowPosition }: { arrowPosition?: number }) => {
+interface IPlatformWindowProps {
+  arrowPosition?: number;
+  unpinnedWindow: boolean;
+}
+
+export default styled.div({}, (props: IPlatformWindowProps) => {
   let mask: string | undefined;
 
-  if (process.platform === 'darwin') {
+  if (process.platform === 'darwin' && !props.unpinnedWindow) {
     const arrowPositionCss =
-      arrowPosition !== undefined ? `${arrowPosition - ARROW_WIDTH * 0.5}px` : '50%';
+      props.arrowPosition !== undefined ? `${props.arrowPosition - ARROW_WIDTH * 0.5}px` : '50%';
 
     mask = [
       `url(../../assets/images/app-triangle.svg) ${arrowPositionCss} 0% no-repeat`,

--- a/gui/src/renderer/components/Preferences.tsx
+++ b/gui/src/renderer/components/Preferences.tsx
@@ -23,7 +23,7 @@ export interface IProps {
   enableSystemNotifications: boolean;
   monochromaticIcon: boolean;
   startMinimized: boolean;
-  enableStartMinimizedToggle: boolean;
+  unpinnedWindow: boolean;
   setAutoStart: (autoStart: boolean) => void;
   setEnableSystemNotifications: (flag: boolean) => void;
   setAutoConnect: (autoConnect: boolean) => void;
@@ -31,6 +31,7 @@ export interface IProps {
   setShowBetaReleases: (showBetaReleases: boolean) => void;
   setStartMinimized: (startMinimized: boolean) => void;
   setMonochromaticIcon: (monochromaticIcon: boolean) => void;
+  setUnpinnedWindow: (unpinnedWindow: boolean) => void;
   onClose: () => void;
 }
 
@@ -178,7 +179,36 @@ export default class Preferences extends React.Component<IProps> {
                   </Cell.Footer>
                 </AriaInputGroup>
 
-                {this.props.enableStartMinimizedToggle ? (
+                {(process.platform === 'win32' ||
+                  (process.platform === 'darwin' && process.env.NODE_ENV === 'development')) && (
+                  <AriaInputGroup>
+                    <Cell.Container>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Unpin app from taskbar')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={this.props.unpinnedWindow}
+                          onChange={this.props.setUnpinnedWindow}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                    <Cell.Footer>
+                      <AriaDescription>
+                        <Cell.FooterText>
+                          {messages.pgettext(
+                            'preferences-view',
+                            'Enable to move the app around as a free-standing window.',
+                          )}
+                        </Cell.FooterText>
+                      </AriaDescription>
+                    </Cell.Footer>
+                  </AriaInputGroup>
+                )}
+
+                {this.props.unpinnedWindow && (
                   <React.Fragment>
                     <AriaInputGroup>
                       <Cell.Container>
@@ -206,7 +236,7 @@ export default class Preferences extends React.Component<IProps> {
                       </Cell.Footer>
                     </AriaInputGroup>
                   </React.Fragment>
-                ) : undefined}
+                )}
 
                 <AriaInputGroup>
                   <Cell.Container disabled={this.props.isBeta}>

--- a/gui/src/renderer/containers/PlatformWindowContainer.tsx
+++ b/gui/src/renderer/containers/PlatformWindowContainer.tsx
@@ -5,6 +5,7 @@ import { IReduxState } from '../redux/store';
 
 const mapStateToProps = (state: IReduxState) => ({
   arrowPosition: state.userInterface.arrowPosition,
+  unpinnedWindow: state.settings.guiSettings.unpinnedWindow,
 });
 
 export default connect(mapStateToProps)(PlatformWindow);

--- a/gui/src/renderer/containers/PreferencesPage.tsx
+++ b/gui/src/renderer/containers/PreferencesPage.tsx
@@ -15,6 +15,7 @@ const mapStateToProps = (state: IReduxState) => ({
   enableSystemNotifications: state.settings.guiSettings.enableSystemNotifications,
   monochromaticIcon: state.settings.guiSettings.monochromaticIcon,
   startMinimized: state.settings.guiSettings.startMinimized,
+  unpinnedWindow: state.settings.guiSettings.unpinnedWindow,
 });
 
 const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
@@ -44,9 +45,11 @@ const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps
     setStartMinimized: (startMinimized: boolean) => {
       props.app.setStartMinimized(startMinimized);
     },
-    enableStartMinimizedToggle: process.platform === 'linux',
     setMonochromaticIcon: (monochromaticIcon: boolean) => {
       props.app.setMonochromaticIcon(monochromaticIcon);
+    },
+    setUnpinnedWindow: (unpinnedWindow: boolean) => {
+      props.app.setUnpinnedWindow(unpinnedWindow);
     },
   };
 };

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -148,6 +148,7 @@ const initialState: ISettingsReduxState = {
     autoConnect: true,
     monochromaticIcon: false,
     startMinimized: false,
+    unpinnedWindow: process.platform !== 'win32' && process.platform !== 'darwin',
   },
   relaySettings: {
     normal: {

--- a/gui/src/shared/gui-settings-state.ts
+++ b/gui/src/shared/gui-settings-state.ts
@@ -20,4 +20,7 @@ export interface IGuiSettingsState {
 
   // Tells the app to hide the main window on start.
   startMinimized: boolean;
+
+  // Tells the app wheter or not it should act as a window or a context menu.
+  unpinnedWindow: boolean;
 }

--- a/gui/src/shared/ipc-event-channel.ts
+++ b/gui/src/shared/ipc-event-channel.ts
@@ -101,6 +101,7 @@ interface IGuiSettingsMethods extends IReceiver<IGuiSettingsState> {
   setStartMinimized(startMinimized: boolean): void;
   setMonochromaticIcon(monochromaticIcon: boolean): void;
   setPreferredLocale(locale: string): void;
+  setUnpinnedWindow(unpinnedWindow: boolean): void;
 }
 
 interface IGuiSettingsHandlers extends ISender<IGuiSettingsState> {
@@ -109,6 +110,7 @@ interface IGuiSettingsHandlers extends ISender<IGuiSettingsState> {
   handleStartMinimized(fn: (startMinimized: boolean) => void): void;
   handleMonochromaticIcon(fn: (monochromaticIcon: boolean) => void): void;
   handleSetPreferredLocale(fn: (locale: string) => void): void;
+  handleSetUnpinnedWindow(fn: (unpinnedWindow: boolean) => void): void;
 }
 
 interface IAccountHandlers extends ISender<IAccountData | undefined> {
@@ -204,6 +206,7 @@ const SET_AUTO_CONNECT = 'set-auto-connect';
 const SET_MONOCHROMATIC_ICON = 'set-monochromatic-icon';
 const SET_START_MINIMIZED = 'set-start-minimized';
 const SET_PREFERRED_LOCALE = 'set-preferred-locale';
+const SET_UNPINNED_WINDOW = 'set-unpinned-window';
 
 const GET_APP_STATE = 'get-app-state';
 
@@ -305,6 +308,7 @@ export class IpcRendererEventChannel {
     setMonochromaticIcon: set(SET_MONOCHROMATIC_ICON),
     setStartMinimized: set(SET_START_MINIMIZED),
     setPreferredLocale: set(SET_PREFERRED_LOCALE),
+    setUnpinnedWindow: set(SET_UNPINNED_WINDOW),
   };
 
   public static autoStart: IAutoStartMethods = {
@@ -412,6 +416,7 @@ export class IpcMainEventChannel {
     handleMonochromaticIcon: handler(SET_MONOCHROMATIC_ICON),
     handleStartMinimized: handler(SET_START_MINIMIZED),
     handleSetPreferredLocale: handler(SET_PREFERRED_LOCALE),
+    handleSetUnpinnedWindow: handler(SET_UNPINNED_WINDOW),
   };
 
   public static autoStart: IAutoStartHandlers = {


### PR DESCRIPTION
This PR adds a new setting which unpins the app from the taskbar in Windows. In addition to that it also:
* Makes sure that the size of the web content is the desired size
* Changes the menu close icon to the arrow when in unpinned mode
* Adds the context menu when in the unpinned mode
* Hides the app on macOS when the tray icon is right-clicked, to make it consistent with Windows
* Makes the start minimized setting visible and respected when in unpinned mode.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2273)
<!-- Reviewable:end -->
