### PR TITLE
Add bash version requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ storePassword = keystore-password
 
 ### All platforms
 
+1. Make sure to use a recent version of `bash`. The default version in macOS (3.2.57) isn't
+   supported.
+
 1. Get the latest **stable** Rust toolchain via [rustup.rs](https://rustup.rs/).
 
 1. *This can be skipped for Android builds*.


### PR DESCRIPTION
This PR adds the requirement of a recent version of bash to the readme. This is needed since older versions fails to run `build.sh`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
