### PR TITLE
Split `RelayListListener`

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -6,6 +6,7 @@ import net.mullvad.mullvadvpn.model.AppVersionInfo as AppVersionInfoData
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.LoginStatus as LoginStatusData
+import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.model.TunnelState
 
@@ -30,6 +31,9 @@ sealed class Event : Message.EventMessage() {
 
     @Parcelize
     data class NewLocation(val location: GeoIpLocation?) : Event()
+
+    @Parcelize
+    data class NewRelayList(val relayList: RelayList?) : Event()
 
     @Parcelize
     data class SettingsUpdate(val settings: Settings?) : Event()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/Relay.kt
@@ -1,6 +1,14 @@
 package net.mullvad.mullvadvpn.model
 
-data class Relay(val hostname: String, val active: Boolean, val tunnels: RelayTunnels) {
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Relay(
+    val hostname: String,
+    val active: Boolean,
+    val tunnels: RelayTunnels
+) : Parcelable {
     val hasWireguardTunnels
         get() = !tunnels.wireguard.isEmpty()
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
@@ -1,5 +1,8 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
 import java.util.ArrayList
+import kotlinx.parcelize.Parcelize
 
-data class RelayList(val countries: ArrayList<RelayListCountry>)
+@Parcelize
+data class RelayList(val countries: ArrayList<RelayListCountry>) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
@@ -1,5 +1,12 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
 import java.util.ArrayList
+import kotlinx.parcelize.Parcelize
 
-data class RelayListCity(val name: String, val code: String, val relays: ArrayList<Relay>)
+@Parcelize
+data class RelayListCity(
+    val name: String,
+    val code: String,
+    val relays: ArrayList<Relay>
+) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
@@ -1,9 +1,12 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
 import java.util.ArrayList
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class RelayListCountry(
     val name: String,
     val code: String,
     val cities: ArrayList<RelayListCity>
-)
+) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayTunnels.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayTunnels.kt
@@ -1,5 +1,8 @@
 package net.mullvad.mullvadvpn.model
 
+import android.os.Parcelable
 import java.util.ArrayList
+import kotlinx.parcelize.Parcelize
 
-data class RelayTunnels(val wireguard: ArrayList<WireguardEndpointData>)
+@Parcelize
+data class RelayTunnels(val wireguard: ArrayList<WireguardEndpointData>) : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/WireguardEndpointData.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/WireguardEndpointData.kt
@@ -1,3 +1,8 @@
 package net.mullvad.mullvadvpn.model
 
-class WireguardEndpointData()
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Suppress("PARCELABLE_PRIMARY_CONSTRUCTOR_IS_EMPTY")
+@Parcelize
+class WireguardEndpointData() : Parcelable

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/RelayListListener.kt
@@ -1,12 +1,16 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 
 class RelayListListener(endpoint: ServiceEndpoint) {
     val daemon = endpoint.intermittentDaemon
 
-    var relayList: RelayList? = null
+    var relayList by observable<RelayList?>(null) { _, _, relays ->
+        endpoint.sendEvent(Event.NewRelayList(relays))
+    }
         private set
 
     init {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/RelayListListener.kt
@@ -1,0 +1,38 @@
+package net.mullvad.mullvadvpn.service.endpoint
+
+import net.mullvad.mullvadvpn.model.RelayList
+import net.mullvad.mullvadvpn.service.MullvadDaemon
+
+class RelayListListener(endpoint: ServiceEndpoint) {
+    val daemon = endpoint.intermittentDaemon
+
+    var relayList: RelayList? = null
+        private set
+
+    init {
+        daemon.registerListener(this) { newDaemon ->
+            newDaemon?.let { daemon ->
+                setUpListener(daemon)
+                fetchInitialRelayList(daemon)
+            }
+        }
+    }
+
+    fun onDestroy() {
+        daemon.unregisterListener(this)
+    }
+
+    private fun setUpListener(daemon: MullvadDaemon) {
+        daemon.onRelayListChange = { relayLocations ->
+            relayList = relayLocations
+        }
+    }
+
+    private fun fetchInitialRelayList(daemon: MullvadDaemon) {
+        synchronized(this) {
+            if (relayList == null) {
+                relayList = daemon.getRelayLocations()
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -44,6 +44,7 @@ class ServiceEndpoint(
     val customDns = CustomDns(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
+    val relayListListener = RelayListListener(this)
     val splitTunneling = SplitTunneling(SplitTunnelingPersistence(context), this)
 
     init {
@@ -62,6 +63,7 @@ class ServiceEndpoint(
         customDns.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
+        relayListListener.onDestroy()
         settingsListener.onDestroy()
         splitTunneling.onDestroy()
     }
@@ -113,6 +115,7 @@ class ServiceEndpoint(
                 Event.SplitTunnelingUpdate(splitTunneling.onChange.latestEvent),
                 Event.CurrentVersion(appVersionInfoCache.currentVersion),
                 Event.AppVersionInfo(appVersionInfoCache.appVersionInfo),
+                Event.NewRelayList(relayListListener.relayList),
                 Event.ListenerReady
             )
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
@@ -13,6 +12,7 @@ import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.CustomDns
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.RelayListListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
@@ -1,4 +1,4 @@
-package net.mullvad.mullvadvpn.dataproxy
+package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -9,7 +9,6 @@ import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.service.MullvadDaemon
-import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 
 class RelayListListener(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
     private val setUpJob = setUp()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
@@ -42,6 +42,7 @@ class RelayListListener(val daemon: MullvadDaemon, val settingsListener: Setting
         setUpJob.cancel()
         settingsListener.relaySettingsNotifier.unsubscribe(this)
         daemon.onRelayListChange = null
+        onRelayListChange = null
     }
 
     private fun setUp() = GlobalScope.launch(Dispatchers.Default) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
@@ -1,18 +1,17 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.RelayConstraints
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
-import net.mullvad.mullvadvpn.service.MullvadDaemon
 
-class RelayListListener(val daemon: MullvadDaemon, val settingsListener: SettingsListener) {
-    private val setUpJob = setUp()
-
+class RelayListListener(
+    eventDispatcher: DispatchingHandler<Event>,
+    val settingsListener: SettingsListener
+) {
     private var relayList: RelayList? = null
     private var relaySettings: RelaySettings? = null
 
@@ -33,37 +32,20 @@ class RelayListListener(val daemon: MullvadDaemon, val settingsListener: Setting
         }
 
     init {
+        eventDispatcher.registerHandler(Event.NewRelayList::class) { event ->
+            event.relayList?.let { relayLocations ->
+                relayListChanged(RelayList(relayLocations))
+            }
+        }
+
         settingsListener.relaySettingsNotifier.subscribe(this) { newRelaySettings ->
             relaySettingsChanged(newRelaySettings)
         }
     }
 
     fun onDestroy() {
-        setUpJob.cancel()
         settingsListener.relaySettingsNotifier.unsubscribe(this)
-        daemon.onRelayListChange = null
         onRelayListChange = null
-    }
-
-    private fun setUp() = GlobalScope.launch(Dispatchers.Default) {
-        setUpListener()
-        fetchInitialRelayList()
-    }
-
-    private fun setUpListener() {
-        daemon.onRelayListChange = { relayLocations ->
-            relayListChanged(RelayList(relayLocations))
-        }
-    }
-
-    private fun fetchInitialRelayList() {
-        val relayLocations = daemon.getRelayLocations()
-
-        synchronized(this) {
-            if (relayList == null && relayLocations != null) {
-                relayListChanged(RelayList(relayLocations))
-            }
-        }
     }
 
     private fun relaySettingsChanged(newRelaySettings: RelaySettings?) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -4,7 +4,6 @@ import android.os.Looper
 import android.os.Messenger
 import android.os.RemoteException
 import android.util.Log
-import net.mullvad.mullvadvpn.dataproxy.RelayListListener
 import net.mullvad.mullvadvpn.di.SERVICE_CONNECTION_SCOPE
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -43,7 +43,7 @@ class ServiceConnection(private val service: ServiceInstance) : KoinScopeCompone
 
     val appVersionInfoCache = AppVersionInfoCache(dispatcher, settingsListener)
     val customDns = CustomDns(service.messenger, settingsListener)
-    var relayListListener = RelayListListener(daemon, settingsListener)
+    var relayListListener = RelayListListener(dispatcher, settingsListener)
 
     init {
         registerListener()


### PR DESCRIPTION
This PR continues the work to run the `MullvadVpnService` in a separate process. The focus of this PR is to split the `RelayListListener` class in a service-side class and a UI-side class. The service side receives relay list events from the daemon, and forwards that to the UI side class.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2675)
<!-- Reviewable:end -->
