### PR TITLE
Create GitHub Actions workflows for the Rust code

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -1,0 +1,63 @@
+name: Mullvad VPN daemon CI
+on:
+    # Build whenever a file that affects a Rust crate is changed by a push
+    push:
+        paths-ignore:
+            - '**/*.md'
+            - .github/workflows/android*.yml
+            - .github/workflows/rustfmt.yml
+            - android/**
+            - audits/**
+            - ci/buildserver-*
+            - ci/ci-*
+            - dist-assets/**
+            - docs/**
+            - graphics/**
+            - gui/**
+            - ios/**
+            - mullvad-jni/**
+            - scripts/**
+            - '.*ignore'
+            - .editorconfig
+            - .gitattributes
+            - .travis.yml
+            - Dockerfile
+            - build.sh
+            - build-apk.sh
+            - integration-tests.sh
+            - prepare-release.sh
+            - rustfmt.toml
+            - update-api-address.sh
+            - update-relays.sh
+            - version-metadata.sh
+    # Build if requested manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    build:
+        strategy:
+            matrix:
+                rust: [stable, beta, nightly]
+
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Checkout binaries submodule
+              run: git submodule update --init --depth=1 dist-assets/binaries
+
+            - name: Install Rust
+              uses: ATiltedTree/setup-rust@v1.0.4
+              with:
+                  rust-version: ${{ matrix.rust }}
+
+            - name: Install Go
+              uses: actions/setup-go@v2.1.3
+              with:
+                  go-version: 1.16
+
+            - name: Install build dependencies
+              run: sudo apt-get install libdbus-1-dev
+
+            - name: Build and test crates
+              run: ./ci/check-rust.sh

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -33,7 +33,7 @@ on:
     # Build if requested manually from the Actions tab
     workflow_dispatch:
 jobs:
-    build:
+    build-linux:
         strategy:
             matrix:
                 rust: [stable, beta, nightly]
@@ -58,6 +58,25 @@ jobs:
 
             - name: Install build dependencies
               run: sudo apt-get install libdbus-1-dev
+
+            - name: Build and test crates
+              run: ./ci/check-rust.sh
+
+    build-macos:
+        runs-on: macos-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install Rust
+              uses: ATiltedTree/setup-rust@v1.0.4
+              with:
+                  rust-version: stable
+
+            - name: Install Go
+              uses: actions/setup-go@v2.1.3
+              with:
+                  go-version: 1.16
 
             - name: Build and test crates
               run: ./ci/check-rust.sh

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -80,3 +80,31 @@ jobs:
 
             - name: Build and test crates
               run: ./ci/check-rust.sh
+
+    build-windows:
+        runs-on: windows-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Checkout submodules
+              run: git submodule update --init --depth=1
+
+            - name: Install Rust
+              uses: ATiltedTree/setup-rust@v1.0.4
+              with:
+                  rust-version: stable
+
+            - name: Install Go
+              uses: actions/setup-go@v2.1.3
+              with:
+                  go-version: 1.16
+
+            - name: Install msbuild
+              uses: microsoft/setup-msbuild@v1.0.2
+              with:
+                  vs-version: 16
+
+            - name: Build and test crates
+              shell: bash
+              run: ./ci/check-rust.sh

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,28 @@
+name: Rust formatting check CI
+on:
+    # Check whenever a file that affects Rust formatting is changed by a push
+    push:
+        paths:
+            - .github/workflows/rustfmt.yml
+            - rustfmt.toml
+            - '**/*.rs'
+    # Check if requested manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    check-formatting:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install nightly Rust
+              uses: ATiltedTree/setup-rust@v1.0.4
+              with:
+                rust-version: nightly
+                components: rustfmt
+
+            - name: Check formatting
+              run: |
+                rustfmt --version
+                cargo fmt -- --check --unstable-features
+

--- a/ci/check-rust.sh
+++ b/ci/check-rust.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eux
+
+export RUSTFLAGS="--deny warnings"
+
+# Build WireGuard Go
+./wireguard/build-wireguard-go.sh
+
+# Build Windows modules
+case "$(uname -s)" in
+  MINGW*|MSYS_NT*)
+    time ./build_windows_modules.sh --dev-build
+    ;;
+esac
+
+# Build Rust crates
+source env.sh
+time cargo build --locked --verbose
+
+# Test Rust crates
+time cargo test --locked --verbose


### PR DESCRIPTION
We're planning on slowly migrating our CI from Travis to GitHub Actions. This PR adds workflows that are equivalent to the Rust jobs we have on Travis, with the small difference that the Rust formatting check is done in a separate workflow so that it runs separately in parallel.

The Travis job was not removed yet, because we will have some time with both CI jobs running for a while so that we can check for any inconsistencies.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tooling change, no changelog entry needed.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2559)
<!-- Reviewable:end -->
