### PR TITLE
Add CI job for checking translations

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -5,6 +5,7 @@ on:
         paths-ignore:
             - '**/*.md'
             - .github/workflows/android*.yml
+            - .github/workflows/ios.yml
             - .github/workflows/rustfmt.yml
             - android/**
             - audits/**

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -8,6 +8,7 @@ on:
             - .github/workflows/frontend.yml
             - .github/workflows/ios.yml
             - .github/workflows/rustfmt.yml
+            - .github/workflows/translations.yml
             - android/**
             - audits/**
             - ci/buildserver-*

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -5,6 +5,7 @@ on:
         paths-ignore:
             - '**/*.md'
             - .github/workflows/android*.yml
+            - .github/workflows/frontend.yml
             - .github/workflows/ios.yml
             - .github/workflows/rustfmt.yml
             - android/**

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,50 @@
+name: Translation check CI
+on:
+    # Check whenever a file that affects Rust formatting is changed by a push
+    push:
+        paths:
+            - .github/workflows/translations.yml
+            - android/translations-converter/**
+            - android/src/**/plurals.xml
+            - android/src/**/strings.xml
+            - gui/**
+    # Check if requested manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    check-translations:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install Node.js
+              uses: actions/setup-node@v2
+              with:
+                node-version: '12'
+
+            - name: Update NPM
+              run: npm i -g npm
+
+            - name: Install and cache JS dependencies
+              uses: bahmutov/npm-install@v1
+              with:
+                  working-directory: gui
+                  install-command: npm ci
+
+            - name: Install nightly Rust
+              uses: ATiltedTree/setup-rust@v1.0.4
+              with:
+                rust-version: stable
+
+            - name: Extract messages from desktop GUI
+              working-directory: gui/locales
+              run: npm run update-translations
+
+            - name: Convert translations into Android resources
+              working-directory: android/translations-converter
+              run: cargo run
+
+            - name: Check if repository is up to date
+              run: |
+                git diff
+                ! git status -s | grep .

--- a/android/src/main/res/values-da/strings.xml
+++ b/android/src/main/res/values-da/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">OPDATERING TILGÆNGELIG</string>
     <string name="update_available_footer">Opdatering tilgængelig, download den for at forblive sikker.</string>
     <string name="user_email_hint">Din e-mail (valgfrit)</string>
-    <string name="user_message_hint">Beskriv dit problem</string>
     <string name="view_logs">Se app-logfiler</string>
     <string name="virtual_adapter_problem">Fejl ved virtuel adapter</string>
     <string name="voucher_already_used">Kuponkode er allerede brugt.</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">UPDATE VERFÜGBAR</string>
     <string name="update_available_footer">Update verfügbar, laden Sie es herunter, um sicher zu bleiben.</string>
     <string name="user_email_hint">Ihre E-Mail-Adresse (optional)</string>
-    <string name="user_message_hint">Beschreiben Sie Ihr Problem</string>
     <string name="view_logs">App-Protokolle anzeigen</string>
     <string name="virtual_adapter_problem">Virtueller Adapterfehler</string>
     <string name="voucher_already_used">Der Gutscheincode wurde bereits verwendet.</string>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">ACTUALIZACIÓN DISPONIBLE</string>
     <string name="update_available_footer">Actualización disponible, descárguela para garantizar su seguridad.</string>
     <string name="user_email_hint">Su correo electrónico (opcional)</string>
-    <string name="user_message_hint">Describa el problema</string>
     <string name="view_logs">Ver registros de la aplicación</string>
     <string name="virtual_adapter_problem">Error del adaptador virtual</string>
     <string name="voucher_already_used">El código del cupón ya se ha usado.</string>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">PÄIVITYS SAATAVILLA</string>
     <string name="update_available_footer">Päivitys saatavilla. Lataa se pysyäksesi turvassa.</string>
     <string name="user_email_hint">Sähköpostisi (valinnainen)</string>
-    <string name="user_message_hint">Kuvaile ongelmaasi</string>
     <string name="view_logs">Tarkastele sovelluslokeja</string>
     <string name="virtual_adapter_problem">Virtuaalisovittimen virhe</string>
     <string name="voucher_already_used">Kuponkikoodi on jo käytetty.</string>

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">MISE À JOUR DISPONIBLE</string>
     <string name="update_available_footer">Mise à jour disponible. Téléchargez-la pour rester en sécurité.</string>
     <string name="user_email_hint">Votre e-mail (facultatif)</string>
-    <string name="user_message_hint">Décrivez votre problème</string>
     <string name="view_logs">Afficher les journaux de l\'application</string>
     <string name="virtual_adapter_problem">Erreur d\'adaptateur virtuel</string>
     <string name="voucher_already_used">Le code du bon a déjà été utilisé.</string>

--- a/android/src/main/res/values-it/strings.xml
+++ b/android/src/main/res/values-it/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">AGGIORNAMENTO DISPONIBILE</string>
     <string name="update_available_footer">Aggiornamento disponibile; scarica per rimanere protetto.</string>
     <string name="user_email_hint">La tua e-mail (opzionale)</string>
-    <string name="user_message_hint">Descrivi il tuo problema</string>
     <string name="view_logs">Visualizza registri app</string>
     <string name="virtual_adapter_problem">Errore scheda virtuale</string>
     <string name="voucher_already_used">Il codice voucher è già stato utilizzato.</string>

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">アップデート可</string>
     <string name="update_available_footer">アップデートできます。ダウンロードしてセキュリティを維持してください。</string>
     <string name="user_email_hint">あなたのメールアドレス（任意）</string>
-    <string name="user_message_hint">問題の内容をご説明ください</string>
     <string name="view_logs">アプリのログを表示</string>
     <string name="virtual_adapter_problem">仮想アダプタエラー</string>
     <string name="voucher_already_used">バウチャーコードはすでに使用されています。</string>

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">업데이트 사용 가능</string>
     <string name="update_available_footer">업데이트 사용 가능, 안전을 유지하기 위해 다운로드하세요.</string>
     <string name="user_email_hint">이메일(선택 사항)</string>
-    <string name="user_message_hint">문제 설명</string>
     <string name="view_logs">앱 로그 보기</string>
     <string name="virtual_adapter_problem">가상 어댑터 오류</string>
     <string name="voucher_already_used">이미 사용된 바우처 코드입니다.</string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">OPPDATERING TILGJENGELIG</string>
     <string name="update_available_footer">Oppdatering tilgjengelig. Last ned for å oppdatere sikkerheten.</string>
     <string name="user_email_hint">E-post (valgfritt)</string>
-    <string name="user_message_hint">Beskriv problemet</string>
     <string name="view_logs">Se applogger</string>
     <string name="virtual_adapter_problem">Virtuell adapterfeil</string>
     <string name="voucher_already_used">Kupongkoden er allerede brukt.</string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -54,7 +54,7 @@
     <string name="failed_to_create_account">Kunne ikke opprette konto</string>
     <string name="failed_to_generate_key">Generering av en nøkkel mislyktes</string>
     <string name="failed_to_send">Kunne ikke sende</string>
-    <string name="failed_to_send_details">Du må gå tilbake til hovedskjermen til appen og trykke på \\\"Koble fra\\\" før du kan prøve på nytt. Men det er ingen grunn til bekymring, informasjonen du har skrevet i skjemaet blir ikke borte.</string>
+    <string name="failed_to_send_details">Du må gå tilbake til hovedskjermen til appen og trykke på \"Koble fra\" før du kan prøve på nytt. Men det er ingen grunn til bekymring, informasjonen du har skrevet i skjemaet blir ikke borte.</string>
     <string name="faqs_and_guides">Ofte stilte spørsmål og veiledninger</string>
     <string name="faqs_and_guides_url">https://mullvad.net/nb/help/tag/mullvad-app/</string>
     <string name="foreground_notification_channel_description">Viser gjeldende VPN-tunnelstatus</string>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">UPDATE BESCHIKBAAR</string>
     <string name="update_available_footer">Update beschikbaar, download deze voor optimale beveiliging.</string>
     <string name="user_email_hint">Uw e-mailadres (optioneel)</string>
-    <string name="user_message_hint">Beschrijf het probleem</string>
     <string name="view_logs">Applogboeken weergeven</string>
     <string name="virtual_adapter_problem">Fout virtuele adapter</string>
     <string name="voucher_already_used">Vouchercode is al gebruikt.</string>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">DOSTĘPNA JEST AKTUALIZACJA</string>
     <string name="update_available_footer">Dostępna jest aktualizacja. Aby zachować bezpieczeństwo, pobierz ją.</string>
     <string name="user_email_hint">Twój adres e-mail (opcjonalnie)</string>
-    <string name="user_message_hint">Opisz problem</string>
     <string name="view_logs">Wyświetl dzienniki aplikacji</string>
     <string name="virtual_adapter_problem">Błąd wirtualnej karty sieciowej</string>
     <string name="voucher_already_used">Kod z tego kuponu został już użyty.</string>

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">ESTÁ DISPONÍVEL UMA ATUALIZAÇÃO</string>
     <string name="update_available_footer">Atualização disponível, transfira-a para ficar seguro.</string>
     <string name="user_email_hint">O seu email (opcional)</string>
-    <string name="user_message_hint">Descreva o seu problema</string>
     <string name="view_logs">Ver os registos da app</string>
     <string name="virtual_adapter_problem">Erro de adaptador virtual</string>
     <string name="voucher_already_used">O código do voucher já foi utilizado.</string>

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">ЕСТЬ ОБНОВЛЕНИЕ</string>
     <string name="update_available_footer">Есть обновление. Чтобы оставаться в безопасности, обновитесь.</string>
     <string name="user_email_hint">Ваша электронная почта (необязательно)</string>
-    <string name="user_message_hint">Опишите проблему</string>
     <string name="view_logs">Открыть журналы</string>
     <string name="virtual_adapter_problem">Ошибка виртуального адаптера</string>
     <string name="voucher_already_used">Этот код ваучера уже использовался.</string>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">UPPDATERING TILLGÄNGLIG</string>
     <string name="update_available_footer">Uppdatering tillgänglig. Ladda ned för att vara säker.</string>
     <string name="user_email_hint">Din e-postadress (valfritt)</string>
-    <string name="user_message_hint">Beskriv ditt problem</string>
     <string name="view_logs">Visa appens loggar</string>
     <string name="virtual_adapter_problem">Fel med virtuell adapter</string>
     <string name="voucher_already_used">Kupongkoden har redan använts.</string>

--- a/android/src/main/res/values-th/strings.xml
+++ b/android/src/main/res/values-th/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">มีการอัปเดตให้ใช้งาน</string>
     <string name="update_available_footer">มีการอัปเดตให้ใช้งาน ดาวน์โหลดเพื่อยกระดับความปลอดภัย</string>
     <string name="user_email_hint">อีเมลของคุณ (ไม่บังคับ)</string>
-    <string name="user_message_hint">ระบุปัญหาของคุณ</string>
     <string name="view_logs">ดูบันทึกของแอป</string>
     <string name="virtual_adapter_problem">ข้อผิดพลาดของอะแดปเตอร์เสมือน</string>
     <string name="voucher_already_used">รหัสบัตรกำนัลถูกใช้ไปแล้ว</string>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">GÜNCELLEME MEVCUT</string>
     <string name="update_available_footer">Güncelleme mevcut, güvende olmak için indirin.</string>
     <string name="user_email_hint">E-posta adresiniz (isteğe bağlı)</string>
-    <string name="user_message_hint">Sorununuzu açıklayın</string>
     <string name="view_logs">Uygulama kayıtlarını görüntüle</string>
     <string name="virtual_adapter_problem">Sanal adaptör hatası</string>
     <string name="voucher_already_used">Kupon kodu zaten kullanılmış.</string>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -111,7 +111,6 @@
     <string name="update_available">有可用更新</string>
     <string name="update_available_footer">有可用更新，请下载以保持安全。</string>
     <string name="user_email_hint">您的电子邮件（可选）</string>
-    <string name="user_message_hint">描述您的问题</string>
     <string name="view_logs">查看应用日志</string>
     <string name="virtual_adapter_problem">虚拟适配器错误</string>
     <string name="voucher_already_used">该优惠券码已被使用。</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -115,7 +115,6 @@
     <string name="update_available">可用的更新</string>
     <string name="update_available_footer">更新可用，請下載以保持安全。</string>
     <string name="user_email_hint">您的電子郵件 (選填)</string>
-    <string name="user_message_hint">描述您的問題</string>
     <string name="view_logs">檢視應用程式日誌</string>
     <string name="virtual_adapter_problem">虛擬配接器錯誤</string>
     <string name="voucher_already_used">此憑證兌換碼已有人用過。</string>

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -43,10 +43,10 @@ pub struct MsgEntry {
 /// A message string or plural set in a gettext translation file.
 #[derive(Clone, Debug)]
 pub enum MsgValue {
-    Invariant(String),
+    Invariant(MsgString),
     Plural {
         plural_id: String,
-        values: Vec<String>,
+        values: Vec<MsgString>,
     },
 }
 
@@ -148,7 +148,7 @@ impl Translation {
                     let variant_msg = parse_line(&plural_translation[variant_id_end..], "] \"", "")
                         .expect("Invalid plural msgstr");
 
-                    variants.insert(variant_id, normalize(variant_msg));
+                    variants.insert(variant_id, MsgString(normalize(variant_msg)));
                     parsing_header = false;
                 }
                 ["\"", header, "\\n\""] => {
@@ -252,7 +252,7 @@ impl Deref for MsgString {
 
 impl From<String> for MsgValue {
     fn from(string: String) -> Self {
-        MsgValue::Invariant(string)
+        MsgValue::Invariant(string.into())
     }
 }
 
@@ -277,12 +277,12 @@ pub fn append_to_template(
         writeln!(writer, "msgid {:?}", entry.id)?;
 
         match entry.value {
-            MsgValue::Invariant(value) => writeln!(writer, "msgstr {:?}", value)?,
+            MsgValue::Invariant(value) => writeln!(writer, r#"msgstr "{}""#, value)?,
             MsgValue::Plural { plural_id, values } => {
                 writeln!(writer, "msgid_plural {:?}", plural_id)?;
 
                 for (index, value) in values.into_iter().enumerate() {
-                    writeln!(writer, "msgstr[{}] {:?}", index, value)?;
+                    writeln!(writer, r#"msgstr[{}] "{}""#, index, value)?;
                 }
             }
         }

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -119,11 +119,11 @@ impl Translation {
         for line in lines {
             match_str! { (line.trim())
                 ["msgid \"", msg_id, "\""] => {
-                    current_id = Some(MsgString(normalize(msg_id)));
+                    current_id = Some(normalize(msg_id));
                 }
                 ["msgstr \"", translation, "\""] => {
                     if let Some(id) = current_id.take() {
-                        let value = MsgValue::from(normalize(translation));
+                        let value = MsgValue::Invariant(normalize(translation));
 
                         parsing_header = id.is_empty() && translation.is_empty();
 
@@ -134,7 +134,7 @@ impl Translation {
                     current_plural_id = None;
                 }
                 ["msgid_plural \"", plural_id, "\""] => {
-                    current_plural_id = Some(MsgString(normalize(plural_id)));
+                    current_plural_id = Some(normalize(plural_id));
                     parsing_header = false;
                 }
                 ["msgstr[", plural_translation, "\""] => {
@@ -148,7 +148,7 @@ impl Translation {
                     let variant_msg = parse_line(&plural_translation[variant_id_end..], "] \"", "")
                         .expect("Invalid plural msgstr");
 
-                    variants.insert(variant_id, MsgString(normalize(variant_msg)));
+                    variants.insert(variant_id, normalize(variant_msg));
                     parsing_header = false;
                 }
                 ["\"", header, "\\n\""] => {
@@ -302,7 +302,7 @@ fn parse_line<'l>(line: &'l str, prefix: &str, suffix: &str) -> Option<&'l str> 
     }
 }
 
-fn normalize(string: &str) -> String {
+fn normalize(string: &str) -> MsgString {
     // Use a single common apostrophe character
     let string = APOSTROPHE_VARIATION.replace_all(&string, "'");
     // Mark where parameters are positioned, removing the parameter name
@@ -310,5 +310,5 @@ fn normalize(string: &str) -> String {
     // Remove escaped double-quotes
     let string = ESCAPED_DOUBLE_QUOTES.replace_all(&string, r#"""#);
 
-    string.into_owned()
+    string.into_owned().into()
 }

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -2,9 +2,11 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use std::{
     collections::BTreeMap,
+    fmt::{self, Display, Formatter},
     fs::{File, OpenOptions},
     io::{self, BufRead, BufReader, BufWriter, Write},
     mem,
+    ops::Deref,
     path::Path,
 };
 
@@ -47,6 +49,10 @@ pub enum MsgValue {
         values: Vec<String>,
     },
 }
+
+/// A message string in a gettext translation file.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct MsgString(String);
 
 /// A helper macro to match a string to various prefix and suffix combinations.
 macro_rules! match_str {
@@ -214,6 +220,33 @@ impl PluralForm {
             }
             other => panic!("Unknown plural formula: {}", other),
         }
+    }
+}
+
+impl From<String> for MsgString {
+    fn from(string: String) -> Self {
+        MsgString(string)
+    }
+}
+
+impl From<&str> for MsgString {
+    fn from(string: &str) -> Self {
+        string.to_owned().into()
+    }
+}
+
+impl Display for MsgString {
+    /// Write the ID message string with proper escaping.
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        self.0.replace(r#"""#, r#"\""#).fmt(formatter)
+    }
+}
+
+impl Deref for MsgString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
     }
 }
 

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -45,7 +45,7 @@ pub struct MsgEntry {
 pub enum MsgValue {
     Invariant(MsgString),
     Plural {
-        plural_id: String,
+        plural_id: MsgString,
         values: Vec<MsgString>,
     },
 }
@@ -134,7 +134,7 @@ impl Translation {
                     current_plural_id = None;
                 }
                 ["msgid_plural \"", plural_id, "\""] => {
-                    current_plural_id = Some(normalize(plural_id));
+                    current_plural_id = Some(MsgString(normalize(plural_id)));
                     parsing_header = false;
                 }
                 ["msgstr[", plural_translation, "\""] => {
@@ -279,7 +279,7 @@ pub fn append_to_template(
         match entry.value {
             MsgValue::Invariant(value) => writeln!(writer, r#"msgstr "{}""#, value)?,
             MsgValue::Plural { plural_id, values } => {
-                writeln!(writer, "msgid_plural {:?}", plural_id)?;
+                writeln!(writer, r#"msgid_plural "{}""#, plural_id)?;
 
                 for (index, value) in values.into_iter().enumerate() {
                     writeln!(writer, r#"msgstr[{}] "{}""#, index, value)?;

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -234,9 +234,12 @@ pub fn append_to_template(
         .write(true)
         .append(true)
         .open(file_path)?;
+    let mut sorted_entries: Vec<_> = entries.collect();
     let mut writer = BufWriter::new(file);
 
-    for entry in entries {
+    sorted_entries.sort_by(|first, second| first.id.cmp(&second.id));
+
+    for entry in sorted_entries {
         writeln!(writer)?;
         writeln!(writer, "msgid {:?}", entry.id)?;
 

--- a/android/translations-converter/src/gettext.rs
+++ b/android/translations-converter/src/gettext.rs
@@ -36,7 +36,7 @@ pub enum PluralForm {
 /// A message entry in a gettext translation file.
 #[derive(Clone, Debug)]
 pub struct MsgEntry {
-    pub id: String,
+    pub id: MsgString,
     pub value: MsgValue,
 }
 
@@ -119,7 +119,7 @@ impl Translation {
         for line in lines {
             match_str! { (line.trim())
                 ["msgid \"", msg_id, "\""] => {
-                    current_id = Some(normalize(msg_id));
+                    current_id = Some(MsgString(normalize(msg_id)));
                 }
                 ["msgstr \"", translation, "\""] => {
                     if let Some(id) = current_id.take() {
@@ -274,7 +274,7 @@ pub fn append_to_template(
 
     for entry in sorted_entries {
         writeln!(writer)?;
-        writeln!(writer, "msgid {:?}", entry.id)?;
+        writeln!(writer, r#"msgid "{}""#, entry.id)?;
 
         match entry.value {
             MsgValue::Invariant(value) => writeln!(writer, r#"msgstr "{}""#, value)?,

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -192,7 +192,7 @@ fn main() {
                         id,
                         value: gettext::MsgValue::Plural {
                             plural_id,
-                            values: vec!["".to_owned(), "".to_owned()],
+                            values: vec!["".into(), "".into()],
                         },
                     }
                 }),
@@ -262,6 +262,8 @@ fn generate_translations(
             }
             gettext::MsgValue::Plural { values, .. } => {
                 if let Some(android_key) = known_plurals.remove(&translation.id) {
+                    let values = values.into_iter().map(|message| message.to_string());
+
                     localized_plurals.push(android::PluralResource::new(
                         android_key,
                         plural_quantities.clone().zip(values),

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -191,7 +191,12 @@ fn main() {
                         .iter()
                         .position(|plural| plural.quantity == android::PluralQuantity::Other)
                         .expect("Missing other variant to use as msgid_plural");
-                    let plural_id = plural.items.remove(other_position).string.to_string();
+                    let plural_id = plural
+                        .items
+                        .remove(other_position)
+                        .string
+                        .to_string()
+                        .into();
 
                     gettext::MsgEntry {
                         id,

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -133,8 +133,8 @@ fn main() {
 
     for message in template {
         match message.value {
-            gettext::MsgValue::Invariant(_) => missing_translations.remove(&message.id),
-            gettext::MsgValue::Plural { .. } => missing_plurals.remove(&message.id),
+            gettext::MsgValue::Invariant(_) => missing_translations.remove(&*message.id),
+            gettext::MsgValue::Plural { .. } => missing_plurals.remove(&*message.id),
         };
     }
 
@@ -147,7 +147,7 @@ fn main() {
                 .into_iter()
                 .inspect(|(missing_translation, id)| println!("  {}: {}", id, missing_translation))
                 .map(|(id, _)| gettext::MsgEntry {
-                    id,
+                    id: id.into(),
                     value: String::new().into(),
                 }),
         )
@@ -179,7 +179,12 @@ fn main() {
                         .iter()
                         .position(|plural| plural.quantity == android::PluralQuantity::One)
                         .expect("Missing singular variant to use as msgid");
-                    let id = plural.items.remove(singular_position).string.to_string();
+                    let id = plural
+                        .items
+                        .remove(singular_position)
+                        .string
+                        .to_string()
+                        .into();
 
                     let other_position = plural
                         .items
@@ -253,7 +258,7 @@ fn generate_translations(
     for translation in translations {
         match translation.value {
             gettext::MsgValue::Invariant(translation_value) => {
-                if let Some(android_key) = known_strings.remove(&translation.id) {
+                if let Some(android_key) = known_strings.remove(&*translation.id) {
                     localized_strings.push(android::StringResource::new(
                         android_key,
                         &translation_value,
@@ -261,7 +266,7 @@ fn generate_translations(
                 }
             }
             gettext::MsgValue::Plural { values, .. } => {
-                if let Some(android_key) = known_plurals.remove(&translation.id) {
+                if let Some(android_key) = known_plurals.remove(&*translation.id) {
                     let values = values.into_iter().map(|message| message.to_string());
 
                     localized_plurals.push(android::PluralResource::new(

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -170,6 +170,10 @@ msgid "Default"
 msgstr ""
 
 msgctxt "advanced-settings-view"
+msgid "e.g. 10.0.0.4"
+msgstr ""
+
+msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr ""
 
@@ -242,6 +246,11 @@ msgstr ""
 
 msgctxt "advanced-settings-view"
 msgid "The app’s built-in kill switch is always on. This setting will additionally block the internet if clicking Disconnect or Quit."
+msgstr ""
+
+#. The hint displayed below the WireGuard port selector.
+msgctxt "advanced-settings-view"
+msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -779,16 +788,16 @@ msgid "Advanced"
 msgstr ""
 
 msgctxt "settings-view"
+msgid "App is out of sync. Please quit and restart."
+msgstr ""
+
+msgctxt "settings-view"
 msgid "App version"
 msgstr ""
 
 #. Link to the webpage
 msgctxt "settings-view"
 msgid "FAQs & Guides"
-msgstr ""
-
-msgctxt "settings-view"
-msgid "Inconsistent internal version information, please restart the app."
 msgstr ""
 
 #. Navigation button to the 'Language' settings view
@@ -815,7 +824,7 @@ msgid "Report a problem"
 msgstr ""
 
 msgctxt "settings-view"
-msgid "Update available, download to remain safe."
+msgid "Update available. Install the latest app version to stay up to date."
 msgstr ""
 
 #. Title label in navigation bar
@@ -847,16 +856,30 @@ msgctxt "split-tunneling-view"
 msgid "Launch application"
 msgstr ""
 
+#. This error message is shown if the user tries to launch a Linux desktop
+#. entry file that doesn't contain the required 'Exec' value.
+msgctxt "split-tunneling-view"
+msgid "Please contact support."
+msgstr ""
+
+#. This error message is shown if the user tries to launch an app that
+#. doesn't exist.
+#. This error message is shown if an application failes during startup.
+msgctxt "split-tunneling-view"
+msgid "Please try again or contact support."
+msgstr ""
+
 msgctxt "split-tunneling-view"
 msgid "Split tunneling"
 msgstr ""
 
-msgctxt "support-view"
-msgid "Continue anyway"
+#. Error message showed in a dialog when an application failes to launch.
+msgctxt "split-tunneling-view"
+msgid "Unable to launch selection. %(detailedErrorMessage)s"
 msgstr ""
 
 msgctxt "support-view"
-msgid "Describe your problem"
+msgid "Continue anyway"
 msgstr ""
 
 msgctxt "support-view"
@@ -871,7 +894,15 @@ msgstr ""
 #. Available placeholders:
 #. %(email)s
 msgctxt "support-view"
-msgid "If needed we will contact you on %(email)s"
+msgid "If needed we will contact you at %(email)s"
+msgstr ""
+
+msgctxt "support-view"
+msgid "If you exit the form and try again later, the information you already entered will still be here."
+msgstr ""
+
+msgctxt "support-view"
+msgid "Please describe your problem in English or Swedish."
 msgstr ""
 
 #. Title label in navigation bar
@@ -925,10 +956,6 @@ msgstr ""
 
 msgctxt "support-view"
 msgid "You are using an old version of the app. Please upgrade and see if the problem still exists before sending a report."
-msgstr ""
-
-msgctxt "support-view"
-msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
 msgstr ""
 
 msgctxt "support-view"
@@ -996,10 +1023,6 @@ msgid "Regenerate key"
 msgstr ""
 
 msgctxt "wireguard-key-view"
-msgid "Unable to manage keys while in a blocked state"
-msgstr ""
-
-msgctxt "wireguard-key-view"
 msgid "Unable to regenerate key: you already have the maximum number of keys. To generate a new key, you first need to revoke one under “Manage keys.”"
 msgstr ""
 
@@ -1016,161 +1039,3 @@ msgstr ""
 msgctxt "wireguard-keys-nav"
 msgid "WireGuard key"
 msgstr ""
-
-msgid "The DNS server you are trying to add might not work because it is public. Currently we only support local DNS servers."
-msgstr ""
-
-msgid "WireGuard error"
-msgstr ""
-
-msgid "Account time reminders"
-msgstr ""
-
-msgid "WireGuard public key"
-msgstr ""
-
-msgid "Copied WireGuard public key to clipboard"
-msgstr ""
-
-msgid "Account credit expires soon"
-msgstr ""
-
-msgid "Account credit expires in a few minutes"
-msgstr ""
-
-msgid "Thanks!"
-msgstr ""
-
-msgid "We will look into this."
-msgstr ""
-
-msgid "You are running an unsupported app version. Please upgrade to %s now to ensure your security"
-msgstr ""
-
-msgid "e.g. 10.0.0.4"
-msgstr ""
-
-msgid "Copied to clipboard"
-msgstr ""
-
-msgid "Too many WireGuard keys registered to account"
-msgstr ""
-
-msgid "Shows current VPN tunnel status"
-msgstr ""
-
-msgid "Copied Mullvad account number to clipboard"
-msgstr ""
-
-msgid "Use custom DNS server"
-msgstr ""
-
-msgid "Add anyway"
-msgstr ""
-
-msgid "Failed to block all network traffic. Please troubleshoot or report the problem to us."
-msgstr ""
-
-msgid "Split tunneling makes it possible to select which applications should not be routed through the VPN tunnel."
-msgstr ""
-
-msgid "less than a day left"
-msgstr ""
-
-msgid "Blocking all connections"
-msgstr ""
-
-msgid "Could not configure IPv6"
-msgstr ""
-
-msgid "Disconnecting"
-msgstr ""
-
-msgid "Enable to add at least one DNS server."
-msgstr ""
-
-msgid "Enable"
-msgstr ""
-
-msgid "No relay server matches the current settings"
-msgstr ""
-
-msgid "VPN permission was denied when creating the tunnel. Please try connecting again."
-msgstr ""
-
-msgid "No bridge relay server matches the current settings"
-msgstr ""
-
-msgid "Shows reminders when the account time is about to expire"
-msgstr ""
-
-msgid "Add a server"
-msgstr ""
-
-msgid "Mullvad account number"
-msgstr ""
-
-msgid "less than a minute ago"
-msgstr ""
-
-msgid "Failed to resolve the hostname of custom server"
-msgstr ""
-
-msgid "Virtual adapter error"
-msgstr ""
-
-msgid "Exclude applications"
-msgstr ""
-
-msgid "VPN tunnel status"
-msgstr ""
-
-msgid "1 year left"
-msgid_plural "%d years left"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "1 month left"
-msgid_plural "%d months left"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "1 day left"
-msgid_plural "%d days left"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "a minute ago"
-msgid_plural "%d minutes ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "an hour ago"
-msgid_plural "%d hours ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "a day ago"
-msgid_plural "%d days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "a month ago"
-msgid_plural "%d months ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "a year ago"
-msgid_plural "%d years ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "Account credit expires in a day"
-msgid_plural "Account credit expires in %d days"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "Account credit expires in an hour"
-msgid_plural "Account credit expires in %d hours"
-msgstr[0] ""
-msgstr[1] ""

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1039,3 +1039,188 @@ msgstr ""
 msgctxt "wireguard-keys-nav"
 msgid "WireGuard key"
 msgstr ""
+
+msgid "Account authentication failed."
+msgstr ""
+
+msgid "Account credit expires in a few minutes"
+msgstr ""
+
+msgid "Account credit expires soon"
+msgstr ""
+
+msgid "Account time reminders"
+msgstr ""
+
+msgid "Blocking all connections"
+msgstr ""
+
+msgid "Blocking internet"
+msgstr ""
+
+msgid "Copied Mullvad account number to clipboard"
+msgstr ""
+
+msgid "Copied WireGuard public key to clipboard"
+msgstr ""
+
+msgid "Copied to clipboard"
+msgstr ""
+
+msgid "Could not configure IPv6"
+msgstr ""
+
+msgid "Critical error (your attention is required)"
+msgstr ""
+
+msgid "Custom DNS server addresses %s are invalid"
+msgstr ""
+
+msgid "Disconnecting"
+msgstr ""
+
+msgid "Enable"
+msgstr ""
+
+msgid "Exclude applications"
+msgstr ""
+
+msgid "Failed to apply firewall rules. The device might currently be unsecured"
+msgstr ""
+
+msgid "Failed to block all network traffic. Please troubleshoot or report the problem to us."
+msgstr ""
+
+msgid "Failed to resolve the hostname of custom server"
+msgstr ""
+
+msgid "Failed to set system DNS server"
+msgstr ""
+
+msgid "Failed to start tunnel connection"
+msgstr ""
+
+msgid "If needed we will contact you on %s"
+msgstr ""
+
+msgid "Install Mullvad VPN (%s) to stay up to date"
+msgstr ""
+
+msgid "Mullvad account number"
+msgstr ""
+
+msgid "No bridge relay server matches the current settings"
+msgstr ""
+
+msgid "No relay server matches the current settings"
+msgstr ""
+
+msgid "Secured"
+msgstr ""
+
+msgid "Shows current VPN tunnel status"
+msgstr ""
+
+msgid "Shows reminders when the account time is about to expire"
+msgstr ""
+
+msgid "Split tunneling makes it possible to select which applications should not be routed through the VPN tunnel."
+msgstr ""
+
+msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under Preferences."
+msgstr ""
+
+msgid "This device is offline, no tunnels can be established"
+msgstr ""
+
+msgid "Too many WireGuard keys registered to account"
+msgstr ""
+
+msgid "Unsecured"
+msgstr ""
+
+msgid "Update available, download to remain safe."
+msgstr ""
+
+msgid "VPN permission was denied when creating the tunnel. Please try connecting again."
+msgstr ""
+
+msgid "VPN tunnel status"
+msgstr ""
+
+msgid "Virtual adapter error"
+msgstr ""
+
+msgid "WireGuard error"
+msgstr ""
+
+msgid "WireGuard public key"
+msgstr ""
+
+msgid "YOU MIGHT BE LEAKING NETWORK TRAFFIC"
+msgstr ""
+
+msgid "You are running an unsupported app version."
+msgstr ""
+
+msgid "You are running an unsupported app version. Please upgrade to %s now to ensure your security"
+msgstr ""
+
+msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
+msgstr ""
+
+msgid "less than a day left"
+msgstr ""
+
+msgid "less than a minute ago"
+msgstr ""
+
+msgid "1 day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "1 month left"
+msgid_plural "%d months left"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "1 year left"
+msgid_plural "%d years left"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Account credit expires in a day"
+msgid_plural "Account credit expires in %d days"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Account credit expires in an hour"
+msgid_plural "Account credit expires in %d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a day ago"
+msgid_plural "%d days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a minute ago"
+msgid_plural "%d minutes ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a month ago"
+msgid_plural "%d months ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a year ago"
+msgid_plural "%d years ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "an hour ago"
+msgid_plural "%d hours ago"
+msgstr[0] ""
+msgstr[1] ""


### PR DESCRIPTION
The process to handle adding translations to the app (desktop and Android) became more complex due to the requirement of keeping gettext files and Android resources synchronized. This PR aims to help with that problem by creating a new CI workflow that will fail in some situations where the translations aren't properly synchronized. More specifically, the workflow will fail in the following scenarios:

- adding a new message to the desktop GUI but not including that message in the template file (`messages.pot`)
- adding a new Android string resource that and either:
  - not adding the translations extracted from the desktop GUI locales for that message
  - not adding the message to the template file
- changing a message in the desktop GUI and not updating the template file or not updating the respective Android translations
- changing a string resource in the Android app and not updating its translations or its entry in the template file
- removing a message in the desktop GUI but not updating the template file or not updating the respective Android translations
- removing a string resource in the Android app and not removing its respective translations or its respective entry in the template file

If this job fails, the fix is to update the translations by running first `npm run update-translations` in the `gui` directory and then running the Android translation converter tool with `cargo run` in the `android/translations-converter` directory.

As part of the PR, the translations converter tool was updated to become more deterministic. The entries appended to the template file are now sorted so that they are always added in the same order. Also, the template file and the Android resources were updated.

A small bug in the tool was also fixed, where the single quote `'` was being incorrectly escaped in strings appended to the template file. The fix was to manually escape only the double quotes `"` instead of relying on `fmt::Debug` to do the escaping for us.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tooling changes, no chaneglog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2624)
<!-- Reviewable:end -->
