### PR TITLE
Rename TAP adapter error state cause on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
@@ -63,7 +63,7 @@ class TunnelStateNotification(
             is ErrorStateCause.SetDnsError -> R.string.set_dns_error
             is ErrorStateCause.StartTunnelError -> R.string.start_tunnel_error
             is ErrorStateCause.IsOffline -> R.string.is_offline
-            is ErrorStateCause.TapAdapterProblem -> R.string.tap_adapter_problem
+            is ErrorStateCause.VirtualAdapterProblem -> R.string.virtual_adapter_problem
             is ErrorStateCause.TunnelParameterError -> {
                 when (cause.error) {
                     ParameterGenerationError.NoMatchingRelay -> R.string.no_matching_relay

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
@@ -8,6 +8,6 @@ sealed class ErrorStateCause {
     class StartTunnelError : ErrorStateCause()
     class TunnelParameterError(val error: ParameterGenerationError) : ErrorStateCause()
     class IsOffline : ErrorStateCause()
-    class TapAdapterProblem : ErrorStateCause()
+    class VirtualAdapterProblem : ErrorStateCause()
     class VpnPermissionDenied : ErrorStateCause()
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -128,7 +128,7 @@
     <string name="custom_tunnel_host_resolution_error">Failed to resolve the hostname of custom
     server</string>
     <string name="is_offline">This device is offline, no tunnels can be established</string>
-    <string name="tap_adapter_problem">TAP adapter error</string>
+    <string name="virtual_adapter_problem">Virtual adapter error</string>
     <string name="wireguard_error">WireGuard error</string>
     <string name="too_many_keys">Too many WireGuard keys registered to account</string>
     <string name="failed_to_generate_key">Failed to generate a key</string>

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -55,7 +55,7 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/talpid/tunnel/ErrorStateCause$StartTunnelError",
     "net/mullvad/talpid/tunnel/ErrorStateCause$TunnelParameterError",
     "net/mullvad/talpid/tunnel/ErrorStateCause$IsOffline",
-    "net/mullvad/talpid/tunnel/ErrorStateCause$TapAdapterProblem",
+    "net/mullvad/talpid/tunnel/ErrorStateCause$VirtualAdapterProblem",
     "net/mullvad/talpid/tunnel/ErrorStateCause$VpnPermissionDenied",
     "net/mullvad/talpid/tunnel/ParameterGenerationError",
     "net/mullvad/talpid/ConnectivityListener",


### PR DESCRIPTION
Fixes an oversight in #2278.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2303)
<!-- Reviewable:end -->
