### PR TITLE
Warn if configured to use a public custom DNS server

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -5,6 +5,7 @@ import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import kotlinx.coroutines.CompletableDeferred
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.ui.customdns.CustomDnsAdapter
@@ -115,6 +116,22 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
             if (!wireguardMtuInput.hasFocus) {
                 wireguardMtuInput.value = settings.tunnelOptions.wireguard.mtu
             }
+        }
+    }
+
+    private fun showConfirmPublicDnsServerDialog(confirmation: CompletableDeferred<Boolean>) {
+        val transaction = fragmentManager?.beginTransaction()
+
+        detachBackButtonHandler()
+        transaction?.addToBackStack(null)
+
+        ConfirmPublicDnsDialogFragment()
+            .apply { confirmPublicDns = confirmation }
+            .show(transaction, null)
+
+        jobTracker.newUiJob("restoreBackButtonHandler") {
+            confirmation.await()
+            attachBackButtonHandler()
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -36,7 +36,11 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
         titleController = CollapsibleTitleController(view, R.id.contents)
 
-        customDnsAdapter = CustomDnsAdapter(customDns)
+        customDnsAdapter = CustomDnsAdapter(customDns).apply {
+            showPublicDnsAddressWarning = { confirmation ->
+                showConfirmPublicDnsServerDialog(confirmation)
+            }
+        }
 
         view.findViewById<CustomRecyclerView>(R.id.contents).apply {
             layoutManager = LinearLayoutManager(parentActivity)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmPublicDnsDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmPublicDnsDialogFragment.kt
@@ -1,0 +1,66 @@
+package net.mullvad.mullvadvpn.ui
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
+import android.widget.Button
+import kotlinx.coroutines.CompletableDeferred
+import net.mullvad.mullvadvpn.R
+
+class ConfirmPublicDnsDialogFragment : DialogFragment() {
+    var confirmPublicDns: CompletableDeferred<Boolean>? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.confirm_public_dns, container, false)
+
+        view.findViewById<Button>(R.id.back_button).setOnClickListener {
+            activity?.onBackPressed()
+        }
+
+        view.findViewById<Button>(R.id.confirm_button).setOnClickListener {
+            confirmPublicDns?.complete(true)
+            confirmPublicDns = null
+            dismiss()
+        }
+
+        return view
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+
+        dialog.window?.setBackgroundDrawable(ColorDrawable(android.R.color.transparent))
+
+        return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        dialog?.window?.setLayout(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+
+        if (confirmPublicDns == null) {
+            dismiss()
+        }
+    }
+
+    override fun onDismiss(dialogInterface: DialogInterface) {
+        confirmPublicDns?.complete(false)
+    }
+
+    override fun onDestroy() {
+        confirmPublicDns?.cancel()
+
+        super.onDestroy()
+    }
+}

--- a/android/src/main/res/layout/confirm_public_dns.xml
+++ b/android/src/main/res/layout/confirm_public_dns.xml
@@ -1,0 +1,32 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scrollbars="none">
+    <LinearLayout android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:padding="30dp"
+                  android:background="@drawable/dialog_background"
+                  android:orientation="vertical"
+                  android:gravity="left"
+                  android:elevation="2dp">
+        <ImageView android:layout_width="44dp"
+                   android:layout_height="44dp"
+                   android:layout_marginTop="8dp"
+                   android:layout_gravity="center"
+                   android:src="@drawable/icon_alert" />
+        <TextView android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:layout_weight="0"
+                  android:layout_marginTop="16dp"
+                  android:textColor="@color/white80"
+                  android:textSize="@dimen/text_small"
+                  android:text="@string/confirm_public_dns" />
+        <Button android:id="@+id/confirm_button"
+                android:layout_marginVertical="@dimen/button_separation"
+                android:text="@string/add_anyway"
+                style="@style/RedButton" />
+        <Button android:id="@+id/back_button"
+                android:text="@string/back"
+                style="@style/BlueButton" />
+    </LinearLayout>
+</ScrollView>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -168,6 +168,9 @@
     <string name="add_a_server">Add a server</string>
     <string name="custom_dns_example">e.g. 123.456.789.111</string>
     <string name="custom_dns_footer">Enable to add at least one DNS server.</string>
+    <string name="confirm_public_dns">The DNS server you are trying to add might not work because
+    it is public. Currently we only support local DNS servers.</string>
+    <string name="add_anyway">Add anyway</string>
     <string name="exclude_applications">Exclude applications</string>
     <string name="account_url">https://mullvad.net/en/account</string>
     <string name="wg_key_url">https://mullvad.net/en/account/ports</string>


### PR DESCRIPTION
Our servers intercept and redirect DNS requests to prevent DNS leaks. This means that configuring a custom DNS server address that needs to be routed through the tunnel doesn't work as expected. Until this is fixed server side, the app will show a dialog warning the user about the issue.

This PR implements that dialog. It uses the `MainActivity` class to synchronize the status between the fragments, which is not ideal, but this code should be removed when things are updated in the servers.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Part of an unreleased feature, so this just reuses the same changelog entry.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2343)
<!-- Reviewable:end -->
