### PR TITLE
Fix quit button in pinned mode on Windows

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1393,8 +1393,6 @@ class ApplicationMain {
       show: false,
       frame: this.guiSettings.unpinnedWindow,
       transparent: !this.guiSettings.unpinnedWindow,
-      minimizable: this.guiSettings.unpinnedWindow,
-      closable: this.guiSettings.unpinnedWindow,
       useContentSize: true,
       webPreferences: {
         nodeIntegration: true,
@@ -1410,6 +1408,8 @@ class ApplicationMain {
           height: contentHeight + headerBarArrowHeight,
           minHeight: contentHeight + headerBarArrowHeight,
           titleBarStyle: this.guiSettings.unpinnedWindow ? 'default' : 'customButtonsOnHover',
+          minimizable: this.guiSettings.unpinnedWindow,
+          closable: this.guiSettings.unpinnedWindow,
         });
 
         // make the window visible on all workspaces


### PR DESCRIPTION
#2273 introduced an issue which causes the quit button to not function properly in Windows when the app is pinned to the taskbar. This was caused by `closable` being set to `false` for the window which wasn't correct.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2280)
<!-- Reviewable:end -->
