### PR TITLE
Settings: rework navigation

### DIFF
--- a/ios/MullvadVPN/SettingsNavigationController.swift
+++ b/ios/MullvadVPN/SettingsNavigationController.swift
@@ -9,7 +9,43 @@
 import Foundation
 import UIKit
 
-class SettingsNavigationController: CustomNavigationController {
+enum SettingsNavigationRoute {
+    case account
+    case wireguardKeys
+    case problemReport
+}
+
+enum SettingsDismissReason {
+    case none
+    case userLoggedOut
+}
+
+protocol SettingsNavigationControllerDelegate: class {
+    func settingsNavigationController(_ controller: SettingsNavigationController, didFinishWithReason reason: SettingsDismissReason)
+}
+
+class SettingsNavigationController: CustomNavigationController, SettingsViewControllerDelegate, AccountViewControllerDelegate, UIAdaptivePresentationControllerDelegate {
+
+    weak var settingsDelegate: SettingsNavigationControllerDelegate?
+
+    init() {
+        super.init(navigationBarClass: CustomNavigationBar.self, toolbarClass: nil)
+
+        let settingsController = SettingsViewController()
+        settingsController.delegate = self
+
+        pushViewController(settingsController, animated: false)
+    }
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        // This initializer exists to prevent crash on iOS 12.
+        // See: https://stackoverflow.com/a/38335090/351305
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,4 +58,38 @@ class SettingsNavigationController: CustomNavigationController {
         Account.shared.updateAccountExpiry()
     }
 
+    // MARK: - SettingsViewControllerDelegate
+
+    func settingsViewControllerDidFinish(_ controller: SettingsViewController) {
+        self.settingsDelegate?.settingsNavigationController(self, didFinishWithReason: .none)
+    }
+
+    // MARK: - AccountViewControllerDelegate
+
+    func accountViewControllerDidLogout(_ controller: AccountViewController) {
+        self.settingsDelegate?.settingsNavigationController(self, didFinishWithReason: .userLoggedOut)
+    }
+
+    // MARK: - Navigation
+
+    func navigate(to route: SettingsNavigationRoute, animated: Bool) {
+        switch route {
+        case .account:
+            let controller = AccountViewController()
+            controller.delegate = self
+            pushViewController(controller, animated: animated)
+
+        case .wireguardKeys:
+            pushViewController(WireguardKeysViewController(), animated: animated)
+
+        case .problemReport:
+            pushViewController(ProblemReportViewController(), animated: animated)
+        }
+    }
+
+    // MARK: - UIAdaptivePresentationControllerDelegate
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        settingsDelegate?.settingsNavigationController(self, didFinishWithReason: .none)
+    }
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Move responsibility to handle the internal view controller navigation from a child `SettingsController` to parent  `SettingsNavigationController`
2. Implement `UIAdaptivePresentationControllerDelegate` on. `SettingsNavigationController` to be able to handle the interactive (swipe gesture) dismissal of the view controller. For that to work the `presentationController.delegate` has to be set to `<SettingsNavigationController>` - this change will be one from `AppDelegate` in the follow up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2650)
<!-- Reviewable:end -->
