### PR TITLE
Fix log entry signaling use of wireguard-go

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -163,7 +163,7 @@ impl WireguardMonitor {
                         log::error!(
                             "{}",
                             err.display_chain_with_msg(
-                                "Failed to initialize WireGuard tunnel via NetworkManager, will try netlink directly"
+                                "Failed to initialize WireGuard tunnel via NetworkManager"
                             )
                         );
                     }
@@ -186,7 +186,7 @@ impl WireguardMonitor {
             }
         }
 
-        #[cfg(traget_os = "linux")]
+        #[cfg(target_os = "linux")]
         log::debug!("Using userspace WireGuard implementation");
         Ok(Box::new(WgGoTunnel::start_tunnel(
             &config,


### PR DESCRIPTION
The daemon wasn't logging about falling back to WireGuard-go on Linux due to a typo of yours truly. This is a fix for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2483)
<!-- Reviewable:end -->
