### PR TITLE
Hide app icon in dock and app switcher on macOS

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1432,9 +1432,13 @@ class ApplicationMain {
           closable: this.guiSettings.unpinnedWindow,
         });
 
-        // make the window visible on all workspaces
-        if (!this.guiSettings.unpinnedWindow) {
+        // make the window visible on all workspaces and prevent the icon from showing in the dock
+        // and app switcher.
+        if (this.guiSettings.unpinnedWindow) {
+          consumePromise(app.dock.show());
+        } else {
           appWindow.setVisibleOnAllWorkspaces(true);
+          app.dock.hide();
         }
 
         return appWindow;


### PR DESCRIPTION
When upgrading to Electron 11 the app started appearing in the dock and app switcher. This PR fixes it by calling `app.dock.hide()` after the `BrowserWindow` has been created. Calling it before creating the window doesn't work. Electron seems to reset this setting after the first window has been created.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2322)
<!-- Reviewable:end -->
