### PR TITLE
Split `AppVersionInfoCache` in a UI-side class and a service-side class

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.ipc
 
 import android.os.Message as RawMessage
 import kotlinx.parcelize.Parcelize
+import net.mullvad.mullvadvpn.model.AppVersionInfo as AppVersionInfoData
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.LoginStatus as LoginStatusData
@@ -14,6 +15,9 @@ sealed class Event : Message.EventMessage() {
 
     @Parcelize
     data class AccountHistory(val history: List<String>?) : Event()
+
+    @Parcelize
+    data class AppVersionInfo(val versionInfo: AppVersionInfoData?) : Event()
 
     @Parcelize
     data class CurrentVersion(val version: String?) : Event()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -16,6 +16,9 @@ sealed class Event : Message.EventMessage() {
     data class AccountHistory(val history: List<String>?) : Event()
 
     @Parcelize
+    data class CurrentVersion(val version: String?) : Event()
+
+    @Parcelize
     object ListenerReady : Event()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/AppVersionInfo.kt
@@ -1,6 +1,10 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class AppVersionInfo(
     val supported: Boolean,
     val suggestedUpgrade: String?
-)
+) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AppVersionInfoCache.kt
@@ -1,10 +1,15 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import android.content.Context
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 
-class AppVersionInfoCache(endpoint: ServiceEndpoint) {
+class AppVersionInfoCache(context: Context, endpoint: ServiceEndpoint) {
+    companion object {
+        val LEGACY_SHARED_PREFERENCES = "app_version_info_cache"
+    }
+
     private val daemon = endpoint.intermittentDaemon
 
     var appVersionInfo by observable<AppVersionInfo?>(null) { _, _, info ->
@@ -18,6 +23,11 @@ class AppVersionInfoCache(endpoint: ServiceEndpoint) {
         private set
 
     init {
+        context.getSharedPreferences(LEGACY_SHARED_PREFERENCES, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+
         daemon.registerListener(this) { newDaemon ->
             if (currentVersion == null && newDaemon != null) {
                 currentVersion = newDaemon.getCurrentVersion()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AppVersionInfoCache.kt
@@ -1,0 +1,44 @@
+package net.mullvad.mullvadvpn.service.endpoint
+
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.model.AppVersionInfo
+
+class AppVersionInfoCache(endpoint: ServiceEndpoint) {
+    private val daemon = endpoint.intermittentDaemon
+
+    var appVersionInfo by observable<AppVersionInfo?>(null) { _, _, info ->
+        endpoint.sendEvent(Event.AppVersionInfo(info))
+    }
+        private set
+
+    var currentVersion by observable<String?>(null) { _, _, version ->
+        endpoint.sendEvent(Event.CurrentVersion(version))
+    }
+        private set
+
+    init {
+        daemon.registerListener(this) { newDaemon ->
+            if (currentVersion == null && newDaemon != null) {
+                currentVersion = newDaemon.getCurrentVersion()
+            }
+
+            newDaemon?.onAppVersionInfoChange = { newAppVersionInfo ->
+                synchronized(this@AppVersionInfoCache) {
+                    appVersionInfo = newAppVersionInfo
+                }
+            }
+
+            // Load initial version info
+            synchronized(this@AppVersionInfoCache) {
+                if (appVersionInfo == null && newDaemon != null) {
+                    appVersionInfo = newDaemon.getVersionInfo()
+                }
+            }
+        }
+    }
+
+    fun onDestroy() {
+        daemon.unregisterListener(this)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AppVersionInfoCache.kt
@@ -1,16 +1,11 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
-import android.content.Context
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 
-class AppVersionInfoCache(context: Context, endpoint: ServiceEndpoint) {
-    companion object {
-        val LEGACY_SHARED_PREFERENCES = "app_version_info_cache"
-    }
-
+class AppVersionInfoCache(endpoint: ServiceEndpoint) {
     private val daemon = endpoint.intermittentDaemon
 
     var appVersionInfo by observable<AppVersionInfo?>(null) { _, _, info ->
@@ -24,11 +19,6 @@ class AppVersionInfoCache(context: Context, endpoint: ServiceEndpoint) {
         private set
 
     init {
-        context.getSharedPreferences(LEGACY_SHARED_PREFERENCES, Context.MODE_PRIVATE)
-            .edit()
-            .clear()
-            .commit()
-
         daemon.registerListener(this) { newDaemon ->
             newDaemon?.let { daemon ->
                 initializeCurrentVersion(daemon)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -40,7 +40,7 @@ class ServiceEndpoint(
     val settingsListener = SettingsListener(this)
 
     val accountCache = AccountCache(this)
-    val appVersionInfoCache = AppVersionInfoCache(this)
+    val appVersionInfoCache = AppVersionInfoCache(context, this)
     val customDns = CustomDns(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -40,7 +40,7 @@ class ServiceEndpoint(
     val settingsListener = SettingsListener(this)
 
     val accountCache = AccountCache(this)
-    val appVersionInfoCache = AppVersionInfoCache(context, this)
+    val appVersionInfoCache = AppVersionInfoCache(this)
     val customDns = CustomDns(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -55,7 +55,7 @@ open class MainActivity : FragmentActivity() {
                 serviceConnection?.onDestroy()
 
                 val newConnection = service?.let { safeService ->
-                    ServiceConnection(safeService, this@MainActivity)
+                    ServiceConnection(safeService)
                 }
 
                 serviceConnection = newConnection

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -5,10 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.CustomDns
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -9,8 +9,8 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.widget.AccountCell
 import net.mullvad.mullvadvpn.ui.widget.AppVersionCell

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
@@ -2,7 +2,7 @@ package net.mullvad.mullvadvpn.ui.notification
 
 import android.content.Context
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
 
 class VersionInfoNotification(
     context: Context,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.content.Context
+import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.AppVersionInfo
@@ -14,13 +15,9 @@ class AppVersionInfoCache(
         val LEGACY_SHARED_PREFERENCES = "app_version_info_cache"
     }
 
-    private var appVersionInfo: AppVersionInfo? = null
-        set(value) {
-            synchronized(this) {
-                field = value
-                onUpdate?.invoke()
-            }
-        }
+    private var appVersionInfo by observable<AppVersionInfo?>(null) { _, _, _ ->
+        onUpdate?.invoke()
+    }
 
     val isSupported
         get() = appVersionInfo?.supported ?: true
@@ -31,19 +28,16 @@ class AppVersionInfoCache(
     val upgradeVersion
         get() = appVersionInfo?.suggestedUpgrade
 
-    var onUpdate: (() -> Unit)? = null
-        set(value) {
-            field = value
-            value?.invoke()
-        }
+    var onUpdate by observable<(() -> Unit)?>(null) { _, _, callback ->
+        callback?.invoke()
+    }
 
-    var showBetaReleases = false
-        private set(value) {
-            if (field != value) {
-                field = value
-                onUpdate?.invoke()
-            }
+    var showBetaReleases by observable(false) { _, wasShowing, shouldShow ->
+        if (shouldShow != wasShowing) {
+            onUpdate?.invoke()
         }
+    }
+        private set
 
     var version: String? = null
         private set

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
@@ -1,20 +1,14 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
-import android.content.Context
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 
 class AppVersionInfoCache(
-    val context: Context,
     eventDispatcher: DispatchingHandler<Event>,
     val settingsListener: SettingsListener
 ) {
-    companion object {
-        val LEGACY_SHARED_PREFERENCES = "app_version_info_cache"
-    }
-
     private var appVersionInfo by observable<AppVersionInfo?>(null) { _, _, _ ->
         onUpdate?.invoke()
     }
@@ -58,13 +52,6 @@ class AppVersionInfoCache(
                 showBetaReleases = settings.showBetaReleases
             }
         }
-    }
-
-    fun onCreate() {
-        context.getSharedPreferences(LEGACY_SHARED_PREFERENCES, Context.MODE_PRIVATE)
-            .edit()
-            .clear()
-            .commit()
     }
 
     fun onDestroy() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.dataproxy
+package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
@@ -6,7 +6,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 
 class AppVersionInfoCache(
     val context: Context,

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
@@ -71,6 +71,7 @@ class AppVersionInfoCache(
         setUpJob.cancel()
         settingsListener.settingsNotifier.unsubscribe(this)
         daemon.onAppVersionInfoChange = null
+        onUpdate = null
     }
 
     private fun setUp() = GlobalScope.launch(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -10,7 +10,6 @@ import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.service.ServiceInstance
-import net.mullvad.mullvadvpn.ui.MainActivity
 import org.koin.core.component.KoinApiExtension
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
@@ -22,8 +21,7 @@ import org.koin.core.scope.get
 // The properties of this class can be used to send events to the service, to listen for events from
 // the service and to get values received from events.
 @OptIn(KoinApiExtension::class)
-class ServiceConnection(private val service: ServiceInstance, mainActivity: MainActivity) :
-    KoinScopeComponent {
+class ServiceConnection(private val service: ServiceInstance) : KoinScopeComponent {
     override val scope = getKoin().createScope(
         SERVICE_CONNECTION_SCOPE,
         named(SERVICE_CONNECTION_SCOPE), this
@@ -44,12 +42,11 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
     )
     val vpnPermission = VpnPermission(service.messenger)
 
-    val appVersionInfoCache = AppVersionInfoCache(mainActivity, dispatcher, settingsListener)
+    val appVersionInfoCache = AppVersionInfoCache(dispatcher, settingsListener)
     val customDns = CustomDns(service.messenger, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)
 
     init {
-        appVersionInfoCache.onCreate()
         registerListener()
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -44,7 +44,7 @@ class ServiceConnection(private val service: ServiceInstance, mainActivity: Main
     )
     val vpnPermission = VpnPermission(service.messenger)
 
-    val appVersionInfoCache = AppVersionInfoCache(mainActivity, daemon, settingsListener)
+    val appVersionInfoCache = AppVersionInfoCache(mainActivity, dispatcher, settingsListener)
     val customDns = CustomDns(service.messenger, settingsListener)
     var relayListListener = RelayListListener(daemon, settingsListener)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -4,7 +4,6 @@ import android.os.Looper
 import android.os.Messenger
 import android.os.RemoteException
 import android.util.Log
-import net.mullvad.mullvadvpn.dataproxy.AppVersionInfoCache
 import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.di.SERVICE_CONNECTION_SCOPE
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler


### PR DESCRIPTION
This PR continues the work to make `MullvadVpnService` run in a separate process. This PR focuses on the app version information. The `AppVersionInfoCache` is now split in two classes, one for the UI side and one for the service side. The relationship between them is that the service side will keep track of the version information and then send updates to the UI side class so that the UI can use that information.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2668)
<!-- Reviewable:end -->
