### PR TITLE
Manually strip native Android libraries

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -66,6 +66,7 @@ jobs:
             # Build APK
             - env:
                 RUSTFLAGS: --deny warnings
+                NDK_TOOLCHAIN_DIR: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin
                 AR_aarch64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
                 CC_aarch64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang
                 ARCHITECTURES: arm64

--- a/android/fdroid-build/env.sh
+++ b/android/fdroid-build/env.sh
@@ -8,14 +8,14 @@ export GOROOT="$HOME/go"
 export PATH="$PATH:$GOROOT/bin"
 
 # Ensure Rust crates know which tools to use for cross-compilation
-export TOOLCHAIN_DIR="$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin"
+export NDK_TOOLCHAIN_DIR="$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
-export AR_i686_linux_android="$TOOLCHAIN_DIR/i686-linux-android-ar"
-export AR_x86_64_linux_android="$TOOLCHAIN_DIR/x86_64-linux-android-ar"
-export AR_aarch64_linux_android="$TOOLCHAIN_DIR/aarch64-linux-android-ar"
-export AR_armv7_linux_androideabi="$TOOLCHAIN_DIR/arm-linux-androideabi-ar"
+export AR_i686_linux_android="$NDK_TOOLCHAIN_DIR/i686-linux-android-ar"
+export AR_x86_64_linux_android="$NDK_TOOLCHAIN_DIR/x86_64-linux-android-ar"
+export AR_aarch64_linux_android="$NDK_TOOLCHAIN_DIR/aarch64-linux-android-ar"
+export AR_armv7_linux_androideabi="$NDK_TOOLCHAIN_DIR/arm-linux-androideabi-ar"
 
-export CC_i686_linux_android="$TOOLCHAIN_DIR/i686-linux-android21-clang"
-export CC_x86_64_linux_android="$TOOLCHAIN_DIR/x86_64-linux-android21-clang"
-export CC_aarch64_linux_android="$TOOLCHAIN_DIR/aarch64-linux-android21-clang"
-export CC_armv7_linux_androideabi="$TOOLCHAIN_DIR/armv7a-linux-androideabi21-clang"
+export CC_i686_linux_android="$NDK_TOOLCHAIN_DIR/i686-linux-android21-clang"
+export CC_x86_64_linux_android="$NDK_TOOLCHAIN_DIR/x86_64-linux-android21-clang"
+export CC_aarch64_linux_android="$NDK_TOOLCHAIN_DIR/aarch64-linux-android21-clang"
+export CC_armv7_linux_androideabi="$NDK_TOOLCHAIN_DIR/armv7a-linux-androideabi21-clang"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -95,18 +95,22 @@ ARCHITECTURES="aarch64 armv7 x86_64 i686"
 for ARCHITECTURE in $ARCHITECTURES; do
     case "$ARCHITECTURE" in
         "x86_64")
+            LLVM_TRIPLE="x86_64-linux-android"
             TARGET="x86_64-linux-android"
             ABI="x86_64"
             ;;
         "i686")
+            LLVM_TRIPLE="i686-linux-android"
             TARGET="i686-linux-android"
             ABI="x86"
             ;;
         "aarch64")
+            LLVM_TRIPLE="aarch64-linux-android"
             TARGET="aarch64-linux-android"
             ABI="arm64-v8a"
             ;;
         "armv7")
+            LLVM_TRIPLE="arm-linux-androideabi"
             TARGET="armv7-linux-androideabi"
             ABI="armeabi-v7a"
             ;;
@@ -115,7 +119,11 @@ for ARCHITECTURE in $ARCHITECTURES; do
     echo "Building mullvad-daemon for $TARGET"
     cargo +stable build $CARGO_ARGS --target "$TARGET" --package mullvad-jni
 
-    cp "$SCRIPT_DIR/target/$TARGET/$BUILD_TYPE/libmullvad_jni.so" "$SCRIPT_DIR/android/build/extraJni/$ABI/"
+    STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/${LLVM_TRIPLE}-strip"
+    STRIPPED_LIB_PATH="$SCRIPT_DIR/android/build/extraJni/$ABI/libmullvad_jni.so"
+    UNSTRIPPED_LIB_PATH="$SCRIPT_DIR/target/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
+
+    $STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
 done
 
 ./update-relays.sh

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -95,7 +95,7 @@ function build_unix {
 
 function build_android {
     echo "Building for android"
-    local docker_image_hash="25151087eb355a6e609db01a9498df0af4a8bec5d59ad561521512ece7bd21e9"
+    local docker_image_hash="5e3ad65f2d344a891343633a7f545b56fd4cbc0a9776b921ce245773150cf781"
 
     if is_docker_build $@; then
         docker run --rm \

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -2,7 +2,7 @@
 #
 # Copyright © 2017-2019 WireGuard LLC. All Rights Reserved.
 
-DESTDIR ?= $(CURDIR)/../../android/build/extraJni/$(ANDROID_ABI)
+DESTDIR ?= $(CURDIR)/../../build/lib/$(RUST_TARGET_TRIPLE)
 
 NDK_GO_ARCH_MAP_x86 := 386
 NDK_GO_ARCH_MAP_x86_64 := amd64

--- a/wireguard/libwg/Dockerfile_AndroidPatchedGoruntime
+++ b/wireguard/libwg/Dockerfile_AndroidPatchedGoruntime
@@ -25,6 +25,7 @@ RUN cd /tmp && \
 
 
 ENV ANDROID_NDK_HOME="/opt/android/android-ndk-r20b"
+ENV NDK_TOOLCHAIN_DIR="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
 ENV GOLANG_VERSION 1.16
 ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -14,28 +14,31 @@ ARCHITECTURES="${ARCHITECTURES:-"arm arm64 x86_64 x86"}"
 for arch in $ARCHITECTURES; do
     case "$arch" in
         "arm64")
-            export ANDROID_LLVM_TRIPLE="aarch64-linux-android"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android21-clang"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android-strip"
             export RUST_TARGET_TRIPLE="aarch64-linux-android"
             export ANDROID_ABI="arm64-v8a"
             ;;
         "x86_64")
-            export ANDROID_LLVM_TRIPLE="x86_64-linux-android"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android21-clang"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android-strip"
             export RUST_TARGET_TRIPLE="x86_64-linux-android"
             export ANDROID_ABI="x86_64"
             ;;
         "arm")
-            export ANDROID_LLVM_TRIPLE="armv7a-linux-androideabi"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/armv7a-linux-androideabi21-clang"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/arm-linux-androideabi-strip"
             export RUST_TARGET_TRIPLE="armv7-linux-androideabi"
             export ANDROID_ABI="armeabi-v7a"
             ;;
         "x86")
-            export ANDROID_LLVM_TRIPLE="i686-linux-android"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/i686-linux-android21-clang"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/i686-linux-android-strip"
             export RUST_TARGET_TRIPLE="i686-linux-android"
             export ANDROID_ABI="x86"
             ;;
     esac
 
-    export ANDROID_C_COMPILER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/${ANDROID_LLVM_TRIPLE}21-clang"
     export ANDROID_ARCH_NAME=$arch
 
     # Build Wireguard-Go
@@ -45,9 +48,15 @@ for arch in $ARCHITECTURES; do
     export CFLAGS="-D__ANDROID_API__=21"
 
     make -f Android.mk
-    # Copy build artifacts to `android/build/extraJni/$ANDROID_ABI` to be able to build the APK
-    mkdir -p ../../android/build/extraJni/$ANDROID_ABI
-    cp ../../build/lib/$RUST_TARGET_TRIPLE/libwg.so ../../android/build/extraJni/$ANDROID_ABI
+
+    # Strip and copy the libray to `android/build/extraJni/$ANDROID_ABI` to be able to build the APK
+    UNSTRIPPED_LIB_PATH="../../build/lib/$RUST_TARGET_TRIPLE/libwg.so"
+    STRIPPED_LIB_PATH="../../android/build/extraJni/$ANDROID_ABI/libwg.so"
+
+    mkdir -p "$(dirname "$STRIPPED_LIB_PATH")"
+
+    $ANDROID_STRIP_TOOL --strip-unneeded --strip-debug -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+
     rm -rf build
 done
 

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -45,13 +45,9 @@ for arch in $ARCHITECTURES; do
     export CFLAGS="-D__ANDROID_API__=21"
 
     make -f Android.mk
-    # Copy build artifacts to `build/libs/$RUST_TARGET_TRIPLE` to be able to build `mullvad-jni`
-    chmod 777 ../../android/build/
-    chmod 777 ../../android/build/extraJni
-    chmod 777 ../../android/build/extraJni/*
-    mkdir -p ../../build/lib/$RUST_TARGET_TRIPLE
-    cp ../../android/build/extraJni/$ANDROID_ABI/libwg.so ../../build/lib/$RUST_TARGET_TRIPLE
-    chmod 777 ../../android/build/extraJni/$ANDROID_ABI/libwg.so ../../build/lib/$RUST_TARGET_TRIPLE
+    # Copy build artifacts to `android/build/extraJni/$ANDROID_ABI` to be able to build the APK
+    mkdir -p ../../android/build/extraJni/$ANDROID_ABI
+    cp ../../build/lib/$RUST_TARGET_TRIPLE/libwg.so ../../android/build/extraJni/$ANDROID_ABI
     rm -rf build
 done
 

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -53,9 +53,14 @@ for arch in $ARCHITECTURES; do
     UNSTRIPPED_LIB_PATH="../../build/lib/$RUST_TARGET_TRIPLE/libwg.so"
     STRIPPED_LIB_PATH="../../android/build/extraJni/$ANDROID_ABI/libwg.so"
 
-    mkdir -p "$(dirname "$STRIPPED_LIB_PATH")"
+    # Create the directories with RWX permissions for all users so that the build server can clean
+    # the directories afterwards
+    mkdir -m 777 -p "$(dirname "$STRIPPED_LIB_PATH")"
 
     $ANDROID_STRIP_TOOL --strip-unneeded --strip-debug -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+
+    # Set permissions so that the build server can clean the outputs afterwards
+    chmod 777 "$STRIPPED_LIB_PATH"
 
     rm -rf build
 done


### PR DESCRIPTION
A previous tool update (#2453) increased the size of the final APK (funny side note: the release notes for the new tool version says that in the new version ["App size significantly reduced for apps using code shrinking"](https://developer.android.com/studio/releases/gradle-plugin#4.1-app-size-reduction) ).

The root cause seems to be that the tool internally changed how it finds the NDK path and fails to find the `strip` tool, so it simply emits a warning and includes the unstripped library. A known workaround is to add a `ndk.dir` property to the `local.properties` file in order to force the old way to find the tool. However, that file should not be versioned since it's environment specific. Therefore, it's not a good solution and would require instead adding documentation for all build environments to have its own custom `local.properties` file.

Since a previous update also led to not-stripping the libraries for a different reason (#1908), this PR fixes the issue by manually stripping the libraries after they have been built. Therefore there is no longer a dependency on the Android Gradle Plugin working as expected.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a minor issue not present in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2568)
<!-- Reviewable:end -->
