### PR TITLE
Implement Intermittent daemon

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
@@ -14,7 +14,7 @@ import net.mullvad.mullvadvpn.util.Intermittent
 private const val API_IP_ADDRESS_FILE = "api-ip-address.txt"
 private const val RELAYS_FILE = "relays.json"
 
-class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDaemon?) -> Unit) {
+class DaemonInstance(val vpnService: MullvadVpnService) {
     private enum class Command {
         START,
         STOP,
@@ -24,7 +24,6 @@ class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDa
 
     private var daemon by observable<MullvadDaemon?>(null) { _, oldInstance, _ ->
         oldInstance?.onDestroy()
-        listener(newInstance)
     }
 
     val intermittentDaemon = Intermittent<MullvadDaemon>()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
+import net.mullvad.mullvadvpn.util.Intermittent
 
 private const val API_IP_ADDRESS_FILE = "api-ip-address.txt"
 private const val RELAYS_FILE = "relays.json"
@@ -21,10 +22,12 @@ class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDa
 
     private val commandChannel = spawnActor()
 
-    private var daemon by observable<MullvadDaemon?>(null) { _, oldInstance, newInstance ->
+    private var daemon by observable<MullvadDaemon?>(null) { _, oldInstance, _ ->
         oldInstance?.onDestroy()
         listener(newInstance)
     }
+
+    val intermittentDaemon = Intermittent<MullvadDaemon>()
 
     fun start() {
         commandChannel.sendBlocking(Command.START)
@@ -36,6 +39,7 @@ class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDa
 
     fun onDestroy() {
         commandChannel.close()
+        intermittentDaemon.onDestroy()
     }
 
     private fun spawnActor() = GlobalScope.actor<Command>(Dispatchers.Default, Channel.UNLIMITED) {
@@ -91,12 +95,16 @@ class DaemonInstance(val vpnService: MullvadVpnService, val listener: (MullvadDa
         }
     }
 
-    private fun startDaemon() {
-        daemon = MullvadDaemon(vpnService).apply {
+    private suspend fun startDaemon() {
+        val newDaemon = MullvadDaemon(vpnService).apply {
             onDaemonStopped = {
+                intermittentDaemon.spawnUpdate(null)
                 daemon = null
             }
         }
+
+        daemon = newDaemon
+        intermittentDaemon.update(newDaemon)
     }
 
     private fun stopDaemon() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -104,11 +104,13 @@ class MullvadVpnService : TalpidVpnService() {
 
         notificationManager.acknowledgeStartForegroundService()
 
-        daemonInstance = DaemonInstance(this) { daemon ->
-            handleDaemonInstance(daemon)
-        }
+        daemonInstance = DaemonInstance(this).apply {
+            intermittentDaemon.registerListener(this@MullvadVpnService) { daemon ->
+                handleDaemonInstance(daemon)
+            }
 
-        daemonInstance.start()
+            start()
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
+import net.mullvad.talpid.util.EventNotifier
 
 // Wrapper to allow awaiting for intermittent values.
 //
@@ -21,13 +22,24 @@ import kotlinx.coroutines.sync.withPermit
 //
 // Calling `update` will set the internal value after it guarantees that no other coroutine is
 // currently reading the value (through a permit from the semaphore). After the value is set, it
-// provides a premit to the semaphore so that suspended coroutines can use the new value.
+// provides a permit to the semaphore so that suspended coroutines can use the new value.
+//
+// Extra initialization can be done on the intermittent value when it becomes available and before
+// it is provided to the awaiting coroutines, through the use of listener callbacks. These are
+// called after the value is updated but before it is made available to the coroutines.
 class Intermittent<T> {
+    private val notifier = EventNotifier<T?>(null)
     private val semaphore = Semaphore(1, 1)
     private val writeLock = Mutex()
 
     private var updateJob: Job? = null
-    private var value: T? = null
+    private var value by notifier.notifiable()
+
+    // When the internal value is updated, listeners can be notified before the awaiting coroutines
+    // resume execution. This allows performing any extra initialization before the value is made
+    // available for usage.
+    fun registerListener(id: Any, listener: (T?) -> Unit) = notifier.subscribe(id, listener)
+    fun unregisterListener(id: Any) = notifier.unsubscribe(id)
 
     suspend fun await(): T {
         return semaphore.withPermit { value!! }
@@ -40,6 +52,7 @@ class Intermittent<T> {
                     semaphore.acquire()
                 }
 
+                // This will trigger the listeners to run before the awaiting coroutines resume
                 value = newValue
 
                 if (newValue != null) {
@@ -62,5 +75,9 @@ class Intermittent<T> {
                 update(newValue)
             }
         }
+    }
+
+    fun onDestroy() {
+        notifier.unsubscribeAll()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
@@ -1,0 +1,66 @@
+package net.mullvad.mullvadvpn.util
+
+import kotlin.properties.Delegates.observable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+
+// Wrapper to allow awaiting for intermittent values.
+//
+// Wraps a property that is changed from time to time and that can become unavailable (null). This
+// behaves in a way similar to `CompletableDeferred`, but the value can be set and reset multiple
+// times.
+//
+// Calling `await` will either provide the value if it's available, or suspend until it becomes
+// available and then return it.
+//
+// Calling `update` will set the internal value after it guarantees that no other coroutine is
+// currently reading the value (through a permit from the semaphore). After the value is set, it
+// provides a premit to the semaphore so that suspended coroutines can use the new value.
+class Intermittent<T> {
+    private val semaphore = Semaphore(1, 1)
+    private val writeLock = Mutex()
+
+    private var updateJob: Job? = null
+    private var value: T? = null
+
+    suspend fun await(): T {
+        return semaphore.withPermit { value!! }
+    }
+
+    suspend fun update(newValue: T?) {
+        writeLock.withLock {
+            if (newValue != value) {
+                if (value != null) {
+                    semaphore.acquire()
+                }
+
+                value = newValue
+
+                if (newValue != null) {
+                    semaphore.release()
+                }
+            }
+        }
+    }
+
+    // Helper method that provides a simple way to change the wrapped value.
+    // 
+    // The method returns a property delegate that will spawn a coroutine to update the wrapped
+    // value every time the property is written to.
+    fun source() = observable<T?>(null) { _, _, newValue ->
+        synchronized(this@Intermittent) {
+            val previousUpdate = updateJob
+
+            updateJob = GlobalScope.launch(Dispatchers.Default) {
+                previousUpdate?.join()
+                update(newValue)
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
@@ -62,11 +62,8 @@ class Intermittent<T> {
         }
     }
 
-    // Helper method that provides a simple way to change the wrapped value.
-    // 
-    // The method returns a property delegate that will spawn a coroutine to update the wrapped
-    // value every time the property is written to.
-    fun source() = observable<T?>(null) { _, _, newValue ->
+    // Helper method that spawns a coroutine to update the value.
+    fun spawnUpdate(newValue: T?) {
         synchronized(this@Intermittent) {
             val previousUpdate = updateJob
 
@@ -75,6 +72,14 @@ class Intermittent<T> {
                 update(newValue)
             }
         }
+    }
+
+    // Helper method that provides a simple way to change the wrapped value.
+    // 
+    // The method returns a property delegate that will spawn a coroutine to update the wrapped
+    // value every time the property is written to.
+    fun source() = observable<T?>(null) { _, _, newValue ->
+        spawnUpdate(newValue)
     }
 
     fun onDestroy() {

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -11,7 +11,7 @@ import kotlin.properties.Delegates.observable
 // If the ID object class (or any of its super-classes) overrides `hashCode` or `equals`,
 // unsubscribe might not work correctly.
 class EventNotifier<T>(private val initialValue: T) {
-    private val listeners = HashMap<Any, (T) -> Unit>()
+    private val listeners = LinkedHashMap<Any, (T) -> Unit>()
 
     var latestEvent = initialValue
         private set


### PR DESCRIPTION
There are certain parts of the app that can only work if a daemon instance is available. Most of the time there will be an instance available, but there are situations where it's not available:

- When the service (and/or the daemon) is still starting
- When the daemon has crashed and is restarting
- When the service was requested to stop but then requested to start shortly afterwards, so it must perform a "soft restart"

Previously, the code that depended on the daemon instance availability would operate through callbacks, so that they can correctly handle the events of an instance becoming available or unavailable. This added complexity to the code, which is exacerbated by the refactor to split the app in two processes.

This PR attempts to collect that complexity into a single helper class, called `Intermittent`. It is responsible for waiting for something (it has a generic type parameter) to become available, and suspends any coroutines that need that something until it becomes available. It still provides an `EventNotifier` endpoint for registering callbacks for the use cases that still need it.

The PR also performs a small change in `EventNotifier` to make it notify listeners in the order that they were registered, so that the creator of an `EventNotifier` can register specific callbacks to be executed before any other listener is notified.

The new `Intermittent` class is then used by the `DaemonInstance` class. The `DaemonInstance` class exposes an `Intermittent<MullvadDaemon>` and updates it internally whenever the instance becomes available or unavailable. The classes that still use `MullvadDaemon` directly will be changed by future PRs that incrementally remove the `ServiceInstance` callback channel.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2439)
<!-- Reviewable:end -->
