### PR TITLE
Fix restarting after `onDestroy` has been called

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -132,7 +132,6 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
         if (state == State.Stopping && !quitCommand) {
-            state = State.Running
             restart()
         }
 
@@ -151,7 +150,6 @@ class MullvadVpnService : TalpidVpnService() {
         isBound = true
 
         if (state == State.Stopping) {
-            state = State.Running
             restart()
         }
     }
@@ -256,6 +254,9 @@ class MullvadVpnService : TalpidVpnService() {
     private fun restart() {
         if (state != State.Stopped) {
             Log.d(TAG, "Restarting service")
+
+            state = State.Running
+
             daemonInstance.apply {
                 stop()
                 start()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -254,10 +254,14 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun restart() {
-        Log.d(TAG, "Restarting service")
-        daemonInstance.apply {
-            stop()
-            start()
+        if (state != State.Stopped) {
+            Log.d(TAG, "Restarting service")
+            daemonInstance.apply {
+                stop()
+                start()
+            }
+        } else {
+            Log.d(TAG, "Ignoring restart because onDestroy has executed")
         }
     }
 


### PR DESCRIPTION
Android may at any moment decide to kill the service. Usually (exception is when swiping away the UI, and Android deciding to kill the hole process) Android calls `onDestroy` when doing that. Attempting to restart the daemon when that happens leads to a crash. A previous PR (#2299) implemented a partial fix to this issue, by avoiding to restart when the daemon stopped if `onDestroy` had been called.

This PR extends that fix to always check the state before restarting, and not just when the daemon has stopped.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes an issue not present in previous releases, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2304)
<!-- Reviewable:end -->
