### PR TITLE
Remove use_fwmark option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Upgrade Wintun from 0.9.2 to 0.10.1.
 
+#### Linux
+- Only allow packets with the mark set to `0x6d6f6c65` to communicate with the relay server.
+  Previously, bridges were expected to run as root instead.
+
 ### Fixed
 - Fix delay in showing/hiding update notification when toggling beta program.
 - Improve responsiveness when reconnecting after some failed connection attempts.

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -66,31 +66,48 @@ fn create_bridge_set_subcommand() -> clap::App<'static, 'static> {
 
 
 fn create_set_custom_settings_subcommand() -> clap::App<'static, 'static> {
+    #[allow(unused_mut)]
+    let mut local_subcommand = clap::SubCommand::with_name("local")
+        .about("Registers a local SOCKS5 proxy")
+        .arg(
+            clap::Arg::with_name("local-port")
+                .help("Specifies the port the local proxy server is listening on")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            clap::Arg::with_name("remote-ip")
+                .help("Specifies the IP of the proxy server peer")
+                .required(true)
+                .index(2),
+        )
+        .arg(
+            clap::Arg::with_name("remote-port")
+                .help("Specifies the port of the proxy server peer")
+                .required(true)
+                .index(3),
+        );
+
+    #[cfg(target_os = "linux")]
+    {
+        local_subcommand = local_subcommand.about(
+            "Registers a local SOCKS5 proxy. The server must be excluded using \
+           'mullvad-exclude', or `SO_MARK` must be set to '0x6d6f6c65', in order \
+           to bypass firewall restrictions",
+        );
+    }
+    #[cfg(target_os = "macos")]
+    {
+        local_subcommand = local_subcommand.help(
+            "Registers a local SOCKS5 proxy. The server must run as root to bypass \
+            firewall restrictions",
+        );
+    }
+
     clap::SubCommand::with_name("custom")
         .about("Configure a SOCKS5 proxy")
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(
-            clap::SubCommand::with_name("local")
-                .about("Registers a local SOCKS5 proxy")
-                .arg(
-                    clap::Arg::with_name("local-port")
-                        .help("Specifies the port the local proxy server is listening on")
-                        .required(true)
-                        .index(1),
-                )
-                .arg(
-                    clap::Arg::with_name("remote-ip")
-                        .help("Specifies the IP of the proxy server peer")
-                        .required(true)
-                        .index(2),
-                )
-                .arg(
-                    clap::Arg::with_name("remote-port")
-                        .help("Specifies the port of the proxy server peer")
-                        .required(true)
-                        .index(3),
-                ),
-        )
+        .subcommand(local_subcommand)
         .subcommand(
             clap::SubCommand::with_name("remote")
                 .about("Registers a remote SOCKS5 proxy")

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -112,10 +112,6 @@ pub enum FirewallPolicy {
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]
         relay_client: PathBuf,
-        /// Whether rule for allowing traffic to endpoint should match a firewall mark or match on
-        /// root UID.
-        #[cfg(target_os = "linux")]
-        use_fwmark: bool,
     },
 
     /// Allow traffic only to server and over tunnel interface
@@ -132,10 +128,6 @@ pub enum FirewallPolicy {
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]
         relay_client: PathBuf,
-        /// Whether rule for allowing traffic to endpoint should match a firewall mark or match on
-        /// root UID.
-        #[cfg(target_os = "linux")]
-        use_fwmark: bool,
     },
 
     /// Block all network traffic in and out from the computer.

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -113,8 +113,6 @@ impl ConnectedState {
                 &shared_values.resource_dir,
                 &self.tunnel_parameters,
             ),
-            #[cfg(target_os = "linux")]
-            use_fwmark: self.tunnel_parameters.get_proxy_endpoint().is_none(),
         }
     }
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -69,8 +69,6 @@ impl ConnectingState {
             allowed_endpoint: shared_values.allowed_endpoint.clone(),
             #[cfg(windows)]
             relay_client: TunnelMonitor::get_relay_client(&shared_values.resource_dir, &params),
-            #[cfg(target_os = "linux")]
-            use_fwmark: params.get_proxy_endpoint().is_none(),
         };
         shared_values
             .firewall


### PR DESCRIPTION
If this setting is set to true, the firewall only permits packets with a particular fwmark to communicate outside the tunnel with the relay server. The alternative is that processes that run as root are allowed to talk to the relay.

It is no longer useful to set this to `false`, not even for bridges since we exclude `sslocal` from the tunnel. This change does mean that one must use `mullvad-exclude` (or, preferably, set the fwmark directly to `talpid_core::linux::TUNNEL_FW_MARK`) to run one's proxy server, or else the firewall will block it. But in practice, this is already the easiest way to go, because the routes are not automatically set up to deal with the other case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2627)
<!-- Reviewable:end -->
