### PR TITLE
Set 644 permissions for daemon plist in installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Fix find `mullvad-vpn.desktop` in `XDG_DATA_DIRS` instead of using hardcoded path.
 
+#### MacOS
+- Set correct permissions for daemon's launch file in installer.
+
+
 ## [2021.3-beta1] - 2021-04-13
 This release is for desktop only.
 

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -59,6 +59,7 @@ pkill -x "Mullvad VPN" || echo "Unable to kill GUI, not running?"
 sleep 1
 
 echo "$DAEMON_PLIST" > $DAEMON_PLIST_PATH
+chmod 644 $DAEMON_PLIST_PATH
 launchctl load -w $DAEMON_PLIST_PATH
 
 mkdir -p /usr/local/bin


### PR DESCRIPTION
Seemingly, the installer can set different file permissions for our `plist` file for the daemon on macOS (#2678) depending on, I guess, the device's serial number or maybe the locale? The root cause doesn't matter - if the permissions are not `644`, then launchctl will refuse our daemon. As such, the installer is changed to always set the permissions to `644` prior to starting the daemon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2684)
<!-- Reviewable:end -->
