### PR TITLE
Split `ConnectionProxy` into a UI-side and a service-side class

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -6,6 +6,7 @@ import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.LoginStatus as LoginStatusData
 import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.model.TunnelState
 
 // Events that can be sent from the service
 sealed class Event : Message.EventMessage() {
@@ -28,6 +29,9 @@ sealed class Event : Message.EventMessage() {
 
     @Parcelize
     data class SplitTunnelingUpdate(val excludedApps: List<String>?) : Event()
+
+    @Parcelize
+    data class TunnelStateChange(val tunnelState: TunnelState) : Event()
 
     @Parcelize
     data class WireGuardKeyStatus(val keyStatus: KeygenEvent?) : Event()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -52,6 +52,9 @@ sealed class Request : Message.RequestMessage() {
     data class SetEnableSplitTunneling(val enable: Boolean) : Request()
 
     @Parcelize
+    data class VpnPermissionResponse(val isGranted: Boolean) : Request()
+
+    @Parcelize
     object WireGuardGenerateKey : Request()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -10,7 +10,13 @@ sealed class Request : Message.RequestMessage() {
     protected override val messageKey = MESSAGE_KEY
 
     @Parcelize
+    object Connect : Request()
+
+    @Parcelize
     object CreateAccount : Request()
+
+    @Parcelize
+    object Disconnect : Request()
 
     @Parcelize
     data class ExcludeApp(val packageName: String) : Request()
@@ -32,6 +38,9 @@ sealed class Request : Message.RequestMessage() {
 
     @Parcelize
     object PersistExcludedApps : Request()
+
+    @Parcelize
+    object Reconnect : Request()
 
     @Parcelize
     data class RegisterListener(val listener: Messenger) : Request()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/TunnelState.kt
@@ -1,16 +1,35 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import net.mullvad.talpid.net.TunnelEndpoint
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.tunnel.ErrorState
 import net.mullvad.talpid.tunnel.ErrorStateCause
 
-sealed class TunnelState() {
-    object Disconnected : TunnelState()
-    class Connecting(val endpoint: TunnelEndpoint?, val location: GeoIpLocation?) : TunnelState()
-    class Connected(val endpoint: TunnelEndpoint, val location: GeoIpLocation?) : TunnelState()
-    class Disconnecting(val actionAfterDisconnect: ActionAfterDisconnect) : TunnelState()
-    class Error(val errorState: ErrorState) : TunnelState()
+sealed class TunnelState() : Parcelable {
+    @Parcelize
+    object Disconnected : TunnelState(), Parcelable
+
+    @Parcelize
+    class Connecting(
+        val endpoint: TunnelEndpoint?,
+        val location: GeoIpLocation?
+    ) : TunnelState(), Parcelable
+
+    @Parcelize
+    class Connected(
+        val endpoint: TunnelEndpoint,
+        val location: GeoIpLocation?
+    ) : TunnelState(), Parcelable
+
+    @Parcelize
+    class Disconnecting(
+        val actionAfterDisconnect: ActionAfterDisconnect
+    ) : TunnelState(), Parcelable
+
+    @Parcelize
+    class Error(val errorState: ErrorState) : TunnelState(), Parcelable
 
     companion object {
         const val DISCONNECTED = "disconnected"
@@ -37,7 +56,7 @@ sealed class TunnelState() {
         }
     }
 
-    override fun toString() = when (this) {
+    override fun toString(): String = when (this) {
         is TunnelState.Disconnected -> DISCONNECTED
         is TunnelState.Connecting -> CONNECTING
         is TunnelState.Connected -> CONNECTED

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -14,13 +14,13 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
 import net.mullvad.mullvadvpn.service.notifications.TunnelStateNotification
-import net.mullvad.talpid.util.EventNotifier
 import net.mullvad.talpid.util.autoSubscribable
 
 class ForegroundNotificationManager(
     val service: MullvadVpnService,
-    val serviceNotifier: EventNotifier<ServiceInstance?>,
+    val connectionProxy: ConnectionProxy,
     val keyguardManager: KeyguardManager
 ) {
     private sealed class UpdaterMessage {
@@ -43,13 +43,6 @@ class ForegroundNotificationManager(
         }
     }
 
-    private var tunnelStateEvents by autoSubscribable<TunnelState>(
-        this,
-        TunnelState.Disconnected
-    ) { newState ->
-        updater.sendBlocking(UpdaterMessage.NewTunnelState(newState))
-    }
-
     private var deviceIsUnlocked by observable(!keyguardManager.isDeviceLocked) { _, _, _ ->
         updater.sendBlocking(UpdaterMessage.UpdateAction())
     }
@@ -59,7 +52,7 @@ class ForegroundNotificationManager(
     }
 
     private val tunnelState
-        get() = tunnelStateEvents?.latestEvent ?: TunnelState.Disconnected
+        get() = connectionProxy.onStateChange.latestEvent
 
     private val shouldBeOnForeground
         get() = lockedToForeground || !(tunnelState is TunnelState.Disconnected)
@@ -76,8 +69,8 @@ class ForegroundNotificationManager(
     }
 
     init {
-        serviceNotifier.subscribe(this) { newServiceInstance ->
-            tunnelStateEvents = newServiceInstance?.connectionProxy?.onStateChange
+        connectionProxy.onStateChange.subscribe(this) { newState ->
+            updater.sendBlocking(UpdaterMessage.NewTunnelState(newState))
         }
 
         service.apply {
@@ -94,11 +87,9 @@ class ForegroundNotificationManager(
     }
 
     fun onDestroy() {
-        serviceNotifier.unsubscribe(this)
-
         accountNumberEvents = null
-        tunnelStateEvents = null
 
+        connectionProxy.onStateChange.unsubscribe(this)
         service.unregisterReceiver(deviceLockListener)
 
         updater.close()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -17,11 +17,11 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     protected var daemonInterfaceAddress = 0L
 
     val onSettingsChange = EventNotifier<Settings?>(null)
+    var onTunnelStateChange = EventNotifier<TunnelState>(TunnelState.Disconnected)
 
     var onAppVersionInfoChange: ((AppVersionInfo) -> Unit)? = null
     var onKeygenEvent: ((KeygenEvent) -> Unit)? = null
     var onRelayListChange: ((RelayList) -> Unit)? = null
-    var onTunnelStateChange: ((TunnelState) -> Unit)? = null
     var onDaemonStopped: (() -> Unit)? = null
 
     init {
@@ -29,6 +29,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
         initialize(vpnService, vpnService.cacheDir.absolutePath, vpnService.filesDir.absolutePath)
 
         onSettingsChange.notify(getSettings())
+        onTunnelStateChange.notify(getState() ?: TunnelState.Disconnected)
     }
 
     fun connect() {
@@ -133,11 +134,11 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
 
     fun onDestroy() {
         onSettingsChange.unsubscribeAll()
+        onTunnelStateChange.unsubscribeAll()
 
         onAppVersionInfoChange = null
         onKeygenEvent = null
         onRelayListChange = null
-        onTunnelStateChange = null
         onDaemonStopped = null
 
         deinitialize()
@@ -205,7 +206,7 @@ class MullvadDaemon(val vpnService: MullvadVpnService) {
     }
 
     private fun notifyTunnelStateEvent(event: TunnelState) {
-        onTunnelStateChange?.invoke(event)
+        onTunnelStateChange.notify(event)
     }
 
     private fun notifyDaemonStopped() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -243,8 +243,6 @@ class MullvadVpnService : TalpidVpnService() {
 
         handlePendingAction(settings)
 
-        endpoint.locationInfoCache.stateEvents = connectionProxy.onStateChange
-
         if (state == State.Running) {
             instance = ServiceInstance(
                 endpoint.messenger,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -230,7 +230,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
-        val connectionProxy = ConnectionProxy(this, daemon)
+        val connectionProxy = ConnectionProxy(this, daemonInstance.intermittentDaemon)
         val customDns = CustomDns(daemon, endpoint.settingsListener)
 
         endpoint.splitTunneling.onChange.subscribe(this@MullvadVpnService) { excludedApps ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -102,7 +102,6 @@ class MullvadVpnService : TalpidVpnService() {
 
         daemonInstance = DaemonInstance(this)
         keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-        tunnelStateUpdater = TunnelStateUpdater(this, serviceNotifier)
 
         endpoint = ServiceEndpoint(
             Looper.getMainLooper(),
@@ -110,6 +109,8 @@ class MullvadVpnService : TalpidVpnService() {
             connectivityListener,
             this
         )
+
+        tunnelStateUpdater = TunnelStateUpdater(this, connectionProxy)
 
         notificationManager =
             ForegroundNotificationManager(this, connectionProxy, keyguardManager).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -246,7 +246,6 @@ class MullvadVpnService : TalpidVpnService() {
                 endpoint.messenger,
                 daemon,
                 daemonInstance.intermittentDaemon,
-                connectionProxy,
                 customDns
             )
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
-import net.mullvad.mullvadvpn.service.endpoint.VpnPermission
 import net.mullvad.mullvadvpn.service.notifications.AccountExpiryNotification
 import net.mullvad.mullvadvpn.service.persistence.SplitTunnelingPersistence
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
@@ -111,7 +110,7 @@ class MullvadVpnService : TalpidVpnService() {
             daemonInstance.intermittentDaemon,
             connectivityListener,
             SplitTunnelingPersistence(this),
-            VpnPermission(this)
+            this
         )
 
         notificationManager =

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
 import net.mullvad.mullvadvpn.service.notifications.AccountExpiryNotification
-import net.mullvad.mullvadvpn.service.persistence.SplitTunnelingPersistence
 import net.mullvad.mullvadvpn.service.tunnelstate.TunnelStateUpdater
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
@@ -109,7 +108,6 @@ class MullvadVpnService : TalpidVpnService() {
             Looper.getMainLooper(),
             daemonInstance.intermittentDaemon,
             connectivityListener,
-            SplitTunnelingPersistence(this),
             this
         )
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -112,7 +112,7 @@ class MullvadVpnService : TalpidVpnService() {
         )
 
         notificationManager =
-            ForegroundNotificationManager(this, serviceNotifier, keyguardManager).apply {
+            ForegroundNotificationManager(this, connectionProxy, keyguardManager).apply {
                 acknowledgeStartForegroundService()
                 accountNumberEvents = endpoint.settingsListener.accountNumberNotifier
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -110,6 +110,12 @@ class MullvadVpnService : TalpidVpnService() {
             this
         )
 
+        endpoint.splitTunneling.onChange.subscribe(this@MullvadVpnService) { excludedApps ->
+            disallowedApps = excludedApps
+            markTunAsStale()
+            connectionProxy.reconnect()
+        }
+
         tunnelStateUpdater = TunnelStateUpdater(this, connectionProxy)
 
         notificationManager =
@@ -232,12 +238,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
         val customDns = CustomDns(daemon, endpoint.settingsListener)
-
-        endpoint.splitTunneling.onChange.subscribe(this@MullvadVpnService) { excludedApps ->
-            disallowedApps = excludedApps
-            markTunAsStale()
-            connectionProxy.reconnect()
-        }
 
         handlePendingAction(settings)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
+import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class ServiceInstance(
@@ -11,7 +12,6 @@ class ServiceInstance(
     val customDns: CustomDns,
 ) {
     fun onDestroy() {
-        connectionProxy.onDestroy()
         customDns.onDestroy()
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,14 +1,12 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class ServiceInstance(
     val messenger: Messenger,
     val daemon: MullvadDaemon,
     val intermittentDaemon: Intermittent<MullvadDaemon>,
-    val connectionProxy: ConnectionProxy,
     val customDns: CustomDns,
 ) {
     fun onDestroy() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
@@ -45,6 +46,10 @@ class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoin
     init {
         daemon.registerListener(this) { newDaemon ->
             newDaemon?.onTunnelStateChange = { newState -> handleNewState(newState) }
+        }
+
+        onStateChange.subscribe(this) { tunnelState ->
+            endpoint.sendEvent(Event.TunnelStateChange(tunnelState))
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.service
+package net.mullvad.mullvadvpn.service.endpoint
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -10,15 +10,13 @@ import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.service.endpoint.VpnPermission
 import net.mullvad.mullvadvpn.ui.MainActivity
-import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.util.EventNotifier
 
 val ANTICIPATED_STATE_TIMEOUT_MS = 1500L
 
-class ConnectionProxy(val vpnPermission: VpnPermission, val daemon: Intermittent<MullvadDaemon>) {
+class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoint) {
     private enum class Command {
         CONNECT,
         RECONNECT,
@@ -26,6 +24,7 @@ class ConnectionProxy(val vpnPermission: VpnPermission, val daemon: Intermittent
     }
 
     private val commandChannel = spawnActor()
+    private val daemon = endpoint.intermittentDaemon
 
     var mainActivity: MainActivity? = null
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
@@ -2,21 +2,16 @@ package net.mullvad.mullvadvpn.service.endpoint
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.MainActivity
-import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.util.EventNotifier
-
-val ANTICIPATED_STATE_TIMEOUT_MS = 1500L
 
 class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoint) {
     private enum class Command {
@@ -27,26 +22,20 @@ class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoin
 
     private val commandChannel = spawnActor()
     private val daemon = endpoint.intermittentDaemon
-
-    var mainActivity: MainActivity? = null
-
-    private var resetAnticipatedStateJob: Job? = null
-
-    private val initialState: TunnelState = TunnelState.Disconnected
-
-    var onStateChange = EventNotifier(initialState)
-    var onUiStateChange = EventNotifier(initialState)
-
-    var state by onStateChange.notifiable()
-        private set
-    var uiState by onUiStateChange.notifiable()
-        private set
+    private val initialState = TunnelState.Disconnected
 
     private val fetchInitialStateJob = fetchInitialState()
 
+    var mainActivity: MainActivity? = null
+
+    var onStateChange = EventNotifier<TunnelState>(initialState)
+
+    var state by onStateChange.notifiable()
+        private set
+
     init {
         daemon.registerListener(this) { newDaemon ->
-            newDaemon?.onTunnelStateChange = { newState -> handleNewState(newState) }
+            newDaemon?.onTunnelStateChange = { newState -> state = newState }
         }
 
         onStateChange.subscribe(this) { tunnelState ->
@@ -61,30 +50,21 @@ class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoin
     }
 
     fun connect() {
-        if (anticipateConnectingState()) {
-            commandChannel.sendBlocking(Command.CONNECT)
-        }
+        commandChannel.sendBlocking(Command.CONNECT)
     }
 
     fun reconnect() {
-        if (anticipateReconnectingState()) {
-            commandChannel.sendBlocking(Command.RECONNECT)
-        }
+        commandChannel.sendBlocking(Command.RECONNECT)
     }
 
     fun disconnect() {
-        if (anticipateDisconnectingState()) {
-            commandChannel.sendBlocking(Command.DISCONNECT)
-        }
+        commandChannel.sendBlocking(Command.DISCONNECT)
     }
 
     fun onDestroy() {
         commandChannel.close()
-
-        onUiStateChange.unsubscribeAll()
-        onStateChange.unsubscribeAll()
-
         fetchInitialStateJob.cancel()
+        onStateChange.unsubscribeAll()
         daemon.unregisterListener(this)
     }
 
@@ -105,88 +85,6 @@ class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoin
         } catch (exception: ClosedReceiveChannelException) {
             // Closed sender, so stop the actor
         }
-    }
-
-    private fun handleNewState(newState: TunnelState) {
-        synchronized(this) {
-            resetAnticipatedStateJob?.cancel()
-            state = newState
-            uiState = newState
-        }
-    }
-
-    private fun anticipateConnectingState(): Boolean {
-        synchronized(this) {
-            val currentState = uiState
-
-            if (currentState is TunnelState.Connecting || currentState is TunnelState.Connected) {
-                return false
-            } else {
-                scheduleToResetAnticipatedState()
-                uiState = TunnelState.Connecting(null, null)
-                return true
-            }
-        }
-    }
-
-    private fun anticipateReconnectingState(): Boolean {
-        synchronized(this) {
-            val currentState = uiState
-
-            val willReconnect = when (currentState) {
-                is TunnelState.Disconnected -> false
-                is TunnelState.Disconnecting -> {
-                    when (currentState.actionAfterDisconnect) {
-                        ActionAfterDisconnect.Nothing -> false
-                        ActionAfterDisconnect.Reconnect -> true
-                        ActionAfterDisconnect.Block -> true
-                    }
-                }
-                is TunnelState.Connecting -> true
-                is TunnelState.Connected -> true
-                is TunnelState.Error -> true
-            }
-
-            if (willReconnect) {
-                scheduleToResetAnticipatedState()
-                uiState = TunnelState.Disconnecting(ActionAfterDisconnect.Reconnect)
-            }
-
-            return willReconnect
-        }
-    }
-
-    private fun anticipateDisconnectingState(): Boolean {
-        synchronized(this) {
-            val currentState = uiState
-
-            if (currentState is TunnelState.Disconnected) {
-                return false
-            } else {
-                scheduleToResetAnticipatedState()
-                uiState = TunnelState.Disconnecting(ActionAfterDisconnect.Nothing)
-                return true
-            }
-        }
-    }
-
-    private fun scheduleToResetAnticipatedState() {
-        resetAnticipatedStateJob?.cancel()
-
-        var currentJob: Job? = null
-
-        val newJob = GlobalScope.launch(Dispatchers.Default) {
-            delay(ANTICIPATED_STATE_TIMEOUT_MS)
-
-            synchronized(this@ConnectionProxy) {
-                if (!currentJob!!.isCancelled) {
-                    uiState = state
-                }
-            }
-        }
-
-        currentJob = newJob
-        resetAnticipatedStateJob = newJob
     }
 
     private fun fetchInitialState() = GlobalScope.launch(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.util.EventNotifier
 
 class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoint) {
@@ -25,8 +24,6 @@ class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoin
     private val initialState = TunnelState.Disconnected
 
     private val fetchInitialStateJob = fetchInitialState()
-
-    var mainActivity: MainActivity? = null
 
     var onStateChange = EventNotifier<TunnelState>(initialState)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ConnectionProxy.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
@@ -50,6 +51,12 @@ class ConnectionProxy(val vpnPermission: VpnPermission, endpoint: ServiceEndpoin
 
         onStateChange.subscribe(this) { tunnelState ->
             endpoint.sendEvent(Event.TunnelStateChange(tunnelState))
+        }
+
+        endpoint.dispatcher.apply {
+            registerHandler(Request.Connect::class) { _ -> connect() }
+            registerHandler(Request.Reconnect::class) { _ -> reconnect() }
+            registerHandler(Request.Disconnect::class) { _ -> disconnect() }
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -100,6 +100,7 @@ class ServiceEndpoint(
             listeners.add(listener)
 
             val initialEvents = listOf(
+                Event.TunnelStateChange(connectionProxy.state),
                 Event.LoginStatus(accountCache.onLoginStatusChange.latestEvent),
                 Event.AccountHistory(accountCache.onAccountHistoryChange.latestEvent),
                 Event.SettingsUpdate(settingsListener.settings),

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import android.content.Context
 import android.os.DeadObjectException
 import android.os.Looper
 import android.os.Messenger
@@ -23,7 +24,7 @@ class ServiceEndpoint(
     internal val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectivityListener: ConnectivityListener,
     splitTunnelingPersistence: SplitTunnelingPersistence,
-    vpnPermission: VpnPermission
+    context: Context
 ) {
     private val listeners = mutableSetOf<Messenger>()
     private val registrationQueue: SendChannel<Messenger> = startRegistrator()
@@ -33,6 +34,8 @@ class ServiceEndpoint(
     }
 
     val messenger = Messenger(dispatcher)
+
+    val vpnPermission = VpnPermission(context)
 
     val connectionProxy = ConnectionProxy(vpnPermission, this)
     val settingsListener = SettingsListener(this)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -22,7 +22,8 @@ class ServiceEndpoint(
     looper: Looper,
     internal val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectivityListener: ConnectivityListener,
-    splitTunnelingPersistence: SplitTunnelingPersistence
+    splitTunnelingPersistence: SplitTunnelingPersistence,
+    vpnPermission: VpnPermission
 ) {
     private val listeners = mutableSetOf<Messenger>()
     private val registrationQueue: SendChannel<Messenger> = startRegistrator()
@@ -33,6 +34,7 @@ class ServiceEndpoint(
 
     val messenger = Messenger(dispatcher)
 
+    val connectionProxy = ConnectionProxy(vpnPermission, this)
     val settingsListener = SettingsListener(this)
 
     val accountCache = AccountCache(this)
@@ -51,6 +53,7 @@ class ServiceEndpoint(
         registrationQueue.close()
 
         accountCache.onDestroy()
+        connectionProxy.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -23,7 +23,6 @@ class ServiceEndpoint(
     looper: Looper,
     internal val intermittentDaemon: Intermittent<MullvadDaemon>,
     val connectivityListener: ConnectivityListener,
-    splitTunnelingPersistence: SplitTunnelingPersistence,
     context: Context
 ) {
     private val listeners = mutableSetOf<Messenger>()
@@ -43,7 +42,7 @@ class ServiceEndpoint(
     val accountCache = AccountCache(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
-    val splitTunneling = SplitTunneling(splitTunnelingPersistence, this)
+    val splitTunneling = SplitTunneling(SplitTunnelingPersistence(context), this)
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -35,7 +35,7 @@ class ServiceEndpoint(
 
     val messenger = Messenger(dispatcher)
 
-    val vpnPermission = VpnPermission(context)
+    val vpnPermission = VpnPermission(context, this)
 
     val connectionProxy = ConnectionProxy(vpnPermission, this)
     val settingsListener = SettingsListener(this)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -3,11 +3,18 @@ package net.mullvad.mullvadvpn.service.endpoint
 import android.content.Context
 import android.content.Intent
 import android.net.VpnService
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.mullvadvpn.util.Intermittent
 
-class VpnPermission(private val context: Context) {
+class VpnPermission(private val context: Context, endpoint: ServiceEndpoint) {
     private val isGranted = Intermittent<Boolean>()
+
+    init {
+        endpoint.dispatcher.registerHandler(Request.VpnPermissionResponse::class) { request ->
+            isGranted.spawnUpdate(request.isGranted)
+        }
+    }
 
     suspend fun request(): Boolean {
         val intent = VpnService.prepare(context)
@@ -27,9 +34,5 @@ class VpnPermission(private val context: Context) {
         }
 
         return isGranted.await()
-    }
-
-    suspend fun grant(permission: Boolean) {
-        isGranted.update(permission)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -1,0 +1,35 @@
+package net.mullvad.mullvadvpn.service.endpoint
+
+import android.content.Context
+import android.content.Intent
+import android.net.VpnService
+import net.mullvad.mullvadvpn.ui.MainActivity
+import net.mullvad.mullvadvpn.util.Intermittent
+
+class VpnPermission(private val context: Context) {
+    private val isGranted = Intermittent<Boolean>()
+
+    suspend fun request(): Boolean {
+        val intent = VpnService.prepare(context)
+
+        if (intent == null) {
+            isGranted.update(true)
+        } else {
+            val activityIntent = Intent(context, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                putExtra(MainActivity.KEY_SHOULD_CONNECT, true)
+            }
+
+            isGranted.update(null)
+
+            context.startActivity(activityIntent)
+        }
+
+        return isGranted.await()
+    }
+
+    suspend fun grant(permission: Boolean) {
+        isGranted.update(permission)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
@@ -1,29 +1,14 @@
 package net.mullvad.mullvadvpn.service.tunnelstate
 
 import android.content.Context
-import net.mullvad.mullvadvpn.service.ServiceInstance
 import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
-import net.mullvad.talpid.util.EventNotifier
 
-class TunnelStateUpdater(context: Context, serviceNotifier: EventNotifier<ServiceInstance?>) {
+class TunnelStateUpdater(context: Context, private val connectionProxy: ConnectionProxy) {
     private val persistence = Persistence(context)
 
-    private var connectionProxy: ConnectionProxy? = null
-    private var stateSubscriptionId: Int? = null
-
     init {
-        serviceNotifier.subscribe(this) { serviceInstance ->
-            onNewServiceInstance(serviceInstance)
-        }
-    }
-
-    private fun onNewServiceInstance(serviceInstance: ServiceInstance?) {
-        connectionProxy?.onStateChange?.unsubscribe(this)
-
-        connectionProxy = serviceInstance?.connectionProxy?.apply {
-            onStateChange.subscribe(this@TunnelStateUpdater) { newState ->
-                persistence.state = newState
-            }
+        connectionProxy.onStateChange.subscribe(this) { newState ->
+            persistence.state = newState
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/tunnelstate/TunnelStateUpdater.kt
@@ -1,8 +1,8 @@
 package net.mullvad.mullvadvpn.service.tunnelstate
 
 import android.content.Context
-import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.ServiceInstance
+import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
 import net.mullvad.talpid.util.EventNotifier
 
 class TunnelStateUpdater(context: Context, serviceNotifier: EventNotifier<ServiceInstance?>) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -231,6 +231,6 @@ open class MainActivity : FragmentActivity() {
     }
 
     private fun setVpnPermission(allow: Boolean) = GlobalScope.launch(Dispatchers.Default) {
-        serviceConnection?.connectionProxy?.vpnPermission?.complete(allow)
+        serviceConnection?.connectionProxy?.vpnPermission?.update(allow)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -231,6 +231,6 @@ open class MainActivity : FragmentActivity() {
     }
 
     private fun setVpnPermission(allow: Boolean) = GlobalScope.launch(Dispatchers.Default) {
-        serviceConnection?.connectionProxy?.vpnPermission?.grant(allow)
+        serviceConnection?.vpnPermission?.grant(allow)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -231,6 +231,6 @@ open class MainActivity : FragmentActivity() {
     }
 
     private fun setVpnPermission(allow: Boolean) = GlobalScope.launch(Dispatchers.Default) {
-        serviceConnection?.connectionProxy?.vpnPermission?.update(allow)
+        serviceConnection?.connectionProxy?.vpnPermission?.grant(allow)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -13,9 +13,6 @@ import android.view.WindowManager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
@@ -138,7 +135,7 @@ open class MainActivity : FragmentActivity() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
-        setVpnPermission(resultCode == Activity.RESULT_OK)
+        serviceConnection?.vpnPermission?.grant(resultCode == Activity.RESULT_OK)
     }
 
     override fun onBackPressed() {
@@ -228,9 +225,5 @@ open class MainActivity : FragmentActivity() {
             add(R.id.main_fragment, LaunchFragment())
             commit()
         }
-    }
-
-    private fun setVpnPermission(allow: Boolean) = GlobalScope.launch(Dispatchers.Default) {
-        serviceConnection?.vpnPermission?.grant(allow)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -9,8 +9,8 @@ import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -7,9 +7,9 @@ import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
-import net.mullvad.mullvadvpn.service.ConnectionProxy
 import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
+import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.tunnel.ErrorState
 import net.mullvad.talpid.tunnel.ErrorStateCause

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/TunnelStateNotification.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.service.ConnectionProxy
+import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.tunnel.ErrorState
 import net.mullvad.talpid.tunnel.ErrorStateCause

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
@@ -1,0 +1,34 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
+import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.talpid.util.EventNotifier
+
+class ConnectionProxy(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+    val onStateChange = EventNotifier<TunnelState>(TunnelState.Disconnected)
+
+    init {
+        eventDispatcher.registerHandler(Event.TunnelStateChange::class) { event ->
+            onStateChange.notify(event.tunnelState)
+        }
+    }
+
+    fun connect() {
+        connection.send(Request.Connect.message)
+    }
+
+    fun disconnect() {
+        connection.send(Request.Disconnect.message)
+    }
+
+    fun reconnect() {
+        connection.send(Request.Reconnect.message)
+    }
+
+    fun onDestroy() {
+        onStateChange.unsubscribeAll()
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
@@ -1,34 +1,139 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.util.EventNotifier
 
+val ANTICIPATED_STATE_TIMEOUT_MS = 1500L
+
 class ConnectionProxy(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+    private var resetAnticipatedStateJob: Job? = null
+
     val onStateChange = EventNotifier<TunnelState>(TunnelState.Disconnected)
+    val onUiStateChange = EventNotifier<TunnelState>(TunnelState.Disconnected)
+
+    var state by onStateChange.notifiable()
+        private set
+    var uiState by onUiStateChange.notifiable()
+        private set
 
     init {
         eventDispatcher.registerHandler(Event.TunnelStateChange::class) { event ->
-            onStateChange.notify(event.tunnelState)
+            handleNewState(event.tunnelState)
         }
     }
 
     fun connect() {
-        connection.send(Request.Connect.message)
+        if (anticipateConnectingState()) {
+            connection.send(Request.Connect.message)
+        }
     }
 
     fun disconnect() {
-        connection.send(Request.Disconnect.message)
+        if (anticipateReconnectingState()) {
+            connection.send(Request.Disconnect.message)
+        }
     }
 
     fun reconnect() {
-        connection.send(Request.Reconnect.message)
+        if (anticipateDisconnectingState()) {
+            connection.send(Request.Reconnect.message)
+        }
     }
 
     fun onDestroy() {
         onStateChange.unsubscribeAll()
+        onUiStateChange.unsubscribeAll()
+    }
+
+    private fun handleNewState(newState: TunnelState) {
+        synchronized(this) {
+            resetAnticipatedStateJob?.cancel()
+            state = newState
+            uiState = newState
+        }
+    }
+
+    private fun anticipateConnectingState(): Boolean {
+        synchronized(this) {
+            val currentState = uiState
+
+            if (currentState is TunnelState.Connecting || currentState is TunnelState.Connected) {
+                return false
+            } else {
+                scheduleToResetAnticipatedState()
+                uiState = TunnelState.Connecting(null, null)
+                return true
+            }
+        }
+    }
+
+    private fun anticipateReconnectingState(): Boolean {
+        synchronized(this) {
+            val currentState = uiState
+
+            val willReconnect = when (currentState) {
+                is TunnelState.Disconnected -> false
+                is TunnelState.Disconnecting -> {
+                    when (currentState.actionAfterDisconnect) {
+                        ActionAfterDisconnect.Nothing -> false
+                        ActionAfterDisconnect.Reconnect -> true
+                        ActionAfterDisconnect.Block -> true
+                    }
+                }
+                is TunnelState.Connecting -> true
+                is TunnelState.Connected -> true
+                is TunnelState.Error -> true
+            }
+
+            if (willReconnect) {
+                scheduleToResetAnticipatedState()
+                uiState = TunnelState.Disconnecting(ActionAfterDisconnect.Reconnect)
+            }
+
+            return willReconnect
+        }
+    }
+
+    private fun anticipateDisconnectingState(): Boolean {
+        synchronized(this) {
+            val currentState = uiState
+
+            if (currentState is TunnelState.Disconnected) {
+                return false
+            } else {
+                scheduleToResetAnticipatedState()
+                uiState = TunnelState.Disconnecting(ActionAfterDisconnect.Nothing)
+                return true
+            }
+        }
+    }
+
+    private fun scheduleToResetAnticipatedState() {
+        resetAnticipatedStateJob?.cancel()
+
+        var currentJob: Job? = null
+
+        val newJob = GlobalScope.launch(Dispatchers.Default) {
+            delay(ANTICIPATED_STATE_TIMEOUT_MS)
+
+            synchronized(this@ConnectionProxy) {
+                if (!currentJob!!.isCancelled) {
+                    uiState = state
+                }
+            }
+        }
+
+        currentJob = newJob
+        resetAnticipatedStateJob = newJob
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -29,7 +29,7 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
 
     val daemon = service.daemon
     val accountCache = AccountCache(service.messenger, dispatcher)
-    val connectionProxy = service.connectionProxy
+    val connectionProxy = ConnectionProxy(service.messenger, dispatcher)
     val customDns = service.customDns
     val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
@@ -44,7 +44,7 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
 
     init {
         appVersionInfoCache.onCreate()
-        connectionProxy.mainActivity = mainActivity
+        service.connectionProxy.mainActivity = mainActivity
         registerListener()
     }
 
@@ -52,13 +52,14 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
         dispatcher.onDestroy()
 
         accountCache.onDestroy()
+        connectionProxy.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()
 
         appVersionInfoCache.onDestroy()
         relayListListener.onDestroy()
-        connectionProxy.mainActivity = null
+        service.connectionProxy.mainActivity = null
     }
 
     private fun registerListener() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -37,6 +37,7 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
     val splitTunneling = get<SplitTunneling>(
         parameters = { parametersOf(service.messenger, dispatcher) }
     )
+    val vpnPermission = VpnPermission(service.messenger)
 
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -44,7 +44,6 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
 
     init {
         appVersionInfoCache.onCreate()
-        service.connectionProxy.mainActivity = mainActivity
         registerListener()
     }
 
@@ -59,7 +58,6 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
 
         appVersionInfoCache.onDestroy()
         relayListListener.onDestroy()
-        service.connectionProxy.mainActivity = null
     }
 
     private fun registerListener() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/VpnPermission.kt
@@ -1,0 +1,10 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import net.mullvad.mullvadvpn.ipc.Request
+
+class VpnPermission(private val connection: Messenger) {
+    fun grant(isGranted: Boolean) {
+        connection.send(Request.VpnPermissionResponse(isGranted).message)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/talpid/net/Endpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/net/Endpoint.kt
@@ -1,5 +1,8 @@
 package net.mullvad.talpid.net
 
+import android.os.Parcelable
 import java.net.InetSocketAddress
+import kotlinx.parcelize.Parcelize
 
-data class Endpoint(val address: InetSocketAddress, val protocol: TransportProtocol)
+@Parcelize
+data class Endpoint(val address: InetSocketAddress, val protocol: TransportProtocol) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/talpid/net/TransportProtocol.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/net/TransportProtocol.kt
@@ -1,5 +1,9 @@
 package net.mullvad.talpid.net
 
-enum class TransportProtocol {
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class TransportProtocol : Parcelable {
     Tcp, Udp
 }

--- a/android/src/main/kotlin/net/mullvad/talpid/net/TunnelEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/net/TunnelEndpoint.kt
@@ -1,3 +1,7 @@
 package net.mullvad.talpid.net
 
-data class TunnelEndpoint(val endpoint: Endpoint)
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TunnelEndpoint(val endpoint: Endpoint) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ActionAfterDisconnect.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ActionAfterDisconnect.kt
@@ -1,5 +1,9 @@
 package net.mullvad.talpid.tunnel
 
-enum class ActionAfterDisconnect {
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class ActionAfterDisconnect : Parcelable {
     Nothing, Block, Reconnect
 }

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorState.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorState.kt
@@ -1,3 +1,7 @@
 package net.mullvad.talpid.tunnel
 
-data class ErrorState(val cause: ErrorStateCause, val isBlocking: Boolean)
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ErrorState(val cause: ErrorStateCause, val isBlocking: Boolean) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
+++ b/android/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
@@ -1,15 +1,34 @@
 package net.mullvad.talpid.tunnel
 
+import android.os.Parcelable
 import java.net.InetAddress
+import kotlinx.parcelize.Parcelize
 
-sealed class ErrorStateCause {
+sealed class ErrorStateCause : Parcelable {
+    @Parcelize
     class AuthFailed(val reason: String?) : ErrorStateCause()
+
+    @Parcelize
     object Ipv6Unavailable : ErrorStateCause()
+
+    @Parcelize
     object SetFirewallPolicyError : ErrorStateCause()
+
+    @Parcelize
     object SetDnsError : ErrorStateCause()
+
+    @Parcelize
     class InvalidDnsServers(val addresses: ArrayList<InetAddress>) : ErrorStateCause()
+
+    @Parcelize
     object StartTunnelError : ErrorStateCause()
+
+    @Parcelize
     class TunnelParameterError(val error: ParameterGenerationError) : ErrorStateCause()
+
+    @Parcelize
     object IsOffline : ErrorStateCause()
+
+    @Parcelize
     object VpnPermissionDenied : ErrorStateCause()
 }


### PR DESCRIPTION
This PR continues the work to separate the Android app in order to run the service in a separate process. This PR focuses on the `ConnectionProxy`. There are now two `ConnectionProxy` classes, one used by the UI and one used by the service. The service-side class handles the actual communication with the daemon, while the UI side class sends requests and receives events, as well as handling a custom UI state that anticipates the real tunnel state.

As part of the changes, the `ConnectionProxy` is now decoupled from both the service and from the `MullvadVpnService`. Two new `VpnPermission` helper classes (one UI-side and one service-side) were created to help with this decoupling.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2644)
<!-- Reviewable:end -->
