### PR TITLE
Update `AccountExpiryNotification` code

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -55,21 +55,11 @@ class MullvadVpnService : TalpidVpnService() {
 
     private var setUpDaemonJob: Job? = null
 
-    private var instance by observable<ServiceInstance?>(null) { _, oldInstance, newInstance ->
-        if (newInstance != oldInstance) {
-            accountExpiryNotification = newInstance?.let { instance ->
-                AccountExpiryNotification(this, instance.daemon, endpoint.accountCache)
-            }
-
-            serviceNotifier.notify(newInstance)
-        }
+    private var instance by observable<ServiceInstance?>(null) { _, _, newInstance ->
+        serviceNotifier.notifyIfChanged(newInstance)
     }
 
-    private var accountExpiryNotification by observable<AccountExpiryNotification?>(null) {
-        _, oldNotification, _ ->
-        oldNotification?.onDestroy()
-    }
-
+    private lateinit var accountExpiryNotification: AccountExpiryNotification
     private lateinit var daemonInstance: DaemonInstance
     private lateinit var endpoint: ServiceEndpoint
     private lateinit var keyguardManager: KeyguardManager
@@ -121,6 +111,12 @@ class MullvadVpnService : TalpidVpnService() {
                 acknowledgeStartForegroundService()
                 accountNumberEvents = endpoint.settingsListener.accountNumberNotifier
             }
+
+        accountExpiryNotification = AccountExpiryNotification(
+            this,
+            daemonInstance.intermittentDaemon,
+            endpoint.accountCache
+        )
 
         daemonInstance.apply {
             intermittentDaemon.registerListener(this@MullvadVpnService) { daemon ->
@@ -192,6 +188,7 @@ class MullvadVpnService : TalpidVpnService() {
     override fun onDestroy() {
         Log.d(TAG, "Service has stopped")
         state = State.Stopped
+        accountExpiryNotification.onDestroy()
         notificationManager.onDestroy()
         daemonInstance.onDestroy()
         instance = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -11,13 +11,14 @@ import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.service.endpoint.AccountCache
+import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.mullvadvpn.util.JobTracker
 import org.joda.time.DateTime
 import org.joda.time.Duration
 
 class AccountExpiryNotification(
     val context: Context,
-    val daemon: MullvadDaemon,
+    val daemon: Intermittent<MullvadDaemon>,
     val accountCache: AccountCache
 ) {
     companion object {
@@ -79,7 +80,7 @@ class AccountExpiryNotification(
 
     private suspend fun build(expiry: DateTime, remainingTime: Duration): Notification {
         val url = jobTracker.runOnBackground {
-            Uri.parse("$buyMoreTimeUrl?token=${daemon.getWwwAuthToken()}")
+            Uri.parse("$buyMoreTimeUrl?token=${daemon.await().getWwwAuthToken()}")
         }
 
         val intent = Intent(Intent.ACTION_VIEW, url)


### PR DESCRIPTION
This PR refactors teh `AccountExpiryNotification` class to use some improvements from previous PRs. It now uses an `Intermittent<Daemon>`, preparing it to better handle service <-> UI reconnections. This allows the `MullvadVpnService` to create one instance of `AccountExpiryNotification`, instead of having to recreate every time the IPC connection changes.

It also uses a `LoginStatus` instead of the expiry directly, so that it can use the event to determine all the information it needs to show or not the notification.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2662)
<!-- Reviewable:end -->
