### PR TITLE
Enable GUI API calls when in the blocked state

### DIFF
--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -256,11 +256,7 @@ export default class ExpiredAccountErrorView extends React.Component<
   }
 
   private onOpenRedeemVoucherAlert = () => {
-    if (this.getRecoveryAction() === RecoveryAction.disableBlockedWhenDisconnected) {
-      this.setState({ showBlockWhenDisconnectedAlert: true });
-    } else {
-      this.setState({ showRedeemVoucherAlert: true });
-    }
+    this.setState({ showRedeemVoucherAlert: true });
   };
 
   private onCloseRedeemVoucherAlert = () => {

--- a/gui/src/renderer/components/RedeemVoucher.tsx
+++ b/gui/src/renderer/components/RedeemVoucher.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useContext, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { VoucherResponse } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import { useScheduler } from '../../shared/scheduler';
 import { useAppContext } from '../context';
 import useActions from '../lib/actionsHook';
 import accountActions from '../redux/account/actions';
-import { IReduxState } from '../redux/store';
 import * as AppButton from './AppButton';
 import { ModalAlert } from './Modal';
 import {
@@ -218,7 +216,6 @@ interface IRedeemVoucherButtonProps {
 }
 
 export function RedeemVoucherButton(props: IRedeemVoucherButtonProps) {
-  const isBlocked = useSelector((state: IReduxState) => state.connection.isBlocked);
   const [showAlert, setShowAlert] = useState(false);
 
   const onClick = useCallback(() => setShowAlert(true), []);
@@ -226,7 +223,7 @@ export function RedeemVoucherButton(props: IRedeemVoucherButtonProps) {
 
   return (
     <>
-      <AppButton.GreenButton disabled={isBlocked} onClick={onClick} className={props.className}>
+      <AppButton.GreenButton onClick={onClick} className={props.className}>
         {messages.pgettext('redeem-voucher-alert', 'Redeem voucher')}
       </AppButton.GreenButton>
       {showAlert && (


### PR DESCRIPTION
This PR enables buttons that perform API calls when the daemon blocks network traffic, since the daemon recently got support for this.

The changes are:
* Redeem voucher button in the account view and in the new account view is enabled
* The "Regenerate key" and "Verify key" buttons in the WireGuard key view is enabled
* Remove message in WireGuard key view saying that keys can't be managed.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2403)
<!-- Reviewable:end -->
