### PR TITLE
Always show error message when VPN permission is denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Line wrap the file at 100 chars.                                              Th
 - Improve navigation in the app using a keyboard, so that touchless devices (like TVs) can be used
   more smoothly.
 - Run app in landscape mode on TVs.
+- Try to connect even if VPN permission is denied, so that the app shows an error message saying
+  that the VPN permission was denied.
 
 #### Linux
 - Make route monitor ignore loopback routes.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -52,9 +52,8 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
             requestVpnPermission()
 
             activeAction = GlobalScope.launch(Dispatchers.Default) {
-                if (vpnPermission.await()) {
-                    daemon.connect()
-                }
+                vpnPermission.await()
+                daemon.connect()
             }
         }
     }


### PR DESCRIPTION
Previously, the VPN permission was handled in two different ways. If the user asked the app to connect but then denied the VPN permission, the app would just stay in the disconnected state. If the user enabled auto-connect and restarted the app, the app would show a message saying that the VPN permission was denied.

This PR makes sure that an error message is always shown if the VPN permission is denied. That means that if the user asks the app to connect and then denies the permission, the app will still try to connect so that it ends up in the error state and shows the error message that the VPN permission wasn't granted.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2289)
<!-- Reviewable:end -->
