### PR TITLE
Refactor notification manager initialization

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -102,7 +102,6 @@ class MullvadVpnService : TalpidVpnService() {
 
         daemonInstance = DaemonInstance(this)
         keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-        notificationManager = ForegroundNotificationManager(this, serviceNotifier, keyguardManager)
         tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
         endpoint = ServiceEndpoint(
@@ -111,7 +110,10 @@ class MullvadVpnService : TalpidVpnService() {
             connectivityListener
         )
 
-        notificationManager.acknowledgeStartForegroundService()
+        notificationManager =
+            ForegroundNotificationManager(this, serviceNotifier, keyguardManager).apply {
+                acknowledgeStartForegroundService()
+            }
 
         daemonInstance.apply {
             intermittentDaemon.registerListener(this@MullvadVpnService) { daemon ->

--- a/android/src/main/res/values-my/strings.xml
+++ b/android/src/main/res/values-my/strings.xml
@@ -53,7 +53,6 @@
     <string name="enter_voucher_code">ဘောက်ချာကုဒ် ဖြည့်သွင်းရန်</string>
     <string name="error_occurred">ချို့ယွင်းချက် ဖြစ်ပေါ်ခဲ့ပါသည်။</string>
     <string name="error_state">ချိတ်ဆက်မှုကို ကာကွယ်ရန် မအောင်မြင်ပါ</string>
-    <string name="exclude_applications">အပလီကေးရှင်းများ ဖယ်ရန်</string>
     <string name="failed_to_block_internet">ကွန်ရက် ကူးလူးမှု အားလုံးကို ပိတ်ဆို့ရန် မအောင်မြင်ပါ။ ပြစ်ချက်ရှာဖွေ ဖယ်ရှားပေးပါ သို့မဟုတ် ပြဿနာကို ကျွန်ုပ်တို့ထံ ရီပို့တ်လုပ်ပေးပါ။</string>
     <string name="failed_to_create_account">အကောင့် ဖန်တီးရန် မအောင်မြင်ခဲ့ပါ</string>
     <string name="failed_to_generate_key">ကီး ထုတ်ရန် မအောင်မြင်ခဲ့ပါ</string>


### PR DESCRIPTION
As part of the ongoing work to split the Android app in two processes, an issue appeared where parts of the service initialization changed order and led to a few race condition problems. This PR refactors the initialization of the `ForegroundNotificationManager` so that it's done after the `ServiceEndpoint` is initialized, which will contain parts that the notification manager will use.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2638)
<!-- Reviewable:end -->
