### PR TITLE
Initialize `HeaderBar` tunnel state to force painting the status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Fix input area sometimes disappearing when returning to the Login screen.
+- Fix status bar having the wrong color after logging out.
 
 
 ## [2021.2] - 2021-02-18

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/HeaderBar.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/HeaderBar.kt
@@ -53,5 +53,7 @@ class HeaderBar @JvmOverloads constructor(
         findViewById<View>(R.id.settings).setOnClickListener {
             (context as? MainActivity)?.openSettings()
         }
+
+        tunnelState = null
     }
 }


### PR DESCRIPTION
When logging out, the status bar keeps the last color of the header bar, while the login screen's header bar is reset to the default color (blue). This may lead to confusion, since the bar might be green while actually the tunnel is disconnected.

This PR fixes that by forcefully setting the `HeaderBar` widget's `tunnelState` to `null` when it is created, so that the setter repaints the status bar.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2594)
<!-- Reviewable:end -->
