### PR TITLE
Use path for app icon instead of data url

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -55,7 +55,7 @@ import { ConnectionObserver, DaemonRpc, SubscriptionListener } from './daemon-rp
 import { InvalidAccountError } from './errors';
 import Expectation from './expectation';
 import GuiSettings from './gui-settings';
-import { getAppIcon } from './linux-desktop-entry';
+import { findIconPath } from './linux-desktop-entry';
 import {
   backupLogFile,
   cleanUpLogDirectory,
@@ -1506,7 +1506,7 @@ class ApplicationMain {
       case 'linux':
         return new BrowserWindow({
           ...options,
-          icon: await getAppIcon('mullvad-vpn'),
+          icon: await findIconPath('mullvad-vpn'),
         });
 
       default: {


### PR DESCRIPTION
This PR changes the window icon on Linux to use a path instead of a data URL. The function returning the image was changed to returning the data URL instead of the path since the path isn't usable in the now sandboxed renderer process. But for the window icon a path is more suitable since it's not running within the sandbox and with the data URL the image wasn't displayed and also causes a segmentation fault in Electron 11.2.0+.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2433)
<!-- Reviewable:end -->
