### PR TITLE
Create `EventDispatcher` type alias

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
@@ -5,8 +5,7 @@ import android.os.Messenger
 import kotlinx.coroutines.Dispatchers
 import net.mullvad.mullvadvpn.applist.ApplicationsIconManager
 import net.mullvad.mullvadvpn.applist.ApplicationsProvider
-import net.mullvad.mullvadvpn.ipc.Event
-import net.mullvad.mullvadvpn.ipc.MessageDispatcher
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 import net.mullvad.mullvadvpn.viewmodel.SplitTunnelingViewModel
 import org.koin.android.ext.koin.androidContext
@@ -27,7 +26,7 @@ val appModule = module {
     }
 
     scope(named(SERVICE_CONNECTION_SCOPE)) {
-        scoped<SplitTunneling> { (messenger: Messenger, dispatcher: MessageDispatcher<Event>) ->
+        scoped<SplitTunneling> { (messenger: Messenger, dispatcher: EventDispatcher) ->
             SplitTunneling(messenger, dispatcher)
         }
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -56,3 +56,5 @@ sealed class Event : Message.EventMessage() {
         fun fromMessage(message: RawMessage): Event? = Message.fromMessage(message, MESSAGE_KEY)
     }
 }
+
+typealias EventDispatcher = MessageDispatcher<Event>

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
@@ -1,14 +1,14 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.LoginStatus
 import net.mullvad.talpid.util.EventNotifier
 import org.joda.time.DateTime
 
-class AccountCache(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+class AccountCache(val connection: Messenger, eventDispatcher: EventDispatcher) {
     val onAccountNumberChange = EventNotifier<String?>(null)
     val onAccountExpiryChange = EventNotifier<DateTime?>(null)
     val onAccountHistoryChange = EventNotifier<List<String>>(listOf<String>())

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
@@ -8,7 +8,7 @@ import net.mullvad.mullvadvpn.model.LoginStatus
 import net.mullvad.talpid.util.EventNotifier
 import org.joda.time.DateTime
 
-class AccountCache(val connection: Messenger, eventDispatcher: EventDispatcher) {
+class AccountCache(private val connection: Messenger, eventDispatcher: EventDispatcher) {
     val onAccountNumberChange = EventNotifier<String?>(null)
     val onAccountExpiryChange = EventNotifier<DateTime?>(null)
     val onAccountHistoryChange = EventNotifier<List<String>>(listOf<String>())

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
@@ -1,12 +1,12 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import kotlin.properties.Delegates.observable
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.model.AppVersionInfo
 
 class AppVersionInfoCache(
-    eventDispatcher: DispatchingHandler<Event>,
+    eventDispatcher: EventDispatcher,
     val settingsListener: SettingsListener
 ) {
     private var appVersionInfo by observable<AppVersionInfo?>(null) { _, _, _ ->

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoCache.kt
@@ -7,7 +7,7 @@ import net.mullvad.mullvadvpn.model.AppVersionInfo
 
 class AppVersionInfoCache(
     eventDispatcher: EventDispatcher,
-    val settingsListener: SettingsListener
+    private val settingsListener: SettingsListener
 ) {
     private var appVersionInfo by observable<AppVersionInfo?>(null) { _, _, _ ->
         onUpdate?.invoke()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AuthTokenCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AuthTokenCache.kt
@@ -7,7 +7,7 @@ import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 
-class AuthTokenCache(val connection: Messenger, eventDispatcher: EventDispatcher) {
+class AuthTokenCache(private val connection: Messenger, eventDispatcher: EventDispatcher) {
     private val fetchQueue = LinkedList<CompletableDeferred<String>>()
 
     init {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AuthTokenCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AuthTokenCache.kt
@@ -3,11 +3,11 @@ package net.mullvad.mullvadvpn.ui.serviceconnection
 import android.os.Messenger
 import java.util.LinkedList
 import kotlinx.coroutines.CompletableDeferred
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 
-class AuthTokenCache(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+class AuthTokenCache(val connection: Messenger, eventDispatcher: EventDispatcher) {
     private val fetchQueue = LinkedList<CompletableDeferred<String>>()
 
     init {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
@@ -15,7 +15,7 @@ import net.mullvad.talpid.util.EventNotifier
 
 val ANTICIPATED_STATE_TIMEOUT_MS = 1500L
 
-class ConnectionProxy(val connection: Messenger, eventDispatcher: EventDispatcher) {
+class ConnectionProxy(private val connection: Messenger, eventDispatcher: EventDispatcher) {
     private var resetAnticipatedStateJob: Job? = null
 
     val onStateChange = EventNotifier<TunnelState>(TunnelState.Disconnected)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ConnectionProxy.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
@@ -15,7 +15,7 @@ import net.mullvad.talpid.util.EventNotifier
 
 val ANTICIPATED_STATE_TIMEOUT_MS = 1500L
 
-class ConnectionProxy(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+class ConnectionProxy(val connection: Messenger, eventDispatcher: EventDispatcher) {
     private var resetAnticipatedStateJob: Job? = null
 
     val onStateChange = EventNotifier<TunnelState>(TunnelState.Disconnected)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
@@ -5,7 +5,7 @@ import java.net.InetAddress
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.talpid.util.EventNotifier
 
-class CustomDns(val connection: Messenger, val settingsListener: SettingsListener) {
+class CustomDns(private val connection: Messenger, private val settingsListener: SettingsListener) {
     val onEnabledChanged = EventNotifier(false)
     val onDnsServersChanged = EventNotifier<List<InetAddress>>(emptyList())
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/KeyStatusListener.kt
@@ -7,7 +7,7 @@ import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.talpid.util.EventNotifier
 
-class KeyStatusListener(val connection: Messenger, val eventDispatcher: EventDispatcher) {
+class KeyStatusListener(private val connection: Messenger, eventDispatcher: EventDispatcher) {
     val onKeyStatusChange = EventNotifier<KeygenEvent?>(null)
 
     var keyStatus by onKeyStatusChange.notifiable()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/KeyStatusListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/KeyStatusListener.kt
@@ -1,13 +1,13 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.talpid.util.EventNotifier
 
-class KeyStatusListener(val connection: Messenger, val eventDispatcher: DispatchingHandler<Event>) {
+class KeyStatusListener(val connection: Messenger, val eventDispatcher: EventDispatcher) {
     val onKeyStatusChange = EventNotifier<KeygenEvent?>(null)
 
     var keyStatus by onKeyStatusChange.notifiable()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
@@ -1,11 +1,11 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import kotlin.properties.Delegates.observable
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 
-class LocationInfoCache(val eventDispatcher: DispatchingHandler<Event>) {
+class LocationInfoCache(val eventDispatcher: EventDispatcher) {
     private var location: GeoIpLocation? by observable(null) { _, _, newLocation ->
         onNewLocation?.invoke(newLocation)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/LocationInfoCache.kt
@@ -5,7 +5,7 @@ import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 
-class LocationInfoCache(val eventDispatcher: EventDispatcher) {
+class LocationInfoCache(eventDispatcher: EventDispatcher) {
     private var location: GeoIpLocation? by observable(null) { _, _, newLocation ->
         onNewLocation?.invoke(newLocation)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
@@ -1,8 +1,8 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.LocationConstraint
@@ -13,7 +13,7 @@ import net.mullvad.mullvadvpn.relaylist.RelayList
 
 class RelayListListener(
     val connection: Messenger,
-    eventDispatcher: DispatchingHandler<Event>,
+    eventDispatcher: EventDispatcher,
     val settingsListener: SettingsListener
 ) {
     private var relayList: RelayList? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/RelayListListener.kt
@@ -12,9 +12,9 @@ import net.mullvad.mullvadvpn.relaylist.RelayItem
 import net.mullvad.mullvadvpn.relaylist.RelayList
 
 class RelayListListener(
-    val connection: Messenger,
+    private val connection: Messenger,
     eventDispatcher: EventDispatcher,
-    val settingsListener: SettingsListener
+    private val settingsListener: SettingsListener
 ) {
     private var relayList: RelayList? = null
     private var relaySettings: RelaySettings? = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -9,7 +9,7 @@ import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.talpid.util.EventNotifier
 
-class SettingsListener(val connection: Messenger, eventDispatcher: EventDispatcher) {
+class SettingsListener(private val connection: Messenger, eventDispatcher: EventDispatcher) {
     val accountNumberNotifier = EventNotifier<String?>(null)
     val dnsOptionsNotifier = EventNotifier<DnsOptions?>(null)
     val relaySettingsNotifier = EventNotifier<RelaySettings?>(null)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -1,15 +1,15 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
-import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.talpid.util.EventNotifier
 
-class SettingsListener(val connection: Messenger, eventDispatcher: DispatchingHandler<Event>) {
+class SettingsListener(val connection: Messenger, eventDispatcher: EventDispatcher) {
     val accountNumberNotifier = EventNotifier<String?>(null)
     val dnsOptionsNotifier = EventNotifier<DnsOptions?>(null)
     val relaySettingsNotifier = EventNotifier<RelaySettings?>(null)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SplitTunneling.kt
@@ -3,13 +3,10 @@ package net.mullvad.mullvadvpn.ui.serviceconnection
 import android.os.Messenger
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.ipc.Event
-import net.mullvad.mullvadvpn.ipc.MessageDispatcher
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 
-class SplitTunneling(
-    private val connection: Messenger,
-    eventDispatcher: MessageDispatcher<Event>
-) {
+class SplitTunneling(private val connection: Messenger, eventDispatcher: EventDispatcher) {
     private var excludedApps: Set<String> = emptySet()
 
     var enabled by observable(false) { _, wasEnabled, isEnabled ->


### PR DESCRIPTION
This PR includes some small improvements to the UI side IPC classes. Most classes were incorrectly using `DispatchingHandler` directly, instead of the safer `MessageDispatcher<Event>` interface. This PR fixes that by using an `EventDispatcher` type alias to `MessageDispatcher<Event>`.

The PR also includes a few improvements to constructor parameters to remove unnecessary properties and making them private by default.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2689)
<!-- Reviewable:end -->
