### PR TITLE
Optimize RelayStatusIndicatorView

### DIFF
--- a/ios/MullvadVPN/RelayStatusIndicatorView.swift
+++ b/ios/MullvadVPN/RelayStatusIndicatorView.swift
@@ -10,8 +10,8 @@ import UIKit
 
 @IBDesignable class RelayStatusIndicatorView: UIControl {
 
-    private let circleLayer: CAShapeLayer = {
-        let layer = CAShapeLayer()
+    private let circleLayer: CALayer = {
+        let layer = CALayer()
         layer.needsDisplayOnBoundsChange = true
         return layer
     }()
@@ -58,13 +58,13 @@ import UIKit
             y: (layer.bounds.height - shortSide) * 0.5
         )
         let circleSize = CGSize(width: shortSide, height: shortSide)
-        let bezierPath = UIBezierPath(ovalIn: CGRect(origin: .zero, size: circleSize))
 
         circleLayer.frame = CGRect(origin: circleOrigin, size: circleSize)
-        circleLayer.path = bezierPath.cgPath
+        circleLayer.cornerRadius = shortSide * 0.5
     }
 
     private func setup() {
+        isUserInteractionEnabled = false
         backgroundColor = UIColor.clear
 
         layer.addSublayer(circleLayer)
@@ -78,6 +78,9 @@ import UIKit
 
         let circleColor: UIColor = isHighlighted ? tintColor : baseColor
 
-        circleLayer.fillColor = circleColor.cgColor
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        circleLayer.backgroundColor = circleColor.cgColor
+        CATransaction.commit()
     }
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Replace `CAShapeLayer` with rounded bezier path to a regular `CALayer` and `cornerRadius` instead. This is something that was suggested by Xcode as a potential performance optimisation. 
2. Use `CATransaction` to disable implicit animations when updating the color of a circle. This particularly was visible when scrolling the relay list very fast. Since the cells are reused in table view, if there is at least one relay that is down, it used to cause the red and green circle to animate like a semaphore.
3. Disable `isUserInteractionEnabled` on indicator view. Previously it was possible to tap on a green circle which would make the circle highlight but not the cell behind it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2583)
<!-- Reviewable:end -->
