### PR TITLE
Enable custom DNS when first IP is added instead of when toggled

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -461,6 +461,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                   {this.state.showAddCustomDns && (
                     <div ref={this.customDnsInputContainerRef}>
                       <Cell.RowInput
+                        placeholder={messages.pgettext('advanced-settings-view', 'e.g. 10.0.0.4')}
                         onSubmit={this.addDnsAddress}
                         onChange={this.addDnsInputChange}
                         invalid={this.state.invalidDnsIp}

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -449,13 +449,13 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                     <AriaInput>
                       <Cell.Switch
                         ref={this.customDnsSwitchRef}
-                        isOn={this.props.dns.custom}
+                        isOn={this.props.dns.custom || this.state.showAddCustomDns}
                         onChange={this.setCustomDnsEnabled}
                       />
                     </AriaInput>
                   </AriaInputGroup>
                 </StyledCustomDnsSwitchContainer>
-                <Accordion expanded={this.props.dns.custom}>
+                <Accordion expanded={this.props.dns.custom || this.state.showAddCustomDns}>
                   <CellList items={this.customDnsItems()} onRemove={this.removeDnsAddress} />
 
                   {this.state.showAddCustomDns && (
@@ -511,10 +511,12 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
   }
 
   private setCustomDnsEnabled = async (enabled: boolean) => {
-    await this.props.setDnsOptions({
-      custom: enabled,
-      addresses: this.props.dns.addresses,
-    });
+    if (this.props.dns.addresses.length > 0) {
+      await this.props.setDnsOptions({
+        custom: enabled,
+        addresses: this.props.dns.addresses,
+      });
+    }
 
     if (enabled && this.props.dns.addresses.length === 0) {
       this.showAddCustomDnsRow();
@@ -548,16 +550,13 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
     ) {
       event?.target.focus();
     } else {
-      this.hideAddCustomDnsRow(false);
+      this.hideAddCustomDnsRow();
     }
   };
 
-  private hideAddCustomDnsRow(justAdded: boolean) {
+  private hideAddCustomDnsRow() {
     if (!this.state.publicDnsIpToConfirm) {
       this.setState({ showAddCustomDns: false });
-      if (!justAdded && this.props.dns.addresses.length === 0) {
-        consumePromise(this.setCustomDnsEnabled(false));
-      }
     }
   }
 
@@ -581,10 +580,10 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
       } else {
         try {
           await this.props.setDnsOptions({
-            custom: this.props.dns.custom,
+            custom: this.props.dns.custom || this.state.showAddCustomDns,
             addresses: [...this.props.dns.addresses, address],
           });
-          this.hideAddCustomDnsRow(true);
+          this.hideAddCustomDnsRow();
         } catch (_e) {
           this.setState({ invalidDnsIp: true });
         }

--- a/gui/src/renderer/components/cell/Input.tsx
+++ b/gui/src/renderer/components/cell/Input.tsx
@@ -244,6 +244,7 @@ interface IRowInputProps {
   paddingLeft?: number;
   invalid?: boolean;
   autofocus?: boolean;
+  placeholder?: string;
 }
 
 export function RowInput(props: IRowInputProps) {
@@ -309,6 +310,7 @@ export function RowInput(props: IRowInputProps) {
           invalid={props.invalid}
           onFocus={props.onFocus}
           onBlur={props.onBlur}
+          placeholder={props.placeholder}
         />
       </StyledInputWrapper>
       <StyledSubmitButton onClick={submit}>


### PR DESCRIPTION
This PR changes the behavior of the custom DNS toggle. Previously enabled it in the daemon when the toggle became enabled, with an empty list of IPs. Now it keeps the toggle state internally and enables the setting in the daemon when the first IP is added to avoid using the feature with an empty list of IPs.

This PR also adds a placeholder to the custom DNS IP input that was previously missing.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2429)
<!-- Reviewable:end -->
