### PR TITLE
Upgrade OpenVPN to 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
 - Make WireGuard automatic key rotation interval mandatory and between 1 and 7 days.
 - Show default, minimum, and maximum key rotation intervals in CLI.
 - Attempt to send problem reports using other endpoints if using the primary one fails.
+- Upgrade OpenVPN from 2.5.0 to 2.5.1.
 
 #### Linux
 - Only allow packets with the mark set to `0x6d6f6c65` to communicate with the relay server.


### PR DESCRIPTION
Bump the binaries submodule to include OpenVPN 2.5.1. Also has the openvpn and sslocal binaries for `aarch64-apple-darwin` to enable future builds for M1 macs.

I have verified that a build with these binaries run on Windows and macOS so far. So seems good.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2657)
<!-- Reviewable:end -->
