### PR TITLE
Ignore new field in `RelayList` for JNI conversion

### DIFF
--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -21,6 +21,7 @@ use talpid_types::net::{
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct RelayList {
+    #[cfg_attr(target_os = "android", jnix(skip))]
     pub etag: Option<String>,
     pub countries: Vec<RelayListCountry>,
 }


### PR DESCRIPTION
A previous PR (#2462) added a new field to the `RelayList` type in order to only download the relay list if it hasn't changed. Unfortunately, the Android app doesn't use the new field, so the conversion from the Rust type to the Java type started failing. This PR marks the new field as to be ignored during the conversion.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any public version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2488)
<!-- Reviewable:end -->
