### PR TITLE
CLI: Read account token from STDIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Line wrap the file at 100 chars.                                              Th
 - Only download a new relay list if it has been modified.
 - Connect to the API only via TLS 1.3
 - Shrink account history capactity from 3 account entries to 1.
+- Allow whitespace in account token in CLI.
+- Read account token from standard input unless given as an argument in CLI.
 
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -1,8 +1,9 @@
 use crate::{new_rpc_client, Command, Error, Result};
 use clap::value_t_or_exit;
+use itertools::Itertools;
 use mullvad_management_interface::{types::Timestamp, Code};
 use mullvad_types::account::AccountToken;
-use itertools::Itertools;
+use std::io::{self, Write};
 
 pub struct Account;
 
@@ -22,7 +23,7 @@ impl Command for Account {
                     .arg(
                         clap::Arg::with_name("token")
                             .help("The Mullvad account token to configure the client with")
-                            .required(true),
+                            .required(false),
                     ),
             )
             .subcommand(
@@ -54,7 +55,20 @@ impl Command for Account {
 
     async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
-            let mut token = value_t_or_exit!(set_matches.value_of("token"), String);
+            let mut token = match set_matches.value_of("token") {
+                Some(token) => token.to_string(),
+                None => {
+                    let mut token = String::new();
+                    io::stdout()
+                        .write_all(b"Enter account token: ")
+                        .expect("Failed to write to STDOUT");
+                    let _ = io::stdout().flush();
+                    io::stdin()
+                        .read_line(&mut token)
+                        .expect("Failed to read from STDIN");
+                    token
+                }
+            };
             token = token.split_whitespace().join("").to_string();
             self.set(Some(token)).await
         } else if let Some(_matches) = matches.subcommand_matches("get") {

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -2,6 +2,7 @@ use crate::{new_rpc_client, Command, Error, Result};
 use clap::value_t_or_exit;
 use mullvad_management_interface::{types::Timestamp, Code};
 use mullvad_types::account::AccountToken;
+use itertools::Itertools;
 
 pub struct Account;
 
@@ -53,7 +54,8 @@ impl Command for Account {
 
     async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
-            let token = value_t_or_exit!(set_matches.value_of("token"), String);
+            let mut token = value_t_or_exit!(set_matches.value_of("token"), String);
+            token = token.split_whitespace().join("").to_string();
             self.set(Some(token)).await
         } else if let Some(_matches) = matches.subcommand_matches("get") {
             self.get().await


### PR DESCRIPTION
Entering the account token through the CLI can be a bit clunky at times. For one, the account token always ends up in the shell history, and the CLI doesn't trim whitespace of the input token, which makes it awkward to copy the token from the website.
I've changed the CLI to read the account token from STDIN by default, but the old behavior of passing it as a parameter is still available via a flag. And now the CLI will filter whitespace characters before sending the token to the daemon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2580)
<!-- Reviewable:end -->
