### PR TITLE
Add `StringRes` annotation to `urlId` in `NotificationWithUrlWithToken`

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrlWithToken.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrlWithToken.kt
@@ -3,12 +3,13 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.annotation.StringRes
 import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 
 abstract class NotificationWithUrlWithToken(
     protected val context: Context,
     protected val authTokenCache: AuthTokenCache,
-    urlId: Int
+    @StringRes urlId: Int
 ) : InAppNotification() {
     private val url = context.getString(urlId)
 


### PR DESCRIPTION
This is a small improvement to mark the `urlId` constructor parameter with the `StringRes` annotation so that it's correctly used as a string resource.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2698)
<!-- Reviewable:end -->
