### PR TITLE
Ignore IPC socket on Android

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -755,7 +755,7 @@ where
         mem::drop(event_listener);
         mem::drop(rpc_runtime);
 
-        #[cfg(not(windows))]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if let Err(err) = fs::remove_file(mullvad_paths::get_rpc_socket_path()) {
             if err.kind() != std::io::ErrorKind::NotFound {
                 log::error!("Failed to remove old RPC socket: {}", err);

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -98,7 +98,7 @@ async fn run_standalone(log_dir: Option<PathBuf>) -> Result<(), String> {
         return Err("Another instance of the daemon is already running".to_owned());
     }
 
-    #[cfg(not(windows))]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     if let Err(err) = tokio::fs::remove_file(mullvad_paths::get_rpc_socket_path()).await {
         if err.kind() != std::io::ErrorKind::NotFound {
             log::error!("Failed to remove old RPC socket: {}", err);


### PR DESCRIPTION
In a recent change to the daemon, I added logic to remove the IPC socket after the daemon has stopped and before it starts. This shouldn't be done on Android, because there is no IPC socket on Android. Thus the code has been changed to not do that on Android.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2546)
<!-- Reviewable:end -->
