### PR TITLE
Make key rotation mandatory and at most 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Line wrap the file at 100 chars.                                              Th
 - Shrink account history capactity from 3 account entries to 1.
 - Allow whitespace in account token in CLI.
 - Read account token from standard input unless given as an argument in CLI.
+- Make WireGuard automatic key rotation interval mandatory and between 1 and 7 days.
+- Show default, minimum, and maximum key rotation intervals in CLI.
 
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -606,9 +606,8 @@ impl ManagementService for ManagementServiceImpl {
         let interval: RotationInterval = Duration::try_from(request.into_inner())
             .map_err(|_| Status::invalid_argument("unexpected negative rotation interval"))?
             .try_into()
-            .map_err(|error| match error {
-                RotationIntervalError::TooSmall => Status::invalid_argument("interval too small"),
-                RotationIntervalError::TooLarge => Status::invalid_argument("interval too large"),
+            .map_err(|error: RotationIntervalError| {
+                Status::invalid_argument(error.display_chain())
             })?;
 
         log::debug!("set_wireguard_rotation_interval({:?})", interval);

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -2,6 +2,7 @@ use log::{debug, error, info};
 use mullvad_types::{
     relay_constraints::{BridgeSettings, BridgeState, RelaySettingsUpdate},
     settings::{DnsOptions, Settings},
+    wireguard::RotationInterval,
 };
 use std::{
     fs::{self, File},
@@ -224,11 +225,11 @@ impl SettingsPersister {
 
     pub fn set_wireguard_rotation_interval(
         &mut self,
-        automatic_rotation: Option<u32>,
+        interval: Option<RotationInterval>,
     ) -> Result<bool, Error> {
         let should_save = Self::update_field(
-            &mut self.settings.tunnel_options.wireguard.automatic_rotation,
-            automatic_rotation,
+            &mut self.settings.tunnel_options.wireguard.rotation_interval,
+            interval,
         );
         self.update(should_save)
     }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -5,6 +5,7 @@ package mullvad_daemon.management_interface;
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/duration.proto";
 
 service ManagementService {
 	// Control and get tunnel state
@@ -52,7 +53,7 @@ service ManagementService {
 	rpc SubmitVoucher(google.protobuf.StringValue) returns (VoucherSubmission) {}
 
 	// WireGuard key management
-	rpc SetWireguardRotationInterval(google.protobuf.UInt32Value) returns (google.protobuf.Empty) {}
+	rpc SetWireguardRotationInterval(google.protobuf.Duration) returns (google.protobuf.Empty) {}
 	rpc ResetWireguardRotationInterval(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 	rpc GenerateWireguardKey(google.protobuf.Empty) returns (KeygenEvent) {}
 	rpc GetWireguardKey(google.protobuf.Empty) returns (PublicKey) {}
@@ -360,13 +361,9 @@ message TunnelOptions {
 		uint32 mssfix = 1;
 	}
 	message WireguardOptions {
-		message RotationInterval {
-			uint32 interval = 1;
-		}
-
 		// NOTE: optional
 		uint32 mtu = 1;
-		RotationInterval automatic_rotation = 2;
+		google.protobuf.Duration rotation_interval = 2;
 	}
 	message GenericOptions {
 		bool enable_ipv6 = 1;

--- a/mullvad-management-interface/src/lib.rs
+++ b/mullvad-management-interface/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod types {
     tonic::include_proto!("mullvad_daemon.management_interface");
 
-    pub use prost_types::Timestamp;
+    pub use prost_types::{Duration, Timestamp};
 }
 
 use parity_tokio_ipc::Endpoint as IpcEndpoint;

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -18,6 +18,8 @@ impl super::SettingsMigration for Migration {
     }
 
     fn migrate(&self, settings: &mut serde_json::Value) -> Result<()> {
+        log::info!("Migrating settings format to V2");
+
         let old_relay_settings: RelaySettings =
             serde_json::from_value(settings["relay_settings"].clone())
                 .map_err(Error::ParseError)?;

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -126,7 +126,7 @@ mod test {
       "enable_ipv6": false
     }
   },
-  "settings_version": 2
+  "settings_version": 3
 }
 "#;
 

--- a/mullvad-types/src/settings/migrations/v2.rs
+++ b/mullvad-types/src/settings/migrations/v2.rs
@@ -1,0 +1,174 @@
+use super::{Error, Result, SettingsVersion};
+use crate::wireguard::{MAX_ROTATION_INTERVAL, MIN_ROTATION_INTERVAL};
+use std::time::Duration;
+
+
+pub(super) struct Migration;
+
+impl super::SettingsMigration for Migration {
+    fn version_matches(&self, settings: &mut serde_json::Value) -> bool {
+        settings
+            .get("settings_version")
+            .map(|version| version == SettingsVersion::V2 as u64)
+            .unwrap_or(false)
+    }
+
+    fn migrate(&self, settings: &mut serde_json::Value) -> Result<()> {
+        // `show_beta_releases` used to be nullable
+        if settings
+            .get_mut("show_beta_releases")
+            .map(|val| val.is_null())
+            .unwrap_or(false)
+        {
+            settings
+                .as_object_mut()
+                .ok_or(Error::NoMatchingVersion)?
+                .remove("show_beta_releases");
+        }
+
+        let automatic_rotation = || -> Option<u64> {
+            settings
+                .get("tunnel_options")?
+                .get("wireguard")?
+                .get("automatic_rotation")
+                .map(|ivl| ivl.as_u64())?
+        }();
+
+        if let Some(interval) = automatic_rotation {
+            let new_ivl = match Duration::from_secs(60 * 60 * interval) {
+                ivl if ivl < MIN_ROTATION_INTERVAL => {
+                    log::warn!("Increasing key rotation interval since it is below minimum");
+                    MIN_ROTATION_INTERVAL
+                }
+                ivl if ivl > MAX_ROTATION_INTERVAL => {
+                    log::warn!("Decreasing key rotation interval since it is above maximum");
+                    MAX_ROTATION_INTERVAL
+                }
+                ivl => ivl,
+            };
+
+            settings["tunnel_options"]["wireguard"]["rotation_interval"] =
+                serde_json::json!(new_ivl);
+        }
+
+        settings["settings_version"] = serde_json::json!(SettingsVersion::V3);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::try_migrate_settings;
+    use serde_json;
+
+    const V2_SETTINGS: &str = r#"
+{
+  "account_token": "1234",
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "country": "se"
+        }
+      },
+      "tunnel": {
+        "only": {
+          "openvpn": {
+            "port": {
+              "only": 53
+            },
+            "protocol": {
+              "only": "udp"
+            }
+          }
+        }
+      }
+    }
+  },
+  "bridge_settings": {
+    "normal": {
+      "location": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "automatic_rotation": 24
+    },
+    "generic": {
+      "enable_ipv6": false
+    }
+  }
+}
+"#;
+
+    pub const NEW_SETTINGS: &str = r#"
+{
+  "account_token": "1234",
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "country": "se"
+        }
+      },
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any"
+      },
+      "openvpn_constraints": {
+        "port": {
+          "only": 53
+        },
+        "protocol": {
+          "only": "udp"
+        }
+      }
+    }
+  },
+  "bridge_settings": {
+    "normal": {
+      "location": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "rotation_interval": {
+          "secs": 86400,
+          "nanos": 0
+      }
+    },
+    "generic": {
+      "enable_ipv6": false
+    }
+  },
+  "settings_version": 3
+}
+"#;
+
+
+    #[test]
+    fn test_v2_migration() {
+        let migrated_settings =
+            try_migrate_settings(V2_SETTINGS.as_bytes()).expect("Migration failed");
+        let new_settings = serde_json::from_str(NEW_SETTINGS).unwrap();
+
+        assert_eq!(&migrated_settings, &new_settings);
+    }
+}

--- a/mullvad-types/src/settings/migrations/v2.rs
+++ b/mullvad-types/src/settings/migrations/v2.rs
@@ -14,6 +14,8 @@ impl super::SettingsMigration for Migration {
     }
 
     fn migrate(&self, settings: &mut serde_json::Value) -> Result<()> {
+        log::info!("Migrating settings format to V3");
+
         // `show_beta_releases` used to be nullable
         if settings
             .get_mut("show_beta_releases")

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -55,7 +55,6 @@ pub struct Settings {
     /// might be located.
     pub tunnel_options: TunnelOptions,
     /// Whether to notify users of beta updates.
-    #[serde(deserialize_with = "deserialize_show_beta_releases")]
     pub show_beta_releases: bool,
     /// Specifies settings schema version
     #[cfg_attr(target_os = "android", jnix(skip))]
@@ -208,21 +207,14 @@ impl Default for TunnelOptions {
     }
 }
 
-/// Used to deserialize the `show_beta_releases` field in the settings struct, as it used to be
-/// a nullable field, but it is no longer.
-fn deserialize_show_beta_releases<'de, D: serde::de::Deserializer<'de>>(
-    field: D,
-) -> std::result::Result<bool, D::Error> {
-    Option::deserialize(field).map(|value| value.unwrap_or(false))
-}
 
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
-    fn test_deserialization_of_2020_4_format() {
-        let old_settings = br#"{
+    fn test_deserialization() {
+        let settings = br#"{
               "account_token": "0000000000000000",
               "relay_settings": {
                 "normal": {
@@ -258,16 +250,16 @@ mod test {
                 },
                 "wireguard": {
                   "mtu": null,
-                  "automatic_rotation": null
+                  "rotation_interval": null
                 },
                 "generic": {
                   "enable_ipv6": true
                 }
               },
-              "settings_version": 2,
-              "show_beta_releases": null
+              "settings_version": 3,
+              "show_beta_releases": false
         }"#;
 
-        let _ = Settings::load_from_bytes(old_settings).unwrap();
+        let _ = Settings::load_from_bytes(settings).unwrap();
     }
 }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -197,7 +197,7 @@ impl Default for TunnelOptions {
             openvpn: openvpn::TunnelOptions::default(),
             wireguard: wireguard::TunnelOptions {
                 options: net::wireguard::TunnelOptions::default(),
-                automatic_rotation: None,
+                rotation_interval: None,
             },
             generic: GenericTunnelOptions {
                 // Enable IPv6 be default on Android

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -1,9 +1,17 @@
 use chrono::{offset::Utc, DateTime};
 #[cfg(target_os = "android")]
 use jnix::IntoJava;
-use serde::{Deserialize, Serialize};
-use std::fmt;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{convert::TryFrom, fmt, time::Duration};
 use talpid_types::net::wireguard;
+
+pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_secs(1 * 24 * 60 * 60);
+pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+pub const DEFAULT_ROTATION_INTERVAL: Duration = if cfg!(target_os = "android") {
+    Duration::from_secs(4 * 24 * 60 * 60)
+} else {
+    Duration::from_secs(7 * 24 * 60 * 60)
+};
 
 /// Contains account specific wireguard data
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -24,6 +32,66 @@ impl WireguardData {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum RotationIntervalError {
+    TooSmall,
+    TooLarge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RotationInterval(Duration);
+
+impl RotationInterval {
+    pub fn new(interval: Duration) -> Result<RotationInterval, RotationIntervalError> {
+        if interval < MIN_ROTATION_INTERVAL {
+            Err(RotationIntervalError::TooSmall)
+        } else if interval > MAX_ROTATION_INTERVAL {
+            Err(RotationIntervalError::TooLarge)
+        } else {
+            Ok(RotationInterval(interval))
+        }
+    }
+
+    pub fn as_duration(&self) -> &Duration {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for RotationInterval {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let ivl = <Duration>::deserialize(deserializer)?;
+        RotationInterval::new(ivl).map_err(|_error| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Other("Duration"),
+                &"interval within allowed range",
+            )
+        })
+    }
+}
+
+impl TryFrom<Duration> for RotationInterval {
+    type Error = RotationIntervalError;
+
+    fn try_from(duration: Duration) -> Result<RotationInterval, RotationIntervalError> {
+        RotationInterval::new(duration)
+    }
+}
+
+impl From<RotationInterval> for Duration {
+    fn from(interval: RotationInterval) -> Duration {
+        *interval.as_duration()
+    }
+}
+
+impl Default for RotationInterval {
+    fn default() -> RotationInterval {
+        RotationInterval::new(DEFAULT_ROTATION_INTERVAL).unwrap()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(
@@ -33,9 +101,9 @@ impl WireguardData {
 pub struct TunnelOptions {
     #[serde(flatten)]
     pub options: wireguard::TunnelOptions,
-    /// Interval used for automatic key rotation, in hours
+    /// Interval used for automatic key rotation
     #[cfg_attr(target_os = "android", jnix(skip))]
-    pub automatic_rotation: Option<u32>,
+    pub rotation_interval: Option<RotationInterval>,
 }
 
 /// Represents a published public key

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -38,6 +38,27 @@ pub enum RotationIntervalError {
     TooLarge,
 }
 
+impl fmt::Display for RotationIntervalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use RotationIntervalError::*;
+
+        match *self {
+            TooSmall => write!(
+                f,
+                "Rotation interval must be at least {} hours",
+                MIN_ROTATION_INTERVAL.as_secs() / 60 / 60
+            ),
+            TooLarge => write!(
+                f,
+                "Rotation interval must be at most {} hours",
+                MAX_ROTATION_INTERVAL.as_secs() / 60 / 60
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RotationIntervalError {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct RotationInterval(Duration);
 


### PR DESCRIPTION
Changes:
* The minimum and maximum rotation intervals are now 1 day and 7 days, respectively.
* The CLI shows the default rotation interval now, as well as the minimum and maximum values if the provided value is out of range:
  ```bash
  $ mullvad tunnel wireguard key rotation-interval get
  Rotation interval: default (168 hours)

  $ mullvad tunnel wireguard key rotation-interval set 20
  error: Invalid value for '<interval>': interval must be at least 24 hours

  $ mullvad tunnel wireguard key rotation-interval set 200
  error: Invalid value for '<interval>': interval must be at most 168 hours
  ```
* The `deserialize_show_beta_releases` was removed by removing nulled values in migration code.
* The settings version was bumped to 3.
* `google.protobuf.Duration` is used instead of integers in protobufs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2601)
<!-- Reviewable:end -->
