### PR TITLE
Refactor problem report into an actor

### DIFF
--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -5,6 +5,7 @@ mod classes;
 mod daemon_interface;
 mod is_null;
 mod jni_event_listener;
+mod problem_report;
 mod talpid_vpn_service;
 
 use crate::{daemon_interface::DaemonInterface, jni_event_listener::JniEventListener};
@@ -12,7 +13,7 @@ use jnix::{
     jni::{
         objects::{GlobalRef, JObject, JString, JValue},
         signature::{JavaType, Primitive},
-        sys::{jboolean, jlong, JNI_FALSE, JNI_TRUE},
+        sys::{jboolean, jlong},
         JNIEnv, JavaVM,
     },
     FromJava, IntoJava, JnixEnv,
@@ -931,69 +932,6 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_updateR
                 "{}",
                 error.display_chain_with_msg("Failed to update relay settings")
             );
-        }
-    }
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemReport_collectReport(
-    env: JNIEnv<'_>,
-    _: JObject<'_>,
-    logDirectory: JString<'_>,
-    outputPath: JString<'_>,
-) -> jboolean {
-    let env = JnixEnv::from(env);
-    let log_dir_string = String::from_java(&env, logDirectory);
-    let log_dir = Path::new(&log_dir_string);
-    let output_path_string = String::from_java(&env, outputPath);
-    let output_path = Path::new(&output_path_string);
-
-    match mullvad_problem_report::collect_report(&[], output_path, Vec::new(), log_dir) {
-        Ok(()) => JNI_TRUE,
-        Err(error) => {
-            log::error!(
-                "{}",
-                error.display_chain_with_msg("Failed to collect problem report")
-            );
-            JNI_FALSE
-        }
-    }
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemReport_sendProblemReport(
-    env: JNIEnv<'_>,
-    _: JObject<'_>,
-    userEmail: JString<'_>,
-    userMessage: JString<'_>,
-    outputPath: JString<'_>,
-    resourcesDirectory: JString<'_>,
-) -> jboolean {
-    let env = JnixEnv::from(env);
-    let user_email = String::from_java(&env, userEmail);
-    let user_message = String::from_java(&env, userMessage);
-    let output_path_string = String::from_java(&env, outputPath);
-    let output_path = Path::new(&output_path_string);
-    let resources_directory_string = String::from_java(&env, resourcesDirectory);
-    let resources_directory = Path::new(&resources_directory_string);
-
-    let send_result = mullvad_problem_report::send_problem_report(
-        &user_email,
-        &user_message,
-        output_path,
-        resources_directory,
-    );
-
-    match send_result {
-        Ok(()) => JNI_TRUE,
-        Err(error) => {
-            log::error!(
-                "{}",
-                error.display_chain_with_msg("Failed to send problem report")
-            );
-            JNI_FALSE
         }
     }
 }

--- a/mullvad-jni/src/problem_report.rs
+++ b/mullvad-jni/src/problem_report.rs
@@ -1,0 +1,73 @@
+use jnix::{
+    jni::{
+        objects::{JObject, JString},
+        sys::{jboolean, JNI_FALSE, JNI_TRUE},
+        JNIEnv,
+    },
+    FromJava, JnixEnv,
+};
+use std::path::Path;
+use talpid_types::ErrorExt;
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemReport_collectReport(
+    env: JNIEnv<'_>,
+    _: JObject<'_>,
+    logDirectory: JString<'_>,
+    outputPath: JString<'_>,
+) -> jboolean {
+    let env = JnixEnv::from(env);
+    let log_dir_string = String::from_java(&env, logDirectory);
+    let log_dir = Path::new(&log_dir_string);
+    let output_path_string = String::from_java(&env, outputPath);
+    let output_path = Path::new(&output_path_string);
+
+    match mullvad_problem_report::collect_report(&[], output_path, Vec::new(), log_dir) {
+        Ok(()) => JNI_TRUE,
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to collect problem report")
+            );
+            JNI_FALSE
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemReport_sendProblemReport(
+    env: JNIEnv<'_>,
+    _: JObject<'_>,
+    userEmail: JString<'_>,
+    userMessage: JString<'_>,
+    outputPath: JString<'_>,
+    resourcesDirectory: JString<'_>,
+) -> jboolean {
+    let env = JnixEnv::from(env);
+    let user_email = String::from_java(&env, userEmail);
+    let user_message = String::from_java(&env, userMessage);
+    let output_path_string = String::from_java(&env, outputPath);
+    let output_path = Path::new(&output_path_string);
+    let resources_directory_string = String::from_java(&env, resourcesDirectory);
+    let resources_directory = Path::new(&resources_directory_string);
+
+    let send_result = mullvad_problem_report::send_problem_report(
+        &user_email,
+        &user_message,
+        output_path,
+        resources_directory,
+    );
+
+    match send_result {
+        Ok(()) => JNI_TRUE,
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to send problem report")
+            );
+            JNI_FALSE
+        }
+    }
+}


### PR DESCRIPTION
A previous PR (#2317) implemented the ability to view the collected logs in a separate screen. As part of that PR, a line was added to set the `collectJob` to `null` when deleting the problem report file. However, the method to delete the file was called by the `collectJob`, which meant that the reference to the job would be overwritten while it was executing, preventing further usages from waiting for it to complete. This broke sending problem reports.

To fix this issue and to avoid similar issues in the future, the `MullvadProblemReport` class was refactor to remove juggling all the coroutine jobs and just have one that is implemented using the actor model. This simplifies the logic, makes the behavior more predictable and easier to maintain.

The PR also moves the native JNI method implementations in Rust to a new module, to make them easier to find and to reduce the size of the main `lib.rs` file.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any released version, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2349)
<!-- Reviewable:end -->
