### PR TITLE
Avoid race condition when updating notification

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -8,6 +8,11 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import kotlin.properties.Delegates.observable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.service.notifications.TunnelStateNotification
 import net.mullvad.talpid.util.EventNotifier
@@ -18,6 +23,15 @@ class ForegroundNotificationManager(
     val serviceNotifier: EventNotifier<ServiceInstance?>,
     val keyguardManager: KeyguardManager
 ) {
+    private sealed class UpdaterMessage {
+        class UpdateNotification : UpdaterMessage()
+        class UpdateAction : UpdaterMessage()
+        class AcknowledgeStartForegroundService : UpdaterMessage()
+        class NewTunnelState(val newState: TunnelState) : UpdaterMessage()
+    }
+
+    private val updater = runUpdater()
+
     private val tunnelStateNotification = TunnelStateNotification(service)
 
     private val deviceLockListener = object : BroadcastReceiver() {
@@ -36,15 +50,16 @@ class ForegroundNotificationManager(
 
     private var tunnelStateEvents
     by autoSubscribable<TunnelState>(this, TunnelState.Disconnected()) { newState ->
-        tunnelStateNotification.tunnelState = newState
-        updateNotification()
+        updater.sendBlocking(UpdaterMessage.NewTunnelState(newState))
     }
 
     private var deviceIsUnlocked by observable(!keyguardManager.isDeviceLocked) { _, _, _ ->
-        updateNotificationAction()
+        updater.sendBlocking(UpdaterMessage.UpdateAction())
     }
 
-    private var loggedIn by observable(false) { _, _, _ -> updateNotificationAction() }
+    private var loggedIn by observable(false) { _, _, _ ->
+        updater.sendBlocking(UpdaterMessage.UpdateAction())
+    }
 
     private val tunnelState
         get() = tunnelStateEvents?.latestEvent ?: TunnelState.Disconnected()
@@ -55,7 +70,9 @@ class ForegroundNotificationManager(
     var onForeground = false
         private set
 
-    var lockedToForeground by observable(false) { _, _, _ -> updateNotification() }
+    var lockedToForeground by observable(false) { _, _, _ ->
+        updater.sendBlocking(UpdaterMessage.UpdateNotification())
+    }
 
     init {
         serviceNotifier.subscribe(this) { newServiceInstance ->
@@ -73,7 +90,7 @@ class ForegroundNotificationManager(
             )
         }
 
-        updateNotification()
+        updater.sendBlocking(UpdaterMessage.UpdateNotification())
     }
 
     fun onDestroy() {
@@ -84,17 +101,40 @@ class ForegroundNotificationManager(
 
         service.unregisterReceiver(deviceLockListener)
 
-        tunnelStateNotification.visible = false
+        updater.close()
     }
 
     fun acknowledgeStartForegroundService() {
+        updater.sendBlocking(UpdaterMessage.AcknowledgeStartForegroundService())
+    }
+
+    private fun runUpdater() = GlobalScope.actor<UpdaterMessage>(
+        Dispatchers.Main,
+        Channel.UNLIMITED
+    ) {
+        for (message in channel) {
+            when (message) {
+                is UpdaterMessage.UpdateNotification -> updateNotification()
+                is UpdaterMessage.UpdateAction -> updateNotificationAction()
+                is UpdaterMessage.AcknowledgeStartForegroundService -> {
+                    doAcknowledgeStartForegroundService()
+                }
+                is UpdaterMessage.NewTunnelState -> {
+                    tunnelStateNotification.tunnelState = message.newState
+                    updateNotification()
+                }
+            }
+        }
+
+        tunnelStateNotification.visible = false
+    }
+
+    private fun doAcknowledgeStartForegroundService() {
         // When sending start commands to the service, it is necessary to request the service to be
         // on the foreground. With such request, when the service is started it must be placed on
         // the foreground with a call to startForeground before a timeout expires, otherwise Android
         // kills the app.
-        synchronized(this) {
-            showOnForeground()
-        }
+        showOnForeground()
 
         // Restore the notification to its correct state.
         updateNotification()
@@ -110,19 +150,17 @@ class ForegroundNotificationManager(
     }
 
     private fun updateNotification() {
-        synchronized(this) {
-            if (shouldBeOnForeground != onForeground) {
-                if (shouldBeOnForeground) {
-                    showOnForeground()
+        if (shouldBeOnForeground != onForeground) {
+            if (shouldBeOnForeground) {
+                showOnForeground()
+            } else {
+                if (Build.VERSION.SDK_INT >= 24) {
+                    service.stopForeground(Service.STOP_FOREGROUND_DETACH)
                 } else {
-                    if (Build.VERSION.SDK_INT >= 24) {
-                        service.stopForeground(Service.STOP_FOREGROUND_DETACH)
-                    } else {
-                        service.stopForeground(false)
-                    }
-
-                    onForeground = false
+                    service.stopForeground(false)
                 }
+
+                onForeground = false
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -113,7 +113,6 @@ class MainActivity : FragmentActivity() {
         }
 
         bindService(intent, serviceConnectionManager, 0)
-        service?.isUiVisible = true
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -71,6 +71,7 @@ class MainActivity : FragmentActivity() {
         override fun onServiceDisconnected(className: ComponentName) {
             android.util.Log.d("mullvad", "UI lost the connection to the service")
             service?.serviceNotifier?.unsubscribe(this@MainActivity)
+            service = null
             serviceConnection = null
             serviceNotifier.notify(null)
         }
@@ -123,6 +124,7 @@ class MainActivity : FragmentActivity() {
         android.util.Log.d("mullvad", "Stoping main activity")
         isUiVisible = false
         service?.isUiVisible = false
+        service = null
         unbindService(serviceConnectionManager)
 
         super.onStop()


### PR DESCRIPTION
Previously, the tunnel state notification could be updated by two threads: the UI thread or a background thread that dispatches tunnel state events. This meant that there was a risk of a race condition. I'm not sure if this has happened before, because I found this issue while investigating another, but I think I might have seen it when swiping away the notification while disconnecting and then the notification reappeared shortly afterwards showing that the daemon was in the disconnected state.

This PR fixes that by dispatching tunnel state events (and settings change events, which also affect the notification because it may show or hide the action button based on the login status) solely on the UI thread.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2283)
<!-- Reviewable:end -->
