### PR TITLE
Add wireguard port explanation

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -144,10 +144,6 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
       },
     ];
 
-    this.wireguardPortItems = [automaticPort].concat(
-      WIREUGARD_UDP_PORTS.map(mapPortToSelectorItem),
-    );
-
     this.bridgeStateItems = [
       {
         label: messages.pgettext('advanced-settings-view', 'Automatic'),

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -19,7 +19,7 @@ import {
   StyledNoWireguardKeyError,
   StyledNoWireguardKeyErrorContainer,
   StyledSelectorContainer,
-  StyledTunnelProtocolSelector,
+  StyledSelectorForFooter,
   StyledTunnelProtocolContainer,
   StyledCustomDnsSwitchContainer,
   StyledCustomDnsFotter,
@@ -246,7 +246,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
 
                 <AriaInputGroup>
                   <StyledTunnelProtocolContainer>
-                    <StyledTunnelProtocolSelector
+                    <StyledSelectorForFooter
                       title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
                       values={this.tunnelProtocolItems(hasWireguardKey)}
                       value={this.props.tunnelProtocol}
@@ -306,7 +306,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                 {this.props.tunnelProtocol === 'wireguard' ? (
                   <AriaInputGroup>
                     <StyledSelectorContainer>
-                      <Selector
+                      <StyledSelectorForFooter
                         // TRANSLATORS: The title for the shadowsocks bridge selector section.
                         title={messages.pgettext('advanced-settings-view', 'WireGuard port')}
                         values={this.wireguardPortItems}
@@ -314,6 +314,19 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                         onSelect={this.onSelectWireguardPort}
                       />
                     </StyledSelectorContainer>
+                    <Cell.Footer>
+                      <AriaDescription>
+                        <Cell.FooterText>
+                          {
+                            // TRANSLATORS: The hint displayed below the WireGuard port selector.
+                            messages.pgettext(
+                              'advanced-settings-view',
+                              'The automatic setting will randomly choose from a wide range of ports.',
+                            )
+                          }
+                        </Cell.FooterText>
+                      </AriaDescription>
+                    </Cell.Footer>
                   </AriaInputGroup>
                 ) : undefined}
 

--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -17,7 +17,7 @@ export const StyledSelectorContainer = styled.div({
   flex: 0,
 });
 
-export const StyledTunnelProtocolSelector = (styled(Selector)({
+export const StyledSelectorForFooter = (styled(Selector)({
   marginBottom: 0,
 }) as unknown) as new <T>() => Selector<T>;
 


### PR DESCRIPTION
This PR adds a footer with a description of the WireGuard port selector. It also removes an assignment to `wireguardPortItems` which is identical to the one 19 lines above it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2586)
<!-- Reviewable:end -->
