### PR TITLE
Split `KeyStatusListener` in a UI-side class and a service-side class

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.ipc
 import android.os.Message as RawMessage
 import kotlinx.parcelize.Parcelize
 import net.mullvad.mullvadvpn.model.GeoIpLocation
+import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.Settings
 
 // Events that can be sent from the service
@@ -18,6 +19,9 @@ sealed class Event : Message() {
 
     @Parcelize
     data class SettingsUpdate(val settings: Settings?) : Event()
+
+    @Parcelize
+    data class WireGuardKeyStatus(val keyStatus: KeygenEvent?) : Event()
 
     companion object {
         private const val MESSAGE_KEY = "event"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -1,24 +1,23 @@
 package net.mullvad.mullvadvpn.ipc
 
 import android.os.Message as RawMessage
-import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.Settings
 
 // Events that can be sent from the service
-sealed class Event : Message(), Parcelable {
+sealed class Event : Message() {
     protected override val messageId = 1
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize
-    object ListenerReady : Event(), Parcelable
+    object ListenerReady : Event()
 
     @Parcelize
-    data class NewLocation(val location: GeoIpLocation?) : Event(), Parcelable
+    data class NewLocation(val location: GeoIpLocation?) : Event()
 
     @Parcelize
-    data class SettingsUpdate(val settings: Settings?) : Event(), Parcelable
+    data class SettingsUpdate(val settings: Settings?) : Event()
 
     companion object {
         private const val MESSAGE_KEY = "event"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -2,16 +2,15 @@ package net.mullvad.mullvadvpn.ipc
 
 import android.os.Message as RawMessage
 import android.os.Messenger
-import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 // Requests that the service can handle
-sealed class Request : Message(), Parcelable {
+sealed class Request : Message() {
     protected override val messageId = 2
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize
-    data class RegisterListener(val listener: Messenger) : Request(), Parcelable
+    data class RegisterListener(val listener: Messenger) : Request()
 
     companion object {
         private const val MESSAGE_KEY = "request"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -12,6 +12,12 @@ sealed class Request : Message() {
     @Parcelize
     data class RegisterListener(val listener: Messenger) : Request()
 
+    @Parcelize
+    object WireGuardGenerateKey : Request()
+
+    @Parcelize
+    object WireGuardVerifyKey : Request()
+
     companion object {
         private const val MESSAGE_KEY = "request"
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Constraint.kt
@@ -6,8 +6,8 @@ import kotlinx.parcelize.Parcelize
 sealed class Constraint<T>() : Parcelable {
     @Parcelize
     @Suppress("PARCELABLE_PRIMARY_CONSTRUCTOR_IS_EMPTY")
-    class Any<T>() : Constraint<T>(), Parcelable
+    class Any<T>() : Constraint<T>()
 
     @Parcelize
-    data class Only<T : Parcelable>(val value: T) : Constraint<T>(), Parcelable
+    data class Only<T : Parcelable>(val value: T) : Constraint<T>()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -1,6 +1,10 @@
 package net.mullvad.mullvadvpn.model
 
-sealed class KeygenEvent {
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+sealed class KeygenEvent : Parcelable {
+    @Parcelize
     class NewKey(
         val publicKey: PublicKey,
         val verified: Boolean?,
@@ -9,7 +13,10 @@ sealed class KeygenEvent {
         constructor(publicKey: PublicKey) : this (publicKey, null, null)
     }
 
+    @Parcelize
     object TooManyKeys : KeygenEvent()
+
+    @Parcelize
     object GenerationFailure : KeygenEvent()
 
     fun failure(): KeygenFailure? {
@@ -21,7 +28,8 @@ sealed class KeygenEvent {
     }
 }
 
-enum class KeygenFailure {
+@Parcelize
+enum class KeygenFailure : Parcelable {
     TooManyKeys,
     GenerationFailure,
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -1,20 +1,12 @@
 package net.mullvad.mullvadvpn.model
 
 sealed class KeygenEvent {
-    class NewKey(val publicKey: PublicKey) : KeygenEvent() {
-        var verified: Boolean? = null
-            private set
-        var replacementFailure: KeygenFailure? = null
-            private set
-
-        constructor(
-            publicKey: PublicKey,
-            verified: Boolean?,
-            replacementFailure: KeygenFailure?
-        ) : this(publicKey) {
-            this.verified = verified
-            this.replacementFailure = replacementFailure
-        }
+    class NewKey(
+        val publicKey: PublicKey,
+        val verified: Boolean?,
+        val replacementFailure: KeygenFailure?
+    ) : KeygenEvent() {
+        constructor(publicKey: PublicKey) : this (publicKey, null, null)
     }
 
     object TooManyKeys : KeygenEvent()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LocationConstraint.kt
@@ -7,16 +7,13 @@ sealed class LocationConstraint : Parcelable {
     abstract val location: GeoIpLocation
 
     @Parcelize
-    data class Country(val countryCode: String) : LocationConstraint(), Parcelable {
+    data class Country(val countryCode: String) : LocationConstraint() {
         override val location: GeoIpLocation
             get() = GeoIpLocation(null, null, countryCode, null, null)
     }
 
     @Parcelize
-    data class City(
-        val countryCode: String,
-        val cityCode: String
-    ) : LocationConstraint(), Parcelable {
+    data class City(val countryCode: String, val cityCode: String) : LocationConstraint() {
         override val location: GeoIpLocation
             get() = GeoIpLocation(null, null, countryCode, cityCode, null)
     }
@@ -26,7 +23,7 @@ sealed class LocationConstraint : Parcelable {
         val countryCode: String,
         val cityCode: String,
         val hostname: String
-    ) : LocationConstraint(), Parcelable {
+    ) : LocationConstraint() {
         override val location: GeoIpLocation
             get() = GeoIpLocation(null, null, countryCode, cityCode, hostname)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/PublicKey.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/PublicKey.kt
@@ -1,3 +1,7 @@
 package net.mullvad.mullvadvpn.model
 
-data class PublicKey(val key: ByteArray, val dateCreated: String)
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PublicKey(val key: ByteArray, val dateCreated: String) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelaySettings.kt
@@ -5,8 +5,8 @@ import kotlinx.parcelize.Parcelize
 
 sealed class RelaySettings : Parcelable {
     @Parcelize
-    object CustomTunnelEndpoint : RelaySettings(), Parcelable
+    object CustomTunnelEndpoint : RelaySettings()
 
     @Parcelize
-    class Normal(val relayConstraints: RelayConstraints) : RelaySettings(), Parcelable
+    class Normal(val relayConstraints: RelayConstraints) : RelaySettings()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -256,7 +256,6 @@ class MullvadVpnService : TalpidVpnService() {
                 daemonInstance.intermittentDaemon,
                 connectionProxy,
                 customDns,
-                endpoint.keyStatusListener,
                 endpoint.settingsListener,
                 splitTunneling
             )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -256,6 +256,7 @@ class MullvadVpnService : TalpidVpnService() {
                 daemonInstance.intermittentDaemon,
                 connectionProxy,
                 customDns,
+                endpoint.keyStatusListener,
                 endpoint.settingsListener,
                 splitTunneling
             )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.service.endpoint.KeyStatusListener
 import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.Intermittent
 
@@ -11,7 +10,6 @@ class ServiceInstance(
     val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
-    val keyStatusListener: KeyStatusListener,
     val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
@@ -21,6 +19,5 @@ class ServiceInstance(
         accountCache.onDestroy()
         connectionProxy.onDestroy()
         customDns.onDestroy()
-        keyStatusListener.onDestroy()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
+import net.mullvad.mullvadvpn.service.endpoint.KeyStatusListener
 import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.Intermittent
 
@@ -10,11 +11,11 @@ class ServiceInstance(
     val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
+    val keyStatusListener: KeyStatusListener,
     val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
     val accountCache = AccountCache(daemon, settingsListener)
-    val keyStatusListener = KeyStatusListener(intermittentDaemon)
 
     fun onDestroy() {
         accountCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -14,7 +14,7 @@ class ServiceInstance(
     val splitTunneling: SplitTunneling
 ) {
     val accountCache = AccountCache(daemon, settingsListener)
-    val keyStatusListener = KeyStatusListener(daemon)
+    val keyStatusListener = KeyStatusListener(intermittentDaemon)
 
     fun onDestroy() {
         accountCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.service.endpoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.talpid.util.EventNotifier
 
@@ -21,6 +22,16 @@ class KeyStatusListener(endpoint: ServiceEndpoint) {
                 }
 
                 onKeygenEvent = { event -> keyStatus = event }
+            }
+        }
+
+        endpoint.dispatcher.apply {
+            registerHandler(Request.WireGuardGenerateKey::class) { _ ->
+                generateKey()
+            }
+
+            registerHandler(Request.WireGuardVerifyKey::class) { _ ->
+                verifyKey()
             }
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
@@ -1,9 +1,10 @@
-package net.mullvad.mullvadvpn.service
+package net.mullvad.mullvadvpn.service.endpoint
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.KeygenEvent
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.util.EventNotifier
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
@@ -3,13 +3,25 @@ package net.mullvad.mullvadvpn.service.endpoint
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.KeygenEvent
 
 class KeyStatusListener(endpoint: ServiceEndpoint) {
+    companion object {
+        private enum class Command {
+            GenerateKey,
+            VerifyKey,
+        }
+    }
+
     private val daemon = endpoint.intermittentDaemon
+
+    private val commandChannel = spawnActor()
 
     var keyStatus by observable<KeygenEvent?>(null) { _, _, status ->
         endpoint.sendEvent(Event.WireGuardKeyStatus(status))
@@ -29,20 +41,33 @@ class KeyStatusListener(endpoint: ServiceEndpoint) {
 
         endpoint.dispatcher.apply {
             registerHandler(Request.WireGuardGenerateKey::class) { _ ->
-                generateKey()
+                commandChannel.sendBlocking(Command.GenerateKey)
             }
 
             registerHandler(Request.WireGuardVerifyKey::class) { _ ->
-                verifyKey()
+                commandChannel.sendBlocking(Command.VerifyKey)
             }
         }
     }
 
     fun onDestroy() {
+        commandChannel.close()
         daemon.unregisterListener(this)
     }
 
-    private fun generateKey() = GlobalScope.launch(Dispatchers.Default) {
+    private fun spawnActor() = GlobalScope.actor<Command>(Dispatchers.Default, Channel.UNLIMITED) {
+        try {
+            for (command in channel) {
+                when (command) {
+                    Command.GenerateKey -> generateKey()
+                    Command.VerifyKey -> verifyKey()
+                }
+            }
+        } catch (exception: ClosedReceiveChannelException) {
+        }
+    }
+
+    private suspend fun generateKey() {
         val oldStatus = keyStatus
         val newStatus = daemon.await().generateWireguardKey()
         val newFailure = newStatus?.failure()
@@ -57,7 +82,7 @@ class KeyStatusListener(endpoint: ServiceEndpoint) {
         }
     }
 
-    private fun verifyKey() = GlobalScope.launch(Dispatchers.Default) {
+    private suspend fun verifyKey() {
         // Only update verification status if the key is actually there
         (keyStatus as? KeygenEvent.NewKey)?.let { currentStatus ->
             keyStatus = KeygenEvent.NewKey(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
@@ -1,8 +1,10 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.talpid.util.EventNotifier
@@ -12,7 +14,11 @@ class KeyStatusListener(endpoint: ServiceEndpoint) {
 
     val onKeyStatusChange = EventNotifier<KeygenEvent?>(null)
 
-    var keyStatus by onKeyStatusChange.notifiable()
+    var keyStatus by observable<KeygenEvent?>(null) { _, _, status ->
+        endpoint.sendEvent(Event.WireGuardKeyStatus(status))
+        onKeyStatusChange.notify(status)
+    }
+        private set
 
     init {
         daemon.registerListener(this) { newDaemon ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
@@ -41,16 +41,13 @@ class KeyStatusListener(val daemon: Intermittent<MullvadDaemon>) {
     }
 
     fun verifyKey() = GlobalScope.launch(Dispatchers.Default) {
-        val verified = daemon.await().verifyWireguardKey()
         // Only update verification status if the key is actually there
-        when (val state = keyStatus) {
-            is KeygenEvent.NewKey -> {
-                keyStatus = KeygenEvent.NewKey(
-                    state.publicKey,
-                    verified,
-                    state.replacementFailure
-                )
-            }
+        (keyStatus as? KeygenEvent.NewKey)?.let { currentStatus ->
+            keyStatus = KeygenEvent.NewKey(
+                currentStatus.publicKey,
+                daemon.await().verifyWireguardKey(),
+                currentStatus.replacementFailure
+            )
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/KeyStatusListener.kt
@@ -4,11 +4,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.KeygenEvent
-import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.util.EventNotifier
 
-class KeyStatusListener(val daemon: Intermittent<MullvadDaemon>) {
+class KeyStatusListener(endpoint: ServiceEndpoint) {
+    private val daemon = endpoint.intermittentDaemon
+
     val onKeyStatusChange = EventNotifier<KeygenEvent?>(null)
 
     var keyStatus by onKeyStatusChange.notifiable()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -33,6 +33,7 @@ class ServiceEndpoint(
 
     val settingsListener = SettingsListener(this)
 
+    val keyStatusListener = KeyStatusListener(intermittentDaemon)
     val locationInfoCache = LocationInfoCache(this)
 
     init {
@@ -45,6 +46,7 @@ class ServiceEndpoint(
         dispatcher.onDestroy()
         registrationQueue.close()
 
+        keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -91,6 +91,7 @@ class ServiceEndpoint(
             val initialEvents = listOf(
                 Event.SettingsUpdate(settingsListener.settings),
                 Event.NewLocation(locationInfoCache.location),
+                Event.WireGuardKeyStatus(keyStatusListener.keyStatus),
                 Event.ListenerReady
             )
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -33,7 +33,7 @@ class ServiceEndpoint(
 
     val settingsListener = SettingsListener(this)
 
-    val keyStatusListener = KeyStatusListener(intermittentDaemon)
+    val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
 
     init {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -12,7 +12,7 @@ import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SplitTunneling
-import net.mullvad.mullvadvpn.service.endpoint.KeyStatusListener
+import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -10,9 +10,9 @@ import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
-import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.KeygenEvent
@@ -40,6 +41,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
     private var greenColor: Int = 0
     private var redColor: Int = 0
 
+    private var actionCompletion: CompletableDeferred<Unit>? = null
     private var tunnelState: TunnelState = TunnelState.Disconnected
 
     private var actionState: ActionState = ActionState.Idle(false)
@@ -63,6 +65,8 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
                 updateStatusMessage()
                 updateGenerateKeyButtonText()
                 updateVerifyKeyButtonState()
+
+                actionCompletion?.complete(Unit)
             }
         }
 
@@ -314,14 +318,21 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         reconnectionExpected = !(tunnelState is TunnelState.Disconnected)
 
         keyStatus = null
-        keyStatusListener.generateKey().join()
+
+        actionCompletion = CompletableDeferred()
+        keyStatusListener.generateKey()
+        actionCompletion?.await()
 
         actionState = ActionState.Idle(false)
     }
 
     private suspend fun onValidateKeyPress() {
         actionState = ActionState.Verifying()
-        keyStatusListener.verifyKey().join()
+
+        actionCompletion = CompletableDeferred()
+        keyStatusListener.verifyKey()
+        actionCompletion?.await()
+
         actionState = ActionState.Idle(true)
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/KeyStatusNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/KeyStatusNotification.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.endpoint.KeyStatusListener
+import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 
 class KeyStatusNotification(
     context: Context,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/KeyStatusNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/KeyStatusNotification.kt
@@ -3,8 +3,8 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.KeygenEvent
-import net.mullvad.mullvadvpn.service.KeyStatusListener
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.endpoint.KeyStatusListener
 
 class KeyStatusNotification(
     context: Context,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/KeyStatusListener.kt
@@ -1,0 +1,33 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
+import net.mullvad.mullvadvpn.model.KeygenEvent
+import net.mullvad.talpid.util.EventNotifier
+
+class KeyStatusListener(val connection: Messenger, val eventDispatcher: DispatchingHandler<Event>) {
+    val onKeyStatusChange = EventNotifier<KeygenEvent?>(null)
+
+    var keyStatus by onKeyStatusChange.notifiable()
+        private set
+
+    init {
+        eventDispatcher.registerHandler(Event.WireGuardKeyStatus::class) { event ->
+            keyStatus = event.keyStatus
+        }
+    }
+
+    fun generateKey() {
+        connection.send(Request.WireGuardGenerateKey.message)
+    }
+
+    fun verifyKey() {
+        connection.send(Request.WireGuardVerifyKey.message)
+    }
+
+    fun onDestroy() {
+        onKeyStatusChange.unsubscribeAll()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -25,7 +25,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val accountCache = service.accountCache
     val connectionProxy = service.connectionProxy
     val customDns = service.customDns
-    val keyStatusListener = service.keyStatusListener
+    val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
     val settingsListener = SettingsListener(dispatcher)
     val splitTunneling = service.splitTunneling
@@ -42,6 +42,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     fun onDestroy() {
         dispatcher.onDestroy()
 
+        keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()
 


### PR DESCRIPTION
This PR continues the work on splitting the app so that the service runs in a separate process. This PR focuses on the `KeyStatusListener` class. This class is responsible for sending verify key and (re)generate key commands while also listening for the status of the WireGuard key, i.e., if it's available or not, or if there was any error with the key generation.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2621)
<!-- Reviewable:end -->
