### PR TITLE
Remove any network device with a conflicting GUID

### DIFF
--- a/windows/driverlogic/src/driverlogic.cpp
+++ b/windows/driverlogic/src/driverlogic.cpp
@@ -818,23 +818,23 @@ std::filesystem::path GetCurrentModulePath()
 
 	SetLastError(ERROR_SUCCESS);
 
-	size_t nextCapacity = 256;
+	size_t nextCapacity = MAX_PATH;
+	DWORD writtenChars = 0;
 
 	do
 	{
-		pathBuffer.reserve(nextCapacity);
-
-		const auto writtenChars = GetModuleFileNameW(nullptr, &pathBuffer[0], static_cast<DWORD>(pathBuffer.capacity()));
+		pathBuffer.resize(nextCapacity);
+		writtenChars = GetModuleFileNameW(nullptr, &pathBuffer[0], static_cast<DWORD>(pathBuffer.size()));
 
 		if (0 == writtenChars)
 		{
 			THROW_WINDOWS_ERROR(GetLastError(), "GetModuleFileNameW");
 		}
 
-		pathBuffer.resize(writtenChars);
-
-		nextCapacity = 2 * pathBuffer.capacity();
+		nextCapacity = 2 * pathBuffer.size();
 	} while (ERROR_INSUFFICIENT_BUFFER == GetLastError());
+
+	pathBuffer.resize(writtenChars);
 
 	return std::filesystem::path(pathBuffer.begin(), pathBuffer.end());
 }

--- a/windows/driverlogic/src/driverlogic.cpp
+++ b/windows/driverlogic/src/driverlogic.cpp
@@ -759,7 +759,7 @@ std::optional<NetworkAdapter> FindAdapterByAlias(const std::set<NetworkAdapter> 
 	return std::nullopt;
 }
 
-bool RemoveNetDevice(const std::wstring &tapHardwareId, const std::wstring &guid)
+bool RemoveNetDevice(const std::optional<std::wstring> tapHardwareId, const std::wstring &guid)
 {
 	bool deletedAdapter = false;
 
@@ -806,7 +806,7 @@ void RemoveNetAdapterByAlias(const std::wstring &hardwareId, const std::wstring 
 	// and delete any adapter whose GUID matches that of the "Mullvad" adapter.
 	//
 
-	if (!RemoveNetDevice(hardwareId, guid))
+	if (!RemoveNetDevice(std::make_optional(hardwareId), guid))
 	{
 		THROW_ERROR("The virtual adapter could not be removed");
 	}
@@ -1037,6 +1037,20 @@ int wmain(int argc, const wchar_t * argv[], const wchar_t * [])
 			const wchar_t *baseName = argv[3];
 
 			RemoveNetAdapterByAlias(hardwareId, baseName);
+		}
+		else if (0 == _wcsicmp(argv[1], L"remove-device-by-guid"))
+		{
+			if (3 != argc)
+			{
+				goto INVALID_ARGUMENTS;
+			}
+
+			const wchar_t *guid = argv[2];
+
+			if (!RemoveNetDevice(std::nullopt, guid))
+			{
+				return ADAPTER_NOT_FOUND;
+			}
 		}
 		else if (0 == _wcsicmp(argv[1], L"device-exists"))
 		{


### PR DESCRIPTION
`WintunCreateAdapter` fails if the `requestedGuid` argument is in use by another network device that belongs to a different Wintun pool or is not a Wintun device at all. This can be verified by creating a Wintun interface in some pool other than `Mullvad` (e.g., using `driverlogic wintun create-adapter test test {AFE43773-E1F8-4EBB-8536-576AB86AFE9A}`) before running `mullvad connect`. This occurs using both wireguard-go and OpenVPN.

In practice, this would have occurred when older versions of the service created a Wintun adapter via wireguard-go and failed to clean up after themselves (e.g. if the daemon was suddenly killed). After upgrading, this adapter would be assigned the same GUID as our new adapter but belong to a different pool.

Previously, this had to be fixed by manually deleting the conflicting device. This PR updates the installer to remove any network device matching the requested GUID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2505)
<!-- Reviewable:end -->
