### PR TITLE
Use per-interface DNS config on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,10 +382,9 @@ echo "org.gradle.jvmargs=-Xmx4608M" >> ~/.gradle/gradle.properties
    WireGuard on Linux.
 
 * `TALPID_DNS_CACHE_POLICY` - On Windows, this changes how DNS is configured:
-  * `1`: The default. This sets a global list of DNS servers that `dnscache` will use instead of
-         the servers specified on each interface.
-  * `0`: Only set DNS servers on the tunnel interface. This will misbehave if local custom DNS
-         servers are used.
+  * `0`: The default. Only set DNS servers on the tunnel interface, excepting local addresses.
+  * `1`: This sets a global list of DNS servers that `dnscache` will use instead of the servers
+         specified on each interface.
 * `TALPID_DISABLE_OFFLINE_MONITOR` - Forces the daemon to always assume the host is online.
 
 

--- a/talpid-core/src/dns/android.rs
+++ b/talpid-core/src/dns/android.rs
@@ -14,7 +14,12 @@ impl super::DnsMonitorT for DnsMonitor {
         Ok(DnsMonitor)
     }
 
-    fn set(&mut self, _interface: &str, _servers: &[IpAddr]) -> Result<(), Self::Error> {
+    fn set(
+        &mut self,
+        _interface: &str,
+        _gateways: &[IpAddr],
+        _servers: &[IpAddr],
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -49,7 +49,7 @@ impl super::DnsMonitorT for DnsMonitor {
         Ok(DnsMonitor { inner: None })
     }
 
-    fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<()> {
+    fn set(&mut self, interface: &str, _gateways: &[IpAddr], servers: &[IpAddr]) -> Result<()> {
         self.reset()?;
         // Creating a new DNS monitor for each set, in case the system changed how it manages DNS.
         let mut inner = DnsMonitorHolder::new()?;

--- a/talpid-core/src/dns/macos.rs
+++ b/talpid-core/src/dns/macos.rs
@@ -149,7 +149,7 @@ impl super::DnsMonitorT for DnsMonitor {
         })
     }
 
-    fn set(&mut self, _interface: &str, servers: &[IpAddr]) -> Result<()> {
+    fn set(&mut self, _interface: &str, _gateways: &[IpAddr], servers: &[IpAddr]) -> Result<()> {
         let servers: Vec<DnsServer> = servers.iter().map(|ip| ip.to_string()).collect();
         let settings = DnsSettings::from_server_addresses(&servers);
         let mut state_lock = self.state.lock();

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -35,7 +35,12 @@ impl DnsMonitor {
     }
 
     /// Set DNS to the given servers. And start monitoring the system for changes.
-    pub fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<(), Error> {
+    pub fn set(
+        &mut self,
+        interface: &str,
+        gateways: &[IpAddr],
+        servers: &[IpAddr],
+    ) -> Result<(), Error> {
         log::info!(
             "Setting DNS servers to {}",
             servers
@@ -44,7 +49,7 @@ impl DnsMonitor {
                 .collect::<Vec<String>>()
                 .join(", ")
         );
-        self.inner.set(interface, servers)
+        self.inner.set(interface, gateways, servers)
     }
 
     /// Reset system DNS settings to what it was before being set by this instance.
@@ -60,7 +65,12 @@ trait DnsMonitorT: Sized {
 
     fn new(cache_dir: impl AsRef<Path>) -> Result<Self, Self::Error>;
 
-    fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<(), Self::Error>;
+    fn set(
+        &mut self,
+        interface: &str,
+        gateways: &[IpAddr],
+        servers: &[IpAddr],
+    ) -> Result<(), Self::Error>;
 
     fn reset(&mut self) -> Result<(), Self::Error>;
 }

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -22,7 +22,7 @@ lazy_static! {
     /// Specifies whether to override per-interface DNS resolvers with a global DNS policy.
     static ref GLOBAL_DNS_CACHE_POLICY: bool = env::var("TALPID_DNS_CACHE_POLICY")
         .map(|v| v != "0")
-        .unwrap_or(true);
+        .unwrap_or(false);
 }
 
 /// Errors that can happen when configuring DNS on Windows.

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -70,15 +70,20 @@ impl super::DnsMonitorT for DnsMonitor {
         Ok(monitor)
     }
 
-    fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<(), Error> {
+    fn set(
+        &mut self,
+        interface: &str,
+        gateways: &[IpAddr],
+        servers: &[IpAddr],
+    ) -> Result<(), Error> {
         let ipv4 = servers
             .iter()
-            .filter(|ip| ip.is_ipv4() && !ip.is_local_address())
+            .filter(|ip| ip.is_ipv4() && (gateways.contains(ip) || !ip.is_local_address()))
             .map(ip_to_widestring)
             .collect::<Vec<_>>();
         let ipv6 = servers
             .iter()
-            .filter(|ip| ip.is_ipv6() && !ip.is_local_address())
+            .filter(|ip| ip.is_ipv6() && (gateways.contains(ip) || !ip.is_local_address()))
             .map(ip_to_widestring)
             .collect::<Vec<_>>();
 

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -1,4 +1,4 @@
-use super::{FirewallArguments, FirewallPolicy, FirewallT};
+use super::{FirewallArguments, FirewallPolicy, FirewallT, IsLocalIpAddress};
 use crate::{split_tunnel, tunnel};
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
@@ -660,7 +660,7 @@ impl<'a> PolicyBatch<'a> {
     ) -> Result<()> {
         let (local_resolvers, remote_resolvers): (Vec<IpAddr>, Vec<IpAddr>) =
             dns_servers.iter().partition(|server| {
-                super::is_local_address(server)
+                server.is_local_address()
                     && *server != &tunnel.ipv4_gateway
                     && !tunnel
                         .ipv6_gateway

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -1,4 +1,4 @@
-use super::{FirewallArguments, FirewallPolicy, FirewallT};
+use super::{FirewallArguments, FirewallPolicy, FirewallT, IsLocalIpAddress};
 use ipnetwork::IpNetwork;
 use pfctl::{DropAction, FilterRuleAction, Uid};
 use std::{
@@ -161,7 +161,7 @@ impl Firewall {
     ) -> Result<Vec<pfctl::FilterRule>> {
         let mut rules = Vec::with_capacity(4);
 
-        let is_local = super::is_local_address(&server)
+        let is_local = server.is_local_address()
             && server != tunnel.ipv4_gateway
             && !tunnel
                 .ipv6_gateway

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -120,9 +120,16 @@ impl ConnectedState {
 
     fn set_dns(&self, shared_values: &mut SharedTunnelStateValues) -> Result<(), BoxedError> {
         let dns_ips = self.get_dns_servers(shared_values);
+
+        let mut tunnel_gateways = vec![];
+        tunnel_gateways.push(self.metadata.ipv4_gateway.into());
+        if let Some(ipv6_gateway) = self.metadata.ipv6_gateway {
+            tunnel_gateways.push(ipv6_gateway.into());
+        };
+
         shared_values
             .dns_monitor
-            .set(&self.metadata.interface, &dns_ips)
+            .set(&self.metadata.interface, &tunnel_gateways, &dns_ips)
             .map_err(BoxedError::new)?;
 
         Ok(())


### PR DESCRIPTION
Previously, DNS servers were configured globally instead of per-interface (#2188). This is potentially better for a few reasons, but it sometimes broke network sharing and resolution of local hostnames. A previous fix (#2378) did not fully resolve this.

This PR reverts back to using per-interface settings, but also solves the problem of slow resolution for local resolvers. This is a safer default. Everything works the same as in the last stable build, unless custom DNS is enabled. The main drawbacks:
* The ordering of custom DNS resolvers is now irrelevant. Public DNS resolvers will be preferred since the tunnel interface has the lowest metric. Arguably, we never made any guarantees about the order anyhow.
* Setting custom local DNS resolvers does not set them on any interface. Currently, the assumption is that your "physical" interface is configured to use them already. This is likely usually the case (e.g., you'll want to set the resolver to something like `192.168.0.1`), but if it isn't, you'll need to manually configure the given network adapter. This could be changed by trying to infer which interface to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2425)
<!-- Reviewable:end -->
