### PR TITLE
Update to NSEventMonitor 1.0.0

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -8693,6 +8693,15 @@
         }
       }
     },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "optional": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "mocha": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
@@ -9128,7 +9137,6 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
       "optional": true
     },
     "nanoid": {
@@ -9190,9 +9198,9 @@
       }
     },
     "needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
       "optional": true,
       "requires": {
         "debug": "^3.2.6",
@@ -9210,9 +9218,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "optional": true
         }
       }
@@ -9294,15 +9302,6 @@
         "tar": "^4.4.2"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -9416,11 +9415,12 @@
       }
     },
     "nseventmonitor": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-0.0.19.tgz",
-      "integrity": "sha512-bucQmCLoMF1LqX/2IspJamFf0nLnX5hJvJG2GZpSONRE8QFphUWs3U6Hp4KSP96+8oIKiav20UvgeWGIRs091w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-1.0.0.tgz",
+      "integrity": "sha512-qqctMJ8NIO3KB87LTO+thmJBADOa4s+pTpBKobajzZpOBBGNqAxxhxXdDV7MnaERozAlMvtp54I6nHCYbIjQfQ==",
       "optional": true,
       "requires": {
+        "nan": "^2.14.2",
         "node-pre-gyp": "^0.16.0"
       }
     },

--- a/gui/package.json
+++ b/gui/package.json
@@ -33,7 +33,7 @@
     "uuid": "^3.0.1"
   },
   "optionalDependencies": {
-    "nseventmonitor": "^0.0.19"
+    "nseventmonitor": "^1.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
This PR updates NSEventMonitor to `1.0.0`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2413)
<!-- Reviewable:end -->
