### PR TITLE
Support WireGuard over TCP for custom relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 - Preserve log of old daemon instance when upgrading on Desktop.
 - When `MULLVAD_MANAGEMENT_SOCKET_GROUP` is set, only allow the specified group to access the
   management interface UDS socket. This means that only users in that group can use the CLI and GUI.
+- Support WireGuard over TCP for custom VPN relays in the CLI.
 
 #### Linux
 - Always enable `src_valid_mark` config option when connecting to allow policty based routing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,8 +445,11 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
+ "atty",
+ "humantime 1.3.0",
  "log 0.4.14",
  "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -456,7 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log 0.4.14",
  "regex",
  "termcolor",
@@ -777,7 +780,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.25",
+ "tokio",
  "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
@@ -858,6 +861,15 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -880,7 +892,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.5",
  "socket2",
- "tokio 0.2.25",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -899,7 +911,7 @@ dependencies = [
  "log 0.4.14",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.25",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -1159,19 +1171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
-dependencies = [
- "libc",
- "log 0.4.14",
- "miow 0.3.6",
- "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,7 +1178,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log 0.4.14",
- "mio 0.6.23",
+ "mio",
  "slab",
 ]
 
@@ -1190,7 +1189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log 0.4.14",
- "mio 0.6.23",
+ "mio",
  "miow 0.3.6",
  "winapi 0.3.9",
 ]
@@ -1203,7 +1202,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.23",
+ "mio",
 ]
 
 [[package]]
@@ -1266,7 +1265,7 @@ dependencies = [
  "natord",
  "serde",
  "talpid-types",
- "tokio 0.2.25",
+ "tokio",
  "winapi 0.3.9",
  "winres",
 ]
@@ -1304,7 +1303,7 @@ dependencies = [
  "talpid-core",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio 0.2.25",
+ "tokio",
  "triggered",
  "uuid",
  "winapi 0.3.9",
@@ -1341,7 +1340,7 @@ dependencies = [
  "rand 0.7.3",
  "talpid-core",
  "talpid-types",
- "tokio 0.2.25",
+ "tokio",
 ]
 
 [[package]]
@@ -1356,7 +1355,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost",
  "prost-types",
- "tokio 0.2.25",
+ "tokio",
  "tonic",
  "tonic-build",
  "tower",
@@ -1387,7 +1386,7 @@ dependencies = [
  "regex",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio 0.2.25",
+ "tokio",
  "uuid",
  "winapi 0.3.9",
  "winres",
@@ -1415,7 +1414,7 @@ dependencies = [
  "socket2",
  "talpid-types",
  "tempfile",
- "tokio 0.2.25",
+ "tokio",
  "tokio-rustls",
  "urlencoding",
  "webpki",
@@ -1436,7 +1435,7 @@ dependencies = [
  "mullvad-types",
  "talpid-core",
  "talpid-types",
- "tokio 0.2.25",
+ "tokio",
  "widestring",
  "winapi 0.3.9",
  "winres",
@@ -1530,7 +1529,7 @@ dependencies = [
  "log 0.4.14",
  "netlink-packet-core",
  "netlink-sys 0.5.0",
- "tokio 0.2.25",
+ "tokio",
  "tokio-util 0.2.0",
 ]
 
@@ -1553,8 +1552,8 @@ dependencies = [
  "futures",
  "libc",
  "log 0.4.14",
- "mio 0.6.23",
- "tokio 0.2.25",
+ "mio",
+ "tokio",
 ]
 
 [[package]]
@@ -1605,6 +1604,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags 1.2.1",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,18 +1627,9 @@ dependencies = [
  "fsevent-sys",
  "inotify",
  "libc",
- "mio 0.6.23",
+ "mio",
  "mio-extras",
  "walkdir",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -1711,7 +1713,7 @@ dependencies = [
  "mio-named-pipes",
  "miow 0.3.6",
  "rand 0.7.3",
- "tokio 0.2.25",
+ "tokio",
  "winapi 0.3.9",
 ]
 
@@ -2651,7 +2653,7 @@ dependencies = [
  "talpid-platform-metadata",
  "talpid-types",
  "tempfile",
- "tokio 0.2.25",
+ "tokio",
  "tonic",
  "tonic-build",
  "triggered",
@@ -2688,7 +2690,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost",
  "talpid-types",
- "tokio 0.2.25",
+ "tokio",
  "tonic",
  "tonic-build",
  "tower",
@@ -2812,31 +2814,15 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.6.23",
+ "mio",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
- "tokio-macros 0.2.6",
+ "tokio-macros",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
-dependencies = [
- "autocfg",
- "bytes 1.0.1",
- "libc",
- "memchr",
- "mio 0.7.9",
- "num_cpus",
- "pin-project-lite 0.2.4",
- "tokio-macros 1.1.0",
 ]
 
 [[package]]
@@ -2851,17 +2837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,7 +2844,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.25",
+ "tokio",
  "webpki",
 ]
 
@@ -2884,7 +2859,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.1.11",
- "tokio 0.2.25",
+ "tokio",
 ]
 
 [[package]]
@@ -2898,7 +2873,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.1.11",
- "tokio 0.2.25",
+ "tokio",
 ]
 
 [[package]]
@@ -2929,7 +2904,7 @@ dependencies = [
  "pin-project 0.4.27",
  "prost",
  "prost-derive",
- "tokio 0.2.25",
+ "tokio",
  "tokio-util 0.3.1",
  "tower",
  "tower-balance",
@@ -2982,7 +2957,7 @@ dependencies = [
  "pin-project 0.4.27",
  "rand 0.7.3",
  "slab",
- "tokio 0.2.25",
+ "tokio",
  "tower-discover",
  "tower-layer",
  "tower-load",
@@ -3000,7 +2975,7 @@ checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.2.25",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3031,7 +3006,7 @@ checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.2.25",
+ "tokio",
  "tower-layer",
  "tower-load",
  "tower-service",
@@ -3046,7 +3021,7 @@ dependencies = [
  "futures-core",
  "log 0.4.14",
  "pin-project 0.4.27",
- "tokio 0.2.25",
+ "tokio",
  "tower-discover",
  "tower-service",
 ]
@@ -3069,7 +3044,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio 0.2.25",
+ "tokio",
  "tower-service",
 ]
 
@@ -3083,7 +3058,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "log 0.4.14",
- "tokio 0.2.25",
+ "tokio",
  "tower-service",
 ]
 
@@ -3095,7 +3070,7 @@ checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.2.25",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -3113,7 +3088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
  "pin-project 0.4.27",
- "tokio 0.2.25",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -3216,14 +3191,15 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 [[package]]
 name = "udp-over-tcp"
 version = "0.1.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=942483b#942483b69651c9f59384606dee9cb1776a0b76fc"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=3d1abafe112ee8c2db47ca401f8e286756454e7a#3d1abafe112ee8c2db47ca401f8e286756454e7a"
 dependencies = [
- "env_logger 0.8.2",
+ "env_logger 0.7.1",
  "err-context",
  "futures",
  "log 0.4.14",
+ "nix 0.20.0",
  "structopt",
- "tokio 1.2.0",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "err-context"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449aad22b1364e927ff3bf50f55404efd705c40065fb47f73f28704de707c89e"
+
+[[package]]
 name = "err-derive"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,7 +777,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
@@ -874,7 +880,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.5",
  "socket2",
- "tokio",
+ "tokio 0.2.25",
  "tower-service",
  "tracing",
  "want",
@@ -893,7 +899,7 @@ dependencies = [
  "log 0.4.14",
  "rustls",
  "rustls-native-certs",
- "tokio",
+ "tokio 0.2.25",
  "tokio-rustls",
  "webpki",
 ]
@@ -1068,9 +1074,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "libdbus-sys"
@@ -1153,6 +1159,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+dependencies = [
+ "libc",
+ "log 0.4.14",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,7 +1179,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log 0.4.14",
- "mio",
+ "mio 0.6.23",
  "slab",
 ]
 
@@ -1171,7 +1190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log 0.4.14",
- "mio",
+ "mio 0.6.23",
  "miow 0.3.6",
  "winapi 0.3.9",
 ]
@@ -1184,7 +1203,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
@@ -1247,7 +1266,7 @@ dependencies = [
  "natord",
  "serde",
  "talpid-types",
- "tokio",
+ "tokio 0.2.25",
  "winapi 0.3.9",
  "winres",
 ]
@@ -1285,7 +1304,7 @@ dependencies = [
  "talpid-core",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio",
+ "tokio 0.2.25",
  "triggered",
  "uuid",
  "winapi 0.3.9",
@@ -1322,7 +1341,7 @@ dependencies = [
  "rand 0.7.3",
  "talpid-core",
  "talpid-types",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -1337,7 +1356,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost",
  "prost-types",
- "tokio",
+ "tokio 0.2.25",
  "tonic",
  "tonic-build",
  "tower",
@@ -1368,7 +1387,7 @@ dependencies = [
  "regex",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio",
+ "tokio 0.2.25",
  "uuid",
  "winapi 0.3.9",
  "winres",
@@ -1396,7 +1415,7 @@ dependencies = [
  "socket2",
  "talpid-types",
  "tempfile",
- "tokio",
+ "tokio 0.2.25",
  "tokio-rustls",
  "urlencoding",
  "webpki",
@@ -1417,7 +1436,7 @@ dependencies = [
  "mullvad-types",
  "talpid-core",
  "talpid-types",
- "tokio",
+ "tokio 0.2.25",
  "widestring",
  "winapi 0.3.9",
  "winres",
@@ -1511,7 +1530,7 @@ dependencies = [
  "log 0.4.14",
  "netlink-packet-core",
  "netlink-sys 0.5.0",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util 0.2.0",
 ]
 
@@ -1534,8 +1553,8 @@ dependencies = [
  "futures",
  "libc",
  "log 0.4.14",
- "mio",
- "tokio",
+ "mio 0.6.23",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -1597,9 +1616,18 @@ dependencies = [
  "fsevent-sys",
  "inotify",
  "libc",
- "mio",
+ "mio 0.6.23",
  "mio-extras",
  "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -1683,7 +1711,7 @@ dependencies = [
  "mio-named-pipes",
  "miow 0.3.6",
  "rand 0.7.3",
- "tokio",
+ "tokio 0.2.25",
  "winapi 0.3.9",
 ]
 
@@ -2454,6 +2482,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,11 +2651,12 @@ dependencies = [
  "talpid-platform-metadata",
  "talpid-types",
  "tempfile",
- "tokio",
+ "tokio 0.2.25",
  "tonic",
  "tonic-build",
  "triggered",
  "tun",
+ "udp-over-tcp",
  "uuid",
  "which 4.0.2",
  "widestring",
@@ -2635,7 +2688,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost",
  "talpid-types",
- "tokio",
+ "tokio 0.2.25",
  "tonic",
  "tonic-build",
  "tower",
@@ -2759,15 +2812,31 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.23",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.6",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.9",
+ "num_cpus",
+ "pin-project-lite 0.2.4",
+ "tokio-macros 1.1.0",
 ]
 
 [[package]]
@@ -2782,6 +2851,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,7 +2869,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio",
+ "tokio 0.2.25",
  "webpki",
 ]
 
@@ -2804,7 +2884,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.1.11",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2818,7 +2898,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.1.11",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2849,7 +2929,7 @@ dependencies = [
  "pin-project 0.4.27",
  "prost",
  "prost-derive",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util 0.3.1",
  "tower",
  "tower-balance",
@@ -2902,7 +2982,7 @@ dependencies = [
  "pin-project 0.4.27",
  "rand 0.7.3",
  "slab",
- "tokio",
+ "tokio 0.2.25",
  "tower-discover",
  "tower-layer",
  "tower-load",
@@ -2920,7 +3000,7 @@ checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.25",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2951,7 +3031,7 @@ checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.25",
  "tower-layer",
  "tower-load",
  "tower-service",
@@ -2966,7 +3046,7 @@ dependencies = [
  "futures-core",
  "log 0.4.14",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.25",
  "tower-discover",
  "tower-service",
 ]
@@ -2989,7 +3069,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio",
+ "tokio 0.2.25",
  "tower-service",
 ]
 
@@ -3003,7 +3083,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "log 0.4.14",
- "tokio",
+ "tokio 0.2.25",
  "tower-service",
 ]
 
@@ -3015,7 +3095,7 @@ checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.25",
  "tower-layer",
  "tower-service",
 ]
@@ -3033,7 +3113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.25",
  "tower-layer",
  "tower-service",
 ]
@@ -3132,6 +3212,19 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "udp-over-tcp"
+version = "0.1.0"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=942483b#942483b69651c9f59384606dee9cb1776a0b76fc"
+dependencies = [
+ "env_logger 0.8.2",
+ "err-context",
+ "futures",
+ "log 0.4.14",
+ "structopt",
+ "tokio 1.2.0",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -349,7 +349,7 @@ impl Relay {
             "udp" => TransportProtocol::Udp,
             "tcp" => TransportProtocol::Tcp,
             _ => clap::Error::with_description(
-                "unknown transport protocol",
+                "invalid transport protocol",
                 clap::ErrorKind::ValueValidation,
             )
             .exit(),

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -52,32 +52,28 @@ impl Command for Relay {
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("protocol")
-                                        .help("Transport protocol")
-                                        .default_value("udp")
-                                        .possible_values(&["udp", "tcp"])
-                                        .required(true),
-                                )
-                                .arg(
-                                    clap::Arg::with_name("peer-key")
+                                    clap::Arg::with_name("peer-pubkey")
                                         .help("Base64 encoded peer public key")
-                                        .required(true)
-                                        .takes_value(true),
-                                )
-                                .arg(
-                                    clap::Arg::with_name("addr")
-                                        .help("Local address of wireguard tunnel")
-                                        .long("addr")
-                                        .required(true)
-                                        .takes_value(true)
-                                        .multiple(true),
+                                        .required(true),
                                 )
                                 .arg(
                                     clap::Arg::with_name("v4-gateway")
                                         .help("IPv4 gateway address")
-                                        .long("v4-gateway")
+                                        .required(true),
+                                )
+                                .arg(
+                                    clap::Arg::with_name("addr")
+                                        .help("Local address of wireguard tunnel")
                                         .required(true)
-                                        .takes_value(true),
+                                        .multiple(true),
+                                )
+                                .arg(
+                                    clap::Arg::with_name("protocol")
+                                        .help("Transport protocol. If TCP is selected, traffic is \
+                                               sent over TCP using a udp-over-tcp proxy")
+                                        .long("protocol")
+                                        .default_value("udp")
+                                        .possible_values(&["udp", "tcp"]),
                                 )
                                 .arg(
                                     clap::Arg::with_name("v6-gateway")
@@ -90,31 +86,29 @@ impl Command for Relay {
                                 .arg(
                                     clap::Arg::with_name("host")
                                         .help("Hostname or IP")
-                                        .required(true)
-                                        .index(1),
+                                        .required(true),
                                 )
                                 .arg(
                                     clap::Arg::with_name("port")
                                         .help("Remote network port")
-                                        .required(true)
-                                        .index(2),
-                                )
-                                .arg(
-                                    clap::Arg::with_name("protocol")
-                                        .help("Transport protocol")
-                                        .index(3)
-                                        .default_value("udp")
-                                        .possible_values(&["udp", "tcp"]),
+                                        .required(true),
                                 )
                                 .arg(
                                     clap::Arg::with_name("username")
                                         .help("Username to be used with the OpenVpn relay")
-                                        .index(4),
+                                        .required(true),
                                 )
                                 .arg(
                                     clap::Arg::with_name("password")
                                         .help("Password to be used with the OpenVpn relay")
-                                        .index(5),
+                                        .required(true),
+                                )
+                                .arg(
+                                    clap::Arg::with_name("protocol")
+                                        .help("Transport protocol")
+                                        .long("protocol")
+                                        .default_value("udp")
+                                        .possible_values(&["udp", "tcp"]),
                                 )
                             )
                     )
@@ -273,7 +267,7 @@ impl Relay {
         let port = value_t!(matches.value_of("port"), u16).unwrap_or_else(|e| e.exit());
         let addresses = values_t!(matches.values_of("addr"), IpAddr).unwrap_or_else(|e| e.exit());
         let peer_key_str =
-            value_t!(matches.value_of("peer-key"), String).unwrap_or_else(|e| e.exit());
+            value_t!(matches.value_of("peer-pubkey"), String).unwrap_or_else(|e| e.exit());
         let ipv4_gateway =
             value_t!(matches.value_of("v4-gateway"), Ipv4Addr).unwrap_or_else(|e| e.exit());
         let ipv6_gateway = match value_t!(matches.value_of("v6-gateway"), Ipv6Addr) {

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -59,13 +59,13 @@ pub fn print_state(state: &TunnelState) {
 fn format_endpoint(endpoint: &TunnelEndpoint) -> String {
     let mut out = format!(
         "{} {} over {}",
-        match TunnelType::from_i32(endpoint.tunnel_type).expect("unknown tunnel protocol") {
+        match TunnelType::from_i32(endpoint.tunnel_type).expect("invalid tunnel protocol") {
             TunnelType::Wireguard => "WireGuard",
             TunnelType::Openvpn => "OpenVPN",
         },
         endpoint.address,
         format_protocol(
-            TransportProtocol::from_i32(endpoint.protocol).expect("unknown transport protocol")
+            TransportProtocol::from_i32(endpoint.protocol).expect("invalid transport protocol")
         ),
     );
 
@@ -73,13 +73,13 @@ fn format_endpoint(endpoint: &TunnelEndpoint) -> String {
         write!(
             &mut out,
             " via {} {} over {}",
-            match ProxyType::from_i32(proxy.proxy_type).expect("unknown proxy type") {
+            match ProxyType::from_i32(proxy.proxy_type).expect("invalid proxy type") {
                 ProxyType::Shadowsocks => "Shadowsocks",
                 ProxyType::Custom => "custom bridge",
             },
             proxy.address,
             format_protocol(
-                TransportProtocol::from_i32(proxy.protocol).expect("unknown transport protocol")
+                TransportProtocol::from_i32(proxy.protocol).expect("invalid transport protocol")
             ),
         )
         .unwrap();

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -916,7 +916,7 @@ fn convert_relay_settings_update(
                         Some(types::TunnelType::Wireguard) => {
                             Some(Constraint::Only(TunnelType::Wireguard))
                         }
-                        None => return Err(Status::invalid_argument("unknown tunnel protocol")),
+                        None => return Err(Status::invalid_argument("invalid tunnel protocol")),
                     },
                     None => Some(Constraint::Any),
                 }
@@ -954,7 +954,7 @@ fn convert_relay_settings_update(
                         Some(types::IpVersion::V4) => Some(IpVersion::V4),
                         Some(types::IpVersion::V6) => Some(IpVersion::V6),
                         None => {
-                            return Err(Status::invalid_argument("unknown ip protocol version"))
+                            return Err(Status::invalid_argument("invalid ip protocol version"))
                         }
                     },
                     None => None,

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -808,15 +808,7 @@ fn convert_relay_settings_update(
                     ConnectionConfig::OpenVpn(openvpn::ConnectionConfig {
                         endpoint: net::Endpoint {
                             address,
-                            protocol: match types::TransportProtocol::from_i32(config.protocol) {
-                                Some(types::TransportProtocol::Udp) => TransportProtocol::Udp,
-                                Some(types::TransportProtocol::Tcp) => TransportProtocol::Tcp,
-                                None => {
-                                    return Err(Status::invalid_argument(
-                                        "invalid transport protocol",
-                                    ))
-                                }
-                            },
+                            protocol: convert_proto_transport_protocol(config.protocol)?,
                         },
                         username: config.username.clone(),
                         password: config.password.clone(),
@@ -893,6 +885,7 @@ fn convert_relay_settings_update(
                             public_key: wireguard::PublicKey::from(public_key),
                             allowed_ips,
                             endpoint,
+                            protocol: convert_proto_transport_protocol(peer.protocol)?,
                         },
                         ipv4_gateway,
                         ipv6_gateway,
@@ -934,13 +927,7 @@ fn convert_relay_settings_update(
             let transport_protocol = if let Some(ref constraints) = settings.openvpn_constraints {
                 match &constraints.protocol {
                     Some(constraint) => {
-                        match types::TransportProtocol::from_i32(constraint.protocol) {
-                            Some(types::TransportProtocol::Udp) => Some(TransportProtocol::Udp),
-                            Some(types::TransportProtocol::Tcp) => Some(TransportProtocol::Tcp),
-                            None => {
-                                return Err(Status::invalid_argument("unknown transport protocol"))
-                            }
-                        }
+                        Some(convert_proto_transport_protocol(constraint.protocol)?)
                     }
                     None => None,
                 }
@@ -1103,6 +1090,10 @@ fn convert_connection_config(config: &ConnectionConfig) -> types::ConnectionConf
                             .map(|address| address.to_string())
                             .collect(),
                         endpoint: config.peer.endpoint.to_string(),
+                        protocol: i32::from(match config.peer.protocol {
+                            TransportProtocol::Udp => types::TransportProtocol::Udp,
+                            TransportProtocol::Tcp => types::TransportProtocol::Tcp,
+                        }),
                     }),
                     ipv4_gateway: config.ipv4_gateway.to_string(),
                     ipv6_gateway: config
@@ -1543,6 +1534,14 @@ fn convert_proto_location(location: types::RelayLocation) -> Constraint<Location
         Constraint::Only(LocationConstraint::Country(location.country))
     } else {
         Constraint::Any
+    }
+}
+
+fn convert_proto_transport_protocol(protocol: i32) -> Result<TransportProtocol, Status> {
+    match types::TransportProtocol::from_i32(protocol) {
+        Some(types::TransportProtocol::Udp) => Ok(TransportProtocol::Udp),
+        Some(types::TransportProtocol::Tcp) => Ok(TransportProtocol::Tcp),
+        None => Err(Status::invalid_argument("invalid transport protocol")),
     }
 }
 

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -697,6 +697,7 @@ impl RelaySelector {
             public_key: data.public_key,
             endpoint: SocketAddr::new(host, port),
             allowed_ips: all_of_the_internet(),
+            protocol: TransportProtocol::Udp,
         };
         Some(MullvadEndpoint::Wireguard {
             peer: peer_config,

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -340,6 +340,7 @@ message ConnectionConfig {
 			bytes public_key = 1;
 			repeated string allowed_ips = 2;
 			string endpoint = 3;
+			TransportProtocol protocol = 4;
 		}
 
 		TunnelConfig tunnel = 1;

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -28,6 +28,7 @@ zeroize = "1"
 chrono = "0.4"
 tokio = { version = "0.2", features =  [ "process", "rt-threaded", "stream" ] }
 rand = "0.7"
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "942483b" }
 
 
 [target.'cfg(not(target_os="android"))'.dependencies]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -26,9 +26,9 @@ talpid-types = { path = "../talpid-types" }
 uuid = { version = "0.8", features = ["v4"] }
 zeroize = "1"
 chrono = "0.4"
-tokio = { version = "0.2", features =  [ "process", "rt-threaded", "stream" ] }
+tokio = { version = "0.2", features = [ "process", "rt-threaded", "stream" ] }
 rand = "0.7"
-udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "942483b" }
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "3d1abafe112ee8c2db47ca401f8e286756454e7a" }
 
 
 [target.'cfg(not(target_os="android"))'.dependencies]

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -215,7 +215,7 @@ impl TunnelMonitor {
         let config = wireguard::config::Config::from_parameters(&params)?;
         let monitor = wireguard::WireguardMonitor::start(
             runtime,
-            &config,
+            config,
             log.as_ref().map(|p| p.as_path()),
             on_event,
             tun_provider,

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -148,6 +148,7 @@ impl TunnelMonitor {
     /// on tunnel state changes.
     #[cfg_attr(any(target_os = "android", windows), allow(unused_variables))]
     pub fn start<L>(
+        runtime: tokio::runtime::Handle,
         tunnel_parameters: &TunnelParameters,
         log_dir: &Option<PathBuf>,
         resource_dir: &Path,
@@ -170,6 +171,7 @@ impl TunnelMonitor {
             TunnelParameters::OpenVpn(_) => Err(Error::UnsupportedPlatform),
 
             TunnelParameters::Wireguard(config) => Self::start_wireguard_tunnel(
+                runtime,
                 &config,
                 log_file,
                 on_event,
@@ -200,6 +202,7 @@ impl TunnelMonitor {
     }
 
     fn start_wireguard_tunnel<L>(
+        runtime: tokio::runtime::Handle,
         params: &wireguard_types::TunnelParameters,
         log: Option<PathBuf>,
         on_event: L,
@@ -211,6 +214,7 @@ impl TunnelMonitor {
     {
         let config = wireguard::config::Config::from_parameters(&params)?;
         let monitor = wireguard::WireguardMonitor::start(
+            runtime,
             &config,
             log.as_ref().map(|p| p.as_path()),
             on_event,

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -74,12 +74,15 @@ lazy_static! {
 impl WireguardMonitor {
     /// Starts a WireGuard tunnel with the given config
     pub fn start<F: Fn(TunnelEvent) + Send + Sync + Clone + 'static>(
+        runtime: tokio::runtime::Handle,
         config: &Config,
         log_path: Option<&Path>,
         on_event: F,
         tun_provider: &mut TunProvider,
         route_manager: &mut routing::RouteManager,
     ) -> Result<WireguardMonitor> {
+        // FIXME: Set up udp2tcp and use it for peer config here
+
         let tunnel = Self::open_tunnel(&config, log_path, tun_provider, route_manager)?;
         let iface_name = tunnel.get_interface_name().to_string();
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -89,6 +89,7 @@ impl ConnectingState {
     }
 
     fn start_tunnel(
+        runtime: tokio::runtime::Handle,
         parameters: TunnelParameters,
         log_dir: &Option<PathBuf>,
         resource_dir: &Path,
@@ -102,6 +103,7 @@ impl ConnectingState {
         };
 
         let monitor = TunnelMonitor::start(
+            runtime,
             &parameters,
             log_dir,
             resource_dir,
@@ -420,6 +422,7 @@ impl TunnelState for ConnectingState {
                     }
 
                     match Self::start_tunnel(
+                        shared_values.runtime.clone(),
                         tunnel_parameters,
                         &shared_values.log_dir,
                         &shared_values.resource_dir,

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -34,7 +34,7 @@ impl ConnectionConfig {
     pub fn get_endpoint(&self) -> Endpoint {
         Endpoint {
             address: self.peer.endpoint,
-            protocol: TransportProtocol::Udp,
+            protocol: self.peer.protocol,
         }
     }
 }
@@ -47,6 +47,14 @@ pub struct PeerConfig {
     pub allowed_ips: Vec<IpNetwork>,
     /// IP address of the WireGuard server.
     pub endpoint: SocketAddr,
+    /// Transport protocol. WireGuard only supports UDP directly.
+    /// If this is set to TCP, then traffic is proxied using [`udp_to_tcp::Udp2Tcp`].
+    #[serde(default = "default_peer_transport")]
+    pub protocol: TransportProtocol,
+}
+
+fn default_peer_transport() -> TransportProtocol {
+    TransportProtocol::Udp
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]


### PR DESCRIPTION
This adds support for reaching WireGuard relays over TCP via [udp-over-tcp](https://github.com/mullvad/udp-over-tcp). Currently, this can only be configured for custom relays (that are running `Tcp2Udp`).

Usage:
```
mullvad relay set custom wireguard <IP> <PORT> tcp <PEER PUBLIC KEY> <GATEWAY> --addr <TUNNEL IP>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2537)
<!-- Reviewable:end -->
