### PR TITLE
Add automatic keyboard responder helper

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 		58FD5BF024238EB300112C88 /* SKProduct+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */; };
 		58FD5BF22424F7D700112C88 /* UserInterfaceInteractionRestriction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BF12424F7D700112C88 /* UserInterfaceInteractionRestriction.swift */; };
 		58FD5BF42428C67600112C88 /* InAppPurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */; };
+		58FEEB58260B662E00A621A8 /* AutomaticKeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FEEB57260B662E00A621A8 /* AutomaticKeyboardResponder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -417,6 +418,7 @@
 		58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Formatting.swift"; sourceTree = "<group>"; };
 		58FD5BF12424F7D700112C88 /* UserInterfaceInteractionRestriction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInterfaceInteractionRestriction.swift; sourceTree = "<group>"; };
 		58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseButton.swift; sourceTree = "<group>"; };
+		58FEEB57260B662E00A621A8 /* AutomaticKeyboardResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticKeyboardResponder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -645,6 +647,7 @@
 				585CA70E25F8C44600B47C62 /* UIMetrics.swift */,
 				583DA21325FA4B5C00318683 /* LocationDataSource.swift */,
 				58B993B02608A34500BA7811 /* LoginContentView.swift */,
+				58FEEB57260B662E00A621A8 /* AutomaticKeyboardResponder.swift */,
 			);
 			path = MullvadVPN;
 			sourceTree = "<group>";
@@ -970,6 +973,7 @@
 				5877153023981F7B001F8237 /* WireguardKeysViewController.swift in Sources */,
 				5850367F25A481D800A43E93 /* IPAddressRange+Codable.swift in Sources */,
 				5871FB96254ADE4E0051A0A4 /* ConsolidatedApplicationLog.swift in Sources */,
+				58FEEB58260B662E00A621A8 /* AutomaticKeyboardResponder.swift in Sources */,
 				58FAEDEF245069C700CB0F5B /* KeychainAttributes.swift in Sources */,
 				58CB0EE024B86751001EF0D8 /* MullvadRest.swift in Sources */,
 				580EE20924B3224200F9D8A1 /* RetryOperation.swift in Sources */,

--- a/ios/MullvadVPN/AutomaticKeyboardResponder.swift
+++ b/ios/MullvadVPN/AutomaticKeyboardResponder.swift
@@ -1,0 +1,128 @@
+//
+//  AutomaticKeyboardResponder.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 24/03/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+class AutomaticKeyboardResponder {
+    weak var targetView: UIView?
+    private let handler: (UIView, CGFloat) -> Void
+
+    private var showsKeyboard = false
+    private var lastKeyboardRect: CGRect?
+
+    private var presentationFrameObserver: NSKeyValueObservation?
+
+    init<T: UIView>(targetView: T, handler: @escaping (T, CGFloat) -> Void) {
+        self.targetView = targetView
+        self.handler = { (view, adjustment) in
+            handler(view as! T, adjustment)
+        }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: UIWindow.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIWindow.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidHide(_:)), name: UIWindow.keyboardDidHideNotification, object: nil)
+    }
+
+    func updateContentInsets() {
+        guard let keyboardRect = lastKeyboardRect else { return }
+
+        adjustContentInsets(keyboardRect: keyboardRect)
+    }
+
+    // MARK: - Keyboard notifications
+
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        showsKeyboard = true
+
+        addPresentationControllerObserver()
+        handleKeyboardNotification(notification)
+    }
+
+    @objc private func keyboardDidHide(_ notification: Notification) {
+        showsKeyboard = false
+        presentationFrameObserver = nil
+    }
+
+    @objc private func keyboardWillChangeFrame(_ notification: Notification) {
+        guard showsKeyboard else { return }
+
+        handleKeyboardNotification(notification)
+    }
+
+    // MARK: - Private
+
+    private func handleKeyboardNotification(_ notification: Notification) {
+        guard let keyboardFrameValue = notification.userInfo?[UIWindow.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+
+        lastKeyboardRect = keyboardFrameValue.cgRectValue
+
+        self.adjustContentInsets(keyboardRect: keyboardFrameValue.cgRectValue)
+    }
+
+    private func addPresentationControllerObserver() {
+        // Presentation controller follows the keyboard on iPad.
+        // Install the observer to listen for the container view frame and adjust the target view
+        // accordingly.
+        guard let containerView = parentViewController?.presentationController?.containerView, isFormSheetPresentation else { return }
+
+        let containingView = containerView.subviews.first { (subview) -> Bool in
+            return targetView?.isDescendant(of: subview) ?? false
+        }
+
+        presentationFrameObserver = containingView?.observe(\.frame, options: [.new], changeHandler: { [weak self] (containingView, change) in
+            guard let self = self, let keyboardFrameValue = self.lastKeyboardRect else { return }
+
+            self.adjustContentInsets(keyboardRect: keyboardFrameValue)
+        })
+    }
+
+    /// Returns the first parent controller in the responder chain
+    private var parentViewController: UIViewController? {
+        var responder: UIResponder? = targetView
+        let iterator = AnyIterator { () -> UIResponder? in
+            let next = responder?.next
+            responder = next
+            return next
+        }
+
+        return iterator.first { $0 is UIViewController } as? UIViewController
+    }
+
+    private var isFormSheetPresentation: Bool {
+        return UIDevice.current.userInterfaceIdiom == .pad &&
+            parentViewController?.modalPresentationStyle == .formSheet
+    }
+
+    private func adjustContentInsets(keyboardRect: CGRect) {
+        guard let targetView = targetView, let superview = targetView.superview else { return }
+
+        // Compute the target view frame within screen coordinates
+        let screenRect = superview.convert(targetView.frame, to: nil)
+
+        // Find the intersection between the keyboard and the view
+        let intersection = keyboardRect.intersection(screenRect)
+
+        handler(targetView, intersection.height)
+    }
+}
+
+extension AutomaticKeyboardResponder {
+
+    /// A convenience initializer that automatically assigns the offset to the scroll view subclasses
+    convenience init<T: UIScrollView>(targetView: T) {
+        self.init(targetView: targetView) { (scrollView, offset) in
+            if scrollView.canBecomeFirstResponder {
+                scrollView.contentInset.bottom = targetView.isFirstResponder ? offset : 0
+                scrollView.scrollIndicatorInsets.bottom = targetView.isFirstResponder ? offset : 0
+            } else {
+                scrollView.contentInset.bottom = offset
+                scrollView.scrollIndicatorInsets.bottom = offset
+            }
+        }
+    }
+}

--- a/ios/MullvadVPN/LoginContentView.swift
+++ b/ios/MullvadVPN/LoginContentView.swift
@@ -10,6 +10,8 @@ import UIKit
 
 class LoginContentView: UIView {
 
+    private var keyboardResponder: AutomaticKeyboardResponder?
+
     lazy var titleLabel: UILabel = {
         let textLabel = UILabel()
         textLabel.font = UIFont.systemFont(ofSize: 32)
@@ -97,8 +99,14 @@ class LoginContentView: UIView {
         backgroundColor = .primaryColor
         layoutMargins = UIMetrics.contentLayoutMargins
 
+        keyboardResponder = AutomaticKeyboardResponder(targetView: self, handler: { [weak self] (view, adjustment) in
+            self?.contentContainerBottomConstraint?.constant = adjustment
+
+            self?.layoutIfNeeded()
+            self?.updateStatusImageVisibility(animated: false)
+        })
+
         addSubviews()
-        addKeyboardHandlers()
     }
 
     required init?(coder: NSCoder) {
@@ -197,51 +205,4 @@ class LoginContentView: UIView {
         ])
     }
 
-    private func addKeyboardHandlers() {
-        let notificationCenter = NotificationCenter.default
-
-        notificationCenter.addObserver(self,
-                                       selector: #selector(keyboardWillShow(_:)),
-                                       name: UIWindow.keyboardWillShowNotification,
-                                       object: nil)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(keyboardWillChangeFrame(_:)),
-                                       name: UIWindow.keyboardWillChangeFrameNotification,
-                                       object: nil)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(keyboardWillHide(_:)),
-                                       name: UIWindow.keyboardWillHideNotification,
-                                       object: nil)
-    }
-
-
-    // MARK: - Keyboard notifications
-
-    @objc private func keyboardWillShow(_ notification: Notification) {
-        guard let keyboardFrameValue = notification.userInfo?[UIWindow.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-
-        makeLoginFormVisible(keyboardFrame: keyboardFrameValue.cgRectValue)
-    }
-
-    @objc private func keyboardWillChangeFrame(_ notification: Notification) {
-        guard let keyboardFrameValue = notification.userInfo?[UIWindow.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-
-        makeLoginFormVisible(keyboardFrame: keyboardFrameValue.cgRectValue)
-    }
-
-    @objc private func keyboardWillHide(_ notification: Notification) {
-        contentContainerBottomConstraint?.constant = 0
-        layoutIfNeeded()
-        updateStatusImageVisibility(animated: false)
-    }
-
-    private func makeLoginFormVisible(keyboardFrame: CGRect) {
-        let viewFrame = convert(bounds, to: nil)
-        let intersection = viewFrame.intersection(keyboardFrame)
-
-        contentContainerBottomConstraint?.constant = intersection.height
-
-        layoutIfNeeded()
-        updateStatusImageVisibility(animated: false)
-    }
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR adds a helper class that automatically handles the keyboard and adds the appropriate content insets to pad the scrollable views in order to account for the keyboard overlay.

This class also handles the formsheet presentation on iOS where the small floating modal window is displayed in the middle of the screen. This kind of presentation automatically centers the view controller above the keyboard. This class tackles this by observing the `frame` of the container view that floats around with keyboard and updating the scroll content insets accordingly.

The concept itself is described here: https://developer.apple.com/library/archive/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/KeyboardManagement/KeyboardManagement.html#//apple_ref/doc/uid/TP40009542-CH5-SW7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2619)
<!-- Reviewable:end -->
