### PR TITLE
Only inspect main table for offline check

### DIFF
--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -135,6 +135,9 @@ async fn public_ip_unreachable(handle: &Handle) -> Result<bool> {
         .map_err(Error::GetRouteError)?
     {
         for nla in message.nlas.iter() {
+            if message.header.table != libc::RT_TABLE_MAIN {
+                continue;
+            }
             if let RouteNla::Gateway(_) | RouteNla::Oif(_) = nla {
                 return Ok(false);
             }


### PR DESCRIPTION
To reduce false negatives in the offline monitor, the offline check should only take into account routes in the main routing table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2385)
<!-- Reviewable:end -->
