### PR TITLE
Fix private IPv4 range definition

### DIFF
--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -74,7 +74,7 @@ HandlePolicyException(const common::error::WindowsException &err)
 wfp::IpNetwork g_privateIpRanges[] = {
 	wfp::IpNetwork(wfp::IpAddress::Literal{127, 0, 0, 0}, 8),
 	wfp::IpNetwork(wfp::IpAddress::Literal{10, 0, 0, 0}, 8),
-	wfp::IpNetwork(wfp::IpAddress::Literal{176, 16, 0, 0}, 12),
+	wfp::IpNetwork(wfp::IpAddress::Literal{172, 16, 0, 0}, 12),
 	wfp::IpNetwork(wfp::IpAddress::Literal{192, 168, 0, 0}, 16),
 	wfp::IpNetwork(wfp::IpAddress::Literal{169, 254, 0, 0}, 16),
 	wfp::IpNetwork(wfp::IpAddress::Literal6{0, 0, 0, 0, 0, 0, 0, 1}, 128),


### PR DESCRIPTION
The `172.16.0.0/12` range cannot be used with local DNS resolvers on Windows due to a typo. This fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2328)
<!-- Reviewable:end -->
