### PR TITLE
Update to newer resolv-conf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "resolv-conf"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "quick-error",
 ]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -49,7 +49,7 @@ jnix = { version = "0.3", features = ["derive"] }
 dbus = "0.9"
 failure = "0.1"
 notify = "4.0"
-resolv-conf = "0.6.1"
+resolv-conf = "0.7"
 rtnetlink = "0.6"
 netlink-packet-core = "0.2"
 netlink-packet-utils = "0.4"


### PR DESCRIPTION
In hopes of fixing issues with parsing newer resolv.conf options, I've updated the `resolv-conf` crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2369)
<!-- Reviewable:end -->
