### PR TITLE
Rename `mullvad relay set relay` to `mullvad relay set hostname`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove WireGuard keys during uninstallation after the firewall is unlocked.
 - Randomly select addresses to use for communicating with the API.
 - Bundle a list of API addresses to use instead of assuming that the primary address can be reached.
+- Rename CLI subcommand `mullvad relay set relay` to `mullvad relay set hostname`.
 
 #### Android
 - Remove the Quit button.

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -117,7 +117,7 @@ impl Command for Relay {
                                    command to show available alternatives.")
                     )
                     .subcommand(
-                        clap::SubCommand::with_name("relay")
+                        clap::SubCommand::with_name("hostname")
                             .about("Set the exact relay to use via its hostname. Shortcut for \
                                 'location <country> <city> <hostname>'.")
                             .arg(
@@ -203,8 +203,8 @@ impl Relay {
             self.set_custom(custom_matches).await
         } else if let Some(location_matches) = matches.subcommand_matches("location") {
             self.set_location(location_matches).await
-        } else if let Some(relay_matches) = matches.subcommand_matches("relay") {
-            self.set_relay(relay_matches).await
+        } else if let Some(relay_matches) = matches.subcommand_matches("hostname") {
+            self.set_hostname(relay_matches).await
         } else if let Some(provider_matches) = matches.subcommand_matches("provider") {
             self.set_provider(provider_matches).await
         } else if let Some(tunnel_matches) = matches.subcommand_matches("tunnel") {
@@ -334,7 +334,7 @@ impl Relay {
         key
     }
 
-    async fn set_relay(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set_hostname(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let hostname = matches.value_of("hostname").unwrap();
         let countries = Self::get_filtered_relays().await?;
 


### PR DESCRIPTION
Closes #2267.

Signed-off-by: Robin Gögge <r.goegge@outlook.com>

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.
This PR changes the `mullvad relay set relay` CLI sucommad to `mullvad relay set hostname` in order to improve the CLI UX.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2287)
<!-- Reviewable:end -->
