### PR TITLE
Create ApplicationsProvider and AppplicationsIcon cache

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,16 +124,18 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'joda-time:joda-time:2.10.2'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.10'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2"
 
     /* Test dependencies */
     testImplementation "io.mockk:mockk:$mockkVersion"
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
 }
 
 buildscript {
     ext {
+        kotlinVersion = '1.4.10'
         mockkVersion = '1.10.6'
     }
     repositories {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppData.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppData.kt
@@ -1,0 +1,3 @@
+package net.mullvad.mullvadvpn.applist
+
+data class AppData(val packageName: String, val iconRes: Int, val name: String)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsIconManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsIconManager.kt
@@ -1,0 +1,26 @@
+package net.mullvad.mullvadvpn.applist
+
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import android.os.Looper
+import androidx.annotation.WorkerThread
+import androidx.collection.LruCache
+
+class ApplicationsIconManager(private val packageManager: PackageManager) {
+    private val iconsCache = LruCache<String, Drawable>(500)
+
+    @WorkerThread
+    fun getAppIcon(packageName: String): Drawable {
+        check(!Looper.getMainLooper().isCurrentThread) { "Should not be called from MainThread" }
+        iconsCache.get(packageName)?.let {
+            return it
+        }
+        return packageManager.getApplicationIcon(packageName).also {
+            iconsCache.put(packageName, it)
+        }
+    }
+
+    fun dispose() {
+        iconsCache.evictAll()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProvider.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProvider.kt
@@ -1,0 +1,39 @@
+package net.mullvad.mullvadvpn.applist
+
+import android.Manifest
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+
+class ApplicationsProvider(
+    private val packageManager: PackageManager,
+    private val thisPackageName: String
+) {
+    private val applicationFilterPredicate: (ApplicationInfo) -> Boolean = { appInfo ->
+        hasInternetPermission(appInfo.packageName) &&
+            isLaunchable(appInfo.packageName) &&
+            !isSelfApplication(appInfo.packageName)
+    }
+
+    fun getAppsList(): List<AppData> {
+        return packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+            .asSequence()
+            .filter(applicationFilterPredicate)
+            .map { info ->
+                AppData(info.packageName, info.icon, info.loadLabel(packageManager).toString())
+            }
+            .toList()
+    }
+
+    private fun hasInternetPermission(packageName: String): Boolean {
+        return PackageManager.PERMISSION_GRANTED ==
+            packageManager.checkPermission(Manifest.permission.INTERNET, packageName)
+    }
+
+    private fun isLaunchable(packageName: String): Boolean {
+        return packageManager.getLaunchIntentForPackage(packageName) != null
+    }
+
+    private fun isSelfApplication(packageName: String): Boolean {
+        return packageName == thisPackageName
+    }
+}

--- a/android/src/test/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsIconManagerTest.kt
+++ b/android/src/test/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsIconManagerTest.kt
@@ -1,0 +1,98 @@
+package net.mullvad.mullvadvpn.applist
+
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import android.os.Looper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class ApplicationsIconManagerTest {
+    private val mockedPackageManager = mockk<PackageManager>()
+    private val mockedMainLooper = mockk<Looper>()
+    private val testSubject = ApplicationsIconManager(mockedPackageManager)
+
+    @Before
+    fun setUp() {
+        mockkStatic(Looper::class)
+        every { Looper.getMainLooper() } returns mockedMainLooper
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun test_first_time_load_icon_from_PM() {
+        val testPackageName = "test"
+        val mockedDrawable = mockk<Drawable>()
+        every { mockedPackageManager.getApplicationIcon(testPackageName) } returns mockedDrawable
+        every { mockedMainLooper.isCurrentThread } returns false
+
+        val result = testSubject.getAppIcon(testPackageName)
+
+        assertEquals(mockedDrawable, result)
+        verify {
+            mockedMainLooper.isCurrentThread
+            mockedPackageManager.getApplicationIcon(testPackageName)
+        }
+    }
+
+    @Test
+    fun test_second_time_load_icon_from_cache() {
+        val testPackageName = "test"
+        val mockedDrawable = mockk<Drawable>()
+        every { mockedPackageManager.getApplicationIcon(testPackageName) } returns mockedDrawable
+        every { mockedMainLooper.isCurrentThread } returns false
+
+        val result = testSubject.getAppIcon(testPackageName)
+        val result2 = testSubject.getAppIcon(testPackageName)
+
+        assertEquals(mockedDrawable, result)
+        assertEquals(mockedDrawable, result2)
+        verify(exactly = 2) {
+            mockedMainLooper.isCurrentThread
+        }
+        verify(exactly = 1) {
+            mockedPackageManager.getApplicationIcon(testPackageName)
+        }
+    }
+
+    @Test
+    fun test_second_time_load_icon_from_PM_after_clear() {
+        val testPackageName = "test"
+        val mockedDrawable = mockk<Drawable>()
+        every { mockedPackageManager.getApplicationIcon(testPackageName) } returns mockedDrawable
+        every { mockedMainLooper.isCurrentThread } returns false
+
+        val result = testSubject.getAppIcon(testPackageName)
+        testSubject.dispose()
+        val result2 = testSubject.getAppIcon(testPackageName)
+
+        assertEquals(mockedDrawable, result)
+        assertEquals(mockedDrawable, result2)
+        verify(exactly = 2) {
+            mockedMainLooper.isCurrentThread
+            mockedPackageManager.getApplicationIcon(testPackageName)
+        }
+    }
+
+    @Test
+    fun throw_exception_when_invoke_from_MainThread() {
+        val testPackageName = "test"
+        every { mockedMainLooper.isCurrentThread } returns true
+
+        assertFails("Should not be called from MainThread") {
+            testSubject.getAppIcon(testPackageName)
+        }
+        verify { mockedMainLooper.isCurrentThread }
+    }
+}

--- a/android/src/test/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProviderTest.kt
+++ b/android/src/test/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProviderTest.kt
@@ -1,0 +1,94 @@
+package net.mullvad.mullvadvpn.applist
+
+import android.Manifest
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verifyAll
+import org.junit.After
+import org.junit.Test
+
+class ApplicationsProviderTest {
+    private val mockedPackageManager = mockk<PackageManager>()
+    private val selfPackageName = "self_package_name"
+    private val testSubject = ApplicationsProvider(mockedPackageManager, selfPackageName)
+    private val internet = Manifest.permission.INTERNET
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun test_get_apps() {
+        val launchWithInternetPackageName = "launch_with_internet_package_name"
+        val launchWithoutInternetPackageName = "launch_without_internet_package_name"
+        val nonLaunchWithInternetPackageName = "non_launch_with_internet_package_name"
+        val nonLaunchWithoutInternetPackageName = "non_launch_without_internet_package_name"
+
+        every {
+            mockedPackageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+        } returns listOf(
+            createApplicationInfo(launchWithInternetPackageName, launch = true, internet = true),
+            createApplicationInfo(launchWithoutInternetPackageName, launch = true),
+            createApplicationInfo(nonLaunchWithInternetPackageName, internet = true),
+            createApplicationInfo(nonLaunchWithoutInternetPackageName),
+            createApplicationInfo(selfPackageName, internet = true, launch = true)
+        )
+
+        val result = testSubject.getAppsList()
+        val expected = listOf(
+            AppData(launchWithInternetPackageName, 0, launchWithInternetPackageName)
+        )
+        assert(
+            expected.size == result.size &&
+                expected.containsAll(result) &&
+                result.containsAll(expected)
+        )
+
+        verifyAll {
+            mockedPackageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+
+            mockedPackageManager.checkPermission(internet, launchWithInternetPackageName)
+            mockedPackageManager.checkPermission(internet, launchWithoutInternetPackageName)
+            mockedPackageManager.checkPermission(internet, nonLaunchWithInternetPackageName)
+            mockedPackageManager.checkPermission(internet, nonLaunchWithoutInternetPackageName)
+            mockedPackageManager.checkPermission(internet, selfPackageName)
+
+            mockedPackageManager.getLaunchIntentForPackage(launchWithInternetPackageName)
+            mockedPackageManager.getLaunchIntentForPackage(nonLaunchWithInternetPackageName)
+            mockedPackageManager.getLaunchIntentForPackage(selfPackageName)
+        }
+    }
+
+    private fun createApplicationInfo(
+        packageName: String,
+        launch: Boolean = false,
+        internet: Boolean = false
+    ): ApplicationInfo {
+        val mockApplicationInfo = mockk<ApplicationInfo>()
+
+        mockApplicationInfo.packageName = packageName
+        mockApplicationInfo.icon = 0
+
+        every { mockApplicationInfo.loadLabel(mockedPackageManager) } returns packageName
+
+        every {
+            mockedPackageManager.getLaunchIntentForPackage(packageName)
+        } returns if (launch)
+            mockk()
+        else
+            null
+
+        every {
+            mockedPackageManager.checkPermission(Manifest.permission.INTERNET, packageName)
+        } returns if (internet)
+            PackageManager.PERMISSION_GRANTED
+        else
+            PackageManager.PERMISSION_DENIED
+
+        return mockApplicationInfo
+    }
+}


### PR DESCRIPTION
This PR separate logic for fetching applications info and filtering it and create an application icons cache manager to help optimise usage of memory and loading icons for installed application on the device. Contains tests for both classes.
Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2605)
<!-- Reviewable:end -->
