### PR TITLE
Fix "untrusted publisher" issue on Windows 7

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -97,6 +97,8 @@
 		Goto InstallWin7Hotfix_return
 	${EndIf}
 
+	MessageBox MB_ICONINFORMATION|MB_YESNO "Windows hotfix KB2921916 must be installed for the app to work on Windows 7. Do you want to install it now?" IDNO InstallWin7Hotfix_return
+
 	log::Log "Extracting KB2921916"
 
 	SetOutPath "$TEMP"
@@ -104,9 +106,13 @@
 
 	log::Log "Installing KB2921916"
 
-	nsExec::ExecToStack '"$SYSDIR\wusa.exe" "$TEMP\Windows6.1-KB2921916-x64.msu"'
+	nsExec::ExecToStack '"$SYSDIR\wusa.exe" "$TEMP\Windows6.1-KB2921916-x64.msu" /quiet /norestart'
 	Pop $0
 	Pop $1
+
+	${If} $0 == 3010
+		MessageBox MB_OK "You may need to restart your computer for the patch to take effect."
+	${EndIf}
 
 	IntFmt $0 "0x%X" $0
 	log::Log "wusa.exe result: $0"


### PR DESCRIPTION
This fixes an issue where the Wintun driver signature is rejected on Windows 7 and must be manually approved. The dialog cannot be displayed when the driver is installed from a service and the driver is rejected instead, so no Wintun adapters can be created at all unless the driver is already installed on the machine. KB2921916 fixes this. It is not installed by Windows Update and is difficult to obtain, so it is included with the installer here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2342)
<!-- Reviewable:end -->
