### PR TITLE
Add Windows to frontend GitHub actions job

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,10 +12,13 @@ jobs:
     check-frontend:
         strategy:
             matrix:
-                os: [ubuntu-latest]
+                os: [ubuntu-latest, windows-latest]
 
         runs-on: ${{ matrix.os }}
         steps:
+            # Prevent conversion of line-breaks on Windows
+            - run: git config --global core.autocrlf input
+
             - name: Checkout repository
               uses: actions/checkout@v2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,6 @@ matrix:
         - npm run build
         - npm test
 
-    - os: windows
-      language: node_js
-      node_js: '12'
-      name: Desktop Frontend, Windows
-      cache: npm
-      before_install:
-        # npm fails to upgrade itself if just doing `npm install -g npm`. See this issue:
-        # https://travis-ci.community/t/command-npm-i-g-npm-latest-fails/431/5
-        - node `npm prefix -g`/node_modules/npm/bin/npm-cli.js i -g npm@latest
-      install: *node_install
-      script: *node_script
-
     # iOS
     - language: swift
       osx_image: xcode12.2
@@ -117,9 +105,6 @@ matrix:
       language: shell
       before_install: *rust_windows_before_install
       script: *rust_windows_script
-
-  allow_failures:
-    - name: Desktop Frontend, Windows
 
 notifications:
   email:

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -78,7 +78,7 @@
         "semver": "^7.3.2",
         "sinon": "^7.1.1",
         "spa-server": "^1.0.0",
-        "ts-node": "^9.1.0",
+        "ts-node": "^9.1.1",
         "tsc-watch": "^4.2.9",
         "typescript": "^4.1.5",
         "vinyl-buffer": "^1.0.1",
@@ -16250,9 +16250,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.0.tgz",
-      "integrity": "sha512-0yqcL4sgruCvM+w64LiAfNJo6+lHfCYc5Ajj4yiLNkJ9oZ2HWaa+Kso7htYOOxVQ7+csAjdUjffOe9PIqC4pMg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
       "dev": true,
       "dependencies": {
         "arg": "^4.1.0",
@@ -16270,6 +16270,9 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
       }
     },
     "node_modules/ts-node/node_modules/diff": {
@@ -31183,9 +31186,9 @@
       }
     },
     "ts-node": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.0.tgz",
-      "integrity": "sha512-0yqcL4sgruCvM+w64LiAfNJo6+lHfCYc5Ajj4yiLNkJ9oZ2HWaa+Kso7htYOOxVQ7+csAjdUjffOe9PIqC4pMg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",

--- a/gui/package.json
+++ b/gui/package.json
@@ -84,7 +84,7 @@
     "semver": "^7.3.2",
     "sinon": "^7.1.1",
     "spa-server": "^1.0.0",
-    "ts-node": "^9.1.0",
+    "ts-node": "^9.1.1",
     "tsc-watch": "^4.2.9",
     "typescript": "^4.1.5",
     "vinyl-buffer": "^1.0.1",


### PR DESCRIPTION
This PR adds Windows to the list of OSes to run the GitHub actions frontend job on. To get it to work a few changes were needed:
* Set the `autocrlf` git setting to prevent git from automatically converting `lf` to `crlf` which makes the linter fail
* Update `ts-node` since the previous version failed when running the tests
* Normalize paths in the logger tests. The tests haven't changed but they now handle paths with `\` as well.

The Travis job for the frontend has been removed as well since it didn't run properly.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2576)
<!-- Reviewable:end -->
