### PR TITLE
Remove `ConnectivityListener` reference from UI

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceConnection.kt
@@ -8,7 +8,6 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val daemon = service.daemon
     val accountCache = service.accountCache
     val connectionProxy = service.connectionProxy
-    val connectivityListener = service.connectivityListener
     val customDns = service.customDns
     val keyStatusListener = service.keyStatusListener
     val locationInfoCache = service.locationInfoCache

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -15,7 +15,6 @@ import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SettingsListener
 import net.mullvad.mullvadvpn.service.SplitTunneling
-import net.mullvad.talpid.ConnectivityListener
 
 abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceAwareFragment() {
     enum class OnNoService {
@@ -40,9 +39,6 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
         private set
 
     lateinit var connectionProxy: ConnectionProxy
-        private set
-
-    lateinit var connectivityListener: ConnectivityListener
         private set
 
     lateinit var customDns: CustomDns
@@ -72,7 +68,6 @@ abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceA
         accountCache = serviceConnection.accountCache
         appVersionInfoCache = serviceConnection.appVersionInfoCache
         connectionProxy = serviceConnection.connectionProxy
-        connectivityListener = serviceConnection.connectivityListener
         customDns = serviceConnection.customDns
         daemon = serviceConnection.daemon
         keyStatusListener = serviceConnection.keyStatusListener


### PR DESCRIPTION
This is the first PR related to splitting the service into a separate process.

The first component that's being split is the `ConnectivityListener`. Since it's not used in the UI anymore it can be safely removed so that it's only referenced in the service side. This is what this PR does.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no changelog entry needed.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2411)
<!-- Reviewable:end -->
