### PR TITLE
Save DNS server address on Enter key

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
@@ -2,15 +2,20 @@ package net.mullvad.mullvadvpn.ui.customdns
 
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.KeyEvent
 import android.view.View
 import android.view.View.OnFocusChangeListener
+import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import java.net.InetAddress
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.talpid.util.addressString
 
-class EditCustomDnsServerHolder(view: View, adapter: CustomDnsAdapter) : CustomDnsItemHolder(view) {
+class EditCustomDnsServerHolder(
+    view: View,
+    val adapter: CustomDnsAdapter
+) : CustomDnsItemHolder(view) {
     private enum class State {
         Normal,
         Error,
@@ -26,6 +31,14 @@ class EditCustomDnsServerHolder(view: View, adapter: CustomDnsAdapter) : CustomD
                     adapter.stopEditing(address)
                 }
             }
+        }
+
+        setOnEditorActionListener { _, action, event ->
+            if (action == EditorInfo.IME_ACTION_DONE || event?.keyCode == KeyEvent.KEYCODE_ENTER) {
+                saveDnsServer()
+            }
+
+            false
         }
     }
 
@@ -71,9 +84,13 @@ class EditCustomDnsServerHolder(view: View, adapter: CustomDnsAdapter) : CustomD
 
     init {
         view.findViewById<View>(R.id.save).setOnClickListener {
-            val onFailCallback = { state = State.Error }
-
-            adapter.saveDnsServer(input.text.toString(), onFailCallback)
+            saveDnsServer()
         }
+    }
+
+    private fun saveDnsServer() {
+        val onFailCallback = { state = State.Error }
+
+        adapter.saveDnsServer(input.text.toString(), onFailCallback)
     }
 }


### PR DESCRIPTION
Previously, pressing the "Done" key in the software keyboard while editing a custom DNS server address, it hides the keyboard but doesn't save the custom DNS address. This PR adds a listener for the "editor action" in order to save the DNS server address.

The listener returns `false` (as if the event wasn't handled) to allow the normal behavior (hiding the keyboard) to still work.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2556)
<!-- Reviewable:end -->
