### PR TITLE
Advance to next screen if already logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Line wrap the file at 100 chars.                                              Th
   or the quick-settings tile for the app to connect or disconnect.
 - Fix app showing that it was blocking connections when it wasn't when VPN permission was denied.
 - Fix internet not working for a minute or two after changing Allow LAN setting.
+- Fix login appearing to be cancelled after leaving the login screen while logging in.
 
 #### Windows
 - Fix log output encoding for Windows modules.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -68,6 +68,18 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyStart() {
+        jobTracker.newBackgroundJob("checkIfAlreadyLoggedIn") {
+            if (accountCache.onAccountNumberChange.latestEvent != null) {
+                val loginResult = if (accountCache.newlyCreatedAccount) {
+                    LoginResult.NewAccount
+                } else {
+                    loginResultForExpiry(accountCache.onAccountExpiryChange.latestEvent)
+                }
+
+                loggedIn.complete(loginResult)
+            }
+        }
+
         jobTracker.newUiJob("advanceToNextScreen") {
             when (loggedIn.await()) {
                 LoginResult.ExistingAccountWithTime -> openNextScreen(ConnectFragment())

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -146,11 +146,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
                         val expiryString = accountDataResult.accountData.expiry
                         val expiry = DateTime.parse(expiryString, AccountCache.EXPIRY_FORMAT)
 
-                        if (expiry.isAfterNow()) {
-                            LoginResult.ExistingAccountWithTime
-                        } else {
-                            LoginResult.ExistingAccountOutOfTime
-                        }
+                        loginResultForExpiry(expiry)
                     }
                     is GetAccountDataResult.RpcError -> {
                         accountCache.login(accountToken)
@@ -205,5 +201,13 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         accountLogin.state = LoginState.Failure
 
         scrollToShow(accountLogin)
+    }
+
+    private fun loginResultForExpiry(expiry: DateTime?): LoginResult {
+        if (expiry == null || expiry.isAfterNow()) {
+            return LoginResult.ExistingAccountWithTime
+        } else {
+            return LoginResult.ExistingAccountOutOfTime
+        }
     }
 }


### PR DESCRIPTION
Previously, if the user left the login screen while logging in, when they returned to that screen it would seem that the login procedure was cancelled. What was actually cancelled was the coroutine that advanced to the next screen. This PR fixes that by checking if the user is already logged when showing the login screen.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2309)
<!-- Reviewable:end -->
