### PR TITLE
Fix race condition that led to multiple daemon instances running at the same time

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
@@ -41,6 +41,7 @@ class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDa
         var isRunning = true
 
         prepareFiles()
+        vpnService.splitTunneling.join()
 
         while (isRunning) {
             if (!waitForCommand(channel, Command.START)) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
@@ -1,0 +1,78 @@
+package net.mullvad.mullvadvpn.service
+
+import kotlin.properties.Delegates.observable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.channels.sendBlocking
+
+class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDaemon?) -> Unit) {
+    private enum class Command {
+        START,
+        STOP,
+    }
+
+    private val commandChannel = spawnActor()
+
+    private var daemon by observable<MullvadDaemon?>(null) { _, _, newInstance ->
+        listener(newInstance)
+    }
+
+    fun start() {
+        commandChannel.sendBlocking(Command.START)
+    }
+
+    fun stop() {
+        commandChannel.sendBlocking(Command.STOP)
+    }
+
+    fun onDestroy() {
+        commandChannel.close()
+    }
+
+    private fun spawnActor() = GlobalScope.actor<Command>(Dispatchers.Default, Channel.UNLIMITED) {
+        var isRunning = true
+
+        while (isRunning) {
+            if (!waitForCommand(channel, Command.START)) {
+                break
+            }
+
+            startDaemon()
+
+            isRunning = waitForCommand(channel, Command.STOP)
+
+            stopDaemon()
+        }
+    }
+
+    private suspend fun waitForCommand(
+        channel: ReceiveChannel<Command>,
+        command: Command
+    ): Boolean {
+        try {
+            while (channel.receive() != command) {
+                // Wait for command
+            }
+
+            return true
+        } catch (exception: ClosedReceiveChannelException) {
+            return false
+        }
+    }
+
+    private fun startDaemon() {
+        daemon = MullvadDaemon(vpnService).apply {
+            onDaemonStopped = {
+                daemon = null
+            }
+        }
+    }
+
+    private fun stopDaemon() {
+        daemon?.shutdown()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -7,7 +7,6 @@ import android.net.VpnService
 import android.os.Binder
 import android.os.IBinder
 import android.util.Log
-import java.io.File
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -20,9 +19,6 @@ import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
 import net.mullvad.talpid.util.EventNotifier
-
-private const val API_IP_ADDRESS_FILE = "api-ip-address.txt"
-private const val RELAYS_FILE = "relays.json"
 
 class MullvadVpnService : TalpidVpnService() {
     companion object {
@@ -225,7 +221,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private fun startDaemon() = GlobalScope.launch(Dispatchers.Default) {
         Log.d(TAG, "Starting daemon")
-        prepareFiles()
         splitTunneling.await()
         daemonInstance.start()
     }
@@ -237,25 +232,6 @@ class MullvadVpnService : TalpidVpnService() {
             setUpInstance(daemon, settings)
         } else {
             restart()
-        }
-    }
-
-    private fun prepareFiles() {
-        FileMigrator(File("/data/data/net.mullvad.mullvadvpn"), filesDir).apply {
-            migrate(RELAYS_FILE)
-            migrate("settings.json")
-            migrate("daemon.log")
-            migrate("daemon.old.log")
-            migrate("wireguard.log")
-            migrate("wireguard.old.log")
-        }
-
-        val shouldOverwriteRelayList =
-            lastUpdatedTime() > File(filesDir, RELAYS_FILE).lastModified()
-
-        FileResourceExtractor(this).apply {
-            extract(API_IP_ADDRESS_FILE, false)
-            extract(RELAYS_FILE, shouldOverwriteRelayList)
         }
     }
 
@@ -329,9 +305,5 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
         startActivity(intent)
-    }
-
-    private fun lastUpdatedTime(): Long {
-        return packageManager.getPackageInfo(packageName, 0).lastUpdateTime
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -41,8 +41,6 @@ class MullvadVpnService : TalpidVpnService() {
     private val binder = LocalBinder()
     private val serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
-    private val splitTunneling = CompletableDeferred<SplitTunneling>()
-
     private var isStopping = false
     private var shouldStop = false
 
@@ -87,6 +85,8 @@ class MullvadVpnService : TalpidVpnService() {
     private var isUiVisible: Boolean by observable(false) { _, _, isUiVisible ->
         notificationManager.lockedToForeground = isUiVisible or isBound
     }
+
+    internal val splitTunneling = CompletableDeferred<SplitTunneling>()
 
     override fun onCreate() {
         super.onCreate()
@@ -221,7 +221,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private fun startDaemon() = GlobalScope.launch(Dispatchers.Default) {
         Log.d(TAG, "Starting daemon")
-        splitTunneling.await()
         daemonInstance.start()
     }
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -128,6 +128,8 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_initial
 
     match start_logging(&resource_dir) {
         Ok(()) => {
+            version::log_version();
+
             LOAD_CLASSES.call_once(|| env.preload_classes(classes::CLASSES.iter().cloned()));
 
             if let Err(error) = initialize(&env, &this, &vpnService, cache_dir, resource_dir) {
@@ -156,7 +158,6 @@ fn initialize_logging(log_dir: &Path) -> Result<(), String> {
         .map_err(|error| error.display_chain_with_msg("Failed to start logger"))?;
     exception_logging::enable();
     log_panics::init();
-    version::log_version();
 
     Ok(())
 }


### PR DESCRIPTION
Previously, it was possible to spawn multiple daemon instances in the right scenario because of a race condition. The condition happened when the service stopped right after it started, while the daemon was still starting. When the service stopped, the daemon had not finished setting up, so the stop handling code couldn't set a shutdown command to the daemon. Because Android may reuse the same process for the service, this meant that a second start would also try to start the daemon again, and the first instance would end up leaking and conflicting with the second instance (they would fight to set up the tunnel, for example).

This PR tries to fix the race condition by refactoring the daemon lifecycle handling code. It tries to use the same approach used [previously](https://github.com/mullvad/mullvadvpn-app/pull/2283) to fix a race condition in the notification, by using an actor model to handle the events. In this case, a new `DaemonInstance` helper actor class was created, and it will always start and stop the daemon serially.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **To the user, this looks like the same issue related to the app restarting by itself, so that changelog entry is being reused.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2286)
<!-- Reviewable:end -->
