### PR TITLE
Reconnect after changing Allow LAN setting on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash that happened sometimes when closing the app or when requesting from the notification
   or the quick-settings tile for the app to connect or disconnect.
 - Fix app showing that it was blocking connections when it wasn't when VPN permission was denied.
+- Fix internet not working for a minute or two after changing Allow LAN setting.
 
 #### Windows
 - Fix log output encoding for Windows modules.


### PR DESCRIPTION
On Android, allow LAN is implemented by changing the routes that go through the tunnel. When it is enabled, LAN routes are excluded from the tunnel device. This means that enabling or disabling the feature requires the tunnel to be recreated for the changes to take effect.

Previously, the tunnel device would be recreated correctly, but the tunnel connection would not have been affected. This meant that the tunnel would simply not work, and all connections would be blocked. And that continued for a couple of minutes when the tunnel would actually reconnect and use the new tunnel device.

This PR changes the Connected and Connecting states of the tunnel state machine to force a reconnection when the Allow LAN setting changes.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2300)
<!-- Reviewable:end -->
