### PR TITLE
Move rotation interval setting to mullvad-types

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelOptions.kt
@@ -1,5 +1,3 @@
 package net.mullvad.mullvadvpn.model
 
-import net.mullvad.talpid.net.wireguard.TunnelOptions as WireguardTunnelOptions
-
 data class TunnelOptions(val wireguard: WireguardTunnelOptions, val dnsOptions: DnsOptions)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/WireguardTunnelOptions.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/WireguardTunnelOptions.kt
@@ -1,0 +1,5 @@
+package net.mullvad.mullvadvpn.model
+
+import net.mullvad.talpid.net.wireguard.TunnelOptions as TalpidWireguardTunnelOptions
+
+data class WireguardTunnelOptions(val options: TalpidWireguardTunnelOptions)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -118,7 +118,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private fun updateUi(settings: Settings) {
         jobTracker.newUiJob("updateUi") {
             if (!wireguardMtuInput.hasFocus) {
-                wireguardMtuInput.value = settings.tunnelOptions.wireguard.mtu
+                wireguardMtuInput.value = settings.tunnelOptions.wireguard.options.mtu
             }
         }
     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1063,7 +1063,7 @@ where
                         ipv4_gateway,
                         ipv6_gateway: Some(ipv6_gateway),
                     },
-                    options: tunnel_options.wireguard,
+                    options: tunnel_options.wireguard.options,
                     generic_options: tunnel_options.generic,
                 }
                 .into())

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1225,7 +1225,7 @@ fn convert_tunnel_options(options: &TunnelOptions) -> types::TunnelOptions {
             mssfix: u32::from(options.openvpn.mssfix.unwrap_or_default()),
         }),
         wireguard: Some(types::tunnel_options::WireguardOptions {
-            mtu: u32::from(options.wireguard.mtu.unwrap_or_default()),
+            mtu: u32::from(options.wireguard.options.mtu.unwrap_or_default()),
             automatic_rotation: options
                 .wireguard
                 .automatic_rotation

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -217,7 +217,8 @@ impl SettingsPersister {
     }
 
     pub fn set_wireguard_mtu(&mut self, mtu: Option<u16>) -> Result<bool, Error> {
-        let should_save = Self::update_field(&mut self.settings.tunnel_options.wireguard.mtu, mtu);
+        let should_save =
+            Self::update_field(&mut self.settings.tunnel_options.wireguard.options.mtu, mtu);
         self.update(should_save)
     }
 

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -60,7 +60,7 @@ impl CustomTunnelEndpoint {
             .into(),
             ConnectionConfig::Wireguard(connection) => wireguard::TunnelParameters {
                 connection,
-                options: tunnel_options.wireguard.clone(),
+                options: tunnel_options.wireguard.options.clone(),
                 generic_options: tunnel_options.generic.clone(),
             }
             .into(),

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -1,6 +1,9 @@
-use crate::relay_constraints::{
-    BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
-    RelayConstraints, RelaySettings, RelaySettingsUpdate,
+use crate::{
+    relay_constraints::{
+        BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
+        RelayConstraints, RelaySettings, RelaySettingsUpdate,
+    },
+    wireguard,
 };
 #[cfg(target_os = "android")]
 use jnix::{FromJava, IntoJava};
@@ -8,7 +11,7 @@ use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::net::IpAddr;
-use talpid_types::net::{openvpn, wireguard, GenericTunnelOptions};
+use talpid_types::net::{self, openvpn, GenericTunnelOptions};
 
 mod migrations;
 
@@ -186,7 +189,7 @@ impl Default for TunnelOptions {
         TunnelOptions {
             openvpn: openvpn::TunnelOptions::default(),
             wireguard: wireguard::TunnelOptions {
-                mtu: None,
+                options: net::wireguard::TunnelOptions::default(),
                 automatic_rotation: None,
             },
             generic: GenericTunnelOptions {

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -24,6 +24,20 @@ impl WireguardData {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(target_os = "android", derive(IntoJava))]
+#[cfg_attr(
+    target_os = "android",
+    jnix(class_name = "net.mullvad.mullvadvpn.model.WireguardTunnelOptions")
+)]
+pub struct TunnelOptions {
+    #[serde(flatten)]
+    pub options: wireguard::TunnelOptions,
+    /// Interval used for automatic key rotation, in hours
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub automatic_rotation: Option<u32>,
+}
+
 /// Represents a published public key
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -57,7 +57,7 @@ pub struct TunnelConfig {
 }
 
 /// Options in [`TunnelParameters`] that apply to any WireGuard connection.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(
     target_os = "android",
@@ -70,9 +70,6 @@ pub struct TunnelOptions {
         jnix(map = "|maybe_mtu| maybe_mtu.map(|mtu| mtu as i32)")
     )]
     pub mtu: Option<u16>,
-    /// Interval used for automatic key rotation, in hours
-    #[cfg_attr(target_os = "android", jnix(skip))]
-    pub automatic_rotation: Option<u32>,
 }
 
 /// Wireguard x25519 private key


### PR DESCRIPTION
Previously, this setting was stored in `talpid_types::wireguard::TunnelOptions`. Since the talpid layer doesn't implement key rotation, it does not belong there. It has been moved to `mullvad_types`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2585)
<!-- Reviewable:end -->
