### PR TITLE
Add new systemd-resolved resolv.conf path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Allow to configure the tunnel to use custom DNS servers.
 
+#### Linux
+- Improved compatiblitiy with newer versions of systemd-resolved.
+
 
 ## [2020.8-beta2] - 2020-12-11
 This release is for desktop only.


### PR DESCRIPTION
`systemd-resolved` has a new stub file path - `/usr/lib/systemd/resolv.conf`. But this one is non-dynamic, it should never be written to. Since `/etc/resolv.conf` can be symlinked to it, it's vulnerable to being overwritten by other software. This means that just checking if `/etc/resolv.conf` is symlinked to it is not enough, the contents have to be verified too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2353)
<!-- Reviewable:end -->
