### PR TITLE
Fix VPN permission request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Line wrap the file at 100 chars.                                              Th
 - Set correct permissions for daemon's launch file in installer.
 - Fix downgrades on macOS silently keeping previous version.
 
+#### Android
+- Fix request to connect from notification or quick-settings tile not connecting if VPN permission
+  isn't granted to the app. The app will now show the UI to ask for the permission and correctly
+  connect after it is granted.
+
 
 ## [2021.3-beta1] - 2021-04-13
 This release is for desktop only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -48,6 +48,9 @@ sealed class Event : Message.EventMessage() {
     data class TunnelStateChange(val tunnelState: TunnelState) : Event()
 
     @Parcelize
+    object VpnPermissionRequest : Event()
+
+    @Parcelize
     data class WireGuardKeyStatus(val keyStatus: KeygenEvent?) : Event()
 
     companion object {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -107,7 +107,7 @@ class ServiceEndpoint(
         synchronized(this) {
             listeners.add(listener)
 
-            val initialEvents = listOf(
+            val initialEvents = mutableListOf(
                 Event.TunnelStateChange(connectionProxy.state),
                 Event.LoginStatus(accountCache.onLoginStatusChange.latestEvent),
                 Event.AccountHistory(accountCache.onAccountHistoryChange.latestEvent),
@@ -121,6 +121,10 @@ class ServiceEndpoint(
                 Event.AuthToken(authTokenCache.authToken),
                 Event.ListenerReady
             )
+
+            if (vpnPermission.waitingForResponse) {
+                initialEvents.add(Event.VpnPermissionRequest)
+            }
 
             initialEvents.forEach { event ->
                 listener.send(event.message)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -11,8 +11,12 @@ import net.mullvad.mullvadvpn.util.Intermittent
 class VpnPermission(private val context: Context, private val endpoint: ServiceEndpoint) {
     private val isGranted = Intermittent<Boolean>()
 
+    var waitingForResponse = false
+        private set
+
     init {
         endpoint.dispatcher.registerHandler(Request.VpnPermissionResponse::class) { request ->
+            waitingForResponse = false
             isGranted.spawnUpdate(request.isGranted)
         }
     }
@@ -30,6 +34,7 @@ class VpnPermission(private val context: Context, private val endpoint: ServiceE
             }
 
             isGranted.update(null)
+            waitingForResponse = true
 
             context.startActivity(activityIntent)
             endpoint.sendEvent(Event.VpnPermissionRequest)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -30,7 +30,6 @@ class VpnPermission(private val context: Context, private val endpoint: ServiceE
             val activityIntent = Intent(context, MainActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                putExtra(MainActivity.KEY_SHOULD_CONNECT, true)
             }
 
             isGranted.update(null)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -3,11 +3,12 @@ package net.mullvad.mullvadvpn.service.endpoint
 import android.content.Context
 import android.content.Intent
 import android.net.VpnService
+import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.mullvadvpn.util.Intermittent
 
-class VpnPermission(private val context: Context, endpoint: ServiceEndpoint) {
+class VpnPermission(private val context: Context, private val endpoint: ServiceEndpoint) {
     private val isGranted = Intermittent<Boolean>()
 
     init {
@@ -31,6 +32,7 @@ class VpnPermission(private val context: Context, endpoint: ServiceEndpoint) {
             isGranted.update(null)
 
             context.startActivity(activityIntent)
+            endpoint.sendEvent(Event.VpnPermissionRequest)
         }
 
         return isGranted.await()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -22,17 +22,12 @@ import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.talpid.util.EventNotifier
 
 open class MainActivity : FragmentActivity() {
-    companion object {
-        const val KEY_SHOULD_CONNECT = "should_connect"
-    }
-
     val problemReport = MullvadProblemReport()
     val serviceNotifier = EventNotifier<ServiceConnection?>(null)
 
     private var isUiVisible = false
     private var service: MullvadVpnService.LocalBinder? = null
     private var serviceConnection: ServiceConnection? = null
-    private var shouldConnect = false
     private var visibleSecureScreens = HashSet<Fragment>()
 
     private val deviceIsTv by lazy {
@@ -62,10 +57,6 @@ open class MainActivity : FragmentActivity() {
 
                 if (service == null) {
                     serviceNotifier.notify(null)
-                }
-
-                if (shouldConnect) {
-                    tryToConnect()
                 }
             }
         }
@@ -98,11 +89,6 @@ open class MainActivity : FragmentActivity() {
 
         if (savedInstanceState == null) {
             addInitialFragment()
-        }
-
-        if (intent.getBooleanExtra(KEY_SHOULD_CONNECT, false)) {
-            shouldConnect = true
-            tryToConnect()
         }
     }
 
@@ -206,13 +192,6 @@ open class MainActivity : FragmentActivity() {
         val intent = VpnService.prepare(this)
 
         startActivityForResult(intent, 0)
-    }
-
-    private fun tryToConnect() {
-        serviceConnection?.apply {
-            connectionProxy.connect()
-            shouldConnect = false
-        }
     }
 
     private fun addInitialFragment() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
+import android.net.VpnService
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -194,13 +195,15 @@ open class MainActivity : FragmentActivity() {
         }
     }
 
-    @Suppress("DEPRECATION")
-    fun requestVpnPermission(intent: Intent) {
-        startActivityForResult(intent, 0)
-    }
-
     private fun handleNewServiceConnection(connection: ServiceConnection) {
         serviceNotifier.notify(connection)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun requestVpnPermission() {
+        val intent = VpnService.prepare(this)
+
+        startActivityForResult(intent, 0)
     }
 
     private fun tryToConnect() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -55,7 +55,9 @@ open class MainActivity : FragmentActivity() {
                 serviceConnection?.onDestroy()
 
                 serviceConnection = service?.let { safeService ->
-                    ServiceConnection(safeService, ::handleNewServiceConnection)
+                    ServiceConnection(safeService, ::handleNewServiceConnection).apply {
+                        vpnPermission.onRequest = ::requestVpnPermission
+                    }
                 }
 
                 if (service == null) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -43,7 +43,7 @@ class ServiceConnection(
     val splitTunneling = get<SplitTunneling>(
         parameters = { parametersOf(service.messenger, dispatcher) }
     )
-    val vpnPermission = VpnPermission(service.messenger)
+    val vpnPermission = VpnPermission(service.messenger, dispatcher)
 
     val appVersionInfoCache = AppVersionInfoCache(dispatcher, settingsListener)
     val customDns = CustomDns(service.messenger, settingsListener)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/VpnPermission.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/VpnPermission.kt
@@ -1,9 +1,19 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import android.os.Messenger
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.MessageDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 
-class VpnPermission(private val connection: Messenger) {
+class VpnPermission(private val connection: Messenger, eventDispatcher: MessageDispatcher<Event>) {
+    var onRequest: (() -> Unit)? = null
+
+    init {
+        eventDispatcher.registerHandler(Event.VpnPermissionRequest::class) { _ ->
+            onRequest?.invoke()
+        }
+    }
+
     fun grant(isGranted: Boolean) {
         connection.send(Request.VpnPermissionResponse(isGranted).message)
     }


### PR DESCRIPTION
A recent refactoring (#2644) broke the logic to request the Android VPN permission. Previously, the `ConnectionProxy` would start the main activity and call a method to request the VPN permission directly. After the refactor, the service side `ConnectionProxy` would instead start the main activity with a request to connect, but that request would not end up requesting for the VPN permission.

While developing a fix, I realized that the intent mechanism wasn't very robust, because it wouldn't be delivered to the activity if the UI was already shown. Therefore, this PR fixes the issue in a different way, leveraging the new IPC channel between the UI and the service. Now, the `VpnPermission` class can send request events to the UI, which will then call the API to request the permission. If the UI is not visible, the permission request event is sent with the initial events when it connects to the service.

This makes the logic more robust, and also fixes a small issue (described in the changelog) where the dialog requesting for the permission wouldn't always show.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
