### PR TITLE
Add iOS changelog entry about problem reports

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -23,15 +23,22 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add ability to report a problem inside the app. Sends logs to support.
+
 ### Changed
 - Migrate to WireGuardKit framework.
+
+### Fixed
 - Fix crash when pasting empty string into account input field.
 - Fix invalid initial text color of "unsecured connection" label on iOS 12.
+
 
 ## [2020.5] - 2020-11-04
 ### Fixed
 - Fix regression where "Internal error" was displayed instead of server error (i.e too many 
   WireGuard keys)
+
 
 ## [2020.4] - 2020-09-10
 ### Added


### PR DESCRIPTION
As far as I know the problem report has been merged. But it was not in the changelog. Is this addition correct?

And minor nitpick cleanup: two empty lines between releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2523)
<!-- Reviewable:end -->
