### PR TITLE
Split `LocationInfoCache` into UI-side and service-side classes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.ipc
 import android.os.Message as RawMessage
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.Settings
 
 // Events that can be sent from the service
@@ -12,6 +13,9 @@ sealed class Event : Message(), Parcelable {
 
     @Parcelize
     object ListenerReady : Event(), Parcelable
+
+    @Parcelize
+    data class NewLocation(val location: GeoIpLocation?) : Event(), Parcelable
 
     @Parcelize
     data class SettingsUpdate(val settings: Settings?) : Event(), Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -11,7 +11,7 @@ sealed class Request : Message(), Parcelable {
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize
-    class RegisterListener(val listener: Messenger) : Request(), Parcelable
+    data class RegisterListener(val listener: Messenger) : Request(), Parcelable
 
     companion object {
         private const val MESSAGE_KEY = "request"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GeoIpLocation.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/GeoIpLocation.kt
@@ -1,11 +1,14 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
 import java.net.InetAddress
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class GeoIpLocation(
     val ipv4: InetAddress?,
     val ipv6: InetAddress?,
     val country: String,
     val city: String?,
     val hostname: String?
-)
+) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
@@ -3,16 +3,15 @@ package net.mullvad.mullvadvpn.model
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-sealed class LocationConstraint(val code: Array<String>) : Parcelable {
+sealed class LocationConstraint : Parcelable {
     @Parcelize
-    data class Country(val countryCode: String) :
-        LocationConstraint(arrayOf(countryCode)), Parcelable
+    data class Country(val countryCode: String) : LocationConstraint(), Parcelable
 
     @Parcelize
     data class City(val countryCode: String, val cityCode: String) :
-        LocationConstraint(arrayOf(countryCode, cityCode)), Parcelable
+        LocationConstraint(), Parcelable
 
     @Parcelize
     data class Hostname(val countryCode: String, val cityCode: String, val hostname: String) :
-        LocationConstraint(arrayOf(countryCode, cityCode, hostname)), Parcelable
+        LocationConstraint(), Parcelable
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
@@ -4,14 +4,30 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 sealed class LocationConstraint : Parcelable {
-    @Parcelize
-    data class Country(val countryCode: String) : LocationConstraint(), Parcelable
+    abstract val location: GeoIpLocation
 
     @Parcelize
-    data class City(val countryCode: String, val cityCode: String) :
-        LocationConstraint(), Parcelable
+    data class Country(val countryCode: String) : LocationConstraint(), Parcelable {
+        override val location: GeoIpLocation
+            get() = GeoIpLocation(null, null, countryCode, null, null)
+    }
 
     @Parcelize
-    data class Hostname(val countryCode: String, val cityCode: String, val hostname: String) :
-        LocationConstraint(), Parcelable
+    data class City(
+        val countryCode: String,
+        val cityCode: String
+    ) : LocationConstraint(), Parcelable {
+        override val location: GeoIpLocation
+            get() = GeoIpLocation(null, null, countryCode, cityCode, null)
+    }
+
+    @Parcelize
+    data class Hostname(
+        val countryCode: String,
+        val cityCode: String,
+        val hostname: String
+    ) : LocationConstraint(), Parcelable {
+        override val location: GeoIpLocation
+            get() = GeoIpLocation(null, null, countryCode, cityCode, hostname)
+    }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -10,12 +10,15 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.withTimeout
+import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.GeoIpLocation
+import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.relaylist.Relay
 import net.mullvad.mullvadvpn.relaylist.RelayCity
 import net.mullvad.mullvadvpn.relaylist.RelayCountry
 import net.mullvad.mullvadvpn.relaylist.RelayItem
+import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.ExponentialBackoff
 import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.ConnectivityListener
@@ -24,6 +27,7 @@ import net.mullvad.talpid.util.autoSubscribable
 
 class LocationInfoCache(
     val connectivityListener: ConnectivityListener,
+    val settingsListener: SettingsListener,
     val daemon: Intermittent<MullvadDaemon>
 ) {
     companion object {
@@ -84,11 +88,15 @@ class LocationInfoCache(
                 fetchRequestChannel.sendBlocking(RequestFetch.ForRealLocation)
             }
         }
+
+        settingsListener.relaySettingsNotifier.subscribe(this, ::updateSelectedLocation)
     }
 
     fun onDestroy() {
         connectivityListener.connectivityNotifier.unsubscribe(this)
+        settingsListener.relaySettingsNotifier.unsubscribe(this)
         stateEvents = null
+
         fetchRequestChannel.close()
 
         onNewLocation = null
@@ -170,5 +178,12 @@ class LocationInfoCache(
         }
 
         location = newLocation
+    }
+
+    private fun updateSelectedLocation(relaySettings: RelaySettings?) {
+        val settings = relaySettings as? RelaySettings.Normal
+        val constraint = settings?.relayConstraints?.location as? Constraint.Only
+
+        selectedRelayLocation = constraint?.value?.location
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -14,10 +14,6 @@ import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.relaylist.Relay
-import net.mullvad.mullvadvpn.relaylist.RelayCity
-import net.mullvad.mullvadvpn.relaylist.RelayCountry
-import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.ExponentialBackoff
 import net.mullvad.mullvadvpn.util.Intermittent
@@ -76,12 +72,6 @@ class LocationInfoCache(
         state = newState
     }
 
-    var selectedRelay by observable<RelayItem?>(null) { _, oldRelay, newRelay ->
-        if (newRelay != oldRelay) {
-            updateSelectedRelayLocation(newRelay)
-        }
-    }
-
     init {
         connectivityListener.connectivityNotifier.subscribe(this) { isConnected ->
             if (isConnected && state is TunnelState.Disconnected) {
@@ -100,27 +90,6 @@ class LocationInfoCache(
         fetchRequestChannel.close()
 
         onNewLocation = null
-    }
-
-    private fun updateSelectedRelayLocation(relayItem: RelayItem?) {
-        selectedRelayLocation = when (relayItem) {
-            is RelayCountry -> GeoIpLocation(null, null, relayItem.name, null, null)
-            is RelayCity -> GeoIpLocation(
-                null,
-                null,
-                relayItem.country.name,
-                relayItem.name,
-                null
-            )
-            is Relay -> GeoIpLocation(
-                null,
-                null,
-                relayItem.city.country.name,
-                relayItem.city.name,
-                relayItem.name
-            )
-            else -> null
-        }
     }
 
     private fun runFetcher() = GlobalScope.actor<RequestFetch>(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/LocationInfoCache.kt
@@ -90,6 +90,8 @@ class LocationInfoCache(
         connectivityListener.connectivityNotifier.unsubscribe(this)
         connectionProxy.onStateChange.unsubscribe(this)
         fetchRequestChannel.close()
+
+        onNewLocation = null
     }
 
     private fun updateSelectedRelayLocation(relayItem: RelayItem?) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -256,7 +256,6 @@ class MullvadVpnService : TalpidVpnService() {
                 daemonInstance.intermittentDaemon,
                 connectionProxy,
                 customDns,
-                endpoint.locationInfoCache,
                 endpoint.settingsListener,
                 splitTunneling
             )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -247,6 +247,7 @@ class MullvadVpnService : TalpidVpnService() {
             instance = ServiceInstance(
                 endpoint.messenger,
                 daemon,
+                daemonInstance.intermittentDaemon,
                 connectionProxy,
                 connectivityListener,
                 customDns,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -105,7 +105,11 @@ class MullvadVpnService : TalpidVpnService() {
         notificationManager = ForegroundNotificationManager(this, serviceNotifier, keyguardManager)
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
-        endpoint = ServiceEndpoint(Looper.getMainLooper(), daemonInstance.intermittentDaemon)
+        endpoint = ServiceEndpoint(
+            Looper.getMainLooper(),
+            daemonInstance.intermittentDaemon,
+            connectivityListener
+        )
 
         notificationManager.acknowledgeStartForegroundService()
 
@@ -243,14 +247,16 @@ class MullvadVpnService : TalpidVpnService() {
 
         handlePendingAction(connectionProxy, settings)
 
+        endpoint.locationInfoCache.stateEvents = connectionProxy.onStateChange
+
         if (state == State.Running) {
             instance = ServiceInstance(
                 endpoint.messenger,
                 daemon,
                 daemonInstance.intermittentDaemon,
                 connectionProxy,
-                connectivityListener,
                 customDns,
+                endpoint.locationInfoCache,
                 endpoint.settingsListener,
                 splitTunneling
             )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -19,7 +19,7 @@ class ServiceInstance(
     val keyStatusListener = KeyStatusListener(daemon)
 
     val locationInfoCache =
-        LocationInfoCache(connectivityListener, intermittentDaemon).apply {
+        LocationInfoCache(connectivityListener, settingsListener, intermittentDaemon).apply {
             stateEvents = connectionProxy.onStateChange
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,27 +1,22 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
+import net.mullvad.mullvadvpn.service.endpoint.LocationInfoCache
 import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.Intermittent
-import net.mullvad.talpid.ConnectivityListener
 
 class ServiceInstance(
     val messenger: Messenger,
     val daemon: MullvadDaemon,
     val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectionProxy: ConnectionProxy,
-    val connectivityListener: ConnectivityListener,
     val customDns: CustomDns,
+    val locationInfoCache: LocationInfoCache,
     val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
     val accountCache = AccountCache(daemon, settingsListener)
     val keyStatusListener = KeyStatusListener(daemon)
-
-    val locationInfoCache =
-        LocationInfoCache(connectivityListener, settingsListener, intermittentDaemon).apply {
-            stateEvents = connectionProxy.onStateChange
-        }
 
     fun onDestroy() {
         accountCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -2,11 +2,13 @@ package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
 import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
+import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.ConnectivityListener
 
 class ServiceInstance(
     val messenger: Messenger,
     val daemon: MullvadDaemon,
+    val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectionProxy: ConnectionProxy,
     val connectivityListener: ConnectivityListener,
     val customDns: CustomDns,
@@ -15,7 +17,9 @@ class ServiceInstance(
 ) {
     val accountCache = AccountCache(daemon, settingsListener)
     val keyStatusListener = KeyStatusListener(daemon)
-    val locationInfoCache = LocationInfoCache(daemon, connectionProxy, connectivityListener)
+
+    val locationInfoCache =
+        LocationInfoCache(connectionProxy, connectivityListener, intermittentDaemon)
 
     fun onDestroy() {
         accountCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -19,7 +19,9 @@ class ServiceInstance(
     val keyStatusListener = KeyStatusListener(daemon)
 
     val locationInfoCache =
-        LocationInfoCache(connectionProxy, connectivityListener, intermittentDaemon)
+        LocationInfoCache(connectivityListener, intermittentDaemon).apply {
+            stateEvents = connectionProxy.onStateChange
+        }
 
     fun onDestroy() {
         accountCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.service.endpoint.LocationInfoCache
 import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.Intermittent
 
@@ -11,7 +10,6 @@ class ServiceInstance(
     val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
-    val locationInfoCache: LocationInfoCache,
     val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
@@ -23,6 +21,5 @@ class ServiceInstance(
         connectionProxy.onDestroy()
         customDns.onDestroy()
         keyStatusListener.onDestroy()
-        locationInfoCache.onDestroy()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/LocationInfoCache.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.service
+package net.mullvad.mullvadvpn.service.endpoint
 
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.Dispatchers
@@ -14,18 +14,11 @@ import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.ExponentialBackoff
-import net.mullvad.mullvadvpn.util.Intermittent
-import net.mullvad.talpid.ConnectivityListener
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.util.autoSubscribable
 
-class LocationInfoCache(
-    val connectivityListener: ConnectivityListener,
-    val settingsListener: SettingsListener,
-    val daemon: Intermittent<MullvadDaemon>
-) {
+class LocationInfoCache(private val endpoint: ServiceEndpoint) {
     companion object {
         private enum class RequestFetch {
             ForRealLocation,
@@ -34,6 +27,9 @@ class LocationInfoCache(
     }
 
     private val fetchRequestChannel = runFetcher()
+
+    private val daemon
+        get() = endpoint.intermittentDaemon
 
     private var lastKnownRealLocation: GeoIpLocation? = null
     private var selectedRelayLocation: GeoIpLocation? = null
@@ -73,18 +69,18 @@ class LocationInfoCache(
     }
 
     init {
-        connectivityListener.connectivityNotifier.subscribe(this) { isConnected ->
+        endpoint.connectivityListener.connectivityNotifier.subscribe(this) { isConnected ->
             if (isConnected && state is TunnelState.Disconnected) {
                 fetchRequestChannel.sendBlocking(RequestFetch.ForRealLocation)
             }
         }
 
-        settingsListener.relaySettingsNotifier.subscribe(this, ::updateSelectedLocation)
+        endpoint.settingsListener.relaySettingsNotifier.subscribe(this, ::updateSelectedLocation)
     }
 
     fun onDestroy() {
-        connectivityListener.connectivityNotifier.unsubscribe(this)
-        settingsListener.relaySettingsNotifier.unsubscribe(this)
+        endpoint.connectivityListener.connectivityNotifier.unsubscribe(this)
+        endpoint.settingsListener.relaySettingsNotifier.unsubscribe(this)
         stateEvents = null
 
         fetchRequestChannel.close()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -88,6 +88,7 @@ class ServiceEndpoint(
 
             val initialEvents = listOf(
                 Event.SettingsUpdate(settingsListener.settings),
+                Event.NewLocation(locationInfoCache.location),
                 Event.ListenerReady
             )
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -15,10 +15,12 @@ import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.util.Intermittent
+import net.mullvad.talpid.ConnectivityListener
 
 class ServiceEndpoint(
     looper: Looper,
-    internal val intermittentDaemon: Intermittent<MullvadDaemon>
+    internal val intermittentDaemon: Intermittent<MullvadDaemon>,
+    val connectivityListener: ConnectivityListener
 ) {
     private val listeners = mutableSetOf<Messenger>()
     private val registrationQueue: SendChannel<Messenger> = startRegistrator()
@@ -31,6 +33,8 @@ class ServiceEndpoint(
 
     val settingsListener = SettingsListener(this)
 
+    val locationInfoCache = LocationInfoCache(this)
+
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->
             registrationQueue.sendBlocking(request.listener)
@@ -41,6 +45,7 @@ class ServiceEndpoint(
         dispatcher.onDestroy()
         registrationQueue.close()
 
+        locationInfoCache.onDestroy()
         settingsListener.onDestroy()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -91,7 +91,6 @@ class ConnectFragment :
 
         relayListListener.onRelayListChange = { _, selectedRelayItem ->
             jobTracker.newUiJob("updateSelectedRelayItem") {
-                locationInfoCache.selectedRelay = selectedRelayItem
                 switchLocationButton.location = selectedRelayItem
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -11,9 +11,9 @@ import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.KeyStatusListener
-import net.mullvad.mullvadvpn.service.LocationInfoCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -13,7 +13,7 @@ import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SplitTunneling
-import net.mullvad.mullvadvpn.service.endpoint.LocationInfoCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
@@ -1,11 +1,24 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
-class LocationInfoCache(
-    val serviceCache: net.mullvad.mullvadvpn.service.endpoint.LocationInfoCache
-) {
-    var onNewLocation
-        get() = serviceCache.onNewLocation
-        set(value) { serviceCache.onNewLocation = value }
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.model.GeoIpLocation
+
+class LocationInfoCache(val eventDispatcher: DispatchingHandler<Event>) {
+    private var location: GeoIpLocation? by observable(null) { _, _, newLocation ->
+        onNewLocation?.invoke(newLocation)
+    }
+
+    var onNewLocation by observable<((GeoIpLocation?) -> Unit)?>(null) { _, _, callback ->
+        callback?.invoke(location)
+    }
+
+    init {
+        eventDispatcher.registerHandler(Event.NewLocation::class) { event ->
+            location = event.location
+        }
+    }
 
     fun onDestroy() {
         onNewLocation = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
@@ -1,0 +1,13 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+class LocationInfoCache(
+    val serviceCache: net.mullvad.mullvadvpn.service.endpoint.LocationInfoCache
+) {
+    var onNewLocation
+        get() = serviceCache.onNewLocation
+        set(value) { serviceCache.onNewLocation = value }
+
+    fun onDestroy() {
+        onNewLocation = null
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -26,7 +26,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val connectionProxy = service.connectionProxy
     val customDns = service.customDns
     val keyStatusListener = service.keyStatusListener
-    val locationInfoCache = service.locationInfoCache
+    val locationInfoCache = LocationInfoCache(service.locationInfoCache)
     val settingsListener = SettingsListener(dispatcher)
     val splitTunneling = service.splitTunneling
 
@@ -42,6 +42,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     fun onDestroy() {
         dispatcher.onDestroy()
 
+        locationInfoCache.onDestroy()
         settingsListener.onDestroy()
 
         appVersionInfoCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -26,7 +26,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val connectionProxy = service.connectionProxy
     val customDns = service.customDns
     val keyStatusListener = service.keyStatusListener
-    val locationInfoCache = LocationInfoCache(service.locationInfoCache)
+    val locationInfoCache = LocationInfoCache(dispatcher)
     val settingsListener = SettingsListener(dispatcher)
     val splitTunneling = service.splitTunneling
 


### PR DESCRIPTION
This PR continues the work on splitting the code base so that the background service can run in a separate process. This PR focuses on the `LocationInfoCache` which is responsible for obtaining the Geo IP location. Now there are two classes, where the service-side `LocationInfoCache` is where the behavior is kept, and the UI side which will register and listen for `NewLocation` events from the IPC channel.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2610)
<!-- Reviewable:end -->
