### PR TITLE
Avoid starting with invisible account input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix app showing that it was blocking connections when it wasn't when VPN permission was denied.
 - Fix internet not working for a minute or two after changing Allow LAN setting.
 - Fix login appearing to be cancelled after leaving the login screen while logging in.
+- Fix login input area missing some times when opening the login screen.
 
 #### Windows
 - Fix log output encoding for Windows modules.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -68,6 +68,8 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyStart() {
+        accountLogin.state = LoginState.Initial
+
         jobTracker.newBackgroundJob("checkIfAlreadyLoggedIn") {
             if (accountCache.onAccountNumberChange.latestEvent != null) {
                 val loginResult = if (accountCache.newlyCreatedAccount) {


### PR DESCRIPTION
Previously, the Login screen sometimes appeared without the account input area. This is likely caused by reusing the fragment after the account input was hidden after showing a login successful message. This PR makes sure to reset the state of the account input widget every time the screen is shown, to prevent that situation from happening.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2314)
<!-- Reviewable:end -->
