### PR TITLE
Paint the navigation bar for the Login screen

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
@@ -17,7 +18,7 @@ import net.mullvad.mullvadvpn.ui.widget.AccountLogin
 import net.mullvad.mullvadvpn.ui.widget.Button
 import org.joda.time.DateTime
 
-class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
+class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen), NavigationBarPainter {
     enum class LoginResult {
         ExistingAccountWithTime,
         ExistingAccountOutOfTime,
@@ -104,6 +105,11 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
                 false
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        paintNavigationBar(ContextCompat.getColor(requireContext(), R.color.darkBlue))
     }
 
     override fun onSafelyStop() {


### PR DESCRIPTION
The login screen currently doesn't automatically paint the navigation bar, which then ends up using the default blue color. However, the bottom of the login screen is painted dark blue, which leads to a minor inconsistency. This PR fixes that by painting the navigation bar dark blue.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2595)
<!-- Reviewable:end -->
