### PR TITLE
Fix Rust nightly issues

### DIFF
--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -285,7 +285,7 @@ impl Bridge {
             };
             let packed_proxy = openvpn::ProxySettings::Local(local_proxy);
             if let Err(error) = openvpn::validate_proxy_settings(&packed_proxy) {
-                panic!(error);
+                panic!("{}", error);
             }
 
             let mut rpc = new_rpc_client().await?;
@@ -324,7 +324,7 @@ impl Bridge {
 
             let packed_proxy = openvpn::ProxySettings::Remote(proxy);
             if let Err(error) = openvpn::validate_proxy_settings(&packed_proxy) {
-                panic!(error);
+                panic!("{}", error);
             }
 
             let mut rpc = new_rpc_client().await?;
@@ -353,7 +353,7 @@ impl Bridge {
 
             let packed_proxy = openvpn::ProxySettings::Shadowsocks(proxy);
             if let Err(error) = openvpn::validate_proxy_settings(&packed_proxy) {
-                panic!(error);
+                panic!("{}", error);
             }
 
             let mut rpc = new_rpc_client().await?;

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -170,8 +170,8 @@ pub struct TunnelOptions {
 }
 
 /// Custom DNS config
-#[serde(default)]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(default)]
 #[cfg_attr(target_os = "android", derive(FromJava, IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct DnsOptions {

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -44,8 +44,8 @@ pub struct AssociatedAddresses {
 }
 
 /// Event that is emitted when the daemon has finished generating a key.
-#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub enum KeygenEvent {

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Types of bridges that can be used to proxy a connection to a tunnel
-#[serde(rename_all = "snake_case")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ProxyType {
     Shadowsocks,
     Custom,


### PR DESCRIPTION
Rust nightly builds fail:
> warning: derive helper attribute is used before it is introduced

The PR fixes these and some warnings about panic string types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2456)
<!-- Reviewable:end -->
