### PR TITLE
Prevent tray icons from being included in asar archive on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Fix "cannot find the file" error while creating a Wintun adapter by upgrading Wintun.
 - Retry when creating a WireGuard tunnel fails due to no default routes being found.
+- Prevent tray icons from being extraced to `%TEMP%` directory.
 
 #### Linux
 - Stop using NM for managing DNS if it's newer than 1.26.

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -180,7 +180,10 @@ const config = {
 function packWin() {
   return builder.build({
     targets: builder.Platform.WINDOWS.createTarget(),
-    config: config,
+    config: {
+      ...config,
+      asarUnpack: ['build/assets/images/menubar icons/win32/lock-*.ico'],
+    },
   });
 }
 


### PR DESCRIPTION
This PR prevents the menubar `.ico` icons on Windows from being included in the asar archive. Previously these files were unpacked by Electron to `%TEMP%/` and Electron never removed them. By not including them in the asar archive they don't need to be unpacked to the temp-directory.

Fixes https://github.com/mullvad/mullvadvpn-app/issues/2636.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2640)
<!-- Reviewable:end -->
