### PR TITLE
Fix unresponsive disconnecting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix delay in showing/hiding update notification when toggling beta program.
+- Improve responsiveness when reconnecting after some failed connection attempts.
 
 #### Windows
 - Fix "cannot find the file" error while creating a Wintun adapter by upgrading Wintun.


### PR DESCRIPTION
When `ConnectingState::enter` immediately fails and enters the disconnecting state, it sometimes passes a terminated (tunnel close event) future to `DisconnectingState::enter`. In `DisconnectingState::handle_event`, the "after-connect" action is immediately taken if the future is terminated, so as to not block until a command is sent.

The problem arises when the after-connect action is to reconnect, and the connecting state keeps failing in the same manner. The tunnel state machine becomes unresponsive to commands until the loop is broken. This can be verified by always returning `Err(RecoverableStartWireguardError);` from `WireguardMonitor::start`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2503)
<!-- Reviewable:end -->
