### PR TITLE
Fix crash when displaying modal immediately when a view is loaded

### DIFF
--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 import { colors } from '../../config.json';
 import log from '../../shared/logging';
-import { Scheduler } from '../../shared/scheduler';
 import ImageView from './ImageView';
 
 const MODAL_CONTAINER_ID = 'modal-container';
@@ -137,7 +136,6 @@ export function ModalAlert(props: IModalAlertProps) {
 class ModalAlertWithContext extends React.Component<IModalAlertProps & IModalContext> {
   private element = document.createElement('div');
   private modalRef = React.createRef<HTMLDivElement>();
-  private appendScheduler = new Scheduler();
 
   constructor(props: IModalAlertProps & IModalContext) {
     super(props);
@@ -155,13 +153,8 @@ class ModalAlertWithContext extends React.Component<IModalAlertProps & IModalCon
 
     const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
     if (modalContainer) {
-      // Mounting the container element immediately results in a graphical issue with the dialog
-      // first rendering with the wrong proportions and then changing to the correct proportions.
-      // Postponing it to the next event cycle solves this issue.
-      this.appendScheduler.schedule(() => {
-        modalContainer.appendChild(this.element);
-        this.modalRef.current?.focus();
-      });
+      modalContainer.appendChild(this.element);
+      this.modalRef.current?.focus();
     } else {
       log.error('Modal container not found when mounting modal');
     }
@@ -170,8 +163,6 @@ class ModalAlertWithContext extends React.Component<IModalAlertProps & IModalCon
   public componentWillUnmount() {
     this.props.setActiveModal(false);
     document.removeEventListener('keydown', this.handleKeyPress, true);
-
-    this.appendScheduler.cancel();
 
     const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
     modalContainer?.removeChild(this.element);

--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 import { colors } from '../../config.json';
+import log from '../../shared/logging';
 import { Scheduler } from '../../shared/scheduler';
 import ImageView from './ImageView';
 
@@ -162,7 +163,7 @@ class ModalAlertWithContext extends React.Component<IModalAlertProps & IModalCon
         this.modalRef.current?.focus();
       });
     } else {
-      throw Error('Modal container not found when mounting modal');
+      log.error('Modal container not found when mounting modal');
     }
   }
 

--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -5,6 +5,8 @@ import { colors } from '../../config.json';
 import { Scheduler } from '../../shared/scheduler';
 import ImageView from './ImageView';
 
+const MODAL_CONTAINER_ID = 'modal-container';
+
 const ModalContent = styled.div({
   position: 'absolute',
   display: 'flex',
@@ -40,7 +42,6 @@ interface IModalContainerProps {
 interface IModalContext {
   activeModal: boolean;
   setActiveModal: (value: boolean) => void;
-  modalContainerRef: React.RefObject<HTMLDivElement>;
   previousActiveElement: React.MutableRefObject<HTMLElement | undefined>;
 }
 
@@ -52,9 +53,6 @@ const ActiveModalContext = React.createContext<IModalContext>({
   setActiveModal(_value) {
     throw noActiveModalContextError;
   },
-  get modalContainerRef(): React.RefObject<HTMLDivElement> {
-    throw noActiveModalContextError;
-  },
   get previousActiveElement(): React.MutableRefObject<HTMLElement | undefined> {
     throw noActiveModalContextError;
   },
@@ -63,13 +61,11 @@ const ActiveModalContext = React.createContext<IModalContext>({
 export function ModalContainer(props: IModalContainerProps) {
   const [activeModal, setActiveModal] = useState(false);
   const previousActiveElement = useRef<HTMLElement>();
-  const modalContainerRef = useRef() as React.RefObject<HTMLDivElement>;
 
   const contextValue = useMemo(
     () => ({
       activeModal,
       setActiveModal,
-      modalContainerRef,
       previousActiveElement,
     }),
     [activeModal],
@@ -83,7 +79,7 @@ export function ModalContainer(props: IModalContainerProps) {
 
   return (
     <ActiveModalContext.Provider value={contextValue}>
-      <StyledModalContainer ref={modalContainerRef}>
+      <StyledModalContainer id={MODAL_CONTAINER_ID}>
         <ModalContent aria-hidden={activeModal}>{props.children}</ModalContent>
       </StyledModalContainer>
     </ActiveModalContext.Provider>
@@ -156,7 +152,7 @@ class ModalAlertWithContext extends React.Component<IModalAlertProps & IModalCon
     // makes sure that this component catches the event before the escape hatch.
     document.addEventListener('keydown', this.handleKeyPress, true);
 
-    const modalContainer = this.props.modalContainerRef.current;
+    const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
     if (modalContainer) {
       // Mounting the container element immediately results in a graphical issue with the dialog
       // first rendering with the wrong proportions and then changing to the correct proportions.
@@ -175,7 +171,9 @@ class ModalAlertWithContext extends React.Component<IModalAlertProps & IModalCon
     document.removeEventListener('keydown', this.handleKeyPress, true);
 
     this.appendScheduler.cancel();
-    this.props.modalContainerRef.current?.removeChild(this.element);
+
+    const modalContainer = document.getElementById(MODAL_CONTAINER_ID);
+    modalContainer?.removeChild(this.element);
   }
 
   public render() {


### PR DESCRIPTION
This PR fixes a few issues with modals that are shown immediately when a view is loaded. The issues that have been fixed are:
* Throws an error. This was caused by the switch to using a ref instead of an id for the container element. This has been fixed by reverting that change. The error has also been replaced by a log message since it shouldn't break the whole app.
* The transition was omitted when `focus()` was called on the modal after a timeout. There are two possibilities, wait until after the transition or remove the timeout entirely. The second one has caused us trouble in the past but seems to be working well with the current solution and setup. I went with the second one.

These issues only affected modals that were shown immediately when a view was loaded and the only case of this is the upgrade question when entering the problem report view using an outdated version. This prevents the user from being able to submit a problem report.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2443)
<!-- Reviewable:end -->
