### PR TITLE
Add license section about the iOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,5 +693,9 @@ the License, or (at your option) any later version.
 
 For the full license agreement, see the LICENSE.md file
 
+The source code for the iOS app is GPL-3 licensed like everything else in this repository.
+But the distributed app on the Apple App Store is not GPL licensed,
+it falls under the [Apple App Store EULA].
 
+[Apple App Store EULA]: https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
 [Mullvad's Open Source page]: https://mullvad.net/en/guides/open-source/


### PR DESCRIPTION
Apps on the App Store can't be GPL licensed. Add a section clarifying that we release the *source code* as GPL-3. But that it's implicitly dual licensed and the binaries on the App Store are by definition licensed under Apple's EULA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2406)
<!-- Reviewable:end -->
