### PR TITLE
Stop using hardcoded path to Linux Desktop Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Prevent tray icons from being extraced to `%TEMP%` directory.
 
+#### Linux
+- Fix find `mullvad-vpn.desktop` in `XDG_DATA_DIRS` instead of using hardcoded path.
 
 ## [2021.3-beta1] - 2021-04-13
 This release is for desktop only.

--- a/gui/src/main/autostart.ts
+++ b/gui/src/main/autostart.ts
@@ -1,15 +1,10 @@
 import { app } from 'electron';
-import * as fs from 'fs';
-import * as path from 'path';
-import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
 import log from '../shared/logging';
+import { getDesktopEntries } from './linux-desktop-entry';
 
 const DESKTOP_FILE_NAME = 'mullvad-vpn.desktop';
-
-const mkdirAsync = promisify(fs.mkdir);
-const statAsync = promisify(fs.stat);
-const symlinkAsync = promisify(fs.symlink);
-const unlinkAsync = promisify(fs.unlink);
 
 export function getOpenAtLogin() {
   if (process.platform === 'linux') {
@@ -32,15 +27,15 @@ export function getOpenAtLogin() {
 export async function setOpenAtLogin(openAtLogin: boolean) {
   if (process.platform === 'linux') {
     try {
-      const desktopFilePath = path.join('/usr/share/applications', DESKTOP_FILE_NAME);
+      const desktopFilePath = await getDesktopEntryPath();
       const autostartDir = path.join(app.getPath('appData'), 'autostart');
       const autostartFilePath = path.join(autostartDir, DESKTOP_FILE_NAME);
 
       if (openAtLogin) {
         await createDirIfNecessary(autostartDir);
-        await symlinkAsync(desktopFilePath, autostartFilePath);
+        await fs.promises.symlink(desktopFilePath, autostartFilePath);
       } else {
-        await unlinkAsync(autostartFilePath);
+        await fs.promises.unlink(autostartFilePath);
       }
     } catch (error) {
       log.error(`Failed to set auto-start: ${error.message}`);
@@ -50,24 +45,34 @@ export async function setOpenAtLogin(openAtLogin: boolean) {
   }
 }
 
+async function getDesktopEntryPath(): Promise<string> {
+  const entries = await getDesktopEntries();
+  const entry = entries.find((entry) => path.parse(entry).base === DESKTOP_FILE_NAME);
+  if (entry) {
+    return entry;
+  } else {
+    throw new Error(`Couldn't find ${DESKTOP_FILE_NAME}`);
+  }
+}
+
 const createDirIfNecessary = async (directory: string) => {
   let stat;
   try {
-    stat = await statAsync(directory);
+    stat = await fs.promises.stat(directory);
   } catch (error) {
     // Path doesn't exist, so it has to be created
-    return mkdirAsync(directory);
+    return fs.promises.mkdir(directory);
   }
 
   // Is there a file instead of a directory?
   if (!stat.isDirectory()) {
     // Try to remove existing file and replace it with a new directory
     try {
-      await unlinkAsync(directory);
+      await fs.promises.unlink(directory);
     } catch (error) {
       log.error(`Failed to remove path before creating a directory for it: ${error.message}`);
     }
 
-    return mkdirAsync(directory);
+    return fs.promises.mkdir(directory);
   }
 };


### PR DESCRIPTION
This PR stops using a hardcoded path when symlinking `mullvad-vpn.desktop` to the autostart directory, instead it searches `XDG_DATA_DIRS` for it. This should fix https://github.com/NixOS/nixpkgs/issues/116401.

I've also replaced the promisified `fs` calls with the built in promisified versions.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2683)
<!-- Reviewable:end -->
