### PR TITLE
Add Go version requirement for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,10 @@ After that copy the files from `gui/src/main/management_interface/` and `gui/bui
 directories into a single directory on your Apple Silicon Mac, and set the value of
 `MANAGEMENT_INTERFACE_PROTO_BUILD_DIR` to that directory while running the main build.
 
-On your Apple Silicon Mac install `protobuf` by running:
+Make sure that the version of Go on your Mac is 1.16 (the first version to add
+[support](https://tip.golang.org/doc/go1.16#darwin) for Apple Silicon) or newer.
+
+Install `protobuf` by running:
 
 ```bash
 brew install protobuf


### PR DESCRIPTION
A small addition to #2500: Go 1.13.6, mentioned in [All platforms](https://github.com/mullvad/mullvadvpn-app#all-platforms), will not work on Apple Silicon. 1.16 is the first version to add Apple Silicon support.
This slipped my attention in the original PR, sorry for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2520)
<!-- Reviewable:end -->
