### PR TITLE
Only keep a WireGuard key for the active account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
 - Only download a new relay list if it has been modified.
 - Connect to the API only via TLS 1.3
 - Shrink account history capactity from 3 account entries to 1.
+- Remove WireGuard key from account history when logging out.
 - Allow whitespace in account token in CLI.
 - Read account token from standard input unless given as an argument in CLI.
 - Make WireGuard automatic key rotation interval mandatory and between 1 and 7 days.

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -223,6 +223,20 @@ impl AccountHistory {
         self.save_to_disk().await
     }
 
+    /// Removes WireGuard keys associated with all accounts
+    pub async fn clear_keys(&mut self) -> Result<()> {
+        log::debug!("account_history::clear_keys");
+
+        for entry in self.accounts.lock().unwrap().iter_mut() {
+            if let Some(wg_data) = &entry.wireguard {
+                tokio::spawn(self.create_remove_wg_key_rpc(&entry.account, &wg_data));
+                entry.wireguard = None;
+            }
+        }
+
+        self.save_to_disk().await
+    }
+
     /// Remove account history
     pub async fn clear(&mut self) -> Result<()> {
         log::debug!("account_history::clear");

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1471,14 +1471,20 @@ where
             self.event_listener
                 .notify_settings(self.settings.to_settings());
 
-            // Bump account history if a token was set
-            if let Some(token) = account_token.clone() {
-                if let Err(e) = self.account_history.bump_history(&token).await {
-                    log::error!("Failed to bump account history: {}", e);
-                }
+            if let Err(error) = self.account_history.clear_keys().await {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Error while clearing account history keys")
+                );
             }
 
-            self.ensure_wireguard_keys_for_current_account().await;
+            if let Some(token) = &account_token {
+                // Bump account history if a token was set
+                if let Err(e) = self.account_history.bump_history(token).await {
+                    log::error!("Failed to bump account history: {}", e);
+                }
+                self.ensure_wireguard_keys_for_current_account().await;
+            }
         }
         Ok(account_changed)
     }


### PR DESCRIPTION
As above. This means that unsetting or logging out causes the key to be removed from the account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2630)
<!-- Reviewable:end -->
