### PR TITLE
Add WireGuard default port (51820) to list of ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Enable isolation of the Electron renderer process to protect against potentially malicious third
   party dependencies.
+- Add 51820 to list of WireGuard ports in app settings.
 
 #### Android
 - Allow reaching the API server when connecting, disconnecting or in a blocked state.

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -49,7 +49,7 @@ const MIN_WIREGUARD_MTU_VALUE = 1280;
 const MAX_WIREGUARD_MTU_VALUE = 1420;
 const UDP_PORTS = [1194, 1195, 1196, 1197, 1300, 1301, 1302];
 const TCP_PORTS = [80, 443];
-const WIREUGARD_UDP_PORTS = [53];
+const WIREUGARD_UDP_PORTS = [51820, 53];
 
 type OptionalPort = number | undefined;
 


### PR DESCRIPTION
This PR adds 51820 to the list of WireGuard ports.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2451)
<!-- Reviewable:end -->
