### PR TITLE
Migrate cache files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Line wrap the file at 100 chars.                                              Th
 - Allow the API to be accessed while in a blocking state.
 - Prefer the last used API endpoint when the service starts back up, as well as in other tools such
   as the problem report tool.
+- Migrate cache to a directory readable by all users, consistent with Android and Linux.
 
 #### Linux
 - Improve offline check to query the routing table to allow users to use a bridged adapter as their

--- a/README.md
+++ b/README.md
@@ -608,8 +608,8 @@ The cache directory can be changed by setting the `MULLVAD_CACHE_DIR` environmen
 | Platform | Path |
 |----------|------|
 | Linux | `/var/cache/mullvad-vpn/` |
-| macOS | `/var/root/Library/Caches/mullvad-vpn/` |
-| Windows | `%LOCALAPPDATA%\Mullvad VPN\` |
+| macOS | `/Library/Caches/mullvad-vpn/` |
+| Windows | `C:\ProgramData\Mullvad VPN\cache` |
 | Android | `/data/data/net.mullvad.mullvadvpn/cache` |
 
 #### RPC address file

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -11,65 +11,10 @@ exec 2>&1 > $LOG_DIR/preinstall.log
 
 echo "Running preinstall at $(date)"
 
-# Uninstall <=2018.1 versions of the app
-OLD_INSTALL_DIR="/Applications/MullvadVPN.app"
-if [ -d "$OLD_INSTALL_DIR" ]; then
-    echo "Found old Mullvad VPN install at $OLD_INSTALL_DIR. Stopping and uninstalling"
-    pkill MullvadVPN || echo "Unable to kill MullvadVPN, not running?"
-    pkill mullvad-daemon || echo "Unable to kill mullvad-daemon, not running?"
-    sleep 0.5
-    rm -r "$OLD_INSTALL_DIR"
-fi
+# Migrate cache files from <=2020.8-beta2 paths
+OLD_CACHE_DIR="/var/root/Library/Caches/mullvad-vpn"
+NEW_CACHE_DIR="/Library/Caches/mullvad-vpn"
 
-# Migrate settings from <=2018.1 paths
-OLD_SETTINGS_DIR="$HOME/Library/Application Support/mullvad-daemon"
-NEW_SETTINGS_DIR="/etc/mullvad-vpn"
-if [ -d "$OLD_SETTINGS_DIR" ]; then
-    echo "Found old setting dir $OLD_SETTINGS_DIR. Moving to $NEW_SETTINGS_DIR"
-    mkdir -p "$NEW_SETTINGS_DIR"
-    mv "$OLD_SETTINGS_DIR/settings.json" "$NEW_SETTINGS_DIR/settings.json" || \
-        echo "Unable to migrate settings, not present in old dir?"
-    rm -rf "$OLD_SETTINGS_DIR"
-fi
-
-# Migrate settings from <=2018.2-betaX paths
-OLD_SETTINGS_DIR="/etc/mullvad-daemon"
-NEW_SETTINGS_DIR="/etc/mullvad-vpn"
-if [ -d "$OLD_SETTINGS_DIR" ]; then
-    echo "Found old setting dir $OLD_SETTINGS_DIR. Moving to $NEW_SETTINGS_DIR"
-    mkdir -p "$NEW_SETTINGS_DIR"
-    mv "$OLD_SETTINGS_DIR/settings.json" "$NEW_SETTINGS_DIR/settings.json" || \
-        echo "Unable to migrate settings, not present in old dir?"
-    rm -rf "$OLD_SETTINGS_DIR"
-fi
-
-# Delete logs from <=2018.1 paths
-OLD_LOG_DIR="$HOME/Library/Logs/MullvadVPN"
-if [ -d "$OLD_LOG_DIR" ]; then
-    echo "Found old log dir $OLD_LOG_DIR. Deleting"
-    rm -rf "$OLD_LOG_DIR"
-fi
-
-# Delete logs from <=2018.2-betaX paths
-OLD_LOG_DIR="/var/log/mullvad-daemon"
-if [ -d "$OLD_LOG_DIR" ]; then
-    echo "Found old log dir $OLD_LOG_DIR. Deleting"
-    rm -rf "$OLD_LOG_DIR"
-fi
-
-# Migrate cache files from <=2018.1 paths
-OLD_CACHE_DIR="$HOME/Library/Caches/mullvad-daemon"
-NEW_CACHE_DIR="/var/root/Library/Caches/mullvad-vpn"
-if [ -d "$OLD_CACHE_DIR" ]; then
-    echo "Found old cache dir at $OLD_CACHE_DIR, moving to $NEW_CACHE_DIR"
-    mkdir -p "$NEW_CACHE_DIR"
-    mv "$OLD_CACHE_DIR"/* "$NEW_CACHE_DIR/" || echo "Unable to migrate cache. No cache files?"
-    rm -rf "$OLD_CACHE_DIR"
-fi
-
-# Migrate cache files from <=2018.2-betaX paths
-OLD_CACHE_DIR="/var/root/Library/Caches/mullvad-daemon"
-NEW_CACHE_DIR="/var/root/Library/Caches/mullvad-vpn"
 if [ -d "$OLD_CACHE_DIR" ]; then
     echo "Found old cache dir at $OLD_CACHE_DIR, moving to $NEW_CACHE_DIR"
     mkdir -p "$NEW_CACHE_DIR"
@@ -80,10 +25,7 @@ fi
 # Remove the existing relay and API address cache lists.
 # There is a risk that they're incompatible with the format this version wants
 rm "$NEW_CACHE_DIR/relays.json" || true
-# Old API IP cache
 rm "$NEW_CACHE_DIR/api-ip-address.txt" || true
-# New API IP cache
-rm "/Library/Caches/mullvad-vpn/api-ip-address.txt" || true
 
 # Notify the running daemon that we are going to kill it and replace it with a newer version.
 # This will make the daemon save it's state to a file and then lock the firewall to prevent

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -324,6 +324,40 @@
 !define InstallTrayIcon '!insertmacro "InstallTrayIcon"'
 
 #
+# MigrateCache
+#
+# Move old cache files to the new cache directory.
+# This is for upgrades from versions <= 2020.8-beta2.
+#
+!macro MigrateCache
+
+	log::Log "MigrateCache()"
+
+	Push $0
+	Push $1
+
+	cleanup::MigrateCache
+
+	Pop $0
+	Pop $1
+
+	${If} $0 != ${MULLVAD_SUCCESS}
+		log::Log "Failed to migrate cache: $1"
+		Goto MigrateCache_return
+	${EndIf}
+
+	log::Log "MigrateCache() completed successfully"
+
+	MigrateCache_return:
+
+	Pop $1
+	Pop $0
+
+!macroend
+
+!define MigrateCache '!insertmacro "MigrateCache"'
+
+#
 # RemoveLogsAndCache
 #
 # Call into helper DLL instructing it to remove all logs and cache
@@ -628,6 +662,7 @@
 	SetShellVarContext current
 	RMDir /r "$LOCALAPPDATA\mullvad-vpn-updater"
 
+	${MigrateCache}
 	${RemoveRelayCache}
 	${RemoveApiAddressCache}
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -485,7 +485,6 @@ where
         resource_dir: PathBuf,
         settings_dir: PathBuf,
         cache_dir: PathBuf,
-        user_cache_dir: PathBuf,
         event_listener: L,
         command_channel: DaemonCommandChannel,
         #[cfg(target_os = "android")] android_context: AndroidContext,
@@ -500,7 +499,7 @@ where
         let mut rpc_runtime = mullvad_rpc::MullvadRpcRuntime::with_cache(
             tokio::runtime::Handle::current(),
             Some(&resource_dir),
-            &user_cache_dir,
+            &cache_dir,
             true,
             move |address| {
                 let (result_tx, result_rx) = oneshot::channel();

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -123,8 +123,6 @@ async fn create_daemon(
         .map_err(|e| e.display_chain_with_msg("Unable to get settings dir"))?;
     let cache_dir = mullvad_paths::cache_dir()
         .map_err(|e| e.display_chain_with_msg("Unable to get cache dir"))?;
-    let user_cache_dir = mullvad_paths::user_cache_dir()
-        .map_err(|e| e.display_chain_with_msg("Unable to get user cache dir"))?;
 
     let command_channel = DaemonCommandChannel::new();
     let event_listener = spawn_management_interface(command_channel.sender()).await?;
@@ -134,7 +132,6 @@ async fn create_daemon(
         resource_dir,
         settings_dir,
         cache_dir,
-        user_cache_dir,
         event_listener,
         command_channel,
     )

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -236,7 +236,6 @@ fn spawn_daemon(
             Some(resource_dir.clone()),
             resource_dir.clone(),
             resource_dir,
-            cache_dir.clone(),
             cache_dir,
             listener,
             command_channel,

--- a/mullvad-paths/src/cache.rs
+++ b/mullvad-paths/src/cache.rs
@@ -4,10 +4,14 @@ use std::{env, path::PathBuf};
 /// Creates and returns the cache directory pointed to by `MULLVAD_CACHE_DIR`, or the default
 /// one if that variable is unset.
 pub fn cache_dir() -> Result<PathBuf> {
-    crate::create_and_return(get_cache_dir, None)
+    #[cfg(not(target_os = "macos"))]
+    let permissions = None;
+    #[cfg(target_os = "macos")]
+    let permissions = Some(std::os::unix::fs::PermissionsExt::from_mode(0o755));
+    crate::create_and_return(get_cache_dir, permissions)
 }
 
-fn get_cache_dir() -> Result<PathBuf> {
+pub fn get_cache_dir() -> Result<PathBuf> {
     match env::var_os("MULLVAD_CACHE_DIR") {
         Some(path) => Ok(PathBuf::from(path)),
         None => get_default_cache_dir(),
@@ -20,39 +24,22 @@ pub fn get_default_cache_dir() -> Result<PathBuf> {
         let dir;
         #[cfg(target_os = "linux")]
         {
-            dir = Ok(PathBuf::from("/var/cache"))
+            dir = PathBuf::from("/var/cache").join(crate::PRODUCT_NAME);
         }
-        #[cfg(any(target_os = "macos", windows))]
+        #[cfg(windows)]
         {
-            dir = dirs_next::cache_dir().ok_or_else(|| crate::Error::FindDirError)
+            dir = crate::get_allusersprofile_dir()?
+                .join(crate::PRODUCT_NAME)
+                .join("cache");
         }
-        dir.map(|dir| dir.join(crate::PRODUCT_NAME))
+        #[cfg(target_os = "macos")]
+        {
+            dir = std::path::Path::new("/Library/Caches").join(crate::PRODUCT_NAME);
+        }
+        Ok(dir)
     }
     #[cfg(target_os = "android")]
     {
         Ok(std::path::Path::new(crate::APP_PATH).join("cache"))
     }
-}
-
-/// Creates and returns a cache directory that is readable by all users.
-pub fn user_cache_dir() -> Result<PathBuf> {
-    #[cfg(not(target_os = "macos"))]
-    let permissions = None;
-    #[cfg(target_os = "macos")]
-    let permissions = Some(std::os::unix::fs::PermissionsExt::from_mode(0o755));
-    crate::create_and_return(get_user_cache_dir, permissions)
-}
-
-pub fn get_user_cache_dir() -> Result<PathBuf> {
-    #[cfg(windows)]
-    {
-        let dir = crate::get_allusersprofile_dir();
-        dir.map(|dir| dir.join(crate::PRODUCT_NAME))
-    }
-    #[cfg(target_os = "macos")]
-    {
-        Ok(std::path::Path::new("/Library/Caches").join(crate::PRODUCT_NAME))
-    }
-    #[cfg(not(any(target_os = "macos", windows)))]
-    get_cache_dir()
 }

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -56,7 +56,7 @@ fn create_and_return(
 }
 
 mod cache;
-pub use crate::cache::{cache_dir, get_default_cache_dir, get_user_cache_dir, user_cache_dir};
+pub use crate::cache::{cache_dir, get_cache_dir, get_default_cache_dir};
 
 mod logs;
 pub use crate::logs::{get_default_log_dir, get_log_dir, log_dir};

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -256,7 +256,7 @@ pub fn send_problem_report(
     user_email: &str,
     user_message: &str,
     report_path: &Path,
-    user_cache_dir: &Path,
+    cache_dir: &Path,
 ) -> Result<(), Error> {
     let report_content = normalize_newlines(
         read_file_lossy(report_path, REPORT_MAX_SIZE).map_err(|source| {
@@ -279,7 +279,7 @@ pub fn send_problem_report(
         .block_on(mullvad_rpc::MullvadRpcRuntime::with_cache(
             runtime.handle().clone(),
             None,
-            user_cache_dir,
+            cache_dir,
             false,
             |_| Ok(()),
         ))

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -113,8 +113,8 @@ fn run() -> Result<(), Error> {
         let report_path = Path::new(send_matches.value_of_os("report").unwrap());
         let user_email = send_matches.value_of("email").unwrap_or("");
         let user_message = send_matches.value_of("message").unwrap_or("");
-        let user_cache_dir = mullvad_paths::get_user_cache_dir()?;
-        send_problem_report(user_email, user_message, report_path, &user_cache_dir)
+        let cache_dir = mullvad_paths::get_cache_dir()?;
+        send_problem_report(user_email, user_message, report_path, &cache_dir)
     } else {
         unreachable!("No sub command given");
     }

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -152,12 +152,12 @@ async fn reset_firewall() -> Result<(), Error> {
 }
 
 async fn clear_history() -> Result<(), Error> {
-    let (user_cache_path, settings_path) = get_paths()?;
+    let (cache_path, settings_path) = get_paths()?;
 
     let mut rpc_runtime = MullvadRpcRuntime::with_cache(
         tokio::runtime::Handle::current(),
         None,
-        &user_cache_path,
+        &cache_path,
         false,
         |_| Ok(()),
     )
@@ -165,7 +165,7 @@ async fn clear_history() -> Result<(), Error> {
     .map_err(Error::RpcInitializationError)?;
 
     let mut account_history = account_history::AccountHistory::new(
-        &user_cache_path,
+        &cache_path,
         &settings_path,
         rpc_runtime.mullvad_rest_handle(),
     )
@@ -180,15 +180,15 @@ async fn clear_history() -> Result<(), Error> {
 
 #[cfg(not(windows))]
 fn get_paths() -> Result<(PathBuf, PathBuf), Error> {
-    let user_cache_path = mullvad_paths::user_cache_dir().map_err(Error::CachePathError)?;
+    let cache_path = mullvad_paths::cache_dir().map_err(Error::CachePathError)?;
     let settings_path = mullvad_paths::settings_dir().map_err(Error::SettingsPathError)?;
-    Ok((user_cache_path, settings_path))
+    Ok((cache_path, settings_path))
 }
 
 #[cfg(windows)]
 fn get_paths() -> Result<(PathBuf, PathBuf), Error> {
-    let user_cache_path = mullvad_paths::user_cache_dir().map_err(Error::CachePathError)?;
+    let cache_path = mullvad_paths::cache_dir().map_err(Error::CachePathError)?;
     let settings_path =
         daemon_paths::get_mullvad_daemon_settings_path().map_err(Error::SettingsPathError)?;
-    Ok((user_cache_path, settings_path))
+    Ok((cache_path, settings_path))
 }

--- a/windows/nsis-plugins/src/cleanup/cleaningops.h
+++ b/windows/nsis-plugins/src/cleanup/cleaningops.h
@@ -3,6 +3,8 @@
 namespace cleaningops
 {
 
+void MigrateCacheServiceUser();
+
 void RemoveLogsCacheCurrentUser();
 void RemoveLogsCacheOtherUsers();
 void RemoveLogsServiceUser();

--- a/windows/nsis-plugins/src/cleanup/cleanup.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleanup.cpp
@@ -23,8 +23,8 @@ void __declspec(dllexport) NSISCALL RemoveLogsAndCache
 	{
 		cleaningops::RemoveLogsCacheCurrentUser,
 		cleaningops::RemoveLogsCacheOtherUsers,
-		cleaningops::RemoveLogsServiceUser,
 		cleaningops::RemoveCacheServiceUser,
+		cleaningops::RemoveLogsServiceUser,
 	};
 
 	bool success = true;
@@ -45,6 +45,36 @@ void __declspec(dllexport) NSISCALL RemoveLogsAndCache
 	}
 
 	pushint(success ? NsisStatus::SUCCESS : NsisStatus::GENERAL_ERROR);
+}
+
+void __declspec(dllexport) NSISCALL MigrateCache
+(
+	HWND hwndParent,
+	int string_size,
+	LPTSTR variables,
+	stack_t** stacktop,
+	extra_parameters* extra,
+	...
+)
+{
+	EXDLL_INIT();
+
+	try
+	{
+		cleaningops::MigrateCacheServiceUser();
+		pushstring(L"");
+		pushint(NsisStatus::SUCCESS);
+	}
+	catch (std::exception &err)
+	{
+		pushstring(common::string::ToWide(err.what()).c_str());
+		pushint(NsisStatus::GENERAL_ERROR);
+	}
+	catch (...)
+	{
+		pushstring(L"Unspecified error");
+		pushint(NsisStatus::GENERAL_ERROR);
+	}
 }
 
 void __declspec(dllexport) NSISCALL RemoveSettings

--- a/windows/nsis-plugins/src/cleanup/cleanup.def
+++ b/windows/nsis-plugins/src/cleanup/cleanup.def
@@ -2,6 +2,7 @@ LIBRARY cleanup
 
 EXPORTS
 
+MigrateCache
 RemoveLogsAndCache
 RemoveSettings
 RemoveRelayCache


### PR DESCRIPTION
The cache directory is currently found in `C:\Windows\System32\config\systemprofile\AppData\Local\Mullvad VPN`. This is a problem for the problem report tool, which needs to be able to obtain the API addresses, even if it is not run as the SYSTEM user (or even admin). For this reason, `api-ip-address.txt` is currently stored in a separate cache directory to which anyone has read access (but not write access). This PR consolidates the two cache directories into `C:\ProgramData\Mullvad VPN\cache`.

The above description is for Windows, but an analogous change had to be made for macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2384)
<!-- Reviewable:end -->
