### PR TITLE
Fix daemon startup race condition

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -174,6 +174,7 @@ class MullvadVpnService : TalpidVpnService() {
         state = State.Stopped
         notificationManager.onDestroy()
         daemonInstance.onDestroy()
+        instance = null
         super.onDestroy()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -236,13 +236,15 @@ class MullvadVpnService : TalpidVpnService() {
 
         handlePendingAction(connectionProxy, settings)
 
-        instance = ServiceInstance(
-            daemon,
-            connectionProxy,
-            connectivityListener,
-            settingsListener,
-            splitTunneling
-        )
+        if (state == State.Running) {
+            instance = ServiceInstance(
+                daemon,
+                connectionProxy,
+                connectivityListener,
+                settingsListener,
+                splitTunneling
+            )
+        }
     }
 
     private fun stop() {


### PR DESCRIPTION
A recent PR (#2286) fixed a race condition that ended up spawning multiple daemons. However, that surfaced an issue where Android kills the service prematurely and quickly after spawning it. When that happens, the daemon instance ends up shutting down before the service has fully initialized the classes that use the daemon. This ends up either setting the `instance` to a shut down daemon or having the dependent classes getting `null`s when requesting data from the daemon.

This PR ensures that the `instance` property is correctly set to `null` if Android kills it prematurely and prevents the race condition of the slow daemon startup to overwrite the `instance` property when the daemon has shut down.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2305)
<!-- Reviewable:end -->
