### PR TITLE
Better handle non responding daemon and version info

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -165,16 +165,8 @@ export class DaemonRpc {
 
   public addConnectionObserver(observer: ConnectionObserver) {
     this.connectionObservers.push(observer);
-    const currentState = this.client.getChannel()?.getConnectivityState(true);
-    if (
-      currentState === grpc.connectivityState.SHUTDOWN ||
-      currentState === grpc.connectivityState.TRANSIENT_FAILURE ||
-      currentState === grpc.connectivityState.IDLE
-    ) {
-      observer.onClose();
-    } else {
-      observer.onOpen();
-    }
+    // Call getConnectivityState(true) to start connecting if idle
+    this.client.getChannel()?.getConnectivityState(true);
   }
 
   public removeConnectionObserver(observer: ConnectionObserver) {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -481,6 +481,7 @@ class ApplicationMain {
   }
 
   private onDaemonConnected = async () => {
+    const wasConnected = this.connectedToDaemon;
     this.connectedToDaemon = true;
 
     // subscribe to events
@@ -559,9 +560,10 @@ class ApplicationMain {
     // reset the reconnect backoff when connection established.
     this.reconnectBackoff.reset();
 
-    // notify renderer
-    if (this.windowController) {
-      IpcMainEventChannel.daemonConnected.notify(this.windowController.webContents);
+    // notify renderer, this.connectedToDaemon could have changed if the daemon disconnected again
+    // before this if-statement is reached.
+    if (this.windowController && !wasConnected && this.connectedToDaemon) {
+      IpcMainEventChannel.daemon.notifyConnected(this.windowController.webContents);
     }
 
     // show window when account is not set
@@ -581,9 +583,6 @@ class ApplicationMain {
     // Reset the daemon event listener since it's going to be invalidated on disconnect
     this.daemonEventListener = undefined;
 
-    // TODO: GRPC doesn't set an error, but without an error, the UI won't be updated
-    error = error === undefined && wasConnected ? new Error('Connection to daemon lost') : error;
-
     if (wasConnected) {
       this.connectedToDaemon = false;
 
@@ -592,10 +591,7 @@ class ApplicationMain {
 
       // notify renderer process
       if (this.windowController) {
-        IpcMainEventChannel.daemonDisconnected.notify(
-          this.windowController.webContents,
-          error ? error.message : undefined,
-        );
+        IpcMainEventChannel.daemon.notifyDisconnected(this.windowController.webContents);
       }
     }
 

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -82,6 +82,7 @@ const DAEMON_RPC_PATH =
 
 const AUTO_CONNECT_FALLBACK_DELAY = 6000;
 
+const GUI_VERSION = app.getVersion().replace('.0', '');
 /// Mirrors the beta check regex in the daemon. Matches only well formed beta versions
 const IS_BETA = /^(\d{4})\.(\d+)-beta(\d+)$/;
 
@@ -165,10 +166,10 @@ class ApplicationMain {
   private relays: IRelayList = { countries: [] };
 
   private currentVersion: ICurrentAppVersionInfo = {
-    daemon: '',
-    gui: '',
+    daemon: undefined,
+    gui: GUI_VERSION,
     isConsistent: true,
-    isBeta: false,
+    isBeta: IS_BETA.test(GUI_VERSION),
   };
 
   private upgradeVersion: IAppVersionInfo = {
@@ -224,7 +225,7 @@ class ApplicationMain {
       app.enableSandbox();
     }
 
-    log.info(`Running version ${app.getVersion()}`);
+    log.info(`Running version ${this.currentVersion.gui}`);
 
     if (process.platform === 'win32') {
       app.setAppUserModelId('net.mullvad.vpn');
@@ -549,14 +550,6 @@ class ApplicationMain {
     // fetch the latest version info in background
     consumePromise(this.fetchLatestVersion());
 
-    // notify user about inconsistent version
-    const notificationProvider = new InconsistentVersionNotificationProvider({
-      consistent: this.currentVersion.isConsistent,
-    });
-    if (notificationProvider.mayDisplay()) {
-      this.notificationController.notify(notificationProvider.getSystemNotification());
-    }
-
     // reset the reconnect backoff when connection established.
     this.reconnectBackoff.reset();
 
@@ -604,12 +597,6 @@ class ApplicationMain {
       }
     } else {
       log.info('Disconnected from the daemon');
-    }
-
-    // Set GUI version info if it hasn't already been done. Only happens if the app starts without a
-    // connection to the daemon.
-    if (this.currentVersion.gui === '') {
-      this.setDaemonVersion('');
     }
   };
 
@@ -849,15 +836,28 @@ class ApplicationMain {
   }
 
   private setDaemonVersion(daemonVersion: string) {
-    const guiVersion = app.getVersion().replace('.0', '');
     const versionInfo = {
+      ...this.currentVersion,
       daemon: daemonVersion,
-      gui: guiVersion,
-      isConsistent: daemonVersion === guiVersion,
-      isBeta: IS_BETA.test(guiVersion),
+      isConsistent: daemonVersion === this.currentVersion.gui,
     };
 
     this.currentVersion = versionInfo;
+
+    if (!versionInfo.isConsistent) {
+      log.info('Inconsistent version', {
+        guiVersion: versionInfo.gui,
+        daemonVersion: versionInfo.daemon,
+      });
+    }
+
+    // notify user about inconsistent version
+    const notificationProvider = new InconsistentVersionNotificationProvider({
+      consistent: versionInfo.isConsistent,
+    });
+    if (notificationProvider.mayDisplay()) {
+      this.notificationController.notify(notificationProvider.getSystemNotification());
+    }
 
     // notify renderer
     if (this.windowController) {

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -107,11 +107,9 @@ export const ipcSchema = {
   windowFocus: {
     '': notifyRenderer<boolean>(),
   },
-  daemonConnected: {
-    '': notifyRenderer<void>(),
-  },
-  daemonDisconnected: {
-    '': notifyRenderer<string | undefined>(),
+  daemon: {
+    connected: notifyRenderer<void>(),
+    disconnected: notifyRenderer<void>(),
   },
   location: {
     '': notifyRenderer<ILocation>(),

--- a/gui/src/shared/ipc-types.ts
+++ b/gui/src/shared/ipc-types.ts
@@ -1,6 +1,6 @@
 export interface ICurrentAppVersionInfo {
   gui: string;
-  daemon: string;
+  daemon?: string;
   isConsistent: boolean;
   isBeta: boolean;
 }


### PR DESCRIPTION
This PR:
* Improves the retrieval and setting of the version information
* Changes the status of the daemon connection to only be kept in the main process and only notify renderer on change
* Stops sending event to daemon connectivity listener when registered. This wasn't necessary and caused a confusing log message.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
