### PR TITLE
Fall back on LLMNR/NetBIOS name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Fix missing app window icon in Xfce.
 
+#### Windows
+- Resolve single-label hostnames correctly.
+
 ### Security
 #### Linux
 - Prevent the private tunnel IPv6 address from being detectable on a local network when using

--- a/README.md
+++ b/README.md
@@ -369,6 +369,12 @@ echo "org.gradle.jvmargs=-Xmx4608M" >> ~/.gradle/gradle.properties
 * `TALPID_FORCE_USERSPACE_WIREGUARD` - Forces the daemon to use the userspace implementation of
    WireGuard on Linux.
 
+* `TALPID_DNS_CACHE_POLICY` - On Windows, this changes how DNS is configured:
+  * `1`: The default. This sets a global list of DNS servers that `dnscache` will use instead of
+         the servers specified on each interface.
+  * `0`: Only set DNS servers on the tunnel interface. This will misbehave if local custom DNS
+         servers are used.
+
 
 ## Building and running the desktop Electron GUI app
 

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -1,7 +1,10 @@
 use crate::logging::windows::{log_sink, LogSink};
 
+use lazy_static::lazy_static;
 use log::{error, trace, warn};
-use std::{ffi::OsString, io, iter, mem, net::IpAddr, os::windows::ffi::OsStrExt, path::Path, ptr};
+use std::{
+    env, ffi::OsString, io, iter, mem, net::IpAddr, os::windows::ffi::OsStrExt, path::Path, ptr,
+};
 use talpid_types::ErrorExt;
 use widestring::WideCString;
 use winapi::um::{
@@ -20,6 +23,13 @@ use self::system_state::SystemStateWriter;
 
 const DNS_STATE_FILENAME: &'static str = "dns-state-backup";
 const DNS_CACHE_POLICY_GUID: &str = "{d57d2750-f971-408e-8e55-cfddb37e60ae}";
+
+lazy_static! {
+    /// Specifies whether to override per-interface DNS resolvers with a global DNS policy.
+    static ref GLOBAL_DNS_CACHE_POLICY: bool = env::var("TALPID_DNS_CACHE_POLICY")
+        .map(|v| v != "0")
+        .unwrap_or(true);
+}
 
 /// Errors that can happen when configuring DNS on Windows.
 #[derive(err_derive::Error, Debug)]
@@ -49,15 +59,6 @@ impl super::DnsMonitorT for DnsMonitor {
     fn new(cache_dir: impl AsRef<Path>) -> Result<Self, Error> {
         unsafe { WinDns_Initialize(Some(log_sink), b"WinDns\0".as_ptr()).into_result()? };
 
-        if is_minimum_windows10() {
-            if let Err(error) = reset_dns_cache_policy() {
-                error!(
-                    "{}",
-                    error.display_chain_with_msg("Failed to reset DNS cache policy")
-                );
-            }
-        }
-
         let backup_writer = SystemStateWriter::new(
             cache_dir
                 .as_ref()
@@ -65,7 +66,11 @@ impl super::DnsMonitorT for DnsMonitor {
                 .into_boxed_path(),
         );
         let _ = backup_writer.remove_backup();
-        Ok(DnsMonitor {})
+
+        let mut monitor = DnsMonitor {};
+        monitor.reset()?;
+
+        Ok(monitor)
     }
 
     fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<(), Error> {
@@ -103,7 +108,7 @@ impl super::DnsMonitorT for DnsMonitor {
             .into_result()
         }?;
 
-        if is_minimum_windows10() {
+        if *GLOBAL_DNS_CACHE_POLICY && is_minimum_windows10() {
             if let Err(error) = set_dns_cache_policy(servers) {
                 error!("{}", error.display_chain());
                 warn!("DNS resolution may be slowed down");
@@ -114,7 +119,7 @@ impl super::DnsMonitorT for DnsMonitor {
     }
 
     fn reset(&mut self) -> Result<(), Error> {
-        if is_minimum_windows10() {
+        if *GLOBAL_DNS_CACHE_POLICY && is_minimum_windows10() {
             reset_dns_cache_policy()
         } else {
             Ok(())
@@ -128,7 +133,7 @@ fn ip_to_widestring(ip: &IpAddr) -> WideCString {
 
 impl Drop for DnsMonitor {
     fn drop(&mut self) {
-        if is_minimum_windows10() {
+        if *GLOBAL_DNS_CACHE_POLICY && is_minimum_windows10() {
             if let Err(error) = reset_dns_cache_policy() {
                 warn!(
                     "{}",


### PR DESCRIPTION
Support for custom DNS was included in the last beta release, and it involved some changes to how DNS is managed. This was because the interface metric was tied to DNS resolver preference in Windows 10, and this worked poorly with local resolvers.

This change caused problems for single-label names (e.g., NetBIOS names). If DNS resolution failed, it would not fall back on using LLMNR. Hence other hosts on a LAN were no longer being identified.

For whatever reason, the [least strict](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnrpt/b5760f13-0a23-4e37-9253-ad12af60e8a6) setting must be used, i.e. "Always fall back to LLMNR and NetBIOS for any kind of name resolution error.". Otherwise, names do not resolve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2378)
<!-- Reviewable:end -->
