### PR TITLE
Fix sending problem reports on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
@@ -13,6 +13,7 @@ const val PROBLEM_REPORT_FILE = "problem_report.txt"
 
 class MullvadProblemReport {
     val logDirectory = CompletableDeferred<File>()
+    val resourcesDirectory = CompletableDeferred<File>()
 
     private val problemReportPath = GlobalScope.async(Dispatchers.Default) {
         File(logDirectory.await(), PROBLEM_REPORT_FILE)
@@ -66,7 +67,8 @@ class MullvadProblemReport {
                         sendProblemReport(
                             userEmail,
                             userMessage,
-                            problemReportPath.await().absolutePath
+                            problemReportPath.await().absolutePath,
+                            resourcesDirectory.await().absolutePath
                         )
 
                     if (result) {
@@ -102,6 +104,7 @@ class MullvadProblemReport {
     private external fun sendProblemReport(
         userEmail: String,
         userMessage: String,
-        reportPath: String
+        reportPath: String,
+        resourcesDirectory: String
     ): Boolean
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -84,7 +84,10 @@ class MainActivity : FragmentActivity() {
 
         super.onCreate(savedInstanceState)
 
-        problemReport.logDirectory.complete(filesDir)
+        problemReport.apply {
+            logDirectory.complete(filesDir)
+            resourcesDirectory.complete(filesDir)
+        }
 
         setContentView(R.layout.main)
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -955,7 +955,7 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemRepor
         Err(error) => {
             log::error!(
                 "{}",
-                error.display_chain_with_msg("Failed to collect problem report")
+                error.display_chain_with_msg("Failed to send problem report")
             );
             JNI_FALSE
         }

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -943,14 +943,24 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemRepor
     userEmail: JString<'_>,
     userMessage: JString<'_>,
     outputPath: JString<'_>,
+    resourcesDirectory: JString<'_>,
 ) -> jboolean {
     let env = JnixEnv::from(env);
     let user_email = String::from_java(&env, userEmail);
     let user_message = String::from_java(&env, userMessage);
     let output_path_string = String::from_java(&env, outputPath);
     let output_path = Path::new(&output_path_string);
+    let resources_directory_string = String::from_java(&env, resourcesDirectory);
+    let resources_directory = Path::new(&resources_directory_string);
 
-    match mullvad_problem_report::send_problem_report(&user_email, &user_message, output_path) {
+    let send_result = mullvad_problem_report::send_problem_report(
+        &user_email,
+        &user_message,
+        output_path,
+        resources_directory,
+    );
+
+    match send_result {
         Ok(()) => JNI_TRUE,
         Err(error) => {
             log::error!(

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -253,6 +253,7 @@ pub fn send_problem_report(
     user_email: &str,
     user_message: &str,
     report_path: &Path,
+    resource_dir: &Path,
 ) -> Result<(), Error> {
     let report_content = normalize_newlines(
         read_file_lossy(report_path, REPORT_MAX_SIZE).map_err(|source| {
@@ -274,7 +275,7 @@ pub fn send_problem_report(
     let mut rpc_manager = runtime
         .block_on(mullvad_rpc::MullvadRpcRuntime::with_cache(
             runtime.handle().clone(),
-            &mullvad_paths::get_resource_dir(),
+            resource_dir,
             None,
         ))
         .map_err(Error::CreateRpcClientError)?;

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -113,7 +113,8 @@ fn run() -> Result<(), Error> {
         let report_path = Path::new(send_matches.value_of_os("report").unwrap());
         let user_email = send_matches.value_of("email").unwrap_or("");
         let user_message = send_matches.value_of("message").unwrap_or("");
-        send_problem_report(user_email, user_message, report_path)
+        let resource_dir = mullvad_paths::get_resource_dir();
+        send_problem_report(user_email, user_message, report_path, &resource_dir)
     } else {
         unreachable!("No sub command given");
     }


### PR DESCRIPTION
A previous PR (#2259) changed a bit how the RPC client is configured when sending problem reports. It now requires the resource directory path so that the RPC client can load the API IP address to use for connecting to the API. However, on Android, the resource directory is determined at runtime because the user can install the app on an SD card. This means that the path can only be determined from the Android `Context` object, and that must be sent from the Java side to the Rust side. The original PR used the static path specified in `mullvad_paths`, which meant that on Android sending problem reports failed because it couldn't initialize the RPC client because the resource directory path was incorrect.

This PR makes sure that the resource directory path on Android is correctly sent to the RPC client when configuring it to send a problem report.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes an issue not present in any released version, so no changelog entry is necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2294)
<!-- Reviewable:end -->
