### PR TITLE
Only apply custom dns config if it's not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Line wrap the file at 100 chars.                                              Th
 - Update Electron from 11.0.2 to 11.2.1 which includes a newer Chromium version and
   security patches.
 
+### Fixed
+#### MacOS
+- When applying empty list of custom DNS servers, the daemon won't get stuck in the offline state.
+
 
 ## [2021.1-beta1] - 2021-01-25
 ### Added

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -54,14 +54,12 @@ async fn main() {
                 Error::RpcFailed(status) => {
                     eprintln!("{}: {:?}: {}", error, status.code(), status.message())
                 }
-                Error::RpcFailedExt(_message, status) => {
-                    eprintln!(
-                        "{}\nCaused by: {:?}: {}",
-                        error,
-                        status.code(),
-                        status.message()
-                    )
-                }
+                Error::RpcFailedExt(_message, status) => eprintln!(
+                    "{}\nCaused by: {:?}: {}",
+                    error,
+                    status.code(),
+                    status.message()
+                ),
                 error => eprintln!("{}", error.display_chain()),
             }
             1

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -698,7 +698,7 @@ where
     }
 
     fn get_custom_resolvers(dns_options: &DnsOptions) -> Option<Vec<IpAddr>> {
-        if dns_options.custom {
+        if dns_options.custom && !dns_options.addresses.is_empty() {
             Some(dns_options.addresses.clone())
         } else {
             None


### PR DESCRIPTION
MacOS get's very confused if we clear the DNS config and this makes the daemon confused, and all this confusion ends up with misery - the daemon gets stuck in the error state due to it detecting an offline state. Since it doesn't make much sense to apply an empty list of DNS servers, we can just not apply the custom DNS config if there are no servers in it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2427)
<!-- Reviewable:end -->
