### PR TITLE
Do not sleep after waking from suspend mode on Windows

### DIFF
--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -4,36 +4,8 @@ use parking_lot::Mutex;
 use std::{
     ffi::c_void,
     io,
-    mem::zeroed,
-    os::windows::io::{IntoRawHandle, RawHandle},
-    ptr,
     sync::{Arc, Weak},
-    thread,
-    time::Duration,
 };
-use winapi::{
-    shared::{
-        basetsd::LONG_PTR,
-        minwindef::{DWORD, LPARAM, LRESULT, UINT, WPARAM},
-        windef::HWND,
-    },
-    um::{
-        handleapi::CloseHandle,
-        libloaderapi::GetModuleHandleW,
-        processthreadsapi::GetThreadId,
-        synchapi::WaitForSingleObject,
-        winbase::INFINITE,
-        winuser::{
-            CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
-            GetWindowLongPtrW, PostQuitMessage, PostThreadMessageW, SetWindowLongPtrW,
-            GWLP_USERDATA, GWLP_WNDPROC, PBT_APMRESUMEAUTOMATIC, PBT_APMSUSPEND, WM_DESTROY,
-            WM_POWERBROADCAST, WM_USER,
-        },
-    },
-};
-
-const CLASS_NAME: &[u8] = b"S\0T\0A\0T\0I\0C\0\0\0";
-const REQUEST_THREAD_SHUTDOWN: UINT = WM_USER + 1;
 
 
 #[derive(err_derive::Error, Debug)]
@@ -46,8 +18,6 @@ pub enum Error {
 
 
 pub struct BroadcastListener {
-    thread_handle: RawHandle,
-    thread_id: DWORD,
     _system_state: Arc<Mutex<SystemState>>,
 }
 
@@ -57,127 +27,14 @@ impl BroadcastListener {
     pub fn start(sender: Weak<UnboundedSender<TunnelCommand>>) -> Result<Self, Error> {
         let mut system_state = Arc::new(Mutex::new(SystemState {
             network_connectivity: None,
-            suspended: false,
             daemon_channel: sender,
         }));
-
-        let power_broadcast_state_ref = system_state.clone();
-
-        let power_broadcast_callback = move |message: UINT, wparam: WPARAM, _lparam: LPARAM| {
-            let state = power_broadcast_state_ref.clone();
-            if message == WM_POWERBROADCAST {
-                if wparam == PBT_APMSUSPEND {
-                    log::debug!("Machine is preparing to enter sleep mode");
-                    apply_system_state_change(state, StateChange::Suspended(true));
-                } else if wparam == PBT_APMRESUMEAUTOMATIC {
-                    log::debug!("Machine is returning from sleep mode");
-                    thread::spawn(move || {
-                        // TAP will be unavailable for approximately 2 seconds on a healthy machine.
-                        thread::sleep(Duration::from_secs(5));
-                        log::debug!("TAP is presumed to have been re-initialized");
-                        apply_system_state_change(state, StateChange::Suspended(false));
-                    });
-                }
-            }
-        };
-
-        let join_handle = thread::Builder::new()
-            .spawn(move || unsafe {
-                Self::message_pump(power_broadcast_callback);
-            })
-            .map_err(Error::ThreadCreationError)?;
-
-        let real_handle = join_handle.into_raw_handle();
 
         unsafe { Self::setup_network_connectivity_listener(&mut system_state)? };
 
         Ok(BroadcastListener {
-            thread_handle: real_handle,
-            thread_id: unsafe { GetThreadId(real_handle) },
             _system_state: system_state,
         })
-    }
-
-    unsafe fn message_pump<F>(client_callback: F)
-    where
-        F: Fn(UINT, WPARAM, LPARAM),
-    {
-        let dummy_window = CreateWindowExW(
-            0,
-            CLASS_NAME.as_ptr() as *const u16,
-            ptr::null_mut(),
-            0,
-            0,
-            0,
-            0,
-            0,
-            ptr::null_mut(),
-            ptr::null_mut(),
-            GetModuleHandleW(ptr::null_mut()),
-            ptr::null_mut(),
-        );
-
-        // Move callback information to the heap.
-        // This enables us to reach the callback through a "thin pointer".
-        let boxed_callback = Box::new(client_callback);
-
-        // Detach callback from Box.
-        let raw_callback = Box::into_raw(boxed_callback) as *mut c_void;
-
-        SetWindowLongPtrW(dummy_window, GWLP_USERDATA, raw_callback as LONG_PTR);
-        SetWindowLongPtrW(
-            dummy_window,
-            GWLP_WNDPROC,
-            Self::window_procedure::<F> as LONG_PTR,
-        );
-
-        let mut msg = zeroed();
-
-        loop {
-            let status = GetMessageW(&mut msg, 0 as HWND, 0, 0);
-
-            if status < 0 {
-                continue;
-            }
-            if status == 0 {
-                break;
-            }
-
-            if msg.hwnd.is_null() {
-                if msg.message == REQUEST_THREAD_SHUTDOWN {
-                    DestroyWindow(dummy_window);
-                }
-            } else {
-                DispatchMessageW(&mut msg);
-            }
-        }
-
-        // Reattach callback to Box for proper clean-up.
-        let _ = Box::from_raw(raw_callback as *mut F);
-    }
-
-    unsafe extern "system" fn window_procedure<F>(
-        window: HWND,
-        message: UINT,
-        wparam: WPARAM,
-        lparam: LPARAM,
-    ) -> LRESULT
-    where
-        F: Fn(UINT, WPARAM, LPARAM),
-    {
-        let raw_callback = GetWindowLongPtrW(window, GWLP_USERDATA);
-
-        if raw_callback != 0 {
-            let typed_callback = &mut *(raw_callback as *mut F);
-            typed_callback(message, wparam, lparam);
-        }
-
-        if message == WM_DESTROY {
-            PostQuitMessage(0);
-            return 0;
-        }
-
-        DefWindowProcW(window, message, wparam, lparam)
     }
 
     /// The caller must make sure the `system_state` reference is valid
@@ -212,9 +69,6 @@ impl BroadcastListener {
 impl Drop for BroadcastListener {
     fn drop(&mut self) {
         unsafe {
-            PostThreadMessageW(self.thread_id, REQUEST_THREAD_SHUTDOWN, 0, 0);
-            WaitForSingleObject(self.thread_handle, INFINITE);
-            CloseHandle(self.thread_handle);
             winnet::WinNet_DeactivateConnectivityMonitor();
         }
     }
@@ -223,12 +77,10 @@ impl Drop for BroadcastListener {
 #[derive(Debug)]
 enum StateChange {
     NetworkConnectivity(bool),
-    Suspended(bool),
 }
 
 struct SystemState {
     network_connectivity: Option<bool>,
-    suspended: bool,
     daemon_channel: Weak<UnboundedSender<TunnelCommand>>,
 }
 
@@ -238,10 +90,6 @@ impl SystemState {
         match change {
             StateChange::NetworkConnectivity(connectivity) => {
                 self.network_connectivity = Some(connectivity);
-            }
-
-            StateChange::Suspended(suspended) => {
-                self.suspended = suspended;
             }
         };
 
@@ -258,7 +106,7 @@ impl SystemState {
     }
 
     fn is_offline_currently(&self) -> Option<bool> {
-        Some(!self.network_connectivity? || self.suspended)
+        Some(!self.network_connectivity?)
     }
 }
 
@@ -268,9 +116,4 @@ pub async fn spawn_monitor(
     sender: Weak<UnboundedSender<TunnelCommand>>,
 ) -> Result<MonitorHandle, Error> {
     BroadcastListener::start(sender)
-}
-
-fn apply_system_state_change(state: Arc<Mutex<SystemState>>, change: StateChange) {
-    let mut state = state.lock();
-    state.apply_change(change);
 }


### PR DESCRIPTION
The daemon currently sleeps after resuming from suspend/hibernation, because it took a while for the TAP adapter to be usable. This was removed since Wintun is now used for OpenVPN.

Do not merge yet since I haven't been able to reproduce the original issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2387)
<!-- Reviewable:end -->
