### PR TITLE
Add multiple providers constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Update Electron from 11.0.2 to 11.2.1 which includes a newer Chromium version and
   security patches.
+- Allow provider constraint to specify multiple hosting providers.
 
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.

--- a/mullvad-cli/src/location.rs
+++ b/mullvad-cli/src/location.rs
@@ -73,9 +73,9 @@ pub fn format_location(location: Option<&RelayLocation>) -> String {
     "any location".to_string()
 }
 
-pub fn format_provider(provider: &str) -> String {
-    if !provider.is_empty() {
-        format!("provider {}", provider)
+pub fn format_providers(providers: &Vec<String>) -> String {
+    if !providers.is_empty() {
+        format!("provider(s) {}", providers.join(", "))
     } else {
         "any provider".to_string()
     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -973,7 +973,7 @@ where
                     BridgeSettings::Normal(settings) => {
                         let bridge_constraints = InternalBridgeConstraints {
                             location: settings.location.clone(),
-                            provider: settings.provider.clone(),
+                            providers: settings.providers.clone(),
                             // FIXME: This is temporary while talpid-core only supports TCP proxies
                             transport_protocol: Constraint::Only(TransportProtocol::Tcp),
                         };

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -14,7 +14,7 @@ use mullvad_types::{
     location::Location,
     relay_constraints::{
         BridgeState, Constraint, InternalBridgeConstraints, LocationConstraint, Match,
-        OpenVpnConstraints, Provider, RelayConstraints, WireguardConstraints,
+        OpenVpnConstraints, Providers, RelayConstraints, WireguardConstraints,
     },
     relay_list::{OpenVpnEndpointData, Relay, RelayList, RelayTunnels, WireguardEndpointData},
 };
@@ -253,7 +253,7 @@ impl RelaySelector {
                 self.preferred_tunnel_constraints(
                     retry_attempt,
                     &original_constraints.location,
-                    &original_constraints.provider,
+                    &original_constraints.providers,
                     wg_key_exists,
                 )
             } else {
@@ -378,7 +378,7 @@ impl RelaySelector {
         &self,
         retry_attempt: u32,
         location_constraint: &Constraint<LocationConstraint>,
-        provider_constraint: &Constraint<Provider>,
+        providers_constraint: &Constraint<Providers>,
         wg_key_exists: bool,
     ) -> (Constraint<u16>, TransportProtocol, TunnelType) {
         #[cfg(not(target_os = "windows"))]
@@ -388,7 +388,7 @@ impl RelaySelector {
                     relay.active
                         && !relay.tunnels.wireguard.is_empty()
                         && location_constraint.matches(relay)
-                        && provider_constraint.matches_eq(&relay.provider)
+                        && providers_constraint.matches(relay)
                 });
             // If location does not support WireGuard, defer to preferred OpenVPN tunnel
             // constraints
@@ -475,7 +475,7 @@ impl RelaySelector {
         if !constraints.location.matches(relay) {
             return None;
         }
-        if !constraints.provider.matches_eq(&relay.provider) {
+        if !constraints.providers.matches(&relay) {
             return None;
         }
 
@@ -543,7 +543,7 @@ impl RelaySelector {
         if !constraints.location.matches(relay) {
             return None;
         }
-        if !constraints.provider.matches_eq(&relay.provider) {
+        if !constraints.providers.matches(relay) {
             return None;
         }
 

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -201,7 +201,7 @@ message AccountHistory {
 message BridgeSettings {
 	message BridgeConstraints {
 		RelayLocation location = 1;
-		string provider = 2;
+		repeated string providers = 2;
 	}
 
 	message LocalProxySettings {
@@ -271,7 +271,7 @@ message TunnelTypeConstraint {
 
 message NormalRelaySettings {
 	RelayLocation location = 1;
-	string provider = 2;
+	repeated string providers = 2;
 	TunnelTypeConstraint tunnel_type = 3;
 	WireguardConstraints wireguard_constraints = 4;
 	OpenvpnConstraints openvpn_constraints = 5;
@@ -280,14 +280,14 @@ message NormalRelaySettings {
 // Constraints are only updated for fields that are provided
 message NormalRelaySettingsUpdate {
 	RelayLocation location = 1;
-	ProviderUpdate provider = 2;
+	ProviderUpdate providers = 2;
 	TunnelTypeUpdate tunnel_type = 3;
 	WireguardConstraints wireguard_constraints = 4;
 	OpenvpnConstraints openvpn_constraints = 5;
 }
 
 message ProviderUpdate {
-	string provider = 1;
+	repeated string providers = 1;
 }
 
 message TunnelTypeUpdate {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -186,7 +186,7 @@ impl RelaySettings {
 pub struct RelayConstraints {
     pub location: Constraint<LocationConstraint>,
     #[cfg_attr(target_os = "android", jnix(skip))]
-    pub provider: Constraint<Provider>,
+    pub providers: Constraint<Providers>,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub tunnel_protocol: Constraint<TunnelType>,
     #[cfg_attr(target_os = "android", jnix(skip))]
@@ -201,7 +201,7 @@ impl Default for RelayConstraints {
         RelayConstraints {
             tunnel_protocol: Constraint::Only(TunnelType::Wireguard),
             location: Constraint::default(),
-            provider: Constraint::default(),
+            providers: Constraint::default(),
             wireguard_constraints: WireguardConstraints::default(),
             openvpn_constraints: OpenVpnConstraints::default(),
         }
@@ -212,7 +212,7 @@ impl RelayConstraints {
     pub fn merge(&self, update: RelayConstraintsUpdate) -> Self {
         RelayConstraints {
             location: update.location.unwrap_or_else(|| self.location.clone()),
-            provider: update.provider.unwrap_or_else(|| self.provider.clone()),
+            providers: update.providers.unwrap_or_else(|| self.providers.clone()),
             tunnel_protocol: update
                 .tunnel_protocol
                 .unwrap_or_else(|| self.tunnel_protocol.clone()),
@@ -252,12 +252,9 @@ impl fmt::Display for RelayConstraints {
             Constraint::Only(ref location_constraint) => location_constraint.fmt(f)?,
         }
         write!(f, " using ")?;
-        match self.provider {
+        match self.providers {
             Constraint::Any => write!(f, "any provider"),
-            Constraint::Only(ref constraint) => {
-                write!(f, "provider ")?;
-                constraint.fmt(f)
-            }
+            Constraint::Only(ref constraint) => constraint.fmt(f),
         }
     }
 }
@@ -480,7 +477,7 @@ pub enum BridgeSettings {
 #[serde(rename_all = "snake_case")]
 pub struct BridgeConstraints {
     pub location: Constraint<LocationConstraint>,
-    pub provider: Constraint<Provider>,
+    pub providers: Constraint<Providers>,
 }
 
 impl fmt::Display for BridgeConstraints {
@@ -518,7 +515,7 @@ impl fmt::Display for BridgeState {
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InternalBridgeConstraints {
     pub location: Constraint<LocationConstraint>,
-    pub provider: Constraint<Provider>,
+    pub providers: Constraint<Providers>,
     pub transport_protocol: Constraint<TransportProtocol>,
 }
 
@@ -566,7 +563,7 @@ impl RelaySettingsUpdate {
 pub struct RelayConstraintsUpdate {
     pub location: Option<Constraint<LocationConstraint>>,
     #[cfg_attr(target_os = "android", jnix(default))]
-    pub provider: Option<Constraint<Provider>>,
+    pub providers: Option<Constraint<Providers>>,
     #[cfg_attr(target_os = "android", jnix(default))]
     pub tunnel_protocol: Option<Constraint<TunnelType>>,
     #[cfg_attr(target_os = "android", jnix(default))]


### PR DESCRIPTION
#2018 added provider relay and bridge constraints, but these only allowed you to specify a single provider. This PR updates it so that one out of multiple providers may be selected.

Usage:

```
mullvad relay set provider any

mullvad relay set provider 31173 M247
mullvad bridge set provider M247
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2446)
<!-- Reviewable:end -->
