### PR TITLE
Explain the vocabulary used around split tunneling

### DIFF
--- a/docs/split-tunneling.md
+++ b/docs/split-tunneling.md
@@ -1,11 +1,21 @@
 # Split tunneling
 
-Split tunneling allows excluding some apps from the VPN tunnel. These apps will communicate
-with the internet as if Mullvad VPN was disconnected or not even running.
+Split tunneling allows excluding selected apps from the VPN tunnel. These apps will communicate with the network as if Mullvad VPN was disconnected or not even running.
+
+## Vocabulary
+
+* **Split tunneling** - The name of the feature.
+* **Excluded app** - An app that only communicates outside of the VPN tunnel.
+* **Included app** - An app that only communicates inside the VPN tunnel (when the tunnel is up).
+  This is the default for all apps until they have been explicitly excluded.
+* **To exclude** - The act of enabling split tunneling for a specific app, excluding its traffic
+  from the VPN tunnel.
+* **To include** - The act of disabling split tunneling for a specific app, including its traffic
+  in the VPN tunnel again.
 
 ## DNS
 
-DNS is a bit problematic to split properly. Ideally DNS requests from excluded apps would
+DNS is a bit problematic to exclude properly. Ideally DNS requests from excluded apps would
 always go outside the tunnel, because that's what they would have done if Mullvad was disconnected
 or not running. But this is very hard/impossible to achieve on some platforms.
 One reason for this is that on some operating systems, programs call into a system service


### PR DESCRIPTION
This is the result of a recent Slack discussion. How should we talk about split tunneling so people understand us and so that we are consistent. The result was to continue calling the feature "split tunneling" but to refer to programs/apps as "excluded" and "included" not "split" and "unsplit" or some other variant. I added this to our documentation so we have it persisted somewhere and don't repeat the same discussion over and over.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2344)
<!-- Reviewable:end -->
