### PR TITLE
Lower account history from 3 to 1 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Allow provider constraint to specify multiple hosting providers.
 - Only download a new relay list if it has been modified.
 - Connect to the API only via TLS 1.3
+- Shrink account history capactity from 3 account entries to 1.
 
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -29,7 +29,7 @@ pub enum Error {
 }
 
 static ACCOUNT_HISTORY_FILE: &str = "account-history.json";
-static ACCOUNT_HISTORY_LIMIT: usize = 3;
+static ACCOUNT_HISTORY_LIMIT: usize = 1;
 
 /// A trivial MRU cache of account data
 pub struct AccountHistory {
@@ -186,7 +186,7 @@ impl AccountHistory {
         accounts.retain(|entry| entry.account != new_entry.account);
         accounts.push_front(new_entry);
 
-        if accounts.len() > ACCOUNT_HISTORY_LIMIT {
+        while accounts.len() > ACCOUNT_HISTORY_LIMIT {
             let last_entry = accounts.pop_back().unwrap();
             if let Some(wg_data) = last_entry.wireguard {
                 tokio::spawn(self.create_remove_wg_key_rpc(&last_entry.account, &wg_data));


### PR DESCRIPTION
Lower account history from 3 accounts to 1. This will result in people losing account entries in their account history once they log in with a new account again - the only entry left will be the one they log in to again. I've tested this and it just works on Linux. I'll try out what happens on Android.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2547)
<!-- Reviewable:end -->
