### PR TITLE
Name arguments that can be on or off consistently in the CLI

### DIFF
--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -153,7 +153,7 @@ fn create_set_state_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("state")
         .about("Set bridge state")
         .arg(
-            clap::Arg::with_name("state")
+            clap::Arg::with_name("policy")
                 .help("Specifies whether a bridge should be used")
                 .required(true)
                 .index(1)
@@ -252,7 +252,7 @@ impl Bridge {
     }
 
     async fn handle_set_bridge_state(matches: &clap::ArgMatches<'_>) -> Result<()> {
-        let state = match matches.value_of("state").unwrap() {
+        let state = match matches.value_of("policy").unwrap() {
             "auto" => BridgeStateType::Auto as i32,
             "on" => BridgeStateType::On as i32,
             "off" => BridgeStateType::Off as i32,

--- a/mullvad-cli/src/cmds/custom_dns.rs
+++ b/mullvad-cli/src/cmds/custom_dns.rs
@@ -39,7 +39,7 @@ impl Command for CustomDns {
                 clap::SubCommand::with_name("set")
                     .about("Enable or disable custom DNS")
                     .arg(
-                        clap::Arg::with_name("enabled")
+                        clap::Arg::with_name("policy")
                             .required(true)
                             .possible_values(&["on", "off"]),
                     ),
@@ -56,8 +56,8 @@ impl Command for CustomDns {
                 _ => unreachable!("No custom-dns server command given"),
             },
             ("set", Some(matches)) => {
-                let enabled = value_t_or_exit!(matches.value_of("enabled"), String);
-                self.set_state(enabled == "on").await
+                let policy = value_t_or_exit!(matches.value_of("policy"), String);
+                self.set_state(policy == "on").await
             }
             ("get", _) => self.get().await,
             _ => unreachable!("No custom-dns command given"),

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -95,7 +95,7 @@ fn create_ipv6_subcommand() -> clap::App<'static, 'static> {
         .subcommand(clap::SubCommand::with_name("get"))
         .subcommand(
             clap::SubCommand::with_name("set").arg(
-                clap::Arg::with_name("enable")
+                clap::Arg::with_name("policy")
                     .required(true)
                     .takes_value(true)
                     .possible_values(&["on", "off"]),
@@ -304,7 +304,7 @@ impl Tunnel {
     }
 
     async fn process_ipv6_set(matches: &clap::ArgMatches<'_>) -> Result<()> {
-        let enabled = matches.value_of("enable").unwrap() == "on";
+        let enabled = matches.value_of("policy").unwrap() == "on";
 
         let mut rpc = new_rpc_client().await?;
         rpc.set_enable_ipv6(enabled).await?;


### PR DESCRIPTION
For example, the argument `enabled` in `mullvad custom-dns set <enabled>` has the possible values `on` and `off`, which can be confusing. For consistency, this PR renames all arguments like this to `policy`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2321)
<!-- Reviewable:end -->
