### PR TITLE
Fix ARMv7 build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,9 +1086,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.87"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libdbus-sys"


### PR DESCRIPTION
`libc` was recently bumped from 0.2.85 to 0.2.87. There was a [regression](https://github.com/rust-lang/libc/pull/2102) in that version that removed `libc::accept4` for this build target. Fix by upgrading the `libc` crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2660)
<!-- Reviewable:end -->
