### PR TITLE
Fix WireGuard-Go usage on Android

### DIFF
--- a/wireguard/libwg/go.mod
+++ b/wireguard/libwg/go.mod
@@ -1,6 +1,6 @@
 module github.com/mullvad/mullvadvpn-app/wireguard/libwg
 
-go 1.13
+go 1.16
 
 require (
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect

--- a/wireguard/libwg/libwg_android.go
+++ b/wireguard/libwg/libwg_android.go
@@ -47,7 +47,7 @@ func wgTurnOn(cSettings *C.char, fd int, logSink LogSink, logContext LogContext)
 		return ERROR_GENERAL_FAILURE
 	}
 
-	device := device.NewDevice(tunDevice, conn.NewDefaultBind(), logger)
+	device := device.NewDevice(tunDevice, conn.NewStdNetBind(), logger)
 
 	setErr := device.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
 	if setErr != nil {


### PR DESCRIPTION
After updating Go to version 1.16 and the WireGuard-Go library (#2539), the Android app started crashing when trying to connect. The cause was that the new version of the library has a new wrapper type for bound sockets for Linux, but that shouldn't be used on Android. This PR fixes that issue by constructing the correct type on Android.

The PR also updates the Go version used for building the library for Android.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes an issue that's not present in any released version, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2587)
<!-- Reviewable:end -->
