### PR TITLE
Stop applying IPv6 routes for OpenVPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix delay in showing/hiding update notification when toggling beta program.
 
+#### Linux
+- Fix crash when trying to apply IPv6 rotues for OpenVPN when IPv6 is disabled.
+
 
 ## [2021.1] - 2021-02-10
 ### Fixed

--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -64,7 +64,8 @@ impl fmt::Display for Route {
 /// default route.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub struct RequiredRoute {
-    prefix: IpNetwork,
+    /// Route's prefix
+    pub prefix: IpNetwork,
     node: NetNode,
     #[cfg(target_os = "linux")]
     table_id: u32,


### PR DESCRIPTION
The OpenVPN event callback would panic when it fails to add an IPv6 route on machines that don't support IPv6. This is because the generic option for enabling IPv6 is not taken into account, and seemingly a considerable amount of users disable IPv6 in their kernels for _reasons_. As such, I've changed the callback to take the option into account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2471)
<!-- Reviewable:end -->
