### PR TITLE
Improve API access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Line wrap the file at 100 chars.                                              Th
   OpenVPN by correctly applying the fix for
   [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122).
 
+### Changed
+- Allow the API to be accessed while in a blocking state.
+- Prefer the last used API endpoint when the service starts back up, as well as in other tools such
+  as the problem report tool.
+
 
 ## [2020.8-beta2] - 2020-12-11
 This release is for desktop only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/MullvadProblemReport.kt
@@ -22,7 +22,7 @@ class MullvadProblemReport {
     }
 
     val logDirectory = CompletableDeferred<File>()
-    val resourcesDirectory = CompletableDeferred<File>()
+    val cacheDirectory = CompletableDeferred<File>()
 
     private val commandChannel = spawnActor()
 
@@ -112,7 +112,7 @@ class MullvadProblemReport {
                 userEmail,
                 userMessage,
                 problemReportPath.await().absolutePath,
-                resourcesDirectory.await().absolutePath
+                cacheDirectory.await().absolutePath
             )
 
         if (result) {
@@ -132,6 +132,6 @@ class MullvadProblemReport {
         userEmail: String,
         userMessage: String,
         reportPath: String,
-        resourcesDirectory: String
+        cacheDirectory: String
     ): Boolean
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : FragmentActivity() {
 
         problemReport.apply {
             logDirectory.complete(filesDir)
-            resourcesDirectory.complete(filesDir)
+            cacheDirectory.complete(cacheDir)
         }
 
         setContentView(R.layout.main)

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -80,7 +80,10 @@ fi
 # Remove the existing relay and API address cache lists.
 # There is a risk that they're incompatible with the format this version wants
 rm "$NEW_CACHE_DIR/relays.json" || true
+# Old API IP cache
 rm "$NEW_CACHE_DIR/api-ip-address.txt" || true
+# New API IP cache
+rm "/Library/Caches/mullvad-vpn/api-ip-address.txt" || true
 
 # Notify the running daemon that we are going to kill it and replace it with a newer version.
 # This will make the daemon save it's state to a file and then lock the firewall to prevent

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -40,7 +40,7 @@ sudo pkgutil --forget net.mullvad.vpn || true
 
 read -p "Do you want to delete the log and cache files the app has created? (y/n) "
 if [[ "$REPLY" =~ [Yy]$ ]]; then
-    sudo rm -rf /var/log/mullvad-vpn /var/root/Library/Caches/mullvad-vpn
+    sudo rm -rf /var/log/mullvad-vpn /var/root/Library/Caches/mullvad-vpn /Library/Caches/mullvad-vpn
     for user in /Users/*; do
         user_log_dir="$user/Library/Logs/Mullvad VPN"
         if [[ -d "$user_log_dir" ]]; then

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -483,6 +483,7 @@ where
         resource_dir: PathBuf,
         settings_dir: PathBuf,
         cache_dir: PathBuf,
+        user_cache_dir: PathBuf,
         event_listener: L,
         command_channel: DaemonCommandChannel,
         #[cfg(target_os = "android")] android_context: AndroidContext,
@@ -492,8 +493,9 @@ where
 
         let mut rpc_runtime = mullvad_rpc::MullvadRpcRuntime::with_cache(
             tokio::runtime::Handle::current(),
-            &resource_dir,
-            Some(&cache_dir),
+            Some(&resource_dir),
+            &user_cache_dir,
+            true,
         )
         .await
         .map_err(Error::InitRpcFactory)?;

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -123,6 +123,8 @@ async fn create_daemon(
         .map_err(|e| e.display_chain_with_msg("Unable to get settings dir"))?;
     let cache_dir = mullvad_paths::cache_dir()
         .map_err(|e| e.display_chain_with_msg("Unable to get cache dir"))?;
+    let user_cache_dir = mullvad_paths::user_cache_dir()
+        .map_err(|e| e.display_chain_with_msg("Unable to get user cache dir"))?;
 
     let command_channel = DaemonCommandChannel::new();
     let event_listener = spawn_management_interface(command_channel.sender()).await?;
@@ -132,6 +134,7 @@ async fn create_daemon(
         resource_dir,
         settings_dir,
         cache_dir,
+        user_cache_dir,
         event_listener,
         command_channel,
     )

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -236,6 +236,7 @@ fn spawn_daemon(
             Some(resource_dir.clone()),
             resource_dir.clone(),
             resource_dir,
+            cache_dir.clone(),
             cache_dir,
             listener,
             command_channel,

--- a/mullvad-jni/src/problem_report.rs
+++ b/mullvad-jni/src/problem_report.rs
@@ -43,21 +43,21 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemRepor
     userEmail: JString<'_>,
     userMessage: JString<'_>,
     outputPath: JString<'_>,
-    resourcesDirectory: JString<'_>,
+    cacheDirectory: JString<'_>,
 ) -> jboolean {
     let env = JnixEnv::from(env);
     let user_email = String::from_java(&env, userEmail);
     let user_message = String::from_java(&env, userMessage);
     let output_path_string = String::from_java(&env, outputPath);
     let output_path = Path::new(&output_path_string);
-    let resources_directory_string = String::from_java(&env, resourcesDirectory);
-    let resources_directory = Path::new(&resources_directory_string);
+    let cache_directory_string = String::from_java(&env, cacheDirectory);
+    let cache_directory = Path::new(&cache_directory_string);
 
     let send_result = mullvad_problem_report::send_problem_report(
         &user_email,
         &user_message,
         output_path,
-        resources_directory,
+        cache_directory,
     );
 
     match send_result {

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -33,3 +33,26 @@ pub fn get_default_cache_dir() -> Result<PathBuf> {
         Ok(std::path::Path::new(crate::APP_PATH).join("cache"))
     }
 }
+
+/// Creates and returns a cache directory that is readable by all users.
+pub fn user_cache_dir() -> Result<PathBuf> {
+    #[cfg(not(target_os = "macos"))]
+    let permissions = None;
+    #[cfg(target_os = "macos")]
+    let permissions = Some(std::os::unix::fs::PermissionsExt::from_mode(0o755));
+    crate::create_and_return(get_user_cache_dir, permissions)
+}
+
+pub fn get_user_cache_dir() -> Result<PathBuf> {
+    #[cfg(windows)]
+    {
+        let dir = crate::get_allusersprofile_dir();
+        dir.map(|dir| dir.join(crate::PRODUCT_NAME))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Ok(std::path::Path::new("/Library/Caches").join(crate::PRODUCT_NAME))
+    }
+    #[cfg(not(any(target_os = "macos", windows)))]
+    get_cache_dir()
+}

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -56,7 +56,7 @@ fn create_and_return(
 }
 
 mod cache;
-pub use crate::cache::{cache_dir, get_default_cache_dir};
+pub use crate::cache::{cache_dir, get_default_cache_dir, get_user_cache_dir, user_cache_dir};
 
 mod logs;
 pub use crate::logs::{get_default_log_dir, get_log_dir, log_dir};

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -281,7 +281,7 @@ pub fn send_problem_report(
             None,
             user_cache_dir,
             false,
-            |_| {},
+            |_| Ok(()),
         ))
         .map_err(Error::CreateRpcClientError)?;
     let rpc_client = mullvad_rpc::ProblemReportProxy::new(rpc_manager.mullvad_rest_handle());

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -281,6 +281,7 @@ pub fn send_problem_report(
             None,
             user_cache_dir,
             false,
+            |_| {},
         ))
         .map_err(Error::CreateRpcClientError)?;
     let rpc_client = mullvad_rpc::ProblemReportProxy::new(rpc_manager.mullvad_rest_handle());

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -69,6 +69,9 @@ pub enum Error {
 
     #[error(display = "Unable to spawn Tokio runtime")]
     CreateRuntime(#[error(source)] io::Error),
+
+    #[error(display = "Unable to find cache directory")]
+    ObtainCacheDirectory(#[error(source)] mullvad_paths::Error),
 }
 
 /// These are errors that can happen during problem report collection.
@@ -253,7 +256,7 @@ pub fn send_problem_report(
     user_email: &str,
     user_message: &str,
     report_path: &Path,
-    resource_dir: &Path,
+    user_cache_dir: &Path,
 ) -> Result<(), Error> {
     let report_content = normalize_newlines(
         read_file_lossy(report_path, REPORT_MAX_SIZE).map_err(|source| {
@@ -275,8 +278,9 @@ pub fn send_problem_report(
     let mut rpc_manager = runtime
         .block_on(mullvad_rpc::MullvadRpcRuntime::with_cache(
             runtime.handle().clone(),
-            resource_dir,
             None,
+            user_cache_dir,
+            false,
         ))
         .map_err(Error::CreateRpcClientError)?;
     let rpc_client = mullvad_rpc::ProblemReportProxy::new(rpc_manager.mullvad_rest_handle());

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -113,8 +113,8 @@ fn run() -> Result<(), Error> {
         let report_path = Path::new(send_matches.value_of_os("report").unwrap());
         let user_email = send_matches.value_of("email").unwrap_or("");
         let user_message = send_matches.value_of("message").unwrap_or("");
-        let resource_dir = mullvad_paths::get_resource_dir();
-        send_problem_report(user_email, user_message, report_path, &resource_dir)
+        let user_cache_dir = mullvad_paths::get_user_cache_dir()?;
+        send_problem_report(user_email, user_message, report_path, &user_cache_dir)
     } else {
         unreachable!("No sub command given");
     }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -69,31 +69,41 @@ impl MullvadRpcRuntime {
     /// if it fails.
     pub async fn with_cache(
         handle: tokio::runtime::Handle,
-        resource_dir: &Path,
-        cache_dir: Option<&Path>,
+        resource_dir: Option<&Path>,
+        cache_dir: &Path,
+        write_changes: bool,
     ) -> Result<Self, Error> {
-        let resource_file = resource_dir.join(API_IP_CACHE_FILENAME);
+        let cache_file = cache_dir.join(API_IP_CACHE_FILENAME);
+        let write_file = if write_changes {
+            Some(cache_file.clone().into_boxed_path())
+        } else {
+            None
+        };
 
-        let address_cache = if let Some(cache_dir) = cache_dir {
-            let cache_file = cache_dir.join(API_IP_CACHE_FILENAME);
-            let cache_file_boxed = cache_file.clone().into_boxed_path();
+        let address_cache = match AddressCache::from_file(&cache_file, write_file.clone()).await {
+            Ok(cache) => cache,
+            Err(error) => {
+                let cache_exists = cache_file.exists();
+                if cache_exists {
+                    log::error!(
+                        "{}",
+                        error.display_chain_with_msg(
+                            "Failed to load cached API addresses. Falling back on bundled list"
+                        )
+                    );
+                }
 
-            match AddressCache::from_file(&cache_file, Some(cache_file_boxed.clone())).await {
-                Ok(cache) => cache,
-                Err(error) => {
-                    if cache_file.exists() {
-                        log::error!(
-                            "{}",
-                            error.display_chain_with_msg(
-                                "Failed to load cached API addresses. Falling back on bundled list"
-                            )
-                        );
+                // Initialize the cache directory cache using the resource directory
+                match resource_dir {
+                    Some(resource_dir) => {
+                        let read_file = resource_dir.join(API_IP_CACHE_FILENAME);
+                        let cache = AddressCache::from_file(&read_file, write_file).await?;
+                        cache.randomize().await?;
+                        cache
                     }
-                    AddressCache::from_file(&resource_file, Some(cache_file_boxed)).await?
+                    None => return Err(Error::AddressCacheError(error)),
                 }
             }
-        } else {
-            AddressCache::from_file(&resource_file, None).await?
         };
 
         let https_connector = HttpsConnectorWithSni::new();

--- a/mullvad-setup/src/daemon_paths.rs
+++ b/mullvad-setup/src/daemon_paths.rs
@@ -15,9 +15,7 @@ use winapi::{
     um::{
         combaseapi::CoTaskMemFree,
         handleapi::CloseHandle,
-        knownfolders::{
-            FOLDERID_LocalAppData, FOLDERID_ProgramFiles, FOLDERID_RoamingAppData, FOLDERID_System,
-        },
+        knownfolders::{FOLDERID_LocalAppData, FOLDERID_System},
         processthreadsapi::{GetCurrentThread, OpenProcess, OpenProcessToken, OpenThreadToken},
         psapi::K32EnumProcesses,
         securitybaseapi::{AdjustTokenPrivileges, ImpersonateSelf, RevertToSelf},
@@ -34,16 +32,6 @@ use winapi::{
 
 pub fn get_mullvad_daemon_settings_path() -> io::Result<PathBuf> {
     get_system_service_known_folder(FOLDERID_LocalAppData)
-        .map(|settings| settings.join(mullvad_paths::PRODUCT_NAME))
-}
-
-pub fn get_mullvad_resource_path() -> io::Result<PathBuf> {
-    get_known_folder_path(FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, ptr::null_mut())
-        .map(|settings| settings.join(mullvad_paths::PRODUCT_NAME).join("resources"))
-}
-
-pub fn get_mullvad_daemon_cache_path() -> io::Result<PathBuf> {
-    get_system_service_known_folder(FOLDERID_RoamingAppData)
         .map(|settings| settings.join(mullvad_paths::PRODUCT_NAME))
 }
 

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -158,6 +158,7 @@ async fn clear_history() -> Result<(), Error> {
         None,
         &user_cache_path,
         false,
+        |_| {},
     )
     .await
     .map_err(Error::RpcInitializationError)?;

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -144,6 +144,7 @@ async fn reset_firewall() -> Result<(), Error> {
     let mut firewall = Firewall::new(FirewallArguments {
         initialize_blocked: false,
         allow_lan: true,
+        allowed_endpoint: None,
     })
     .map_err(Error::FirewallError)?;
 
@@ -158,7 +159,7 @@ async fn clear_history() -> Result<(), Error> {
         None,
         &user_cache_path,
         false,
-        |_| {},
+        |_| Ok(()),
     )
     .await
     .map_err(Error::RpcInitializationError)?;

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -98,9 +98,11 @@ impl Firewall {
             FirewallPolicy::Connecting {
                 peer_endpoint,
                 allow_lan,
+                allowed_endpoint,
                 pingable_hosts,
             } => {
                 let mut rules = vec![self.get_allow_relay_rule(peer_endpoint)?];
+                rules.push(self.get_allowed_endpoint_rule(allowed_endpoint)?);
                 rules.extend(self.get_allow_pingable_hosts(&pingable_hosts)?);
                 if allow_lan {
                     // Important to block DNS after allow relay rule (so the relay can operate
@@ -136,8 +138,12 @@ impl Firewall {
 
                 Ok(rules)
             }
-            FirewallPolicy::Blocked { allow_lan } => {
+            FirewallPolicy::Blocked {
+                allow_lan,
+                allowed_endpoint,
+            } => {
                 let mut rules = Vec::new();
+                rules.push(self.get_allowed_endpoint_rule(allowed_endpoint)?);
                 if allow_lan {
                     // Important to block DNS before allow LAN (so DNS does not leak to the LAN)
                     rules.append(&mut self.get_block_dns_rules()?);
@@ -243,6 +249,22 @@ impl Firewall {
             .keep_state(pfctl::StatePolicy::Keep)
             .tcp_flags(Self::get_tcp_flags())
             .user(Uid::from(ROOT_UID))
+            .quick(true)
+            .build()?)
+    }
+
+    fn get_allowed_endpoint_rule(
+        &self,
+        allowed_endpoint: net::Endpoint,
+    ) -> Result<pfctl::FilterRule> {
+        let pfctl_proto = as_pfctl_proto(allowed_endpoint.protocol);
+
+        Ok(self
+            .create_rule_builder(FilterRuleAction::Pass)
+            .direction(pfctl::Direction::Out)
+            .to(allowed_endpoint.address)
+            .proto(pfctl_proto)
+            .keep_state(pfctl::StatePolicy::Keep)
             .quick(true)
             .build()?)
     }

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -107,6 +107,8 @@ pub enum FirewallPolicy {
         pingable_hosts: Vec<IpAddr>,
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
+        /// Host that should be reachable by the tunnel client while connecting.
+        allowed_endpoint: Endpoint,
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]
         relay_client: PathBuf,
@@ -140,6 +142,8 @@ pub enum FirewallPolicy {
     Blocked {
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
+        /// Host that should be reachable while in the blocked state.
+        allowed_endpoint: Endpoint,
     },
 }
 
@@ -182,10 +186,14 @@ impl fmt::Display for FirewallPolicy {
                 tunnel.ipv6_gateway,
                 if *allow_lan { "Allowing" } else { "Blocking" }
             ),
-            FirewallPolicy::Blocked { allow_lan } => write!(
+            FirewallPolicy::Blocked {
+                allow_lan,
+                allowed_endpoint,
+            } => write!(
                 f,
-                "Blocked, {} LAN",
-                if *allow_lan { "Allowing" } else { "Blocking" }
+                "Blocked. {} LAN. Allowing endpoint {}",
+                if *allow_lan { "Allowing" } else { "Blocking" },
+                allowed_endpoint,
             ),
         }
     }
@@ -203,6 +211,8 @@ pub struct FirewallArguments {
     pub initialize_blocked: bool,
     /// This argument is required for the blocked state to configure the firewall correctly.
     pub allow_lan: bool,
+    /// This argument is required for the blocked state to configure the firewall correctly.
+    pub allowed_endpoint: Option<Endpoint>,
 }
 
 impl Firewall {

--- a/talpid-core/src/tunnel/tun_provider/android/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/android/mod.rs
@@ -66,6 +66,7 @@ pub struct AndroidTunProvider {
     object: GlobalRef,
     last_tun_config: TunConfig,
     allow_lan: bool,
+    allowed_endpoint: IpAddr,
     custom_dns_servers: Option<Vec<IpAddr>>,
 }
 
@@ -74,6 +75,7 @@ impl AndroidTunProvider {
     pub fn new(
         context: AndroidContext,
         allow_lan: bool,
+        allowed_endpoint: IpAddr,
         custom_dns_servers: Option<Vec<IpAddr>>,
     ) -> Self {
         let env = JnixEnv::from(
@@ -90,6 +92,7 @@ impl AndroidTunProvider {
             object: context.vpn_service,
             last_tun_config: TunConfig::default(),
             allow_lan,
+            allowed_endpoint,
             custom_dns_servers,
         }
     }
@@ -101,6 +104,10 @@ impl AndroidTunProvider {
         }
 
         Ok(())
+    }
+
+    pub fn set_allowed_endpoint(&mut self, endpoint: IpAddr) {
+        self.allowed_endpoint = endpoint;
     }
 
     pub fn set_custom_dns_servers(&mut self, servers: Option<Vec<IpAddr>>) -> Result<(), Error> {
@@ -127,6 +134,19 @@ impl AndroidTunProvider {
             class: self.class.clone(),
             object: self.object.clone(),
         })
+    }
+
+    /// Open a tunnel device that routes everything but `allowed_endpoint`, custom DNS, and (potentially)
+    /// LAN routes via the tunnel device.
+    ///
+    /// Will open a new tunnel if there is already an active tunnel. The previous tunnel will be
+    /// closed.
+    pub fn create_blocking_tun(&mut self) -> Result<(), Error> {
+        let mut config = TunConfig::default();
+        self.prepare_tun_config(&mut config);
+        self.prepare_tun_config_for_allowed_endpoint(&mut config);
+        let _ = self.get_tun(config)?;
+        Ok(())
     }
 
     /// Open a tunnel device using the previous or the default configuration.
@@ -229,6 +249,24 @@ impl AndroidTunProvider {
             JValue::Void => Ok(()),
             value => Err(Error::InvalidMethodResult("getTun", format!("{:?}", value))),
         }
+    }
+
+    fn prepare_tun_config_for_allowed_endpoint(&self, config: &mut TunConfig) {
+        let endpoint_net = IpNetwork::from(self.allowed_endpoint);
+        let routes = config
+            .routes
+            .iter()
+            .flat_map(|&route| {
+                if route.is_ipv4() && endpoint_net.is_ipv4() {
+                    route.sub(endpoint_net).collect()
+                } else if route.is_ipv6() && endpoint_net.is_ipv6() {
+                    route.sub(endpoint_net).collect()
+                } else {
+                    vec![route]
+                }
+            })
+            .collect();
+        config.routes = routes;
     }
 
     fn prepare_tun_config(&self, config: &mut TunConfig) {

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -192,6 +192,13 @@ impl ConnectedState {
                     }
                 }
             }
+            Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
+                let _ = shared_values.set_allowed_endpoint(endpoint);
+                if let Err(_) = tx.send(()) {
+                    log::error!("The AllowEndpoint receiver was dropped");
+                }
+                SameState(self.into())
+            }
             Some(TunnelCommand::CustomDns(servers)) => {
                 match shared_values.set_custom_dns(servers) {
                     Ok(true) => {

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -32,6 +32,13 @@ impl DisconnectingState {
                     let _ = shared_values.set_allow_lan(allow_lan);
                     AfterDisconnect::Nothing
                 }
+                Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
+                    let _ = shared_values.set_allowed_endpoint(endpoint);
+                    if let Err(_) = tx.send(()) {
+                        log::error!("The AllowEndpoint receiver was dropped");
+                    }
+                    AfterDisconnect::Nothing
+                }
                 Some(TunnelCommand::CustomDns(servers)) => {
                     let _ = shared_values.set_custom_dns(servers);
                     AfterDisconnect::Nothing
@@ -51,6 +58,13 @@ impl DisconnectingState {
             AfterDisconnect::Block(reason) => match command {
                 Some(TunnelCommand::AllowLan(allow_lan)) => {
                     let _ = shared_values.set_allow_lan(allow_lan);
+                    AfterDisconnect::Block(reason)
+                }
+                Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
+                    let _ = shared_values.set_allowed_endpoint(endpoint);
+                    if let Err(_) = tx.send(()) {
+                        log::error!("The AllowEndpoint receiver was dropped");
+                    }
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {
@@ -77,6 +91,13 @@ impl DisconnectingState {
             AfterDisconnect::Reconnect(retry_attempt) => match command {
                 Some(TunnelCommand::AllowLan(allow_lan)) => {
                     let _ = shared_values.set_allow_lan(allow_lan);
+                    AfterDisconnect::Reconnect(retry_attempt)
+                }
+                Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
+                    let _ = shared_values.set_allowed_endpoint(endpoint);
+                    if let Err(_) = tx.send(()) {
+                        log::error!("The AllowEndpoint receiver was dropped");
+                    }
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::CustomDns(servers)) => {

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -144,6 +144,10 @@ impl Endpoint {
             protocol,
         }
     }
+
+    pub fn from_socket_address(address: SocketAddr, protocol: TransportProtocol) -> Self {
+        Endpoint { address, protocol }
+    }
 }
 
 impl fmt::Display for Endpoint {

--- a/windows/nsis-plugins/src/cleanup/cleaningops.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleaningops.cpp
@@ -333,14 +333,14 @@ void RemoveRelayCacheServiceUser()
 
 void RemoveApiAddressCacheServiceUser()
 {
-	const auto localAppData = GetSystemUserLocalAppData();
-	const auto mullvadAppData = std::filesystem::path(localAppData).append(L"Mullvad VPN");
+	const auto programData = common::fs::GetKnownFolderPath(FOLDERID_ProgramData, KF_FLAG_DEFAULT, nullptr);
+	const auto mullvadProgramData = std::filesystem::path(programData).append(L"Mullvad VPN");
 
 	common::fs::ScopedNativeFileSystem nativeFileSystem;
 
-	common::security::AddAdminToObjectDacl(mullvadAppData, SE_FILE_OBJECT);
+	common::security::AddAdminToObjectDacl(mullvadProgramData, SE_FILE_OBJECT);
 
-	const auto cacheFile = std::filesystem::path(mullvadAppData).append(L"api-ip-address.txt");
+	const auto cacheFile = std::filesystem::path(mullvadProgramData).append(L"api-ip-address.txt");
 
 	std::filesystem::remove(cacheFile);
 }

--- a/windows/winfw/src/extras/cli/commands/winfw/policy.cpp
+++ b/windows/winfw/src/extras/cli/commands/winfw/policy.cpp
@@ -26,9 +26,9 @@ WinFwProtocol TranslateProtocol(const std::wstring &protocol)
 	return (0 == _wcsicmp(protocol.c_str(), L"tcp") ? WinFwProtocol::Tcp : WinFwProtocol::Udp);
 }
 
-WinFwRelay CreateRelay(const wchar_t *ip, const std::wstring &port, const std::wstring &protocol)
+WinFwEndpoint CreateRelay(const wchar_t *ip, const std::wstring &port, const std::wstring &protocol)
 {
-	WinFwRelay r;
+	WinFwEndpoint r;
 
 	r.ip = ip;
 	r.port = common::string::LexicalCast<uint16_t>(port);

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -31,32 +31,6 @@ using namespace rules;
 namespace
 {
 
-multi::PermitVpnRelay::Protocol TranslateProtocol(WinFwProtocol protocol)
-{
-	switch (protocol)
-	{
-		case Tcp: return multi::PermitVpnRelay::Protocol::Tcp;
-		case Udp: return multi::PermitVpnRelay::Protocol::Udp;
-		default:
-		{
-			THROW_ERROR("Missing case handler in switch clause");
-		}
-	};
-}
-
-baseline::PermitEndpoint::Protocol TranslateEndpointProtocol(WinFwProtocol protocol)
-{
-	switch (protocol)
-	{
-		case Tcp: return baseline::PermitEndpoint::Protocol::Tcp;
-		case Udp: return baseline::PermitEndpoint::Protocol::Udp;
-		default:
-		{
-			THROW_ERROR("Missing case handler in switch clause");
-		}
-	};
-}
-
 //
 // Since the PermitLan rule doesn't specifically address DNS, it will allow DNS requests targetting
 // a local resolver to leave the machine. From the local resolver the request will either be
@@ -119,7 +93,7 @@ void AppendRelayRules
 	ruleset.emplace_back(std::make_unique<multi::PermitVpnRelay>(
 		wfp::IpAddress(relay.ip),
 		relay.port,
-		TranslateProtocol(relay.protocol),
+		relay.protocol,
 		relayClient,
 		sublayer
 	));
@@ -137,7 +111,7 @@ void AppendAllowedEndpointRules
 	ruleset.emplace_back(std::make_unique<baseline::PermitEndpoint>(
 		wfp::IpAddress(endpoint.ip),
 		endpoint.port,
-		TranslateEndpointProtocol(endpoint.protocol)
+		endpoint.protocol
 	));
 }
 

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -20,7 +20,8 @@ public:
 	FwContext
 	(
 		uint32_t timeout,
-		const WinFwSettings &settings
+		const WinFwSettings &settings,
+		const std::optional<WinFwEndpoint> &allowedEndpoint
 	);
 
 	struct PingableHosts
@@ -32,22 +33,26 @@ public:
 	bool applyPolicyConnecting
 	(
 		const WinFwSettings &settings,
-		const WinFwRelay &relay,
+		const WinFwEndpoint &relay,
 		const std::wstring &relayClient,
-		const std::optional<PingableHosts> &pingableHosts
+		const std::optional<PingableHosts> &pingableHosts,
+		const std::optional<WinFwEndpoint> &allowedEndpoint
 	);
 
 	bool applyPolicyConnected
 	(
 		const WinFwSettings &settings,
-		const WinFwRelay &relay,
+		const WinFwEndpoint &relay,
 		const std::wstring &relayClient,
 		const std::wstring &tunnelInterfaceAlias,
 		const std::vector<wfp::IpAddress> &tunnelDnsServers,
 		const std::vector<wfp::IpAddress> &nonTunnelDnsServers
 	);
 
-	bool applyPolicyBlocked(const WinFwSettings &settings);
+	bool applyPolicyBlocked(
+		const WinFwSettings &settings,
+		const std::optional<WinFwEndpoint> &allowedEndpoint
+	);
 
 	bool reset();
 
@@ -68,10 +73,10 @@ private:
 	FwContext(const FwContext &) = delete;
 	FwContext &operator=(const FwContext &) = delete;
 
-	Ruleset composePolicyBlocked(const WinFwSettings &settings);
+	Ruleset composePolicyBlocked(const WinFwSettings &settings, const std::optional<WinFwEndpoint> &allowedEndpoint);
 
 	bool applyBaseConfiguration();
-	bool applyBlockedBaseConfiguration(const WinFwSettings &settings, uint32_t &checkpoint);
+	bool applyBlockedBaseConfiguration(const WinFwSettings &settings, const std::optional<WinFwEndpoint> &allowedEndpoint, uint32_t &checkpoint);
 	bool applyCommonBaseConfiguration(SessionController &controller, wfp::FilterEngine &engine);
 
 	bool applyRuleset(const Ruleset &ruleset);

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -129,6 +129,7 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcpServer_Inbound_Request_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcpServer_Outbound_Response_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4()));
@@ -638,6 +639,20 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnRelay()
 		0xdb40,
 		0x4f79,
 		{ 0x90, 0x6d, 0xfd, 0xa1, 0xe1, 0xc1, 0x8a, 0x70 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint()
+{
+	static const GUID g =
+	{
+		0x99dc8dac,
+		0x8520,
+		0x41be,
+		{ 0xbf, 0xab, 0x0c, 0x9, 0xbf, 0x12, 0xeb, 0 }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -69,6 +69,8 @@ public:
 
 	static const GUID &Filter_Baseline_PermitVpnRelay();
 
+	static const GUID &Filter_Baseline_PermitEndpoint();
+
 	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4();
 	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6();
 

--- a/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
@@ -1,0 +1,87 @@
+#include "stdafx.h"
+#include "permitendpoint.h"
+#include <winfw/mullvadguids.h>
+#include <libwfp/filterbuilder.h>
+#include <libwfp/conditionbuilder.h>
+#include <libwfp/conditions/conditionprotocol.h>
+#include <libwfp/conditions/conditionip.h>
+#include <libwfp/conditions/conditionport.h>
+#include <libwfp/conditions/conditionapplication.h>
+#include <libcommon/error.h>
+
+using namespace wfp::conditions;
+
+namespace rules::baseline
+{
+
+namespace
+{
+
+const GUID &OutboundLayerFromIp(const wfp::IpAddress &ip)
+{
+	switch (ip.type())
+	{
+		case wfp::IpAddress::Type::Ipv4: return FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+		case wfp::IpAddress::Type::Ipv6: return FWPM_LAYER_ALE_AUTH_CONNECT_V6;
+		default:
+		{
+			THROW_ERROR("Missing case handler in switch clause");
+		}
+	};
+}
+
+std::unique_ptr<ConditionProtocol> CreateProtocolCondition(PermitEndpoint::Protocol protocol)
+{
+	switch (protocol)
+	{
+		case PermitEndpoint::Protocol::Tcp: return ConditionProtocol::Tcp();
+		case PermitEndpoint::Protocol::Udp: return ConditionProtocol::Udp();
+		default:
+		{
+			THROW_ERROR("Missing case handler in switch clause");
+		}
+	};
+}
+
+} // anonymous namespace
+
+PermitEndpoint::PermitEndpoint
+(
+	const wfp::IpAddress &address,
+	uint16_t port,
+	Protocol protocol
+)
+	: m_address(address)
+	, m_port(port)
+	, m_protocol(protocol)
+{
+}
+
+bool PermitEndpoint::apply(IObjectInstaller &objectInstaller)
+{
+	wfp::FilterBuilder filterBuilder;
+
+	//
+	// Permit outbound connections to endpoint.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitEndpoint())
+		.name(L"Permit outbound connections to a given endpoint")
+		.description(L"This filter is part of a rule that permits traffic to a specific endpoint")
+		.provider(MullvadGuids::Provider())
+		.layer(OutboundLayerFromIp(m_address))
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Max)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(OutboundLayerFromIp(m_address));
+
+	conditionBuilder.add_condition(ConditionIp::Remote(m_address));
+	conditionBuilder.add_condition(ConditionPort::Remote(m_port));
+	conditionBuilder.add_condition(CreateProtocolCondition(m_protocol));
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+}

--- a/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
@@ -30,12 +30,12 @@ const GUID &OutboundLayerFromIp(const wfp::IpAddress &ip)
 	};
 }
 
-std::unique_ptr<ConditionProtocol> CreateProtocolCondition(PermitEndpoint::Protocol protocol)
+std::unique_ptr<ConditionProtocol> CreateProtocolCondition(WinFwProtocol protocol)
 {
 	switch (protocol)
 	{
-		case PermitEndpoint::Protocol::Tcp: return ConditionProtocol::Tcp();
-		case PermitEndpoint::Protocol::Udp: return ConditionProtocol::Udp();
+		case WinFwProtocol::Tcp: return ConditionProtocol::Tcp();
+		case WinFwProtocol::Udp: return ConditionProtocol::Udp();
 		default:
 		{
 			THROW_ERROR("Missing case handler in switch clause");
@@ -49,7 +49,7 @@ PermitEndpoint::PermitEndpoint
 (
 	const wfp::IpAddress &address,
 	uint16_t port,
-	Protocol protocol
+	WinFwProtocol protocol
 )
 	: m_address(address)
 	, m_port(port)

--- a/windows/winfw/src/winfw/rules/baseline/permitendpoint.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitendpoint.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <winfw/rules/ifirewallrule.h>
+#include <libwfp/ipaddress.h>
+#include <string>
+
+namespace rules::baseline
+{
+
+class PermitEndpoint : public IFirewallRule
+{
+public:
+
+	enum class Protocol
+	{
+		Tcp,
+		Udp
+	};
+
+	PermitEndpoint
+	(
+		const wfp::IpAddress &address,
+		uint16_t port,
+		Protocol protocol
+	);
+	
+	bool apply(IObjectInstaller &objectInstaller) override;
+
+private:
+
+	const wfp::IpAddress m_address;
+	const uint16_t m_port;
+	const Protocol m_protocol;
+};
+
+}

--- a/windows/winfw/src/winfw/rules/baseline/permitendpoint.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitendpoint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <winfw/rules/ifirewallrule.h>
+#include <winfw/winfw.h>
 #include <libwfp/ipaddress.h>
 #include <string>
 
@@ -11,17 +12,11 @@ class PermitEndpoint : public IFirewallRule
 {
 public:
 
-	enum class Protocol
-	{
-		Tcp,
-		Udp
-	};
-
 	PermitEndpoint
 	(
 		const wfp::IpAddress &address,
 		uint16_t port,
-		Protocol protocol
+		WinFwProtocol protocol
 	);
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
@@ -30,7 +25,7 @@ private:
 
 	const wfp::IpAddress m_address;
 	const uint16_t m_port;
-	const Protocol m_protocol;
+	const WinFwProtocol m_protocol;
 };
 
 }

--- a/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
+++ b/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "permitvpnrelay.h"
 #include <winfw/mullvadguids.h>
+#include <winfw/winfw.h>
 #include <libwfp/filterbuilder.h>
 #include <libwfp/conditionbuilder.h>
 #include <libwfp/conditions/conditionprotocol.h>
@@ -30,12 +31,12 @@ const GUID &LayerFromIp(const wfp::IpAddress &ip)
 	};
 }
 
-std::unique_ptr<ConditionProtocol> CreateProtocolCondition(PermitVpnRelay::Protocol protocol)
+std::unique_ptr<ConditionProtocol> CreateProtocolCondition(WinFwProtocol protocol)
 {
 	switch (protocol)
 	{
-		case PermitVpnRelay::Protocol::Tcp: return ConditionProtocol::Tcp();
-		case PermitVpnRelay::Protocol::Udp: return ConditionProtocol::Udp();
+		case WinFwProtocol::Tcp: return ConditionProtocol::Tcp();
+		case WinFwProtocol::Udp: return ConditionProtocol::Udp();
 		default:
 		{
 			THROW_ERROR("Missing case handler in switch clause");
@@ -62,7 +63,7 @@ PermitVpnRelay::PermitVpnRelay
 (
 	const wfp::IpAddress &relay,
 	uint16_t relayPort,
-	Protocol protocol,
+	WinFwProtocol protocol,
 	const std::wstring &relayClient,
 	Sublayer sublayer
 )

--- a/windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
+++ b/windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <winfw/rules/ifirewallrule.h>
+#include <winfw/winfw.h>
 #include <libwfp/ipaddress.h>
 #include <string>
 
@@ -10,12 +11,6 @@ namespace rules::multi
 class PermitVpnRelay : public IFirewallRule
 {
 public:
-
-	enum class Protocol
-	{
-		Tcp,
-		Udp
-	};
 
 	enum class Sublayer
 	{
@@ -27,7 +22,7 @@ public:
 	(
 		const wfp::IpAddress &relay,
 		uint16_t relayPort,
-		Protocol protocol,
+		WinFwProtocol protocol,
 		const std::wstring &relayClient,
 		Sublayer sublayer
 	);
@@ -38,7 +33,7 @@ private:
 
 	const wfp::IpAddress m_relay;
 	const uint16_t m_relayPort;
-	const Protocol m_protocol;
+	const WinFwProtocol m_protocol;
 	const std::wstring m_relayClient;
 	const Sublayer m_sublayer;
 };

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -37,13 +37,13 @@ enum WinFwProtocol : uint8_t
 	Udp = 1
 };
 
-typedef struct tag_WinFwRelay
+typedef struct tag_WinFwEndpoint
 {
 	const wchar_t *ip;
 	uint16_t port;
 	WinFwProtocol protocol;
 }
-WinFwRelay;
+WinFwEndpoint;
 
 #pragma pack(pop)
 
@@ -88,6 +88,7 @@ WINFW_API
 WinFw_InitializeBlocked(
 	uint32_t timeout,
 	const WinFwSettings *settings,
+	const WinFwEndpoint *allowedEndpoint,
 	MullvadLogSink logSink,
 	void *logSinkContext
 );
@@ -155,9 +156,10 @@ WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
-	const WinFwRelay *relay,
+	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
-	const PingableHosts *pingableHosts
+	const PingableHosts *pingableHosts,
+	const WinFwEndpoint *allowedEndpoint
 );
 
 //
@@ -183,7 +185,7 @@ WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyConnected(
 	const WinFwSettings *settings,
-	const WinFwRelay *relay,
+	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
 	const wchar_t *tunnelInterfaceAlias,
 	const wchar_t *v4Gateway,
@@ -203,7 +205,8 @@ WINFW_LINKAGE
 WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyBlocked(
-	const WinFwSettings *settings
+	const WinFwSettings *settings,
+	const WinFwEndpoint *allowedEndpoint
 );
 
 //

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="rules\baseline\permitdhcp.cpp" />
     <ClCompile Include="rules\baseline\permitdhcpserver.cpp" />
     <ClCompile Include="rules\baseline\permitdns.cpp" />
+    <ClCompile Include="rules\baseline\permitendpoint.cpp" />
     <ClCompile Include="rules\baseline\permitlan.cpp" />
     <ClCompile Include="rules\baseline\permitlanservice.cpp" />
     <ClCompile Include="rules\baseline\permitloopback.cpp" />
@@ -61,6 +62,7 @@
     <ClInclude Include="rules\baseline\permitdhcp.h" />
     <ClInclude Include="rules\baseline\permitdhcpserver.h" />
     <ClInclude Include="rules\baseline\permitdns.h" />
+    <ClInclude Include="rules\baseline\permitendpoint.h" />
     <ClInclude Include="rules\baseline\permitlan.h" />
     <ClInclude Include="rules\baseline\permitlanservice.h" />
     <ClInclude Include="rules\baseline\permitloopback.h" />

--- a/windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClCompile Include="rules\persistent\blockall.cpp">
       <Filter>rules\persistent</Filter>
     </ClCompile>
+    <ClCompile Include="rules\baseline\permitendpoint.cpp">
+      <Filter>rules\baseline</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -131,6 +134,9 @@
     </ClInclude>
     <ClInclude Include="rules\persistent\blockall.h">
       <Filter>rules\persistent</Filter>
+    </ClInclude>
+    <ClInclude Include="rules\baseline\permitendpoint.h">
+      <Filter>rules\baseline</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR makes a number of changes to how the API is reached:

When the daemon is first run, it reads `api-ip-address.txt` from the resources directory, shuffles it, and outputs a cache file in the "user cache"* directory. It starts by using a random endpoint. When the daemon is started and a cache file already exists, it initially uses the first address in this cache and shuffles the other addresses.

If the daemon fails to reach the API, it selects the next address in the cache and outputs a new cache file, storing the selected address on top, so that it is the first to be used by daemon, `mullvad-setup`, or the problem report tool. This makes it likelier that a working endpoint will keep being used when it is eventually found.

An `allow_endpoint` option was added to the firewall, which specifies an endpoint that should be accessible even when the tunnel state machine is in the connecting or error state**. This is initialized to the current API endpoint, and whenever the daemon receives a new API address from the cache, it sets `allow_endpoint` to the new address.

\* "User cache" is a new directory that is readable but not writable by all users. On Linux and Android, it is identical to the cache path, e.g. `/var/cache/mullvad-vpn` on Linux. On Windows, it is `C:\ProgramData\Mullvad VPN`. On macOS, it is `/Users/Shared/mullvad-vpn`.

\*\* On Android, the API is reachable from the error state but not while connecting. This is because it uses routing to block the internet rather than a firewall, and changing the routes seems to require reconnecting. It also lets you reach anything on the API IP, not just using the specific protocol and port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2356)
<!-- Reviewable:end -->
