### PR TITLE
Use the IPC channel to update settings values

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -69,6 +69,9 @@ sealed class Request : Message.RequestMessage() {
     data class SetAccount(val account: String?) : Request()
 
     @Parcelize
+    data class SetAllowLan(val allow: Boolean) : Request()
+
+    @Parcelize
     data class SetEnableCustomDns(val enable: Boolean) : Request()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -4,6 +4,7 @@ import android.os.Message as RawMessage
 import android.os.Messenger
 import java.net.InetAddress
 import kotlinx.parcelize.Parcelize
+import net.mullvad.mullvadvpn.model.LocationConstraint
 import org.joda.time.DateTime
 
 // Requests that the service can handle
@@ -72,6 +73,9 @@ sealed class Request : Message.RequestMessage() {
 
     @Parcelize
     data class SetEnableSplitTunneling(val enable: Boolean) : Request()
+
+    @Parcelize
+    data class SetRelayLocation(val relayLocation: LocationConstraint?) : Request()
 
     @Parcelize
     data class SetWireGuardMtu(val mtu: Int?) : Request()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -72,6 +72,9 @@ sealed class Request : Message.RequestMessage() {
     data class SetAllowLan(val allow: Boolean) : Request()
 
     @Parcelize
+    data class SetAutoConnect(val autoConnect: Boolean) : Request()
+
+    @Parcelize
     data class SetEnableCustomDns(val enable: Boolean) : Request()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -74,6 +74,9 @@ sealed class Request : Message.RequestMessage() {
     data class SetEnableSplitTunneling(val enable: Boolean) : Request()
 
     @Parcelize
+    data class SetWireGuardMtu(val mtu: Int?) : Request()
+
+    @Parcelize
     data class VpnPermissionResponse(val isGranted: Boolean) : Request()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -65,6 +65,9 @@ sealed class Request : Message.RequestMessage() {
     ) : Request()
 
     @Parcelize
+    data class SetAccount(val account: String?) : Request()
+
+    @Parcelize
     data class SetEnableCustomDns(val enable: Boolean) : Request()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -57,6 +57,14 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
     private var createdAccountExpiry: DateTime? = null
     private var oldAccountExpiry: DateTime? = null
 
+    var account: String?
+        get() = endpoint.settingsListener.accountNumberNotifier.latestEvent
+        set(value) {
+            jobTracker.newBackgroundJob("setAccount") {
+                daemon.await().setAccount(value)
+            }
+        }
+
     var loginStatus by onLoginStatusChange.notifiable()
         private set
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
@@ -17,6 +17,7 @@ import net.mullvad.talpid.util.EventNotifier
 class SettingsListener(endpoint: ServiceEndpoint) {
     private sealed class Command {
         class SetAllowLan(val allow: Boolean) : Command()
+        class SetAutoConnect(val autoConnect: Boolean) : Command()
         class SetWireGuardMtu(val mtu: Int?) : Command()
     }
 
@@ -46,6 +47,10 @@ class SettingsListener(endpoint: ServiceEndpoint) {
         endpoint.dispatcher.apply {
             registerHandler(Request.SetAllowLan::class) { request ->
                 commandChannel.sendBlocking(Command.SetAllowLan(request.allow))
+            }
+
+            registerHandler(Request.SetAutoConnect::class) { request ->
+                commandChannel.sendBlocking(Command.SetAutoConnect(request.autoConnect))
             }
 
             registerHandler(Request.SetWireGuardMtu::class) { request ->
@@ -111,6 +116,7 @@ class SettingsListener(endpoint: ServiceEndpoint) {
             for (command in channel) {
                 when (command) {
                     is Command.SetAllowLan -> daemon.await().setAllowLan(command.allow)
+                    is Command.SetAutoConnect -> daemon.await().setAutoConnect(command.autoConnect)
                     is Command.SetWireGuardMtu -> daemon.await().setWireguardMtu(command.mtu)
                 }
             }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
@@ -1,6 +1,13 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
@@ -8,6 +15,11 @@ import net.mullvad.mullvadvpn.service.MullvadDaemon
 import net.mullvad.talpid.util.EventNotifier
 
 class SettingsListener(endpoint: ServiceEndpoint) {
+    private sealed class Command {
+        class SetWireGuardMtu(val mtu: Int?) : Command()
+    }
+
+    private val commandChannel = spawnActor()
     private val daemon = endpoint.intermittentDaemon
 
     val accountNumberNotifier = EventNotifier<String?>(null)
@@ -29,9 +41,16 @@ class SettingsListener(endpoint: ServiceEndpoint) {
         settingsNotifier.subscribe(this) { settings ->
             endpoint.sendEvent(Event.SettingsUpdate(settings))
         }
+
+        endpoint.dispatcher.apply {
+            registerHandler(Request.SetWireGuardMtu::class) { request ->
+                commandChannel.sendBlocking(Command.SetWireGuardMtu(request.mtu))
+            }
+        }
     }
 
     fun onDestroy() {
+        commandChannel.close()
         daemon.unregisterListener(this)
 
         accountNumberNotifier.unsubscribeAll()
@@ -79,6 +98,18 @@ class SettingsListener(endpoint: ServiceEndpoint) {
 
                 settings = newSettings
             }
+        }
+    }
+
+    private fun spawnActor() = GlobalScope.actor<Command>(Dispatchers.Default, Channel.UNLIMITED) {
+        try {
+            for (command in channel) {
+                when (command) {
+                    is Command.SetWireGuardMtu -> daemon.await().setWireguardMtu(command.mtu)
+                }
+            }
+        } catch (exception: ClosedReceiveChannelException) {
+            // Closed sender, so stop the actor
         }
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -75,11 +75,7 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
     private fun configureHeader(view: View) {
         wireguardMtuInput = view.findViewById<MtuCell>(R.id.wireguard_mtu).apply {
-            onSubmit = { mtu ->
-                jobTracker.newBackgroundJob("updateMtu") {
-                    daemon.setWireguardMtu(mtu)
-                }
-            }
+            onSubmit = { mtu -> settingsListener.wireguardMtu = mtu }
         }
 
         view.findViewById<NavigateCell>(R.id.wireguard_keys).apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/PreferencesFragment.kt
@@ -28,8 +28,8 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
         allowLanToggle = view.findViewById<ToggleCell>(R.id.allow_lan).apply {
             listener = { state ->
                 when (state) {
-                    CellSwitch.State.ON -> daemon.setAllowLan(true)
-                    CellSwitch.State.OFF -> daemon.setAllowLan(false)
+                    CellSwitch.State.ON -> settingsListener.allowLan = true
+                    CellSwitch.State.OFF -> settingsListener.allowLan = false
                 }
             }
         }
@@ -37,8 +37,8 @@ class PreferencesFragment : ServiceDependentFragment(OnNoService.GoBack) {
         autoConnectToggle = view.findViewById<ToggleCell>(R.id.auto_connect).apply {
             listener = { state ->
                 when (state) {
-                    CellSwitch.State.ON -> daemon.setAutoConnect(true)
-                    CellSwitch.State.OFF -> daemon.setAutoConnect(false)
+                    CellSwitch.State.ON -> settingsListener.autoConnect = true
+                    CellSwitch.State.OFF -> settingsListener.autoConnect = false
                 }
             }
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/SelectLocationFragment.kt
@@ -15,11 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.KeygenEvent
-import net.mullvad.mullvadvpn.model.LocationConstraint
-import net.mullvad.mullvadvpn.model.RelayConstraintsUpdate
-import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 import net.mullvad.mullvadvpn.relaylist.RelayListAdapter
@@ -46,7 +42,7 @@ class SelectLocationFragment :
         relayListAdapter = RelayListAdapter(context.resources).apply {
             onSelect = { relayItem ->
                 jobTracker.newBackgroundJob("selectRelay") {
-                    updateLocationConstraint(relayItem)
+                    relayListListener.selectedRelayLocation = relayItem?.location
                     maybeConnect()
 
                     jobTracker.newUiJob("close") {
@@ -150,13 +146,6 @@ class SelectLocationFragment :
 
     fun close() {
         activity?.onBackPressed()
-    }
-
-    private fun updateLocationConstraint(relayItem: RelayItem?) {
-        val constraint: Constraint<LocationConstraint> =
-            relayItem?.run { Constraint.Only(location) } ?: Constraint.Any()
-
-        daemon.updateRelaySettings(RelaySettingsUpdate.Normal(RelayConstraintsUpdate(constraint)))
     }
 
     private fun updateRelayList(relayList: RelayList, selectedItem: RelayItem?) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
@@ -1,14 +1,18 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
+import android.os.Messenger
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.Constraint
+import net.mullvad.mullvadvpn.model.LocationConstraint
 import net.mullvad.mullvadvpn.model.RelayConstraints
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 
 class RelayListListener(
+    val connection: Messenger,
     eventDispatcher: DispatchingHandler<Event>,
     val settingsListener: SettingsListener
 ) {
@@ -17,6 +21,17 @@ class RelayListListener(
 
     var selectedRelayItem: RelayItem? = null
         private set
+
+    var selectedRelayLocation: LocationConstraint?
+        get() {
+            val settings = relaySettings as? RelaySettings.Normal
+            val location = settings?.relayConstraints?.location as? Constraint.Only
+
+            return location?.value
+        }
+        set(value) {
+            connection.send(Request.SetRelayLocation(value).message)
+        }
 
     var onRelayListChange: ((RelayList, RelayItem?) -> Unit)? = null
         set(value) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -36,7 +36,7 @@ class ServiceConnection(private val service: ServiceInstance) : KoinScopeCompone
     val connectionProxy = ConnectionProxy(service.messenger, dispatcher)
     val keyStatusListener = KeyStatusListener(service.messenger, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
-    val settingsListener = SettingsListener(dispatcher)
+    val settingsListener = SettingsListener(service.messenger, dispatcher)
     val splitTunneling = get<SplitTunneling>(
         parameters = { parametersOf(service.messenger, dispatcher) }
     )

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -44,7 +44,7 @@ class ServiceConnection(private val service: ServiceInstance) : KoinScopeCompone
 
     val appVersionInfoCache = AppVersionInfoCache(dispatcher, settingsListener)
     val customDns = CustomDns(service.messenger, settingsListener)
-    var relayListListener = RelayListListener(dispatcher, settingsListener)
+    var relayListListener = RelayListListener(service.messenger, dispatcher, settingsListener)
 
     init {
         registerListener()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -21,6 +21,10 @@ class SettingsListener(val connection: Messenger, eventDispatcher: DispatchingHa
         get() = accountNumberNotifier.latestEvent
         set(value) { connection.send(Request.SetAccount(value).message) }
 
+    var wireguardMtu: Int?
+        get() = settingsNotifier.latestEvent?.tunnelOptions?.wireguard?.options?.mtu
+        set(value) { connection.send(Request.SetWireGuardMtu(value).message) }
+
     init {
         eventDispatcher.registerHandler(Event.SettingsUpdate::class, ::handleNewEvent)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -1,19 +1,25 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
+import android.os.Messenger
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.talpid.util.EventNotifier
 
-class SettingsListener(eventDispatcher: DispatchingHandler<Event>) {
+class SettingsListener(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
     val accountNumberNotifier = EventNotifier<String?>(null)
     val dnsOptionsNotifier = EventNotifier<DnsOptions?>(null)
     val relaySettingsNotifier = EventNotifier<RelaySettings?>(null)
     val settingsNotifier = EventNotifier<Settings?>(null)
 
     private var settings by settingsNotifier.notifiable()
+
+    var account: String?
+        get() = accountNumberNotifier.latestEvent
+        set(value) { connection.send(Request.SetAccount(value).message) }
 
     init {
         eventDispatcher.registerHandler(Event.SettingsUpdate::class, ::handleNewEvent)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -21,6 +21,10 @@ class SettingsListener(val connection: Messenger, eventDispatcher: DispatchingHa
         get() = accountNumberNotifier.latestEvent
         set(value) { connection.send(Request.SetAccount(value).message) }
 
+    var allowLan: Boolean
+        get() = settingsNotifier.latestEvent?.allowLan ?: false
+        set(value) { connection.send(Request.SetAllowLan(value).message) }
+
     var wireguardMtu: Int?
         get() = settingsNotifier.latestEvent?.tunnelOptions?.wireguard?.options?.mtu
         set(value) { connection.send(Request.SetWireGuardMtu(value).message) }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -25,6 +25,10 @@ class SettingsListener(val connection: Messenger, eventDispatcher: DispatchingHa
         get() = settingsNotifier.latestEvent?.allowLan ?: false
         set(value) { connection.send(Request.SetAllowLan(value).message) }
 
+    var autoConnect: Boolean
+        get() = settingsNotifier.latestEvent?.autoConnect ?: false
+        set(value) { connection.send(Request.SetAutoConnect(value).message) }
+
     var wireguardMtu: Int?
         get() = settingsNotifier.latestEvent?.tunnelOptions?.wireguard?.options?.mtu
         set(value) { connection.send(Request.SetWireGuardMtu(value).message) }


### PR DESCRIPTION
This PR continues the work to make `MullvadVpnService` run on a separate process. The focus of this PR is to have the UI update settings values through the IPC channel. New `Request` variants were made to set specific settings, and the UI side IPC classes now have some properties that when set will send those requests so that the service side IPC classes can actually apply those changes.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no changelog needed.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2685)
<!-- Reviewable:end -->
