### PR TITLE
Open correct part of download page when running a beta version

### DIFF
--- a/gui/src/config.json
+++ b/gui/src/config.json
@@ -4,6 +4,7 @@
     "manageKeys": "https://mullvad.net/account/ports/",
     "faq": "https://mullvad.net/help/tag/mullvad-app/",
     "download": "https://mullvad.net/download/",
+    "betaDownload": "https://mullvad.net/download/#beta",
     "supportEmail": "support@mullvad.net"
   },
   "colors": {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -861,7 +861,13 @@ class ApplicationMain {
   }
 
   private setLatestVersion(latestVersionInfo: IAppVersionInfo) {
-    this.upgradeVersion = latestVersionInfo;
+    const suggestedIsBeta =
+      latestVersionInfo.suggestedUpgrade !== undefined &&
+      IS_BETA.test(latestVersionInfo.suggestedUpgrade);
+    this.upgradeVersion = {
+      ...latestVersionInfo,
+      suggestedIsBeta,
+    };
 
     // notify user to update the app if it became unsupported
     const notificationProviders = [
@@ -869,9 +875,11 @@ class ApplicationMain {
         supported: latestVersionInfo.supported,
         consistent: this.currentVersion.isConsistent,
         suggestedUpgrade: latestVersionInfo.suggestedUpgrade,
+        suggestedIsBeta,
       }),
       new UpdateAvailableNotificationProvider({
         suggestedUpgrade: latestVersionInfo.suggestedUpgrade,
+        suggestedIsBeta,
       }),
     ];
     const notificationProvider = notificationProviders.find((notificationProvider) =>

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -33,6 +33,7 @@ export interface IProps {
   appVersion: string;
   consistentVersion: boolean;
   upToDateVersion: boolean;
+  suggestedIsBeta: boolean;
   isOffline: boolean;
   onQuit: () => void;
   onClose: () => void;
@@ -85,7 +86,8 @@ export default class Settings extends React.Component<IProps> {
     );
   }
 
-  private openDownloadLink = () => this.props.onExternalLink(links.download);
+  private openDownloadLink = () =>
+    this.props.onExternalLink(this.props.suggestedIsBeta ? links.betaDownload : links.download);
   private openFaqLink = () => this.props.onExternalLink(links.faq);
 
   private renderQuitButton() {

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -58,6 +58,7 @@ interface ISupportProps {
   collectProblemReport: (accountsToRedact: string[]) => Promise<string>;
   sendProblemReport: (email: string, message: string, savedReport: string) => Promise<void>;
   outdatedVersion: boolean;
+  suggestedIsBeta: boolean;
   onExternalLink: (url: string) => void;
 }
 
@@ -272,7 +273,8 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
     this.setState({ showOutdatedVersionWarning: false });
   };
 
-  private openDownloadLink = () => this.props.onExternalLink(links.download);
+  private openDownloadLink = () =>
+    this.props.onExternalLink(this.props.suggestedIsBeta ? links.betaDownload : links.download);
 
   private renderOutdateVersionWarningDialog() {
     const message = messages.pgettext(

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -14,6 +14,7 @@ const mapStateToProps = (state: IReduxState, props: IAppContext) => ({
   appVersion: state.version.current,
   consistentVersion: state.version.consistent,
   upToDateVersion: state.version.suggestedUpgrade ? false : true,
+  suggestedIsBeta: state.version.suggestedIsBeta ?? false,
   isOffline: state.connection.isBlocked,
 });
 const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {

--- a/gui/src/renderer/containers/SupportPage.tsx
+++ b/gui/src/renderer/containers/SupportPage.tsx
@@ -13,6 +13,7 @@ const mapStateToProps = (state: IReduxState) => ({
   accountHistory: state.account.accountHistory,
   isOffline: state.connection.isBlocked,
   outdatedVersion: state.version.suggestedUpgrade ? true : false,
+  suggestedIsBeta: state.version.suggestedIsBeta ?? false,
 });
 
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext & RouteComponentProps) => {

--- a/gui/src/renderer/redux/version/reducers.ts
+++ b/gui/src/renderer/redux/version/reducers.ts
@@ -5,6 +5,7 @@ export interface IVersionReduxState {
   supported: boolean;
   isBeta: boolean;
   suggestedUpgrade?: string;
+  suggestedIsBeta?: boolean;
   consistent: boolean;
 }
 
@@ -13,6 +14,7 @@ const initialState: IVersionReduxState = {
   supported: true,
   isBeta: false,
   suggestedUpgrade: undefined,
+  suggestedIsBeta: false,
   consistent: true,
 };
 
@@ -26,6 +28,7 @@ export default function (
         ...state,
         supported: action.latestInfo.supported,
         suggestedUpgrade: action.latestInfo.suggestedUpgrade,
+        suggestedIsBeta: action.latestInfo.suggestedIsBeta,
       };
 
     case 'UPDATE_VERSION':

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -291,6 +291,7 @@ export interface IShadowsocksProxySettings {
 export interface IAppVersionInfo {
   supported: boolean;
   suggestedUpgrade?: string;
+  suggestedIsBeta?: boolean;
 }
 
 export interface ISettings {

--- a/gui/src/shared/notifications/unsupported-version.ts
+++ b/gui/src/shared/notifications/unsupported-version.ts
@@ -11,6 +11,7 @@ interface UnsupportedVersionNotificationContext {
   supported: boolean;
   consistent: boolean;
   suggestedUpgrade?: string;
+  suggestedIsBeta?: boolean;
 }
 
 export class UnsupportedVersionNotificationProvider
@@ -27,7 +28,7 @@ export class UnsupportedVersionNotificationProvider
       critical: true,
       action: {
         type: 'open-url',
-        url: links.download,
+        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
         text: messages.pgettext('notifications', 'Upgrade'),
       },
       presentOnce: { value: true, name: this.constructor.name },
@@ -40,7 +41,10 @@ export class UnsupportedVersionNotificationProvider
       indicator: 'error',
       title: messages.pgettext('in-app-notifications', 'UNSUPPORTED VERSION'),
       subtitle: this.getMessage(),
-      action: { type: 'open-url', url: links.download },
+      action: {
+        type: 'open-url',
+        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
+      },
     };
   }
 

--- a/gui/src/shared/notifications/update-available.ts
+++ b/gui/src/shared/notifications/update-available.ts
@@ -9,6 +9,7 @@ import {
 
 interface UpdateAvailableNotificationContext {
   suggestedUpgrade?: string;
+  suggestedIsBeta?: boolean;
 }
 
 export class UpdateAvailableNotificationProvider
@@ -28,7 +29,10 @@ export class UpdateAvailableNotificationProvider
         'in-app-notifications',
         'Install the latest app version to stay up to date.',
       ),
-      action: { type: 'open-url', url: links.download },
+      action: {
+        type: 'open-url',
+        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
+      },
     };
   }
 
@@ -41,7 +45,7 @@ export class UpdateAvailableNotificationProvider
       critical: false,
       action: {
         type: 'open-url',
-        url: links.download,
+        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
         text: messages.pgettext('notifications', 'Upgrade'),
       },
       presentOnce: { value: true, name: this.constructor.name },


### PR DESCRIPTION
This PR adds `#beta` to the download URL if the suggested upgrade version is a beta version. This ensures that the correct part of the download page is shown when opened in a browser.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2442)
<!-- Reviewable:end -->
