### PR TITLE
Fix disappearing account input when account history is empty

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -59,9 +59,9 @@ class AccountLogin : RelativeLayout {
         get() = MAX_ACCOUNT_HISTORY_ENTRIES * (historyEntryHeight + dividerHeight)
 
     private val expandedHeight: Int
-        get() = collapsedHeight + historyHeight
+        get() = collapsedHeight + (historyHeight ?: 0)
 
-    private var historyHeight by observable(0) { _, oldHistoryHeight, newHistoryHeight ->
+    private var historyHeight by observable<Int?>(null) { _, oldHistoryHeight, newHistoryHeight ->
         if (newHistoryHeight != oldHistoryHeight) {
             historyAnimation.setIntValues(collapsedHeight, expandedHeight)
             reposition()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -173,6 +173,8 @@ class AccountLogin : RelativeLayout {
                 }
             )
         }
+
+        historyAnimation.setIntValues(collapsedHeight, expandedHeight)
     }
 
     fun onDestroy() {


### PR DESCRIPTION
Previous PRs (#2534, #2538) fixed an issue where the account input area would sometimes disappear. Part of the fix involved changing the initial value used for the account login widget height. When I tested the fix, I only tested with the account history having at least one entry. I didn't realize that having an empty account history could lead to an issue.

Unfortunately, there was an issue when the account history was empty. The account history collapse-expand animation was initialized with zero source and target values, but they were updated when the account history was set. If it wasn't set, the values would stay zero, which meant that as soon as an animation condition started the animation, the login input area would disappear because its height would be set to zero.

This PR fixes that issue by initializing the `historyAnimation` with correct initial source and target values, in case the history stays empty. It also changes the initial `historyHeight` to be `null` in the beginning, so that setting it to zero early on (when an empty account history is configured) still leads to a call to `reposition` to properly configure the bottom margin, avoiding UI jumping glitches when tapping the input area for the first time.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Previous PR already added a changelog entry.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2543)
<!-- Reviewable:end -->
