### PR TITLE
Fix invalid unsecured label color

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Migrate to WireGuardKit framework.
 - Fix crash when pasting empty string into account input field.
+- Fix invalid initial text color of "unsecured connection" label on iOS 12.
 
 ## [2020.5] - 2020-11-04
 ### Fixed

--- a/ios/MullvadVPN/ConnectViewController.xib
+++ b/ios/MullvadVPN/ConnectViewController.xib
@@ -31,7 +31,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="366" height="24"/>
                             <accessibility key="accessibilityConfiguration" identifier="SecureConnectionLabel"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
-                            <color key="textColor" name="Success"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="daZ-9L-RFn">
@@ -108,9 +108,6 @@
     <resources>
         <namedColor name="Primary">
             <color red="0.16078431372549021" green="0.30196078431372547" blue="0.45098039215686275" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="Success">
-            <color red="0.26666666666666666" green="0.67843137254901964" blue="0.30196078431372547" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

It looks like when using a custom _named_ color in XIB interfaces files, the label color is applied after the `viewDidLoad()` but only on iOS 12.

The comical fix is to use any standard color (i.e white) in interface files. Since we override the color in code, it doesn't really matter what color is set in interface builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2517)
<!-- Reviewable:end -->
