### PR TITLE
Handle DNS server addresses that Android consider invalid

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
@@ -53,10 +53,20 @@ class TunnelStateNotification(
     }
 
     private fun show(error: ErrorState?) {
-        val cause = error?.cause
+        // if the error state is null, we can assume that we are secure
+        if (error?.isBlocking ?: true) {
+            title = blockingTitle
+            message = error?.cause?.let { cause -> blockingErrorMessage(cause) }
+        } else {
+            title = notBlockingTitle
+            message = notBlockingErrorMessage(error?.cause)
+        }
 
-        val messageText = when (cause) {
-            null -> null
+        shouldShow = true
+    }
+
+    private fun blockingErrorMessage(cause: ErrorStateCause): String {
+        val messageId = when (cause) {
             is ErrorStateCause.AuthFailed -> R.string.auth_failed
             is ErrorStateCause.Ipv6Unavailable -> R.string.ipv6_unavailable
             is ErrorStateCause.SetFirewallPolicyError -> R.string.set_firewall_policy_error
@@ -79,21 +89,16 @@ class TunnelStateNotification(
             is ErrorStateCause.VpnPermissionDenied -> R.string.vpn_permission_denied_error
         }
 
-        // if the error state is null, we can assume that we are secure
-        if (error?.isBlocking ?: true) {
-            title = blockingTitle
-            message = messageText?.let { id -> context.getString(id) }
-        } else {
-            val updatedMessageText = when (cause) {
-                is ErrorStateCause.VpnPermissionDenied -> messageText
-                else -> R.string.failed_to_block_internet
-            }
+        return context.getString(messageId)
+    }
 
-            title = notBlockingTitle
-            message = updatedMessageText?.let { id -> context.getString(id) }
+    private fun notBlockingErrorMessage(cause: ErrorStateCause?): String {
+        val messageId = when (cause) {
+            is ErrorStateCause.VpnPermissionDenied -> R.string.vpn_permission_denied_error
+            else -> R.string.failed_to_block_internet
         }
 
-        shouldShow = true
+        return context.getString(messageId)
     }
 
     private fun hide() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
@@ -8,6 +8,7 @@ import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.tunnel.ErrorState
 import net.mullvad.talpid.tunnel.ErrorStateCause
 import net.mullvad.talpid.tunnel.ParameterGenerationError
+import net.mullvad.talpid.util.addressString
 
 class TunnelStateNotification(
     private val context: Context,
@@ -67,11 +68,17 @@ class TunnelStateNotification(
 
     private fun blockingErrorMessage(cause: ErrorStateCause): String {
         val messageId = when (cause) {
+            is ErrorStateCause.InvalidDnsServers -> {
+                val addresses = cause.addresses
+                    .map { address -> address.addressString() }
+                    .joinToString()
+
+                return context.getString(R.string.invalid_dns_servers, addresses)
+            }
             is ErrorStateCause.AuthFailed -> R.string.auth_failed
             is ErrorStateCause.Ipv6Unavailable -> R.string.ipv6_unavailable
             is ErrorStateCause.SetFirewallPolicyError -> R.string.set_firewall_policy_error
             is ErrorStateCause.SetDnsError -> R.string.set_dns_error
-            is ErrorStateCause.InvalidDnsServers -> R.string.set_dns_error
             is ErrorStateCause.StartTunnelError -> R.string.start_tunnel_error
             is ErrorStateCause.IsOffline -> R.string.is_offline
             is ErrorStateCause.TunnelParameterError -> {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
@@ -61,6 +61,7 @@ class TunnelStateNotification(
             is ErrorStateCause.Ipv6Unavailable -> R.string.ipv6_unavailable
             is ErrorStateCause.SetFirewallPolicyError -> R.string.set_firewall_policy_error
             is ErrorStateCause.SetDnsError -> R.string.set_dns_error
+            is ErrorStateCause.InvalidDnsServers -> R.string.set_dns_error
             is ErrorStateCause.StartTunnelError -> R.string.start_tunnel_error
             is ErrorStateCause.IsOffline -> R.string.is_offline
             is ErrorStateCause.TunnelParameterError -> {

--- a/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
@@ -1,0 +1,7 @@
+package net.mullvad.talpid
+
+sealed class CreateTunResult {
+    class Success(val tunFd: Int) : CreateTunResult()
+    class PermissionDenied : CreateTunResult()
+    class TunnelDeviceError : CreateTunResult()
+}

--- a/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
@@ -1,10 +1,20 @@
 package net.mullvad.talpid
 
+import java.net.InetAddress
+
 sealed class CreateTunResult {
     open val isOpen
         get() = false
 
     class Success(val tunFd: Int) : CreateTunResult() {
+        override val isOpen
+            get() = true
+    }
+
+    class InvalidDnsServers(
+        val addresses: ArrayList<InetAddress>,
+        val tunFd: Int
+    ) : CreateTunResult() {
         override val isOpen
             get() = true
     }

--- a/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
@@ -1,7 +1,14 @@
 package net.mullvad.talpid
 
 sealed class CreateTunResult {
-    class Success(val tunFd: Int) : CreateTunResult()
+    open val isOpen
+        get() = false
+
+    class Success(val tunFd: Int) : CreateTunResult() {
+        override val isOpen
+            get() = true
+    }
+
     class PermissionDenied : CreateTunResult()
     class TunnelDeviceError : CreateTunResult()
 }

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -11,8 +11,14 @@ import net.mullvad.talpid.tun_provider.TunConfig
 
 open class TalpidVpnService : VpnService() {
     private var activeTunStatus by observable<CreateTunResult?>(null) { _, oldTunStatus, _ ->
-        if (oldTunStatus is CreateTunResult.Success) {
-            ParcelFileDescriptor.adoptFd(oldTunStatus.tunFd).close()
+        val oldTunFd = when (oldTunStatus) {
+            is CreateTunResult.Success -> oldTunStatus.tunFd
+            is CreateTunResult.InvalidDnsServers -> oldTunStatus.tunFd
+            else -> null
+        }
+
+        if (oldTunFd != null) {
+            ParcelFileDescriptor.adoptFd(oldTunFd).close()
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -57,7 +57,7 @@ open class TalpidVpnService : VpnService() {
 
     fun createTunIfClosed(): Boolean {
         synchronized(this) {
-            if (activeTunStatus == null) {
+            if (activeTunStatus !is CreateTunResult.Success) {
                 activeTunStatus = createTun(currentTunConfig)
             }
 
@@ -67,7 +67,7 @@ open class TalpidVpnService : VpnService() {
 
     fun recreateTunIfOpen(config: TunConfig) {
         synchronized(this) {
-            if (activeTunStatus != null) {
+            if (activeTunStatus is CreateTunResult.Success) {
                 currentTunConfig = config
                 activeTunStatus = createTun(config)
             }

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -122,13 +122,13 @@ open class TalpidVpnService : VpnService() {
         val vpnInterface = builder.establish()
         val tunFd = vpnInterface?.detachFd()
 
-        if (tunFd != null) {
-            waitForTunnelUp(tunFd, config.routes.any { route -> route.isIpv6 })
-
-            return CreateTunResult.Success(tunFd)
-        } else {
+        if (tunFd == null) {
             return CreateTunResult.TunnelDeviceError()
         }
+
+        waitForTunnelUp(tunFd, config.routes.any { route -> route.isIpv6 })
+
+        return CreateTunResult.Success(tunFd)
     }
 
     fun bypass(socket: Int): Boolean {

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
@@ -1,10 +1,13 @@
 package net.mullvad.talpid.tunnel
 
+import java.net.InetAddress
+
 sealed class ErrorStateCause {
     class AuthFailed(val reason: String?) : ErrorStateCause()
     class Ipv6Unavailable : ErrorStateCause()
     class SetFirewallPolicyError : ErrorStateCause()
     class SetDnsError : ErrorStateCause()
+    class InvalidDnsServers(val addresses: ArrayList<InetAddress>) : ErrorStateCause()
     class StartTunnelError : ErrorStateCause()
     class TunnelParameterError(val error: ParameterGenerationError) : ErrorStateCause()
     class IsOffline : ErrorStateCause()

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="set_firewall_policy_error">Failed to apply firewall rules. The device might
     currently be unsecured</string>
     <string name="set_dns_error">Failed to set system DNS server</string>
+    <string name="invalid_dns_servers">Custom DNS server addresses %1$s are invalid</string>
     <string name="start_tunnel_error">Failed to start tunnel connection</string>
     <string name="vpn_permission_denied_error">VPN permission was denied when creating the tunnel.
     Please try connecting again.</string>

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -60,6 +60,7 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/talpid/tunnel/ParameterGenerationError",
     "net/mullvad/talpid/ConnectivityListener",
     "net/mullvad/talpid/CreateTunResult$Success",
+    "net/mullvad/talpid/CreateTunResult$InvalidDnsServers",
     "net/mullvad/talpid/CreateTunResult$PermissionDenied",
     "net/mullvad/talpid/CreateTunResult$TunnelDeviceError",
     "net/mullvad/talpid/TalpidVpnService",

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -56,6 +56,7 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/talpid/tunnel/ErrorStateCause$StartTunnelError",
     "net/mullvad/talpid/tunnel/ErrorStateCause$TunnelParameterError",
     "net/mullvad/talpid/tunnel/ErrorStateCause$IsOffline",
+    "net/mullvad/talpid/tunnel/ErrorStateCause$InvalidDnsServers",
     "net/mullvad/talpid/tunnel/ErrorStateCause$VpnPermissionDenied",
     "net/mullvad/talpid/tunnel/ParameterGenerationError",
     "net/mullvad/talpid/ConnectivityListener",

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -59,5 +59,8 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/talpid/tunnel/ErrorStateCause$VpnPermissionDenied",
     "net/mullvad/talpid/tunnel/ParameterGenerationError",
     "net/mullvad/talpid/ConnectivityListener",
+    "net/mullvad/talpid/CreateTunResult$Success",
+    "net/mullvad/talpid/CreateTunResult$PermissionDenied",
+    "net/mullvad/talpid/CreateTunResult$TunnelDeviceError",
     "net/mullvad/talpid/TalpidVpnService",
 ];

--- a/talpid-core/src/tunnel/tun_provider/android/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/android/mod.rs
@@ -193,15 +193,13 @@ impl AndroidTunProvider {
 
         let result = self.call_method(
             "getTun",
-            "(Lnet/mullvad/talpid/tun_provider/TunConfig;)I",
-            JavaType::Primitive(Primitive::Int),
+            "(Lnet/mullvad/talpid/tun_provider/TunConfig;)Lnet/mullvad/talpid/CreateTunResult;",
+            JavaType::Object("net/mullvad/talpid/CreateTunResult".to_owned()),
             &[JValue::Object(java_config.as_obj())],
         )?;
 
         match result {
-            JValue::Int(0) => Err(Error::TunnelDeviceError),
-            JValue::Int(-1) => Err(Error::PermissionDenied),
-            JValue::Int(fd) => Ok(fd),
+            JValue::Object(result) => CreateTunResult::from_java(&env, result).into(),
             value => Err(Error::InvalidMethodResult("getTun", format!("{:?}", value))),
         }
     }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -422,6 +422,14 @@ impl TunnelState for ConnectingState {
                                             ),
                                         ),
                                     ) => ErrorStateCause::VpnPermissionDenied,
+                                    #[cfg(target_os = "android")]
+                                    tunnel::Error::WireguardTunnelMonitoringError(
+                                        tunnel::wireguard::Error::TunnelError(
+                                            tunnel::wireguard::TunnelError::SetupTunnelDeviceError(
+                                                tun_provider::Error::InvalidDnsServers(addresses),
+                                            ),
+                                        ),
+                                    ) => ErrorStateCause::InvalidDnsServers(addresses),
                                     _ => ErrorStateCause::StartTunnelError,
                                 };
                                 ErrorState::enter(shared_values, block_reason)


### PR DESCRIPTION
When specifying the DNS server addresses to use for the tunnel device, Android may throw an exception saying that the DNS server address is invalid. This has currently only been seen when using a localhost address (`127.0.0.1`), and the code for custom DNS already prevents using localhost addresses to avoid having issues. However, not only is it hard to be sure what the exact list of invalid DNS server addresses is, it is impossible to know if that list will change in future versions of Android. 

To prevent crashes from using an unexpected invalid custom DNS server address, this PR changes the tunnel creation code to handle that failure gracefully. If the invalid DNS server address exception is thrown, `TalpidVpnService` will still continue creating the tunnel, but it will return an error state back to the tunnel state machine. This allows it to enter the blocking state gracefully, and have the error reported to the UI.

As part of the PR, the tunnel device creation was refactored to return a custom result type instead of either the tunnel file descriptor directly or a negative integer error code.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2354)
<!-- Reviewable:end -->
