### PR TITLE
Enable downgrades on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### MacOS
 - Set correct permissions for daemon's launch file in installer.
+- Fix downgrades on macOS silently keeping previous version.
 
 
 ## [2021.3-beta1] - 2021-04-13

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -78,6 +78,7 @@ const config = {
     allowAnywhere: false,
     allowCurrentUserHome: false,
     isRelocatable: false,
+    isVersionChecked: false,
   },
 
   nsis: {


### PR DESCRIPTION
This PR enables downgrades on macOS. Previously it didn't replace newer versions with older versions when installing.

From the `electron-builder` documentation:
> `isVersionChecked` = `true` Boolean - Don’t install bundle if newer version on disk?

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2688)
<!-- Reviewable:end -->
