### PR TITLE
Fix Linux bulid process race condition and cleanup

### DIFF
--- a/gui/gulpfile.js
+++ b/gui/gulpfile.js
@@ -1,5 +1,5 @@
+const fs = require('fs');
 const { task, series, parallel } = require('gulp');
-const rimraf = require('rimraf');
 
 const scripts = require('./tasks/scripts');
 const assets = require('./tasks/assets');
@@ -7,7 +7,7 @@ const watch = require('./tasks/watch');
 const dist = require('./tasks/distribution');
 
 task('clean', function (done) {
-  rimraf('./build', done);
+  fs.rmdir('./build', { recursive: true }, done);
 });
 task('build-proto', scripts.buildProto);
 task('build', series('clean', parallel(assets.copyAll, scripts.buildProto), scripts.build));

--- a/gui/package.json
+++ b/gui/package.json
@@ -88,7 +88,6 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^5.0.1",
     "prettier": "^2.2.1",
-    "rimraf": "^2.7.1",
     "semver": "^7.3.2",
     "sinon": "^7.1.1",
     "spa-server": "^1.0.0",

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs');
 const builder = require('electron-builder');
-const rimraf = require('rimraf');
 const parseSemver = require('semver/functions/parse');
 const util = require('util');
 const { notarize } = require('electron-notarize');
@@ -207,7 +206,7 @@ function packMac() {
           await notarizeMac(buildResult.artifactPaths[0]);
         }
         // remove the folder that contains the unpacked app
-        return rimrafAsync(appOutDir);
+        return fs.promises.rmdir(appOutDir, { recursive: true });
       },
       afterSign: noAppleNotarization
         ? undefined

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -233,14 +233,11 @@ function packLinux() {
         const sourceExecutable = path.join(context.appOutDir, 'mullvad-vpn');
         const targetExecutable = path.join(context.appOutDir, 'mullvad-gui');
         const launcherScript = path.join(context.appOutDir, 'mullvad-gui-launcher.sh');
-        const chromeSandbox = path.join(context.appOutDir, 'chrome-sandbox');
 
         // rename mullvad-vpn to mullvad-gui
         await fs.promises.rename(sourceExecutable, targetExecutable);
         // rename launcher script to mullvad-vpn
         await fs.promises.rename(launcherScript, sourceExecutable);
-        // remove the chrome-sandbox file since we explicitly disable it
-        await fs.promises.unlink(chromeSandbox);
       },
     },
   });


### PR DESCRIPTION
This PR:
* Makes sure the renaming of `mullvad-vpn` to `mullvad-gui` and `mullvad-gui-launcher.sh` to `mullvad-gui` is done in sequence. I ran into this and realized that both `mullvad-gui` and `mullvad-vpn` had the contents of `mullvad-gui-launcher`.
* Removes the `rimraf` dependency and instead uses `fs.rmdir` with the `{ recursive: true }` option.
* Keeps the `chrome-sandbox` file. The sandbox seemed to work without it as well though.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2435)
<!-- Reviewable:end -->
