### PR TITLE
Enable option to "Select all" when viewing app logs

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -24,6 +24,11 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Enable option to "Select all" when viewing app logs.
+
+
+## [2021.1] - 2021-03-16
+### Added
 - Add ability to report a problem inside the app. Sends logs to support.
 
 ### Changed

--- a/ios/MullvadVPN/ProblemReportReviewViewController.swift
+++ b/ios/MullvadVPN/ProblemReportReviewViewController.swift
@@ -55,6 +55,10 @@ class ProblemReportReviewViewController: UIViewController {
         view.layoutIfNeeded()
     }
 
+    override func selectAll(_ sender: Any?) {
+        textView.selectAll(sender)
+    }
+
     // MARK: - Actions
 
     @objc func handleDismissButton(_ sender: Any) {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- Enable the "Select all" option in the popup menu when viewing app logs. This option enables user to select the entire text app log to be able to copy the entire text in clipboard.
- Update CHANGELOG to reflect the most recent release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2631)
<!-- Reviewable:end -->
