### PR TITLE
Move down buttons in the Account screen on Android

### DIFF
--- a/android/src/main/res/layout/account.xml
+++ b/android/src/main/res/layout/account.xml
@@ -29,8 +29,8 @@
         </FrameLayout>
         <net.mullvad.mullvadvpn.ui.widget.ListenableScrollView android:id="@+id/scroll_area"
                                                                android:layout_width="match_parent"
-                                                               android:layout_height="match_parent">
-
+                                                               android:layout_height="match_parent"
+                                                               android:fillViewport="true">
             <LinearLayout android:layout_width="match_parent"
                           android:layout_height="match_parent"
                           android:layout_marginTop="2dp"
@@ -59,6 +59,9 @@
                                                                   android:paddingVertical="@dimen/half_vertical_space"
                                                                   mullvad:description="@string/paid_until"
                                                                   mullvad:whenMissing="hide" />
+                <Space android:layout_width="match_parent"
+                       android:layout_height="0dp"
+                       android:layout_weight="1" />
                 <include layout="@layout/payment_buttons" />
                 <net.mullvad.mullvadvpn.ui.widget.Button android:id="@+id/logout"
                                                          android:layout_width="match_parent"


### PR DESCRIPTION
The WireGuard Key screen and the Account screen are very similar, but there is one inconsistency: the position of the buttons. This PR updates the Account screen to move the buttons down so that it has the same appearance as the WireGuard Key screen.

To push the buttons down, the same approach used in the WireGuard Key screen was used. A spacing view was added between the top information and the bottom buttons. The spacer is the only view inside the `LinearLayout` group that has a weight, so its height is calculated to be the maximum possible, pushing the buttons down. To make sure the `ScrollView` containing the `LinearLayout` fills the whole screen, it has been updated to have the `fillViewport` attribute enabled.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2444)
<!-- Reviewable:end -->
