### PR TITLE
Fix "Manage Keys" button in the WireGuard Key screen always being disabled

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -73,7 +73,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
                 updateStatusMessage()
                 updateGenerateKeyButtonState()
                 updateVerifyKeyButtonState()
-                manageKeysButton.setEnabled(value)
+                manageKeysButton.setEnabled(!value)
             }
         }
 


### PR DESCRIPTION
A recent PR (#2415) improved the way the app accesses the API server, allowing it to be reached even when the app is in the blocked state. As part of the PR, the name of a field was changed in a way that inverted its semantics, but one of the usages still considered the old semantics. More specifically, the field was previously `hasConnectivity`, and the "Manage Keys" button was enabled using the value of that field. When the PR was merged, the field changed to `isOffline`, but the code to update the "Manage Keys" button still used the value directly.

This PR fixes that by using the correct semantics.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not present in any publicly released version, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2532)
<!-- Reviewable:end -->
