### PR TITLE
Update nftnl crate to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Line wrap the file at 100 chars.                                              Th
   is used to manage DNS via systemd-resolved.
 - Fix incorrect version string in .deb installer causing downgrade warnings when upgrading from beta
   to stable.
+- Fix memory leak in firewall code via updating `nftnl` dependency.
 
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "nftnl"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7528eff501558f9f892c5001e945b0d7e980cb464a7969101c94e18481c4563"
+checksum = "f8458833d3dd636d15b07f12aa22916d2f73c7607a072247068ecfe7cf28b660"
 dependencies = [
  "bitflags 1.2.1",
  "err-derive",
@@ -1535,11 +1535,11 @@ dependencies = [
 
 [[package]]
 name = "nftnl-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe241d8ce673ef755c8d2b8717cd74990d4e0a61d437792054750ce9a35743d0"
+checksum = "4de1b9f700ed2553ce1c7bcef72fb6d52e56cdf2bd6ef74ceb0cef89800fe153"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "pkg-config",
 ]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -57,7 +57,7 @@ netlink-packet-route = "0.4"
 netlink-proto = "0.4"
 netlink-sys = "0.4"
 byteorder = "1"
-nftnl = { version = "0.5", features = ["nftnl-1-1-0"] }
+nftnl = { version = "0.6", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2.0", features = ["mnl-1-0-4"] }
 which = { version = "4.0", default-features = false }
 tun = "0.5"


### PR DESCRIPTION
Update `nftnl` crate to version 0.6 to fix memory leak in Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2291)
<!-- Reviewable:end -->
