### PR TITLE
Paint the status and navigation bars for the Login screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
@@ -17,7 +18,7 @@ import net.mullvad.mullvadvpn.ui.widget.AccountLogin
 import net.mullvad.mullvadvpn.ui.widget.Button
 import org.joda.time.DateTime
 
-class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
+class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen), NavigationBarPainter {
     enum class LoginResult {
         ExistingAccountWithTime,
         ExistingAccountOutOfTime,
@@ -104,6 +105,11 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
                 false
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        paintNavigationBar(ContextCompat.getColor(requireContext(), R.color.darkBlue))
     }
 
     override fun onSafelyStop() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -18,7 +18,8 @@ import net.mullvad.mullvadvpn.ui.widget.AccountLogin
 import net.mullvad.mullvadvpn.ui.widget.Button
 import org.joda.time.DateTime
 
-class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen), NavigationBarPainter {
+class LoginFragment :
+    ServiceDependentFragment(OnNoService.GoToLaunchScreen), NavigationBarPainter, StatusBarPainter {
     enum class LoginResult {
         ExistingAccountWithTime,
         ExistingAccountOutOfTime,
@@ -110,6 +111,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen), Na
     override fun onResume() {
         super.onResume()
         paintNavigationBar(ContextCompat.getColor(requireContext(), R.color.darkBlue))
+        paintStatusBar(ContextCompat.getColor(requireContext(), R.color.blue))
     }
 
     override fun onSafelyStop() {


### PR DESCRIPTION
When logging out, the status bar ends up painted with the color of the header bar. However, this leads to sometimes the status bar ending up green, even though the tunnel has disconnected. In order to prevent this causing a misunderstanding for the user, this PR paints the status and navigation bars for the Login screen.

~Because the `HeaderBar` posts a coroutine to paint the status bar, that coroutine ends up painting the status bar after `LoginFragment.onResume` has been executed. To prevent that from painting over the Login screen's chosen color, a coroutine is spawned in the `LoginFragment.onResume` method, so that the code to paint the status bar is queued to be executed after the header bar paints the status bar.~

~This workaround should be improved in the future, likely with the usage of coroutine scopes so that the `HeaderBar` can't paint the status bar if the fragment is stopping.~

**EDIT:** The coroutine scheduling workaround was removed because PR #2569 fixes the issue that made the workaround necessary.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UI tweak, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2544)
<!-- Reviewable:end -->
