### PR TITLE
Rework offline detection on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Line wrap the file at 100 chars.                                              Th
 - Prefer the last used API endpoint when the service starts back up, as well as in other tools such
   as the problem report tool.
 
+#### Linux
+- Improve offline check to query the routing table to allow users to use a bridged adapter as their
+  primary interface.
 
 ## [2020.8-beta2] - 2020-12-11
 This release is for desktop only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add header containing OS version to version-check API call to enable OS specific compatibility and
   vulnerability checks.
+- Add `TALPID_DISABLE_OFFLINE_MONITOR` environment variable to allow users to disable offline
+  detection.
 
 #### Android
 - Allow to configure the tunnel to use custom DNS servers.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ echo "org.gradle.jvmargs=-Xmx4608M" >> ~/.gradle/gradle.properties
          the servers specified on each interface.
   * `0`: Only set DNS servers on the tunnel interface. This will misbehave if local custom DNS
          servers are used.
+* `TALPID_DISABLE_OFFLINE_MONITOR` - Forces the daemon to always assume the host is online.
 
 
 ## Building and running the desktop Electron GUI app


### PR DESCRIPTION
To improve offline detection on Linux and desktop in general, I've done two things:
- Add an environment variable to allow disabling the offline check entirely, leaving it in an open state. This could later be reworked to being a proper option.
- Change offline detection on Linux to query the routing table for a path to a public IPv4 address to infer connectivity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2377)
<!-- Reviewable:end -->
