### PR TITLE
Improve keyboard navigation in `AccountLogin` widget

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -95,11 +95,21 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
                 accountLogin.accountHistory = history
             }
         }
+
+        parentActivity.backButtonHandler = {
+            if (accountLogin.hasFocus) {
+                background.requestFocus()
+                true
+            } else {
+                false
+            }
+        }
     }
 
     override fun onSafelyStop() {
         jobTracker.cancelJob("advanceToNextScreen")
         accountCache.onAccountHistoryChange.unsubscribe(this)
+        parentActivity.backButtonHandler = null
     }
 
     private fun scrollToShow(view: View) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -77,6 +77,8 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    var backButtonHandler: (() -> Boolean)? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (deviceIsTv) {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE)
@@ -120,6 +122,14 @@ class MainActivity : FragmentActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
         setVpnPermission(resultCode == Activity.RESULT_OK)
+    }
+
+    override fun onBackPressed() {
+        val handled = backButtonHandler?.invoke() ?: false
+
+        if (!handled) {
+            super.onBackPressed()
+        }
     }
 
     override fun onStop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -95,6 +95,9 @@ class AccountLogin : RelativeLayout {
         }
     }
 
+    val hasFocus
+        get() = focused
+
     var accountHistory by observable<ArrayList<String>?>(null) { _, _, history ->
         val entryCount = history?.size ?: 0
 

--- a/android/src/main/res/layout/account_history_entry.xml
+++ b/android/src/main/res/layout/account_history_entry.xml
@@ -5,6 +5,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:focusable="true"
+              android:nextFocusRight="@id/remove"
               android:background="@drawable/account_history_entry_background"
               android:paddingHorizontal="12dp"
               android:gravity="center_vertical"
@@ -15,6 +16,7 @@
                  android:layout_width="@dimen/account_history_entry_height"
                  android:layout_height="@dimen/account_history_entry_height"
                  android:layout_gravity="right"
+                 android:nextFocusLeft="@id/remove"
                  android:background="?android:attr/selectableItemBackground"
                  android:src="@drawable/account_history_remove" />
 </FrameLayout>


### PR DESCRIPTION
Previously, when navigating on the login screen with the keyboard (like on TVs), it was impossible to remove an account from the account history list on the login screen. This PR fixes that and also adds a small tweak to the behavior of the back button.

It is now possible to use the left and right arrows on the keyboard to move between the account history item and it's remove button.

And pressing the back button will first remove the focus of the account login widget in order to collapse the history. Pressing back again will then leave the app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweaks, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2315)
<!-- Reviewable:end -->
