### PR TITLE
Pick random relay if no tunnel type is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,7 @@ This release is for Android only.
 ### Fixed
 - Fix missing map animation after selecting a new location in the desktop app.
 - Fix crash on older kernels which report a default route through the loopback interface.
+- Fix relay selection failing to pick a WireGuard relay when no tunnel protocol is specified.
 
 #### Android
 - Fix connect action button sometimes showing itself as "Cancel" instead of "Secure my connection"


### PR DESCRIPTION
On macOS and Linux, when the location constraints contain no OpenVPN relays and the tunnel protocol is unconstrained (`Constraint::Any`), the daemon will fail to select a perfectly valid and available WireGuard relay if the daemon fails to connect more than 2 times. Since the tunnel protocol is not constrained, the daemon will try to use preferred constraints, but these will fail attempt to select an OpenVPN relay after the first 2 tries. The daemon should successfully fall back to using the original constraints rather than the preferred ones, but the relay selection will only use OpenVPN relays in the case that there is no tunnel protocol specified. 
Thus, the appropriate fix is to select a random relay on macOS and Linux when there is no tunnel protocol specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2578)
<!-- Reviewable:end -->
