### PR TITLE
Remove z-index property on navigation bar back button

### DIFF
--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -87,7 +87,6 @@ export const StyledBackBarItemButton = styled.button({
   flexDirection: 'row',
   alignItems: 'center',
   backgroundColor: 'transparent',
-  zIndex: 1,
 });
 
 export const StyledBackBarItemIcon = styled(ImageView)({


### PR DESCRIPTION
This PR removes the `z-index` property on the navigation bar back button which was previously required due to some invisible element, used for measuring the title placement, being placed in front. I have a vague memory of fixing this in some other way at a later time and after removing the `z-index` property everything seems to work as expected.

The `z-index` property caused the button to be places on top of the modal background making it fully visible and clickable while a modal was showing.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2454)
<!-- Reviewable:end -->
