### PR TITLE
Use `TVActivity` class when asking for VPN permission on TVs

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -1,14 +1,19 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import android.app.UiModeManager
 import android.content.Context
+import android.content.Context.UI_MODE_SERVICE
 import android.content.Intent
+import android.content.res.Configuration.UI_MODE_TYPE_TELEVISION
 import android.net.VpnService
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.ui.MainActivity
+import net.mullvad.mullvadvpn.ui.activities.TVActivity
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class VpnPermission(private val context: Context, private val endpoint: ServiceEndpoint) {
+    private val activityClass = discoverActivityClass()
     private val isGranted = Intermittent<Boolean>()
 
     var waitingForResponse = false
@@ -27,7 +32,7 @@ class VpnPermission(private val context: Context, private val endpoint: ServiceE
         if (intent == null) {
             isGranted.update(true)
         } else {
-            val activityIntent = Intent(context, MainActivity::class.java).apply {
+            val activityIntent = Intent(context, activityClass).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
@@ -40,5 +45,15 @@ class VpnPermission(private val context: Context, private val endpoint: ServiceE
         }
 
         return isGranted.await()
+    }
+
+    private fun discoverActivityClass(): Class<out MainActivity> {
+        val uiModeManager = context.getSystemService(UI_MODE_SERVICE) as UiModeManager
+
+        return if (uiModeManager.currentModeType == UI_MODE_TYPE_TELEVISION) {
+            TVActivity::class.java
+        } else {
+            MainActivity::class.java
+        }
     }
 }


### PR DESCRIPTION
When the app runs on TVs, a different activity class (`TVActivity`) is used to make sure the UI is displayed correctly. A recent refactor (#2644) included a hard-coded reference to the non-TV class (`MainActivity`), which ended up breaking requesting the Android VPN permission when running on TVs.

This PR fixes that by detecting if the app is running on a TV device or not and selecting the appropriate class.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2681)
<!-- Reviewable:end -->
