### PR TITLE
Rotate WireGuard key more frequently on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Line wrap the file at 100 chars.                                              Th
 - Update Electron from 11.0.2 to 11.2.1 which includes a newer Chromium version and
   security patches.
 
+#### Android
+- WireGuard key is now rotated sooner: every four days instead of seven.
+
 ### Fixed
 #### MacOS
 - When applying empty list of custom DNS servers, the daemon won't get stuck in the offline state.

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -21,7 +21,12 @@ pub use talpid_types::net::wireguard::{
 use talpid_types::ErrorExt;
 
 /// Default automatic key rotation
+#[cfg(not(target_os = "android"))]
 const DEFAULT_AUTOMATIC_KEY_ROTATION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+/// Default automatic key rotation
+#[cfg(target_os = "android")]
+const DEFAULT_AUTOMATIC_KEY_ROTATION: Duration = Duration::from_secs(4 * 24 * 60 * 60);
+
 /// How long to wait before reattempting to rotate keys on failure
 const AUTOMATIC_ROTATION_RETRY_DELAY: Duration = Duration::from_secs(60 * 15);
 /// How long to wait before starting the first key rotation.


### PR DESCRIPTION
Ideally, it would be best to rotate the WireGuard key as much as possible in order to increase privacy. However, the more frequent the rotation occurs, the more likely the user will experience "connection hiccups" while the tunnel reconnects with a new key. On desktop, it was decided to keep the interval at once a week. However, on mobile this interval was decided to be reduced to once every four days.

This PR applies the new interval for Android. Since the Android code for the key rotation is the same code used by the desktop app, the constant for the default interval was split in two, one for Android and one for the other platforms. I also separated that constant from the rest with a new-line to emphasis that the two constant declarations refer to the same parameter, in an attempt to avoid any mistakes that could be caused by overlooking them and treating them as two unrelated constants.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2432)
<!-- Reviewable:end -->
