### PR TITLE
Don't restart after `onDestroy` has been called

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -41,6 +41,7 @@ class MullvadVpnService : TalpidVpnService() {
     private val binder = LocalBinder()
     private val serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
+    private var hasStopped = false
     private var isStopping = false
     private var shouldStop = false
 
@@ -172,6 +173,7 @@ class MullvadVpnService : TalpidVpnService() {
 
     override fun onDestroy() {
         Log.d(TAG, "Service has stopped")
+        hasStopped = true
         notificationManager.onDestroy()
         daemonInstance.onDestroy()
         super.onDestroy()
@@ -206,7 +208,7 @@ class MullvadVpnService : TalpidVpnService() {
             Log.d(TAG, "Daemon has stopped")
             instance = null
 
-            if (!isStopping) {
+            if (!isStopping && !hasStopped) {
                 restart()
             }
         }


### PR DESCRIPTION
Android may decide to kill the service at any time. On Android 11, this is more frequent. If that happens, the daemon is stopped, but since there was no request for the service to stop, the `isStopping` flag was not set to `true`, and that makes the daemon restart, which then leads to a crash.

This PR fixes that by adding another flag, called `hasStopped`. It is only set in the `onDestroy` method, which is the last method called before the service is killed. This means that when the daemon is stopped, it will not restart if either the `isStopping` or the `hasStopped` flag is set.

This crash only happens due to the `DaemonInstance` refactor, because the channel to communicate with the actor is closed, and the restart tries to send a command through the closed channel. Before the refactor, I guess the daemon would restart but the process would just get killed after a while.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Crash didn't happen on previous releases.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2299)
<!-- Reviewable:end -->
