### PR TITLE
Change missing translation detection

### DIFF
--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -10,6 +10,7 @@ use std::{
 
 lazy_static! {
     static ref APOSTROPHE_VARIATION: Regex = Regex::new("’").unwrap();
+    static ref ESCAPED_DOUBLE_QUOTES: Regex = Regex::new(r#"\\""#).unwrap();
     static ref PARAMETERS: Regex = Regex::new(r"%\([^)]*\)").unwrap();
 }
 
@@ -270,6 +271,8 @@ fn normalize(string: &str) -> String {
     let string = APOSTROPHE_VARIATION.replace_all(&string, "'");
     // Mark where parameters are positioned, removing the parameter name
     let string = PARAMETERS.replace_all(&string, "%");
+    // Remove escaped double-quotes
+    let string = ESCAPED_DOUBLE_QUOTES.replace_all(&string, r#"""#);
 
     string.into_owned()
 }

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -100,13 +100,17 @@ impl Translation {
         let mut current_plural_id = None;
         let mut plural_form = None;
         let mut variants = BTreeMap::new();
+
         let file = BufReader::new(File::open(file_path).expect("Failed to open gettext file"));
+        // Ensure there's an empty line at the end so that the "else" part of the string matching
+        // code will run for the last message in the file.
+        let lines = file
+            .lines()
+            .map(|line_result| line_result.expect("Failed to read from gettext file"))
+            .chain(Some(String::new()));
 
-        for line in file.lines() {
-            let line = line.expect("Failed to read from gettext file");
-            let line = line.trim();
-
-            match_str! { (line)
+        for line in lines {
+            match_str! { (line.trim())
                 ["msgid \"", msg_id, "\""] => {
                     current_id = Some(normalize(msg_id));
                 }

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -14,6 +14,7 @@ lazy_static! {
 }
 
 /// A parsed gettext translation file.
+#[derive(Clone, Debug)]
 pub struct Translation {
     pub plural_form: Option<PluralForm>,
     entries: Vec<MsgEntry>,


### PR DESCRIPTION
The translations converter tool had a few issues:

1. It would not load the last message of a gettext messages (or template) file
2. It would not unescape double-quotes in gettext messages
3. It would build a list of missing translations based only on translations, not on the translations template file

This PR fixes those issues by, respectively:

1. Adding an empty line to the list of parsed lines so that the "else" clause of the string matching loop is executed for the last iteration
2. Unescaping double-quotes in gettext messages when normalizing it. There's no need to escape it since when they are written the code uses `{:?}` which automatically escapes the double quotes
3. The list of missing translations (messages and plurals) is now built solely based on the messages template file, so that no duplicates are added and entries that are translated but not in the template file are also added.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tool change, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2612)
<!-- Reviewable:end -->
