### PR TITLE
Log less about timeouts when connecting via WireGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
 - Upgrade OpenVPN from 2.4.9 to 2.5.0.
 - Upgrade Electron from 8.5.2 to Electron 11.0.2.
 - Upgrade wireguard-go to v0.0.20201118.
+- Reduce logging about time outs when conneting to a WireGuard tunnel.
 
 #### Android
 - Remove the Quit button.

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -168,6 +168,12 @@ impl ConnectingState {
                     );
                     Some(ErrorStateCause::VirtualAdapterProblem)
                 }
+                tunnel::Error::WireguardTunnelMonitoringError(
+                    tunnel::wireguard::Error::TimeoutError,
+                ) => {
+                    log::debug!("WireGuard tunnel timed out");
+                    None
+                }
                 error => {
                     warn!(
                         "{}",


### PR DESCRIPTION
All WireGuard tunnel errors were logged about with the warning level in the connecting state, which can be confusing to users and other developers, since a time out is a WireGuard tunnel error. With this I'm changing the logging to log about time outs with the debug level, all other errors are still logged about with the warning level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2312)
<!-- Reviewable:end -->
