### PR TITLE
Fix double quotes escaping when extracting missing Android translations

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -78,7 +78,7 @@
     will be attached to this message. Your data will remain secure and private, as it is anonymised
     before being sent over an encrypted channel.</string>
     <string name="user_email_hint">Your email (optional)</string>
-    <string name="user_message_hint">Please describe your problem in English or Swedish</string>
+    <string name="user_message_hint">Please describe your problem in English or Swedish.</string>
     <string name="view_logs">View app logs</string>
     <string name="send">Send</string>
     <string name="sending">Sending...</string>

--- a/android/translations-converter/src/android.rs
+++ b/android/translations-converter/src/android.rs
@@ -9,6 +9,7 @@ use std::{
 lazy_static! {
     static ref LINE_BREAKS: Regex = Regex::new(r"\s*\n\s*").unwrap();
     static ref APOSTROPHES: Regex = Regex::new(r"\\'").unwrap();
+    static ref DOUBLE_QUOTES: Regex = Regex::new(r#"\\""#).unwrap();
     static ref PARAMETERS: Regex = Regex::new(r"%[0-9]*\$").unwrap();
 }
 
@@ -316,6 +317,8 @@ impl StringValue {
         let value = LINE_BREAKS.replace_all(&self.0, " ");
         // Unescape apostrophes
         let value = APOSTROPHES.replace_all(&value, "'");
+        // Unescape double quotes
+        let value = DOUBLE_QUOTES.replace_all(&value, r#"""#);
         // Mark where parameters are positioned, removing the parameter index
         let value = PARAMETERS.replace_all(&value, "%");
 


### PR DESCRIPTION
Trying to update the translations template file revealed an issue with the Android translations converter tool. While it would properly add escaped double quotes to Android translations, it would not unescape these double quotes when extracting them to add them to the templates file. This PR fixes the issue by properly unescaping the double quotes when a `StringValue` type is normalized (i.e., unescaped and prepared for comparison with gettext translation messages).

This PR also adds a small fix to an Android string so that the tool can find it's respective translations correctly.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tool change, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2602)
<!-- Reviewable:end -->
