### PR TITLE
Change custom DNS warning message for public IPs

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -254,7 +254,7 @@ msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr ""
 
 msgctxt "advanced-settings-view"
-msgid "The DNS server you are trying to add might not work because it is public. Currently we only support local DNS servers."
+msgid "The DNS server you want to add is public and will only work with WireGuard. To ensure that it always works, set the \"Tunnel protocol\" (in Advanced settings) to WireGuard."
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -1128,6 +1128,9 @@ msgid "Shows reminders when the account time is about to expire"
 msgstr ""
 
 msgid "Split tunneling makes it possible to select which applications should not be routed through the VPN tunnel."
+msgstr ""
+
+msgid "The DNS server you are trying to add might not work because it is public. Currently we only support local DNS servers."
 msgstr ""
 
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under Preferences."

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -651,7 +651,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
         close={this.hideCustomDnsConfirmationDialog}
         message={messages.pgettext(
           'advanced-settings-view',
-          'The DNS server you are trying to add might not work because it is public. Currently we only support local DNS servers.',
+          'The DNS server you want to add is public and will only work with WireGuard. To ensure that it always works, set the "Tunnel protocol" (in Advanced settings) to WireGuard.',
         )}></ModalAlert>
     );
   };


### PR DESCRIPTION
This PR changes the warning message shown when a public custom DNS server is added.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2659)
<!-- Reviewable:end -->
