### PR TITLE
Prepare Andorid IPC channel between UI and service

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.github.triplet.play'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-parcelize'
 
 def repoRootPath = projectDir.absoluteFile.parentFile.absolutePath
 def extraAssetsDirectory = "$project.buildDir/extraAssets"
@@ -120,7 +121,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.triplet.gradle:play-publisher:2.7.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20'
     }
 }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/DispatchingHandler.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/DispatchingHandler.kt
@@ -1,0 +1,48 @@
+package net.mullvad.mullvadvpn.ipc
+
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.util.Log
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.withLock
+import kotlin.reflect.KClass
+
+class DispatchingHandler<T : Any>(
+    looper: Looper,
+    private val extractor: (Message) -> T?
+) : Handler(looper) {
+    private val handlers = HashMap<KClass<out T>, (T) -> Unit>()
+    private val lock = ReentrantReadWriteLock()
+
+    fun <V : T> registerHandler(variant: KClass<V>, handler: (V) -> Unit) {
+        lock.writeLock().withLock {
+            handlers.put(variant) { instance ->
+                @Suppress("UNCHECKED_CAST")
+                handler(instance as V)
+            }
+        }
+    }
+
+    override fun handleMessage(message: Message) {
+        lock.readLock().withLock {
+            val instance = extractor(message)
+
+            if (instance != null) {
+                val handler = handlers.get(instance::class)
+
+                handler?.invoke(instance)
+            } else {
+                Log.e("mullvad", "Dispatching handler received an unexpected message")
+            }
+        }
+    }
+
+    fun onDestroy() {
+        lock.writeLock().withLock {
+            handlers.clear()
+        }
+
+        removeCallbacksAndMessages(null)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -1,0 +1,20 @@
+package net.mullvad.mullvadvpn.ipc
+
+import android.os.Message as RawMessage
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+// Events that can be sent from the service
+sealed class Event : Message(), Parcelable {
+    protected override val messageId = 1
+    protected override val messageKey = MESSAGE_KEY
+
+    @Parcelize
+    object ListenerReady : Event(), Parcelable
+
+    companion object {
+        private const val MESSAGE_KEY = "event"
+
+        fun fromMessage(message: RawMessage): Event? = Message.fromMessage(message, MESSAGE_KEY)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Message.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Message.kt
@@ -1,0 +1,25 @@
+package net.mullvad.mullvadvpn.ipc
+
+import android.os.Bundle
+import android.os.Message as RawMessage
+import android.os.Parcelable
+
+abstract class Message : Parcelable {
+    protected abstract val messageId: Int
+    protected abstract val messageKey: String
+
+    val message: RawMessage
+        get() = RawMessage.obtain().also { message ->
+            message.what = messageId
+            message.data = Bundle()
+            message.data.putParcelable(messageKey, this)
+        }
+
+    companion object {
+        internal fun <T : Parcelable> fromMessage(message: RawMessage, key: String): T? {
+            val data = message.data
+
+            return data.getParcelable(key)
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -1,12 +1,17 @@
 package net.mullvad.mullvadvpn.ipc
 
 import android.os.Message as RawMessage
+import android.os.Messenger
 import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
 // Requests that the service can handle
 sealed class Request : Message(), Parcelable {
     protected override val messageId = 2
     protected override val messageKey = MESSAGE_KEY
+
+    @Parcelize
+    class RegisterListener(val listener: Messenger) : Request(), Parcelable
 
     companion object {
         private const val MESSAGE_KEY = "request"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -1,0 +1,16 @@
+package net.mullvad.mullvadvpn.ipc
+
+import android.os.Message as RawMessage
+import android.os.Parcelable
+
+// Requests that the service can handle
+sealed class Request : Message(), Parcelable {
+    protected override val messageId = 2
+    protected override val messageKey = MESSAGE_KEY
+
+    companion object {
+        private const val MESSAGE_KEY = "request"
+
+        fun fromMessage(message: RawMessage): Request? = Message.fromMessage(message, MESSAGE_KEY)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -101,15 +101,16 @@ class MullvadVpnService : TalpidVpnService() {
 
         initializeSplitTunneling()
 
+        daemonInstance = DaemonInstance(this)
         keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         notificationManager = ForegroundNotificationManager(this, serviceNotifier, keyguardManager)
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
-        endpoint = ServiceEndpoint(Looper.getMainLooper())
+        endpoint = ServiceEndpoint(Looper.getMainLooper(), daemonInstance.intermittentDaemon)
 
         notificationManager.acknowledgeStartForegroundService()
 
-        daemonInstance = DaemonInstance(this).apply {
+        daemonInstance.apply {
             intermittentDaemon.registerListener(this@MullvadVpnService) { daemon ->
                 handleDaemonInstance(daemon)
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.VpnService
 import android.os.Binder
 import android.os.IBinder
+import android.os.Looper
 import android.util.Log
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.CompletableDeferred
@@ -14,6 +15,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
 import net.mullvad.mullvadvpn.service.notifications.AccountExpiryNotification
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
 import net.mullvad.mullvadvpn.ui.MainActivity
@@ -69,6 +71,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private lateinit var daemonInstance: DaemonInstance
+    private lateinit var endpoint: ServiceEndpoint
     private lateinit var keyguardManager: KeyguardManager
     private lateinit var notificationManager: ForegroundNotificationManager
     private lateinit var tunnelStateUpdater: TunnelStateUpdater
@@ -101,6 +104,8 @@ class MullvadVpnService : TalpidVpnService() {
         keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         notificationManager = ForegroundNotificationManager(this, serviceNotifier, keyguardManager)
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
+
+        endpoint = ServiceEndpoint(Looper.getMainLooper())
 
         notificationManager.acknowledgeStartForegroundService()
 
@@ -241,6 +246,7 @@ class MullvadVpnService : TalpidVpnService() {
 
         if (state == State.Running) {
             instance = ServiceInstance(
+                endpoint.messenger,
                 daemon,
                 connectionProxy,
                 connectivityListener,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,8 +1,10 @@
 package net.mullvad.mullvadvpn.service
 
+import android.os.Messenger
 import net.mullvad.talpid.ConnectivityListener
 
 class ServiceInstance(
+    val messenger: Messenger,
     val daemon: MullvadDaemon,
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -6,11 +6,19 @@ import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Request
 
 class ServiceEndpoint(looper: Looper) {
+    private val listeners = mutableSetOf<Messenger>()
+
     internal val dispatcher = DispatchingHandler(looper) { message ->
         Request.fromMessage(message)
     }
 
     val messenger = Messenger(dispatcher)
+
+    init {
+        dispatcher.registerHandler(Request.RegisterListener::class) { request ->
+            listeners.add(request.listener)
+        }
+    }
 
     fun onDestroy() {
         dispatcher.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
 import android.os.Looper
+import android.os.Messenger
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Request
 
@@ -8,6 +9,8 @@ class ServiceEndpoint(looper: Looper) {
     internal val dispatcher = DispatchingHandler(looper) { message ->
         Request.fromMessage(message)
     }
+
+    val messenger = Messenger(dispatcher)
 
     fun onDestroy() {
         dispatcher.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -1,0 +1,15 @@
+package net.mullvad.mullvadvpn.service.endpoint
+
+import android.os.Looper
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Request
+
+class ServiceEndpoint(looper: Looper) {
+    internal val dispatcher = DispatchingHandler(looper) { message ->
+        Request.fromMessage(message)
+    }
+
+    fun onDestroy() {
+        dispatcher.onDestroy()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.service.endpoint
 import android.os.Looper
 import android.os.Messenger
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 
 class ServiceEndpoint(looper: Looper) {
@@ -16,11 +17,23 @@ class ServiceEndpoint(looper: Looper) {
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->
-            listeners.add(request.listener)
+            registerListener(request.listener)
         }
     }
 
     fun onDestroy() {
         dispatcher.onDestroy()
+    }
+
+    private fun registerListener(listener: Messenger) {
+        synchronized(this) {
+            listeners.add(listener)
+
+            val initialEvents = listOf(Event.ListenerReady)
+
+            initialEvents.forEach { event ->
+                listener.send(event.message)
+            }
+        }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import kotlinx.coroutines.CompletableDeferred
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 
 class LaunchFragment : ServiceAwareFragment() {
     private val hasAccountToken = CompletableDeferred<Boolean>()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -72,6 +72,7 @@ class MainActivity : FragmentActivity() {
         override fun onServiceDisconnected(className: ComponentName) {
             android.util.Log.d("mullvad", "UI lost the connection to the service")
             service?.serviceNotifier?.unsubscribe(this@MainActivity)
+            serviceConnection?.onDestroy()
             service = null
             serviceConnection = null
             serviceNotifier.notify(null)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -20,6 +20,7 @@ import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
 import net.mullvad.mullvadvpn.service.MullvadVpnService
+import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.talpid.util.EventNotifier
 
 class MainActivity : FragmentActivity() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.service.MullvadVpnService
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.talpid.util.EventNotifier
@@ -61,7 +62,14 @@ class MainActivity : FragmentActivity() {
                 }
 
                 serviceConnection = newConnection
-                serviceNotifier.notify(newConnection)
+
+                if (newConnection != null) {
+                    newConnection.dispatcher.registerHandler(Event.ListenerReady::class) { _ ->
+                        serviceNotifier.notify(newConnection)
+                    }
+                } else {
+                    serviceNotifier.notify(null)
+                }
 
                 if (shouldConnect) {
                     tryToConnect()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceAwareFragment.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.ui
 
 import android.content.Context
 import net.mullvad.mullvadvpn.ui.fragments.BaseFragment
+import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.util.JobTracker
 
 abstract class ServiceAwareFragment : BaseFragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -15,6 +15,7 @@ import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SettingsListener
 import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 
 abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceAwareFragment() {
     enum class OnNoService {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -8,6 +8,7 @@ import android.widget.ImageButton
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.service.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.widget.AccountCell
 import net.mullvad.mullvadvpn.ui.widget.AppVersionCell
 import net.mullvad.mullvadvpn.ui.widget.NavigateCell

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -5,6 +5,10 @@ import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.ServiceInstance
 import net.mullvad.mullvadvpn.ui.MainActivity
 
+// Container of classes that communicate with the service through an active connection
+//
+// The properties of this class can be used to send events to the service, to listen for events from
+// the service and to get values received from events.
 class ServiceConnection(private val service: ServiceInstance, val mainActivity: MainActivity) {
     val daemon = service.daemon
     val accountCache = service.accountCache

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -1,7 +1,14 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
+import android.os.Looper
+import android.os.Messenger
+import android.os.RemoteException
+import android.util.Log
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.service.ServiceInstance
 import net.mullvad.mullvadvpn.ui.MainActivity
 
@@ -10,6 +17,10 @@ import net.mullvad.mullvadvpn.ui.MainActivity
 // The properties of this class can be used to send events to the service, to listen for events from
 // the service and to get values received from events.
 class ServiceConnection(private val service: ServiceInstance, val mainActivity: MainActivity) {
+    val dispatcher = DispatchingHandler(Looper.getMainLooper()) { message ->
+        Event.fromMessage(message)
+    }
+
     val daemon = service.daemon
     val accountCache = service.accountCache
     val connectionProxy = service.connectionProxy
@@ -25,11 +36,25 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     init {
         appVersionInfoCache.onCreate()
         connectionProxy.mainActivity = mainActivity
+        registerListener()
     }
 
     fun onDestroy() {
+        dispatcher.onDestroy()
+
         appVersionInfoCache.onDestroy()
         relayListListener.onDestroy()
         connectionProxy.mainActivity = null
+    }
+
+    private fun registerListener() {
+        val listener = Messenger(dispatcher)
+        val request = Request.RegisterListener(listener)
+
+        try {
+            service.messenger.send(request.message)
+        } catch (exception: RemoteException) {
+            Log.e("mullvad", "Failed to register listener for service events", exception)
+        }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -1,8 +1,9 @@
-package net.mullvad.mullvadvpn.ui
+package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.ServiceInstance
+import net.mullvad.mullvadvpn.ui.MainActivity
 
 class ServiceConnection(private val service: ServiceInstance, val mainActivity: MainActivity) {
     val daemon = service.daemon


### PR DESCRIPTION
This PR creates the packages and classes that serve as the base for the IPC channel for communication between the UI and service once they become separate processes. To serialize and deserialize classes through the channel, they are converted to `Parcel`s using the Parcelize plugin. Two types of Parcels are implemented in this PR, an `Event` class for sending events from the service to the UI and a `Request` for sending requests from the UI to the service.

The only request that can be made is to register an event listener, and the only event that is currently sent is to notify that the listener was successfully registered. A `DispatchingHandler` helper class extends the Android message `Handler` class and servers as the incoming message dispatcher. Listeners can register handlers for specific message sub-types, and get executed once messages of that type are received. A `DispatchingHandler<Request>` is instanced in the service side to handle incoming requests and a `DispatchingHandler<Event>` is instanced in the UI side to handle incoming events.

The existing `ServiceConnection` class in the UI side now sends a request to the service to register the event dispatching handler instance as listener, and the `MainActivity` registers a handler for the `ListenerReady` event so that it can notify the UI classes that the service is available and ready.

On the service side, the `ServiceEndpoint` serves as the endpoint that sends events and instances the dispatching handler for incoming requests. The only request it handles right now is to register a listener, which is added to a set of listeners. After registering a listener, the first `Event` is sent to notify that the listener is registered, but it is only sent after the daemon instance has successfully started. This is used in future PRs to make sure that the listener receives initial events with valid initial values obtained from the daemon.

The `ServiceEndpoint` provides a `sendEvent` method that can be used to send an `Event` to all registers listeners, and will remove from the listener set the listeners for which it fails to send to. This method is used by service-side classes when they want to send events through the channel.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2463)
<!-- Reviewable:end -->
