### PR TITLE
Stop logging ENETUNREACH errors when deducing geoip.

### DIFF
--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -16,6 +16,7 @@ fern = { version = "0.6", features = ["colored"] }
 futures = "0.3"
 ipnetwork = "0.16"
 lazy_static = "1.0"
+libc = "0.2"
 log = "0.4"
 log-panics = "2.0.0"
 parking_lot = "0.11"
@@ -41,7 +42,6 @@ mullvad-management-interface = { path = "../mullvad-management-interface" }
 android_logger = "0.8"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
 nix = "0.19"
 simple-signal = "1.1"
 


### PR DESCRIPTION
It's a burden to any consumers of the daemon logs to read through 4 lines of logging about how an IPv6 address was unreachable everytime the daemon connects and the current location and exit IPs are requested. As such, I've changed the logging code to not log `libc::ENETUNREACH` errors.

As an aside, I've also witnessed `ECONNREFUSED` when running the client from within a Linux VM. And whenever I initiated a reconnect on Windows via the GUI, both geoip requests would fail. But they would succeed later on, if the location is requested via `mullvad status --location`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2635)
<!-- Reviewable:end -->
