### PR TITLE
Clear editing position when disabling custom DNS

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/CustomDnsAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/CustomDnsAdapter.kt
@@ -47,6 +47,7 @@ class CustomDnsAdapter(val customDns: CustomDns) : Adapter<CustomDnsItemHolder>(
                 }
             } else {
                 notifyItemRangeRemoved(0, cachedCustomDnsServers.size + 1)
+                editingPosition = null
             }
         }
     }


### PR DESCRIPTION
Previously, the Advanced screen would break the back button behavior after enabling and disabling custom DNS (while having no custom DNS servers configured). The back button is overridden in order to cancel editing the custom DNS server address. The bug happens because disabling custom DNS does not mark internally that editing has stopped, so the back button handler still thinks it should try to stop editing.

This PR fixes that by marking the editing position as `null` when custom DNS is disabled.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2560)
<!-- Reviewable:end -->
