### PR TITLE
Fix long press on quick-settings tile

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -47,9 +47,6 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
-            </intent-filter>
         </activity>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"
                  android:permission="android.permission.BIND_VPN_SERVICE">


### PR DESCRIPTION
A recent PR improved support for Android TV (#2480). As part of the improvement, a new activity was created. The activity's declaration in the manifest is almost the same as the previous activity. Unfortunately, that led to a conflict where there were two intent-filters for the quick-settings tile long press intent. This caused long pressing the quick-settings tile to not work on recent Android versions.

This PR fixes that by removing the intent filter from the TV-specific activity. It will still be good to verify later if TVs have quick-settings tiles and if so what would be the best way to handle that. For now, this solution only fixes the problem on non-TV devices.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes an issue not present in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2541)
<!-- Reviewable:end -->
