### PR TITLE
Pipe route deletion stderr on macOS to /dev/null

### DIFF
--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -224,7 +224,8 @@ impl RouteManagerImpl {
             .arg("-n")
             .arg("delete")
             .arg(ip_vers(destination))
-            .arg(destination.to_string());
+            .arg(destination.to_string())
+            .stderr(Stdio::null());
 
         cmd.status().await.map_err(Error::FailedToRemoveRoute)
     }


### PR DESCRIPTION
This PR pipes `stderr` to `/dev/null` when calling `route delete` on macOS. This is to prevent spamming of this message:
```
route: writing to routing socket: not in table
route: writing to routing socket: not in table
route: writing to routing socket: not in table
....
```

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2308)
<!-- Reviewable:end -->
