### PR TITLE
Stop pushing WireGuard keys for invalid account tokens

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1927,7 +1927,10 @@ where
                 Self::oneshot_send(tx, Ok(key_event), "generate_wireguard_key");
             }
             Err(e) => {
-                log::error!("Failed to generate new wireguard key - {}", e);
+                log::error!(
+                    "{}",
+                    e.display_chain_with_msg("Failed to generate new wireguard key")
+                );
                 Self::oneshot_send(tx, Err(e), "generate_wireguard_key");
             }
         }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1910,12 +1910,12 @@ where
                 .map(|entry| entry.map(|e| e.wireguard.is_none()).unwrap_or(true))
                 .unwrap_or(true)
             {
-                log::info!("Automatically generating new wireguard key for account");
+                log::info!("Generating new WireGuard key for account");
                 self.wireguard_key_manager
                     .spawn_key_generation_task(account, Some(FIRST_KEY_PUSH_TIMEOUT))
                     .await;
             } else {
-                log::info!("Account already has wireguard key, starting key rotation.");
+                log::info!("Account already has WireGuard key");
                 self.ensure_key_rotation().await;
             }
         }

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -38,6 +38,9 @@ pub const VOUCHER_USED: &str = "VOUCHER_USED";
 /// Error code returned by the Mullvad API if the voucher code is invalid.
 pub const INVALID_VOUCHER: &str = "INVALID_VOUCHER";
 
+/// Error code returned by the Mullvad API if the account token is invalid.
+pub const INVALID_ACCOUNT: &str = "INVALID_ACCOUNT";
+
 const API_HOST: &str = "api.mullvad.net";
 pub const API_IP_CACHE_FILENAME: &str = "api-ip-address.txt";
 const API_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(193, 138, 218, 78));


### PR DESCRIPTION
If the API returned an invalid account error, the daemon would try to push a new key after a while. The maximum delay was 1 hour. This has been fixed. The code has been refactored in general as well.

Main changes:
* Stop trying to push a WireGuard key if the account token is invalid. It will stop after the first failed attempt.
* Increase the maximum retry delay for the initial key push from 1 hour to 1 day.
* Use exponential backoff for retrying automatic key rotation (instead of always retrying after 15 minutes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2554)
<!-- Reviewable:end -->
