### PR TITLE
Use NetworkManager to create a WireGuard device

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,10 +367,6 @@ echo "org.gradle.jvmargs=-Xmx4608M" >> ~/.gradle/gradle.properties
 * `TALPID_FORCE_USERSPACE_WIREGUARD` - Forces the daemon to use the userspace implementation of
    WireGuard on Linux.
 
-* `TALPID_FORCE_NM_WIREGUARD` - Forces the daemon to use NetworkManager to create a WireGuard
-  device instead of relying on netlink. This is highly inadvisable currently, as NetworkManager is
-  exhibiting buggy behavior.
-
 
 ## Building and running the desktop Electron GUI app
 


### PR DESCRIPTION
Since all the recent changes should have fixed the issues the daemon was experiencing when using NM to create WireGuard tunnels, I think it's reasonable to remove the environment variable gating the use of NM and try to use NM in all cases where NM would be managing DNS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2292)
<!-- Reviewable:end -->
