### PR TITLE
Add logging to the Windows uninstaller

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -546,6 +546,8 @@
 #
 !macro ClearFirewallRules
 
+	log::Log "ClearFirewallRules()"
+
 	Push $0
 	Push $1
 
@@ -553,7 +555,11 @@
 	Pop $0
 	Pop $1
 
-	log::Log "Resetting firewall: $0 $1"
+	${If} $0 != ${MVSETUP_OK}
+		log::LogWithDetails "ClearFirewallRules() failed" $1
+	${Else}
+		log::Log "ClearFirewallRules() completed successfully"
+	${EndIf}
 
 	Pop $1
 	Pop $0
@@ -569,6 +575,8 @@
 #
 !macro ClearAccountHistory
 
+	log::Log "ClearAccountHistory()"
+
 	Push $0
 	Push $1
 
@@ -576,7 +584,11 @@
 	Pop $0
 	Pop $1
 
-	log::Log "Remove account history: $0 $1"
+	${If} $0 != ${MVSETUP_OK}
+		log::LogWithDetails "ClearAccountHistory() failed" $1
+	${Else}
+		log::Log "ClearAccountHistory() completed successfully"
+	${EndIf}
 
 	Pop $1
 	Pop $0

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -33,8 +33,8 @@
 !define DL_GENERAL_SUCCESS 0
 
 # Log targets
-!define LOG_FILE 0
-!define LOG_VOID 1
+!define LOG_INSTALL 0
+!define LOG_UNINSTALL 1
 
 # Windows error codes
 !define ERROR_SERVICE_DOES_NOT_EXIST 1060
@@ -699,7 +699,7 @@
 
 	Push $R0
 
-	log::Initialize ${LOG_FILE}
+	log::Initialize ${LOG_INSTALL}
 
 	log::Log "Running installer for ${PRODUCT_NAME} ${VERSION}"
 	log::LogWindowsVersion
@@ -798,19 +798,19 @@
 	Var /GLOBAL Silent
 	Var /GLOBAL NewVersion
 
+	log::Initialize ${LOG_UNINSTALL}
+
+	log::Log "Running uninstaller for ${PRODUCT_NAME} ${VERSION}"
+
 	${GetParameters} $0
 	${GetOptions} $0 "/S" $1
 	${If} ${Errors}
 		Push 0
-		log::Initialize ${LOG_VOID}
 	${Else}
 		Push 1
-		log::Initialize ${LOG_FILE}
 	${EndIf}
 
 	Pop $Silent
-
-	log::Log "Running uninstaller for ${PRODUCT_NAME} ${VERSION}"
 
 	${ExtractMullvadSetup}
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -35,6 +35,7 @@
 # Log targets
 !define LOG_INSTALL 0
 !define LOG_UNINSTALL 1
+!define LOG_VOID 2
 
 # Windows error codes
 !define ERROR_SERVICE_DOES_NOT_EXIST 1060
@@ -650,7 +651,7 @@
 	Push $1
 	Push $R0
 
-	log::Initialize ${LOG_INSTALL}
+	log::SetLogTarget ${LOG_INSTALL}
 
 	log::Log "Running installer for ${PRODUCT_NAME} ${VERSION}"
 	log::LogWindowsVersion
@@ -859,7 +860,7 @@
 	Var /GLOBAL Silent
 	Var /GLOBAL NewVersion
 
-	log::Initialize ${LOG_UNINSTALL}
+	log::SetLogTarget ${LOG_UNINSTALL}
 
 	log::Log "Running uninstaller for ${PRODUCT_NAME} ${VERSION}"
 
@@ -940,6 +941,8 @@
 		${ExtractWintun}
 		${RemoveWintun}
 
+		log::SetLogTarget ${LOG_VOID}
+
 		${RemoveLogsAndCache}
 		${If} $Silent != 1
 			MessageBox MB_ICONQUESTION|MB_YESNO "Would you like to remove settings files as well?" IDNO customRemoveFiles_after_remove_settings
@@ -947,6 +950,8 @@
 		${EndIf}
 		customRemoveFiles_after_remove_settings:
 	${Else}
+		log::SetLogTarget ${LOG_VOID}
+
 		SetShellVarContext all
 		Delete "$LOCALAPPDATA\Mullvad VPN\uninstall.log"
 	${EndIf}

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -46,6 +46,7 @@
 !define MVSETUP_OK 0
 !define MVSETUP_ERROR 1
 !define MVSETUP_VERSION_NOT_OLDER 2
+!define MVSETUP_DAEMON_NOT_RUNNING 3
 
 # Override electron-builder generated application settings key.
 # electron-builder uses a GUID here rather than the application name.
@@ -916,7 +917,12 @@
 		Pop $0
 		Pop $1
 
-		# Ignore any errors -- the command will fail if the daemon is not running
+		${If} $0 != ${MVSETUP_OK}
+		${AndIf} $0 != ${MVSETUP_DAEMON_NOT_RUNNING}
+			StrCpy $R0 "Failed to send prepare-restart to service"
+			log::LogWithDetails $R0 $1
+			Goto customRemoveFiles_abort
+		${EndIf}
 	${EndIf}
 
 	${StopAndDeleteService}

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -19,6 +19,16 @@ enum ExitStatus {
     Ok = 0,
     Error = 1,
     VersionNotOlder = 2,
+    DaemonNotRunning = 3,
+}
+
+impl From<Error> for ExitStatus {
+    fn from(error: Error) -> ExitStatus {
+        match error {
+            Error::RpcConnectionError(_) => ExitStatus::DaemonNotRunning,
+            _ => ExitStatus::Error,
+        }
+    }
 }
 
 #[cfg(windows)]
@@ -112,7 +122,7 @@ async fn main() {
 
     if let Err(e) = result {
         eprintln!("{}", e.display_chain());
-        process::exit(ExitStatus::Error as i32);
+        process::exit(ExitStatus::from(e) as i32);
     }
 }
 

--- a/windows/nsis-plugins/src/log/log.cpp
+++ b/windows/nsis-plugins/src/log/log.cpp
@@ -184,17 +184,18 @@ std::wstring GetWindowsVersion()
 } // anonymous namespace
 
 //
-// Initialize
+// SetLogTarget
 //
 // Opens and maintains an open handle to the log file.
 //
 enum class LogTarget
 {
 	LOG_INSTALL = 0,
-	LOG_UNINSTALL = 1
+	LOG_UNINSTALL = 1,
+	LOG_VOID = 2
 };
 
-void __declspec(dllexport) NSISCALL Initialize
+void __declspec(dllexport) NSISCALL SetLogTarget
 (
 	HWND hwndParent,
 	int string_size,
@@ -224,6 +225,12 @@ void __declspec(dllexport) NSISCALL Initialize
 			{
 				logfile = L"uninstall.log";
 				break;
+			}
+			case static_cast<int>(LogTarget::LOG_VOID):
+			{
+				delete g_logger;
+				g_logger = nullptr;
+				return;
 			}
 			default:
 			{
@@ -263,7 +270,7 @@ void __declspec(dllexport) NSISCALL Initialize
 	{
 		std::stringstream ss;
 
-		ss << "Failed to initialize logging plugin."
+		ss << "Failed to set logging plugin target."
 			<< std::endl
 			<< err.what();
 

--- a/windows/nsis-plugins/src/log/log.def
+++ b/windows/nsis-plugins/src/log/log.def
@@ -2,7 +2,7 @@ LIBRARY log
 
 EXPORTS
 
-Initialize
+SetLogTarget
 Log
 LogWithDetails
 LogWindowsVersion


### PR DESCRIPTION
This adds logging to the uninstaller. It also ensures that the uninstaller aborts if a serious error occurs. If the uninstaller aborts, the log file (`uninstall.log`) is kept. Otherwise, it is deleted. The presence of the log file is also used (imperfectly) to infer whether a previous version was removed. If it exists, the installer aborts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2590)
<!-- Reviewable:end -->
