### PR TITLE
Make sure the actual GUID is used for the ComponentId fix

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -72,7 +72,7 @@ tun = "0.5"
 [target.'cfg(windows)'.dependencies]
 widestring = "0.4"
 winreg = { version = "0.7", features = ["transactions"] }
-winapi = { version = "0.3.6", features = [ "combaseapi", "handleapi", "ifdef", "libloaderapi", "netioapi", "stringapiset", "synchapi", "winbase", "winuser"] }
+winapi = { version = "0.3.6", features = ["combaseapi", "handleapi", "ifdef", "libloaderapi", "netioapi", "stringapiset", "synchapi", "winbase", "winerror", "winuser"] }
 socket2 = "0.3"
 pnet_packet = "0.26"
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }

--- a/talpid-core/src/tunnel/openvpn/windows.rs
+++ b/talpid-core/src/tunnel/openvpn/windows.rs
@@ -342,4 +342,35 @@ mod tests {
     fn test_wintun_imports() {
         WintunDll::new_inner(ptr::null_mut(), get_proc_fn).unwrap();
     }
+
+    #[test]
+    fn guid_to_string() {
+        let guids = [
+            (
+                "{AFE43773-E1F8-4EBB-8536-576AB86AFE9A}",
+                GUID {
+                    Data1: 0xAFE43773,
+                    Data2: 0xE1F8,
+                    Data3: 0x4EBB,
+                    Data4: [0x85, 0x36, 0x57, 0x6A, 0xB8, 0x6A, 0xFE, 0x9A],
+                },
+            ),
+            (
+                "{00000000-0000-0000-0000-000000000000}",
+                GUID {
+                    Data1: 0,
+                    Data2: 0,
+                    Data3: 0,
+                    Data4: [0; 8],
+                },
+            ),
+        ];
+
+        for (expected_str, guid) in &guids {
+            assert_eq!(
+                string_from_guid(guid).as_str().to_lowercase(),
+                expected_str.to_lowercase()
+            );
+        }
+    }
 }

--- a/talpid-core/src/tunnel/openvpn/windows.rs
+++ b/talpid-core/src/tunnel/openvpn/windows.rs
@@ -13,6 +13,8 @@ use winapi::{
         guiddef::GUID,
         ifdef::NET_LUID,
         minwindef::{BOOL, FARPROC, HINSTANCE, HMODULE},
+        netioapi::ConvertInterfaceLuidToGuid,
+        winerror::NO_ERROR,
     },
     um::{
         libloaderapi::{
@@ -151,6 +153,15 @@ impl WintunAdapter {
 
     pub fn luid(&self) -> NET_LUID {
         unsafe { self.dll_handle.get_adapter_luid(self.handle) }
+    }
+
+    pub fn guid(&self) -> io::Result<GUID> {
+        let mut guid = mem::MaybeUninit::zeroed();
+        let result = unsafe { ConvertInterfaceLuidToGuid(&self.luid(), guid.as_mut_ptr()) };
+        if result != NO_ERROR {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(unsafe { guid.assume_init() })
     }
 }
 


### PR DESCRIPTION
The previous code should not have caused any serious issues, except in the case where the requested GUID was not used, and the "ComponentId" workaround (#2338) happened to be needed. In that case, the workaround would have failed. Mostly, it filled the log with pointless error messages.

Other changes:
* Add `WintunAdapter::guid()`.
* Add `WintunAdapter::luid()`.
* Unit test for GUID to string conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2490)
<!-- Reviewable:end -->
