### PR TITLE
Update `jnix` dependency to version 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,15 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.2.1",
-]
-
-[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,21 +1004,21 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jnix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c610361550ad147bf2d7ddf71b67035706759ebf6f503cc6cbe4a581004de8a"
+checksum = "fd1aa8ee934c87d39f4ce8d180ac50c7eee455e99b8faaeda98adae4e71a0145"
 dependencies = [
  "jni",
  "jnix-macros",
  "once_cell",
- "parking_lot 0.9.0",
+ "parking_lot",
 ]
 
 [[package]]
 name = "jnix-macros"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e87ff0edc1c5199f084e3175e9a3f5ee2bb56035403b685d0ec8edd5157250"
+checksum = "66a28c447e7a02784315280fb972e692b21ae7c18a44bfb37fce670946dc2dba"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1083,15 +1074,6 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
@@ -1125,12 +1107,6 @@ checksum = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
 dependencies = [
  "log 0.4.14",
 ]
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -1290,7 +1266,7 @@ dependencies = [
  "mullvad-rpc",
  "mullvad-types",
  "nix 0.19.1",
- "parking_lot 0.11.1",
+ "parking_lot",
  "rand 0.7.3",
  "regex",
  "serde",
@@ -1701,39 +1677,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.2",
- "parking_lot_core 0.8.2",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "rustc_version",
- "smallvec 0.6.14",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1746,7 +1696,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.1.57",
- "smallvec 1.6.1",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
@@ -2272,15 +2222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,21 +2317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,15 +2405,6 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
 
 [[package]]
 name = "smallvec"
@@ -2653,7 +2570,7 @@ dependencies = [
  "openvpn-plugin",
  "os_pipe",
  "parity-tokio-ipc",
- "parking_lot 0.11.1",
+ "parking_lot",
  "pfctl",
  "pnet_packet",
  "prost",

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
@@ -2,7 +2,8 @@ package net.mullvad.mullvadvpn.model
 
 sealed class Constraint<T>() {
     class Any<T>() : Constraint<T>()
-    class Only<T>(val value: T) : Constraint<T>() {
+
+    data class Only<T>(val value: T) : Constraint<T>() {
         fun get0() = value
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
@@ -2,8 +2,5 @@ package net.mullvad.mullvadvpn.model
 
 sealed class Constraint<T>() {
     class Any<T>() : Constraint<T>()
-
-    data class Only<T>(val value: T) : Constraint<T>() {
-        fun get0() = value
-    }
+    data class Only<T>(val value: T) : Constraint<T>()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GetAccountDataResult.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GetAccountDataResult.kt
@@ -2,25 +2,7 @@ package net.mullvad.mullvadvpn.model
 
 sealed class GetAccountDataResult {
     class Ok(val accountData: AccountData) : GetAccountDataResult()
-
-    class InvalidAccount : GetAccountDataResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = InvalidAccount()
-        }
-    }
-
-    class RpcError : GetAccountDataResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = RpcError()
-        }
-    }
-
-    class OtherError : GetAccountDataResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = OtherError()
-        }
-    }
+    object InvalidAccount : GetAccountDataResult()
+    object RpcError : GetAccountDataResult()
+    object OtherError : GetAccountDataResult()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GetAccountDataResult.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GetAccountDataResult.kt
@@ -2,7 +2,25 @@ package net.mullvad.mullvadvpn.model
 
 sealed class GetAccountDataResult {
     class Ok(val accountData: AccountData) : GetAccountDataResult()
-    class InvalidAccount : GetAccountDataResult()
-    class RpcError : GetAccountDataResult()
-    class OtherError : GetAccountDataResult()
+
+    class InvalidAccount : GetAccountDataResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = InvalidAccount()
+        }
+    }
+
+    class RpcError : GetAccountDataResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = RpcError()
+        }
+    }
+
+    class OtherError : GetAccountDataResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = OtherError()
+        }
+    }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -16,8 +16,21 @@ sealed class KeygenEvent {
             this.replacementFailure = replacementFailure
         }
     }
-    class TooManyKeys : KeygenEvent()
-    class GenerationFailure : KeygenEvent()
+
+    class TooManyKeys : KeygenEvent() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = TooManyKeys()
+        }
+    }
+
+    class GenerationFailure : KeygenEvent() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = GenerationFailure()
+        }
+    }
+
 
     fun failure(): KeygenFailure? {
         return when (this) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -17,20 +17,8 @@ sealed class KeygenEvent {
         }
     }
 
-    class TooManyKeys : KeygenEvent() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = TooManyKeys()
-        }
-    }
-
-    class GenerationFailure : KeygenEvent() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = GenerationFailure()
-        }
-    }
-
+    object TooManyKeys : KeygenEvent()
+    object GenerationFailure : KeygenEvent()
 
     fun failure(): KeygenFailure? {
         return when (this) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -21,14 +21,14 @@ sealed class KeygenEvent {
 
     fun failure(): KeygenFailure? {
         return when (this) {
-            is KeygenEvent.TooManyKeys -> KeygenFailure.TooManyKeys()
-            is KeygenEvent.GenerationFailure -> KeygenFailure.GenerationFailure()
-            else -> { null }
+            is KeygenEvent.TooManyKeys -> KeygenFailure.TooManyKeys
+            is KeygenEvent.GenerationFailure -> KeygenFailure.GenerationFailure
+            else -> null
         }
     }
 }
 
-sealed class KeygenFailure() {
-    class TooManyKeys() : KeygenFailure()
-    class GenerationFailure() : KeygenFailure()
+enum class KeygenFailure {
+    TooManyKeys,
+    GenerationFailure,
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
@@ -1,17 +1,17 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class LocationConstraint(val code: Array<String>) {
-    class Country(var countryCode: String) : LocationConstraint(arrayOf(countryCode)) {
+    data class Country(var countryCode: String) : LocationConstraint(arrayOf(countryCode)) {
         fun get0() = countryCode
     }
 
-    class City(var countryCode: String, var cityCode: String) :
+    data class City(var countryCode: String, var cityCode: String) :
         LocationConstraint(arrayOf(countryCode, cityCode)) {
         fun get0() = countryCode
         fun get1() = cityCode
     }
 
-    class Hostname(var countryCode: String, var cityCode: String, var hostname: String) :
+    data class Hostname(var countryCode: String, var cityCode: String, var hostname: String) :
         LocationConstraint(arrayOf(countryCode, cityCode, hostname)) {
         fun get0() = countryCode
         fun get1() = cityCode

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
@@ -1,20 +1,11 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class LocationConstraint(val code: Array<String>) {
-    data class Country(var countryCode: String) : LocationConstraint(arrayOf(countryCode)) {
-        fun get0() = countryCode
-    }
+    data class Country(var countryCode: String) : LocationConstraint(arrayOf(countryCode))
 
     data class City(var countryCode: String, var cityCode: String) :
-        LocationConstraint(arrayOf(countryCode, cityCode)) {
-        fun get0() = countryCode
-        fun get1() = cityCode
-    }
+        LocationConstraint(arrayOf(countryCode, cityCode))
 
     data class Hostname(var countryCode: String, var cityCode: String, var hostname: String) :
-        LocationConstraint(arrayOf(countryCode, cityCode, hostname)) {
-        fun get0() = countryCode
-        fun get1() = cityCode
-        fun get2() = hostname
-    }
+        LocationConstraint(arrayOf(countryCode, cityCode, hostname))
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
@@ -1,12 +1,6 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class RelaySettings {
-    class CustomTunnelEndpoint() : RelaySettings() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = CustomTunnelEndpoint()
-        }
-    }
-
+    object CustomTunnelEndpoint : RelaySettings()
     class Normal(var relayConstraints: RelayConstraints) : RelaySettings()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
@@ -1,6 +1,12 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class RelaySettings {
-    class CustomTunnelEndpoint() : RelaySettings()
+    class CustomTunnelEndpoint() : RelaySettings() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = CustomTunnelEndpoint()
+        }
+    }
+
     class Normal(var relayConstraints: RelayConstraints) : RelaySettings()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.model
 sealed class RelaySettingsUpdate {
     class CustomTunnelEndpoint() : RelaySettingsUpdate()
 
-    class Normal(var constraints: RelayConstraintsUpdate) : RelaySettingsUpdate() {
+    data class Normal(var constraints: RelayConstraintsUpdate) : RelaySettingsUpdate() {
         fun get0() = constraints
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
@@ -1,7 +1,12 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class RelaySettingsUpdate {
-    class CustomTunnelEndpoint() : RelaySettingsUpdate()
+    class CustomTunnelEndpoint() : RelaySettingsUpdate() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = CustomTunnelEndpoint()
+        }
+    }
 
     data class Normal(var constraints: RelayConstraintsUpdate) : RelaySettingsUpdate() {
         fun get0() = constraints

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
@@ -2,8 +2,5 @@ package net.mullvad.mullvadvpn.model
 
 sealed class RelaySettingsUpdate {
     object CustomTunnelEndpoint : RelaySettingsUpdate()
-
-    data class Normal(var constraints: RelayConstraintsUpdate) : RelaySettingsUpdate() {
-        fun get0() = constraints
-    }
+    data class Normal(var constraints: RelayConstraintsUpdate) : RelaySettingsUpdate()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettingsUpdate.kt
@@ -1,12 +1,7 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class RelaySettingsUpdate {
-    class CustomTunnelEndpoint() : RelaySettingsUpdate() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = CustomTunnelEndpoint()
-        }
-    }
+    object CustomTunnelEndpoint : RelaySettingsUpdate()
 
     data class Normal(var constraints: RelayConstraintsUpdate) : RelaySettingsUpdate() {
         fun get0() = constraints

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
@@ -28,13 +28,11 @@ sealed class TunnelState() {
                 CONNECTED -> TunnelState.Connected(endpoint!!, null)
                 RECONNECTING -> TunnelState.Disconnecting(ActionAfterDisconnect.Reconnect)
                 DISCONNECTING -> TunnelState.Disconnecting(ActionAfterDisconnect.Nothing)
-                BLOCKING -> TunnelState.Error(ErrorState(ErrorStateCause.StartTunnelError(), true))
+                BLOCKING -> TunnelState.Error(ErrorState(ErrorStateCause.StartTunnelError, true))
                 ERROR -> {
-                    TunnelState.Error(ErrorState(ErrorStateCause.SetFirewallPolicyError(), false))
+                    TunnelState.Error(ErrorState(ErrorStateCause.SetFirewallPolicyError, false))
                 }
-                else -> {
-                    TunnelState.Error(ErrorState(ErrorStateCause.SetFirewallPolicyError(), false))
-                }
+                else -> TunnelState.Error(ErrorState(ErrorStateCause.SetFirewallPolicyError, false))
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
@@ -6,13 +6,7 @@ import net.mullvad.talpid.tunnel.ErrorState
 import net.mullvad.talpid.tunnel.ErrorStateCause
 
 sealed class TunnelState() {
-    class Disconnected() : TunnelState() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = Disconnected()
-        }
-    }
-
+    object Disconnected : TunnelState()
     class Connecting(val endpoint: TunnelEndpoint?, val location: GeoIpLocation?) : TunnelState()
     class Connected(val endpoint: TunnelEndpoint, val location: GeoIpLocation?) : TunnelState()
     class Disconnecting(val actionAfterDisconnect: ActionAfterDisconnect) : TunnelState()
@@ -29,7 +23,7 @@ sealed class TunnelState() {
 
         fun fromString(description: String, endpoint: TunnelEndpoint?): TunnelState {
             return when (description) {
-                DISCONNECTED -> TunnelState.Disconnected()
+                DISCONNECTED -> TunnelState.Disconnected
                 CONNECTING -> TunnelState.Connecting(endpoint, null)
                 CONNECTED -> TunnelState.Connected(endpoint!!, null)
                 RECONNECTING -> TunnelState.Disconnecting(ActionAfterDisconnect.Reconnect)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
@@ -6,7 +6,13 @@ import net.mullvad.talpid.tunnel.ErrorState
 import net.mullvad.talpid.tunnel.ErrorStateCause
 
 sealed class TunnelState() {
-    class Disconnected() : TunnelState()
+    class Disconnected() : TunnelState() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = Disconnected()
+        }
+    }
+
     class Connecting(val endpoint: TunnelEndpoint?, val location: GeoIpLocation?) : TunnelState()
     class Connected(val endpoint: TunnelEndpoint, val location: GeoIpLocation?) : TunnelState()
     class Disconnecting(val actionAfterDisconnect: ActionAfterDisconnect) : TunnelState()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/VoucherSubmissionResult.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/VoucherSubmissionResult.kt
@@ -2,8 +2,32 @@ package net.mullvad.mullvadvpn.model
 
 sealed class VoucherSubmissionResult {
     class Ok(val submission: VoucherSubmission) : VoucherSubmissionResult()
-    class InvalidVoucher : VoucherSubmissionResult()
-    class VoucherAlreadyUsed : VoucherSubmissionResult()
-    class RpcError : VoucherSubmissionResult()
-    class OtherError : VoucherSubmissionResult()
+
+    class InvalidVoucher : VoucherSubmissionResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = InvalidVoucher()
+        }
+    }
+
+    class VoucherAlreadyUsed : VoucherSubmissionResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = VoucherAlreadyUsed()
+        }
+    }
+
+    class RpcError : VoucherSubmissionResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = RpcError()
+        }
+    }
+
+    class OtherError : VoucherSubmissionResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = OtherError()
+        }
+    }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/VoucherSubmissionResult.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/VoucherSubmissionResult.kt
@@ -2,32 +2,8 @@ package net.mullvad.mullvadvpn.model
 
 sealed class VoucherSubmissionResult {
     class Ok(val submission: VoucherSubmission) : VoucherSubmissionResult()
-
-    class InvalidVoucher : VoucherSubmissionResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = InvalidVoucher()
-        }
-    }
-
-    class VoucherAlreadyUsed : VoucherSubmissionResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = VoucherAlreadyUsed()
-        }
-    }
-
-    class RpcError : VoucherSubmissionResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = RpcError()
-        }
-    }
-
-    class OtherError : VoucherSubmissionResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = OtherError()
-        }
-    }
+    object InvalidVoucher : VoucherSubmissionResult()
+    object VoucherAlreadyUsed : VoucherSubmissionResult()
+    object RpcError : VoucherSubmissionResult()
+    object OtherError : VoucherSubmissionResult()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ConnectionProxy.kt
@@ -22,7 +22,7 @@ class ConnectionProxy(val context: Context, val daemon: MullvadDaemon) {
     private var activeAction: Job? = null
     private var resetAnticipatedStateJob: Job? = null
 
-    private val initialState: TunnelState = TunnelState.Disconnected()
+    private val initialState: TunnelState = TunnelState.Disconnected
 
     var onStateChange = EventNotifier(initialState)
     var onUiStateChange = EventNotifier(initialState)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -49,7 +49,7 @@ class ForegroundNotificationManager(
 
     private var tunnelStateEvents by autoSubscribable<TunnelState>(
         this,
-        TunnelState.Disconnected()
+        TunnelState.Disconnected
     ) { newState ->
         updater.sendBlocking(UpdaterMessage.NewTunnelState(newState))
     }
@@ -63,7 +63,7 @@ class ForegroundNotificationManager(
     }
 
     private val tunnelState
-        get() = tunnelStateEvents?.latestEvent ?: TunnelState.Disconnected()
+        get() = tunnelStateEvents?.latestEvent ?: TunnelState.Disconnected
 
     private val shouldBeOnForeground
         get() = lockedToForeground || !(tunnelState is TunnelState.Disconnected)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/KeyStatusListener.kt
@@ -32,7 +32,7 @@ class KeyStatusListener(val daemon: MullvadDaemon) {
                 newFailure
             )
         } else {
-            keyStatus = newStatus ?: KeygenEvent.GenerationFailure()
+            keyStatus = newStatus ?: KeygenEvent.GenerationFailure
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -45,7 +45,7 @@ class LocationInfoCache(
         onNewLocation?.invoke(newLocation)
     }
 
-    var state by observable<TunnelState>(TunnelState.Disconnected()) { _, _, newState ->
+    var state by observable<TunnelState>(TunnelState.Disconnected) { _, _, newState ->
         when (newState) {
             is TunnelState.Disconnected -> {
                 location = lastKnownRealLocation

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -58,7 +58,7 @@ class TunnelStateNotification(val context: Context) {
 
     var showAction by observable(false) { _, _, _ -> update() }
 
-    var tunnelState by observable<TunnelState>(TunnelState.Disconnected()) { _, _, newState ->
+    var tunnelState by observable<TunnelState>(TunnelState.Disconnected) { _, _, newState ->
         reconnecting =
             (
             newState is TunnelState.Disconnecting &&

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectActionButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectActionButton.kt
@@ -33,7 +33,7 @@ class ConnectActionButton(val parentView: View) {
             }
         }
 
-    var tunnelState: TunnelState = TunnelState.Disconnected()
+    var tunnelState: TunnelState = TunnelState.Disconnected
         set(value) {
             when (value) {
                 is TunnelState.Disconnected -> disconnected()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -43,7 +43,7 @@ class ConnectFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         val view = inflater.inflate(R.layout.connect, container, false)
 
         headerBar = view.findViewById<HeaderBar>(R.id.header_bar).apply {
-            tunnelState = TunnelState.Disconnected()
+            tunnelState = TunnelState.Disconnected
         }
 
         notificationBanner = view.findViewById<NotificationBanner>(R.id.notification_banner).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
@@ -37,7 +37,7 @@ class LocationInfo(val parentView: View, val context: Context) {
             updateOutAddress(value)
         }
 
-    var state: TunnelState = TunnelState.Disconnected()
+    var state: TunnelState = TunnelState.Disconnected
         set(value) {
             field = value
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -24,7 +24,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
     private lateinit var disconnectButton: Button
     private lateinit var redeemButton: RedeemVoucherButton
 
-    private var tunnelState by observable<TunnelState>(TunnelState.Disconnected()) { _, _, state ->
+    private var tunnelState by observable<TunnelState>(TunnelState.Disconnected) { _, _, state ->
         updateDisconnectButton()
         updateBuyButtons()
         headerBar.tunnelState = state

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -30,7 +30,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         val view = inflater.inflate(R.layout.welcome, container, false)
 
         view.findViewById<HeaderBar>(R.id.header_bar).apply {
-            tunnelState = TunnelState.Disconnected()
+            tunnelState = TunnelState.Disconnected
         }
 
         accountLabel = view.findViewById<TextView>(R.id.account_number).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -306,8 +306,8 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
 
     private fun failureMessage(failure: KeygenFailure): Int {
         when (failure) {
-            is KeygenFailure.TooManyKeys -> return R.string.too_many_keys
-            is KeygenFailure.GenerationFailure -> return R.string.failed_to_generate_key
+            KeygenFailure.TooManyKeys -> return R.string.too_many_keys
+            KeygenFailure.GenerationFailure -> return R.string.failed_to_generate_key
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -40,7 +40,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     private var greenColor: Int = 0
     private var redColor: Int = 0
 
-    private var tunnelState: TunnelState = TunnelState.Disconnected()
+    private var tunnelState: TunnelState = TunnelState.Disconnected
 
     private var actionState: ActionState = ActionState.Idle(false)
         set(value) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SwitchLocationButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SwitchLocationButton.kt
@@ -35,7 +35,7 @@ class SwitchLocationButton : FrameLayout {
         buttonWithLocation.text = location?.locationName ?: ""
     }
 
-    var tunnelState by observable<TunnelState>(TunnelState.Disconnected()) { _, _, state ->
+    var tunnelState by observable<TunnelState>(TunnelState.Disconnected) { _, _, state ->
         when (state) {
             is TunnelState.Disconnected -> showLocation()
             is TunnelState.Disconnecting -> {

--- a/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
@@ -19,17 +19,7 @@ sealed class CreateTunResult {
             get() = true
     }
 
-    class PermissionDenied : CreateTunResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = PermissionDenied()
-        }
-    }
+    object PermissionDenied : CreateTunResult()
 
-    class TunnelDeviceError : CreateTunResult() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = TunnelDeviceError()
-        }
-    }
+    object TunnelDeviceError : CreateTunResult()
 }

--- a/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/CreateTunResult.kt
@@ -19,6 +19,17 @@ sealed class CreateTunResult {
             get() = true
     }
 
-    class PermissionDenied : CreateTunResult()
-    class TunnelDeviceError : CreateTunResult()
+    class PermissionDenied : CreateTunResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = PermissionDenied()
+        }
+    }
+
+    class TunnelDeviceError : CreateTunResult() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = TunnelDeviceError()
+        }
+    }
 }

--- a/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -98,7 +98,7 @@ open class TalpidVpnService : VpnService() {
     private fun createTun(config: TunConfig): CreateTunResult {
         if (VpnService.prepare(this) != null) {
             // VPN permission wasn't granted
-            return CreateTunResult.PermissionDenied()
+            return CreateTunResult.PermissionDenied
         }
 
         var invalidDnsServerAddresses = ArrayList<InetAddress>()
@@ -138,7 +138,7 @@ open class TalpidVpnService : VpnService() {
         val tunFd = vpnInterface?.detachFd()
 
         if (tunFd == null) {
-            return CreateTunResult.TunnelDeviceError()
+            return CreateTunResult.TunnelDeviceError
         }
 
         waitForTunnelUp(tunFd, config.routes.any { route -> route.isIpv6 })

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
@@ -4,12 +4,50 @@ import java.net.InetAddress
 
 sealed class ErrorStateCause {
     class AuthFailed(val reason: String?) : ErrorStateCause()
-    class Ipv6Unavailable : ErrorStateCause()
-    class SetFirewallPolicyError : ErrorStateCause()
-    class SetDnsError : ErrorStateCause()
+
+    class Ipv6Unavailable : ErrorStateCause() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = Ipv6Unavailable()
+        }
+    }
+
+    class SetFirewallPolicyError : ErrorStateCause() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = SetFirewallPolicyError()
+        }
+    }
+
+    class SetDnsError : ErrorStateCause() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = SetDnsError()
+        }
+    }
+
     class InvalidDnsServers(val addresses: ArrayList<InetAddress>) : ErrorStateCause()
-    class StartTunnelError : ErrorStateCause()
+
+    class StartTunnelError : ErrorStateCause() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = StartTunnelError()
+        }
+    }
+
     class TunnelParameterError(val error: ParameterGenerationError) : ErrorStateCause()
-    class IsOffline : ErrorStateCause()
-    class VpnPermissionDenied : ErrorStateCause()
+
+    class IsOffline : ErrorStateCause() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = IsOffline()
+        }
+    }
+
+    class VpnPermissionDenied : ErrorStateCause() {
+        companion object {
+            @JvmStatic
+            val INSTANCE = VpnPermissionDenied()
+        }
+    }
 }

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
@@ -4,50 +4,12 @@ import java.net.InetAddress
 
 sealed class ErrorStateCause {
     class AuthFailed(val reason: String?) : ErrorStateCause()
-
-    class Ipv6Unavailable : ErrorStateCause() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = Ipv6Unavailable()
-        }
-    }
-
-    class SetFirewallPolicyError : ErrorStateCause() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = SetFirewallPolicyError()
-        }
-    }
-
-    class SetDnsError : ErrorStateCause() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = SetDnsError()
-        }
-    }
-
+    object Ipv6Unavailable : ErrorStateCause()
+    object SetFirewallPolicyError : ErrorStateCause()
+    object SetDnsError : ErrorStateCause()
     class InvalidDnsServers(val addresses: ArrayList<InetAddress>) : ErrorStateCause()
-
-    class StartTunnelError : ErrorStateCause() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = StartTunnelError()
-        }
-    }
-
+    object StartTunnelError : ErrorStateCause()
     class TunnelParameterError(val error: ParameterGenerationError) : ErrorStateCause()
-
-    class IsOffline : ErrorStateCause() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = IsOffline()
-        }
-    }
-
-    class VpnPermissionDenied : ErrorStateCause() {
-        companion object {
-            @JvmStatic
-            val INSTANCE = VpnPermissionDenied()
-        }
-    }
+    object IsOffline : ErrorStateCause()
+    object VpnPermissionDenied : ErrorStateCause()
 }

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -14,7 +14,7 @@ crate_type = ["cdylib"]
 err-derive = "0.3.0"
 futures = "0.3"
 ipnetwork = "0.16"
-jnix = { version = "0.3", features = ["derive"] }
+jnix = { version = "0.4", features = ["derive"] }
 lazy_static = "1"
 log = "0.4"
 log-panics = "2"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -20,4 +20,4 @@ serde_json = "1.0"
 talpid-types = { path = "../talpid-types" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.3", features = ["derive"] }
+jnix = { version = "0.4", features = ["derive"] }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -42,7 +42,7 @@ nix = "0.19"
 
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.3", features = ["derive"] }
+jnix = { version = "0.4", features = ["derive"] }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -16,4 +16,4 @@ rand = "0.7"
 err-derive = "0.3.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.3", features = ["derive"] }
+jnix = { version = "0.4", features = ["derive"] }


### PR DESCRIPTION
This PR updates the `jnix` crate dependency to version `0.4`. This is needed for future PRs related to running the Android service in a separate process, because some types that can be converted between Rust and Java will have to implement `Parcelable`, so the type erasure that happens behind the scenes requires different type bounds. The new version of `jnix` allow specifying the bounds to be used for type erasure.

The new version of `jnix` also changes a few things about conversions, so this PR also updates that. Namely, `getN` methods are no longer necessary as long as the class is a Kotlin `data class` and Rust unit variants of enums are now mapped to singleton Java objects in a few cases.

A minor tweak was also included, changing the `KeygenFailure` type to be an `enum class` instead of a `sealed class`, making the representation a bit simpler.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **No user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2491)
<!-- Reviewable:end -->
