### PR TITLE
Initialize target state to "secured" if the cache cannot be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Line wrap the file at 100 chars.                                              Th
 - Resolve single-label hostnames correctly.
 
 ### Security
+- Default to connecting when the daemon starts if the target state cache cannot be read or parsed.
+
 #### Linux
 - Prevent the private tunnel IPv6 address from being detectable on a local network when using
   OpenVPN by correctly applying the fix for

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -564,7 +564,11 @@ where
                     Err(Error::OpenCachedTargetState(e))
                 }
             }
-        }?;
+        }
+        .unwrap_or_else(|error| {
+            error!("{}", error.display_chain());
+            Some(TargetState::Secured)
+        });
         if let Some(cached_target_state) = &cached_target_state {
             info!(
                 "Loaded cached target state \"{}\" from {}",


### PR DESCRIPTION
The daemon will fail to start if the target state cache cannot be read or parsed (as long as it exists). Obviously, it is safer to assume that the daemon should immediately connect if this is the case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2408)
<!-- Reviewable:end -->
