### PR TITLE
Reduce superfluous openvpn logging

### DIFF
--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -949,7 +949,7 @@ mod event_server {
             &self,
             request: Request<EventType>,
         ) -> std::result::Result<Response<()>, tonic::Status> {
-            log::info!("OpenVPN event {:?}", request);
+            log::trace!("OpenVPN event {:?}", request);
 
             let request = request.into_inner();
 

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -324,7 +324,6 @@ impl OpenVpnMonitor<OpenVpnCommand> {
                         panic!("Failed to add routes");
                     }
 
-                    #[cfg(target_os = "linux")]
                     if let Err(error) = route_manager_handle.create_routing_rules(ipv6_enabled) {
                         log::error!("{}", error.display_chain());
                         panic!("Failed to add routes");

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -35,6 +35,7 @@ pub enum Error {
 /// events.
 pub static INTERESTING_EVENTS: &'static [EventType] = &[
     EventType::AuthFailed,
+    #[cfg(target_os = "linux")]
     EventType::Up,
     EventType::RouteUp,
     EventType::RoutePredown,


### PR DESCRIPTION
The `OpenVPN event {:?}` log has two problems:

1) It's outputting debug formatting on a log level lower than DEBUG. We should not do this unless well motivated.
2) It's a very very verbose log line and as far as I know we never use/read this line for debugging.

So I moved it to TRACE to get rid of it from problem reports.

I also noticed on a Windows log the following line:
```
[talpid_core::tunnel::openvpn][DEBUG] Ignoring OpenVpnEvent Up
```
And I was confused for a while. But I then realized we use `RouteUp` to detect the tunnel up stuff. `Up` is Linux specific but has been registered as an interesting event on all platforms anyway back in #2106 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2551)
<!-- Reviewable:end -->
