### PR TITLE
Fix return value of `CustomDns.addServer` method

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
@@ -29,11 +29,11 @@ class CustomDns(val connection: Messenger, val settingsListener: SettingsListene
     }
 
     fun addDnsServer(server: InetAddress): Boolean {
-        val alreadyHadServer = onDnsServersChanged.latestEvent.contains(server)
+        val didntAlreadyHaveServer = !onDnsServersChanged.latestEvent.contains(server)
 
         connection.send(Request.AddCustomDnsServer(server).message)
 
-        return alreadyHadServer
+        return didntAlreadyHaveServer
     }
 
     fun replaceDnsServer(oldServer: InetAddress, newServer: InetAddress): Boolean {


### PR DESCRIPTION
The UI side method returns a boolean flag indicating if the DNS server
was successfully added, which is basically a check if the DNS server
address wasn't already added to the list. Unfortunately, there was a bug
in the method that returned the negated value. This led to a weird bug
where adding a new DNS server caused it to fail first, but succeed on
the second attempt.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any publicly released version, no changelog entry necessary.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2663)
<!-- Reviewable:end -->
