### PR TITLE
Give Windows 7 users the option to restart

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -124,7 +124,7 @@
 
 	${If} $0 != 0
 		${If} $0 == 3010
-			MessageBox MB_OK "You may need to restart your computer for the patch to take effect."
+			SetRebootFlag true
 		${Else}
 			StrCpy $R0 "Failed to install the hotfix: error $0"
 			log::Log $R0


### PR DESCRIPTION
The "you may need to restart your computer" message was pretty ambiguous, as rebooting is actually required. Simply setting the reboot flag gives users the option to reboot before the installer exits:

![Reboot option](https://user-images.githubusercontent.com/2653485/108743484-1ae91280-7539-11eb-92e4-0dd53003feda.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2499)
<!-- Reviewable:end -->
