### PR TITLE
Log in after pressing the enter key when typing the account number

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/EditCustomDnsServerHolder.kt
@@ -2,14 +2,13 @@ package net.mullvad.mullvadvpn.ui.customdns
 
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.KeyEvent
 import android.view.View
 import android.view.View.OnFocusChangeListener
-import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import java.net.InetAddress
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.util.setOnEnterOrDoneAction
 import net.mullvad.talpid.util.addressString
 
 class EditCustomDnsServerHolder(
@@ -33,13 +32,7 @@ class EditCustomDnsServerHolder(
             }
         }
 
-        setOnEditorActionListener { _, action, event ->
-            if (action == EditorInfo.IME_ACTION_DONE || event?.keyCode == KeyEvent.KEYCODE_ENTER) {
-                saveDnsServer()
-            }
-
-            false
-        }
+        setOnEnterOrDoneAction(::saveDnsServer)
     }
 
     private val watcher: TextWatcher = object : TextWatcher {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -16,6 +16,7 @@ import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.LoginState
 import net.mullvad.mullvadvpn.util.SegmentedInputFormatter
+import net.mullvad.mullvadvpn.util.setOnEnterOrDoneAction
 import net.mullvad.talpid.util.EventNotifier
 
 const val MIN_ACCOUNT_TOKEN_LENGTH = 10
@@ -46,6 +47,7 @@ class AccountInput : LinearLayout {
 
     private val input = container.findViewById<EditText>(R.id.login_input).apply {
         addTextChangedListener(inputWatcher)
+        setOnEnterOrDoneAction(::login)
 
         onFocusChangeListener = OnFocusChangeListener { view, inputHasFocus ->
             hasFocus = inputHasFocus && view.isEnabled
@@ -63,9 +65,7 @@ class AccountInput : LinearLayout {
     }
 
     private val button = container.findViewById<ImageButton>(R.id.login_button).apply {
-        setOnClickListener {
-            onLogin?.invoke(input.text.replace(Regex("[^0-9]"), ""))
-        }
+        setOnClickListener { login() }
     }
 
     val onFocusChanged = EventNotifier(false)
@@ -108,6 +108,10 @@ class AccountInput : LinearLayout {
     fun loginWith(accountNumber: String) {
         input.setText(accountNumber)
         onLogin?.invoke(accountNumber)
+    }
+
+    private fun login() {
+        onLogin?.invoke(input.text.replace(Regex("[^0-9]"), ""))
     }
 
     private fun initialState() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/EditTextExt.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/EditTextExt.kt
@@ -1,0 +1,15 @@
+package net.mullvad.mullvadvpn.util
+
+import android.view.KeyEvent
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+
+fun EditText.setOnEnterOrDoneAction(callback: () -> Unit) {
+    setOnEditorActionListener { _, action, event ->
+        if (action == EditorInfo.IME_ACTION_DONE || event?.keyCode == KeyEvent.KEYCODE_ENTER) {
+            callback()
+        }
+
+        false
+    }
+}


### PR DESCRIPTION
Previously, in order to log in the user had to type the account number and then press the green button next to the input area. This PR improves the user experience by allowing them to use the keyboard's enter key to log in.

Since this PR does something similar to PR #2560, an extension was implemented to contain the common code.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Minor UX improvement, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2563)
<!-- Reviewable:end -->
