### PR TITLE
Add frontend.log to log file cleanup

### DIFF
--- a/gui/src/main/logging.ts
+++ b/gui/src/main/logging.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { IpcMainEventChannel } from './ipc-event-channel';
 import { LogLevel, ILogInput, ILogOutput } from '../shared/logging-types';
 
-export const OLD_LOG_FILES = ['main.log', 'renderer.log'];
+export const OLD_LOG_FILES = ['main.log', 'renderer.log', 'frontend.log'];
 
 export class FileOutput implements ILogOutput {
   private fileDescriptor: number;


### PR DESCRIPTION
The last PR modifying the file names for the frontend logging was missing `frontend.log` in the list of files to clean up.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2530)
<!-- Reviewable:end -->
