### PR TITLE
Lower priority of update available notification banner

### DIFF
--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -53,7 +53,6 @@ export default function NotificationArea(props: IProps) {
     new NoValidKeyNotificationProvider({ tunnelProtocol, wireGuardKey }),
     new InconsistentVersionNotificationProvider({ consistent: version.consistent }),
     new UnsupportedVersionNotificationProvider(version),
-    new UpdateAvailableNotificationProvider(version),
   ];
 
   if (accountExpiry) {
@@ -61,6 +60,8 @@ export default function NotificationArea(props: IProps) {
       new CloseToAccountExpiryNotificationProvider({ accountExpiry, locale }),
     );
   }
+
+  notificationProviders.push(new UpdateAvailableNotificationProvider(version));
 
   const notificationProvider = notificationProviders.find((notification) =>
     notification.mayDisplay(),


### PR DESCRIPTION
This PR changes the priority of the "Update available" notification banner to lower the "Account will soon expire" one.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2511)
<!-- Reviewable:end -->
