### PR TITLE
Add support for building universal macOS app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@
 /dist-assets/sslocal
 /dist-assets/sslocal.exe
 /dist-assets/shell-completions/
+/dist-assets/aarch64-apple-darwin/
+/dist-assets/x86_64-apple-darwin/
 /windows/**/bin/
 /windows/**/*.user
 /android/keystore.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 - When `MULLVAD_MANAGEMENT_SOCKET_GROUP` is set, only allow the specified group to access the
   management interface UDS socket. This means that only users in that group can use the CLI and GUI.
 - Support WireGuard over TCP for custom VPN relays in the CLI.
+- Make app native on Apple Silicon.
 
 ### Changed
 - Upgrade OpenVPN from 2.5.0 to 2.5.1.

--- a/README.md
+++ b/README.md
@@ -296,7 +296,12 @@ This should produce an installer exe, pkg or rpm+deb file in the `dist/` directo
 
 Building this requires at least 1GB of memory.
 
-#### Apple ARM64 (aka Apple Silicon)
+#### macOS
+
+By default a universal app is built on macOS. To build specifically for x86_64 or ARM64 add
+`--target x86_64-apple-darwin` or `--target aarch64-apple-darwin`.
+
+##### Apple ARM64 (aka Apple Silicon)
 
 Due to inability to build the management interface proto files on ARM64 (see
 [this](https://github.com/grpc/grpc-node/issues/1497) issue) the Apple ARM64 build must be done in 2 stages:


### PR DESCRIPTION
This PR adds support for cross compiling the app for the M1 macs on x86 macs as well as support for making universal builds.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2673)
<!-- Reviewable:end -->
