### PR TITLE
Handle `null` values returned when daemon has stopped

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -108,7 +108,9 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
 
     private fun fetchAccountHistory() {
         jobTracker.newBackgroundJob("fetchHistory") {
-            accountHistory = daemon.getAccountHistory()
+            daemon.getAccountHistory()?.let { history ->
+                accountHistory = history
+            }
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -194,7 +194,7 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
         val currentState = daemon.getState()
 
         synchronized(this) {
-            if (state === initialState) {
+            if (state === initialState && currentState != null) {
                 state = currentState
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -146,7 +146,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     private external fun getCurrentLocation(daemonInterfaceAddress: Long): GeoIpLocation?
     private external fun getCurrentVersion(daemonInterfaceAddress: Long): String?
     private external fun getRelayLocations(daemonInterfaceAddress: Long): RelayList?
-    private external fun getSettings(daemonInterfaceAddress: Long): Settings
+    private external fun getSettings(daemonInterfaceAddress: Long): Settings?
     private external fun getState(daemonInterfaceAddress: Long): TunnelState?
     private external fun getVersionInfo(daemonInterfaceAddress: Long): AppVersionInfo?
     private external fun getWireguardKey(daemonInterfaceAddress: Long): PublicKey?

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -50,7 +50,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return getAccountData(daemonInterfaceAddress, accountToken)
     }
 
-    fun getAccountHistory(): ArrayList<String> {
+    fun getAccountHistory(): ArrayList<String>? {
         return getAccountHistory(daemonInterfaceAddress)
     }
 
@@ -141,7 +141,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         daemonInterfaceAddress: Long,
         accountToken: String
     ): GetAccountDataResult
-    private external fun getAccountHistory(daemonInterfaceAddress: Long): ArrayList<String>
+    private external fun getAccountHistory(daemonInterfaceAddress: Long): ArrayList<String>?
     private external fun getWwwAuthToken(daemonInterfaceAddress: Long): String
     private external fun getCurrentLocation(daemonInterfaceAddress: Long): GeoIpLocation?
     private external fun getCurrentVersion(daemonInterfaceAddress: Long): String

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -55,7 +55,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     }
 
     fun getWwwAuthToken(): String {
-        return getWwwAuthToken(daemonInterfaceAddress)
+        return getWwwAuthToken(daemonInterfaceAddress) ?: ""
     }
 
     fun getCurrentLocation(): GeoIpLocation? {
@@ -142,7 +142,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         accountToken: String
     ): GetAccountDataResult
     private external fun getAccountHistory(daemonInterfaceAddress: Long): ArrayList<String>?
-    private external fun getWwwAuthToken(daemonInterfaceAddress: Long): String
+    private external fun getWwwAuthToken(daemonInterfaceAddress: Long): String?
     private external fun getCurrentLocation(daemonInterfaceAddress: Long): GeoIpLocation?
     private external fun getCurrentVersion(daemonInterfaceAddress: Long): String
     private external fun getRelayLocations(daemonInterfaceAddress: Long): RelayList?

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -62,7 +62,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return getCurrentLocation(daemonInterfaceAddress)
     }
 
-    fun getCurrentVersion(): String {
+    fun getCurrentVersion(): String? {
         return getCurrentVersion(daemonInterfaceAddress)
     }
 
@@ -144,7 +144,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     private external fun getAccountHistory(daemonInterfaceAddress: Long): ArrayList<String>?
     private external fun getWwwAuthToken(daemonInterfaceAddress: Long): String?
     private external fun getCurrentLocation(daemonInterfaceAddress: Long): GeoIpLocation?
-    private external fun getCurrentVersion(daemonInterfaceAddress: Long): String
+    private external fun getCurrentVersion(daemonInterfaceAddress: Long): String?
     private external fun getRelayLocations(daemonInterfaceAddress: Long): RelayList?
     private external fun getSettings(daemonInterfaceAddress: Long): Settings
     private external fun getState(daemonInterfaceAddress: Long): TunnelState?

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -74,7 +74,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return getSettings(daemonInterfaceAddress)
     }
 
-    fun getState(): TunnelState {
+    fun getState(): TunnelState? {
         return getState(daemonInterfaceAddress)
     }
 
@@ -147,7 +147,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     private external fun getCurrentVersion(daemonInterfaceAddress: Long): String
     private external fun getRelayLocations(daemonInterfaceAddress: Long): RelayList?
     private external fun getSettings(daemonInterfaceAddress: Long): Settings
-    private external fun getState(daemonInterfaceAddress: Long): TunnelState
+    private external fun getState(daemonInterfaceAddress: Long): TunnelState?
     private external fun getVersionInfo(daemonInterfaceAddress: Long): AppVersionInfo?
     private external fun getWireguardKey(daemonInterfaceAddress: Long): PublicKey?
     private external fun reconnect(daemonInterfaceAddress: Long)

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -524,7 +524,7 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_getAcco
 
         GetAccountDataResult::from(result).into_java(&env).forget()
     } else {
-        JObject::null()
+        GetAccountDataResult::OtherError.into_java(&env).forget()
     }
 }
 


### PR DESCRIPTION
A previous issue surfaced a race condition when starting and stopping the daemon too quickly. The issue is fixed by a separate PR (#2305). However, one of the symptoms was a `NullPointerException` that was thrown when using a valued returned by the stopped daemon. The daemon proxy implementation returns `null` values when it has lost the connection to the daemon. In theory this shouldn't be an issue since when the daemon stops the UI returns to the launch screen and fetches are stopped. However, this may be an issue in some cases if some data is requested from the daemon right after it stopped and before the UI changes.

This PR improves the robustness of the daemon proxy by marking the returned values as nullable and handling `null` values where appropriate.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2306)
<!-- Reviewable:end -->
