### PR TITLE
Added iOS info

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ state of latest master, not necessarily any existing release.
 | WireGuard                     |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
 | OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |
 | Optional local network access |    ✓    |   ✓   |   ✓   |    ✓    |  ✓\* |
+
 Note:
 \* The local network is always accessible on iOS with the current implementation
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ in other DEs, but we don't regularly test those.
 Here is a table containing the features of the app across platforms. This reflects the current
 state of latest master, not necessarily any existing release.
 
-|                               | Windows | Linux | macOS | Android |
-|-------------------------------|:-------:|:-----:|:-----:|:-------:|
-| OpenVPN                       |    ✓    |   ✓   |   ✓   |         |
-| WireGuard                     |    ✓    |   ✓   |   ✓   |    ✓    |
-| OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |
-| Optional local network access |    ✓    |   ✓   |   ✓   |    ✓    |
+|                               | Windows | Linux | macOS | Android | iOS |
+|-------------------------------|:-------:|:-----:|:-----:|:-------:|:---:|
+| OpenVPN                       |    ✓    |   ✓   |   ✓   |         |     |
+| WireGuard                     |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |
+| Optional local network access |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
 
 ## Security and anonymity
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ state of latest master, not necessarily any existing release.
 | OpenVPN                       |    ✓    |   ✓   |   ✓   |         |     |
 | WireGuard                     |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
 | OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |
-| Optional local network access |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| Optional local network access |    ✓    |   ✓   |   ✓   |    ✓    |  ✓\* |
+Note:
+\* The local network is always accessible on iOS with the current implementation
 
 ## Security and anonymity
 


### PR DESCRIPTION
Not sure, but I think the iOS app handles "WireGuard" and "Optional local network access" as the Android app does.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2350)
<!-- Reviewable:end -->
