### PR TITLE
Remove menubar on Windows

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1478,17 +1478,21 @@ class ApplicationMain {
         return appWindow;
       }
 
-      case 'win32':
+      case 'win32': {
         // setup window flags to mimic an overlay window
-        return new BrowserWindow({
+        const appWindow = new BrowserWindow({
           ...options,
           // Due to a bug in Electron the app is sometimes placed behind other apps when opened.
           // Setting alwaysOnTop to true ensures that the app is placed on top. Electron issue:
           // https://github.com/electron/electron/issues/25915
           alwaysOnTop: !this.guiSettings.unpinnedWindow,
           skipTaskbar: !this.guiSettings.unpinnedWindow,
-          autoHideMenuBar: true,
         });
+
+        appWindow.removeMenu();
+
+        return appWindow;
+      }
 
       case 'linux':
         return new BrowserWindow({


### PR DESCRIPTION
This PR disables the menubar in the Windows app. The menu should never be displayed but was possible to toggle by pressing `alt`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2393)
<!-- Reviewable:end -->
