### PR TITLE
Fix login input area disappearing sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Fix DNS issues where NM would overwrite Mullvad tunnel's DNS config in systemd-resolved.
 
+#### Android
+- Fix input area sometimes disappearing when returning to the Login screen.
+
 
 ## [2021.2] - 2021-02-18
 This release is for desktop only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -212,7 +212,7 @@ class AccountLogin : RelativeLayout {
     }
 
     private fun reposition() {
-        historyAnimation.end()
+        historyAnimation.cancel()
 
         if (shouldShowAccountHistory) {
             updateHeight(expandedHeight)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.MeasureSpec
 import android.view.View.OnLayoutChangeListener
 import android.view.inputmethod.InputMethodManager
 import android.widget.RelativeLayout
@@ -68,7 +69,9 @@ class AccountLogin : RelativeLayout {
         }
     }
 
-    private var collapsedHeight by observable(0) { _, oldCollapsedHeight, newCollapsedHeight ->
+    private var collapsedHeight by observable(
+        calculateInitialInputHeight()
+    ) { _, oldCollapsedHeight, newCollapsedHeight ->
         if (newCollapsedHeight != oldCollapsedHeight) {
             historyAnimation.setIntValues(newCollapsedHeight, expandedHeight)
             reposition()
@@ -176,6 +179,17 @@ class AccountLogin : RelativeLayout {
     fun onDestroy() {
         input.onFocusChanged.unsubscribe(this)
         input.onTextChanged.unsubscribe(this)
+    }
+
+    private fun calculateInitialInputHeight(): Int {
+        if (input.height == 0) {
+            val widthMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.EXACTLY)
+            val heightMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+
+            input.measure(widthMeasureSpec, heightMeasureSpec)
+        }
+
+        return input.height
     }
 
     private fun updateBorder() {


### PR DESCRIPTION
Previously, it was possible for the account input area to disappear from the Login screen sometimes. This could be reproduced by logging out, pressing back on the login screen to leave the app, and then opening the app again. The cause of the issue was that the custom animation code would reset the height of the account input area to a calculated `collapsedHeight` value. That value was only calculated after a layout change, and when recreating the widget there would be no layout change so the listener wouldn't get called, meaning the value stayed at zero.

This PR fixes that by forcing the initial value to be always calculated during initialization, and updated on layout changes. The PR also changes stopping the animation by using `cancel()` instead of `end()` to prevent the animation from sending a new height value right before the height value is forcefully set to a known value, causing two successive height updates.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2534)
<!-- Reviewable:end -->
