### PR TITLE
Warn when adding a local custom DNS server and "Allow LAN" is disabled

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -125,7 +125,8 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
     private suspend fun confirmAddAddress(address: InetAddress): Boolean {
         return when {
             address.isLinkLocalAddress() || address.isSiteLocalAddress() -> {
-                showConfirmDnsServerDialog(R.string.confirm_local_dns)
+                settingsListener.settings.allowLan ||
+                    showConfirmDnsServerDialog(R.string.confirm_local_dns)
             }
             else -> showConfirmDnsServerDialog(R.string.confirm_public_dns)
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -140,8 +140,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
         detachBackButtonHandler()
         transaction.addToBackStack(null)
 
-        ConfirmDnsDialogFragment()
-            .also { dialog -> dialog.confirmation = confirmation }
+        ConfirmDnsDialogFragment(confirmation)
             .show(transaction, null)
 
         jobTracker.newUiJob("restoreBackButtonHandler") {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -123,21 +123,22 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
     }
 
     private suspend fun confirmAddAddress(address: InetAddress): Boolean {
-        return if (address.isLinkLocalAddress() || address.isSiteLocalAddress()) {
-            return true
-        } else {
-            showConfirmDnsServerDialog()
+        return when {
+            address.isLinkLocalAddress() || address.isSiteLocalAddress() -> {
+                showConfirmDnsServerDialog(R.string.confirm_local_dns)
+            }
+            else -> showConfirmDnsServerDialog(R.string.confirm_public_dns)
         }
     }
 
-    private suspend fun showConfirmDnsServerDialog(): Boolean {
+    private suspend fun showConfirmDnsServerDialog(message: Int): Boolean {
         val confirmation = CompletableDeferred<Boolean>()
         val transaction = parentFragmentManager.beginTransaction()
 
         detachBackButtonHandler()
         transaction.addToBackStack(null)
 
-        ConfirmDnsDialogFragment(R.string.confirm_public_dns, confirmation)
+        ConfirmDnsDialogFragment(message, confirmation)
             .show(transaction, null)
 
         val result = confirmation.await()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -129,12 +129,12 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
         val confirmation = CompletableDeferred<Boolean>()
 
-        showConfirmPublicDnsServerDialog(confirmation)
+        showConfirmDnsServerDialog(confirmation)
 
         return confirmation.await()
     }
 
-    private fun showConfirmPublicDnsServerDialog(confirmation: CompletableDeferred<Boolean>) {
+    private fun showConfirmDnsServerDialog(confirmation: CompletableDeferred<Boolean>) {
         val transaction = parentFragmentManager.beginTransaction()
 
         detachBackButtonHandler()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -140,8 +140,8 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
         detachBackButtonHandler()
         transaction.addToBackStack(null)
 
-        ConfirmPublicDnsDialogFragment()
-            .apply { confirmPublicDns = confirmation }
+        ConfirmDnsDialogFragment()
+            .also { dialog -> dialog.confirmation = confirmation }
             .show(transaction, null)
 
         jobTracker.newUiJob("restoreBackButtonHandler") {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -137,7 +137,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
         detachBackButtonHandler()
         transaction.addToBackStack(null)
 
-        ConfirmDnsDialogFragment(confirmation)
+        ConfirmDnsDialogFragment(R.string.confirm_public_dns, confirmation)
             .show(transaction, null)
 
         val result = confirmation.await()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
@@ -9,11 +9,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.widget.Button
+import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import kotlinx.coroutines.CompletableDeferred
 import net.mullvad.mullvadvpn.R
 
 class ConfirmDnsDialogFragment @JvmOverloads constructor(
+    private val message: Int = R.string.confirm_public_dns,
     private var confirmation: CompletableDeferred<Boolean>? = null
 ) : DialogFragment() {
     override fun onCreateView(
@@ -22,6 +24,8 @@ class ConfirmDnsDialogFragment @JvmOverloads constructor(
         savedInstanceState: Bundle?
     ): View {
         val view = inflater.inflate(R.layout.confirm_dns, container, false)
+
+        view.findViewById<TextView>(R.id.message).setText(message)
 
         view.findViewById<Button>(R.id.back_button).setOnClickListener {
             activity?.onBackPressed()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
@@ -13,9 +13,9 @@ import androidx.fragment.app.DialogFragment
 import kotlinx.coroutines.CompletableDeferred
 import net.mullvad.mullvadvpn.R
 
-class ConfirmDnsDialogFragment : DialogFragment() {
-    var confirmation: CompletableDeferred<Boolean>? = null
-
+class ConfirmDnsDialogFragment @JvmOverloads constructor(
+    private var confirmation: CompletableDeferred<Boolean>? = null
+) : DialogFragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
@@ -21,7 +21,7 @@ class ConfirmDnsDialogFragment @JvmOverloads constructor(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val view = inflater.inflate(R.layout.confirm_public_dns, container, false)
+        val view = inflater.inflate(R.layout.confirm_dns, container, false)
 
         view.findViewById<Button>(R.id.back_button).setOnClickListener {
             activity?.onBackPressed()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConfirmDnsDialogFragment.kt
@@ -13,8 +13,8 @@ import androidx.fragment.app.DialogFragment
 import kotlinx.coroutines.CompletableDeferred
 import net.mullvad.mullvadvpn.R
 
-class ConfirmPublicDnsDialogFragment : DialogFragment() {
-    var confirmPublicDns: CompletableDeferred<Boolean>? = null
+class ConfirmDnsDialogFragment : DialogFragment() {
+    var confirmation: CompletableDeferred<Boolean>? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -28,8 +28,8 @@ class ConfirmPublicDnsDialogFragment : DialogFragment() {
         }
 
         view.findViewById<Button>(R.id.confirm_button).setOnClickListener {
-            confirmPublicDns?.complete(true)
-            confirmPublicDns = null
+            confirmation?.complete(true)
+            confirmation = null
             dismiss()
         }
 
@@ -49,17 +49,17 @@ class ConfirmPublicDnsDialogFragment : DialogFragment() {
 
         dialog?.window?.setLayout(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
 
-        if (confirmPublicDns == null) {
+        if (confirmation == null) {
             dismiss()
         }
     }
 
     override fun onDismiss(dialogInterface: DialogInterface) {
-        confirmPublicDns?.complete(false)
+        confirmation?.complete(false)
     }
 
     override fun onDestroy() {
-        confirmPublicDns?.cancel()
+        confirmation?.cancel()
 
         super.onDestroy()
     }

--- a/android/src/main/res/layout/confirm_dns.xml
+++ b/android/src/main/res/layout/confirm_dns.xml
@@ -20,7 +20,7 @@
                   android:layout_marginTop="16dp"
                   android:textColor="@color/white80"
                   android:textSize="@dimen/text_small"
-                  android:text="@string/confirm_public_dns" />
+                  android:text="" />
         <Button android:id="@+id/confirm_button"
                 android:layout_marginVertical="@dimen/button_separation"
                 android:text="@string/add_anyway"

--- a/android/src/main/res/layout/confirm_dns.xml
+++ b/android/src/main/res/layout/confirm_dns.xml
@@ -13,7 +13,8 @@
                    android:layout_marginTop="8dp"
                    android:layout_gravity="center"
                    android:src="@drawable/icon_alert" />
-        <TextView android:layout_width="wrap_content"
+        <TextView android:id="@+id/message"
+                  android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:layout_weight="0"
                   android:layout_marginTop="16dp"

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -170,6 +170,8 @@
     <string name="add_a_server">Add a server</string>
     <string name="custom_dns_example">e.g. 10.0.0.4</string>
     <string name="custom_dns_footer">Enable to add at least one DNS server.</string>
+    <string name="confirm_local_dns">The local DNS server will not work unless you enable \"Local
+    Network Sharing\" under Preferences.</string>
     <string name="confirm_public_dns">The DNS server you are trying to add might not work because
     it is public. Currently we only support local DNS servers.</string>
     <string name="add_anyway">Add anyway</string>


### PR DESCRIPTION
The ability to configure custom DNS servers was recently introduced (#2331). However, because the relay will intercept DNS requests sent through the tunnel, currently only DNS requests sent out of the tunnel (to the local LAN) work. There already was a warning when adding custom DNS servers that have a public IP, so that the user is aware that it won't work. This PR adds another warning saying that the "Allow LAN" setting must be enabled to allow the DNS requests to reach the local DNS server. The warning is not shown if "Allow LAN" is already enabled.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Part of the custom DNS feature for Android, which already has a changelog entry.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2592)
<!-- Reviewable:end -->
