### PR TITLE
Really fix disappearing account login input

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
-import android.view.View.MeasureSpec
 import android.view.View.OnLayoutChangeListener
 import android.view.inputmethod.InputMethodManager
 import android.widget.RelativeLayout
@@ -70,7 +69,7 @@ class AccountLogin : RelativeLayout {
     }
 
     private var collapsedHeight by observable(
-        calculateInitialInputHeight()
+        resources.getDimensionPixelSize(R.dimen.account_login_input_height)
     ) { _, oldCollapsedHeight, newCollapsedHeight ->
         if (newCollapsedHeight != oldCollapsedHeight) {
             historyAnimation.setIntValues(newCollapsedHeight, expandedHeight)
@@ -179,17 +178,6 @@ class AccountLogin : RelativeLayout {
     fun onDestroy() {
         input.onFocusChanged.unsubscribe(this)
         input.onTextChanged.unsubscribe(this)
-    }
-
-    private fun calculateInitialInputHeight(): Int {
-        if (input.height == 0) {
-            val widthMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.EXACTLY)
-            val heightMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
-
-            input.measure(widthMeasureSpec, heightMeasureSpec)
-        }
-
-        return input.height
     }
 
     private fun updateBorder() {

--- a/android/src/main/res/layout/account_login.xml
+++ b/android/src/main/res/layout/account_login.xml
@@ -6,7 +6,7 @@
                                                          android:layout_alignParentBottom="true" />
     <net.mullvad.mullvadvpn.ui.widget.AccountInput android:id="@+id/input"
                                                    android:layout_width="match_parent"
-                                                   android:layout_height="48dp"
+                                                   android:layout_height="@dimen/account_login_input_height"
                                                    android:layout_alignParentTop="true"
                                                    android:orientation="horizontal" />
     <androidx.recyclerview.widget.RecyclerView android:id="@+id/history"

--- a/android/src/main/res/values/dimensions.xml
+++ b/android/src/main/res/values/dimensions.xml
@@ -4,6 +4,7 @@
     <dimen name="relay_row_padding">50dp</dimen>
     <dimen name="list_item_divider">1dp</dimen>
     <dimen name="dialog_margin">14dp</dimen>
+    <dimen name="account_login_input_height">48dp</dimen>
     <dimen name="account_login_corner_radius">4dp</dimen>
     <dimen name="account_login_border_width">2dp</dimen>
     <dimen name="account_history_divider">1dp</dimen>


### PR DESCRIPTION
A previous PR (#2534) included a fix for the account input area sometimes disappearing from the Login screen. Unfortunately, the implementation wasn't correct. It was calculating the initial value using the configured height instead of the measured height. It worked with my internal testing because my debug build included some extra code that ended up not calling the `updateHeight` when it new that the height was zero, so that was what actually "fixed" the issue during testing.

After more research, I realized that using the measured height yielded bad aesthetics (because the measured height is the minimum height, and the actual height was configured by the container through `LayoutParams`). I also realized that the container was setting a fixed value `48dp` for the height, so there was actually no need to measure it.

This PR finally fixes the issue by using the fixed initial height value for the collapsed height when creating the `AccountLogin` widget. It creates a new dimension resource so that both the code and the layout XML file can reference the same value.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Previous PR already added the changelog entry for this fix.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2538)
<!-- Reviewable:end -->
