### PR TITLE
Upgrade go to 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ matrix:
         # --privileged is required because nightly cargo uses statx instead of stat, and that
         # syscall is so new that it's not on the docker whitelist yet.
         # https://github.com/rust-lang/rust/issues/65662
-        - docker run -d --privileged --name mvd-build -v $(pwd):/travis -w /travis  quay.io/mullvad/mullvadvpn-app-build:latest tail -f /dev/null
+        - docker run -d --privileged --name mvd-build -v $(pwd):/travis -w /travis quay.io/mullvad/mullvadvpn-app-build@sha256:bdccd0bd76929509f1fb979f4cbf5065f92434d988241debf5f319f6896d51d8 tail -f /dev/null
         - docker ps
       script:
         - docker exec -t mvd-build bash ci/ci-rust-script.sh nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ matrix:
       before_script:
         - env
         # installing Go
-        - curl -s https://dl.google.com/go/go1.13.6.darwin-amd64.pkg --output go-installer.pkg
+        - curl -s https://dl.google.com/go/go1.16.darwin-amd64.pkg --output go-installer.pkg
+        - echo "2906bd8e6bf60d0e15d2e771318ed382f67da88509bb86f9b21018022ab788b1 go-installer.pkg" | sha256sum -c
         - sudo installer -pkg ./go-installer.pkg -target /
         - export PATH="/usr/local/go/bin:$PATH"
       script:
@@ -103,9 +104,10 @@ matrix:
         - ./vs_BuildTools.exe --wait -q --norestart --add Microsoft.VisualStudio.Workload.VCTools\;includeRecommended --add Microsoft.Component.MSBuild
         - git submodule update --init
         # Installing Go
-        - curl -s https://dl.google.com/go/go1.13.6.windows-amd64.msi --output go-installer.msi
+        - curl -s https://dl.google.com/go/go1.16.windows-amd64.msi --output go-installer.msi
+        - echo "0fd550a74f6c8ef5df405751f5e39a0ba25786930c5d61503bf71d3c3efa2414 go-installer.msi" | sha256sum -c
         - cmd.exe '/c msiexec /i go-installer.msi /quiet /qn'
-        - export PATH="/c/Go/bin/:$PATH"
+        - export PATH="/c/Program Files/Go/bin/:$PATH"
       script: &rust_windows_script
         - ./ci/ci-rust-script.sh $RUST_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@
 # docker build . -t quay.io/mullvad/mullvadvpn-app-build
 # To push the image to Quay.io:
 # docker push quay.io/mullvad/mullvadvpn-app-build
-FROM debian:stable@sha256:75f7d0590b45561bfa443abad0b3e0f86e2811b1fc176f786cd30eb078d1846f
-RUN apt update -y
-RUN apt install build-essential \
+FROM debian:stretch@sha256:a5934d79acb9d1182ef5c747e23e462784f6345479e33b40c979fbe8dce5db40
+RUN apt update -y && apt install build-essential \
 	gcc \
 	libdbus-1-dev \
 	rpm \
@@ -15,20 +14,19 @@ RUN apt install build-essential \
 
 
 # Install golang
-ENV GOLANG_VERSION 1.13.5
+ENV GOLANG_VERSION 1.16
 # Found on https://golang.org/dl/
-ENV GOLANG_HASH 512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569
+ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
 RUN curl -Lo go.tgz https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
 	echo $(sha256sum go.tgz) && \
 	echo "${GOLANG_HASH} go.tgz" | sha256sum -c - && \
 	tar -C /usr/local -xzf go.tgz && \
 	rm go.tgz && \
-	rm -rf /var/lib/apt/lists/* && \
-	export PATH="/usr/local/go/bin:$PATH" && \
-	go version
+	rm -rf /var/lib/apt/lists/*
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN go version
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 RUN mkdir /mvd

--- a/README.md
+++ b/README.md
@@ -276,9 +276,8 @@ storePassword = keystore-password
    #### Windows
    Download the Node.js installer from the official website.
 
-1. Install Go (ideally version `1.13.6`) by following the [official
-   instructions](https://golang.org/doc/install).  Newer versions of Go may be used. Earlier
-   versions may be used, but versions older than `1.12` are known to not work, newer versions may
+1. Install Go (ideally version `1.16`) by following the [official
+   instructions](https://golang.org/doc/install).  Newer versions may work
    too. Since `cgo` is being used, make sure to have a C compiler in your path. [*On
    Windows*](https://github.com/golang/go/wiki/cgo#windows) `mingw`'s `gcc` compiler should work.
    `gcc` on most Linux distributions should work, and `clang` for MacOS.


### PR DESCRIPTION
Bump go to 1.16 in the readme and CI (.travis.yml, GitHub Actions, and quay.io). The container used to build wireguard-go for Android (in `wireguard/build-wireguard-go.sh`) is not yet updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2539)
<!-- Reviewable:end -->
