### PR TITLE
Add FAQs and Guides entry in the Settings screen on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Allow reaching the API server when connecting, disconnecting or in a blocked state.
+- Add FAQs & Guides menu entry to the Settings screen.
 
 ### Changed
 - Update Electron from 11.0.2 to 11.2.1 which includes a newer Chromium version and

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.ui.widget
 
 import android.content.Context
-import android.content.Intent
 import android.graphics.Typeface
 import android.net.Uri
 import android.util.AttributeSet
@@ -12,7 +11,7 @@ import android.widget.TextView
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 
-class AppVersionCell : Cell {
+class AppVersionCell : UrlCell {
     private val warningIcon = ImageView(context).apply {
         val iconSize = resources.getDimensionPixelSize(R.dimen.app_version_warning_icon_size)
 
@@ -40,13 +39,6 @@ class AppVersionCell : Cell {
         text = ""
     }
 
-    private val externalLinkIcon = ImageView(context).apply {
-        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, 0.0f)
-        alpha = 0.6f
-
-        setImageResource(R.drawable.icon_extlink)
-    }
-
     var updateAvailable by observable(false) { _, _, updateAvailable ->
         if (updateAvailable) {
             warningIcon.visibility = VISIBLE
@@ -61,32 +53,20 @@ class AppVersionCell : Cell {
         versionLabel.text = version
     }
 
-    constructor(context: Context) : super(context) {}
-
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
-
-    constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
-
+    @JvmOverloads
     constructor(
         context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
+        attributes: AttributeSet? = null,
+        defaultStyleAttribute: Int = 0,
+        defaultStyleResource: Int = 0
     ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
 
     init {
         cell.addView(warningIcon, 0)
-        cell.addView(versionLabel)
-        cell.addView(externalLinkIcon)
+        cell.addView(versionLabel, cell.getChildCount() - 1)
 
-        onClickListener = { openLink() }
-    }
-
-    private fun openLink() {
-        val url = context.getString(R.string.download_url)
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-
-        context.startActivity(intent)
+        if (url == null) {
+            url = Uri.parse(context.getString(R.string.download_url))
+        }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Cell.kt
@@ -61,38 +61,19 @@ open class Cell : LinearLayout {
 
     var onClickListener: (() -> Unit)? = null
 
-    constructor(context: Context, footer: TextView? = null) : super(context) {
-        this.footer = footer
-    }
-
-    constructor(context: Context, attributes: AttributeSet, footer: TextView? = null) :
-        super(context, attributes) {
-            this.footer = footer
-            loadAttributes(attributes)
-        }
-
+    @JvmOverloads
     constructor(
         context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        footer: TextView? = null
-    ) : super(context, attributes, defaultStyleAttribute) {
-        this.footer = footer
-        loadAttributes(attributes)
-    }
-
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int,
+        attributes: AttributeSet? = null,
+        defaultStyleAttribute: Int = 0,
+        defaultStyleResource: Int = 0,
         footer: TextView? = null
     ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {
         this.footer = footer
         loadAttributes(attributes)
     }
 
-    private fun loadAttributes(attributes: AttributeSet) {
+    private fun loadAttributes(attributes: AttributeSet?) {
         context.theme.obtainStyledAttributes(attributes, R.styleable.TextAttribute, 0, 0).apply {
             try {
                 label.text = getString(R.styleable.TextAttribute_text) ?: ""

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/MtuCell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/MtuCell.kt
@@ -44,28 +44,19 @@ class MtuCell : Cell {
         }
     }
 
-    constructor(context: Context) : super(context, TextView(context)) {}
-
-    constructor(context: Context, attributes: AttributeSet) :
-        super(context, attributes, TextView(context)) {}
-
-    constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute, TextView(context)) {}
-
+    @JvmOverloads
     constructor(
         context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
+        attributes: AttributeSet? = null,
+        defaultStyleAttribute: Int = 0,
+        defaultStyleResource: Int = 0
     ) : super(
         context,
         attributes,
         defaultStyleAttribute,
         defaultStyleResource,
         TextView(context)
-    ) {}
-
-    init {
+    ) {
         cell.apply {
             setEnabled(false)
             setFocusable(false)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
@@ -78,11 +78,16 @@ open class UrlButton : Button {
     }
 
     private fun loadAttributes(attributes: AttributeSet) {
-        val styleableId = R.styleable.UrlButton
-
-        context.theme.obtainStyledAttributes(attributes, styleableId, 0, 0).apply {
+        context.theme.obtainStyledAttributes(attributes, R.styleable.Url, 0, 0).apply {
             try {
-                url = getString(R.styleable.UrlButton_url)
+                url = getString(R.styleable.Url_url)
+            } finally {
+                recycle()
+            }
+        }
+
+        context.theme.obtainStyledAttributes(attributes, R.styleable.UrlButton, 0, 0).apply {
+            try {
                 withToken = getBoolean(R.styleable.UrlButton_withToken, false)
             } finally {
                 recycle()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlCell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlCell.kt
@@ -1,0 +1,53 @@
+package net.mullvad.mullvadvpn.ui.widget
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.AttributeSet
+import android.widget.ImageView
+import net.mullvad.mullvadvpn.R
+
+open class UrlCell : Cell {
+    private val externalLinkIcon = ImageView(context).apply {
+        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, 0.0f)
+        alpha = 0.6f
+
+        setImageResource(R.drawable.icon_extlink)
+    }
+
+    var url: Uri? = null
+
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attributes: AttributeSet? = null,
+        defaultStyleAttribute: Int = 0,
+        defaultStyleResource: Int = 0
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {
+        loadAttributes(attributes)
+
+        cell.addView(externalLinkIcon)
+
+        onClickListener = { openLink() }
+    }
+
+    private fun loadAttributes(attributes: AttributeSet?) {
+        context.theme.obtainStyledAttributes(attributes, R.styleable.Url, 0, 0).apply {
+            try {
+                getString(R.styleable.Url_url)?.let { urlString ->
+                    url = Uri.parse(urlString)
+                }
+            } finally {
+                recycle()
+            }
+        }
+    }
+
+    private fun openLink() {
+        url?.let { url ->
+            val intent = Intent(Intent.ACTION_VIEW, url)
+
+            context.startActivity(intent)
+        }
+    }
+}

--- a/android/src/main/res/layout/settings.xml
+++ b/android/src/main/res/layout/settings.xml
@@ -69,6 +69,12 @@
                                                                android:layout_height="wrap_content"
                                                                android:layout_marginTop="@dimen/vertical_space"
                                                                mullvad:text="@string/report_a_problem" />
+                <net.mullvad.mullvadvpn.ui.widget.UrlCell android:id="@+id/faqs_and_guides"
+                                                          android:layout_width="match_parent"
+                                                          android:layout_height="wrap_content"
+                                                          android:layout_marginTop="1dp"
+                                                          mullvad:text="@string/faqs_and_guides"
+                                                          mullvad:url="@string/faqs_and_guides_url" />
             </LinearLayout>
         </net.mullvad.mullvadvpn.ui.widget.ListenableScrollView>
     </LinearLayout>

--- a/android/src/main/res/values-da/strings.xml
+++ b/android/src/main/res/values-da/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Kunne ikke generere en nøgle</string>
     <string name="failed_to_send">Kunne ikke sende</string>
     <string name="failed_to_send_details">Du skal muligvis vende tilbage til appens hovedskærm og klikke på Afbryd forbindelse, før du prøver igen. Bare rolig, de angivne oplysninger bliver ikke slettet fra formularen.</string>
+    <string name="faqs_and_guides">Ofte stillede spørgsmål og vejledninger</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/da/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Viser den aktuelle VPN-tunnelstatus</string>
     <string name="foreground_notification_channel_name">VPN-tunnelstatus</string>
     <string name="here_is_your_account_number">Her er dit kontonummer. Gem det!</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Fehler beim Generieren eines Schlüssels</string>
     <string name="failed_to_send">Fehler beim Senden</string>
     <string name="failed_to_send_details">Möglicherweise müssen Sie zum Hauptbildschirm der App zurückgehen und auf Trennen klicken, bevor Sie es erneut versuchen. Keine Sorge, die eingegebenen Informationen bleiben im Formular gespeichert.</string>
+    <string name="faqs_and_guides">Häufig gestellte Fragen &amp; Anleitungen</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/de/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Zeigt den aktuellen VPN-Tunnel-Status an</string>
     <string name="foreground_notification_channel_name">VPN-Tunnel-Status</string>
     <string name="here_is_your_account_number">Hier ist Ihre Kundennummer. Verlieren Sie sie nicht!</string>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">No se pudo generar una clave</string>
     <string name="failed_to_send">No se pudo enviar</string>
     <string name="failed_to_send_details">Para volver a intentarlo, puede que necesite volver a la pantalla principal de la aplicación y hacer clic en Desconectar. No se preocupe, la información que ha especificado permanecerá en el formulario.</string>
+    <string name="faqs_and_guides">Preguntas frecuentes y guías</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/es/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Muestra el estado actual del túnel VPN</string>
     <string name="foreground_notification_channel_name">Estado del túnel VPN</string>
     <string name="here_is_your_account_number">Este es un número de cuenta. ¡Guárdelo bien!</string>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Avaimen luominen epäonnistui</string>
     <string name="failed_to_send">Lähetys epäonnistui</string>
     <string name="failed_to_send_details">Ennen kuin yrität uudelleen sinun on ehkä palattava sovelluksen päänäytölle ja napsautettava yhteyden katkaisua. Älä huoli, syöttämäsi tiedot säilyvät lomakkeella.</string>
+    <string name="faqs_and_guides">UKK:t ja oppaat</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/fi/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Näyttää VPN-tunnelin nykyisen tilan</string>
     <string name="foreground_notification_channel_name">VPN-tunnelin tila</string>
     <string name="here_is_your_account_number">Tässä tulee tilisi numero. Laita se talteen!</string>

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Échec de la génération de clé</string>
     <string name="failed_to_send">Échec de l\'envoi</string>
     <string name="failed_to_send_details">Vous allez peut-être devoir retourner à l\'écran principal de l\'application pour cliquer sur Déconnexion avant de réessayer. Ne vous inquiétez pas, les informations saisies resteront dans le formulaire.</string>
+    <string name="faqs_and_guides">FAQ et guides</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/fr/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Affiche l\'état actuel du tunnel VPN</string>
     <string name="foreground_notification_channel_name">État du tunnel VPN</string>
     <string name="here_is_your_account_number">Voici votre numéro de compte. Gardez-le !</string>

--- a/android/src/main/res/values-it/strings.xml
+++ b/android/src/main/res/values-it/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Impossibile generare una chiave</string>
     <string name="failed_to_send">Impossibile inviare</string>
     <string name="failed_to_send_details">Prima di riprovare, potresti dover tornare alla schermata principale dell\'app e fare clic su Disconnetti. Non preoccuparti: le informazioni inserite rimarranno nel modulo.</string>
+    <string name="faqs_and_guides">FAQ e guide</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/it/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Mostra lo stato attuale del tunnel VPN</string>
     <string name="foreground_notification_channel_name">Stato del tunnel VPN</string>
     <string name="here_is_your_account_number">Ecco il tuo numero di account. Salvalo!</string>

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">鍵の生成に失敗しました</string>
     <string name="failed_to_send">送信に失敗しました</string>
     <string name="failed_to_send_details">再試行する前に、アプリのメイン画面に戻って「接続解除」をクリックする必要があるかもしれません。すでにフォームに入力された情報が失われることはありませんので、ご安心ください。</string>
+    <string name="faqs_and_guides">よくある質問とガイド</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/ja/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">現在のVPNトンネルのステータスを表示します</string>
     <string name="foreground_notification_channel_name">VPNトンネルのステータス</string>
     <string name="here_is_your_account_number">これがあなたのアカウント番号です。保存してください！</string>

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">키를 생성하지 못함</string>
     <string name="failed_to_send">전송하지 못함</string>
     <string name="failed_to_send_details">다시 시도하기 전에 앱의 메인 화면으로 돌아가서 연결 끊기를 클릭해야 할 수도 있습니다. 입력한 정보는 양식에서 그대로 유지됩니다.</string>
+    <string name="faqs_and_guides">FAQ 및 가이드</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/ko/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">현재 VPN 터널 상태 표시</string>
     <string name="foreground_notification_channel_name">VPN 터널 상태</string>
     <string name="here_is_your_account_number">계정 번호는 다음과 같습니다. 저장하세요!</string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Generering av en nøkkel mislyktes</string>
     <string name="failed_to_send">Kunne ikke sende</string>
     <string name="failed_to_send_details">Du må gå tilbake til hovedskjermen til appen og trykke på \\\"Koble fra\\\" før du kan prøve på nytt. Men det er ingen grunn til bekymring, informasjonen du har skrevet i skjemaet blir ikke borte.</string>
+    <string name="faqs_and_guides">Ofte stilte spørsmål og veiledninger</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/nb/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Viser gjeldende VPN-tunnelstatus</string>
     <string name="foreground_notification_channel_name">VPN-tunnelstatus</string>
     <string name="here_is_your_account_number">Dette er kontonummeret ditt. Ta vare på det!</string>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Sleutel genereren mislukt</string>
     <string name="failed_to_send">Verzenden mislukt</string>
     <string name="failed_to_send_details">Voordat u het opnieuw probeert, keert u eventueel terug naar het hoofdscherm van de app en klikt u op Verbinding verbreken. Geen zorgen, de ingevoerde informatie blijft in het formulier staan.</string>
+    <string name="faqs_and_guides">Veelgestelde vragen en gidsen</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/nl/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Toont huidige status van VPN-tunnel</string>
     <string name="foreground_notification_channel_name">Status VPN-tunnel</string>
     <string name="here_is_your_account_number">Hier is uw accountnummer. Sla het op!</string>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Nie można wygenerować klucza</string>
     <string name="failed_to_send">Błąd wysyłania</string>
     <string name="failed_to_send_details">Być może przed ponowną próbą trzeba będzie wrócić do głównego ekranu aplikacji i kliknąć przycisk Rozłącz. Nie martw się, wprowadzone informacje pozostaną w formularzu.</string>
+    <string name="faqs_and_guides">Często zadawane pytania i poradniki</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/pl/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Pokazuje bieżący status tunelu VPN</string>
     <string name="foreground_notification_channel_name">Status tunelu VPN</string>
     <string name="here_is_your_account_number">Oto Twój numer konta. Zachowaj go!</string>

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Não foi possível gerar uma chave</string>
     <string name="failed_to_send">Erro no envio</string>
     <string name="failed_to_send_details">Pode ter de voltar ao ecrã principal da app e clicar em Desligar antes de tentar novamente. Não se preocupe, a informação que introduziu permanecerá no formulário.</string>
+    <string name="faqs_and_guides">Perguntas frequentes e guias</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/pt/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Indica o estado atual do túnel VPN</string>
     <string name="foreground_notification_channel_name">Estado do túnel VPN</string>
     <string name="here_is_your_account_number">Aqui tem o seu número de conta. Guarde-o!</string>

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Не удалось сгенерировать ключ</string>
     <string name="failed_to_send">Ошибка отправки</string>
     <string name="failed_to_send_details">Прежде чем повторить попытку, может понадобиться вернуться на главный экран приложения и нажать «Отключить». Не волнуйтесь: введенные в форму данные сохранятся.</string>
+    <string name="faqs_and_guides">Ответы на вопросы и руководства</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/ru/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Показывает текущее состояние VPN-туннеля</string>
     <string name="foreground_notification_channel_name">Состояние туннеля VPN</string>
     <string name="here_is_your_account_number">Вот номер вашей учетной записи. Сохраните его!</string>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Det gick inte att generera en nyckel</string>
     <string name="failed_to_send">Det gick inte att skicka</string>
     <string name="failed_to_send_details">Du kan behöva gå tillbaka till appens huvudskärm och klicka på Koppla från innan du försöker igen. Oroa dig inte, den information du angett i formuläret kommer att bli kvar där.</string>
+    <string name="faqs_and_guides">Vanliga frågor och guider</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/sv/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Visar nuvarande status för VPN-tunnel</string>
     <string name="foreground_notification_channel_name">VPN-tunnelstatus</string>
     <string name="here_is_your_account_number">Här är ditt kontonummer. Spara det!</string>

--- a/android/src/main/res/values-th/strings.xml
+++ b/android/src/main/res/values-th/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">ไม่สามารถสร้างคีย์ได้</string>
     <string name="failed_to_send">ไม่สามารถส่งได้</string>
     <string name="failed_to_send_details">คุณอาจจำเป็นต้องย้อนกลับไปที่หน้าจอหลักของแอป และคลิกตัดการเชื่อมต่อ ก่อนที่จะลองใหม่อีกครั้ง และไม่ต้องกังวลไป เพราะข้อมูลที่คุณป้อนไว้จะยังคงอยู่ในแบบฟอร์มเหมือนเดิม</string>
+    <string name="faqs_and_guides">FAQ และคำแนะนำ</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/th/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">แสดงสถานะช่องทาง VPN ในปัจจุบัน</string>
     <string name="foreground_notification_channel_name">สถานะช่องทาง VPN</string>
     <string name="here_is_your_account_number">นี่คือหมายเลขบัญชีของคุณ จดบันทึกไว้ด้วยนะ!</string>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">Anahtar oluşturulamadı</string>
     <string name="failed_to_send">Gönderme başarısız</string>
     <string name="failed_to_send_details">Yeniden denemeden önce uygulamanın ana ekranına dönüp Bağlantıyı Kes\'e tıklamanız gerekebilir. Endişelenmeyin, girdiğiniz bilgiler formda kalacaktır.</string>
+    <string name="faqs_and_guides">SSS ve Kılavuzlar</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/tr/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Mevcut VPN tünelinin durumunu gösterir</string>
     <string name="foreground_notification_channel_name">VPN tüneli durumu</string>
     <string name="here_is_your_account_number">İşte hesap numaranız. Kaydedin!</string>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -52,6 +52,7 @@
     <string name="failed_to_generate_key">无法生成密钥</string>
     <string name="failed_to_send">无法发送</string>
     <string name="failed_to_send_details">在重试之前，您需要返回应用的主屏幕并点击“断开连接”。别担心，您输入的信息将保留在窗体中。</string>
+    <string name="faqs_and_guides">常见问题解答与指南</string>
     <string name="foreground_notification_channel_description">显示当前的 VPN 隧道状态</string>
     <string name="foreground_notification_channel_name">VPN 隧道状态</string>
     <string name="here_is_your_account_number">以下是您的帐号。请妥善保存！</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -55,6 +55,8 @@
     <string name="failed_to_generate_key">無法產生金鑰</string>
     <string name="failed_to_send">無法傳送</string>
     <string name="failed_to_send_details">在重試之前，您可能需要返回應用程式的主畫面，然後按一下「中斷連線」。請不用擔心，您輸入的資訊將保留在表單中。</string>
+    <string name="faqs_and_guides">常見問題集與指南</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/zh-hant/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">顯示目前的 VPN 通道狀態</string>
     <string name="foreground_notification_channel_name">VPN 通道狀態</string>
     <string name="here_is_your_account_number">以下是您的帳號。請妥善保管！</string>

--- a/android/src/main/res/values/attrs.xml
+++ b/android/src/main/res/values/attrs.xml
@@ -47,9 +47,11 @@
         <attr name="text"
               format="reference|string" />
     </declare-styleable>
-    <declare-styleable name="UrlButton">
+    <declare-styleable name="Url">
         <attr name="url"
               format="reference|string" />
+    </declare-styleable>
+    <declare-styleable name="UrlButton">
         <attr name="withToken"
               format="boolean" />
     </declare-styleable>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="app_version">App version</string>
     <string name="update_available_footer">Update available, download to remain safe.</string>
     <string name="report_a_problem">Report a problem</string>
+    <string name="faqs_and_guides">FAQs &amp; Guides</string>
     <string name="account_number">Account number</string>
     <string name="mullvad_account_number">Mullvad account number</string>
     <string name="copied_mullvad_account_number">Copied Mullvad account number to
@@ -177,5 +178,6 @@
     <string name="wg_key_url">https://mullvad.net/en/account/ports</string>
     <string name="create_account_url">https://mullvad.net/en/account/create</string>
     <string name="download_url">https://mullvad.net/en/download</string>
+    <string name="faqs_and_guides_url">https://mullvad.net/en/help/tag/mullvad-app/</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>
 </resources>


### PR DESCRIPTION
The desktop app has an entry in the Settings page called "FAQs & Guides" that when pressed opens the browser on the help page for the app. This PR adds the same entry to the Android app.

To implement the new settings entry, a new `UrlCell` widget was created. It's based off the `AppVersionCell` widget, which also opens an external link when tapped. The new widget supports configuring the target URL through a style attribute.

As part of the PR, the `AppVersionCell` widget was refactored to sub-class the new `UrlCell` widget in order to reduce the repeated code.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2445)
<!-- Reviewable:end -->
