### PR TITLE
Split `SettingsListener` in server side and UI side classes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -54,7 +54,7 @@ class AppVersionInfoCache(
         private set
 
     init {
-        settingsListener.subscribe(this) { settings ->
+        settingsListener.settingsNotifier.subscribe(this) { settings ->
             showBetaReleases = settings.showBetaReleases
         }
     }
@@ -68,7 +68,7 @@ class AppVersionInfoCache(
 
     fun onDestroy() {
         setUpJob.cancel()
-        settingsListener.unsubscribe(this)
+        settingsListener.settingsNotifier.unsubscribe(this)
         daemon.onAppVersionInfoChange = null
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.SettingsListener
+import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 
 class AppVersionInfoCache(
     val context: Context,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
+import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 
 class AppVersionInfoCache(
     val context: Context,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/AppVersionInfoCache.kt
@@ -54,8 +54,10 @@ class AppVersionInfoCache(
         private set
 
     init {
-        settingsListener.settingsNotifier.subscribe(this) { settings ->
-            showBetaReleases = settings.showBetaReleases
+        settingsListener.settingsNotifier.subscribe(this) { maybeSettings ->
+            maybeSettings?.let { settings ->
+                showBetaReleases = settings.showBetaReleases
+            }
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -9,7 +9,7 @@ import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.SettingsListener
+import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 
 class RelayListListener(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
     private val setUpJob = setUp()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -9,7 +9,7 @@ import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
+import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 
 class RelayListListener(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
     private val setUpJob = setUp()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/dataproxy/RelayListListener.kt
@@ -34,14 +34,14 @@ class RelayListListener(val daemon: MullvadDaemon, val settingsListener: Setting
         }
 
     init {
-        settingsListener.onRelaySettingsChange = { newRelaySettings ->
+        settingsListener.relaySettingsNotifier.subscribe(this) { newRelaySettings ->
             relaySettingsChanged(newRelaySettings)
         }
     }
 
     fun onDestroy() {
         setUpJob.cancel()
-        settingsListener.onRelaySettingsChange = null
+        settingsListener.relaySettingsNotifier.unsubscribe(this)
         daemon.onRelayListChange = null
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.ipc
 import android.os.Message as RawMessage
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import net.mullvad.mullvadvpn.model.Settings
 
 // Events that can be sent from the service
 sealed class Event : Message(), Parcelable {
@@ -11,6 +12,9 @@ sealed class Event : Message(), Parcelable {
 
     @Parcelize
     object ListenerReady : Event(), Parcelable
+
+    @Parcelize
+    data class SettingsUpdate(val settings: Settings?) : Event(), Parcelable
 
     companion object {
         private const val MESSAGE_KEY = "event"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
@@ -1,6 +1,13 @@
 package net.mullvad.mullvadvpn.model
 
-sealed class Constraint<T>() {
-    class Any<T>() : Constraint<T>()
-    data class Only<T>(val value: T) : Constraint<T>()
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+sealed class Constraint<T>() : Parcelable {
+    @Parcelize
+    @Suppress("PARCELABLE_PRIMARY_CONSTRUCTOR_IS_EMPTY")
+    class Any<T>() : Constraint<T>(), Parcelable
+
+    @Parcelize
+    data class Only<T : Parcelable>(val value: T) : Constraint<T>(), Parcelable
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/DnsOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/DnsOptions.kt
@@ -1,6 +1,9 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
 import java.net.InetAddress
 import java.util.ArrayList
+import kotlinx.parcelize.Parcelize
 
-data class DnsOptions(val custom: Boolean, val addresses: ArrayList<InetAddress>)
+@Parcelize
+data class DnsOptions(val custom: Boolean, val addresses: ArrayList<InetAddress>) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
@@ -1,11 +1,11 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class LocationConstraint(val code: Array<String>) {
-    data class Country(var countryCode: String) : LocationConstraint(arrayOf(countryCode))
+    data class Country(val countryCode: String) : LocationConstraint(arrayOf(countryCode))
 
-    data class City(var countryCode: String, var cityCode: String) :
+    data class City(val countryCode: String, val cityCode: String) :
         LocationConstraint(arrayOf(countryCode, cityCode))
 
-    data class Hostname(var countryCode: String, var cityCode: String, var hostname: String) :
+    data class Hostname(val countryCode: String, val cityCode: String, val hostname: String) :
         LocationConstraint(arrayOf(countryCode, cityCode, hostname))
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
@@ -1,11 +1,18 @@
 package net.mullvad.mullvadvpn.model
 
-sealed class LocationConstraint(val code: Array<String>) {
-    data class Country(val countryCode: String) : LocationConstraint(arrayOf(countryCode))
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
+sealed class LocationConstraint(val code: Array<String>) : Parcelable {
+    @Parcelize
+    data class Country(val countryCode: String) :
+        LocationConstraint(arrayOf(countryCode)), Parcelable
+
+    @Parcelize
     data class City(val countryCode: String, val cityCode: String) :
-        LocationConstraint(arrayOf(countryCode, cityCode))
+        LocationConstraint(arrayOf(countryCode, cityCode)), Parcelable
 
+    @Parcelize
     data class Hostname(val countryCode: String, val cityCode: String, val hostname: String) :
-        LocationConstraint(arrayOf(countryCode, cityCode, hostname))
+        LocationConstraint(arrayOf(countryCode, cityCode, hostname)), Parcelable
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayConstraints.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayConstraints.kt
@@ -1,3 +1,7 @@
 package net.mullvad.mullvadvpn.model
 
-data class RelayConstraints(val location: Constraint<LocationConstraint>)
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class RelayConstraints(val location: Constraint<LocationConstraint>) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
@@ -2,5 +2,5 @@ package net.mullvad.mullvadvpn.model
 
 sealed class RelaySettings {
     object CustomTunnelEndpoint : RelaySettings()
-    class Normal(var relayConstraints: RelayConstraints) : RelaySettings()
+    class Normal(val relayConstraints: RelayConstraints) : RelaySettings()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
@@ -1,6 +1,12 @@
 package net.mullvad.mullvadvpn.model
 
-sealed class RelaySettings {
-    object CustomTunnelEndpoint : RelaySettings()
-    class Normal(val relayConstraints: RelayConstraints) : RelaySettings()
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+sealed class RelaySettings : Parcelable {
+    @Parcelize
+    object CustomTunnelEndpoint : RelaySettings(), Parcelable
+
+    @Parcelize
+    class Normal(val relayConstraints: RelayConstraints) : RelaySettings(), Parcelable
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
@@ -1,5 +1,9 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class Settings(
     val accountToken: String?,
     val relaySettings: RelaySettings,
@@ -7,4 +11,4 @@ data class Settings(
     val autoConnect: Boolean,
     val tunnelOptions: TunnelOptions,
     val showBetaReleases: Boolean
-)
+) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Settings.kt
@@ -1,10 +1,10 @@
 package net.mullvad.mullvadvpn.model
 
 data class Settings(
-    var accountToken: String?,
-    var relaySettings: RelaySettings,
-    var allowLan: Boolean,
-    var autoConnect: Boolean,
-    var tunnelOptions: TunnelOptions,
-    var showBetaReleases: Boolean
+    val accountToken: String?,
+    val relaySettings: RelaySettings,
+    val allowLan: Boolean,
+    val autoConnect: Boolean,
+    val tunnelOptions: TunnelOptions,
+    val showBetaReleases: Boolean
 )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelOptions.kt
@@ -1,3 +1,10 @@
 package net.mullvad.mullvadvpn.model
 
-data class TunnelOptions(val wireguard: WireguardTunnelOptions, val dnsOptions: DnsOptions)
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TunnelOptions(
+    val wireguard: WireguardTunnelOptions,
+    val dnsOptions: DnsOptions
+) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/WireguardTunnelOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/WireguardTunnelOptions.kt
@@ -1,5 +1,8 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import net.mullvad.talpid.net.wireguard.TunnelOptions as TalpidWireguardTunnelOptions
 
-data class WireguardTunnelOptions(val options: TalpidWireguardTunnelOptions)
+@Parcelize
+data class WireguardTunnelOptions(val options: TalpidWireguardTunnelOptions) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.service
 
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
+import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.ExponentialBackoff
 import net.mullvad.mullvadvpn.util.JobTracker
 import net.mullvad.talpid.util.EventNotifier

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -21,9 +21,11 @@ class CustomDns(val daemon: MullvadDaemon, val settingsListener: SettingsListene
     val onDnsServersChanged = EventNotifier<List<InetAddress>>(emptyList())
 
     init {
-        settingsListener.dnsOptionsNotifier.subscribe(this) { dnsOptions ->
-            enabled = dnsOptions.custom
-            dnsServers = ArrayList(dnsOptions.addresses)
+        settingsListener.dnsOptionsNotifier.subscribe(this) { maybeDnsOptions ->
+            maybeDnsOptions?.let { dnsOptions ->
+                enabled = dnsOptions.custom
+                dnsServers = ArrayList(dnsOptions.addresses)
+            }
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -4,6 +4,7 @@ import java.net.InetAddress
 import java.util.ArrayList
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.model.DnsOptions
+import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.talpid.util.EventNotifier
 
 class CustomDns(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -24,7 +24,7 @@ class CustomDns(val daemon: MullvadDaemon, val settingsListener: SettingsListene
         settingsListener.dnsOptionsNotifier.subscribe(this) { maybeDnsOptions ->
             maybeDnsOptions?.let { dnsOptions ->
                 enabled = dnsOptions.custom
-                dnsServers = ArrayList(dnsOptions.addresses)
+                dnsServers = dnsOptions.addresses
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -232,7 +232,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
-        val settingsListener = SettingsListener(daemon, settings)
+        val settingsListener = SettingsListener(settings, daemonInstance.intermittentDaemon)
         val connectionProxy = ConnectionProxy(this, daemon)
         val customDns = CustomDns(daemon, settingsListener)
         val splitTunneling = splitTunneling.await()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -78,10 +78,9 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var pendingAction by observable<PendingAction?>(null) { _, _, _ ->
         instance?.let { activeInstance ->
-            handlePendingAction(
-                activeInstance.connectionProxy,
-                activeInstance.settingsListener.settings
-            )
+            activeInstance.settingsListener.settings?.let { currentSettings ->
+                handlePendingAction(activeInstance.connectionProxy, currentSettings)
+            }
         }
     }
 
@@ -232,7 +231,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
-        val settingsListener = SettingsListener(settings, daemonInstance.intermittentDaemon)
+        val settingsListener = SettingsListener(daemonInstance.intermittentDaemon)
         val connectionProxy = ConnectionProxy(this, daemon)
         val customDns = CustomDns(daemon, settingsListener)
         val splitTunneling = splitTunneling.await()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -78,7 +78,7 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var pendingAction by observable<PendingAction?>(null) { _, _, _ ->
         instance?.let { activeInstance ->
-            activeInstance.settingsListener.settings?.let { currentSettings ->
+            endpoint.settingsListener.settings?.let { currentSettings ->
                 handlePendingAction(activeInstance.connectionProxy, currentSettings)
             }
         }
@@ -231,9 +231,8 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
-        val settingsListener = SettingsListener(daemonInstance.intermittentDaemon)
         val connectionProxy = ConnectionProxy(this, daemon)
-        val customDns = CustomDns(daemon, settingsListener)
+        val customDns = CustomDns(daemon, endpoint.settingsListener)
         val splitTunneling = splitTunneling.await()
 
         splitTunneling.onChange = { excludedApps ->
@@ -251,7 +250,7 @@ class MullvadVpnService : TalpidVpnService() {
                 connectionProxy,
                 connectivityListener,
                 customDns,
-                settingsListener,
+                endpoint.settingsListener,
                 splitTunneling
             )
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
+import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.talpid.ConnectivityListener
 
 class ServiceInstance(
@@ -22,6 +23,5 @@ class ServiceInstance(
         customDns.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
-        settingsListener.onDestroy()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -4,17 +4,13 @@ import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.talpid.util.EventNotifier
 
 class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings) {
-    var settings: Settings = initialSettings
-        private set(value) {
-            settingsNotifier.notify(value)
-            field = value
-        }
-
-    private val settingsNotifier: EventNotifier<Settings> = EventNotifier(settings)
-
     val accountNumberNotifier = EventNotifier(initialSettings.accountToken)
     val dnsOptionsNotifier = EventNotifier(initialSettings.tunnelOptions.dnsOptions)
     val relaySettingsNotifier = EventNotifier(initialSettings.relaySettings)
+    val settingsNotifier: EventNotifier<Settings> = EventNotifier(initialSettings)
+
+    var settings by settingsNotifier.notifiable()
+        private set
 
     init {
         daemon.onSettingsChange.subscribe(this) { maybeSettings ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -26,6 +26,7 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
         daemon.onSettingsChange.unsubscribe(this)
 
         accountNumberNotifier.unsubscribeAll()
+        dnsOptionsNotifier.unsubscribeAll()
         relaySettingsNotifier.unsubscribeAll()
         settingsNotifier.unsubscribeAll()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/SettingsListener.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn.service
 
-import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.talpid.util.EventNotifier
 
@@ -15,14 +14,7 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
 
     val accountNumberNotifier = EventNotifier(initialSettings.accountToken)
     val dnsOptionsNotifier = EventNotifier(initialSettings.tunnelOptions.dnsOptions)
-
-    var onRelaySettingsChange: ((RelaySettings?) -> Unit)? = null
-        set(value) {
-            synchronized(this) {
-                field = value
-                value?.invoke(settings.relaySettings)
-            }
-        }
+    val relaySettingsNotifier = EventNotifier(initialSettings.relaySettings)
 
     init {
         daemon.onSettingsChange.subscribe(this) { maybeSettings ->
@@ -34,6 +26,7 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
         daemon.onSettingsChange.unsubscribe(this)
 
         accountNumberNotifier.unsubscribeAll()
+        relaySettingsNotifier.unsubscribeAll()
         settingsNotifier.unsubscribeAll()
     }
 
@@ -56,7 +49,7 @@ class SettingsListener(val daemon: MullvadDaemon, val initialSettings: Settings)
             }
 
             if (settings.relaySettings != newSettings.relaySettings) {
-                onRelaySettingsChange?.invoke(newSettings.relaySettings)
+                relaySettingsNotifier.notify(newSettings.relaySettings)
             }
 
             settings = newSettings

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -16,7 +16,10 @@ import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.util.Intermittent
 
-class ServiceEndpoint(looper: Looper, private val intermittentDaemon: Intermittent<MullvadDaemon>) {
+class ServiceEndpoint(
+    looper: Looper,
+    internal val intermittentDaemon: Intermittent<MullvadDaemon>
+) {
     private val listeners = mutableSetOf<Messenger>()
     private val registrationQueue: SendChannel<Messenger> = startRegistrator()
 
@@ -26,7 +29,7 @@ class ServiceEndpoint(looper: Looper, private val intermittentDaemon: Intermitte
 
     val messenger = Messenger(dispatcher)
 
-    val settingsListener = SettingsListener(intermittentDaemon)
+    val settingsListener = SettingsListener(this)
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -26,6 +26,8 @@ class ServiceEndpoint(looper: Looper, private val intermittentDaemon: Intermitte
 
     val messenger = Messenger(dispatcher)
 
+    val settingsListener = SettingsListener(intermittentDaemon)
+
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->
             registrationQueue.sendBlocking(request.listener)
@@ -35,6 +37,8 @@ class ServiceEndpoint(looper: Looper, private val intermittentDaemon: Intermitte
     fun onDestroy() {
         dispatcher.onDestroy()
         registrationQueue.close()
+
+        settingsListener.onDestroy()
     }
 
     internal fun sendEvent(event: Event) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -81,7 +81,10 @@ class ServiceEndpoint(
         synchronized(this) {
             listeners.add(listener)
 
-            val initialEvents = listOf(Event.ListenerReady)
+            val initialEvents = listOf(
+                Event.SettingsUpdate(settingsListener.settings),
+                Event.ListenerReady
+            )
 
             initialEvents.forEach { event ->
                 listener.send(event.message)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
@@ -1,8 +1,9 @@
-package net.mullvad.mullvadvpn.service
+package net.mullvad.mullvadvpn.service.endpoint
 
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.util.EventNotifier
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
@@ -47,36 +47,32 @@ class SettingsListener(val daemon: Intermittent<MullvadDaemon>) {
     }
 
     private fun registerListener(daemon: MullvadDaemon) {
-        daemon.onSettingsChange.subscribe(this) { maybeSettings ->
-            synchronized(this) {
-                maybeSettings?.let { newSettings -> handleNewSettings(newSettings) }
-            }
-        }
+        daemon.onSettingsChange.subscribe(this, ::handleNewSettings)
     }
 
     private fun fetchInitialSettings(daemon: MullvadDaemon) {
         synchronized(this) {
-            daemon.getSettings()?.let { newSettings ->
-                handleNewSettings(newSettings)
-            }
+            handleNewSettings(daemon.getSettings())
         }
     }
 
-    private fun handleNewSettings(newSettings: Settings) {
-        synchronized(this) {
-            if (settings?.accountToken != newSettings.accountToken) {
-                accountNumberNotifier.notify(newSettings.accountToken)
-            }
+    private fun handleNewSettings(newSettings: Settings?) {
+        if (newSettings != null) {
+            synchronized(this) {
+                if (settings?.accountToken != newSettings.accountToken) {
+                    accountNumberNotifier.notify(newSettings.accountToken)
+                }
 
-            if (settings?.tunnelOptions?.dnsOptions != newSettings.tunnelOptions.dnsOptions) {
-                dnsOptionsNotifier.notify(newSettings.tunnelOptions.dnsOptions)
-            }
+                if (settings?.tunnelOptions?.dnsOptions != newSettings.tunnelOptions.dnsOptions) {
+                    dnsOptionsNotifier.notify(newSettings.tunnelOptions.dnsOptions)
+                }
 
-            if (settings?.relaySettings != newSettings.relaySettings) {
-                relaySettingsNotifier.notify(newSettings.relaySettings)
-            }
+                if (settings?.relaySettings != newSettings.relaySettings) {
+                    relaySettingsNotifier.notify(newSettings.relaySettings)
+                }
 
-            settings = newSettings
+                settings = newSettings
+            }
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
@@ -1,13 +1,15 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.util.EventNotifier
 
-class SettingsListener(val daemon: Intermittent<MullvadDaemon>) {
+class SettingsListener(endpoint: ServiceEndpoint) {
+    private val daemon = endpoint.intermittentDaemon
+
     val accountNumberNotifier = EventNotifier<String?>(null)
     val dnsOptionsNotifier = EventNotifier<DnsOptions?>(null)
     val relaySettingsNotifier = EventNotifier<RelaySettings?>(null)
@@ -22,6 +24,10 @@ class SettingsListener(val daemon: Intermittent<MullvadDaemon>) {
                 registerListener(newDaemon)
                 fetchInitialSettings(newDaemon)
             }
+        }
+
+        settingsNotifier.subscribe(this) { settings ->
+            endpoint.sendEvent(Event.SettingsUpdate(settings))
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -67,7 +67,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
         detachBackButtonHandler()
         customDnsAdapter.onDestroy()
         titleController.onDestroy()
-        settingsListener.unsubscribe(this)
+        settingsListener.settingsNotifier.unsubscribe(this)
     }
 
     private fun configureHeader(view: View) {
@@ -109,7 +109,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
             }
         }
 
-        settingsListener.subscribe(this) { settings ->
+        settingsListener.settingsNotifier.subscribe(this) { settings ->
             updateUi(settings)
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -18,6 +18,8 @@ import net.mullvad.mullvadvpn.ui.widget.ToggleCell
 import net.mullvad.mullvadvpn.util.AdapterWithHeader
 
 class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
+    private var isAllowLanEnabled = false
+
     private lateinit var customDnsAdapter: CustomDnsAdapter
     private lateinit var customDnsToggle: ToggleCell
     private lateinit var wireguardMtuInput: MtuCell
@@ -113,6 +115,8 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
             maybeSettings?.let { settings ->
                 updateUi(settings)
             }
+
+            isAllowLanEnabled = maybeSettings?.allowLan ?: false
         }
     }
 
@@ -127,9 +131,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private suspend fun confirmAddAddress(address: InetAddress): Boolean {
         return when {
             address.isLinkLocalAddress() || address.isSiteLocalAddress() -> {
-                val allowLanEnabled = settingsListener.settings?.allowLan ?: false
-
-                allowLanEnabled || showConfirmDnsServerDialog(R.string.confirm_local_dns)
+                isAllowLanEnabled || showConfirmDnsServerDialog(R.string.confirm_local_dns)
             }
             else -> showConfirmDnsServerDialog(R.string.confirm_public_dns)
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -109,8 +109,10 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
             }
         }
 
-        settingsListener.settingsNotifier.subscribe(this) { settings ->
-            updateUi(settings)
+        settingsListener.settingsNotifier.subscribe(this) { maybeSettings ->
+            maybeSettings?.let { settings ->
+                updateUi(settings)
+            }
         }
     }
 
@@ -125,8 +127,9 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private suspend fun confirmAddAddress(address: InetAddress): Boolean {
         return when {
             address.isLinkLocalAddress() || address.isSiteLocalAddress() -> {
-                settingsListener.settings.allowLan ||
-                    showConfirmDnsServerDialog(R.string.confirm_local_dns)
+                val allowLanEnabled = settingsListener.settings?.allowLan ?: false
+
+                allowLanEnabled || showConfirmDnsServerDialog(R.string.confirm_local_dns)
             }
             else -> showConfirmDnsServerDialog(R.string.confirm_public_dns)
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
@@ -12,7 +12,9 @@ class LaunchFragment : ServiceAwareFragment() {
     private val hasAccountToken = CompletableDeferred<Boolean>()
 
     override fun onNewServiceConnection(serviceConnection: ServiceConnection) {
-        hasAccountToken.complete(serviceConnection.settingsListener.settings.accountToken != null)
+        serviceConnection.settingsListener.accountNumberNotifier.subscribe(this) { accountToken ->
+            hasAccountToken.complete(accountToken != null)
+        }
     }
 
     override fun onCreateView(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -26,8 +26,6 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
 
         allowLanToggle = view.findViewById<ToggleCell>(R.id.allow_lan).apply {
-            forcefullySetState(boolToSwitchState(settingsListener.settings.allowLan))
-
             listener = { state ->
                 when (state) {
                     CellSwitch.State.ON -> daemon.setAllowLan(true)
@@ -37,8 +35,6 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
 
         autoConnectToggle = view.findViewById<ToggleCell>(R.id.auto_connect).apply {
-            forcefullySetState(boolToSwitchState(settingsListener.settings.autoConnect))
-
             listener = { state ->
                 when (state) {
                     CellSwitch.State.ON -> daemon.setAutoConnect(true)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -43,8 +43,10 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
             }
         }
 
-        settingsListener.settingsNotifier.subscribe(this) { settings ->
-            updateUi(settings)
+        settingsListener.settingsNotifier.subscribe(this) { maybeSettings ->
+            maybeSettings?.let { settings ->
+                updateUi(settings)
+            }
         }
 
         titleController = CollapsibleTitleController(view)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -56,16 +56,16 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
         return view
     }
 
+    override fun onSafelyDestroyView() {
+        titleController.onDestroy()
+        settingsListener.unsubscribe(this)
+    }
+
     private fun updateUi(settings: Settings) {
         jobTracker.newUiJob("updateUi") {
             allowLanToggle.state = boolToSwitchState(settings.allowLan)
             autoConnectToggle.state = boolToSwitchState(settings.autoConnect)
         }
-    }
-
-    override fun onSafelyDestroyView() {
-        titleController.onDestroy()
-        settingsListener.unsubscribe(this)
     }
 
     private fun boolToSwitchState(pref: Boolean): CellSwitch.State {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -63,8 +63,16 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
     private fun updateUi(settings: Settings) {
         jobTracker.newUiJob("updateUi") {
-            allowLanToggle.state = boolToSwitchState(settings.allowLan)
-            autoConnectToggle.state = boolToSwitchState(settings.autoConnect)
+            val allowLanState = boolToSwitchState(settings.allowLan)
+            val autoConnectState = boolToSwitchState(settings.autoConnect)
+
+            if (isVisible) {
+                allowLanToggle.state = allowLanState
+                autoConnectToggle.state = autoConnectState
+            } else {
+                allowLanToggle.forcefullySetState(allowLanState)
+                autoConnectToggle.forcefullySetState(autoConnectState)
+            }
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -43,7 +43,7 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
             }
         }
 
-        settingsListener.subscribe(this) { settings ->
+        settingsListener.settingsNotifier.subscribe(this) { settings ->
             updateUi(settings)
         }
 
@@ -54,7 +54,7 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
     override fun onSafelyDestroyView() {
         titleController.onDestroy()
-        settingsListener.unsubscribe(this)
+        settingsListener.settingsNotifier.unsubscribe(this)
     }
 
     private fun updateUi(settings: Settings) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -14,8 +14,8 @@ import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SplitTunneling
-import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
+import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 
 abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceAwareFragment() {
     enum class OnNoService {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -13,8 +13,8 @@ import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.SettingsListener
 import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 
 abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceAwareFragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -27,7 +27,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val customDns = service.customDns
     val keyStatusListener = service.keyStatusListener
     val locationInfoCache = service.locationInfoCache
-    val settingsListener = service.settingsListener
+    val settingsListener = SettingsListener(dispatcher)
     val splitTunneling = service.splitTunneling
 
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
@@ -41,6 +41,8 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
 
     fun onDestroy() {
         dispatcher.onDestroy()
+
+        settingsListener.onDestroy()
 
         appVersionInfoCache.onDestroy()
         relayListListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -1,0 +1,48 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.model.DnsOptions
+import net.mullvad.mullvadvpn.model.RelaySettings
+import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.talpid.util.EventNotifier
+
+class SettingsListener(eventDispatcher: DispatchingHandler<Event>) {
+    val accountNumberNotifier = EventNotifier<String?>(null)
+    val dnsOptionsNotifier = EventNotifier<DnsOptions?>(null)
+    val relaySettingsNotifier = EventNotifier<RelaySettings?>(null)
+    val settingsNotifier = EventNotifier<Settings?>(null)
+
+    private var settings by settingsNotifier.notifiable()
+
+    init {
+        eventDispatcher.registerHandler(Event.SettingsUpdate::class, ::handleNewEvent)
+    }
+
+    fun onDestroy() {
+        accountNumberNotifier.unsubscribeAll()
+        dnsOptionsNotifier.unsubscribeAll()
+        relaySettingsNotifier.unsubscribeAll()
+        settingsNotifier.unsubscribeAll()
+    }
+
+    private fun handleNewEvent(event: Event.SettingsUpdate) {
+        event.settings?.let { settings -> handleNewSettings(settings) }
+    }
+
+    private fun handleNewSettings(newSettings: Settings) {
+        if (settings?.accountToken != newSettings.accountToken) {
+            accountNumberNotifier.notify(newSettings.accountToken)
+        }
+
+        if (settings?.tunnelOptions?.dnsOptions != newSettings.tunnelOptions.dnsOptions) {
+            dnsOptionsNotifier.notify(newSettings.tunnelOptions.dnsOptions)
+        }
+
+        if (settings?.relaySettings != newSettings.relaySettings) {
+            relaySettingsNotifier.notify(newSettings.relaySettings)
+        }
+
+        settings = newSettings
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/talpid/net/wireguard/TunnelOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/net/wireguard/TunnelOptions.kt
@@ -1,3 +1,7 @@
 package net.mullvad.talpid.net.wireguard
 
-data class TunnelOptions(val mtu: Int?)
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TunnelOptions(val mtu: Int?) : Parcelable

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -22,6 +22,7 @@ pub trait Match<T> {
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(target_os = "android", derive(FromJava, IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
+#[cfg_attr(target_os = "android", jnix(bounds = "T: android.os.Parcelable"))]
 pub enum Constraint<T: fmt::Debug + Clone + Eq + PartialEq> {
     Any,
     Only(T),


### PR DESCRIPTION
This PR continues the work to run the service in a separate process by splitting the `SettingsListener` class in two, one for the UI side process and one for the service side process. They communicate through the IPC channel that was configured in a [previous PR](#2463). For now, only sending events from the service side to the UI side is implemented, using a new `Event.SettingsUpdate` message. Changing individual settings by sending requests from the UI to the service will be implemented in one or more future PRs.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2496)
<!-- Reviewable:end -->
