### PR TITLE
Remove nseventmonitor from dependencies group

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -30,8 +30,7 @@
     "redux": "^4.0.5",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.1.1",
-    "uuid": "^3.0.1",
-    "nseventmonitor": "^0.0.19"
+    "uuid": "^3.0.1"
   },
   "optionalDependencies": {
     "nseventmonitor": "^1.0.0"


### PR DESCRIPTION
This PR removes `nseventmonitor` from the `dependencies` group in `package.json`, it's still in `optionalDependencies` though. The reason to why it's in `dependencies` as well is that npm 7+ adds it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2458)
<!-- Reviewable:end -->
