### PR TITLE
Respect auto-connect setting on login and change default value to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Line wrap the file at 100 chars.                                              Th
 - Prefer the last used API endpoint when the service starts back up, as well as in other tools such
   as the problem report tool.
 - Migrate cache to a directory readable by all users, consistent with Android and Linux.
+- Change the default value of the GUI auto-connect setting to "off" and respect the setting when
+  logging in.
 
 #### Linux
 - Improve offline check to query the routing table to allow users to use a bridged adapter as their

--- a/gui/src/main/gui-settings.ts
+++ b/gui/src/main/gui-settings.ts
@@ -15,7 +15,7 @@ const settingsSchema = {
 
 const defaultSettings: IGuiSettingsState = {
   preferredLocale: SYSTEM_PREFERRED_LOCALE_KEY,
-  autoConnect: true,
+  autoConnect: false,
   enableSystemNotifications: true,
   monochromaticIcon: false,
   startMinimized: false,

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1184,7 +1184,7 @@ class ApplicationMain {
         log.warn(`Failed to get account data, logging in anyway: ${verification.error.message}`);
       }
 
-      this.autoConnectOnWireguardKeyEvent = true;
+      this.autoConnectOnWireguardKeyEvent = this.guiSettings.autoConnect;
       await this.daemonRpc.setAccount(accountToken);
 
       // Fallback if daemon doesn't send event.


### PR DESCRIPTION
This PR changes the default value of the GUI auto-connect setting to `false` and respects the setting when logging in.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2409)
<!-- Reviewable:end -->
