### PR TITLE
Add CI job for auditing Cargo.lock files

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,23 @@
+name: Audit Rust dependencies CI
+on:
+    push:
+        paths:
+            - .github/workflows/cargo-audit.yml
+            - Cargo.lock
+    # Check if requested manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    audit:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install cargo-audit
+              uses: actions-rs/install@v0.1.2
+              with:
+                  crate: cargo-audit
+                  version: latest
+
+            - name: Audit
+              run: cargo audit


### PR DESCRIPTION
This CI job looks for crates with vulnerabilities in the RustSec Advisory Database. Warnings (e.g. for unmaintained crates) are currently ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2682)
<!-- Reviewable:end -->
