### PR TITLE
Fix regression that caused a missing call to `startForeground`

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -111,7 +111,7 @@ class ForegroundNotificationManager(
         showOnForeground()
 
         // Restore the notification to its correct state.
-        updater.sendBlocking(UpdaterMessage.UpdateNotification())
+        updateNotification()
     }
 
     private fun runUpdater() = GlobalScope.actor<UpdaterMessage>(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -26,7 +26,6 @@ class ForegroundNotificationManager(
     private sealed class UpdaterMessage {
         class UpdateNotification : UpdaterMessage()
         class UpdateAction : UpdaterMessage()
-        class AcknowledgeStartForegroundService : UpdaterMessage()
         class NewTunnelState(val newState: TunnelState) : UpdaterMessage()
     }
 
@@ -105,7 +104,14 @@ class ForegroundNotificationManager(
     }
 
     fun acknowledgeStartForegroundService() {
-        updater.sendBlocking(UpdaterMessage.AcknowledgeStartForegroundService())
+        // When sending start commands to the service, it is necessary to request the service to be
+        // on the foreground. With such request, when the service is started it must be placed on
+        // the foreground with a call to startForeground before a timeout expires, otherwise Android
+        // kills the app.
+        showOnForeground()
+
+        // Restore the notification to its correct state.
+        updater.sendBlocking(UpdaterMessage.UpdateNotification())
     }
 
     private fun runUpdater() = GlobalScope.actor<UpdaterMessage>(
@@ -116,9 +122,6 @@ class ForegroundNotificationManager(
             when (message) {
                 is UpdaterMessage.UpdateNotification -> updateNotification()
                 is UpdaterMessage.UpdateAction -> updateNotificationAction()
-                is UpdaterMessage.AcknowledgeStartForegroundService -> {
-                    doAcknowledgeStartForegroundService()
-                }
                 is UpdaterMessage.NewTunnelState -> {
                     tunnelStateNotification.tunnelState = message.newState
                     updateNotification()
@@ -127,17 +130,6 @@ class ForegroundNotificationManager(
         }
 
         tunnelStateNotification.visible = false
-    }
-
-    private fun doAcknowledgeStartForegroundService() {
-        // When sending start commands to the service, it is necessary to request the service to be
-        // on the foreground. With such request, when the service is started it must be placed on
-        // the foreground with a call to startForeground before a timeout expires, otherwise Android
-        // kills the app.
-        showOnForeground()
-
-        // Restore the notification to its correct state.
-        updateNotification()
     }
 
     private fun showOnForeground() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -101,6 +101,8 @@ class ForegroundNotificationManager(
         service.unregisterReceiver(deviceLockListener)
 
         updater.close()
+
+        tunnelStateNotification.visible = false
     }
 
     fun acknowledgeStartForegroundService() {
@@ -128,8 +130,6 @@ class ForegroundNotificationManager(
                 }
             }
         }
-
-        tunnelStateNotification.visible = false
     }
 
     private fun showOnForeground() {


### PR DESCRIPTION
There was a previous fix (#2222) for an issue where Android would kill the service due to a missing call to `startForeground`. However, the issue reappeared after a previous PR (#2283) refactored the notification handling code. Unfortunately, the new code introduces a delay when updating the notification and also fails to run the clean-up operation of removing the notification when the actor has finished handling messages. The former happens because even though the call to `startForeground` happens on the UI thread, it has to wait until the main operation of the thread has finished (and the `Handler` starts handling scheduled tasks, including the co-routine). The latter happens because when stopping, the service closes the actor's channel but finishes executing `onDestroy` before the actor has received the closed channel signal. And since after `onDestroy` it stops executing, the scheduled tasks (including the actor's coroutine job) doesn't execute.

This PR fixes the issues first by moving the code to be executed out of the actor's coroutine task. Since the calls still happen on the UI thread, no synchronization is needed. The acknowledgement of the `startForeground` call now is guaranteed to be executed inside the `onCreate` and `onStartCommand` methods, without delays. And the clean-up is now executed inside the `onDestroy` method, also without delay.

The `acknowledgeStartForegroundService` could have sent a message to update the notification to its required state. That wouldn't have caused any issues with Android's `startForeground` check. However, that would have caused issues with the `onForeground` flag, because it would have a delay removing the notification from the foreground (if needed) and during that delay the service would ignore the quit command and consequently it wouldn't be possible to swipe away the notification (it would just reappear).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **This PR fixes an issue after a regression, so there's already a changelog entry for that issue.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2297)
<!-- Reviewable:end -->
