### PR TITLE
Use non-quick rules for blocking all traffic on macOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Line wrap the file at 100 chars.                                              Th
   security patches.
 - Allow provider constraint to specify multiple hosting providers.
 
+#### macOS
+- Change blocking firewall rules to not be _quick_ to allow for user specified rules in `pf` to
+  circumvent our rules.
+
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.
 

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -75,13 +75,11 @@ impl Firewall {
         let return_out_rule = self
             .create_rule_builder(FilterRuleAction::Drop(DropAction::Return))
             .direction(pfctl::Direction::Out)
-            .quick(true)
             .build()?;
         new_filter_rules.push(return_out_rule);
 
         let drop_all_rule = self
             .create_rule_builder(FilterRuleAction::Drop(DropAction::Drop))
-            .quick(true)
             .build()?;
         new_filter_rules.push(drop_all_rule);
 


### PR DESCRIPTION
To allow users to add their own custom firewall rules, we shouldn't have all of our rules be eagerly evaluated, more specifically, our all encompassing blocking rules shouldn't be eagerly evaluated. These changes make it so.

I've tested these changes for leaks when changing between all states and I have also added a permissive rule to `/etc/pf.conf` to allow UDP traffic to 8.8.8.8 on port 53 (both ways), and this _hole_ does work in all the blocking states too, so I am asuming my changes achieve the wanted results in #2171.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2460)
<!-- Reviewable:end -->
