### PR TITLE
Split `CustomDns` into service-side and UI-side classes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -2,12 +2,16 @@ package net.mullvad.mullvadvpn.ipc
 
 import android.os.Message as RawMessage
 import android.os.Messenger
+import java.net.InetAddress
 import kotlinx.parcelize.Parcelize
 import org.joda.time.DateTime
 
 // Requests that the service can handle
 sealed class Request : Message.RequestMessage() {
     protected override val messageKey = MESSAGE_KEY
+
+    @Parcelize
+    data class AddCustomDnsServer(val address: InetAddress) : Request()
 
     @Parcelize
     object Connect : Request()
@@ -47,6 +51,18 @@ sealed class Request : Message.RequestMessage() {
 
     @Parcelize
     data class RemoveAccountFromHistory(val account: String?) : Request()
+
+    @Parcelize
+    data class RemoveCustomDnsServer(val address: InetAddress) : Request()
+
+    @Parcelize
+    data class ReplaceCustomDnsServer(
+        val oldAddress: InetAddress,
+        val newAddress: InetAddress
+    ) : Request()
+
+    @Parcelize
+    data class SetEnableCustomDns(val enable: Boolean) : Request()
 
     @Parcelize
     data class SetEnableSplitTunneling(val enable: Boolean) : Request()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -36,29 +36,13 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
             }
 
             registerHandler(Request.SetEnableCustomDns::class) { request ->
-                if (request.enable) {
-                    enable()
-                } else {
-                    disable()
-                }
+                setEnabled(request.enable)
             }
         }
     }
 
     fun onDestroy() {
         endpoint.settingsListener.dnsOptionsNotifier.unsubscribe(this)
-    }
-
-    fun enable() {
-        synchronized(this) {
-            changeDnsOptions(true, dnsServers)
-        }
-    }
-
-    fun disable() {
-        synchronized(this) {
-            changeDnsOptions(false, dnsServers)
-        }
     }
 
     fun addDnsServer(server: InetAddress): Boolean {
@@ -100,6 +84,10 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
                 changeDnsOptions(enabled, dnsServers)
             }
         }
+    }
+
+    fun setEnabled(enable: Boolean) {
+        changeDnsOptions(enable, dnsServers)
     }
 
     private fun changeDnsOptions(enable: Boolean, dnsServers: ArrayList<InetAddress>) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -45,37 +45,27 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
         endpoint.settingsListener.dnsOptionsNotifier.unsubscribe(this)
     }
 
-    fun addDnsServer(server: InetAddress): Boolean {
+    fun addDnsServer(server: InetAddress) {
         synchronized(this) {
             if (!dnsServers.contains(server)) {
                 dnsServers.add(server)
                 changeDnsOptions(enabled, dnsServers)
-
-                return true
             }
         }
-
-        return false
     }
 
-    fun replaceDnsServer(oldServer: InetAddress, newServer: InetAddress): Boolean {
+    fun replaceDnsServer(oldServer: InetAddress, newServer: InetAddress) {
         synchronized(this) {
-            if (oldServer == newServer) {
-                return true
-            } else if (!dnsServers.contains(newServer)) {
+            if (oldServer != newServer && !dnsServers.contains(newServer)) {
                 val index = dnsServers.indexOf(oldServer)
 
                 if (index >= 0) {
                     dnsServers.removeAt(index)
                     dnsServers.add(index, newServer)
                     changeDnsOptions(enabled, dnsServers)
-
-                    return true
                 }
             }
         }
-
-        return false
     }
 
     fun removeDnsServer(server: InetAddress) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -2,29 +2,17 @@ package net.mullvad.mullvadvpn.service
 
 import java.net.InetAddress
 import java.util.ArrayList
-import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.runBlocking
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
-import net.mullvad.talpid.util.EventNotifier
 
 class CustomDns(private val endpoint: ServiceEndpoint) {
-    private var enabled by observable(false) { _, oldValue, newValue ->
-        if (oldValue != newValue) {
-            onEnabledChanged.notify(newValue)
-        }
-    }
-
     private val daemon
         get() = runBlocking { endpoint.intermittentDaemon.await() }
 
-    private var dnsServers by observable<ArrayList<InetAddress>>(ArrayList()) { _, _, servers ->
-        onDnsServersChanged.notify(servers.toList())
-    }
-
-    val onEnabledChanged = EventNotifier(false)
-    val onDnsServersChanged = EventNotifier<List<InetAddress>>(emptyList())
+    private var dnsServers = ArrayList<InetAddress>()
+    private var enabled = false
 
     init {
         endpoint.settingsListener.dnsOptionsNotifier.subscribe(this) { maybeDnsOptions ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/CustomDns.kt
@@ -38,19 +38,21 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
 
         endpoint.dispatcher.apply {
             registerHandler(Request.AddCustomDnsServer::class) { request ->
-                addDnsServer(request.address)
+                commandChannel.sendBlocking(Command.AddDnsServer(request.address))
             }
 
             registerHandler(Request.RemoveCustomDnsServer::class) { request ->
-                removeDnsServer(request.address)
+                commandChannel.sendBlocking(Command.RemoveDnsServer(request.address))
             }
 
             registerHandler(Request.ReplaceCustomDnsServer::class) { request ->
-                replaceDnsServer(request.oldAddress, request.newAddress)
+                commandChannel.sendBlocking(
+                    Command.ReplaceDnsServer(request.oldAddress, request.newAddress)
+                )
             }
 
             registerHandler(Request.SetEnableCustomDns::class) { request ->
-                setEnabled(request.enable)
+                commandChannel.sendBlocking(Command.SetEnabled(request.enable))
             }
         }
     }
@@ -58,22 +60,6 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
     fun onDestroy() {
         endpoint.settingsListener.dnsOptionsNotifier.unsubscribe(this)
         commandChannel.close()
-    }
-
-    fun addDnsServer(server: InetAddress) {
-        commandChannel.sendBlocking(Command.AddDnsServer(server))
-    }
-
-    fun replaceDnsServer(oldServer: InetAddress, newServer: InetAddress) {
-        commandChannel.sendBlocking(Command.ReplaceDnsServer(oldServer, newServer))
-    }
-
-    fun removeDnsServer(server: InetAddress) {
-        commandChannel.sendBlocking(Command.RemoveDnsServer(server))
-    }
-
-    fun setEnabled(enabled: Boolean) {
-        commandChannel.sendBlocking(Command.SetEnabled(enabled))
     }
 
     private fun spawnActor() = GlobalScope.actor<Command>(Dispatchers.Default, Channel.UNLIMITED) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -237,7 +237,9 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
-        val customDns = CustomDns(daemon, endpoint.settingsListener)
+        val customDns = CustomDns(endpoint)
+
+        endpoint.customDns = customDns
 
         handlePendingAction(settings)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -235,10 +235,6 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private suspend fun setUpInstance(daemon: MullvadDaemon, settings: Settings) {
-        val customDns = CustomDns(endpoint)
-
-        endpoint.customDns = customDns
-
         handlePendingAction(settings)
 
         if (state == State.Running) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -57,8 +57,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var instance by observable<ServiceInstance?>(null) { _, oldInstance, newInstance ->
         if (newInstance != oldInstance) {
-            oldInstance?.onDestroy()
-
             accountExpiryNotification = newInstance?.let { instance ->
                 AccountExpiryNotification(this, instance.daemon, endpoint.accountCache)
             }
@@ -244,12 +242,7 @@ class MullvadVpnService : TalpidVpnService() {
         handlePendingAction(settings)
 
         if (state == State.Running) {
-            instance = ServiceInstance(
-                endpoint.messenger,
-                daemon,
-                daemonInstance.intermittentDaemon,
-                customDns
-            )
+            instance = ServiceInstance(endpoint.messenger, daemon)
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ServiceInstance.kt
@@ -1,15 +1,5 @@
 package net.mullvad.mullvadvpn.service
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.util.Intermittent
 
-class ServiceInstance(
-    val messenger: Messenger,
-    val daemon: MullvadDaemon,
-    val intermittentDaemon: Intermittent<MullvadDaemon>,
-    val customDns: CustomDns,
-) {
-    fun onDestroy() {
-        customDns.onDestroy()
-    }
-}
+class ServiceInstance(val messenger: Messenger, val daemon: MullvadDaemon)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
 import java.net.InetAddress
-import java.util.ArrayList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
@@ -20,18 +20,19 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
     }
 
     private val commandChannel = spawnActor()
+    private val dnsServers = ArrayList<InetAddress>()
 
     private val daemon
         get() = endpoint.intermittentDaemon
 
-    private var dnsServers = ArrayList<InetAddress>()
     private var enabled = false
 
     init {
         endpoint.settingsListener.dnsOptionsNotifier.subscribe(this) { maybeDnsOptions ->
             maybeDnsOptions?.let { dnsOptions ->
                 enabled = dnsOptions.custom
-                dnsServers = dnsOptions.addresses
+                dnsServers.clear()
+                dnsServers.addAll(dnsOptions.addresses)
             }
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
@@ -72,7 +72,7 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
                     is Command.ReplaceDnsServer -> {
                         doReplaceDnsServer(command.oldServer, command.newServer)
                     }
-                    is Command.SetEnabled -> changeDnsOptions(command.enabled, dnsServers)
+                    is Command.SetEnabled -> changeDnsOptions(command.enabled)
                 }
             }
         } catch (exception: ClosedReceiveChannelException) {
@@ -83,7 +83,7 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
     private suspend fun doAddDnsServer(server: InetAddress) {
         if (!dnsServers.contains(server)) {
             dnsServers.add(server)
-            changeDnsOptions(enabled, dnsServers)
+            changeDnsOptions(enabled)
         }
     }
 
@@ -94,18 +94,18 @@ class CustomDns(private val endpoint: ServiceEndpoint) {
             if (index >= 0) {
                 dnsServers.removeAt(index)
                 dnsServers.add(index, newServer)
-                changeDnsOptions(enabled, dnsServers)
+                changeDnsOptions(enabled)
             }
         }
     }
 
     private suspend fun doRemoveDnsServer(server: InetAddress) {
         if (dnsServers.remove(server)) {
-            changeDnsOptions(enabled, dnsServers)
+            changeDnsOptions(enabled)
         }
     }
 
-    private suspend fun changeDnsOptions(enable: Boolean, dnsServers: ArrayList<InetAddress>) {
+    private suspend fun changeDnsOptions(enable: Boolean) {
         val options = DnsOptions(enable, dnsServers)
 
         daemon.await().setDnsOptions(options)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/CustomDns.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.service
+package net.mullvad.mullvadvpn.service.endpoint
 
 import java.net.InetAddress
 import java.util.ArrayList
@@ -10,7 +10,6 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.DnsOptions
-import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
 
 class CustomDns(private val endpoint: ServiceEndpoint) {
     private sealed class Command {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
-import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.persistence.SplitTunnelingPersistence
 import net.mullvad.mullvadvpn.util.Intermittent
@@ -41,11 +40,10 @@ class ServiceEndpoint(
     val settingsListener = SettingsListener(this)
 
     val accountCache = AccountCache(this)
+    val customDns = CustomDns(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
     val splitTunneling = SplitTunneling(SplitTunnelingPersistence(context), this)
-
-    var customDns: CustomDns? = null
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->
@@ -59,6 +57,7 @@ class ServiceEndpoint(
 
         accountCache.onDestroy()
         connectionProxy.onDestroy()
+        customDns.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         settingsListener.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
+import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.persistence.SplitTunnelingPersistence
 import net.mullvad.mullvadvpn.util.Intermittent
@@ -43,6 +44,8 @@ class ServiceEndpoint(
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
     val splitTunneling = SplitTunneling(SplitTunnelingPersistence(context), this)
+
+    var customDns: CustomDns? = null
 
     init {
         dispatcher.registerHandler(Request.RegisterListener::class) { request ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -7,10 +7,10 @@ import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
-import net.mullvad.mullvadvpn.service.CustomDns
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
+import net.mullvad.mullvadvpn.ui.serviceconnection.CustomDns
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/CustomDnsAdapter.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/CustomDnsAdapter.kt
@@ -8,7 +8,7 @@ import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.CustomDns
+import net.mullvad.mullvadvpn.ui.serviceconnection.CustomDns
 import net.mullvad.mullvadvpn.util.JobTracker
 import org.apache.commons.validator.routines.InetAddressValidator
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
@@ -1,0 +1,28 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import java.net.InetAddress
+import net.mullvad.talpid.util.EventNotifier
+
+class CustomDns(val connection: Messenger, val settingsListener: SettingsListener) {
+    val onEnabledChanged = EventNotifier(false)
+    val onDnsServersChanged = EventNotifier<List<InetAddress>>(emptyList())
+
+    init {
+        settingsListener.dnsOptionsNotifier.subscribe(this) { maybeDnsOptions ->
+            maybeDnsOptions?.let { dnsOptions ->
+                synchronized(this) {
+                    onEnabledChanged.notifyIfChanged(dnsOptions.custom)
+                    onDnsServersChanged.notifyIfChanged(dnsOptions.addresses)
+                }
+            }
+        }
+    }
+
+    fun onDestroy() {
+        onEnabledChanged.unsubscribeAll()
+        onDnsServersChanged.unsubscribeAll()
+
+        settingsListener.dnsOptionsNotifier.unsubscribe(this)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
 import java.net.InetAddress
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.talpid.util.EventNotifier
 
 class CustomDns(val connection: Messenger, val settingsListener: SettingsListener) {
@@ -17,6 +18,38 @@ class CustomDns(val connection: Messenger, val settingsListener: SettingsListene
                 }
             }
         }
+    }
+
+    fun enable() {
+        connection.send(Request.SetEnableCustomDns(true).message)
+    }
+
+    fun disable() {
+        connection.send(Request.SetEnableCustomDns(false).message)
+    }
+
+    fun addDnsServer(server: InetAddress): Boolean {
+        val alreadyHadServer = onDnsServersChanged.latestEvent.contains(server)
+
+        connection.send(Request.AddCustomDnsServer(server).message)
+
+        return alreadyHadServer
+    }
+
+    fun replaceDnsServer(oldServer: InetAddress, newServer: InetAddress): Boolean {
+        synchronized(this) {
+            val dnsServers = onDnsServersChanged.latestEvent
+            val containsOldServer = dnsServers.contains(oldServer)
+            val replacementIsValid = oldServer == newServer || !dnsServers.contains(newServer)
+
+            connection.send(Request.ReplaceCustomDnsServer(oldServer, newServer).message)
+
+            return containsOldServer && replacementIsValid
+        }
+    }
+
+    fun removeDnsServer(server: InetAddress) {
+        connection.send(Request.RemoveCustomDnsServer(server).message)
     }
 
     fun onDestroy() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -30,7 +30,6 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
     val daemon = service.daemon
     val accountCache = AccountCache(service.messenger, dispatcher)
     val connectionProxy = ConnectionProxy(service.messenger, dispatcher)
-    val customDns = service.customDns
     val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
     val settingsListener = SettingsListener(dispatcher)
@@ -40,6 +39,7 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
     val vpnPermission = VpnPermission(service.messenger)
 
     val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
+    val customDns = CustomDns(service.messenger, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)
 
     init {
@@ -57,6 +57,7 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
         settingsListener.onDestroy()
 
         appVersionInfoCache.onDestroy()
+        customDns.onDestroy()
         relayListListener.onDestroy()
     }
 


### PR DESCRIPTION
This PR continues the work to split the Android app so that the service runs in a separate process. This PR focuses on the custom DNS functionality, splitting the `CustomDns` class in two, one for the service side and one for the UI side. The UI side class sends requests to add/remove/replace custom DNS servers, and to enable or disable the functionality. The service side then handles those requests.

The service side class does not need to send any events to the UI side `CustomDns` class because they are included in settings updates sent by the `SettingsListener`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2656)
<!-- Reviewable:end -->
