### PR TITLE
Partially deserialize settings to reduce duplication in settings migration

### DIFF
--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -1,78 +1,33 @@
-use super::{Error, Result, VersionedSettings};
+use super::{Error, Result};
 use crate::{
     custom_tunnel::CustomTunnelEndpoint,
     relay_constraints::{
-        BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
-        OpenVpnConstraints, RelaySettings as NewRelaySettings, WireguardConstraints,
+        Constraint, LocationConstraint, OpenVpnConstraints, RelaySettings as NewRelaySettings,
+        WireguardConstraints,
     },
-    settings::TunnelOptions,
 };
 use serde::{Deserialize, Serialize};
-use std::io::Read;
 use talpid_types::net::TunnelType;
 
 
-/// Mullvad daemon settings.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
-pub struct Settings {
-    account_token: Option<String>,
-    relay_settings: RelaySettings,
-    bridge_settings: BridgeSettings,
-    bridge_state: BridgeState,
-    /// If the daemon should allow communication with private (LAN) networks.
-    allow_lan: bool,
-    /// Extra level of kill switch. When this setting is on, the disconnected state will block
-    /// the firewall to not allow any traffic in or out.
-    block_when_disconnected: bool,
-    /// If the daemon should connect the VPN tunnel directly on start or not.
-    auto_connect: bool,
-    /// Options that should be applied to tunnels of a specific type regardless of where the relays
-    /// might be located.
-    tunnel_options: TunnelOptions,
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Settings {
-            account_token: None,
-            relay_settings: RelaySettings::Normal(RelayConstraints {
-                location: Constraint::Only(LocationConstraint::Country("se".to_owned())),
-                tunnel: Constraint::Any,
-            }),
-            bridge_settings: BridgeSettings::Normal(BridgeConstraints::default()),
-            bridge_state: BridgeState::Auto,
-            allow_lan: false,
-            block_when_disconnected: false,
-            auto_connect: false,
-            tunnel_options: TunnelOptions::default(),
-        }
-    }
-}
-
 pub(super) struct Migration;
+
 impl super::SettingsMigration for Migration {
-    fn read(&self, mut reader: &mut dyn Read) -> Result<VersionedSettings> {
-        serde_json::from_reader(&mut reader)
-            .map(VersionedSettings::V1)
-            .map_err(Error::ParseError)
+    fn version_matches(&self, settings: &mut serde_json::Value) -> bool {
+        settings.get("settings_version").is_none()
     }
-    fn migrate(&self, old: VersionedSettings) -> VersionedSettings {
-        match old {
-            VersionedSettings::V1(old) => VersionedSettings::V2(crate::settings::Settings {
-                account_token: old.account_token,
-                relay_settings: migrate_relay_settings(old.relay_settings),
-                bridge_settings: old.bridge_settings,
-                bridge_state: old.bridge_state,
-                allow_lan: old.allow_lan,
-                block_when_disconnected: old.block_when_disconnected,
-                auto_connect: old.auto_connect,
-                tunnel_options: old.tunnel_options,
-                show_beta_releases: false,
-                settings_version: super::SettingsVersion::V2,
-            }),
-            VersionedSettings::V2(new) => VersionedSettings::V2(new),
-        }
+
+    fn migrate(&self, settings: &mut serde_json::Value) -> Result<()> {
+        let old_relay_settings: RelaySettings =
+            serde_json::from_value(settings["relay_settings"].clone())
+                .map_err(Error::ParseError)?;
+        let new_relay_settings = migrate_relay_settings(old_relay_settings);
+
+        settings["relay_settings"] = serde_json::json!(new_relay_settings);
+        settings["show_beta_releases"] = serde_json::json!(false);
+        settings["settings_version"] = serde_json::json!(super::SettingsVersion::V2);
+
+        Ok(())
     }
 }
 
@@ -124,56 +79,10 @@ pub enum TunnelConstraints {
 
 #[cfg(test)]
 mod test {
-    use super::super::SettingsMigration;
+    use super::super::try_migrate_settings;
     use serde_json;
-    const OLD_SETTINGS: &str = r#"
-{
-  "account_token": "1234",
-  "relay_settings": {
-    "normal": {
-      "location": {
-        "only": {
-          "country": "se"
-        }
-      },
-      "tunnel": {
-        "only": {
-          "openvpn": {
-            "port": {
-              "only": 53
-            },
-            "protocol": {
-              "only": "udp"
-            }
-          }
-        }
-      }
-    }
-  },
-  "bridge_settings": {
-    "normal": {
-      "location": "any"
-    }
-  },
-  "bridge_state": "auto",
-  "allow_lan": true,
-  "block_when_disconnected": false,
-  "auto_connect": false,
-  "tunnel_options": {
-    "openvpn": {
-      "mssfix": null
-    },
-    "wireguard": {
-      "mtu": null
-    },
-    "generic": {
-      "enable_ipv6": false
-    }
-  }
-}
-"#;
 
-    const NEW_SETTINGS: &str = r#"
+    pub const NEW_SETTINGS: &str = r#"
 {
   "account_token": "1234",
   "relay_settings": {
@@ -221,7 +130,54 @@ mod test {
 }
 "#;
 
-    const SETTINGS_2019V3: &str = r#"
+    const V1_SETTINGS: &str = r#"
+{
+  "account_token": "1234",
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "country": "se"
+        }
+      },
+      "tunnel": {
+        "only": {
+          "openvpn": {
+            "port": {
+              "only": 53
+            },
+            "protocol": {
+              "only": "udp"
+            }
+          }
+        }
+      }
+    }
+  },
+  "bridge_settings": {
+    "normal": {
+      "location": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    }
+  }
+}
+"#;
+
+    const V1_SETTINGS_2019V3: &str = r#"
 {
   "account_token": "1234",
   "relay_settings": {
@@ -265,34 +221,20 @@ mod test {
 "#;
 
     #[test]
-    fn test_migration() {
-        let m = super::Migration;
-        let old_settings = m
-            .read(&mut OLD_SETTINGS.as_bytes())
-            .expect("Failed to deserialize old format");
-        let new_settings = serde_json::from_str(&NEW_SETTINGS).unwrap();
+    fn test_v1_migration() {
+        let migrated_settings =
+            try_migrate_settings(V1_SETTINGS.as_bytes()).expect("Migration failed");
+        let new_settings = serde_json::from_str(NEW_SETTINGS).unwrap();
 
-        assert_eq!(&m.migrate(old_settings).unwrap(), &new_settings);
+        assert_eq!(&migrated_settings, &new_settings);
     }
 
     #[test]
-    #[should_panic]
-    fn test_deserialization_failure() {
-        let m = super::Migration;
-        m.read(&mut NEW_SETTINGS.as_bytes())
-            .expect("Failed to deserialize old format");
-    }
+    fn test_v1_2019v3_migration() {
+        let migrated_settings =
+            try_migrate_settings(V1_SETTINGS_2019V3.as_bytes()).expect("Migration failed");
+        let new_settings = serde_json::from_str(NEW_SETTINGS).unwrap();
 
-    #[test]
-    fn test_2019v3_migration() {
-        let m = super::Migration;
-        let old_settings = m
-            .read(&mut SETTINGS_2019V3.as_bytes())
-            .expect("Failed to deserialize old format");
-
-        let new_settings = serde_json::from_str(&NEW_SETTINGS).unwrap();
-
-
-        assert_eq!(&m.migrate(old_settings).unwrap(), &new_settings);
+        assert_eq!(&migrated_settings, &new_settings);
     }
 }


### PR DESCRIPTION
Previously, `Settings` was duplicated in the migration module. This would result in lots of duplicate types (even for minor changes), and it also risked breaking if any of the non-duplicated types changed. A `serde_json::Value` is now passed to the migration code instead, so that only relevant parts need to be deserialized or modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2599)
<!-- Reviewable:end -->
