### PR TITLE
Change beta update link

### DIFF
--- a/gui/src/config.json
+++ b/gui/src/config.json
@@ -4,7 +4,7 @@
     "manageKeys": "https://mullvad.net/account/ports/",
     "faq": "https://mullvad.net/help/tag/mullvad-app/",
     "download": "https://mullvad.net/download/",
-    "betaDownload": "https://mullvad.net/download/#beta",
+    "betaDownload": "https://mullvad.net/download/beta",
     "supportEmail": "support@mullvad.net"
   },
   "colors": {


### PR DESCRIPTION
This PR changes the download-url for beta versions from `https://mullvad.net/download/#beta` to `https://mullvad.net/download/beta`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2512)
<!-- Reviewable:end -->
