### PR TITLE
Get rid of blocking file I/O in `mullvad-daemon`

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -561,7 +561,7 @@ where
             let _ = settings.set_show_beta_releases(true).await;
         }
 
-        let app_version_info = version_check::load_cache(&cache_dir);
+        let app_version_info = version_check::load_cache(&cache_dir).await;
         let (version_updater, version_updater_handle) = version_check::VersionUpdater::new(
             rpc_handle.clone(),
             cache_dir.clone(),


### PR DESCRIPTION
There were some blocking file operations running on worker threads in `mullvad-daemon` in the root, `settings`, and `version_check` modules. Not greatly significant, but this fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2632)
<!-- Reviewable:end -->
