### PR TITLE
Save initial target state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix input area sometimes disappearing when returning to the Login screen.
 - Fix status bar having the wrong color after logging out.
 
+### Security
+- Always reconnect appropriately after an upgrade. Previously, installing the app twice in
+  succession, with auto-connect disabled, would cause it to re-launch in the disconnected state.
+
 
 ## [2021.2] - 2021-02-18
 This release is for desktop only.


### PR DESCRIPTION
Previously, the target state cache was deleted after being restored by the daemon. This means that the daemon would not enter the correct state after a crash (or restart during an upgrade) in this situation. This was fixed by caching the initial target state.

For example, this might occur if `mullvad-setup prepare-restart && net stop mullvadvpn && net start mullvadvpn` is run twice while initially connected. The second time the daemon is stopped, there is no target state. When started again, it will not immediately connect unless auto-connect is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2608)
<!-- Reviewable:end -->
