### PR TITLE
Fix crash when trying to add custom DNS server on Android

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
@@ -16,9 +16,8 @@ class EditCustomDnsServerHolder(view: View, adapter: CustomDnsAdapter) : CustomD
         Error,
     }
 
-    private val context = view.context
-    private val errorColor = context.getColor(R.color.red)
-    private val normalColor = context.getColor(R.color.blue)
+    private val errorColor = view.context.getColor(R.color.red)
+    private val normalColor = view.context.getColor(R.color.blue)
 
     private val input: EditText = view.findViewById<EditText>(R.id.input).apply {
         onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
@@ -70,9 +70,9 @@ class EditCustomDnsServerHolder(view: View, adapter: CustomDnsAdapter) : CustomD
 
     init {
         view.findViewById<View>(R.id.save).setOnClickListener {
-            adapter.saveDnsServer(input.text.toString(), onFailCallback) {
-                state = State.Error
-            }
+            val onFailCallback = { state = State.Error }
+
+            adapter.saveDnsServer(input.text.toString(), onFailCallback)
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
@@ -39,16 +39,18 @@ class EditCustomDnsServerHolder(view: View, adapter: CustomDnsAdapter) : CustomD
         override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {}
     }
 
-    private var state by observable(State.Normal) { _, _, newState ->
-        input.apply {
-            when (newState) {
-                State.Normal -> {
-                    setTextColor(normalColor)
-                    removeTextChangedListener(watcher)
-                }
-                State.Error -> {
-                    setTextColor(errorColor)
-                    addTextChangedListener(watcher)
+    private var state by observable(State.Normal) { _, oldState, newState ->
+        if (oldState != newState) {
+            input.apply {
+                when (newState) {
+                    State.Normal -> {
+                        setTextColor(normalColor)
+                        removeTextChangedListener(watcher)
+                    }
+                    State.Error -> {
+                        setTextColor(errorColor)
+                        addTextChangedListener(watcher)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, it was possible to run into a crash when trying to add a custom DNS server on Android. The scenario required four steps in the Advanced Settings screen:

1. Trying to add an invalid IP address as a custom DNS server (will fail and make the IP address text red)
2. Pressing the confirm icon again (can be repeated multiple times)
3. Pressing the Android back button until the edit text to enter the custom DNS server IP address disappears
4. Pressing the row to add a new custom DNS server

This happened because the logic of the row holder logic to handle the text color would add a text watcher every time adding a custom DNS server failed, and that text watcher would later remove itself. The purpose of the text watcher was simply to reset the color of the text from red back to the standard color. Since after it fulfilled its purpose there was no need for it to listen for any further text changes, it removed itself from the list of text change listeners.

The two problems that led to the issue were that the same listener was registered more than once, and that Android's TextView is completely ignorant to listener removals happening while events are sent to the listeners.

As can be seen in the [Android code](http://androidxref.com/9.0.0_r3/xref/frameworks/base/core/java/android/widget/TextView.java#9770), the code notifies the listeners by iterating through a list. The problem is that the listener code can change that list (I could not find any documentation advising against that), which can lead the loop to not notify a listener, notify it twice of the same event, or worse, crash if the list is truncated before reaching the last listener.

This last point is important, because if you join it with the first problem where the same listener was registered more than once, the listener would be queued to be called twice, but during the first time it is executed it will remove itself, which then truncates the list before it has processed all listeners, causing an `IndexOutOfBoundsException`.

This PR solves that issue by refactoring the code so that the holder keeps track of its current state (normal or error), and only perform the state change operations (changing the text color and adding or removing the listener) when the state changes. This guarantees that the text watcher will never be registered more than once, preventing the crash from happening.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any public release, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2440)
<!-- Reviewable:end -->
