### PR TITLE
Treat Kotlin compiler warnings as errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,6 +70,14 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ObsoleteCoroutinesApi",
+        ]
+    }
+}
+
 play {
     serviceAccountCredentials = file("play-api-key.json")
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,6 +72,8 @@ android {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
+        allWarningsAsErrors = true
+
         kotlinOptions.freeCompilerArgs += [
             "-Xuse-experimental=kotlinx.coroutines.ObsoleteCoroutinesApi",
         ]

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -72,7 +72,7 @@ class MullvadVpnService : TalpidVpnService() {
     private lateinit var notificationManager: ForegroundNotificationManager
     private lateinit var tunnelStateUpdater: TunnelStateUpdater
 
-    private var pendingAction by observable<PendingAction?>(null) { _, _, action ->
+    private var pendingAction by observable<PendingAction?>(null) { _, _, _ ->
         instance?.let { activeInstance ->
             handlePendingAction(
                 activeInstance.connectionProxy,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -41,7 +41,6 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         savedInstanceState: Bundle?
     ): View {
         val view = inflater.inflate(R.layout.connect, container, false)
-        val resources = parentActivity.resources
 
         headerBar = view.findViewById<HeaderBar>(R.id.header_bar).apply {
             tunnelState = TunnelState.Disconnected()


### PR DESCRIPTION
Historically, the Android app code-base has slowly accumulated Kotlin compiler warnings. This is entirely my fault for missing them and merging PRs that add more warnings. From time to time a PR would be merged to fix all of them on once, but that is not the ideal way to organize things.

This PR enables a flag for the Android build to treat warnings as errors. This will make it harder to ignore the warnings and the CI builds will fail if warnings are still left in PRs.

The PR also fixes the warnings that remained in the code base, mostly due to unused variables. There was also the requirement to opt-in into the API for coroutine channels, which is marked as obsolete. From what I could understand after a quick glance on the internet, there is no current substitute API, but the developers marked it as such because it is in the process of being rewritten. So in the future we'll likely need to update the code when we update the Kotlin version and/or the Kotlin coroutines library version.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2285)
<!-- Reviewable:end -->
