### PR TITLE
Fix issue with --cipher argument

### DIFF
--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -29,7 +29,7 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--rcvbuf", "1048576"],
     &["--sndbuf", "1048576"],
     &["--fast-io"],
-    &["--cipher", "AES-256-CBC"],
+    &["--data-ciphers-fallback", "AES-256-GCM"],
     &["--tls-version-min", "1.3"],
     &["--verb", "3"],
     #[cfg(windows)]


### PR DESCRIPTION
Since our upgrade to OpenVPN 2.5 our `openvpn.log` has started out with:
```
2021-01-08 15:42:18 DEPRECATED OPTION: --cipher set to 'AES-256-CBC' but missing in --data-ciphers (AES-256-GCM:AES-128-GCM). Future OpenVPN version will ignore --cipher for cipher negotiations. Add 'AES-256-CBC' to --data-ciphers or change --cipher 'AES-256-CBC' to --data-ciphers-fallback 'AES-256-CBC' to silence this warning.
```
This PR fixes that.

I wanted to get rid of `--cipher AES-256-CBC` completely and only rely on `AES-256-GCM` since that's what we end up using anyway thanks to NCP. But this did not work. Our servers have `--cipher AES-256-CBC` specified, so if my `--cipher` or `--data-ciphers` did *not* contain CBC it failed with an error (unable to negotiate cipher) and if I did include it it did use CBC instead of GCM, which would give worse performance. So this was the only solution I could find.

Sadly this introduced **another** warning:
```
2021-01-13 15:02:33 WARNING: 'auth' is used inconsistently, local='auth [null-digest]', remote='auth SHA1'
```
And the strange part is that I get the same warning even if I specify `--auth SHA512` :shrug:. Either way, it should agree on a better digest algorithm thanks to NCP, it's just the log being a bit grumpy. The same was true for the state before this PR even, but the new warning sounds a bit less scary than the old one.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2388)
<!-- Reviewable:end -->
