### PR TITLE
Only update the relay list if it has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Line wrap the file at 100 chars.                                              Th
 - Update Electron from 11.0.2 to 11.2.1 which includes a newer Chromium version and
   security patches.
 - Allow provider constraint to specify multiple hosting providers.
+- Only download a new relay list if it has been modified.
 
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -831,7 +831,8 @@ impl RelayListUpdater {
                 cmd = cmd_rx.next() => {
                     match cmd {
                         Some(_) => {
-                            self.consume_new_relay_list(self.rpc_client.relay_list(None).await).await;
+                            let tag = self.parsed_relays.lock().tag().map(|tag| tag.to_string());
+                            self.consume_new_relay_list(self.rpc_client.relay_list(tag).await).await;
                         },
                         None => {
                             log::error!("Relay list updater shutting down");

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -140,6 +140,10 @@ impl ParsedRelays {
     pub fn relays(&self) -> &Vec<Relay> {
         &self.relays
     }
+
+    pub fn tag(&self) -> Option<&str> {
+        self.locations.etag.as_deref()
+    }
 }
 
 pub struct RelaySelector {
@@ -813,7 +817,8 @@ impl RelayListUpdater {
             futures::select! {
                 _check_update = check_interval.next() => {
                     if download_future.is_terminated() && self.should_update() {
-                        download_future = Box::pin(Self::download_relay_list(self.rpc_client.clone()).fuse());
+                        let tag = self.parsed_relays.lock().tag().map(|tag| tag.to_string());
+                        download_future = Box::pin(Self::download_relay_list(self.rpc_client.clone(), tag).fuse());
                         self.earliest_next_try = Instant::now() + UPDATE_INTERVAL;
                     }
                 },
@@ -876,8 +881,9 @@ impl RelayListUpdater {
 
     fn download_relay_list(
         rpc_handle: RelayListProxy,
+        tag: Option<String>,
     ) -> impl Future<Output = Result<Option<RelayList>, mullvad_rpc::rest::Error>> + 'static {
-        let download_futures = move || rpc_handle.relay_list(None);
+        let download_futures = move || rpc_handle.relay_list(tag.clone());
 
         let exponential_backoff = ExponentialBackoff::from_millis(EXPONENTIAL_BACKOFF_DELAY_MS)
             .factor(EXPONENTIAL_BACKOFF_FACTOR)

--- a/mullvad-rpc/src/bin/relay_list.rs
+++ b/mullvad-rpc/src/bin/relay_list.rs
@@ -10,7 +10,7 @@ async fn main() {
         MullvadRpcRuntime::new(tokio::runtime::Handle::current()).expect("Failed to load runtime");
 
     let relay_list_request = RelayListProxy::new(runtime.mullvad_rest_handle())
-        .relay_list()
+        .relay_list(None)
         .await;
 
     let relay_list = match relay_list_request {

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -365,7 +365,7 @@ impl AppVersionProxy {
 
         async move {
             let mut request = request?;
-            request.add_header("M-Platform-Version", platform_version)?;
+            request.add_header("M-Platform-Version", &platform_version)?;
 
             let response = service.request(request).await?;
             let parsed_response = rest::parse_rest_response(response, StatusCode::OK).await?;

--- a/mullvad-rpc/src/relay_list.rs
+++ b/mullvad-rpc/src/relay_list.rs
@@ -112,9 +112,13 @@ impl ServerRelayList {
         Self::add_wireguard_relays(&mut countries, wireguard);
         Self::add_bridge_relays(&mut countries, bridge);
 
-
         relay_list::RelayList {
-            etag,
+            etag: etag.map(|mut tag| {
+                if tag.starts_with("\"") {
+                    tag.insert_str(0, "W/");
+                }
+                tag
+            }),
             countries: countries
                 .into_iter()
                 .map(|(_key, country)| country)

--- a/mullvad-rpc/src/relay_list.rs
+++ b/mullvad-rpc/src/relay_list.rs
@@ -38,13 +38,12 @@ impl RelayListProxy {
             let mut request = request?;
             request.set_timeout(RELAY_LIST_TIMEOUT);
 
-            let has_tag = etag.is_some();
-            if let Some(tag) = etag {
-                request.add_header("If-None-Match", tag)?;
+            if let Some(ref tag) = etag {
+                request.add_header(header::IF_NONE_MATCH, tag)?;
             }
 
             let response = service.request(request).await?;
-            if has_tag && response.status() == StatusCode::NOT_MODIFIED {
+            if etag.is_some() && response.status() == StatusCode::NOT_MODIFIED {
                 return Ok(None);
             }
             if response.status() != StatusCode::OK {

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -342,9 +342,8 @@ impl RestRequest {
         self.timeout
     }
 
-    pub fn add_header(&mut self, key: &'static str, value: String) -> Result<()> {
-        let header_value =
-            http::HeaderValue::from_str(&value).map_err(Error::InvalidHeaderError)?;
+    pub fn add_header<T: header::IntoHeaderName>(&mut self, key: T, value: &str) -> Result<()> {
+        let header_value = http::HeaderValue::from_str(value).map_err(Error::InvalidHeaderError)?;
         self.request.headers_mut().insert(key, header_value);
         Ok(())
     }

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -21,12 +21,14 @@ use talpid_types::net::{
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct RelayList {
+    pub etag: Option<String>,
     pub countries: Vec<RelayListCountry>,
 }
 
 impl RelayList {
     pub fn empty() -> Self {
         Self {
+            etag: None,
             countries: Vec::new(),
         }
     }


### PR DESCRIPTION
The relay list endpoint (https://api.mullvad.net/v1/relays) will soonish include ETags in its responses. Setting the `If-None-Match` header to this value allows the server to respond with 304 instead of sending back the entire unmodified list (saving ~0.166 MB per hour).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2462)
<!-- Reviewable:end -->
