### PR TITLE
Fix tunnel metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Improved compatiblitiy with newer versions of systemd-resolved.
 
+### Security
+#### Linux
+- Prevent the private tunnel IPv6 address from being detectable on a local network when using
+  OpenVPN by correctly applying the fix for
+  [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122).
+
 
 ## [2020.8-beta2] - 2020-12-11
 This release is for desktop only.

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -107,11 +107,14 @@ impl TunnelEvent {
                     .get("dev")
                     .expect("No \"dev\" in tunnel up event")
                     .to_owned();
-                let ips = vec![env
+                let mut ips = vec![env
                     .get("ifconfig_local")
                     .expect("No \"ifconfig_local\" in tunnel up event")
                     .parse()
                     .expect("Tunnel IP not in valid format")];
+                if let Some(ipv6_address) = env.get("ifconfig_ipv6_local") {
+                    ips.push(ipv6_address.parse().expect("Tunnel IP not in valid format"));
+                }
                 let ipv4_gateway = env
                     .get("route_vpn_gateway")
                     .expect("No \"route_vpn_gateway\" in tunnel up event")

--- a/windows/winnet/src/winnet/routing/helpers.cpp
+++ b/windows/winnet/src/winnet/routing/helpers.cpp
@@ -12,7 +12,8 @@ namespace
 // Interface description substrings found for virtual adapters.
 const wchar_t *TUNNEL_INTERFACE_DESCS[] = {
 	L"WireGuard",
-	L"TAP Adapter"
+	L"Wintun",
+	L"Tunnel"
 };
 
 bool IsRouteOnPhysicalInterface(const MIB_IPFORWARD_ROW2 &route)


### PR DESCRIPTION
This PR fixes a couple of issues:
* The `TunnelMetadata` instance returned for OpenVPN tunnels does not include the IPv6 address in its `ips` field. This has long been the case, but it has never caused any issues because it was apparently only used in logging. Fixed because the split tunneling feature relies on this (on Windows).
* Unrelatedly, it also corrects the default route filter on Windows. `get_best_default_route` incorrectly returned the default route for the tunnel when the protocol was OpenVPN, since the switch to Wintun. Again, this doesn't fix anything in master, as the function is not used for OpenVPN there (and the WireGuard route is correctly identified because it has no gateway). But it is used on the split tunneling branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2358)
<!-- Reviewable:end -->
