### PR TITLE
Migrate Android CI from Travis CI to GitHub Actions workflows 

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -1,0 +1,77 @@
+name: Android app CI
+on:
+    # Build whenever a file that affects Android is changed by a push
+    push:
+        paths:
+            - .github/workflows/android-app.yml
+            - android/**
+            - mullvad-daemon/**
+            - mullvad-jni/**
+            - mullvad-paths/**
+            - mullvad-problem-report/**
+            - mullvad-rpc/**
+            - mullvad-types/**
+            - talpid-core/**
+            - talpid-platform-metadata/**
+            - talpid-types/**
+            - talpid-types/**
+            - wireguard/**
+            - Cargo.toml
+            - build-apk.sh
+            - update-api-metadata.sh
+            - update-version-metadata.sh
+            - version-metadata.sh
+    # Build if requested manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            # Checkout repository
+            - uses: actions/checkout@v2
+
+            # Install Rust
+            - uses: ATiltedTree/setup-rust@v1.0.4
+              with:
+                  rust-version: stable
+                  targets: aarch64-linux-android
+
+            # Install Go
+            - uses: actions/setup-go@v2.1.3
+              with:
+                  go-version: 1.13.5
+
+            # Install Android SDK
+            - uses: maxim-lobanov/setup-android-tools@v1
+              with:
+                  packages: |
+                      platforms;android-30
+                      build-tools;30.0.3
+                  cache: true
+
+            # Install Android NDK
+            - id: install-android-ndk
+              uses: nttld/setup-ndk@v1
+              with:
+                  ndk-version: r20b
+
+            # Configure Cargo to use NDK toolchain
+            - run: |
+                cat >> $HOME/.cargo/config << EOF
+                [target.aarch64-linux-android]
+                ar = "${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+                linker = "${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+                EOF
+
+            # Build APK
+            - env:
+                RUSTFLAGS: --deny warnings
+                AR_aarch64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
+                CC_aarch64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang
+                ARCHITECTURES: arm64
+              run: |
+                ./wireguard/build-wireguard-go.sh --android --no-docker
+                source env.sh aarch64-linux-android
+                cargo build --target aarch64-linux-android --verbose --package mullvad-jni
+                cd android
+                ./gradlew --console plain assembleDebug

--- a/.github/workflows/android-ktlint.yml
+++ b/.github/workflows/android-ktlint.yml
@@ -1,0 +1,25 @@
+name: Android app Kotlin linter
+on:
+    # Run linter whenever a Kotlin file changes
+    push:
+        paths:
+            - .github/workflows/android-ktlint.yml
+            - android/**/*.kt
+    # Run linter if requested manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    ktlint:
+        runs-on: ubuntu-latest
+        steps:
+            # Checkout repository
+            - uses: actions/checkout@v2
+
+            # Install Ktlint
+            - uses: nbadal/action-ktlint-setup@v1
+              with:
+                  ktlint_version: 0.40.0
+
+            # Check formatting
+            - run: |
+                cd android
+                ktlint -a

--- a/.github/workflows/android-xml-tidy.yml
+++ b/.github/workflows/android-xml-tidy.yml
@@ -1,0 +1,21 @@
+name: Android app XML formatting verifier
+on:
+    # Run verifier whenever an Android XML file changes
+    push:
+        paths:
+            - .github/workflows/android-xml-tidy.yml
+            - android/**/*.xml
+    # Run verifier if requested manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    xml-tidy:
+        runs-on: ubuntu-latest
+        steps:
+            # Checkout repository
+            - uses: actions/checkout@v2
+
+            # Check formatting
+            - run: |
+                sudo apt-get install tidy
+                source ci/ci-android-xml.sh
+                tidy-verify-xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,49 +37,6 @@ matrix:
       install: *node_install
       script: *node_script
 
-    # Android
-    - language: android
-      name: Android
-      android:
-        components:
-          - android-30
-          - build-tools-30.0.3
-      install:
-        - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable --profile minimal -y
-        - source $HOME/.cargo/env
-        - rustup target add aarch64-linux-android
-        - curl -sf -L -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
-        - sudo mkdir /opt/android
-        - sudo unzip -q -d /opt/android/ /tmp/ndk.zip
-        - sudo /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm64 --install-dir=/opt/android/toolchains/android21-aarch64
-        - sudo apt install tidy
-        - |
-            curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.40.0/ktlint &&
-            chmod a+x ktlint &&
-            sudo mv ktlint /usr/local/bin/
-        - |
-            cat >> $HOME/.cargo/config << EOF
-            [target.aarch64-linux-android]
-            ar = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
-            linker = "/opt/android/android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
-      before_script:
-        - mkdir "$ANDROID_HOME/licenses" || true
-        - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
-        - export RUSTFLAGS="--deny warnings"
-        - export AR_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android-ar
-        - export CC_aarch64_linux_android=/opt/android/toolchains/android21-aarch64/bin/aarch64-linux-android21-clang
-        - source env.sh aarch64-linux-android
-        - env
-      script:
-        - ./wireguard/build-wireguard-go.sh --android
-        - cargo build --target aarch64-linux-android --verbose --package mullvad-jni
-        - cd android
-        - ./gradlew --console plain assembleDebug
-        # Run ktlint with extra andorid rules
-        - ktlint -a
-        - cd ..
-        - source ci/ci-android-xml.sh && tidy-verify-xml
-
     # iOS
     - language: swift
       osx_image: xcode12.2

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -10,7 +10,8 @@ cd $script_dir
 export GOPATH=$script_dir/../../build/android-go-path/
 mkdir -p $GOPATH
 
-for arch in arm arm64 x86_64 x86; do
+ARCHITECTURES="${ARCHITECTURES:-"arm arm64 x86_64 x86"}"
+for arch in $ARCHITECTURES; do
     case "$arch" in
         "arm64")
             export ANDROID_LLVM_TRIPLE="aarch64-linux-android"


### PR DESCRIPTION
This PR is based on some initial experimentation with GitHub Actions. I've managed to create three workflows that are roughly equivalent to the previous Travis CI job. I configured them so that they only run when Android relevant files change, so they should only be triggered when it's appropriate.

I'm still learning things, so we can probably tweak this a lot, but hopefully it's good enough to start migrating from Travis.

For building WireGuard-Go for Android, I tweaked the build script a bit so that the architectures to build for can be configured through an environment variable so that we don't waste time building for more than one architecture on CI.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2469)
<!-- Reviewable:end -->
