### PR TITLE
Restrict renderer process

### DIFF
--- a/gui/src/config.json
+++ b/gui/src/config.json
@@ -1,11 +1,11 @@
 {
+  "supportEmail": "support@mullvad.net",
   "links": {
     "purchase": "https://mullvad.net/account/",
     "manageKeys": "https://mullvad.net/account/ports/",
     "faq": "https://mullvad.net/help/tag/mullvad-app/",
     "download": "https://mullvad.net/download/",
-    "betaDownload": "https://mullvad.net/download/beta",
-    "supportEmail": "support@mullvad.net"
+    "betaDownload": "https://mullvad.net/download/beta"
   },
   "colors": {
     "darkBlue": "rgb(25, 46, 69)",

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -385,6 +385,7 @@ class ApplicationMain {
     // fetching.  https://github.com/electron/electron/issues/22995
     session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');
 
+    this.blockPermissionRequests();
     this.blockRequests();
 
     this.translations = this.updateCurrentLocale();
@@ -1397,6 +1398,13 @@ class ApplicationMain {
       messages: messagesTranslations,
       relayLocations: relayLocationsTranslations,
     };
+  }
+
+  private blockPermissionRequests() {
+    session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
+      callback(false);
+    });
+    session.defaultSession.setPermissionCheckHandler(() => false);
   }
 
   // Since the app frontend never performs any network requests, all requests originating from the

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -387,6 +387,7 @@ class ApplicationMain {
 
     this.blockPermissionRequests();
     this.blockRequests();
+    this.blockNavigation();
 
     this.translations = this.updateCurrentLocale();
 
@@ -1436,6 +1437,14 @@ class ApplicationMain {
         }
       },
     );
+  }
+
+  private blockNavigation() {
+    app.on('web-contents-created', (_event, contents) => {
+      contents.on('will-navigate', (event) => {
+        event.preventDefault();
+      });
+    });
   }
 
   private async installDevTools() {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -14,6 +14,7 @@ import moment from 'moment';
 import * as path from 'path';
 import { sprintf } from 'sprintf-js';
 import * as uuid from 'uuid';
+import config from '../config.json';
 import { hasExpired } from '../shared/account-expiry';
 import BridgeSettingsBuilder from '../shared/bridge-settings-builder';
 import {
@@ -1186,7 +1187,11 @@ class ApplicationMain {
     });
 
     IpcMainEventChannel.app.handleQuit(() => app.quit());
-    IpcMainEventChannel.app.handleOpenUrl((url) => shell.openExternal(url));
+    IpcMainEventChannel.app.handleOpenUrl(async (url) => {
+      if (Object.values(config.links).find((link) => url.startsWith(link))) {
+        await shell.openExternal(url);
+      }
+    });
     IpcMainEventChannel.app.handleOpenPath((path) => shell.openPath(path));
     IpcMainEventChannel.app.handleShowOpenDialog((options) => dialog.showOpenDialog(options));
   }

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -460,9 +460,13 @@ export default class AppRenderer {
   public async sendProblemReport(
     email: string,
     message: string,
-    savedReport: string,
+    savedReportId: string,
   ): Promise<void> {
-    await IpcRendererEventChannel.problemReport.sendReport({ email, message, savedReport });
+    await IpcRendererEventChannel.problemReport.sendReport({ email, message, savedReportId });
+  }
+
+  public viewLog(id: string): Promise<string> {
+    return IpcRendererEventChannel.problemReport.viewLog(id);
   }
 
   public quit(): void {
@@ -471,10 +475,6 @@ export default class AppRenderer {
 
   public openUrl(url: string): Promise<void> {
     return IpcRendererEventChannel.app.openUrl(url);
-  }
-
-  public openPath(path: string): Promise<string> {
-    return IpcRendererEventChannel.app.openPath(path);
   }
 
   public showOpenDialog(

--- a/gui/src/renderer/components/ErrorBoundary.tsx
+++ b/gui/src/renderer/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { colors, links } from '../../config.json';
+import { colors, supportEmail } from '../../config.json';
 import { messages } from '../../shared/gettext';
 import log from '../../shared/logging';
 import PlatformWindowContainer from '../containers/PlatformWindowContainer';
@@ -71,7 +71,7 @@ export default class ErrorBoundary extends React.Component<IProps, IState> {
         messages
           .pgettext('error-boundary-view', 'Something went wrong. Please contact us at %(email)s')
           .split('%(email)s', 2);
-      reachBackMessage.splice(1, 0, <Email>{links.supportEmail}</Email>);
+      reachBackMessage.splice(1, 0, <Email>{supportEmail}</Email>);
 
       return (
         <PlatformWindowContainer>

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -40,7 +40,7 @@ enum SendState {
 interface ISupportState {
   email: string;
   message: string;
-  savedReport?: string;
+  savedReportId?: string;
   sendState: SendState;
   disableActions: boolean;
   showOutdatedVersionWarning: boolean;
@@ -56,7 +56,7 @@ interface ISupportProps {
   saveReportForm: (form: ISupportReportForm) => void;
   clearReportForm: () => void;
   collectProblemReport: (accountsToRedact: string[]) => Promise<string>;
-  sendProblemReport: (email: string, message: string, savedReport: string) => Promise<void>;
+  sendProblemReport: (email: string, message: string, savedReportId: string) => Promise<void>;
   outdatedVersion: boolean;
   suggestedIsBeta: boolean;
   onExternalLink: (url: string) => void;
@@ -66,7 +66,7 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
   public state = {
     email: '',
     message: '',
-    savedReport: undefined,
+    savedReportId: undefined,
     sendState: SendState.initial,
     disableActions: false,
     showOutdatedVersionWarning: false,
@@ -102,8 +102,8 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
   public onViewLog = () => {
     this.performWithActionsDisabled(async () => {
       try {
-        const reportPath = await this.collectLog();
-        this.props.viewLog(reportPath);
+        const reportId = await this.collectLog();
+        this.props.viewLog(reportId);
       } catch (error) {
         // TODO: handle error
       }
@@ -199,9 +199,9 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
       this.collectLogPromise = collectPromise;
 
       try {
-        const reportPath = await collectPromise;
+        const reportId = await collectPromise;
         return new Promise((resolve) => {
-          this.setState({ savedReport: reportPath }, () => resolve(reportPath));
+          this.setState({ savedReportId: reportId }, () => resolve(reportId));
         });
       } catch (error) {
         this.collectLogPromise = undefined;
@@ -216,8 +216,8 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
       this.setState({ sendState: SendState.sending }, async () => {
         try {
           const { email, message } = this.state;
-          const reportPath = await this.collectLog();
-          await this.props.sendProblemReport(email, message, reportPath);
+          const reportId = await this.collectLog();
+          await this.props.sendProblemReport(email, message, reportId);
           this.props.clearReportForm();
           this.setState({ sendState: SendState.success }, () => {
             resolve();

--- a/gui/src/renderer/containers/SupportPage.tsx
+++ b/gui/src/renderer/containers/SupportPage.tsx
@@ -23,8 +23,8 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext & RouteC
     onClose() {
       props.history.goBack();
     },
-    viewLog(path: string) {
-      consumePromise(props.app.openPath(path));
+    viewLog(id: string) {
+      consumePromise(props.app.viewLog(id));
     },
     saveReportForm,
     clearReportForm,

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -126,7 +126,6 @@ export const ipcSchema = {
   app: {
     quit: send<void>(),
     openUrl: invoke<string, void>(),
-    openPath: invoke<string, string>(),
     showOpenDialog: invoke<Electron.OpenDialogOptions, Electron.OpenDialogReturnValue>(),
   },
   tunnel: {
@@ -185,7 +184,8 @@ export const ipcSchema = {
   },
   problemReport: {
     collectLogs: invoke<string[], string>(),
-    sendReport: invoke<{ email: string; message: string; savedReport: string }, void>(),
+    sendReport: invoke<{ email: string; message: string; savedReportId: string }, void>(),
+    viewLog: invoke<string, string>(),
   },
   logging: {
     log: send<ILogEntry>(),


### PR DESCRIPTION
This PR further locks down the renderer process. The changes are:
* automatically deny any permission requests
* block navigation
* block `file://` access to files outside build directory
* limit ipc calls to `openUrl` to only allow mullvad.net URLs
* replaced `openPath` ipc method with `viewLog` which only needs the ID instead of the full path to open.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2565)
<!-- Reviewable:end -->
