### PR TITLE
Make the kernel take the firewall mark into account when doing RPF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add TV banner for better user experience and requirements.
 - Style StatucBar and NavigationBar to make our app a bit more beautiful.
 
+#### Linux
+- Always enable `src_valid_mark` config option when connecting to allow policty based routing.
+
 ### Changed
 - Update Electron from 11.0.2 to 11.2.1 which includes a newer Chromium version and
   security patches.

--- a/README.md
+++ b/README.md
@@ -411,6 +411,12 @@ echo "org.gradle.jvmargs=-Xmx4608M" >> ~/.gradle/gradle.properties
     * Set to `"pass"` to add logging to rules allowing packets.
     * Set to `"drop"` to add logging to rules blocking packets.
 
+* `TALPID_FIREWALL_DONT_SET_SRC_VALID_MARK` - Forces the daemon to not set `src_valid_mark` config
+    on Linux. The kernel config option is set because otherwise strict reverse path filtering may
+    prevent relay traffic from reaching the daemon. If `rp_filter` is set to `1` on the interface
+    that will be receiving relay traffic, and `src_valid_mark` is not set to `1`, the daemon will
+    not be able to receive relay traffic.
+
 * `TALPID_DNS_MODULE` - Allows changing the method that will be used for DNS configuration on Linux.
   By default this is automatically detected, but you can set it to one of the options below to
   choose a specific method:

--- a/talpid-core/src/linux/mod.rs
+++ b/talpid-core/src/linux/mod.rs
@@ -1,7 +1,9 @@
 use std::{
     ffi::{self, CString},
-    io,
+    fs, io,
 };
+
+const PROC_SYS_NET_IPV4_CONF_SRC_VALID_MARK: &str = "/proc/sys/net/ipv4/conf/all/src_valid_mark";
 
 /// Converts an interface name into the corresponding index.
 pub fn iface_index(name: &str) -> Result<libc::c_uint, IfaceIndexLookupError> {
@@ -29,3 +31,7 @@ pub enum IfaceIndexLookupError {
 // b"mole" is [ 0x6d, 0x6f 0x6c, 0x65 ]
 pub const TUNNEL_FW_MARK: u32 = 0x6d6f6c65;
 pub const TUNNEL_TABLE_ID: u32 = 0x6d6f6c65;
+
+pub fn set_src_valid_mark_sysctl() -> io::Result<()> {
+    fs::write(PROC_SYS_NET_IPV4_CONF_SRC_VALID_MARK, b"1")
+}


### PR DESCRIPTION
Some users will have enabled strict reverse path filtering in the kernel. To ensure that the daemon still works, we should set `sysctl net.ipv4.conf.all.src_valid_mark=1` when we connect to allow our traffic to pass through the filter. Now the linux firewall module will do that every time it's applying a connecting policy. This kernel config option will never be reverted by our code. The users can disable this behavior by setting `TALPID_FIREWALL_DONT_SET_SRC_VALID_MARK` environment variable to a non-zero value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2548)
<!-- Reviewable:end -->
