### PR TITLE
Add relay selector into the simulated tunnel

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		58B0A2AA238EE6A900BC001D /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58781CD422AFBA39009B9D8E /* RelaySelector.swift */; };
 		58B0A2AC238EE6D500BC001D /* IPAddress+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250022B1124600E4CFEC /* IPAddress+Codable.swift */; };
 		58B0A2AD238EE6EC00BC001D /* MullvadEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */; };
+		58B67B482602079E008EF58E /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58781CD422AFBA39009B9D8E /* RelaySelector.swift */; };
 		58B8743222B25A7600015324 /* WireguardAssociatedAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B8743122B25A7600015324 /* WireguardAssociatedAddresses.swift */; };
 		58B8743B22B788D200015324 /* PacketTunnelSettingsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B8743722B25EAB00015324 /* PacketTunnelSettingsGenerator.swift */; };
 		58B9814E24FEA70D00C0D59E /* WireguardKeysViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 58B9814D24FEA70D00C0D59E /* WireguardKeysViewController.xib */; };
@@ -170,6 +171,8 @@
 		58C3B06724EA768100C0348E /* LogStreamerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3B06624EA768100C0348E /* LogStreamerViewController.swift */; };
 		58C3B06924EAA25000C0348E /* StringStreamIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3B06824EAA25000C0348E /* StringStreamIterator.swift */; };
 		58C4CB0124EBE5A700A22D49 /* LogEntryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C4CB0024EBE5A700A22D49 /* LogEntryParser.swift */; };
+		58CAF4EA26025927007C5886 /* PacketTunnelIpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */; };
+		58CAF4EF26025954007C5886 /* SimulatorTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */; };
 		58CB0EE024B86751001EF0D8 /* MullvadRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CB0EDF24B86751001EF0D8 /* MullvadRest.swift */; };
 		58CB0EE124B86751001EF0D8 /* MullvadRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CB0EDF24B86751001EF0D8 /* MullvadRest.swift */; };
 		58CC40EF24A601900019D96E /* ObserverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CC40EE24A601900019D96E /* ObserverList.swift */; };
@@ -905,6 +908,7 @@
 				5896AE81246ACE81005B36CB /* KeychainMatchLimit.swift in Sources */,
 				5896AE80246ACE79005B36CB /* KeychainClass.swift in Sources */,
 				582AE3132440CA2700E6733A /* AccountTokenInput.swift in Sources */,
+				58CAF4EF26025954007C5886 /* SimulatorTunnelProvider.swift in Sources */,
 				5857F23724C8446400CF6F47 /* AssociatedValue.swift in Sources */,
 				5857F23B24C8448600CF6F47 /* OperationProtocol.swift in Sources */,
 				58B0A2AA238EE6A900BC001D /* RelaySelector.swift in Sources */,
@@ -928,6 +932,7 @@
 				5896AE7E246ACE65005B36CB /* KeychainAttributes.swift in Sources */,
 				58B0A2A9238EE6A100BC001D /* RelayConstraints.swift in Sources */,
 				5807E2C2243203D000F5FF30 /* StringTests.swift in Sources */,
+				58CAF4EA26025927007C5886 /* PacketTunnelIpc.swift in Sources */,
 				5857F23E24C844A000CF6F47 /* OperationBlockObserver.swift in Sources */,
 				5857F23024C843ED00CF6F47 /* ChainedError.swift in Sources */,
 				58A8BE81239FBE62006B74AC /* IPEndpoint.swift in Sources */,
@@ -994,6 +999,7 @@
 				580EE20F24B322E700F9D8A1 /* TransformOperation.swift in Sources */,
 				58B8743222B25A7600015324 /* WireguardAssociatedAddresses.swift in Sources */,
 				5850368C25A49E2200A43E93 /* PrivateKeyWithMetadata.swift in Sources */,
+				58B67B482602079E008EF58E /* RelaySelector.swift in Sources */,
 				58DF28A52417CB4B00E836B0 /* AppStorePaymentManager.swift in Sources */,
 				580EE22124B3240100F9D8A1 /* TransformOperationObserver.swift in Sources */,
 				582BB1AF229566420055B6EF /* SettingsCell.swift in Sources */,

--- a/ios/MullvadVPN/Operations/AnyOperationObserver.swift
+++ b/ios/MullvadVPN/Operations/AnyOperationObserver.swift
@@ -10,6 +10,10 @@ import Foundation
 
 class AnyOperationObserver<OperationType: OperationProtocol>: OperationBlockObserver<OperationType> {
     init<T: OperationObserver>(_ observer: T) where T.OperationType == OperationType {
-        super.init(willFinish: observer.operationWillFinish, didFinish: observer.operationDidFinish)
+        super.init(
+            willExecute: observer.operationWillExecute,
+            willFinish: observer.operationWillFinish,
+            didFinish: observer.operationDidFinish
+        )
     }
 }

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -47,6 +47,7 @@ class AsyncOperation: Operation, OperationProtocol {
             if self.isCancelled {
                 self.finish()
             } else {
+                self.observers.forEach { $0.operationWillExecute(self) }
                 self.setExecuting(true)
                 self.main()
             }

--- a/ios/MullvadVPN/Operations/OperationBlockObserver.swift
+++ b/ios/MullvadVPN/Operations/OperationBlockObserver.swift
@@ -9,15 +9,30 @@
 import Foundation
 
 class OperationBlockObserver<OperationType: OperationProtocol>: OperationObserver {
+    private var willExecute: ((OperationType) -> Void)?
     private var willFinish: ((OperationType) -> Void)?
     private var didFinish: ((OperationType) -> Void)?
 
     let queue: DispatchQueue?
 
-    init(queue: DispatchQueue? = nil, willFinish: ((OperationType) -> Void)? = nil, didFinish: ((OperationType) -> Void)? = nil) {
+    init(
+        queue: DispatchQueue? = nil,
+        willExecute: ((OperationType) -> Void)? = nil,
+        willFinish: ((OperationType) -> Void)? = nil,
+        didFinish: ((OperationType) -> Void)? = nil
+    ) {
         self.queue = queue
+        self.willExecute = willExecute
         self.willFinish = willFinish
         self.didFinish = didFinish
+    }
+
+    func operationWillExecute(_ operation: OperationType) {
+        if let willExecute = willExecute {
+            scheduleEvent {
+                willExecute(operation)
+            }
+        }
     }
 
     func operationWillFinish(_ operation: OperationType) {

--- a/ios/MullvadVPN/Operations/OperationObserver.swift
+++ b/ios/MullvadVPN/Operations/OperationObserver.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol OperationObserver {
     associatedtype OperationType: OperationProtocol
 
+    func operationWillExecute(_ operation: OperationType)
     func operationWillFinish(_ operation: OperationType)
     func operationDidFinish(_ operation: OperationType)
 }

--- a/ios/MullvadVPN/Operations/TransformOperationObserver.swift
+++ b/ios/MullvadVPN/Operations/TransformOperationObserver.swift
@@ -11,12 +11,18 @@ import Foundation
 /// A private type erasing observer that type casts the input operation type to the expected
 /// operation type before calling the wrapped observer
 class TransformOperationObserver<S: OperationProtocol>: OperationObserver {
+    private let willExecute: (S) -> Void
     private let willFinish: (S) -> Void
     private let didFinish: (S) -> Void
 
     init<T: OperationObserver>(_ observer: T) {
+        willExecute = Self.wrap(observer.operationWillExecute)
         willFinish = Self.wrap(observer.operationWillFinish)
         didFinish = Self.wrap(observer.operationDidFinish)
+    }
+
+    func operationWillExecute(_ operation: S) {
+        willExecute(operation)
     }
 
     func operationWillFinish(_ operation: S) {

--- a/ios/MullvadVPN/RelaySelector.swift
+++ b/ios/MullvadVPN/RelaySelector.swift
@@ -20,6 +20,17 @@ private struct RelayWithLocation {
     var location: Location
 }
 
+extension RelaySelectorResult {
+    var tunnelConnectionInfo: TunnelConnectionInfo {
+        return TunnelConnectionInfo(
+            ipv4Relay: self.endpoint.ipv4Relay,
+            ipv6Relay: self.endpoint.ipv6Relay,
+            hostname: self.relay.hostname,
+            location: self.location
+        )
+    }
+}
+
 struct RelaySelector {
 
     private let relays: ServerRelaysResponse

--- a/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
@@ -15,30 +15,25 @@ import Logging
 
 class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
 
+    private enum ExclusivityCategory {
+        case exclusive
+    }
+
     private var connectionInfo: TunnelConnectionInfo?
     private let logger = Logger(label: "SimulatorTunnelProviderHost")
 
-    func startTunnel(options: [String: Any]?, completionHandler: @escaping (Error?) -> Void) {
-        DispatchQueue.main.async {
-            self.connectionInfo = TunnelConnectionInfo(
-                ipv4Relay: IPv4Endpoint(ip: IPv4Address("10.0.0.1")!, port: 53),
-                ipv6Relay: nil,
-                hostname: "au4-wireguard",
-                location: Location(
-                    country: "Australia",
-                    countryCode: "au",
-                    city: "Melbourne",
-                    cityCode: "mel",
-                    latitude: -37.815018,
-                    longitude: 144.946014
-                )
-            )
+    private let operationQueue = OperationQueue()
+    private lazy var exclusivityController = ExclusivityController<ExclusivityCategory>(operationQueue: operationQueue)
 
+    override func startTunnel(options: [String: Any]?, completionHandler: @escaping (Error?) -> Void) {
+        let startOperation = makeStartOperation()
+        startOperation.addDidFinishBlockObserver(queue: .main) { _ in
             completionHandler(nil)
         }
+        exclusivityController.addOperation(startOperation, categories: [.exclusive])
     }
 
-    func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+    override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         DispatchQueue.main.async {
             self.connectionInfo = nil
 
@@ -46,14 +41,28 @@ class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
         }
     }
 
-    func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
+    override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
         DispatchQueue.main.async {
             let result = PacketTunnelIpcHandler.decodeRequest(messageData: messageData)
             switch result {
             case .success(let request):
                 switch request {
                 case .reloadTunnelSettings:
-                    self.replyAppMessage(true, completionHandler: completionHandler)
+                    let operationObserver = OperationBlockObserver<AsyncBlockOperation>(
+                        queue: .main,
+                        willExecute: { _ in
+                            self.reasserting = true
+                        },
+                        willFinish: { _ in
+                            self.reasserting = false
+                        },
+                        didFinish: { _ in
+                            self.replyAppMessage(true, completionHandler: completionHandler)
+                        })
+
+                    let startOperation = self.makeStartOperation()
+                    startOperation.addObserver(operationObserver)
+                    self.exclusivityController.addOperation(startOperation, categories: [.exclusive])
 
                 case .tunnelInformation:
                     self.replyAppMessage(self.connectionInfo, completionHandler: completionHandler)
@@ -65,8 +74,7 @@ class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
         }
     }
 
-    private func replyAppMessage<T: Codable>(_ response: T, completionHandler: ((Data?) -> Void)?)
-    {
+    private func replyAppMessage<T: Codable>(_ response: T, completionHandler: ((Data?) -> Void)?) {
         switch PacketTunnelIpcHandler.encodeResponse(response: response) {
         case .success(let data):
             completionHandler?(data)
@@ -74,6 +82,45 @@ class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
         case .failure(let error):
             self.logger.error(chainedError: error)
             completionHandler?(nil)
+        }
+    }
+
+    private func makeStartOperation() -> AsyncBlockOperation {
+        return AsyncBlockOperation { [weak self] (finish) in
+            guard let self = self else {
+                finish()
+                return
+            }
+
+            self.pickRelay { (selectorResult) in
+                DispatchQueue.main.async {
+                    self.connectionInfo = selectorResult?.tunnelConnectionInfo
+                    finish()
+                }
+            }
+        }
+    }
+
+    private func pickRelay(completion: @escaping (RelaySelectorResult?) -> Void) {
+        RelayCache.shared.read { (result) in
+            switch result {
+            case .success(let cachedRelays):
+                let keychainReference = self.protocolConfiguration.passwordReference!
+                switch TunnelSettingsManager.load(searchTerm: .persistentReference(keychainReference)) {
+                case .success(let entry):
+                    let relayConstraints = entry.tunnelSettings.relayConstraints
+                    let relaySelector = RelaySelector(relays: cachedRelays.relays)
+                    let selectorResult = relaySelector.evaluate(with: relayConstraints)
+                    completion(selectorResult)
+
+                case .failure(let error):
+                    self.logger.error(chainedError: error)
+                    completion(nil)
+                }
+            case .failure(let error):
+                self.logger.error(chainedError: error)
+                completion(nil)
+            }
         }
     }
 

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -539,17 +539,6 @@ extension PacketTunnelState: CustomStringConvertible, CustomDebugStringConvertib
     }
 }
 
-extension RelaySelectorResult {
-    var tunnelConnectionInfo: TunnelConnectionInfo {
-        return TunnelConnectionInfo(
-            ipv4Relay: self.endpoint.ipv4Relay,
-            ipv6Relay: self.endpoint.ipv6Relay,
-            hostname: self.relay.hostname,
-            location: self.location
-        )
-    }
-}
-
 extension WireGuardLogLevel {
     var loggerLevel: Logger.Level {
         switch self {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR makes simulated VPN tunnel (when running on iOS Simulator) to behave closer to the real one (when running on device), including emitting the `reasserting` events when "reconnecting" the tunnel and selecting relays with `RelaySelector`.

1. Add relay selector into the simulated tunnel.
1. Add `willExecute` observer to `AsyncOperation`
1. Emit `reasserting` events when reconnecting the simulated tunnel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2588)
<!-- Reviewable:end -->
