### PR TITLE
Linux - only apply IPv6 routing rules when IPv6 is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - Fix crash when trying to apply IPv6 rotues for OpenVPN when IPv6 is disabled.
+- Ignore failure to  add IPv6 split-tunneling routing rules when they fail due to IPv6 being
+  unavailable.
 
 
 ## [2021.1] - 2021-02-10

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -314,7 +314,7 @@ impl OpenVpnMonitor<OpenVpnCommand> {
                     }
 
                     #[cfg(target_os = "linux")]
-                    if let Err(error) = route_manager_handle.create_routing_rules() {
+                    if let Err(error) = route_manager_handle.create_routing_rules(ipv6_enabled) {
                         log::error!("{}", error.display_chain());
                         panic!("Failed to add routes");
                     }

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     /// Firewall mark
     #[cfg(target_os = "linux")]
     pub fwmark: u32,
+    /// Enable IPv6 routing rules
+    #[cfg(target_os = "linux")]
+    pub enable_ipv6: bool,
 }
 
 const DEFAULT_MTU: u16 = 1380;
@@ -101,6 +104,8 @@ impl Config {
             mtu,
             #[cfg(target_os = "linux")]
             fwmark: crate::linux::TUNNEL_FW_MARK,
+            #[cfg(target_os = "linux")]
+            enable_ipv6: generic_options.enable_ipv6,
         })
     }
 

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -85,7 +85,7 @@ impl WireguardMonitor {
 
         #[cfg(target_os = "linux")]
         route_manager
-            .create_routing_rules()
+            .create_routing_rules(config.enable_ipv6)
             .map_err(Error::SetupRoutingError)?;
 
         route_manager


### PR DESCRIPTION
The route manager adds IPv6 routing rules even if IPv6 is disabled. On some machines, this fails spectacularly. As such, I've changed the code so IPv6 rules are only added if the user has enabled IPv6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2478)
<!-- Reviewable:end -->
