### PR TITLE
Upgrade quickcheck dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,21 +1987,20 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quickcheck"
-version = "0.9.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger 0.8.2",
  "log 0.4.14",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.3",
 ]
 
 [[package]]
 name = "quickcheck_macros"
-version = "0.9.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -83,5 +83,5 @@ tonic-build = { version = "0.3", default-features = false, features = ["transpor
 
 [dev-dependencies]
 tempfile = "3.0"
-quickcheck = "0.9"
-quickcheck_macros = "0.9"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"


### PR DESCRIPTION
This updates `quickcheck` and `quickcheck-macros` to 1.0. Unfortunately, it looks like `quickcheck::Gen` is now very limited, exposing only a `choose(slice)` method, so the provided PRNG cannot be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2455)
<!-- Reviewable:end -->
