### PR TITLE
Use correct resource path in mullvad-setup on Windows

### DIFF
--- a/mullvad-setup/src/daemon_paths.rs
+++ b/mullvad-setup/src/daemon_paths.rs
@@ -15,7 +15,9 @@ use winapi::{
     um::{
         combaseapi::CoTaskMemFree,
         handleapi::CloseHandle,
-        knownfolders::{FOLDERID_LocalAppData, FOLDERID_RoamingAppData, FOLDERID_System},
+        knownfolders::{
+            FOLDERID_LocalAppData, FOLDERID_ProgramFiles, FOLDERID_RoamingAppData, FOLDERID_System,
+        },
         processthreadsapi::{GetCurrentThread, OpenProcess, OpenProcessToken, OpenThreadToken},
         psapi::K32EnumProcesses,
         securitybaseapi::{AdjustTokenPrivileges, ImpersonateSelf, RevertToSelf},
@@ -33,6 +35,11 @@ use winapi::{
 pub fn get_mullvad_daemon_settings_path() -> io::Result<PathBuf> {
     get_system_service_known_folder(FOLDERID_LocalAppData)
         .map(|settings| settings.join(mullvad_paths::PRODUCT_NAME))
+}
+
+pub fn get_mullvad_resource_path() -> io::Result<PathBuf> {
+    get_known_folder_path(FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, ptr::null_mut())
+        .map(|settings| settings.join(mullvad_paths::PRODUCT_NAME).join("resources"))
 }
 
 pub fn get_mullvad_daemon_cache_path() -> io::Result<PathBuf> {

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -51,6 +51,10 @@ pub enum Error {
     #[error(display = "Failed to obtain settings directory path")]
     SettingsPathError(#[error(source)] PathError),
 
+    #[cfg(windows)]
+    #[error(display = "Failed to obtain resource directory path")]
+    ResourcePathError(#[error(source)] PathError),
+
     #[error(display = "Failed to obtain cache directory path")]
     CachePathError(#[error(source)] PathError),
 
@@ -187,7 +191,8 @@ fn get_paths() -> Result<(PathBuf, PathBuf, PathBuf), Error> {
 fn get_paths() -> Result<(PathBuf, PathBuf, PathBuf), Error> {
     let settings_path =
         daemon_paths::get_mullvad_daemon_settings_path().map_err(Error::CachePathError)?;
-    let resource_path = mullvad_paths::get_resource_dir();
+    let resource_path =
+        daemon_paths::get_mullvad_resource_path().map_err(Error::ResourcePathError)?;
     let cache_path =
         daemon_paths::get_mullvad_daemon_cache_path().map_err(Error::SettingsPathError)?;
 


### PR DESCRIPTION
`mullvad-setup` is run from a temporary directory on Windows, and `mullvad_paths::resource_dir()` simply returns the directory of the currently running executable. `api-ip-address.txt` will of course not be found there. This means that `mullvad-setup` cannot reach the API during uninstall unless there is an updated cache in SYSTEM's AppData directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2326)
<!-- Reviewable:end -->
