### PR TITLE
Only unload Wintun when the daemon is stopped

### DIFF
--- a/talpid-core/src/tunnel/openvpn/windows.rs
+++ b/talpid-core/src/tunnel/openvpn/windows.rs
@@ -50,6 +50,7 @@ pub struct WintunDll {
     func_delete: WintunDeleteAdapterFn,
 }
 
+unsafe impl Send for WintunDll {}
 unsafe impl Sync for WintunDll {}
 
 type RebootRequired = bool;


### PR DESCRIPTION
wintun.dll is not [intended](https://git.zx2c4.com/wintun/commit/?id=7710ff187b5079d9f2573608b6cb33b15262b2b8) to be loaded and freed more than once by a given process, something that is currently done by `OpenVpnMonitor`. Creating a Wintun adapter can (rarely) fail due to `ERROR_FILE_NOT_FOUND`, which may be related to this, though this hasn't been verified. Regardless, this change lazily loads wintun.dll to ensure that it isn't incorrectly re-initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2428)
<!-- Reviewable:end -->
