### PR TITLE
Fix not setting account when not connected to daemon

### DIFF
--- a/gui/src/renderer/lib/history.ts
+++ b/gui/src/renderer/lib/history.ts
@@ -80,6 +80,13 @@ export default class History {
     this.notify(affectedEntries);
   };
 
+  public resetWithIfDifferent = (nextLocation: LocationDescriptor<S>, nextState?: S) => {
+    const location = this.createLocation(nextLocation, nextState);
+    if (this.entries[0].pathname !== location.pathname) {
+      this.resetWith(nextLocation, nextState);
+    }
+  };
+
   public canGo(n: number) {
     const nextIndex = this.index + n;
     return nextIndex >= 0 && nextIndex < this.entries.length;


### PR DESCRIPTION
This PR fixes and issue with the account not being set in the renderer if not connected to the daemon. This was introduced in https://github.com/mullvad/mullvadvpn-app/pull/2566.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2572)
<!-- Reviewable:end -->
