### PR TITLE
Secure filtering of forwarded packets on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ This release is for desktop only.
 - Always reconnect appropriately after an upgrade. Previously, installing the app twice in
   succession, with auto-connect disabled, would cause it to re-launch in the disconnected state.
 
+#### Linux
+- Drop packets being forwarded unless they are approved by the same rules as incoming or outgoing
+  traffic.
+
 
 ## [android/2021.1-beta1] - 2021-04-06
 This releas is for Android only. From now on, Android releases will have this new header format

--- a/docs/security.md
+++ b/docs/security.md
@@ -90,6 +90,11 @@ The following network traffic is allowed or blocked independent of state:
      * Incoming UDP from `*:68` to `255.255.255.255:67`
      * Outgoing UDP from `*:67` to `*:68`
 
+#### Packet forwarding
+
+On Linux, any situation that permits incoming or outgoing traffic also allows that traffic to be
+forwarded. All other forward traffic is rejected.
+
 #### macOS deviations
 
 * The app does not look at ICMPv6 type and code headers. So all ICMPv6 is allowed between the

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -600,6 +600,15 @@ impl<'a> PolicyBatch<'a> {
                 allow_lan,
                 dns_servers,
             } => {
+                // The forward chain is also hit by the tunnel
+                self.batch.add(
+                    &allow_interface_rule(
+                        &self.forward_chain,
+                        Direction::In,
+                        &tunnel.interface[..],
+                    )?,
+                    nftnl::MsgType::Add,
+                );
                 self.add_allow_tunnel_endpoint_rules(peer_endpoint);
                 self.add_allow_dns_rules(tunnel, &dns_servers, TransportProtocol::Udp)?;
                 self.add_allow_dns_rules(tunnel, &dns_servers, TransportProtocol::Tcp)?;

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -826,6 +826,10 @@ impl<'a> PolicyBatch<'a> {
             nftnl::MsgType::Add,
         );
         self.batch.add(
+            &allow_interface_rule(&self.forward_chain, Direction::Out, &tunnel.interface[..])?,
+            nftnl::MsgType::Add,
+        );
+        self.batch.add(
             &allow_interface_rule(&self.in_chain, Direction::In, &tunnel.interface[..])?,
             nftnl::MsgType::Add,
         );

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -638,12 +638,14 @@ impl<'a> PolicyBatch<'a> {
         }
 
         // Reject any remaining outgoing traffic
-        let mut reject_rule = Rule::new(&self.out_chain);
-        add_verdict(
-            &mut reject_rule,
-            &Verdict::Reject(RejectionType::Icmp(IcmpCode::PortUnreach)),
-        );
-        self.batch.add(&reject_rule, nftnl::MsgType::Add);
+        for chain in &[&self.out_chain, &self.forward_chain] {
+            let mut reject_rule = Rule::new(chain);
+            add_verdict(
+                &mut reject_rule,
+                &Verdict::Reject(RejectionType::Icmp(IcmpCode::PortUnreach)),
+            );
+            self.batch.add(&reject_rule, nftnl::MsgType::Add);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Previously, the app only filtered packets at the output and input hooks in netfilter, ignoring the forward hook. This meant that forwarded traffic was unfiltered. So a machine/router running Mullvad was able to pass on traffic without any restrictions. For example, if "Always require VPN" was enabled, it would still forward packets from other hosts.

Perhaps more importantly, this also had consequences for virtual networks/bridges, such as when Mullvad was running on a host with virtual machines. For example, guests were able to reach the internet even though the daemon was in a blocking state. In the connected state, it was also able to resolve hostnames using any resolver. Moreover, the local network (except the host machine) could be reached from a guest, even if local network sharing was disabled.

The new chain lets through traffic under essentially the same [conditions](https://github.com/mullvad/mullvadvpn-app/blob/master/docs/security.md) as the output and input chains, e.g. allowing LAN (if enabled), NDP, DHCP, DNS requests for the selected servers, tunnel traffic, etc., when connected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2658)
<!-- Reviewable:end -->
