### PR TITLE
Retry if creating a WG tunnel fails because there is no default route (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix "cannot find the file" error while creating a Wintun adapter by upgrading Wintun.
+- Retry when creating a WireGuard tunnel fails due to no default routes being found.
 
 
 ## [2021.2] - 2021-02-18

--- a/talpid-core/src/routing/windows.rs
+++ b/talpid-core/src/routing/windows.rs
@@ -20,7 +20,7 @@ pub enum Error {
     FailedToStartManager,
     /// Failure to add routes
     #[error(display = "Failed to add routes")]
-    AddRoutesFailed,
+    AddRoutesFailed(#[error(source)] winnet::Error),
     /// Failure to clear routes
     #[error(display = "Failed to clear applied routes")]
     ClearRoutesFailed,
@@ -118,11 +118,9 @@ impl RouteManager {
                         })
                         .collect();
 
-                    if winnet::routing_manager_add_routes(&routes) {
-                        let _ = tx.send(Ok(()));
-                    } else {
-                        let _ = tx.send(Err(Error::AddRoutesFailed));
-                    }
+                    let _ = tx.send(
+                        winnet::routing_manager_add_routes(&routes).map_err(Error::AddRoutesFailed),
+                    );
                 }
                 RouteManagerCommand::Shutdown => {
                     break;

--- a/windows/winnet/src/winnet/routing/routemanager.h
+++ b/windows/winnet/src/winnet/routing/routemanager.h
@@ -18,6 +18,51 @@
 namespace winnet::routing
 {
 
+namespace error
+{
+
+class RouteManagerError : public std::runtime_error
+{
+public:
+
+	RouteManagerError(const char* message)
+		: std::runtime_error(message)
+	{
+	}
+};
+
+class NoDefaultRoute : public RouteManagerError
+{
+public:
+
+	NoDefaultRoute(const char* message)
+		: RouteManagerError(message)
+	{
+	}
+};
+
+class DeviceNameNotFound : public RouteManagerError
+{
+public:
+
+	DeviceNameNotFound(const char* message)
+		: RouteManagerError(message)
+	{
+	}
+};
+
+class DeviceGatewayNotFound : public RouteManagerError
+{
+public:
+
+	DeviceGatewayNotFound(const char* message)
+		: RouteManagerError(message)
+	{
+	}
+};
+
+}
+
 class RouteManager
 {
 public:

--- a/windows/winnet/src/winnet/winnet.cpp
+++ b/windows/winnet/src/winnet/winnet.cpp
@@ -280,7 +280,7 @@ WinNet_ActivateRouteManager(
 
 extern "C"
 WINNET_LINKAGE
-bool
+WINNET_AR_STATUS
 WINNET_API
 WinNet_AddRoutes(
 	const WINNET_ROUTE *routes,
@@ -291,7 +291,7 @@ WinNet_AddRoutes(
 
 	if (nullptr == g_RouteManager)
 	{
-		return false;
+		return WINNET_AR_STATUS_GENERAL_ERROR;
 	}
 
 	try
@@ -302,22 +302,37 @@ WinNet_AddRoutes(
 		}
 
 		g_RouteManager->addRoutes(winnet::ConvertRoutes(routes, numRoutes));
-		return true;
+		return WINNET_AR_STATUS_SUCCESS;
+	}
+	catch (const winnet::routing::error::NoDefaultRoute &err)
+	{
+		common::error::UnwindException(err, g_RouteManagerLogSink);
+		return WINNET_AR_STATUS_NO_DEFAULT_ROUTE;
+	}
+	catch (const winnet::routing::error::DeviceNameNotFound &err)
+	{
+		common::error::UnwindException(err, g_RouteManagerLogSink);
+		return WINNET_AR_STATUS_NAME_NOT_FOUND;
+	}
+	catch (const winnet::routing::error::DeviceGatewayNotFound &err)
+	{
+		common::error::UnwindException(err, g_RouteManagerLogSink);
+		return WINNET_AR_STATUS_GATEWAY_NOT_FOUND;
 	}
 	catch (const std::exception &err)
 	{
 		common::error::UnwindException(err, g_RouteManagerLogSink);
-		return false;
+		return WINNET_AR_STATUS_GENERAL_ERROR;
 	}
 	catch (...)
 	{
-		return false;
+		return WINNET_AR_STATUS_GENERAL_ERROR;
 	}
 }
 
 extern "C"
 WINNET_LINKAGE
-bool
+WINNET_AR_STATUS
 WINNET_API
 WinNet_AddRoute(
 	const WINNET_ROUTE *route

--- a/windows/winnet/src/winnet/winnet.h
+++ b/windows/winnet/src/winnet/winnet.h
@@ -96,9 +96,18 @@ WinNet_ActivateRouteManager(
 	void *logSinkContext
 );
 
+enum WINNET_AR_STATUS
+{
+	WINNET_AR_STATUS_SUCCESS = 0,
+	WINNET_AR_STATUS_GENERAL_ERROR = 1,
+	WINNET_AR_STATUS_NO_DEFAULT_ROUTE = 2,
+	WINNET_AR_STATUS_NAME_NOT_FOUND = 3,
+	WINNET_AR_STATUS_GATEWAY_NOT_FOUND = 4,
+};
+
 extern "C"
 WINNET_LINKAGE
-bool
+WINNET_AR_STATUS
 WINNET_API
 WinNet_AddRoutes(
 	const WINNET_ROUTE *routes,
@@ -107,7 +116,7 @@ WinNet_AddRoutes(
 
 extern "C"
 WINNET_LINKAGE
-bool
+WINNET_AR_STATUS
 WINNET_API
 WinNet_AddRoute(
 	const WINNET_ROUTE *route


### PR DESCRIPTION
Previously, if there was no default route, the daemon would transition to the error state and keep blocking even if such a route was later added. This might have occurred if the offline monitor reported the offline state too late (after attempting to connect), inaccurately reported "connected", or was disabled using `TALPID_DISABLE_OFFLINE_MONITOR=1`.

These changes cause the daemon to retry if the tunnel cannot be created because there's no default route.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2514)
<!-- Reviewable:end -->
