### PR TITLE
AccountTextField: handle return key on iPad

### DIFF
--- a/ios/MullvadVPN/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/AccountInputGroupView.swift
@@ -26,6 +26,8 @@ class AccountInputGroupView: UIView {
         textField.smartQuotesType = .no
         textField.spellCheckingType = .no
         textField.keyboardType = .numberPad
+        textField.returnKeyType = .done
+        textField.enablesReturnKeyAutomatically = false
 
         return textField
     }()

--- a/ios/MullvadVPN/AccountTextField.swift
+++ b/ios/MullvadVPN/AccountTextField.swift
@@ -8,9 +8,11 @@
 
 import UIKit
 
-@IBDesignable class AccountTextField: UITextField {
+class AccountTextField: UITextField, UITextFieldDelegate {
 
     private let input = AccountTokenInput()
+
+    var onReturnKey: ((AccountTextField) -> Bool)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -25,8 +27,15 @@ import UIKit
     private func setup() {
         backgroundColor = UIColor.clear
 
-        delegate = input
+        delegate = self
         pasteDelegate = input
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIWindow.keyboardWillShowNotification,
+            object: nil
+        )
     }
 
     var autoformattingText: String {
@@ -43,12 +52,47 @@ import UIKit
         return input.parsedString
     }
 
+    var enableReturnKey: Bool = true {
+        didSet {
+            updateKeyboardReturnKey()
+        }
+    }
+
     override func textRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.insetBy(dx: 14, dy: 12)
     }
 
     override func editingRect(forBounds bounds: CGRect) -> CGRect {
         return textRect(forBounds: bounds)
+    }
+
+    // MARK: - UITextFieldDelegate
+
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return input.textField(textField, shouldChangeCharactersIn: range, replacementString: string)
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        return onReturnKey?(self) ?? true
+    }
+
+    // MARK: - Keyboard notifications
+
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        if self.isFirstResponder {
+            updateKeyboardReturnKey()
+        }
+    }
+
+    private func updateKeyboardReturnKey() {
+        setEnableKeyboardReturnKey(enableReturnKey)
+    }
+
+    private func setEnableKeyboardReturnKey(_ enableReturnKey: Bool) {
+        let selector = NSSelectorFromString("setReturnKeyEnabled:")
+        if let inputDelegate = self.inputDelegate as? NSObject, inputDelegate.responds(to: selector) {
+            inputDelegate.setValue(enableReturnKey, forKey: "returnKeyEnabled")
+        }
     }
 
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR adds the return key to the on-screen keyboard on iPad. I picked the return type key that says "Join", seemed more suitable than others but I am open to changing this. The supported return key types are defined here https://developer.apple.com/documentation/uikit/uireturnkeytype and shortly are "return", "Go", "Google", "Join", "Next", "Route", "Send", "Yahoo", "Done", "Emergency call" and "Continue".

Note that this PR is only relevant for iPad, as on iPhone we have a numpad keyboard which does not have the return key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2648)
<!-- Reviewable:end -->
