### PR TITLE
Fix daemon cleanup on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
@@ -21,7 +21,8 @@ class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDa
 
     private val commandChannel = spawnActor()
 
-    private var daemon by observable<MullvadDaemon?>(null) { _, _, newInstance ->
+    private var daemon by observable<MullvadDaemon?>(null) { _, oldInstance, newInstance ->
+        oldInstance?.onDestroy()
         listener(newInstance)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -139,6 +139,8 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         onRelayListChange = null
         onTunnelStateChange = null
         onDaemonStopped = null
+
+        deinitialize()
     }
 
     private external fun initialize(
@@ -208,9 +210,5 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
 
     private fun notifyDaemonStopped() {
         onDaemonStopped?.invoke()
-    }
-
-    private fun finalize() {
-        deinitialize()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -131,6 +131,16 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         return verifyWireguardKey(daemonInterfaceAddress)
     }
 
+    fun onDestroy() {
+        onSettingsChange.unsubscribeAll()
+
+        onAppVersionInfoChange = null
+        onKeygenEvent = null
+        onRelayListChange = null
+        onTunnelStateChange = null
+        onDaemonStopped = null
+    }
+
     private external fun initialize(
         vpnService: MullvadVpnService,
         cacheDirectory: String,


### PR DESCRIPTION
@axti noticed that the `MullvadDaemon.finalize` method was incorrect, and therefore the daemon command sender endpoint was never closed correctly. Fixing the finalizer method is possible, but it leads to linter warnings.

This PR takes a different approach to fix the issue. Since the `MullvadDaemon` instance is only handled by the `DaemonInstance` actor, it can call the destructor once the daemon stops. Therefore, a new `onDestory` destructor method is created and called from `DaemonInstance`. This new destructor also cleans up all callbacks that were configured on the daemon.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's very likely not visible to the user.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2410)
<!-- Reviewable:end -->
