### PR TITLE
Remove old IPC socket during shutdown and startup of the daemon

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -755,6 +755,13 @@ where
         mem::drop(event_listener);
         mem::drop(rpc_runtime);
 
+        #[cfg(not(windows))]
+        if let Err(err) = fs::remove_file(mullvad_paths::get_rpc_socket_path()) {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                log::error!("Failed to remove old RPC socket: {}", err);
+            }
+        }
+
         if clean_up_target_cache {
             let target_cache = cache_dir.join(TARGET_START_STATE_FILE);
             let _ = fs::remove_file(target_cache).map_err(|e| {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -98,6 +98,13 @@ async fn run_standalone(log_dir: Option<PathBuf>) -> Result<(), String> {
         return Err("Another instance of the daemon is already running".to_owned());
     }
 
+    #[cfg(not(windows))]
+    if let Err(err) = tokio::fs::remove_file(mullvad_paths::get_rpc_socket_path()).await {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            log::error!("Failed to remove old RPC socket: {}", err);
+        }
+    }
+
     if !running_as_admin() {
         warn!("Running daemon as a non-administrator user, clients might refuse to connect");
     }


### PR DESCRIPTION
The daemon can fail to start if a subsequently started daemon didn't clean up it's RPC socket. So I've changed the startup code and shutdown code to remove the RPC socket. This is not done on Windows because it's not actually possible to remove a named pipe AFAICT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2540)
<!-- Reviewable:end -->
