### PR TITLE
Stop using NM if it's too new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix "cannot find the file" error while creating a Wintun adapter by upgrading Wintun.
 - Retry when creating a WireGuard tunnel fails due to no default routes being found.
 
+#### Linux
+- Stop using NM for managing DNS if it's newer than 1.26.
+
 
 ## [2021.2] - 2021-02-18
 This release is for desktop only.

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -17,6 +17,7 @@ impl NetworkManager {
         let connection = DBus::new()?;
         connection.ensure_resolv_conf_is_managed()?;
         connection.ensure_network_manager_exists()?;
+        connection.nm_version_dns_works()?;
         let manager = NetworkManager {
             connection,
             device: None,

--- a/talpid-platform-metadata/src/linux.rs
+++ b/talpid-platform-metadata/src/linux.rs
@@ -94,7 +94,7 @@ fn kernel_version() -> Option<(String, String)> {
 /// > 1.26.0
 fn nm_version() -> Option<(String, String)> {
     let nm = talpid_dbus::network_manager::NetworkManager::new().ok()?;
-    Some(("nm".to_string(), nm.version().ok()?))
+    Some(("nm".to_string(), nm.version_string().ok()?))
 }
 
 /// `/sys/module/wireguard/version` contains only a numeric version string


### PR DESCRIPTION
As of 1.28, NM won't manage DNS for devices that it doesn't wholly manage when it manages DNS via `/etc/resolv.conf`. Of course, the daemon won't be able to notice this, so we cannot rely on newer versions of NM to manage DNS for us. So I've changed NM code to not manage DNS or create WireGuard devices if it's too new.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2524)
<!-- Reviewable:end -->
