### PR TITLE
Block in-tunnel traffic for `mullvad-exclude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ Line wrap the file at 100 chars.                                              Th
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and
   "Always require VPN" were disabled, the service would reset the firewall upon starting back up,
   even if the tunnel was up when the crash occurred.
+- Add firewall rules for `mullvad-exclude`, i.e. split tunneling, that disallow all traffic in the
+  tunnel other than non-custom DNS traffic. This prevents leaks into the tunnel.
 
 #### Windows
 - Block all traffic received or sent before the BFE service and daemon service have started during

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -125,10 +125,16 @@ impl ConnectedState {
             .map_err(BoxedError::new)?;
 
         #[cfg(target_os = "linux")]
-        shared_values
-            .route_manager
-            .route_exclusions_dns(&self.metadata.interface, &dns_ips)
-            .map_err(BoxedError::new)?;
+        {
+            let mut dns_routes = vec![IpAddr::V4(self.metadata.ipv4_gateway)];
+            if let Some(gateway) = self.metadata.ipv6_gateway {
+                dns_routes.push(IpAddr::V6(gateway));
+            }
+            shared_values
+                .route_manager
+                .route_exclusions_dns(&self.metadata.interface, &dns_routes)
+                .map_err(BoxedError::new)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This updates the firewall to disallow any traffic going inside the tunnel when using `mullvad-exclude`, excepting non-custom DNS. DNS traffic is also blocked in the tunnel if custom DNS servers are configured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2274)
<!-- Reviewable:end -->
