### PR TITLE
Properly destroy `ServiceConnection` scope after unbinding from service

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -55,7 +55,6 @@ open class MainActivity : FragmentActivity() {
         override fun onServiceDisconnected(className: ComponentName) {
             android.util.Log.d("mullvad", "UI lost the connection to the service")
             serviceConnection = null
-            serviceNotifier.notify(null)
         }
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -115,6 +115,8 @@ open class MainActivity : FragmentActivity() {
         unbindService(serviceConnectionManager)
 
         super.onStop()
+
+        serviceConnection = null
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Previously, it was possible to crash the app when leaving it then coming back to it. The cause was that the `ServiceConnection` scope was being recreated without first destroying the old scope. This only happened because the `serviceConnection` property was never set to `null` when intentionally unbinding from the service, because the `onServiceDisconnected` callback is only called if the service disconnects unintentionally.

This PR fixes that by setting the `serviceConnection` to `null` right after unbinding from the service. The call currently has to be done after calling `super.onStop` because the `ServiceDependentFragment` will only properly ignore the disconnection if it has detected that the state has changed to stopped.

The PR also removes a redundant `null` notification of the service connection.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Fixes a bug not present in any publicly released version.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2702)
<!-- Reviewable:end -->
