### PR TITLE
Run `MullvadVpnService` on a separate process on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Line wrap the file at 100 chars.                                              Th
 - Only allow packets with the mark set to `0x6d6f6c65` to communicate with the relay server.
   Previously, bridges were expected to run as root instead.
 
+#### Android
+- Improve stability by running the UI and the tunnel management logic in separate processes.
+
 ### Fixed
 - Fix relay selection failing to pick a WireGuard relay when no tunnel protocol is specified.
 - Fix time left not always being translated in desktop app settings.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -50,7 +50,8 @@
             </intent-filter>
         </activity>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"
-                 android:permission="android.permission.BIND_VPN_SERVICE">
+                 android:permission="android.permission.BIND_VPN_SERVICE"
+                 android:process=":mullvadvpn_daemon">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Message.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Message.kt
@@ -21,6 +21,8 @@ sealed class Message(private val messageId: Int) : Parcelable {
         internal fun <T : Parcelable> fromMessage(message: RawMessage, key: String): T? {
             val data = message.data
 
+            data.classLoader = Message::class.java.classLoader
+
             return data.getParcelable(key)
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -4,7 +4,6 @@ import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
 import android.net.VpnService
-import android.os.Binder
 import android.os.IBinder
 import android.os.Looper
 import android.util.Log
@@ -45,7 +44,6 @@ class MullvadVpnService : TalpidVpnService() {
         Stopped,
     }
 
-    private val binder = LocalBinder()
     private val serviceNotifier = EventNotifier<ServiceInstance?>(null)
 
     private val connectionProxy
@@ -193,15 +191,6 @@ class MullvadVpnService : TalpidVpnService() {
         daemonInstance.onDestroy()
         instance = null
         super.onDestroy()
-    }
-
-    inner class LocalBinder : Binder() {
-        val serviceNotifier
-            get() = this@MullvadVpnService.serviceNotifier
-
-        var isUiVisible
-            get() = this@MullvadVpnService.isUiVisible
-            set(value) { this@MullvadVpnService.isUiVisible = value }
     }
 
     private fun handleDaemonInstance(daemon: MullvadDaemon?) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -224,18 +224,18 @@ class MullvadVpnService : TalpidVpnService() {
             val settings = daemon.getSettings()
 
             if (settings != null) {
-                setUpInstance(daemon, settings)
+                setUpInstance(settings)
             } else {
                 restart()
             }
         }
     }
 
-    private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
+    private suspend fun setUpInstance(settings: Settings) {
         handlePendingAction(settings)
 
         if (state == State.Running) {
-            instance = ServiceInstance(endpoint.messenger, daemon)
+            instance = ServiceInstance(endpoint.messenger)
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -18,7 +18,6 @@ import net.mullvad.mullvadvpn.service.notifications.AccountExpiryNotification
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
-import net.mullvad.talpid.util.EventNotifier
 
 class MullvadVpnService : TalpidVpnService() {
     companion object {
@@ -44,18 +43,12 @@ class MullvadVpnService : TalpidVpnService() {
         Stopped,
     }
 
-    private val serviceNotifier = EventNotifier<ServiceInstance?>(null)
-
     private val connectionProxy
         get() = endpoint.connectionProxy
 
     private var state = State.Running
 
     private var setUpDaemonJob: Job? = null
-
-    private var instance by observable<ServiceInstance?>(null) { _, _, newInstance ->
-        serviceNotifier.notifyIfChanged(newInstance)
-    }
 
     private lateinit var accountExpiryNotification: AccountExpiryNotification
     private lateinit var daemonInstance: DaemonInstance
@@ -65,12 +58,8 @@ class MullvadVpnService : TalpidVpnService() {
     private lateinit var tunnelStateUpdater: TunnelStateUpdater
 
     private var pendingAction by observable<PendingAction?>(null) { _, _, _ ->
-        // The service instance awaits the split tunneling initialization, which also starts the
-        // endpoint. So if the instance is not null, the endpoint has certainly been initialized.
-        if (instance != null) {
-            endpoint.settingsListener.settings?.let { settings ->
-                handlePendingAction(settings)
-            }
+        endpoint.settingsListener.settings?.let { settings ->
+            handlePendingAction(settings)
         }
     }
 
@@ -189,7 +178,6 @@ class MullvadVpnService : TalpidVpnService() {
         accountExpiryNotification.onDestroy()
         notificationManager.onDestroy()
         daemonInstance.onDestroy()
-        instance = null
         super.onDestroy()
     }
 
@@ -200,7 +188,6 @@ class MullvadVpnService : TalpidVpnService() {
             setUpDaemonJob = setUpDaemon(daemon)
         } else {
             Log.d(TAG, "Daemon has stopped")
-            instance = null
 
             if (state == State.Running) {
                 restart()
@@ -213,18 +200,10 @@ class MullvadVpnService : TalpidVpnService() {
             val settings = daemon.getSettings()
 
             if (settings != null) {
-                setUpInstance(settings)
+                handlePendingAction(settings)
             } else {
                 restart()
             }
-        }
-    }
-
-    private suspend fun setUpInstance(settings: Settings) {
-        handlePendingAction(settings)
-
-        if (state == State.Running) {
-            instance = ServiceInstance(endpoint.messenger)
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -158,7 +158,7 @@ class MullvadVpnService : TalpidVpnService() {
         Log.d(TAG, "New connection to service")
         isBound = true
 
-        return super.onBind(intent) ?: binder
+        return super.onBind(intent) ?: endpoint.messenger.binder
     }
 
     override fun onRebind(intent: Intent) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -2,4 +2,4 @@ package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
 
-class ServiceInstance(val messenger: Messenger, val daemon: MullvadDaemon)
+class ServiceInstance(val messenger: Messenger)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,5 +1,0 @@
-package net.mullvad.mullvadvpn.service
-
-import android.os.Messenger
-
-class ServiceInstance(val messenger: Messenger)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -10,6 +10,7 @@ import android.net.VpnService
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.os.Messenger
 import android.view.WindowManager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -27,7 +28,6 @@ open class MainActivity : FragmentActivity() {
     val serviceNotifier = EventNotifier<ServiceConnection?>(null)
 
     private var isUiVisible = false
-    private var service: MullvadVpnService.LocalBinder? = null
     private var visibleSecureScreens = HashSet<Fragment>()
 
     private val deviceIsTv by lazy {
@@ -49,27 +49,12 @@ open class MainActivity : FragmentActivity() {
     private val serviceConnectionManager = object : android.content.ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
             android.util.Log.d("mullvad", "UI successfully connected to the service")
-            val localBinder = binder as MullvadVpnService.LocalBinder
-
-            service = localBinder
-
-            localBinder.isUiVisible = isUiVisible
-
-            localBinder.serviceNotifier.subscribe(this@MainActivity) { service ->
-                android.util.Log.d("mullvad", "UI connection to the service changed: $service")
-
-                serviceConnection = service?.let { safeService ->
-                    ServiceConnection(safeService, ::handleNewServiceConnection).apply {
-                        vpnPermission.onRequest = ::requestVpnPermission
-                    }
-                }
-            }
+            serviceConnection = ServiceConnection(Messenger(binder), ::handleNewServiceConnection)
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
             android.util.Log.d("mullvad", "UI lost the connection to the service")
             serviceConnection = null
-            service = null
             serviceNotifier.notify(null)
         }
     }
@@ -127,7 +112,6 @@ open class MainActivity : FragmentActivity() {
     override fun onStop() {
         android.util.Log.d("mullvad", "Stoping main activity")
         isUiVisible = false
-        service = null
         unbindService(serviceConnectionManager)
 
         super.onStop()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
@@ -50,9 +49,6 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
     lateinit var customDns: CustomDns
         private set
 
-    lateinit var daemon: MullvadDaemon
-        private set
-
     lateinit var keyStatusListener: KeyStatusListener
         private set
 
@@ -76,7 +72,6 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         authTokenCache = serviceConnection.authTokenCache
         connectionProxy = serviceConnection.connectionProxy
         customDns = serviceConnection.customDns
-        daemon = serviceConnection.daemon
         keyStatusListener = serviceConnection.keyStatusListener
         locationInfoCache = serviceConnection.locationInfoCache
         relayListListener = serviceConnection.relayListListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -33,7 +33,6 @@ class ServiceConnection(
         named(SERVICE_CONNECTION_SCOPE), this
     )
 
-    val daemon = service.daemon
     val accountCache = AccountCache(service.messenger, dispatcher)
     val authTokenCache = AuthTokenCache(service.messenger, dispatcher)
     val connectionProxy = ConnectionProxy(service.messenger, dispatcher)


### PR DESCRIPTION
This is the final PR to run the `MullvadVpnService` in a separate process. It marks the service to run as a separate process in the manifest, and it removes the `LocalBinder` and the `ServiceInstance` that was used for communication. Now, all communication only happen through the IPC channel.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2396)
<!-- Reviewable:end -->
