### PR TITLE
Do not fail if Wintun adapter is assigned a different alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ Line wrap the file at 100 chars.                                              Th
 - Ignore failure to  add IPv6 split-tunneling routing rules when they fail due to IPv6 being
   unavailable.
 
+#### Windows
+- Fix failure when Wintun adapter name conflicts with that of a non-Wintun adapter.
+
 
 ## [2021.1] - 2021-02-10
 This release is for desktop only.

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -142,7 +142,7 @@ pub enum Error {
     #[error(display = "Failed to determine alias of Wintun adapter")]
     WintunFindAlias(#[error(source)] io::Error),
 
-    /// cannot create a wintun interface
+    /// cannot delete wintun interface
     #[cfg(windows)]
     #[error(display = "Failed to delete existing Wintun adapter")]
     WintunDeleteExistingError(#[error(source)] io::Error),

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -389,6 +389,11 @@ pub enum TunnelError {
     #[error(display = "Invalid tunnel interface name")]
     InterfaceNameError(#[error(source)] std::ffi::NulError),
 
+    /// Failed to convert adapter alias to UTF-8.
+    #[cfg(target_os = "windows")]
+    #[error(display = "Failed to convert adapter alias")]
+    InvalidAlias,
+
     /// Failed to set ip addresses on tunnel interface.
     #[cfg(target_os = "windows")]
     #[error(display = "Failed to set IP addresses on WireGuard interface")]

--- a/windows/libshared/src/libshared/network/interfaceutils.cpp
+++ b/windows/libshared/src/libshared/network/interfaceutils.cpp
@@ -5,18 +5,6 @@
 #include <libcommon/error.h>
 #include <libcommon/string.h>
 
-namespace
-{
-
-// Interface description substrings found for virtual adapters.
-const wchar_t *TUNNEL_INTERFACE_DESCS[] = {
-	L"WireGuard",
-	L"Wintun",
-	L"Mullvad"
-};
-
-} // anonymous namespace
-
 namespace shared::network
 {
 

--- a/wireguard/libwg/interfacewatcher/interfacewatcher_windows.go
+++ b/wireguard/libwg/interfacewatcher/interfacewatcher_windows.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT
  *
  * Copyright (C) 2019 WireGuard LLC. All Rights Reserved.
- * Copyright (C) 2020 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
  */
 
 package interfacewatcher

--- a/wireguard/libwg/libwg.go
+++ b/wireguard/libwg/libwg.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2020 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard/libwg/libwg_android.go
+++ b/wireguard/libwg/libwg_android.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2020 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard/libwg/libwg_default.go
+++ b/wireguard/libwg/libwg_default.go
@@ -4,7 +4,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2020 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard/libwg/libwg_windows.go
+++ b/wireguard/libwg/libwg_windows.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2020 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard/libwg/logging/logging.go
+++ b/wireguard/libwg/logging/logging.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2020 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
  */
 
 package logging


### PR DESCRIPTION
Currently, if a non-Wintun device has an alias that conflicts with ours, starting the tunnel fails with `ERROR_ALREADY_EXISTS`. These changes make sure that whatever alias is assigned to the adapter is used instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2476)
<!-- Reviewable:end -->
