### PR TITLE
Improve rotation interval constant declaration

### DIFF
--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -21,12 +21,11 @@ pub use talpid_types::net::wireguard::{
 use talpid_types::ErrorExt;
 
 /// Default automatic key rotation
-#[cfg(not(target_os = "android"))]
-const DEFAULT_AUTOMATIC_KEY_ROTATION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-/// Default automatic key rotation
-#[cfg(target_os = "android")]
-const DEFAULT_AUTOMATIC_KEY_ROTATION: Duration = Duration::from_secs(4 * 24 * 60 * 60);
-
+const DEFAULT_AUTOMATIC_KEY_ROTATION: Duration = if cfg!(target_os = "android") {
+    Duration::from_secs(4 * 24 * 60 * 60)
+} else {
+    Duration::from_secs(7 * 24 * 60 * 60)
+};
 /// How long to wait before reattempting to rotate keys on failure
 const AUTOMATIC_ROTATION_RETRY_DELAY: Duration = Duration::from_secs(60 * 15);
 /// How long to wait before starting the first key rotation.


### PR DESCRIPTION
A previous PR (#2432) reduced the default WireGuard key rotation interval on Android from 7 days to 4 days. This PR refactors that code to remove the repeated documentation attribute and the repeated variable name so that the code is easier to read and more resilient to the possibility of mistakes in the future.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Previous PR already added a changelog entry.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2434)
<!-- Reviewable:end -->
