### PR TITLE
Improve version cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix Turkish translations for on/off in the bridge settings. They were inverted, so it was
   confusing to change the setting.
+- Stop returning bogus version information when there is no version cache.
 
 #### Linux
 - Fix missing app window icon in Xfce.

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -208,7 +208,7 @@ pub enum DaemonCommand {
     /// Verify if the currently set wireguard key is valid.
     VerifyWireguardKey(oneshot::Sender<bool>),
     /// Get information about the currently running and latest app versions
-    GetVersionInfo(oneshot::Sender<AppVersionInfo>),
+    GetVersionInfo(oneshot::Sender<Option<AppVersionInfo>>),
     /// Get current version of the app
     GetCurrentVersion(oneshot::Sender<AppVersion>),
     /// Remove settings and clear the cache
@@ -467,7 +467,7 @@ pub struct Daemon<L: EventListener> {
     relay_selector: relays::RelaySelector,
     last_generated_relay: Option<Relay>,
     last_generated_bridge_relay: Option<Relay>,
-    app_version_info: AppVersionInfo,
+    app_version_info: Option<AppVersionInfo>,
     shutdown_callbacks: Vec<Box<dyn FnOnce()>>,
     /// oneshot channel that completes once the tunnel state machine has been shut down
     tunnel_state_machine_shutdown_signal: oneshot::Receiver<()>,
@@ -1221,7 +1221,7 @@ where
     }
 
     fn handle_new_app_version_info(&mut self, app_version_info: AppVersionInfo) {
-        self.app_version_info = app_version_info.clone();
+        self.app_version_info = Some(app_version_info.clone());
         self.event_listener.notify_app_version(app_version_info);
     }
 
@@ -1468,7 +1468,7 @@ where
         }
     }
 
-    fn on_get_version_info(&mut self, tx: oneshot::Sender<AppVersionInfo>) {
+    fn on_get_version_info(&mut self, tx: oneshot::Sender<Option<AppVersionInfo>>) {
         Self::oneshot_send(
             tx,
             self.app_version_info.clone(),

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -150,8 +150,9 @@ impl ManagementService for ManagementServiceImpl {
 
         let (tx, rx) = oneshot::channel();
         self.send_command_to_daemon(DaemonCommand::GetVersionInfo(tx))?;
-        rx.await
-            .map_err(|_| Status::internal("internal error"))
+        let version_info = rx.await.map_err(|_| Status::internal("internal error"))?;
+        version_info
+            .ok_or(Status::not_found("no version cache"))
             .map(|version_info| convert_version_info(&version_info))
             .map(Response::new)
     }

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -144,7 +144,9 @@ impl DaemonInterface {
 
         self.send_command(DaemonCommand::GetVersionInfo(tx))?;
 
-        block_on(rx).map_err(|_| Error::NoResponse)
+        block_on(rx)
+            .map_err(|_| Error::NoResponse)?
+            .ok_or(Error::NoResponse)
     }
 
     pub fn reconnect(&self) -> Result<()> {


### PR DESCRIPTION
Makes a couple of simple changes:
* Instead of defaulting to incorrect information in the daemon when there is no cache, store an optional `AppVersionInfo`.
* If the daemon has no version info when it is requested by frontends, run the version check right away. If that fails, return a "not found" status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2405)
<!-- Reviewable:end -->
