### PR TITLE
Change placeholder in custom DNS input

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -220,10 +220,6 @@ msgid "Default"
 msgstr ""
 
 msgctxt "advanced-settings-view"
-msgid "e.g. 10.0.0.4"
-msgstr ""
-
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr ""
 
@@ -237,6 +233,10 @@ msgstr ""
 
 msgctxt "advanced-settings-view"
 msgid "Enable to add at least one DNS server."
+msgstr ""
+
+msgctxt "advanced-settings-view"
+msgid "Enter IP"
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -1220,6 +1220,9 @@ msgid "You are running an unsupported app version. Please upgrade to %s now to e
 msgstr ""
 
 msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
+msgstr ""
+
+msgid "e.g. 10.0.0.4"
 msgstr ""
 
 msgid "Account credit expires in a day"

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -470,7 +470,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                   {this.state.showAddCustomDns && (
                     <div ref={this.customDnsInputContainerRef}>
                       <Cell.RowInput
-                        placeholder={messages.pgettext('advanced-settings-view', 'e.g. 10.0.0.4')}
+                        placeholder={messages.pgettext('advanced-settings-view', 'Enter IP')}
                         onSubmit={this.addDnsAddress}
                         onChange={this.addDnsInputChange}
                         invalid={this.state.invalidDnsIp}


### PR DESCRIPTION
This PR changes the placeholder text in the custom DNS input from `e.g. 10.0.0.4` to `Enter IP` since the previous placeholder confused users.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2679)
<!-- Reviewable:end -->
