### PR TITLE
Refactor `LocationInfoCache` into actor

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,6 +75,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         allWarningsAsErrors = true
 
         kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi",
             "-Xuse-experimental=kotlinx.coroutines.ObsoleteCoroutinesApi",
         ]
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -138,7 +138,7 @@ class LocationInfoCache(
         val fetchId = newFetchId()
         val previousFetch = activeFetch
 
-        activeFetch = GlobalScope.launch(Dispatchers.Main) {
+        activeFetch = GlobalScope.launch(Dispatchers.Default) {
             val delays = ExponentialBackoff().apply {
                 scale = 50
                 cap = 30 /* min */ * 60 /* s */ * 1000 /* ms */
@@ -151,7 +151,7 @@ class LocationInfoCache(
 
             while (newLocation == null && fetchId == fetchIdCounter) {
                 delay(delays.next())
-                newLocation = executeFetch().await()
+                newLocation = daemon.getCurrentLocation()
             }
 
             synchronized(this@LocationInfoCache) {
@@ -164,9 +164,5 @@ class LocationInfoCache(
                 }
             }
         }
-    }
-
-    private fun executeFetch() = GlobalScope.async(Dispatchers.Default) {
-        daemon.getCurrentLocation()
     }
 }


### PR DESCRIPTION
Previously, the `LocationInfoCache` had some slightly complex logic to make sure only one fetch was running and to make sure that fetches were serialized. This PR simplifies that by refactoring the class to use an actor to fetch the location.

The fetches now happen entirely in the background thread, where previously the management part happened in the UI thread. Running parts of it in the UI thread was unnecessary, because the only receiver of location events (the `ConnectFragment`) was already spawning a UI thread coroutine to handle the location updates.

The logic for fetching should stay the same. The actor waits for a request to fetch, and then retries the fetch with an exponential back-off until a valid location is fetched. Cancelling the fetch was removed, but since cancelling is a cooperative action (i.e., suspend methods must check for a cancellation event and handle it accordingly) and the daemon side of the fetch never cancelled the underlying Rust-side future, the behavior still stays the same.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2324)
<!-- Reviewable:end -->
