### PR TITLE
Don't perform actions on a destroyed window

### DIFF
--- a/gui/src/shared/ipc-helpers.ts
+++ b/gui/src/shared/ipc-helpers.ts
@@ -4,7 +4,7 @@ import log from './logging';
 
 type Handler<T, R> = (callback: (arg: T) => R) => void;
 type Sender<T, R> = (arg: T) => R;
-type Notifier<T> = (webContents: WebContents, arg: T) => void;
+type Notifier<T> = (webContents: WebContents | undefined, arg: T) => void;
 type Listener<T> = (callback: (arg: T) => void) => void;
 
 interface MainToRenderer<T> {
@@ -152,8 +152,8 @@ export function notifyRenderer<T>(): MainToRenderer<T> {
 }
 
 function notifyRendererImpl<T>(event: string, _ipcMain: EIpcMain): Notifier<T> {
-  return (webContents: WebContents, value: T) => {
-    if (webContents.isDestroyed()) {
+  return (webContents, value) => {
+    if (webContents === undefined) {
       log.error(`sender(${event}): webContents is already destroyed!`);
     } else {
       webContents.send(event, value);


### PR DESCRIPTION
This PR changes `windowController.window` and `windowController.webContents` to return `undefined` if the window/webContents have been destroyed.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2553)
<!-- Reviewable:end -->
