### PR TITLE
Silence logs from noisy 'tracing' crate

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -39,7 +39,7 @@ pub const SILENCED_CRATES: &[&str] = &[
     "rustls",
     "netlink_proto",
     "netlink_sys",
-    "iproute2",
+    "tracing",
 ];
 const SLIGHTLY_SILENCED_CRATES: &[&str] = &["mnl", "nftnl"];
 


### PR DESCRIPTION
When the log level is set to trace, there are a lot of entries logged by the `tracing` crate:
```
[2021-03-22 19:54:16.100][tracing::span][TRACE] -- FramedRead::poll_next
[2021-03-22 19:54:16.100][tracing::span][TRACE] try_reclaim_frame
[2021-03-22 19:54:16.100][tracing::span::active][TRACE] -> try_reclaim_frame
[2021-03-22 19:54:16.100][tracing::span::active][TRACE] <- try_reclaim_frame
[2021-03-22 19:54:16.100][tracing::span][TRACE] -- try_reclaim_frame
[2021-03-22 19:54:16.100][tracing::span][TRACE] pop_frame
[2021-03-22 19:54:16.100][tracing::span::active][TRACE] -> pop_frame
[2021-03-22 19:54:16.100][tracing::span::active][TRACE] <- pop_frame
[2021-03-22 19:54:16.100][tracing::span][TRACE] -- pop_frame
[2021-03-22 19:54:16.100][tracing::span][TRACE] FramedWrite::flush
[2021-03-22 19:54:16.100][tracing::span::active][TRACE] -> FramedWrite::flush
[2021-03-22 19:54:16.100][tracing::span::active][TRACE] <- FramedWrite::flush
[2021-03-22 19:54:16.100][tracing::span][TRACE] -- FramedWrite::flush
[2021-03-22 19:54:16.101][tracing::span][TRACE] try_reclaim_frame
[2021-03-22 19:54:16.101][tracing::span::active][TRACE] -> try_reclaim_frame
[2021-03-22 19:54:16.101][tracing::span::active][TRACE] <- try_reclaim_frame
[2021-03-22 19:54:16.101][tracing::span][TRACE] -- try_reclaim_frame
[2021-03-22 19:54:16.101][tracing::span::active][TRACE] <- poll
[2021-03-22 19:54:16.101][tracing::span][TRACE] -- poll
[2021-03-22 19:54:16.101][tracing::span::active][TRACE] <- Connection
[2021-03-22 19:54:16.101][tracing::span][TRACE] -- Connection
```

`tracing` is used by `tonic` and `hyper`, but these logs aren't particularly useful to us, so they can be silenced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2607)
<!-- Reviewable:end -->
