### PR TITLE
Stop using NM when it uses dnsmasq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix memory leak in firewall code via updating `nftnl` dependency.
 - Handle IPv6 traffic correctly using `mullvad-exclude` when there is no default route to any
   non-tunnel interface.
+- Fix issues managing DNS when dnsmasq is used with NetworkManager.
 
 ### Security
 - Restore the last target state if the daemon crashes. Previously, if auto-connect and

--- a/talpid-core/src/linux/network_manager.rs
+++ b/talpid-core/src/linux/network_manager.rs
@@ -83,6 +83,9 @@ pub enum Error {
     #[error(display = "NetworkManager not detected")]
     NetworkManagerNotDetected,
 
+    #[error(display = "NetworkManager is using dnsmasq to manage DNS")]
+    UsingDnsmasq,
+
     #[error(display = "NetworkManager is too old: {}", 0)]
     TooOldNetworkManager(String),
 
@@ -491,6 +494,8 @@ impl NetworkManager {
             .map_err(Error::Dbus)?;
 
         match dns_mode.as_ref() {
+            // NM can't setup config for multiple interfaces with dnsmasq
+            "dnsmasq" => return Err(Error::UsingDnsmasq),
             // If NetworkManager isn't managing DNS for us, it's useless.
             "none" => return Err(Error::NetworkManagerNotManagingDns),
             _ => (),


### PR DESCRIPTION
NetworkManager will just not apply our DNS config when managing DNS via dnsmasq, so the correct thing to do is to fall back to `resolvconf` and using a static file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2296)
<!-- Reviewable:end -->
