### PR TITLE
Use lifecycle scope to update the tunnel state in the Connect screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
@@ -96,7 +97,7 @@ class ConnectFragment :
         }
 
         connectionProxy.onUiStateChange.subscribe(this) { uiState ->
-            jobTracker.newUiJob("updateTunnelState") {
+            viewLifecycleOwner.lifecycleScope.launchWhenStarted {
                 updateTunnelState(uiState, connectionProxy.state)
             }
         }


### PR DESCRIPTION
The recent improvement to paint the navigation and status bars (#2521) surfaced a bug that was previously present on the Connect screen but hadn't manifested itself before. Since the new painting code makes the `HeaderBar` widget paint the status bar based on the tunnel state updates dispatched by the `ConnectFragment`, it was possible to see that when logging out the status bar would still get painted, even though the flow was theoretically was from `AccountFragment` to the `LoginFragment` (i.e., it doesn't pass through the `ConnectFragment`). Nevertheless, after debugging it was possible to see that because of how the back stack was managed, the `ConnectFragment` was started and then destroyed, which caused a tunnel state job to be scheduled and executed afterwards. So there are two bugs:

1. The `ConnectFragment` is started and destroyed even though it's not part of the flow (and doesn't become visible).
2. The `ConnectFragment` schedules a job to update the view based on the tunnel state, and this job ends up executing after the Connect screen has been destroyed.

This PR fixes the second bug by using the fragment view's lifecycle coroutine scope. So the job is now cancelled when the fragment's view is destroyed. Fixing this bug should be enough to unblock painting the login screen correctly.

The first bug should be fixed later, because it will likely require rethinking how screen navigation is performed and could result in big changes that should not be included in the upcoming release.

Note that ideally, all `jobTracker` usages in `ConnectFragment` could be replaced with proper coroutine scopes, however, it's best to do that in a separate PR as to not include it in the upcoming release and avoid any risks because of the changes.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that doesn't manifest itself to the user in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2569)
<!-- Reviewable:end -->
