### PR TITLE
Add IP version constraint for WireGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 - Enable isolation of the Electron renderer process to protect against potentially malicious third
   party dependencies.
 - Add 51820 to list of WireGuard ports in app settings.
+- Add option to connect to WireGuard relays over IPv6.
 
 #### Android
 - Allow reaching the API server when connecting, disconnecting or in a blocked state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1240,7 @@ dependencies = [
  "env_logger 0.8.2",
  "err-derive 0.3.0",
  "futures",
+ "itertools 0.10.0",
  "mullvad-management-interface",
  "mullvad-paths",
  "mullvad-types",
@@ -1952,7 +1962,7 @@ checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
  "bytes 0.5.6",
  "heck",
- "itertools",
+ "itertools 0.8.2",
  "log 0.4.14",
  "multimap",
  "petgraph",
@@ -1969,7 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2",
  "quote",
  "syn",

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = "0.8.2"
 futures = "0.3"
 natord = "1.0.9"
 serde = "1.0"
+itertools = "0.10"
 
 mullvad-types = { path = "../mullvad-types" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -1,5 +1,6 @@
 use crate::{location, new_rpc_client, Command, Error, Result};
 use clap::{value_t, values_t};
+use itertools::Itertools;
 use std::{
     io::{self, BufRead},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -643,9 +644,16 @@ impl Relay {
                         (false, true) => "WireGuard",
                         _ => unreachable!("Bug in relay filtering earlier on"),
                     };
+                    let mut addresses = vec![&relay.ipv4_addr_in];
+                    if !relay.ipv6_addr_in.is_empty() {
+                        addresses.push(&relay.ipv6_addr_in);
+                    }
                     println!(
                         "\t\t{} ({}) - {}, hosted by {}",
-                        relay.hostname, relay.ipv4_addr_in, support_msg, relay.provider
+                        relay.hostname,
+                        addresses.iter().join(", "),
+                        support_msg,
+                        relay.provider
                     );
                 }
             }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -157,8 +157,8 @@ impl Command for Relay {
                                     .possible_values(&["any", "udp", "tcp"]),
                             )
                             .arg(
-                                clap::Arg::with_name("ip protocol")
-                                    .long("ip")
+                                clap::Arg::with_name("ip version")
+                                    .long("ipv")
                                     .required(false)
                                     .default_value("any")
                                     .possible_values(&["any", "4", "6"]),
@@ -475,7 +475,7 @@ impl Relay {
         let vpn_protocol = matches.value_of("vpn protocol").unwrap();
         let port = parse_port_constraint(matches.value_of("port").unwrap())?;
         let protocol = parse_protocol_constraint(matches.value_of("transport protocol").unwrap());
-        let ip_proto = parse_ip_protocol_constraint(matches.value_of("ip protocol").unwrap());
+        let ip_version = parse_ip_version_constraint(matches.value_of("ip version").unwrap());
 
         match vpn_protocol {
             "wireguard" => {
@@ -487,7 +487,7 @@ impl Relay {
                         NormalRelaySettingsUpdate {
                             wireguard_constraints: Some(WireguardConstraints {
                                 port: port.unwrap_or(0) as u32,
-                                ip_protocol: ip_proto.option().map(|protocol| {
+                                ip_version: ip_version.option().map(|protocol| {
                                     IpVersionConstraint {
                                         protocol: protocol as i32,
                                     }
@@ -500,7 +500,7 @@ impl Relay {
                 .await
             }
             "openvpn" => {
-                if let Constraint::Only(_) = ip_proto {
+                if let Constraint::Only(_) = ip_version {
                     return Err(Error::InvalidCommand(
                         "OpenVPN does not support the IP version constraint",
                     ));
@@ -716,7 +716,7 @@ impl Relay {
                 Self::format_port(constraints.port),
                 Self::format_ip_version(
                     constraints
-                        .ip_protocol
+                        .ip_version
                         .clone()
                         .map(|protocol| IpVersion::from_i32(protocol.protocol).unwrap())
                 )
@@ -784,7 +784,7 @@ fn parse_protocol_constraint(raw_protocol: &str) -> Constraint<TransportProtocol
     }
 }
 
-fn parse_ip_protocol_constraint(raw_protocol: &str) -> Constraint<IpVersion> {
+fn parse_ip_version_constraint(raw_protocol: &str) -> Constraint<IpVersion> {
     match raw_protocol {
         "any" => Constraint::Any,
         "4" => Constraint::Only(IpVersion::V4),

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -668,6 +668,14 @@ impl Relay {
         Ok(())
     }
 
+    fn format_ip_version(protocol: Option<IpVersion>) -> &'static str {
+        match protocol {
+            None => "IPv4 or IPv6",
+            Some(IpVersion::V4) => "IPv4",
+            Some(IpVersion::V6) => "IPv6",
+        }
+    }
+
     fn format_transport_protocol(protocol: Option<TransportProtocol>) -> &'static str {
         match protocol {
             None => "any transport protocol",
@@ -703,9 +711,18 @@ impl Relay {
 
     fn format_wireguard_constraints(constraints: Option<&WireguardConstraints>) -> String {
         if let Some(constraints) = constraints {
-            Self::format_port(constraints.port)
+            format!(
+                "{} over {}",
+                Self::format_port(constraints.port),
+                Self::format_ip_version(
+                    constraints
+                        .ip_protocol
+                        .clone()
+                        .map(|protocol| IpVersion::from_i32(protocol.protocol).unwrap())
+                )
+            )
         } else {
-            "any port".to_string()
+            "any port over IPv4 or IPv6".to_string()
         }
     }
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -949,8 +949,8 @@ fn convert_relay_settings_update(
             } else {
                 None
             };
-            let ip_protocol = if let Some(ref constraints) = settings.wireguard_constraints {
-                match &constraints.ip_protocol {
+            let ip_version = if let Some(ref constraints) = settings.wireguard_constraints {
+                match &constraints.ip_version {
                     Some(constraint) => match types::IpVersion::from_i32(constraint.protocol) {
                         Some(types::IpVersion::V4) => Some(IpVersion::V4),
                         Some(types::IpVersion::V6) => Some(IpVersion::V6),
@@ -975,7 +975,7 @@ fn convert_relay_settings_update(
                         } else {
                             Constraint::Any
                         },
-                        ip_protocol: Constraint::from(ip_protocol),
+                        ip_version: Constraint::from(ip_version),
                     }
                 }),
                 openvpn_constraints: settings.openvpn_constraints.map(|constraints| {
@@ -1018,9 +1018,9 @@ fn convert_relay_settings(settings: &RelaySettings) -> types::RelaySettings {
 
                 wireguard_constraints: Some(types::WireguardConstraints {
                     port: u32::from(constraints.wireguard_constraints.port.unwrap_or(0)),
-                    ip_protocol: constraints
+                    ip_version: constraints
                         .wireguard_constraints
-                        .ip_protocol
+                        .ip_version
                         .option()
                         .map(|version| match version {
                             IpVersion::V4 => types::IpVersion::V4,

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -27,7 +27,7 @@ use std::{
     sync::{mpsc, Arc},
 };
 use talpid_types::{
-    net::{TransportProtocol, TunnelType},
+    net::{IpVersion, TransportProtocol, TunnelType},
     ErrorExt,
 };
 
@@ -949,6 +949,20 @@ fn convert_relay_settings_update(
             } else {
                 None
             };
+            let ip_protocol = if let Some(ref constraints) = settings.wireguard_constraints {
+                match &constraints.ip_protocol {
+                    Some(constraint) => match types::IpVersion::from_i32(constraint.protocol) {
+                        Some(types::IpVersion::V4) => Some(IpVersion::V4),
+                        Some(types::IpVersion::V6) => Some(IpVersion::V6),
+                        None => {
+                            return Err(Status::invalid_argument("unknown ip protocol version"))
+                        }
+                    },
+                    None => None,
+                }
+            } else {
+                None
+            };
 
             Ok(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
                 location,
@@ -961,6 +975,7 @@ fn convert_relay_settings_update(
                         } else {
                             Constraint::Any
                         },
+                        ip_protocol: Constraint::from(ip_protocol),
                     }
                 }),
                 openvpn_constraints: settings.openvpn_constraints.map(|constraints| {
@@ -1003,6 +1018,17 @@ fn convert_relay_settings(settings: &RelaySettings) -> types::RelaySettings {
 
                 wireguard_constraints: Some(types::WireguardConstraints {
                     port: u32::from(constraints.wireguard_constraints.port.unwrap_or(0)),
+                    ip_protocol: constraints
+                        .wireguard_constraints
+                        .ip_protocol
+                        .option()
+                        .map(|version| match version {
+                            IpVersion::V4 => types::IpVersion::V4,
+                            IpVersion::V6 => types::IpVersion::V6,
+                        })
+                        .map(|version| types::IpVersionConstraint {
+                            protocol: i32::from(version),
+                        }),
                 }),
 
                 openvpn_constraints: Some(types::OpenvpnConstraints {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -30,7 +30,10 @@ use std::{
 };
 use talpid_core::future_retry::{retry_future_with_backoff, ExponentialBackoff, Jittered};
 use talpid_types::{
-    net::{all_of_the_internet, openvpn::ProxySettings, wireguard, TransportProtocol, TunnelType},
+    net::{
+        all_of_the_internet, openvpn::ProxySettings, wireguard, IpVersion, TransportProtocol,
+        TunnelType,
+    },
     ErrorExt,
 };
 use tokio::fs::File;
@@ -464,12 +467,13 @@ impl RelaySelector {
 
         self.pick_random_relay(&matching_relays)
             .and_then(|selected_relay| {
-                info!(
-                    "Selected relay {} at {}",
-                    selected_relay.hostname, selected_relay.ipv4_addr_in
-                );
-                self.get_random_tunnel(&selected_relay, &constraints)
-                    .map(|endpoint| (selected_relay.clone(), endpoint))
+                let endpoint = self.get_random_tunnel(&selected_relay, &constraints);
+                let addr_in = endpoint
+                    .as_ref()
+                    .map(|endpoint| endpoint.to_endpoint().address.ip())
+                    .unwrap_or(IpAddr::from(selected_relay.ipv4_addr_in));
+                info!("Selected relay {} at {}", selected_relay.hostname, addr_in);
+                endpoint.map(|endpoint| (selected_relay.clone(), endpoint))
             })
     }
 
@@ -638,52 +642,38 @@ impl RelaySelector {
         relay: &Relay,
         constraints: &RelayConstraints,
     ) -> Option<MullvadEndpoint> {
+        let mut new_wg_endpoint = || {
+            relay
+                .tunnels
+                .wireguard
+                .choose(&mut self.rng)
+                .cloned()
+                .and_then(|wg_tunnel| {
+                    self.wg_data_to_endpoint(relay, wg_tunnel, constraints.wireguard_constraints)
+                })
+        };
+
+        #[cfg(not(target_os = "android"))]
         match constraints.tunnel_protocol {
-            // TODO: Handle Constraint::Any case by selecting from both openvpn and wireguard
-            // tunnels once wireguard is mature enough
-            #[cfg(not(target_os = "android"))]
             Constraint::Only(TunnelType::OpenVpn) | Constraint::Any => relay
                 .tunnels
                 .openvpn
                 .choose(&mut self.rng)
                 .cloned()
                 .map(|endpoint| endpoint.into_mullvad_endpoint(relay.ipv4_addr_in.into())),
-            Constraint::Only(TunnelType::Wireguard) => relay
-                .tunnels
-                .wireguard
-                .choose(&mut self.rng)
-                .cloned()
-                .and_then(|wg_tunnel| {
-                    self.wg_data_to_endpoint(
-                        relay.ipv4_addr_in.into(),
-                        wg_tunnel,
-                        constraints.wireguard_constraints,
-                    )
-                }),
-            #[cfg(target_os = "android")]
-            Constraint::Any => relay
-                .tunnels
-                .wireguard
-                .choose(&mut self.rng)
-                .cloned()
-                .and_then(|wg_tunnel| {
-                    self.wg_data_to_endpoint(
-                        relay.ipv4_addr_in.into(),
-                        wg_tunnel,
-                        WireguardConstraints::default(),
-                    )
-                }),
-            #[cfg(target_os = "android")]
-            Constraint::Only(TunnelType::OpenVpn) => None,
+            Constraint::Only(TunnelType::Wireguard) => new_wg_endpoint(),
         }
+        #[cfg(target_os = "android")]
+        new_wg_endpoint()
     }
 
     fn wg_data_to_endpoint(
         &mut self,
-        host: IpAddr,
+        relay: &Relay,
         data: WireguardEndpointData,
         constraints: WireguardConstraints,
     ) -> Option<MullvadEndpoint> {
+        let host = self.get_address_for_wireguard_relay(relay, constraints)?;
         let port = self.get_port_for_wireguard_relay(&data, constraints)?;
         let peer_config = wireguard::PeerConfig {
             public_key: data.public_key,
@@ -695,6 +685,17 @@ impl RelaySelector {
             ipv4_gateway: data.ipv4_gateway,
             ipv6_gateway: data.ipv6_gateway,
         })
+    }
+
+    fn get_address_for_wireguard_relay(
+        &mut self,
+        relay: &Relay,
+        constraints: WireguardConstraints,
+    ) -> Option<IpAddr> {
+        match constraints.ip_protocol {
+            Constraint::Any | Constraint::Only(IpVersion::V4) => Some(relay.ipv4_addr_in.into()),
+            Constraint::Only(IpVersion::V6) => relay.ipv6_addr_in.map(|addr| addr.into()),
+        }
     }
 
     fn get_port_for_wireguard_relay(

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -692,7 +692,7 @@ impl RelaySelector {
         relay: &Relay,
         constraints: WireguardConstraints,
     ) -> Option<IpAddr> {
-        match constraints.ip_protocol {
+        match constraints.ip_version {
             Constraint::Any | Constraint::Only(IpVersion::V4) => Some(relay.ipv4_addr_in.into()),
             Constraint::Only(IpVersion::V6) => relay.ipv6_addr_in.map(|addr| addr.into()),
         }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -302,9 +302,20 @@ message OpenvpnConstraints {
 	uint32 port = 1;
 	TransportProtocolConstraint protocol = 2;
 }
+
+enum IpVersion {
+	V4 = 0;
+	V6 = 1;
+}
+
+message IpVersionConstraint {
+	IpVersion protocol = 1;
+}
+
 message WireguardConstraints {
 	// NOTE: optional
 	uint32 port = 1;
+	IpVersionConstraint ip_protocol = 2;
 }
 
 message CustomRelaySettings {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -315,7 +315,7 @@ message IpVersionConstraint {
 message WireguardConstraints {
 	// NOTE: optional
 	uint32 port = 1;
-	IpVersionConstraint ip_protocol = 2;
+	IpVersionConstraint ip_version = 2;
 }
 
 message CustomRelaySettings {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -443,8 +443,13 @@ pub struct WireguardConstraints {
 impl fmt::Display for WireguardConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.port {
-            Constraint::Any => write!(f, "any port"),
-            Constraint::Only(port) => write!(f, "port {}", port),
+            Constraint::Any => write!(f, "any port")?,
+            Constraint::Only(port) => write!(f, "port {}", port)?,
+        }
+        write!(f, " over ")?;
+        match self.ip_protocol {
+            Constraint::Any => write!(f, "IPv4 or IPv6"),
+            Constraint::Only(protocol) => write!(f, "{}", protocol),
         }
     }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -10,7 +10,7 @@ use crate::{
 use jnix::{FromJava, IntoJava};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fmt};
-use talpid_types::net::{openvpn::ProxySettings, TransportProtocol, TunnelType};
+use talpid_types::net::{openvpn::ProxySettings, IpVersion, TransportProtocol, TunnelType};
 
 
 pub trait Match<T> {
@@ -434,8 +434,10 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 
 /// [`Constraint`]s applicable to WireGuard relay servers.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
 pub struct WireguardConstraints {
     pub port: Constraint<u16>,
+    pub ip_protocol: Constraint<IpVersion>,
 }
 
 impl fmt::Display for WireguardConstraints {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -437,7 +437,7 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 #[serde(default)]
 pub struct WireguardConstraints {
     pub port: Constraint<u16>,
-    pub ip_protocol: Constraint<IpVersion>,
+    pub ip_version: Constraint<IpVersion>,
 }
 
 impl fmt::Display for WireguardConstraints {
@@ -447,7 +447,7 @@ impl fmt::Display for WireguardConstraints {
             Constraint::Only(port) => write!(f, "port {}", port)?,
         }
         write!(f, " over ")?;
-        match self.ip_protocol {
+        match self.ip_version {
             Constraint::Any => write!(f, "IPv4 or IPv6"),
             Constraint::Only(protocol) => write!(f, "{}", protocol),
         }

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -170,6 +170,15 @@ impl Default for IpVersion {
     }
 }
 
+impl fmt::Display for IpVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match *self {
+            IpVersion::V4 => "IPv4".fmt(f),
+            IpVersion::V6 => "IPv6".fmt(f),
+        }
+    }
+}
+
 /// Representation of a transport protocol, either UDP or TCP.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -156,6 +156,20 @@ impl fmt::Display for Endpoint {
     }
 }
 
+/// IP protocol version.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IpVersion {
+    V4,
+    V6,
+}
+
+impl Default for IpVersion {
+    fn default() -> IpVersion {
+        IpVersion::V4
+    }
+}
+
 /// Representation of a transport protocol, either UDP or TCP.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
This adds a relay constraint for connecting to relays over IPv6. It can be enabled in the CLI:

```
mullvad relay set tunnel wireguard --ipv 6
```

If the constraint is set to either `4` or `Any`, then the relay selector will always prefer the IPv4 address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2422)
<!-- Reviewable:end -->
