### PR TITLE
Shorten platform version header

### DIFF
--- a/mullvad-platform-metadata/src/android.rs
+++ b/mullvad-platform-metadata/src/android.rs
@@ -4,7 +4,7 @@ mod command;
 use command::command_stdout_lossy;
 
 pub fn version() -> String {
-    let version = get_prop("ro.build.version.release").unwrap_or_else(|| "N/A".to_owned());
+    let version = os_version();
     let api_level = get_prop("ro.build.version.sdk").unwrap_or_else(|| "N/A".to_owned());
 
     let manufacturer =
@@ -18,7 +18,13 @@ pub fn version() -> String {
 }
 
 pub fn short_version() -> String {
-    version()
+    let version = os_version();
+
+    format!("Android {}", version)
+}
+
+fn os_version() -> String {
+    get_prop("ro.build.version.release").unwrap_or_else(|| "N/A".to_owned())
 }
 
 pub fn extra_metadata() -> HashMap<String, String> {

--- a/mullvad-platform-metadata/src/linux.rs
+++ b/mullvad-platform-metadata/src/linux.rs
@@ -18,7 +18,27 @@ pub fn version() -> String {
 }
 
 pub fn short_version() -> String {
-    version()
+    let version = read_os_release_file_short().unwrap_or_else(|| {
+        parse_lsb_release().unwrap_or_else(|| String::from("[Failed to detect version]"))
+    });
+
+    format!("Linux {}", version)
+}
+
+fn read_os_release_file_short() -> Option<String> {
+    let mut os_release_info = rs_release::get_os_release().ok()?;
+    let os_name = os_release_info.remove("NAME");
+    let os_version_id = os_release_info.remove("VERSION_ID");
+
+    if let Some(os_name) = os_name {
+        if os_name != "NixOS" {
+            if let Some(os_version_id) = os_version_id {
+                return Some(format!("{} {}", os_name, os_version_id));
+            }
+        }
+    }
+
+    os_release_info.remove("PRETTY_NAME")
 }
 
 fn read_os_release_file() -> Result<String, Option<String>> {


### PR DESCRIPTION
This PR shortens the platform version value in the version check `M-Platform-Version` call on Linux and Android.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2407)
<!-- Reviewable:end -->
