### PR TITLE
Fix login failure not sending login status to UI

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -183,10 +183,6 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
     }
 
     private suspend fun doLogin(account: String) {
-        if (account == accountNumber) {
-            return
-        }
-
         val result = daemon.await().getAccountData(account)
 
         val expiry = when (result) {


### PR DESCRIPTION
A bug was recently introduced after refactoring the `AccountCache` to be split into UI and service side classes (#2628). As part of the refactor, the login procedure was rewritten to happen on the service side and send `LoginStatus` events to the UI after the login procedure finished. Unfortunately, after that change the app had a bug where trying to log in with an invalid account would never finish.

This happened because even though the logging in logic on the service side would run correctly and catch the login error, it wouldn't notify the UI that the login procedure failed. This PR fixes that by making sure the `LoginStatus` event is always sent to the UI when the login procedure finishes.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any publicly released version, no changelog entry needed.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2680)
<!-- Reviewable:end -->
