### PR TITLE
Use threaded scheduler in problem report

### DIFF
--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -270,7 +270,8 @@ pub fn send_problem_report(
         ProblemReport::parse_metadata(&report_content).unwrap_or_else(|| metadata::collect());
 
     let mut runtime = tokio::runtime::Builder::new()
-        .basic_scheduler()
+        .threaded_scheduler()
+        .core_threads(2)
         .enable_all()
         .build()
         .map_err(Error::CreateRuntime)?;


### PR DESCRIPTION
Since the address cache calls `tokio::task::block_in_place` in a number of places in `mullvad-rpc`, we should be using a mutli-threaded runtime in the problem report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2484)
<!-- Reviewable:end -->
