### PR TITLE
Use only TLS 1.3 when connecting to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
   security patches.
 - Allow provider constraint to specify multiple hosting providers.
 - Only download a new relay list if it has been modified.
+- Connect to the API only via TLS 1.3
 
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.

--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use tokio::{net::TcpStream as TokioTcpStream, runtime::Handle, time::timeout};
-use tokio_rustls::rustls;
+use tokio_rustls::rustls::{self, ProtocolVersion};
 use webpki::DNSNameRef;
 
 // Old LetsEncrypt root certificate
@@ -65,6 +65,7 @@ impl HttpsConnectorWithSni {
         let mut config = rustls::ClientConfig::new();
         config.enable_sni = true;
         config.root_store = Self::read_cert_store();
+        config.versions = vec![ProtocolVersion::TLSv1_3];
 
         HttpsConnectorWithSni {
             next_socket_id: 0,


### PR DESCRIPTION
Force rustls to only use TLS 1.3 when connecting to our API. 

For OpenVPN, we specify specific cyphersuits that we believe are not weak, should we do the same here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2485)
<!-- Reviewable:end -->
