### PR TITLE
Fix `AccountCache` only handling first request

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -163,12 +163,12 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
 
     private fun spawnActor() = GlobalScope.actor<Command>(Dispatchers.Default, Channel.UNLIMITED) {
         try {
-            val command = channel.receive()
-
-            when (command) {
-                is Command.CreateAccount -> doCreateAccount()
-                is Command.Login -> doLogin(command.account)
-                is Command.Logout -> doLogout()
+            for (command in channel) {
+                when (command) {
+                    is Command.CreateAccount -> doCreateAccount()
+                    is Command.Login -> doLogin(command.account)
+                    is Command.Logout -> doLogout()
+                }
             }
         } catch (exception: ClosedReceiveChannelException) {
             // Command channel was closed, stop the actor


### PR DESCRIPTION
The app would previously crash when the UI side `AccountCache` class
sent a second request message to the service side `AccountCache` class.
The simplest way to reproduce this was to log out and log in again. This
was happening because the service side `AccountCache` actor
implementation was only handling one request and then stopping.

This is now fixed by having the actor run a loop to handle all incoming
requests.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug that's not present in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2669)
<!-- Reviewable:end -->
