### PR TITLE
Fix crash when pasting empty string into account token input

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Changed
 - Migrate to WireGuardKit framework.
+- Fix crash when pasting empty string into account input field.
 
 ## [2020.5] - 2020-11-04
 ### Fixed

--- a/ios/MullvadVPN/AccountTokenInput.swift
+++ b/ios/MullvadVPN/AccountTokenInput.swift
@@ -60,7 +60,7 @@ class AccountTokenInput: NSObject
 
         // Since removing separator alone makes no sense, this computation extends the string range
         // to include the digit preceding a separator.
-        if replacementString.isEmpty && emptySelection {
+        if replacementString.isEmpty && emptySelection && !formattedString.isEmpty  {
             let precedingDigitIndex = formattedString
                 .prefix(through: stringRange.lowerBound)
                 .lastIndex { Self.isDigit($0) } ?? formattedString.startIndex


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes a crash that may occur when pasting an empty string into empty account input field. The reason for that is that `String.prefix(through:)` picks the characters up to _and_ including the character at the given index, so the following just does not work:

```
var s = ""
s.prefix(through: s.startIndex) // Index is out of bounds
```

This PR addresses this by guarding against empty string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2459)
<!-- Reviewable:end -->
