### PR TITLE
Enable Electron sandbox on Linux when possible

### DIFF
--- a/dist-assets/linux/mullvad-gui-launcher.sh
+++ b/dist-assets/linux/mullvad-gui-launcher.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 set -eu
 
+UNPRIVILEGED_USERNS_PATH="/proc/sys/kernel/unprivileged_userns_clone"
+if [ -e $UNPRIVILEGED_USERNS_PATH ] && grep -q 0 $UNPRIVILEGED_USERNS_PATH; then
+    SANDBOX_FLAG="--no-sandbox"
+else
+    SANDBOX_FLAG=""
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-exec "$SCRIPT_DIR/mullvad-gui" --no-sandbox "$@"
+exec "$SCRIPT_DIR/mullvad-gui" $SANDBOX_FLAG "$@"

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -85,6 +85,8 @@ const AUTO_CONNECT_FALLBACK_DELAY = 6000;
 /// Mirrors the beta check regex in the daemon. Matches only well formed beta versions
 const IS_BETA = /^(\d{4})\.(\d+)-beta(\d+)$/;
 
+const SANDBOX_DISABLED = app.commandLine.hasSwitch('no-sandbox');
+
 enum AppQuitStage {
   unready,
   initiated,
@@ -209,10 +211,6 @@ class ApplicationMain {
       app.commandLine.appendSwitch('wm-window-animations-disabled');
     }
 
-    if (process.platform !== 'linux') {
-      app.enableSandbox();
-    }
-
     this.overrideAppPaths();
 
     if (this.ensureSingleInstance()) {
@@ -220,6 +218,11 @@ class ApplicationMain {
     }
 
     this.initLogging();
+
+    log.debug(`Chromium sandbox disabled: ${SANDBOX_DISABLED}`);
+    if (!SANDBOX_DISABLED) {
+      app.enableSandbox();
+    }
 
     log.info(`Running version ${app.getVersion()}`);
 
@@ -1453,7 +1456,7 @@ class ApplicationMain {
         nodeIntegrationInWorker: false,
         nodeIntegrationInSubFrames: false,
         enableRemoteModule: false,
-        sandbox: process.platform !== 'linux',
+        sandbox: !SANDBOX_DISABLED,
         contextIsolation: true,
         spellcheck: false,
         devTools: process.env.NODE_ENV === 'development',


### PR DESCRIPTION
This PR enables the Chromium sandbox for the Electron renderer process on Linux when possible. There's still one situation when it's disabled which is when the `unprivileged_userns_clone` Debian kernel patch is enabled.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2419)
<!-- Reviewable:end -->
