### PR TITLE
Preserve the daemon log from the old installation when upgrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add 51820 to list of WireGuard ports in app settings.
 - Add option to connect to WireGuard relays over IPv6.
 - Add Burmese translations.
+- Preserve log of old daemon instance when upgrading on Desktop.
 
 #### Android
 - Allow reaching the API server when connecting, disconnecting or in a blocked state.

--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -6,6 +6,8 @@ if which systemctl &> /dev/null; then
         /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
         systemctl stop mullvad-daemon.service
         systemctl disable mullvad-daemon.service
+        cp /var/log/mullvad-vpn/daemon.log /var/log/mullvad-vpn/old-install-daemon.log \
+            || echo "Failed to copy old daemon log"
     fi
 fi
 

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -55,6 +55,8 @@ pkill -x "Mullvad VPN" || echo "Unable to kill GUI, not running?"
 sleep 1
 
 launchctl unload -w $DAEMON_PLIST_PATH
+cp "$LOG_DIR/daemon.log" "$LOG_DIR/old-install-daemon.log" \
+  || echo "Failed to copy old daemon log"
 echo "$DAEMON_PLIST" > $DAEMON_PLIST_PATH
 launchctl load -w $DAEMON_PLIST_PATH
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -847,6 +847,10 @@
 	Pop $0
 	Pop $1
 
+	# Copy over the daemon log from the old install for debugging purposes
+	SetShellVarContext all
+	CopyFiles /SILENT /FILESONLY "$LOCALAPPDATA\Mullvad VPN\daemon.log" "$LOCALAPPDATA\Mullvad VPN\old-install-daemon.log"
+
 	nsExec::ExecToStack '"$SYSDIR\sc.exe" delete mullvadvpn'
 
 	# Discard return value


### PR DESCRIPTION
To aid with debugging the issues with failing to upgrade the daemon, the daemon log from the old instance should be preserved - otherwise, by the time the user sends a problem report, the old daemon logs have been overwritten so no useful information about what happened during the installation can be inferred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2573)
<!-- Reviewable:end -->
