### PR TITLE
Add transition animation listener for enter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'joda-time:joda-time:2.10.2'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.10'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
 }
 
 buildscript {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragments/BaseFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragments/BaseFragment.kt
@@ -1,11 +1,22 @@
 package net.mullvad.mullvadvpn.ui.fragments
 
 import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import androidx.annotation.LayoutRes
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.util.transitionFinished
 
-abstract class BaseFragment : Fragment() {
+abstract class BaseFragment : Fragment {
+    constructor() : super()
+    constructor (@LayoutRes contentLayoutId: Int) : super(contentLayoutId)
+
+    protected var transitionFinishedFlow: Flow<Unit> = emptyFlow()
+        private set
+
     override fun onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation? {
         val zAdjustment = if (animationsToAdjustZorder.contains(nextAnim)) {
             1f
@@ -13,7 +24,13 @@ abstract class BaseFragment : Fragment() {
             0f
         }
         ViewCompat.setTranslationZ(requireView(), zAdjustment)
-        return super.onCreateAnimation(transit, enter, nextAnim)
+        return if (nextAnim != 0 && enter) {
+            AnimationUtils.loadAnimation(context, nextAnim)?.apply {
+                transitionFinishedFlow = transitionFinished()
+            }
+        } else {
+            super.onCreateAnimation(transit, enter, nextAnim)
+        }
     }
 
     companion object {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
@@ -1,0 +1,28 @@
+package net.mullvad.mullvadvpn.util
+
+import android.view.animation.Animation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.take
+
+fun <T> SendChannel<T>.safeOffer(element: T): Boolean {
+    return runCatching { offer(element) }.getOrDefault(false)
+}
+
+fun Animation.transitionFinished(): Flow<Unit> = callbackFlow<Unit> {
+    val transitionAnimationListener = object : Animation.AnimationListener {
+        override fun onAnimationStart(animation: Animation?) {}
+        override fun onAnimationEnd(animation: Animation?) { safeOffer(Unit) }
+        override fun onAnimationRepeat(animation: Animation?) {}
+    }
+    setAnimationListener(transitionAnimationListener)
+    awaitClose {
+        Dispatchers.Main.dispatch(EmptyCoroutineContext) {
+            setAnimationListener(null)
+        }
+    }
+}.take(1)


### PR DESCRIPTION
This PR will help to keep track on enter transition animation. We will use it to present data and colouring StatusBar when fragments are changed.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2516)
<!-- Reviewable:end -->
