### PR TITLE
Move entries related to unreleased changes to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Upgrade wireguard-go to v0.0.20201118.
+- Reduce logging about time outs when conneting to a WireGuard tunnel.
+
+### Fixed
+#### Android
+- Fix login appearing to be cancelled after leaving the login screen while logging in.
+- Fix login input area missing some times when opening the login screen.
 
 
 ## [2020.8-beta1] - 2020-11-30
@@ -49,8 +57,6 @@ This release is for Android only.
 - Rename CLI subcommand `mullvad relay set relay` to `mullvad relay set hostname`.
 - Upgrade OpenVPN from 2.4.9 to 2.5.0.
 - Upgrade Electron from 8.5.2 to Electron 11.0.2.
-- Upgrade wireguard-go to v0.0.20201118.
-- Reduce logging about time outs when conneting to a WireGuard tunnel.
 
 #### Android
 - Remove the Quit button.
@@ -91,8 +97,6 @@ This release is for Android only.
   or the quick-settings tile for the app to connect or disconnect.
 - Fix app showing that it was blocking connections when it wasn't when VPN permission was denied.
 - Fix internet not working for a minute or two after changing Allow LAN setting.
-- Fix login appearing to be cancelled after leaving the login screen while logging in.
-- Fix login input area missing some times when opening the login screen.
 
 #### Windows
 - Fix log output encoding for Windows modules.


### PR DESCRIPTION
A rebase after releasing version `2020.8-beta1` for Android caused some changelog entries related to unreleased changes to be included in the released section. This PR moves those entries to the "Unreleased" section.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2319)
<!-- Reviewable:end -->
