### PR TITLE
Update rustfmt config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,7 +4,7 @@ use_field_init_shorthand = true
 condense_wildcard_suffixes = true
 normalize_comments = true
 wrap_comments = true
-merge_imports = true
+imports_granularity = "Crate"
 
 # Heavily subjective style choices
 comment_width = 100


### PR DESCRIPTION
As of some days ago, the nightly toolchain's `rustfmt` has been complaining about deprecating `merge_imports` in favor of the more versatile `imports_granularity` config option. So I went ahead and changed over to the new config option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2482)
<!-- Reviewable:end -->
