### PR TITLE
Change in-app banner notification prioritization

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/InAppNotificationController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/InAppNotificationController.kt
@@ -1,12 +1,16 @@
 package net.mullvad.mullvadvpn.ui.notification
 
+import java.util.PriorityQueue
 import kotlin.properties.Delegates.observable
 
 class InAppNotificationController(private val onNotificationChanged: (InAppNotification?) -> Unit) {
-    private val indices = HashMap<InAppNotification, Int>()
-    private val notifications = ArrayList<InAppNotification>()
+    private val notificationPrioritizer =
+        compareByDescending<InAppNotification> { it.shouldShow }
+            .thenBy { it.status }
+            .thenBy { notifications.get(it)!! }
 
-    private var currentIndex: Int? = null
+    private val activeNotifications = PriorityQueue(notificationPrioritizer)
+    private val notifications = HashMap<InAppNotification, Int>()
 
     var current by observable<InAppNotification?>(null) { _, oldNotification, newNotification ->
         if (oldNotification != newNotification) {
@@ -17,64 +21,36 @@ class InAppNotificationController(private val onNotificationChanged: (InAppNotif
     fun register(notification: InAppNotification) {
         notification.controller = this
 
-        indices.put(notification, notifications.size)
-        notifications.add(notification)
+        notifications.put(notification, notifications.size)
 
         notificationChanged(notification)
     }
 
     fun onResume() {
-        for (notification in notifications) {
+        for (notification in notifications.keys) {
             notification.onResume()
         }
     }
 
     fun onPause() {
-        for (notification in notifications) {
+        for (notification in notifications.keys) {
             notification.onPause()
         }
     }
 
     fun onDestroy() {
-        for (notification in notifications) {
+        for (notification in notifications.keys) {
             notification.onDestroy()
         }
     }
 
     fun notificationChanged(notification: InAppNotification) {
-        if (notification.shouldShow) {
-            maybeShowNotification(notification)
+        if (notification.shouldShow && !activeNotifications.contains(notification)) {
+            activeNotifications.add(notification)
         } else {
-            maybeHideNotification(notification)
+            activeNotifications.remove(notification)
         }
-    }
 
-    private fun maybeShowNotification(notification: InAppNotification) {
-        indices.get(notification)?.let { index ->
-            if (index <= (currentIndex ?: Int.MAX_VALUE)) {
-                current = notification
-                currentIndex = index
-            }
-        }
-    }
-
-    private fun maybeHideNotification(notification: InAppNotification) {
-        if (current == notification) {
-            val start = currentIndex!! + 1
-            val end = notifications.size
-
-            for (index in start until end) {
-                val candidate = notifications.get(index)
-
-                if (candidate.shouldShow) {
-                    current = candidate
-                    currentIndex = index
-                    return
-                }
-            }
-
-            current = null
-            currentIndex = null
-        }
+        current = activeNotifications.peek()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/InAppNotificationController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/InAppNotificationController.kt
@@ -8,8 +8,10 @@ class InAppNotificationController(private val onNotificationChanged: (InAppNotif
 
     private var currentIndex: Int? = null
 
-    var current by observable<InAppNotification?>(null) { _, _, notification ->
-        onNotificationChanged.invoke(notification)
+    var current by observable<InAppNotification?>(null) { _, oldNotification, newNotification ->
+        if (oldNotification != newNotification) {
+            onNotificationChanged.invoke(newNotification)
+        }
     }
 
     fun register(notification: InAppNotification) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/StatusLevel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/StatusLevel.kt
@@ -1,6 +1,6 @@
 package net.mullvad.mullvadvpn.ui.notification
 
 enum class StatusLevel {
-    Warning,
     Error,
+    Warning,
 }


### PR DESCRIPTION
Previously, the app would only consider the registration order when deciding which in-app notification to show. This led to a situation where an "Update available" message would have a higher priority than "Account expires in 1 day" message. It's desirable to have the account expiration message have a higher priority than the update warning.

This PR changes the logic to prioritize `StatusLevel.Error` messages over `StatusLevel.Warning` messages. Currently, the only notification that has `StatusLevel.Warning` is the update available message. This change also ensures any future warnings will have a lower priority than the error messages.

The way the prioritization was initially implemented was by having an `ArrayList` of registered notifications, and the lower the index of a notification the higher the priority. The app would then show a notification if it is marked to be shown and had an index lower than the index of the currently shown notification. When a notification was marked to be hidden, the app would search all notifications with higher indices to see if it should show some other lower priority notification.

This PR simplifies the prioritization code to use a `PriorityQueue`. A custom `notificationPrioritizer` comparator was implemented to compare notifications and determine which one has a higher priority and should come first (i.e., a higher priority notification is technically "less than" a lower priority notification).

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2513)
<!-- Reviewable:end -->
