### PR TITLE
Fix UI loses service events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Line wrap the file at 100 chars.                                              Th
 - Set correct permissions for daemon's launch file in installer.
 - Fix downgrades on macOS silently keeping previous version.
 
+#### Android
+- Fix UI sometimes not updating correctly while no split screen or after having a dialog from
+  another app appear on top.
+
 
 ## [2021.3-beta2] - 2021-04-22
 This release is for Windows only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -87,6 +87,10 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
             when (state) {
                 State.Uninitialized -> state = State.Initialized
                 State.WaitingForReconnection -> state = State.Stopped
+                State.Active -> {
+                    onSafelyStop()
+                    onSafelyStart()
+                }
                 else -> {}
             }
         }


### PR DESCRIPTION
When I was testing the VPN permission request fix, I realized that sometimes the connect screen wouldn't update after the tunnel connected. The easiest way to reproduce this was to:

1. open the app
2. disconnect
3. open the Android VPN settings
4. revoke the VPN permission for the app
5. return to the app
6. swipe down from the notification bar to show the app's notification
7. press "Connect" on the notification
8. swipe up to close the notifications
9. approve the VPN permission on the dialog

After the steps, the notification would show (correctly) that the tunnel was connected, while the UI would show (incorrectly) that the tunnel was disconnected.

The cause of this issue is that most fragments only set up event listeners in the `onSafelyStart` method, and unsubscribe those listeners in the `onSafelyStop` method. However, when something else shows on the screen (I'm not sure if in this case it's the notifications drawer or the VPN permission dialog) the UI ends up reconnecting to the service, and `ServiceDependentFragment` correctly updates the references to the IPC classes, but it doesn't notify the sub-classes that there was a reconnection. This meant that the sub-classes didn't get a chance to subscribe to the new connection, and would therefore miss all incoming events.

This PR fixes that updating `ServiceDependentFragment` by calling `onSafelyStop` followed by `onSafelyStart` on a reconnection if the UI stayed visible during the process. This is not the best fix, but it works for now and will provide more time to design a more thorough fix, which might require rethinking `ServiceDependentFragment` entirely.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2693)
<!-- Reviewable:end -->
