### PR TITLE
Add rules to allow relay traffic through reverse path filtering on Linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - Fix DNS issues where NM would overwrite Mullvad tunnel's DNS config in systemd-resolved.
+- Fix issues with hosts where the firewall is doing reverse path filtering.
 
 #### Android
 - Fix input area sometimes disappearing when returning to the Login screen.


### PR DESCRIPTION
When the daemon runs on a system that attempts to do strict reverse path filtering, incoming relay traffic would be filtered out, leaving the user without a working connection, because the daemon would never receive the tunnel traffic, leaving it in a reconnection loop. This is because on Linux, we use policy based routing, and an incoming TCP or UDP packet does not have the necessary context at the filtering stage to determine if a response to said packet would be routed through the same interface. To fix this, I've added a new chain to our main table that will apply the correct firewall mark to the relay traffic so that it would still work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2535)
<!-- Reviewable:end -->
