### PR TITLE
Require daemon-connection when navigating to connect or login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix delay in showing/hiding update notification when toggling beta program.
 - Improve responsiveness when reconnecting after some failed connection attempts.
+- Fix GUI not showing correct view if disconnected from the daemon during app startup.
 
 #### Windows
 - Fix "cannot find the file" error while creating a Wintun adapter by upgrading Wintun.


### PR DESCRIPTION
This PR handles a race condition caused by the daemon stopping during the startup of the app. If the main process finishes fetching the account data before the daemon stops and the deamon stops before the initialization is done, the GUI will navigate to `/connect`. This PR ensures that the app is still connected to the daemon when navigating to `/login` and `/connect`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2566)
<!-- Reviewable:end -->
