### PR TITLE
Wait for Wintun adapter's unicast addresses to be usable

### DIFF
--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -234,8 +234,8 @@ impl KeyManager {
         timeout: Option<Duration>,
     ) -> Box<
         dyn FnMut() -> Pin<
-                Box<dyn Future<Output = std::result::Result<WireguardData, RestError>> + Send>,
-            > + Send,
+            Box<dyn Future<Output = std::result::Result<WireguardData, RestError>> + Send>,
+        > + Send,
     > {
         let mut rpc = mullvad_rpc::WireguardKeyProxy::new(self.http_handle.clone());
         let public_key = private_key.public_key();


### PR DESCRIPTION
OpenVPN doesn't wait for the network interfaces to be fully usable before considering the tunnel to be up. As a result, there may be no connectivity for up to 3 seconds after the daemon enters the connected state. This can be verified by pinging any address immediately after connecting.

The docs for [CreateUnicastIpAddressEntry](https://docs.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-createunicastipaddressentry) state:
> The unicast IP address passed in the Address member of the MIB_UNICASTIPADDRESS_ROW pointed to by the Row parameter is not usable immediately. The IP address is usable after the duplicate address detection process has completed successfully. It can take several seconds for the duplicate address detection process to complete since IP packets need to be sent and potential responses must be awaited. For IPv6, the duplicate address detection process typically takes about a second. For IPv4, the duplicate address detection process typically takes about three seconds.

This PR fixes the issue by polling the addresses using `GetUnicastIpAddressEntry` until `DadState == IpDadStatePreferred` (as suggested in the link above).

DAD could also be skipped on (only) Windows 10, assuming that this is safe, but OpenVPN doesn't do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2330)
<!-- Reviewable:end -->
