### PR TITLE
Fix upgrade leak on macOS

### DIFF
--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -11,6 +11,12 @@ exec 2>&1 > $LOG_DIR/preinstall.log
 
 echo "Running preinstall at $(date)"
 
+# Notify the running daemon that we are going to kill it and replace it with a newer version.
+# This will make the daemon save it's state to a file and then lock the firewall to prevent
+# leaks during the upgrade.
+"$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" prepare-restart || \
+    echo "Failed to send 'prepare-restart' command to old mullvad-daemon"
+
 # Migrate cache files from <=2020.8-beta2 paths
 OLD_CACHE_DIR="/var/root/Library/Caches/mullvad-vpn"
 NEW_CACHE_DIR="/Library/Caches/mullvad-vpn"
@@ -26,9 +32,3 @@ fi
 # There is a risk that they're incompatible with the format this version wants
 rm "$NEW_CACHE_DIR/relays.json" || true
 rm "$NEW_CACHE_DIR/api-ip-address.txt" || true
-
-# Notify the running daemon that we are going to kill it and replace it with a newer version.
-# This will make the daemon save it's state to a file and then lock the firewall to prevent
-# leaks during the upgrade.
-"$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" prepare-restart || \
-    echo "Failed to send 'prepare-restart' command to old mullvad-daemon"

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -12,8 +12,6 @@ exec 2>&1 > $LOG_DIR/preinstall.log
 echo "Running preinstall at $(date)"
 
 # Notify the running daemon that we are going to kill it and replace it with a newer version.
-# This will make the daemon save it's state to a file and then lock the firewall to prevent
-# leaks during the upgrade.
 "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" prepare-restart || \
     echo "Failed to send 'prepare-restart' command to old mullvad-daemon"
 


### PR DESCRIPTION
Fixes an issue where the daemon does not restore the correct target state after upgrading on macOS, if auto-connect is disabled and the target state is "secured". This is simply because `mullvad-setup prepare-restart` is run before the migration code (#2384), and `target-start-state.json` is not moved to the new cache directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2397)
<!-- Reviewable:end -->
