### PR TITLE
Improve Linux offline monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Line wrap the file at 100 chars.                                              Th
 - Stop using NM for managing DNS if it's newer than 1.26.
 - Fix DNS issues where NM would overwrite Mullvad tunnel's DNS config in systemd-resolved.
 - Fix issues with hosts where the firewall is doing reverse path filtering.
+- Further improve offline monitor to properly receive `ENETUNREACH`.
 
 #### Android
 - Fix input area sometimes disappearing when returning to the Login screen.


### PR DESCRIPTION
Previously, Linux connection check would request routes via NLM_F_REQUEST | NLM_F_DUMP, which would just return a list regardless of actual connectivity in some cases, sometimes having a loopback route, sometimes a real one. The end result was that the offline monitor was too permissive.  If this causes issues for users, they should probably use an env var to force the offline monitor off.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2591)
<!-- Reviewable:end -->
