### PR TITLE
Fix app showing it was blocking connections when it wasn't when the VPN permission was denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix apps not being excluded from the tunnel sometimes if auto-connect was enabled.
 - Fix crash that happened sometimes when closing the app or when requesting from the notification
   or the quick-settings tile for the app to connect or disconnect.
+- Fix app showing that it was blocking connections when it wasn't when VPN permission was denied.
 
 #### Windows
 - Fix log output encoding for Windows modules.

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -55,11 +55,13 @@ open class TalpidVpnService : VpnService() {
         }
     }
 
-    fun createTunIfClosed() {
+    fun createTunIfClosed(): Boolean {
         synchronized(this) {
             if (activeTunDevice == null) {
                 activeTunDevice = createTun(currentTunConfig)
             }
+
+            return activeTunDevice?.let { tunFd -> tunFd > 0 } ?: false
         }
     }
 

--- a/talpid-core/src/tunnel/tun_provider/android/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/android/mod.rs
@@ -7,6 +7,7 @@ use jnix::{
     jni::{
         objects::{GlobalRef, JValue},
         signature::{JavaType, Primitive},
+        sys::JNI_FALSE,
         JavaVM,
     },
     IntoJava, JnixEnv,
@@ -133,13 +134,14 @@ impl AndroidTunProvider {
     pub fn create_tun_if_closed(&mut self) -> Result<(), Error> {
         let result = self.call_method(
             "createTunIfClosed",
-            "()V",
-            JavaType::Primitive(Primitive::Void),
+            "()Z",
+            JavaType::Primitive(Primitive::Boolean),
             &[],
         )?;
 
         match result {
-            JValue::Void => Ok(()),
+            JValue::Bool(JNI_FALSE) => Err(Error::TunnelDeviceError),
+            JValue::Bool(_) => Ok(()),
             value => Err(Error::InvalidMethodResult(
                 "createTunIfClosed",
                 format!("{:?}", value),


### PR DESCRIPTION
The app can fail creating the tun device when auto-connect is enabled but the VPN permission is not granted. When that happens, the tunnel state machine proceeds to enter the error state. When entering that state, it requests a tunnel device to be created. Previously, the app did not check if the tunnel device was created or not in the Java side. This meant that the tunnel state machine would think that the creation of the tun device succeeded, and assume it was in the blocking state. However, if the VPN permission isn't granted, it will never be able to create the tun device. That meant that the app was reporting that it was blocking connections even if it wasn't.

This PR fixes that by returning a boolean flag to indicate if the tunnel is up or not, which the Rust side can then convert into an error that the tunnel state machine will recognize as a failure to block connections. The app then correctly enters the critical error state.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2288)
<!-- Reviewable:end -->
