### PR TITLE
Fix missing `api-ip-address.txt` file no Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -21,6 +21,7 @@ import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
 import net.mullvad.talpid.util.EventNotifier
 
+private const val API_IP_ADDRESS_FILE = "api-ip-address.txt"
 private const val RELAYS_FILE = "relays.json"
 
 class MullvadVpnService : TalpidVpnService() {
@@ -239,6 +240,7 @@ class MullvadVpnService : TalpidVpnService() {
             lastUpdatedTime() > File(filesDir, RELAYS_FILE).lastModified()
 
         FileResourceExtractor(this).apply {
+            extract(API_IP_ADDRESS_FILE, false)
             extract(RELAYS_FILE, shouldOverwriteRelayList)
         }
     }

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -119,6 +119,7 @@ for ARCHITECTURE in $ARCHITECTURES; do
 done
 
 ./update-relays.sh
+./update-api-address.sh
 
 cd "$SCRIPT_DIR/android"
 $GRADLE_CMD --console plain "$GRADLE_TASK"


### PR DESCRIPTION
A previous PR (#2259) improved the API address cache in a few ways. One of them was to fetch an up-to-date address during the build procedure and distribute it with the app. However, although the file was included in the Android APK, it wasn't extracted during runtime, and the daemon would fail to start without it. On Android, unfortunately, files can't be included directly in the APK, and instead they must be included as byte stream "assets", which the app must then extract and store in files in the filesystem when it is first executed, before starting the daemon.

This PR fixes that by extracting the file during runtime together with the relay list file. The PR also updates Android's build script to also fetch an up-to-date address to be included in the APK, in case the desktop build wasn't executed before the Android build.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any released version, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2293)
<!-- Reviewable:end -->
