### PR TITLE
Split `AccountCache` into UI-side and service-side classes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -12,6 +12,9 @@ sealed class Event : Message.EventMessage() {
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize
+    data class AccountHistory(val history: List<String>?) : Event()
+
+    @Parcelize
     object ListenerReady : Event()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -4,6 +4,7 @@ import android.os.Message as RawMessage
 import kotlinx.parcelize.Parcelize
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.KeygenEvent
+import net.mullvad.mullvadvpn.model.LoginStatus as LoginStatusData
 import net.mullvad.mullvadvpn.model.Settings
 
 // Events that can be sent from the service
@@ -12,6 +13,9 @@ sealed class Event : Message.EventMessage() {
 
     @Parcelize
     object ListenerReady : Event()
+
+    @Parcelize
+    data class LoginStatus(val status: LoginStatusData?) : Event()
 
     @Parcelize
     data class NewLocation(val location: GeoIpLocation?) : Event()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -7,8 +7,7 @@ import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.Settings
 
 // Events that can be sent from the service
-sealed class Event : Message() {
-    protected override val messageId = 1
+sealed class Event : Message.EventMessage() {
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Message.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Message.kt
@@ -4,8 +4,10 @@ import android.os.Bundle
 import android.os.Message as RawMessage
 import android.os.Parcelable
 
-abstract class Message : Parcelable {
-    protected abstract val messageId: Int
+sealed class Message(private val messageId: Int) : Parcelable {
+    abstract class EventMessage : Message(1)
+    abstract class RequestMessage : Message(2)
+
     protected abstract val messageKey: String
 
     val message: RawMessage

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -5,8 +5,7 @@ import android.os.Messenger
 import kotlinx.parcelize.Parcelize
 
 // Requests that the service can handle
-sealed class Request : Message() {
-    protected override val messageId = 2
+sealed class Request : Message.RequestMessage() {
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -3,13 +3,32 @@ package net.mullvad.mullvadvpn.ipc
 import android.os.Message as RawMessage
 import android.os.Messenger
 import kotlinx.parcelize.Parcelize
+import org.joda.time.DateTime
 
 // Requests that the service can handle
 sealed class Request : Message.RequestMessage() {
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize
+    object CreateAccount : Request()
+
+    @Parcelize
+    object FetchAccountExpiry : Request()
+
+    @Parcelize
+    data class InvalidateAccountExpiry(val expiry: DateTime) : Request()
+
+    @Parcelize
+    data class Login(val account: String?) : Request()
+
+    @Parcelize
+    object Logout : Request()
+
+    @Parcelize
     data class RegisterListener(val listener: Messenger) : Request()
+
+    @Parcelize
+    data class RemoveAccountFromHistory(val account: String?) : Request()
 
     @Parcelize
     object WireGuardGenerateKey : Request()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LoginStatus.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/LoginStatus.kt
@@ -1,0 +1,15 @@
+package net.mullvad.mullvadvpn.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import org.joda.time.DateTime
+
+@Parcelize
+data class LoginStatus(
+    val account: String,
+    val expiry: DateTime?,
+    val isNewAccount: Boolean
+) : Parcelable {
+    val isExpired: Boolean
+        get() = expiry != null && expiry.isAfterNow()
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -23,7 +23,7 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
 
     val onAccountNumberChange = EventNotifier<String?>(null)
     val onAccountExpiryChange = EventNotifier<DateTime?>(null)
-    val onAccountHistoryChange = EventNotifier<ArrayList<String>>(ArrayList())
+    val onAccountHistoryChange = EventNotifier<List<String>>(listOf<String>())
 
     var newlyCreatedAccount = false
         private set

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/AccountCache.kt
@@ -105,6 +105,10 @@ class AccountCache(val daemon: MullvadDaemon, val settingsListener: SettingsList
     fun onDestroy() {
         settingsListener.accountNumberNotifier.unsubscribe(this)
         jobTracker.cancelAllJobs()
+
+        onAccountNumberChange.unsubscribeAll()
+        onAccountExpiryChange.unsubscribeAll()
+        onAccountHistoryChange.unsubscribeAll()
     }
 
     private fun fetchAccountHistory() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -43,10 +43,6 @@ class ForegroundNotificationManager(
         }
     }
 
-    private var accountNumberEvents by autoSubscribable<String?>(this, null) { accountNumber ->
-        loggedIn = accountNumber != null
-    }
-
     private var tunnelStateEvents by autoSubscribable<TunnelState>(
         this,
         TunnelState.Disconnected
@@ -68,6 +64,10 @@ class ForegroundNotificationManager(
     private val shouldBeOnForeground
         get() = lockedToForeground || !(tunnelState is TunnelState.Disconnected)
 
+    var accountNumberEvents by autoSubscribable<String?>(this, null) { accountNumber ->
+        loggedIn = accountNumber != null
+    }
+
     var onForeground = false
         private set
 
@@ -77,7 +77,6 @@ class ForegroundNotificationManager(
 
     init {
         serviceNotifier.subscribe(this) { newServiceInstance ->
-            accountNumberEvents = newServiceInstance?.settingsListener?.accountNumberNotifier
             tunnelStateEvents = newServiceInstance?.connectionProxy?.onStateChange
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -239,6 +239,8 @@ class MullvadVpnService : TalpidVpnService() {
         val customDns = CustomDns(daemon, endpoint.settingsListener)
         val splitTunneling = splitTunneling.await()
 
+        notificationManager.accountNumberEvents = endpoint.settingsListener.accountNumberNotifier
+
         splitTunneling.onChange = { excludedApps ->
             disallowedApps = excludedApps
             markTunAsStale()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -254,6 +254,7 @@ class MullvadVpnService : TalpidVpnService() {
                 endpoint.messenger,
                 daemon,
                 daemonInstance.intermittentDaemon,
+                endpoint.accountCache,
                 connectionProxy,
                 customDns,
                 endpoint.settingsListener,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -58,7 +58,7 @@ class MullvadVpnService : TalpidVpnService() {
             oldInstance?.onDestroy()
 
             accountExpiryNotification = newInstance?.let { instance ->
-                AccountExpiryNotification(this, instance.daemon, instance.accountCache)
+                AccountExpiryNotification(this, instance.daemon, endpoint.accountCache)
             }
 
             serviceNotifier.notify(newInstance)
@@ -256,7 +256,6 @@ class MullvadVpnService : TalpidVpnService() {
                 endpoint.messenger,
                 daemon,
                 daemonInstance.intermittentDaemon,
-                endpoint.accountCache,
                 connectionProxy,
                 customDns,
                 splitTunneling

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -259,7 +259,6 @@ class MullvadVpnService : TalpidVpnService() {
                 endpoint.accountCache,
                 connectionProxy,
                 customDns,
-                endpoint.settingsListener,
                 splitTunneling
             )
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -13,7 +13,7 @@ class ServiceInstance(
     val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
-    val accountCache = AccountCache(daemon, settingsListener)
+    val accountCache = AccountCache(settingsListener, intermittentDaemon)
 
     fun onDestroy() {
         accountCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,14 +1,12 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class ServiceInstance(
     val messenger: Messenger,
     val daemon: MullvadDaemon,
     val intermittentDaemon: Intermittent<MullvadDaemon>,
-    val accountCache: AccountCache,
     val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
     val splitTunneling: SplitTunneling

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
+import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.Intermittent
 
@@ -8,15 +9,13 @@ class ServiceInstance(
     val messenger: Messenger,
     val daemon: MullvadDaemon,
     val intermittentDaemon: Intermittent<MullvadDaemon>,
+    val accountCache: AccountCache,
     val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
     val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
-    val accountCache = AccountCache(settingsListener, intermittentDaemon)
-
     fun onDestroy() {
-        accountCache.onDestroy()
         connectionProxy.onDestroy()
         customDns.onDestroy()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
 import net.mullvad.mullvadvpn.service.endpoint.AccountCache
-import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class ServiceInstance(
@@ -12,7 +11,6 @@ class ServiceInstance(
     val accountCache: AccountCache,
     val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
-    val settingsListener: SettingsListener,
     val splitTunneling: SplitTunneling
 ) {
     fun onDestroy() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -1,8 +1,8 @@
-package net.mullvad.mullvadvpn.service
+package net.mullvad.mullvadvpn.service.endpoint
 
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
-import net.mullvad.mullvadvpn.service.endpoint.SettingsListener
+import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.util.ExponentialBackoff
 import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.mullvadvpn.util.JobTracker

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -50,11 +50,11 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
         }
     }
 
-    suspend fun createNewAccount(): String? {
+    suspend fun createNewAccount() {
         newlyCreatedAccount = true
         createdAccountExpiry = null
 
-        return daemon.await().createNewAccount()
+        daemon.await().createNewAccount()
     }
 
     suspend fun login(account: String) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -65,6 +65,10 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
             handleNewAccountNumber(accountNumber)
         }
 
+        onAccountHistoryChange.subscribe(this) { history ->
+            endpoint.sendEvent(Event.AccountHistory(history))
+        }
+
         onLoginStatusChange.subscribe(this) { status ->
             endpoint.sendEvent(Event.LoginStatus(status))
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.delay
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.model.LoginStatus
@@ -62,6 +63,10 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
     init {
         endpoint.settingsListener.accountNumberNotifier.subscribe(this) { accountNumber ->
             handleNewAccountNumber(accountNumber)
+        }
+
+        onLoginStatusChange.subscribe(this) { status ->
+            endpoint.sendEvent(Event.LoginStatus(status))
         }
 
         endpoint.dispatcher.apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -1,5 +1,11 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.model.LoginStatus
@@ -19,7 +25,14 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
         // This is only used if the expiry was invalidated and fetching a new expiry returns the
         // same value as before the invalidation.
         private const val MAX_INVALIDATED_RETRIES = 7
+
+        private sealed class Command {
+            object CreateAccount : Command()
+            data class Login(val account: String) : Command()
+        }
     }
+
+    private val commandChannel = spawnActor()
 
     private val daemon
         get() = endpoint.intermittentDaemon
@@ -50,18 +63,12 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
         }
     }
 
-    suspend fun createNewAccount() {
-        newlyCreatedAccount = true
-        createdAccountExpiry = null
-
-        daemon.await().createNewAccount()
+    fun createNewAccount() {
+        commandChannel.sendBlocking(Command.CreateAccount)
     }
 
-    suspend fun login(account: String) {
-        if (account != accountNumber) {
-            markAccountAsNotNew()
-            daemon.await().setAccount(account)
-        }
+    fun login(account: String) {
+        commandChannel.sendBlocking(Command.Login(account))
     }
 
     fun fetchAccountExpiry() {
@@ -117,6 +124,35 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
         onAccountExpiryChange.unsubscribeAll()
         onAccountHistoryChange.unsubscribeAll()
         onLoginStatusChange.unsubscribeAll()
+
+        commandChannel.close()
+    }
+
+    private fun spawnActor() = GlobalScope.actor<Command>(Dispatchers.Default, Channel.UNLIMITED) {
+        try {
+            val command = channel.receive()
+
+            when (command) {
+                is Command.CreateAccount -> doCreateAccount()
+                is Command.Login -> doLogin(command.account)
+            }
+        } catch (exception: ClosedReceiveChannelException) {
+            // Command channel was closed, stop the actor
+        }
+    }
+
+    private suspend fun doCreateAccount() {
+        newlyCreatedAccount = true
+        createdAccountExpiry = null
+
+        daemon.await().createNewAccount()
+    }
+
+    private suspend fun doLogin(account: String) {
+        if (account != accountNumber) {
+            markAccountAsNotNew()
+            daemon.await().setAccount(account)
+        }
     }
 
     private fun fetchAccountHistory() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -92,6 +92,7 @@ class ServiceEndpoint(
 
             val initialEvents = listOf(
                 Event.LoginStatus(accountCache.onLoginStatusChange.latestEvent),
+                Event.AccountHistory(accountCache.onAccountHistoryChange.latestEvent),
                 Event.SettingsUpdate(settingsListener.settings),
                 Event.NewLocation(locationInfoCache.location),
                 Event.WireGuardKeyStatus(keyStatusListener.keyStatus),

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -33,7 +33,7 @@ class ServiceEndpoint(
 
     val settingsListener = SettingsListener(this)
 
-    val accountCache = AccountCache(settingsListener, intermittentDaemon)
+    val accountCache = AccountCache(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -33,6 +33,7 @@ class ServiceEndpoint(
 
     val settingsListener = SettingsListener(this)
 
+    val accountCache = AccountCache(settingsListener, intermittentDaemon)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
 
@@ -46,6 +47,7 @@ class ServiceEndpoint(
         dispatcher.onDestroy()
         registrationQueue.close()
 
+        accountCache.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -91,6 +91,7 @@ class ServiceEndpoint(
             listeners.add(listener)
 
             val initialEvents = listOf(
+                Event.LoginStatus(accountCache.onLoginStatusChange.latestEvent),
                 Event.SettingsUpdate(settingsListener.settings),
                 Event.NewLocation(locationInfoCache.location),
                 Event.WireGuardKeyStatus(keyStatusListener.keyStatus),

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -9,8 +9,8 @@ import android.net.Uri
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.util.JobTracker
 import org.joda.time.DateTime
 import org.joda.time.Duration

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -155,15 +155,9 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
     }
 
     private suspend fun logout() {
-        clearAccountNumber()
+        accountCache.logout()
         clearBackStack()
         goToLoginScreen()
-    }
-
-    private suspend fun clearAccountNumber() {
-        jobTracker.runOnBackground {
-            daemon.setAccount(null)
-        }
     }
 
     private fun clearBackStack() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
-import net.mullvad.mullvadvpn.service.AccountCache
+import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.ui.widget.AccountLogin
 import net.mullvad.mullvadvpn.ui.widget.Button
 import org.joda.time.DateTime

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -10,7 +10,6 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.model.LoginStatus
 import net.mullvad.mullvadvpn.ui.widget.AccountLogin
 import net.mullvad.mullvadvpn.ui.widget.Button
@@ -159,19 +158,7 @@ class LoginFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen), Na
 
         scrollToShow(loggingInStatus)
 
-        performLogin(accountToken)
-    }
-
-    private fun performLogin(accountToken: String) {
-        jobTracker.newBackgroundJob("login") {
-            val accountDataResult = daemon.getAccountData(accountToken)
-            val loginSucceded = accountDataResult is GetAccountDataResult.Ok
-                || accountDataResult is GetAccountDataResult.RpcError
-
-            if (loginSucceded) {
-                accountCache.login(accountToken)
-            }
-        }
+        accountCache.login(accountToken)
     }
 
     private suspend fun loggedIn() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
@@ -16,7 +16,7 @@ import androidx.fragment.app.DialogFragment
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.VoucherSubmissionResult
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.endpoint.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.util.JobTracker
 import net.mullvad.mullvadvpn.util.SegmentedInputFormatter

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
@@ -15,8 +15,8 @@ import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.VoucherSubmissionResult
-import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.util.JobTracker
 import net.mullvad.mullvadvpn.util.SegmentedInputFormatter

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -7,11 +7,11 @@ import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
-import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -11,7 +11,7 @@ import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.SplitTunneling
-import net.mullvad.mullvadvpn.service.endpoint.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
-import net.mullvad.mullvadvpn.service.AccountCache
+import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.widget.AccountCell
 import net.mullvad.mullvadvpn.ui.widget.AppVersionCell

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
-import net.mullvad.mullvadvpn.service.endpoint.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.widget.AccountCell
 import net.mullvad.mullvadvpn.ui.widget.AppVersionCell

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
@@ -2,8 +2,8 @@ package net.mullvad.mullvadvpn.ui.notification
 
 import android.content.Context
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.AccountCache
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.util.TimeLeftFormatter
 import org.joda.time.DateTime
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.endpoint.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.util.TimeLeftFormatter
 import org.joda.time.DateTime
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
@@ -1,0 +1,67 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
+import net.mullvad.mullvadvpn.model.LoginStatus
+import net.mullvad.talpid.util.EventNotifier
+import org.joda.time.DateTime
+
+class AccountCache(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+    val onAccountNumberChange = EventNotifier<String?>(null)
+    val onAccountExpiryChange = EventNotifier<DateTime?>(null)
+    val onAccountHistoryChange = EventNotifier<List<String>>(listOf<String>())
+    val onLoginStatusChange = EventNotifier<LoginStatus?>(null)
+
+    private var accountHistory by onAccountHistoryChange.notifiable()
+    private var loginStatus by onLoginStatusChange.notifiable()
+
+    init {
+        eventDispatcher.apply {
+            registerHandler(Event.AccountHistory::class) { event ->
+                accountHistory = event.history ?: listOf<String>()
+            }
+
+            registerHandler(Event.LoginStatus::class) { event ->
+                loginStatus = event.status
+
+                onAccountNumberChange.notifyIfChanged(loginStatus?.account)
+                onAccountExpiryChange.notifyIfChanged(loginStatus?.expiry)
+            }
+        }
+    }
+
+    fun createNewAccount() {
+        connection.send(Request.CreateAccount.message)
+    }
+
+    fun login(account: String) {
+        connection.send(Request.Login(account).message)
+    }
+
+    fun logout() {
+        connection.send(Request.Logout.message)
+    }
+
+    fun fetchAccountExpiry() {
+        connection.send(Request.FetchAccountExpiry.message)
+    }
+
+    fun invalidateAccountExpiry(accountExpiryToInvalidate: DateTime) {
+        val request = Request.InvalidateAccountExpiry(accountExpiryToInvalidate)
+
+        connection.send(request.message)
+    }
+
+    fun removeAccountFromHistory(account: String) {
+        connection.send(Request.RemoveAccountFromHistory(account).message)
+    }
+
+    fun onDestroy() {
+        onAccountNumberChange.unsubscribeAll()
+        onAccountExpiryChange.unsubscribeAll()
+        onAccountHistoryChange.unsubscribeAll()
+        onLoginStatusChange.unsubscribeAll()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -22,7 +22,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     }
 
     val daemon = service.daemon
-    val accountCache = service.accountCache
+    val accountCache = AccountCache(service.messenger, dispatcher)
     val connectionProxy = service.connectionProxy
     val customDns = service.customDns
     val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
@@ -42,6 +42,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     fun onDestroy() {
         dispatcher.onDestroy()
 
+        accountCache.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountHistoryAdapter.kt
@@ -14,7 +14,7 @@ class AccountHistoryAdapter : Adapter<AccountHistoryHolder>() {
         }
     }
 
-    var accountHistory by observable(ArrayList<String>()) { _, _, _ ->
+    var accountHistory by observable(listOf<String>()) { _, _, _ ->
         notifyDataSetChanged()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -99,7 +99,7 @@ class AccountLogin : RelativeLayout {
     val hasFocus
         get() = focused
 
-    var accountHistory by observable<ArrayList<String>?>(null) { _, _, history ->
+    var accountHistory by observable<List<String>?>(null) { _, _, history ->
         val entryCount = history?.size ?: 0
 
         historyHeight = entryCount * (historyEntryHeight + dividerHeight)

--- a/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/util/EventNotifier.kt
@@ -26,6 +26,14 @@ class EventNotifier<T>(private val initialValue: T) {
         }
     }
 
+    fun notifyIfChanged(event: T) {
+        synchronized(this) {
+            if (latestEvent != event) {
+                notify(event)
+            }
+        }
+    }
+
     fun subscribe(id: Any, listener: (T) -> Unit) {
         synchronized(this) {
             listeners.put(id, listener)


### PR DESCRIPTION
This PR continues the work to split the Android app into two processes, so that the service can run in a separate process. This PR focuses on the `AccountCache` class. The class is responsible for handling the account token, the account history and fetching the account expiration.

After this PR, the service side `AccountCache` will also handle the login procedure logic. It can now receive `Login`, `Logout` and `CreateAccount` requests and will respond by sending a `LoginStatus` event that contains a tuple `(accountToken, optionalExpiry, isNewFlag)` and also has a helper property `isExpired` calculated from the `optionalExpiry`.

For the account history, it's possible to send a `RemoveAccountFromHistory` request in order to remove an account token from the history list. Every change to the account history sends an `AccountHistory` event.

The account expiry can be requested to be fetched either by a `FetchAccountExpiry` request or by a `InvalidateAccountExpiry` request. The difference is that the latter has a extra parameter that represents the account expiry that should be invalidated. What that means is that the fetch will retry while the fetch result is the same invalid expiry. This is used after a voucher code is redeemed, for example.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes yet.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2628)
<!-- Reviewable:end -->
