### PR TITLE
Update suggested upgrade version when enabling/disabling beta program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.
 
+### Fixed
+- Fix delay in showing/hiding update notification when toggling beta program.
+
 
 ## [2021.1-beta2] - 2021-02-03
 ### Fixed

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(rust_2018_idioms)]
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
This PR updates the value of `suggested_upgrade` and emits it to clients when `set_show_beta_releases` is called. This fixes the issue where the GUI doesn't show/hide the notification telling the user to upgrade after the beta program toggle has been changed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2447)
<!-- Reviewable:end -->
