### PR TITLE
Retry if sending problem reports fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Line wrap the file at 100 chars.                                              Th
 - Read account token from standard input unless given as an argument in CLI.
 - Make WireGuard automatic key rotation interval mandatory and between 1 and 7 days.
 - Show default, minimum, and maximum key rotation intervals in CLI.
+- Attempt to send problem reports using other endpoints if using the primary one fails.
 
 #### Android
 - WireGuard key is now rotated sooner: every four days instead of seven.


### PR DESCRIPTION
The top address in `api-ip-address.txt` (ie the one last used by the service) is always preferred, and the problem report tool is not allowed to replace the cache. This meant that previously `mullvad-problem-report` would always use the same IP address to contact the API even if it failed using it before. Retrying a couple of times makes sure that two random addresses are used as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2620)
<!-- Reviewable:end -->
