### PR TITLE
Migrate from deprecated dirs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,18 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-
-[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,17 +149,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "bumpalo"
@@ -294,12 +271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,17 +285,6 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
-]
 
 [[package]]
 name = "ct-logs"
@@ -449,19 +409,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "3.0.1"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "dirs-sys",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.5"
+name = "dirs-sys-next"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
 dependencies = [
  "libc",
  "redox_users",
@@ -1270,7 +1231,7 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
- "dirs",
+ "dirs-next",
  "duct",
  "err-derive",
  "fern",
@@ -1355,7 +1316,7 @@ dependencies = [
 name = "mullvad-paths"
 version = "0.1.0"
 dependencies = [
- "dirs",
+ "dirs-next",
  "err-derive",
  "log 0.4.11",
 ]
@@ -1365,7 +1326,7 @@ name = "mullvad-problem-report"
 version = "2020.8.0-beta2"
 dependencies = [
  "clap",
- "dirs",
+ "dirs-next",
  "duct",
  "env_logger",
  "err-derive",
@@ -2114,7 +2075,6 @@ checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom",
  "redox_syscall",
- "rust-argon2",
 ]
 
 [[package]]
@@ -2186,18 +2146,6 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "thiserror",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -49,7 +49,7 @@ ctrlc = "3.0"
 duct = "0.13"
 windows-service = "0.3"
 winapi = { version = "0.3", features = ["errhandlingapi", "handleapi", "libloaderapi", "ntlsa", "synchapi", "tlhelp32", "winbase", "winerror", "winuser"] }
-dirs = "3.0"
+dirs-next = "2.0"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -323,7 +323,7 @@ mod windows {
         let destination_settings_dir =
             mullvad_paths::settings_dir().map_err(Error::FindSettings)?;
 
-        let system_appdata_dir = dirs::data_local_dir().ok_or(Error::FindAppData)?;
+        let system_appdata_dir = dirs_next::data_local_dir().ok_or(Error::FindAppData)?;
         if !destination_settings_dir.starts_with(system_appdata_dir) {
             return Ok(None);
         }

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -12,4 +12,4 @@ err-derive = "0.2.1"
 log = "0.4"
 
 [target.'cfg(any(windows, target_os = "macos"))'.dependencies]
-dirs = "3.0"
+dirs-next = "2.0"

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -24,7 +24,7 @@ pub fn get_default_cache_dir() -> Result<PathBuf> {
         }
         #[cfg(any(target_os = "macos", windows))]
         {
-            dir = dirs::cache_dir().ok_or_else(|| crate::Error::FindDirError)
+            dir = dirs_next::cache_dir().ok_or_else(|| crate::Error::FindDirError)
         }
         dir.map(|dir| dir.join(crate::PRODUCT_NAME))
     }

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -24,7 +24,7 @@ pub fn get_default_settings_dir() -> Result<PathBuf> {
         }
         #[cfg(windows)]
         {
-            dir = dirs::data_local_dir().ok_or_else(|| crate::Error::FindDirError);
+            dir = dirs_next::data_local_dir().ok_or_else(|| crate::Error::FindDirError);
         }
         dir.map(|dir| dir.join(crate::PRODUCT_NAME))
     }

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 clap = "2.25"
-dirs = "3.0"
+dirs-next = "2.0"
 env_logger = "0.7"
 err-derive = "0.2.1"
 lazy_static = "1.0"

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -205,7 +205,7 @@ fn frontend_log_dir() -> Option<Result<PathBuf, LogError>> {
     #[cfg(target_os = "linux")]
     {
         Some(
-            dirs::home_dir()
+            dirs_next::home_dir()
                 .ok_or(LogError::NoHomeDir)
                 .map(|home_dir| home_dir.join(".config/Mullvad VPN/logs")),
         )
@@ -213,7 +213,7 @@ fn frontend_log_dir() -> Option<Result<PathBuf, LogError>> {
     #[cfg(target_os = "macos")]
     {
         Some(
-            dirs::home_dir()
+            dirs_next::home_dir()
                 .ok_or(LogError::NoHomeDir)
                 .map(|home_dir| home_dir.join("Library/Logs/Mullvad VPN")),
         )
@@ -369,7 +369,7 @@ impl ProblemReport {
     }
 
     fn redact_home_dir(input: &str) -> Cow<'_, str> {
-        match dirs::home_dir() {
+        match dirs_next::home_dir() {
             Some(home) => Cow::from(input.replace(home.to_string_lossy().as_ref(), "~")),
             None => Cow::from(input),
         }


### PR DESCRIPTION
Since it is no longer being maintained: https://github.com/RustSec/advisory-db/blob/master/crates/dirs/RUSTSEC-2020-0053.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2372)
<!-- Reviewable:end -->
