### PR TITLE
Split `AuthTokenCache` into service side and UI side classes

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -21,6 +21,9 @@ sealed class Event : Message.EventMessage() {
     data class AppVersionInfo(val versionInfo: AppVersionInfoData?) : Event()
 
     @Parcelize
+    data class AuthToken(val token: String?) : Event()
+
+    @Parcelize
     data class CurrentVersion(val version: String?) : Event()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -29,6 +29,9 @@ sealed class Request : Message.RequestMessage() {
     object FetchAccountExpiry : Request()
 
     @Parcelize
+    object FetchAuthToken : Request()
+
+    @Parcelize
     data class IncludeApp(val packageName: String) : Request()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AuthTokenCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AuthTokenCache.kt
@@ -1,0 +1,46 @@
+package net.mullvad.mullvadvpn.service.endpoint
+
+import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
+import net.mullvad.mullvadvpn.service.MullvadDaemon
+
+class AuthTokenCache(endpoint: ServiceEndpoint) {
+    private var waitingForDaemon = false
+
+    var authToken by observable<String?>(null) { _, _, token ->
+        endpoint.sendEvent(Event.AuthToken(token))
+    }
+        private set
+
+    var daemon by observable<MullvadDaemon?>(null) { _, _, _ ->
+        synchronized(this@AuthTokenCache) {
+            if (waitingForDaemon) {
+                fetchNewToken()
+            }
+        }
+    }
+
+    init {
+        endpoint.dispatcher.registerHandler(Request.FetchAuthToken::class) { _ ->
+            fetchNewToken()
+        }
+    }
+
+    fun onDestroy() {
+        daemon = null
+    }
+
+    private fun fetchNewToken() {
+        synchronized(this) {
+            val daemon = this.daemon
+
+            if (daemon != null) {
+                authToken = daemon.getWwwAuthToken()
+                waitingForDaemon = false
+            } else {
+                waitingForDaemon = true
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -41,6 +41,7 @@ class ServiceEndpoint(
 
     val accountCache = AccountCache(this)
     val appVersionInfoCache = AppVersionInfoCache(this)
+    val authTokenCache = AuthTokenCache(this)
     val customDns = CustomDns(this)
     val keyStatusListener = KeyStatusListener(this)
     val locationInfoCache = LocationInfoCache(this)
@@ -59,6 +60,7 @@ class ServiceEndpoint(
 
         accountCache.onDestroy()
         appVersionInfoCache.onDestroy()
+        authTokenCache.onDestroy()
         connectionProxy.onDestroy()
         customDns.onDestroy()
         keyStatusListener.onDestroy()
@@ -116,6 +118,7 @@ class ServiceEndpoint(
                 Event.CurrentVersion(appVersionInfoCache.currentVersion),
                 Event.AppVersionInfo(appVersionInfoCache.appVersionInfo),
                 Event.NewRelayList(relayListListener.relayList),
+                Event.AuthToken(authTokenCache.authToken),
                 Event.ListenerReady
             )
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -68,7 +68,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         sitePaymentButton = view.findViewById<SitePaymentButton>(R.id.site_payment).apply {
             newAccount = false
 
-            prepare(daemon, jobTracker) {
+            prepare(authTokenCache, jobTracker) {
                 checkForAddedTime()
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -52,9 +52,9 @@ class ConnectFragment :
         notificationBanner = view.findViewById<NotificationBanner>(R.id.notification_banner).apply {
             notifications.apply {
                 register(TunnelStateNotification(parentActivity, connectionProxy))
-                register(KeyStatusNotification(parentActivity, daemon, keyStatusListener))
+                register(KeyStatusNotification(parentActivity, authTokenCache, keyStatusListener))
                 register(VersionInfoNotification(parentActivity, appVersionInfoCache))
-                register(AccountExpiryNotification(parentActivity, daemon, accountCache))
+                register(AccountExpiryNotification(parentActivity, authTokenCache, accountCache))
             }
         }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -53,7 +53,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
 
         sitePaymentButton = view.findViewById<SitePaymentButton>(R.id.site_payment).apply {
             newAccount = false
-            prepare(daemon, jobTracker)
+            prepare(authTokenCache, jobTracker)
         }
 
         redeemButton = view.findViewById<RedeemVoucherButton>(R.id.redeem_voucher).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -8,6 +8,7 @@ import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.CustomDns
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
@@ -40,6 +41,9 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
     lateinit var appVersionInfoCache: AppVersionInfoCache
         private set
 
+    lateinit var authTokenCache: AuthTokenCache
+        private set
+
     lateinit var connectionProxy: ConnectionProxy
         private set
 
@@ -69,6 +73,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         // initialization of the fields doesn't have to be synchronized
         accountCache = serviceConnection.accountCache
         appVersionInfoCache = serviceConnection.appVersionInfoCache
+        authTokenCache = serviceConnection.authTokenCache
         connectionProxy = serviceConnection.connectionProxy
         customDns = serviceConnection.customDns
         daemon = serviceConnection.daemon

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -43,7 +43,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
         view.findViewById<SitePaymentButton>(R.id.site_payment).apply {
             newAccount = true
-            prepare(daemon, jobTracker)
+            prepare(authTokenCache, jobTracker)
         }
 
         view.findViewById<RedeemVoucherButton>(R.id.redeem_voucher).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -138,7 +138,7 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
         verifyingKeySpinner = view.findViewById(R.id.verifying_key_spinner)
 
         manageKeysButton = view.findViewById<UrlButton>(R.id.manage_keys).apply {
-            prepare(daemon, jobTracker)
+            prepare(authTokenCache, jobTracker)
         }
 
         titleController = CollapsibleTitleController(view)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
@@ -2,16 +2,16 @@ package net.mullvad.mullvadvpn.ui.notification
 
 import android.content.Context
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 import net.mullvad.mullvadvpn.util.TimeLeftFormatter
 import org.joda.time.DateTime
 
 class AccountExpiryNotification(
     context: Context,
-    daemon: MullvadDaemon,
+    authTokenCache: AuthTokenCache,
     private val accountCache: AccountCache
-) : NotificationWithUrlWithToken(context, daemon, R.string.account_url) {
+) : NotificationWithUrlWithToken(context, authTokenCache, R.string.account_url) {
     private val timeLeftFormatter = TimeLeftFormatter(context.resources)
 
     init {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/KeyStatusNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/KeyStatusNotification.kt
@@ -3,14 +3,14 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.KeygenEvent
-import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 
 class KeyStatusNotification(
     context: Context,
-    daemon: MullvadDaemon,
+    authTokenCache: AuthTokenCache,
     private val keyStatusListener: KeyStatusListener
-) : NotificationWithUrlWithToken(context, daemon, R.string.wg_key_url) {
+) : NotificationWithUrlWithToken(context, authTokenCache, R.string.wg_key_url) {
     private val failedToGenerateKey = context.getString(R.string.failed_to_generate_key)
     private val tooManyKeys = context.getString(R.string.too_many_keys)
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrlWithToken.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrlWithToken.kt
@@ -3,11 +3,11 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 
 abstract class NotificationWithUrlWithToken(
     protected val context: Context,
-    protected val daemon: MullvadDaemon,
+    protected val authTokenCache: AuthTokenCache,
     urlId: Int
 ) : InAppNotification() {
     private val url = context.getString(urlId)
@@ -21,5 +21,5 @@ abstract class NotificationWithUrlWithToken(
         showIcon = true
     }
 
-    private fun buildUrl() = Uri.parse("$url?token=${daemon.getWwwAuthToken()}")
+    private suspend fun buildUrl() = Uri.parse("$url?token=${authTokenCache.fetchAuthToken()}")
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AuthTokenCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AuthTokenCache.kt
@@ -1,0 +1,42 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import java.util.LinkedList
+import kotlinx.coroutines.CompletableDeferred
+import net.mullvad.mullvadvpn.ipc.DispatchingHandler
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
+
+class AuthTokenCache(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+    private val fetchQueue = LinkedList<CompletableDeferred<String>>()
+
+    init {
+        eventDispatcher.registerHandler(Event.AuthToken::class) { event ->
+            synchronized(this@AuthTokenCache) {
+                fetchQueue.poll()?.complete(event.token ?: "")
+            }
+        }
+    }
+
+    suspend fun fetchAuthToken(): String {
+        val authToken = CompletableDeferred<String>()
+
+        synchronized(this) {
+            fetchQueue.offer(authToken)
+        }
+
+        connection.send(Request.FetchAuthToken.message)
+
+        return authToken.await()
+    }
+
+    fun onDestroy() {
+        synchronized(this) {
+            for (pendingFetch in fetchQueue) {
+                pendingFetch.cancel()
+            }
+
+            fetchQueue.clear()
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -32,6 +32,7 @@ class ServiceConnection(private val service: ServiceInstance) : KoinScopeCompone
 
     val daemon = service.daemon
     val accountCache = AccountCache(service.messenger, dispatcher)
+    val authTokenCache = AuthTokenCache(service.messenger, dispatcher)
     val connectionProxy = ConnectionProxy(service.messenger, dispatcher)
     val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
@@ -54,6 +55,7 @@ class ServiceConnection(private val service: ServiceInstance) : KoinScopeCompone
         dispatcher.onDestroy()
 
         accountCache.onDestroy()
+        authTokenCache.onDestroy()
         connectionProxy.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
@@ -110,6 +110,7 @@ class NotificationBanner : FrameLayout {
 
     fun onDestroy() {
         notifications.onDestroy()
+        jobTracker.cancelAllJobs()
     }
 
     protected override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
@@ -8,11 +8,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 import net.mullvad.mullvadvpn.util.JobTracker
 
 open class UrlButton : Button {
-    private lateinit var daemon: MullvadDaemon
+    private lateinit var authTokenCache: AuthTokenCache
 
     private var shouldEnable = true
 
@@ -46,7 +46,7 @@ open class UrlButton : Button {
     }
 
     fun prepare(
-        daemon: MullvadDaemon,
+        authTokenCache: AuthTokenCache,
         jobTracker: JobTracker,
         jobName: String = "fetchUrl",
         extraOnClickAction: (suspend () -> Unit)? = null
@@ -54,7 +54,7 @@ open class UrlButton : Button {
         synchronized(this) {
             super.setEnabled(shouldEnable)
 
-            this.daemon = daemon
+            this.authTokenCache = authTokenCache
 
             setOnClickAction(jobName, jobTracker) {
                 super.setEnabled(false)
@@ -71,7 +71,7 @@ open class UrlButton : Button {
         synchronized(this) {
             shouldEnable = enabled
 
-            if (!withToken || this::daemon.isInitialized) {
+            if (!withToken || this::authTokenCache.isInitialized) {
                 super.setEnabled(enabled)
             }
         }
@@ -98,7 +98,7 @@ open class UrlButton : Button {
     private suspend fun buildIntent(jobTracker: JobTracker): Intent {
         val buildIntent = GlobalScope.async(Dispatchers.Default) {
             val uri = if (withToken) {
-                Uri.parse(url + "?token=" + daemon.getWwwAuthToken())
+                Uri.parse(url + "?token=" + authTokenCache.fetchAuthToken())
             } else {
                 Uri.parse(url)
             }


### PR DESCRIPTION
This PR continues the work to make `MullvadVpnService` run in a separate process. The focus of this PR is on the `AuthTokenCache` which will now be split into a service-side class and a UI-side class. The UI side class can be used to obtain WWW authentication tokens to access the website. It does this by sending a request to the service side class and waiting for an event with the token. The service side class has a queue to handle one request at a time.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2677)
<!-- Reviewable:end -->
