### PR TITLE
MacOS - Drop the patch from the short version

### DIFF
--- a/talpid-platform-metadata/src/macos.rs
+++ b/talpid-platform-metadata/src/macos.rs
@@ -2,17 +2,31 @@ mod command;
 use command::command_stdout_lossy;
 
 pub fn version() -> String {
-    format!(
-        "macOS {}",
-        command_stdout_lossy("sw_vers", &["-productVersion"])
-            .unwrap_or(String::from("[Failed to detect version]"))
-    )
+    let version = run_sw_vers().unwrap_or(String::from("N/A"));
+    format!("macOS {}", version)
 }
 
+
 pub fn short_version() -> String {
-    version()
+    let version = run_sw_vers()
+        .and_then(parse_short_version_output)
+        .map(|(major, minor)| format!("{}.{}", major, minor))
+        .unwrap_or(String::from("N/A"));
+    format!("macOS {}", version)
 }
 
 pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
     std::iter::empty()
+}
+
+/// Outputs a string in a format `$major.$minor.$patch`, e.g. `11.0.1`
+fn run_sw_vers() -> Option<String> {
+    command_stdout_lossy("sw_vers", &["-productVersion"])
+}
+
+fn parse_short_version_output(output: String) -> Option<(u32, u32)> {
+    let mut parts = output.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    Some((major, minor))
 }


### PR DESCRIPTION
Reporting the patch in the version of macOS in the version check is proving to be too granular, so I've changed the version check code to only report the full version in problem reports and only use the major and minor versions in the version check header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2479)
<!-- Reviewable:end -->
