### PR TITLE
Blur cell input field when enter is pressed

### DIFF
--- a/gui/src/renderer/components/cell/Input.tsx
+++ b/gui/src/renderer/components/cell/Input.tsx
@@ -79,6 +79,8 @@ export class Input extends React.Component<IInputProps, IInputState> {
     focused: false,
   };
 
+  public inputRef = React.createRef<HTMLInputElement>();
+
   public componentDidUpdate(prevProps: IInputProps, _prevState: IInputState) {
     if (
       !this.state.focused &&
@@ -118,6 +120,7 @@ export class Input extends React.Component<IInputProps, IInputState> {
       <CellDisabledContext.Consumer>
         {(disabled) => (
           <StyledInput
+            ref={this.inputRef}
             type="text"
             valid={valid}
             aria-invalid={!valid}
@@ -157,6 +160,7 @@ export class Input extends React.Component<IInputProps, IInputState> {
   private onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       this.props.onSubmitValue?.(this.state.value);
+      this.inputRef.current?.blur();
     }
     this.props.onKeyPress?.(event);
   };


### PR DESCRIPTION
This PR blurs the cell input fields when enter is pressed since there is no reason for them to stay focused.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2696)
<!-- Reviewable:end -->
