### PR TITLE
Split `SplitTunneling` into UI-side class and service-side class

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
+import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 import net.mullvad.mullvadvpn.util.JobTracker
 
 class AppListAdapter(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListAdapter.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
 import net.mullvad.mullvadvpn.util.JobTracker
 
 class AppListAdapter(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
@@ -8,7 +8,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
+import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 import net.mullvad.mullvadvpn.ui.widget.CellSwitch
 import net.mullvad.mullvadvpn.util.JobTracker
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppListItemHolder.kt
@@ -8,7 +8,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
 import net.mullvad.mullvadvpn.ui.widget.CellSwitch
 import net.mullvad.mullvadvpn.util.JobTracker
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
@@ -1,10 +1,16 @@
 package net.mullvad.mullvadvpn.di
 
 import android.content.pm.PackageManager
+import android.os.Messenger
 import kotlinx.coroutines.Dispatchers
 import net.mullvad.mullvadvpn.applist.ApplicationsIconManager
 import net.mullvad.mullvadvpn.applist.ApplicationsProvider
-import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.MessageDispatcher
+import net.mullvad.mullvadvpn.service.ServiceInstance
+import net.mullvad.mullvadvpn.ui.MainActivity
+import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
+import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 import net.mullvad.mullvadvpn.viewmodel.SplitTunnelingViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -14,7 +20,6 @@ import org.koin.dsl.onClose
 
 val appModule = module {
 
-    single<SplitTunneling> { SplitTunneling(androidContext()) }
     single<PackageManager> { androidContext().packageManager }
     single<String> (named(SELF_PACKAGE_NAME)) { androidContext().packageName }
 
@@ -22,6 +27,15 @@ val appModule = module {
         viewModel { SplitTunnelingViewModel(get(), get(), Dispatchers.Default) }
         scoped { ApplicationsIconManager(get()) } onClose { it?.dispose() }
         scoped { ApplicationsProvider(get(), get(named(SELF_PACKAGE_NAME))) }
+    }
+
+    scope<ServiceConnection> {
+        scoped<ServiceConnection> { (service: ServiceInstance, mainActivity: MainActivity) ->
+            ServiceConnection(service, mainActivity)
+        } onClose { it?.onDestroy() }
+        scoped<SplitTunneling> { (messenger: Messenger, dispatcher: MessageDispatcher<Event>) ->
+            SplitTunneling(messenger, dispatcher)
+        }
     }
 }
 const val APPS_SCOPE = "APPS_SCOPE"

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/DispatchingHandler.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/DispatchingHandler.kt
@@ -11,11 +11,11 @@ import kotlin.reflect.KClass
 class DispatchingHandler<T : Any>(
     looper: Looper,
     private val extractor: (Message) -> T?
-) : Handler(looper) {
+) : Handler(looper), MessageDispatcher<T> {
     private val handlers = HashMap<KClass<out T>, (T) -> Unit>()
     private val lock = ReentrantReadWriteLock()
 
-    fun <V : T> registerHandler(variant: KClass<V>, handler: (V) -> Unit) {
+    override fun <V : T> registerHandler(variant: KClass<V>, handler: (V) -> Unit) {
         lock.writeLock().withLock {
             handlers.put(variant) { instance ->
                 @Suppress("UNCHECKED_CAST")

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -27,6 +27,9 @@ sealed class Event : Message.EventMessage() {
     data class SettingsUpdate(val settings: Settings?) : Event()
 
     @Parcelize
+    data class SplitTunnelingUpdate(val excludedApps: List<String>?) : Event()
+
+    @Parcelize
     data class WireGuardKeyStatus(val keyStatus: KeygenEvent?) : Event()
 
     companion object {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/MessageDispatcher.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/MessageDispatcher.kt
@@ -1,0 +1,7 @@
+package net.mullvad.mullvadvpn.ipc
+
+import kotlin.reflect.KClass
+
+interface MessageDispatcher<T : Any> {
+    fun <V : T> registerHandler(variant: KClass<V>, handler: (V) -> Unit)
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -13,7 +13,13 @@ sealed class Request : Message.RequestMessage() {
     object CreateAccount : Request()
 
     @Parcelize
+    data class ExcludeApp(val packageName: String) : Request()
+
+    @Parcelize
     object FetchAccountExpiry : Request()
+
+    @Parcelize
+    data class IncludeApp(val packageName: String) : Request()
 
     @Parcelize
     data class InvalidateAccountExpiry(val expiry: DateTime) : Request()
@@ -25,10 +31,16 @@ sealed class Request : Message.RequestMessage() {
     object Logout : Request()
 
     @Parcelize
+    object PersistExcludedApps : Request()
+
+    @Parcelize
     data class RegisterListener(val listener: Messenger) : Request()
 
     @Parcelize
     data class RemoveAccountFromHistory(val account: String?) : Request()
+
+    @Parcelize
+    data class SetEnableSplitTunneling(val enable: Boolean) : Request()
 
     @Parcelize
     object WireGuardGenerateKey : Request()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/DaemonInstance.kt
@@ -45,7 +45,6 @@ class DaemonInstance(val vpnService: MullvadVpnService) {
         var isRunning = true
 
         prepareFiles()
-        vpnService.splitTunneling.join()
 
         while (isRunning) {
             if (!waitForCommand(channel, Command.START)) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -95,9 +95,6 @@ class MullvadVpnService : TalpidVpnService() {
         notificationManager.lockedToForeground = isUiVisible or isBound
     }
 
-    internal lateinit var splitTunneling: SplitTunneling
-        private set
-
     override fun onCreate() {
         super.onCreate()
         Log.d(TAG, "Initializing service")
@@ -106,14 +103,8 @@ class MullvadVpnService : TalpidVpnService() {
         keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
-        splitTunneling = SplitTunneling(this@MullvadVpnService).apply {
-            onChange = { excludedApps ->
-                disallowedApps = excludedApps
-                markTunAsStale()
-            }
-        }
-
         endpoint = ServiceEndpoint(
+            this,
             Looper.getMainLooper(),
             daemonInstance.intermittentDaemon,
             connectivityListener
@@ -239,7 +230,7 @@ class MullvadVpnService : TalpidVpnService() {
         val connectionProxy = ConnectionProxy(this, daemon)
         val customDns = CustomDns(daemon, endpoint.settingsListener)
 
-        splitTunneling.onChange = { excludedApps ->
+        endpoint.splitTunneling.onChange = { excludedApps ->
             disallowedApps = excludedApps
             markTunAsStale()
             connectionProxy.reconnect()
@@ -256,7 +247,7 @@ class MullvadVpnService : TalpidVpnService() {
                 daemonInstance.intermittentDaemon,
                 connectionProxy,
                 customDns,
-                splitTunneling
+                endpoint.splitTunneling
             )
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -246,8 +246,7 @@ class MullvadVpnService : TalpidVpnService() {
                 daemon,
                 daemonInstance.intermittentDaemon,
                 connectionProxy,
-                customDns,
-                endpoint.splitTunneling
+                customDns
             )
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -216,13 +216,15 @@ class MullvadVpnService : TalpidVpnService() {
         }
     }
 
-    private fun setUpDaemon(daemon: MullvadDaemon) = GlobalScope.launch(Dispatchers.Default) {
-        val settings = daemon.getSettings()
+    private fun setUpDaemon(daemon: MullvadDaemon) = GlobalScope.launch(Dispatchers.Main) {
+        if (state != State.Stopped) {
+            val settings = daemon.getSettings()
 
-        if (settings != null) {
-            setUpInstance(daemon, settings)
-        } else {
-            restart()
+            if (settings != null) {
+                setUpInstance(daemon, settings)
+            } else {
+                restart()
+            }
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -230,7 +230,7 @@ class MullvadVpnService : TalpidVpnService() {
         val connectionProxy = ConnectionProxy(this, daemon)
         val customDns = CustomDns(daemon, endpoint.settingsListener)
 
-        endpoint.splitTunneling.onChange = { excludedApps ->
+        endpoint.splitTunneling.onChange.subscribe(this@MullvadVpnService) { excludedApps ->
             disallowedApps = excludedApps
             markTunAsStale()
             connectionProxy.reconnect()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
 import net.mullvad.mullvadvpn.service.notifications.AccountExpiryNotification
+import net.mullvad.mullvadvpn.service.persistence.SplitTunnelingPersistence
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
@@ -104,10 +105,10 @@ class MullvadVpnService : TalpidVpnService() {
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
         endpoint = ServiceEndpoint(
-            this,
             Looper.getMainLooper(),
             daemonInstance.intermittentDaemon,
-            connectivityListener
+            connectivityListener,
+            SplitTunnelingPersistence(this)
         )
 
         notificationManager =

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class ServiceInstance(
@@ -10,7 +9,6 @@ class ServiceInstance(
     val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
-    val splitTunneling: SplitTunneling
 ) {
     fun onDestroy() {
         connectionProxy.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
+import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class ServiceInstance(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -100,6 +100,7 @@ class ServiceEndpoint(
                 Event.SettingsUpdate(settingsListener.settings),
                 Event.NewLocation(locationInfoCache.location),
                 Event.WireGuardKeyStatus(keyStatusListener.keyStatus),
+                Event.SplitTunnelingUpdate(splitTunneling.onChange.latestEvent),
                 Event.ListenerReady
             )
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -38,7 +38,7 @@ class ServiceEndpoint(
     val accountCache = AccountCache(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
-    val splitTunneling = SplitTunneling(context)
+    val splitTunneling = SplitTunneling(context, this)
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import android.content.Context
 import android.os.DeadObjectException
 import android.os.Looper
 import android.os.Messenger
@@ -18,6 +19,7 @@ import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.ConnectivityListener
 
 class ServiceEndpoint(
+    context: Context,
     looper: Looper,
     internal val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectivityListener: ConnectivityListener
@@ -36,6 +38,7 @@ class ServiceEndpoint(
     val accountCache = AccountCache(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
+    val splitTunneling = SplitTunneling(context)
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -54,6 +54,7 @@ class ServiceEndpoint(
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()
+        splitTunneling.onDestroy()
     }
 
     internal fun sendEvent(event: Event) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
-import android.content.Context
 import android.os.DeadObjectException
 import android.os.Looper
 import android.os.Messenger
@@ -15,14 +14,15 @@ import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.persistence.SplitTunnelingPersistence
 import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.ConnectivityListener
 
 class ServiceEndpoint(
-    context: Context,
     looper: Looper,
     internal val intermittentDaemon: Intermittent<MullvadDaemon>,
-    val connectivityListener: ConnectivityListener
+    val connectivityListener: ConnectivityListener,
+    splitTunnelingPersistence: SplitTunnelingPersistence
 ) {
     private val listeners = mutableSetOf<Messenger>()
     private val registrationQueue: SendChannel<Messenger> = startRegistrator()
@@ -38,7 +38,7 @@ class ServiceEndpoint(
     val accountCache = AccountCache(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
-    val splitTunneling = SplitTunneling(context, this)
+    val splitTunneling = SplitTunneling(splitTunnelingPersistence, this)
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
@@ -54,6 +54,10 @@ class SplitTunneling(context: Context) {
         appListFile.writeText(excludedApps.joinToString(separator = "\n"))
     }
 
+    fun onDestroy() {
+        onChange = null
+    }
+
     private fun enabledChanged() {
         preferences.edit().apply {
             putBoolean(KEY_ENABLED, enabled)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
@@ -21,14 +21,14 @@ class SplitTunneling(context: Context, endpoint: ServiceEndpoint) {
         get() = if (enabled) {
             excludedApps.toList()
         } else {
-            emptyList()
+            null
         }
 
     var enabled by observable(preferences.getBoolean(KEY_ENABLED, false)) { _, _, _ ->
         enabledChanged()
     }
 
-    var onChange by observable<((List<String>) -> Unit)?>(null) { _, _, _ ->
+    var onChange by observable<((List<String>?) -> Unit)?>(null) { _, _, _ ->
         update()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.service
+package net.mullvad.mullvadvpn.service.endpoint
 
 import android.content.Context
 import java.io.File

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.service.endpoint
 import android.content.Context
 import java.io.File
 import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.talpid.util.EventNotifier
 
@@ -28,6 +29,10 @@ class SplitTunneling(context: Context, endpoint: ServiceEndpoint) {
         if (appListFile.exists()) {
             excludedApps.addAll(appListFile.readLines())
             update()
+        }
+
+        onChange.subscribe(this) { excludedApps ->
+            endpoint.sendEvent(Event.SplitTunnelingUpdate(excludedApps))
         }
 
         endpoint.dispatcher.apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/persistence/SplitTunnelingPersistence.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/persistence/SplitTunnelingPersistence.kt
@@ -1,0 +1,35 @@
+package net.mullvad.mullvadvpn.service.persistence
+
+import android.content.Context
+import java.io.File
+import kotlin.properties.Delegates.observable
+
+// The spelling of the shared preferences location can't be changed to American English without
+// either having users lose their preferences on update or implementing some migration code.
+private const val SHARED_PREFERENCES = "split_tunnelling"
+private const val KEY_ENABLED = "enabled"
+
+class SplitTunnelingPersistence(context: Context) {
+    // The spelling of the app list file name can't be changed to American English without either
+    // having users lose their preferences on update or implementing some migration code.
+    private val appListFile = File(context.filesDir, "split-tunnelling.txt")
+    private val preferences = context.getSharedPreferences(SHARED_PREFERENCES, Context.MODE_PRIVATE)
+
+    var enabled by observable(preferences.getBoolean(KEY_ENABLED, false)) { _, _, isEnabled ->
+        preferences.edit().apply {
+            putBoolean(KEY_ENABLED, isEnabled)
+            apply()
+        }
+    }
+
+    var excludedApps by observable(loadExcludedApps()) { _, _, excludedAppsSet ->
+        appListFile.writeText(excludedAppsSet.joinToString(separator = "\n"))
+    }
+
+    private fun loadExcludedApps(): Set<String> {
+        return when {
+            appListFile.exists() -> appListFile.readLines().toSet()
+            else -> emptySet()
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -10,12 +10,12 @@ import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
+import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 
 abstract class ServiceDependentFragment(val onNoService: OnNoService) : ServiceAwareFragment() {
     enum class OnNoService {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -10,7 +10,7 @@ import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -28,7 +28,7 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
     val settingsListener = SettingsListener(dispatcher)
-    val splitTunneling = service.splitTunneling
+    val splitTunneling = SplitTunneling(service.messenger, dispatcher)
 
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -11,12 +11,18 @@ import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.service.ServiceInstance
 import net.mullvad.mullvadvpn.ui.MainActivity
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import org.koin.core.parameter.parametersOf
 
 // Container of classes that communicate with the service through an active connection
 //
 // The properties of this class can be used to send events to the service, to listen for events from
 // the service and to get values received from events.
-class ServiceConnection(private val service: ServiceInstance, val mainActivity: MainActivity) {
+@OptIn(KoinApiExtension::class)
+class ServiceConnection(private val service: ServiceInstance, mainActivity: MainActivity) :
+    KoinComponent {
     val dispatcher = DispatchingHandler(Looper.getMainLooper()) { message ->
         Event.fromMessage(message)
     }
@@ -28,7 +34,9 @@ class ServiceConnection(private val service: ServiceInstance, val mainActivity: 
     val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
     val settingsListener = SettingsListener(dispatcher)
-    val splitTunneling = SplitTunneling(service.messenger, dispatcher)
+    val splitTunneling = get<SplitTunneling>(
+        parameters = { parametersOf(service.messenger, dispatcher) }
+    )
 
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SplitTunneling.kt
@@ -2,11 +2,14 @@ package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
 import kotlin.properties.Delegates.observable
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.MessageDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 
-class SplitTunneling(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+class SplitTunneling(
+    private val connection: Messenger,
+    eventDispatcher: MessageDispatcher<Event>
+) {
     private var excludedApps: Set<String> = emptySet()
 
     var enabled by observable(false) { _, wasEnabled, isEnabled ->
@@ -28,15 +31,11 @@ class SplitTunneling(val connection: Messenger, eventDispatcher: DispatchingHand
 
     fun isAppExcluded(appPackageName: String): Boolean = excludedApps.contains(appPackageName)
 
-    fun excludeApp(appPackageName: String) {
+    fun excludeApp(appPackageName: String) =
         connection.send(Request.ExcludeApp(appPackageName).message)
-    }
 
-    fun includeApp(appPackageName: String) {
+    fun includeApp(appPackageName: String) =
         connection.send(Request.IncludeApp(appPackageName).message)
-    }
 
-    fun persist() {
-        connection.send(Request.PersistExcludedApps.message)
-    }
+    fun persist() = connection.send(Request.PersistExcludedApps.message)
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SplitTunneling.kt
@@ -1,0 +1,42 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
+
+class SplitTunneling(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+    private var excludedApps: Set<String> = emptySet()
+
+    var enabled by observable(false) { _, wasEnabled, isEnabled ->
+        if (wasEnabled != isEnabled) {
+            connection.send(Request.SetEnableSplitTunneling(isEnabled).message)
+        }
+    }
+
+    init {
+        eventDispatcher.registerHandler(Event.SplitTunnelingUpdate::class) { event ->
+            if (event.excludedApps != null) {
+                enabled = true
+                excludedApps = event.excludedApps.toSet()
+            } else {
+                enabled = false
+            }
+        }
+    }
+
+    fun isAppExcluded(appPackageName: String): Boolean = excludedApps.contains(appPackageName)
+
+    fun excludeApp(appPackageName: String) {
+        connection.send(Request.ExcludeApp(appPackageName).message)
+    }
+
+    fun includeApp(appPackageName: String) {
+        connection.send(Request.IncludeApp(appPackageName).message)
+    }
+
+    fun persist() {
+        connection.send(Request.PersistExcludedApps.message)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
@@ -92,7 +92,7 @@ class SplitTunnelingViewModel(
 
     private suspend fun fetchData() {
         appsProvider.getAppsList()
-            .partition { app -> splitTunneling.excludedAppList?.contains(app.packageName) ?: false }
+            .partition { app -> splitTunneling.isAppExcluded(app.packageName) }
             .let { (excludedAppsList, notExcludedAppsList) ->
                 // TODO: remove potential package names from splitTunneling list
                 //       if they already uninstalled or filtered; but not in ViewModel

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
@@ -92,7 +92,7 @@ class SplitTunnelingViewModel(
 
     private suspend fun fetchData() {
         appsProvider.getAppsList()
-            .partition { app -> splitTunneling.excludedAppList.contains(app.packageName) }
+            .partition { app -> splitTunneling.excludedAppList?.contains(app.packageName) ?: false }
             .let { (excludedAppsList, notExcludedAppsList) ->
                 // TODO: remove potential package names from splitTunneling list
                 //       if they already uninstalled or filtered; but not in ViewModel

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
@@ -18,7 +18,7 @@ import net.mullvad.mullvadvpn.applist.ApplicationsProvider
 import net.mullvad.mullvadvpn.applist.ViewIntent
 import net.mullvad.mullvadvpn.model.ListItemData
 import net.mullvad.mullvadvpn.model.WidgetState
-import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
+import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 
 class SplitTunnelingViewModel(
     private val appsProvider: ApplicationsProvider,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
@@ -18,7 +18,7 @@ import net.mullvad.mullvadvpn.applist.ApplicationsProvider
 import net.mullvad.mullvadvpn.applist.ViewIntent
 import net.mullvad.mullvadvpn.model.ListItemData
 import net.mullvad.mullvadvpn.model.WidgetState
-import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.service.endpoint.SplitTunneling
 
 class SplitTunnelingViewModel(
     private val appsProvider: ApplicationsProvider,

--- a/android/src/test/kotlin/net/mullvad/mullvadvpn/di/AppModuleTest.kt
+++ b/android/src/test/kotlin/net/mullvad/mullvadvpn/di/AppModuleTest.kt
@@ -1,0 +1,47 @@
+package net.mullvad.mullvadvpn.di
+
+import android.os.Messenger
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlin.test.assertEquals
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.MessageDispatcher
+import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
+import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+import org.koin.test.KoinTest
+import org.koin.test.KoinTestRule
+
+class AppModuleTest : KoinTest {
+
+    @get:Rule
+    val koinTestRule = KoinTestRule.create {
+        modules(appModule)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun test_scope_linking() {
+        val appsScope: Scope = getKoin().createScope(APPS_SCOPE, named(APPS_SCOPE))
+        val serviceConnectionScope = getKoin().createScope<ServiceConnection>()
+
+        appsScope.linkTo(serviceConnectionScope)
+
+        val mockedMessenger = mockk<Messenger>()
+        val mockedEventMessageHandler = mockk<MessageDispatcher<Event>>(relaxed = true)
+        val serviceConnectionSplitTunneling = serviceConnectionScope.get<SplitTunneling>(
+            parameters = { parametersOf(mockedMessenger, mockedEventMessageHandler) }
+        )
+
+        assertEquals(appsScope.get<SplitTunneling>(), serviceConnectionSplitTunneling)
+    }
+}

--- a/android/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModelTest.kt
+++ b/android/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModelTest.kt
@@ -21,7 +21,7 @@ import net.mullvad.mullvadvpn.applist.ViewIntent
 import net.mullvad.mullvadvpn.assertLists
 import net.mullvad.mullvadvpn.model.ListItemData
 import net.mullvad.mullvadvpn.model.WidgetState
-import net.mullvad.mullvadvpn.service.SplitTunneling
+import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule

--- a/android/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModelTest.kt
+++ b/android/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModelTest.kt
@@ -80,7 +80,8 @@ class SplitTunnelingViewModelTest {
     fun test_apps_list_delivered() = runBlockingTest(testCoroutineRule.testDispatcher) {
         val appExcluded = AppData("test.excluded", 0, "testName1")
         val appNotExcluded = AppData("test.not.excluded", 0, "testName2")
-        every { mockedSplitTunneling.excludedAppList } returns listOf(appExcluded.packageName)
+        every { mockedSplitTunneling.isAppExcluded(appExcluded.packageName) } returns true
+        every { mockedSplitTunneling.isAppExcluded(appNotExcluded.packageName) } returns false
 
         initTestSubject(listOf(appExcluded, appNotExcluded))
         testSubject.processIntent(ViewIntent.ViewIsReady)
@@ -99,14 +100,15 @@ class SplitTunnelingViewModelTest {
         assertLists(expectedList, actualList)
         verifyAll {
             mockedSplitTunneling.enabled
-            mockedSplitTunneling.excludedAppList
+            mockedSplitTunneling.isAppExcluded(appExcluded.packageName)
+            mockedSplitTunneling.isAppExcluded(appNotExcluded.packageName)
         }
     }
 
     @Test
     fun test_remove_app_from_excluded() = runBlockingTest(testCoroutineRule.testDispatcher) {
         val app = AppData("test", 0, "testName")
-        every { mockedSplitTunneling.excludedAppList } returns listOf(app.packageName)
+        every { mockedSplitTunneling.isAppExcluded(app.packageName) } returns true
         every { mockedSplitTunneling.includeApp(app.packageName) } just Runs
 
         initTestSubject(listOf(app))
@@ -137,7 +139,7 @@ class SplitTunnelingViewModelTest {
 
         verifyAll {
             mockedSplitTunneling.enabled
-            mockedSplitTunneling.excludedAppList
+            mockedSplitTunneling.isAppExcluded(app.packageName)
             mockedSplitTunneling.includeApp(app.packageName)
         }
     }
@@ -145,7 +147,7 @@ class SplitTunnelingViewModelTest {
     @Test
     fun test_add_app_to_excluded() = runBlockingTest(testCoroutineRule.testDispatcher) {
         val app = AppData("test", 0, "testName")
-        every { mockedSplitTunneling.excludedAppList } returns emptyList()
+        every { mockedSplitTunneling.isAppExcluded(app.packageName) } returns false
         every { mockedSplitTunneling.excludeApp(app.packageName) } just Runs
         initTestSubject(listOf(app))
         testSubject.processIntent(ViewIntent.ViewIsReady)
@@ -175,7 +177,7 @@ class SplitTunnelingViewModelTest {
 
         verifyAll {
             mockedSplitTunneling.enabled
-            mockedSplitTunneling.excludedAppList
+            mockedSplitTunneling.isAppExcluded(app.packageName)
             mockedSplitTunneling.excludeApp(app.packageName)
         }
     }


### PR DESCRIPTION
This PR continues the work to split the Android app to run in two separate processes, by focusing on the `SplitTunneling` class. Now there are two `SplitTunneling` classes, one on the UI side and one on the service side.

The two classes communicate through the IPC channel. The UI can send requests to exclude an app from the tunnel, include an app in the tunnel, persist the split tunneling configuration to disk, and to enable or disable split tunneling. The service side class only sends split tunneling events which contain the list of excluded apps, or `null` if split tunneling is disabled.

The PR also contains a fix to an issue that becomes apparent with the changes included in this PR. There was previously the possibility of a race condition that ended up starting the daemon again while quitting. The fix was to not restart the daemon if the service was already in the `Stopped` state.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2634)
<!-- Reviewable:end -->
