### PR TITLE
Fix XML escaping in translations converter

### DIFF
--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -290,7 +290,7 @@ pub struct StringValue(String);
 
 impl From<&str> for StringValue {
     fn from(string: &str) -> Self {
-        let value_with_parameters = htmlize::unescape(string)
+        let value_with_parameters = htmlize::escape_text(string)
             .replace(r"\", r"\\")
             .replace("\"", "\\\"")
             .replace(r"'", r"\'");
@@ -320,7 +320,7 @@ impl StringValue {
         let value = PARAMETERS.replace_all(&value, "%");
 
         // Unescape XML characters
-        self.0 = htmlize::escape_text(value.as_bytes());
+        self.0 = htmlize::unescape(value.as_bytes());
     }
 
     /// Clones the internal string value.


### PR DESCRIPTION
A previous PR (#2449) improved string escaping when converting the translation strings for the desktop into translations strings for the Android app. However, it unfortunately included a small mistake where XML escaping was inverted. This PR fixes that.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tool change, not visible to end users.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2525)
<!-- Reviewable:end -->
