### PR TITLE
Handle keyboard in formsheet presentation (Take 2)

### DIFF
--- a/ios/MullvadVPN/AutomaticKeyboardResponder.swift
+++ b/ios/MullvadVPN/AutomaticKeyboardResponder.swift
@@ -88,20 +88,19 @@ class AutomaticKeyboardResponder {
     private var parentViewController: UIViewController? {
         var responder: UIResponder? = targetView
         let iterator = AnyIterator { () -> UIResponder? in
-            let next = responder?.next
-            responder = next
-            return next
+            responder = responder?.next
+            return responder
         }
 
         return iterator.first { $0 is UIViewController } as? UIViewController
     }
 
+    /// Returns the presentation container view that's moved along with the keyboard on iPad
     private var presentationContainerView: UIView? {
         var currentView = parentViewController?.view
         let iterator = AnyIterator { () -> UIView? in
-            let next = currentView?.superview
-            currentView = next
-            return next
+            currentView = currentView?.superview
+            return currentView
         }
 
         // Find the container view that private `_UIFormSheetPresentationController` moves

--- a/ios/MullvadVPN/AutomaticKeyboardResponder.swift
+++ b/ios/MullvadVPN/AutomaticKeyboardResponder.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Logging
 
 class AutomaticKeyboardResponder {
     weak var targetView: UIView?
@@ -15,6 +16,7 @@ class AutomaticKeyboardResponder {
     private var showsKeyboard = false
     private var lastKeyboardRect: CGRect?
 
+    private let logger = Logger(label: "AutomaticKeyboardResponder")
     private var presentationFrameObserver: NSKeyValueObservation?
 
     init<T: UIView>(targetView: T, handler: @escaping (T, CGFloat) -> Void) {
@@ -65,16 +67,17 @@ class AutomaticKeyboardResponder {
     }
 
     private func addPresentationControllerObserver() {
+        guard isFormSheetPresentation else { return }
+
         // Presentation controller follows the keyboard on iPad.
         // Install the observer to listen for the container view frame and adjust the target view
         // accordingly.
-        guard let containerView = parentViewController?.presentationController?.containerView, isFormSheetPresentation else { return }
-
-        let containingView = containerView.subviews.first { (subview) -> Bool in
-            return targetView?.isDescendant(of: subview) ?? false
+        guard let containerView = presentationContainerView else {
+            logger.warning("Cannot determine the container view in form sheet presentation.")
+            return
         }
 
-        presentationFrameObserver = containingView?.observe(\.frame, options: [.new], changeHandler: { [weak self] (containingView, change) in
+        presentationFrameObserver = containerView.observe(\.frame, options: [.new], changeHandler: { [weak self] (containingView, change) in
             guard let self = self, let keyboardFrameValue = self.lastKeyboardRect else { return }
 
             self.adjustContentInsets(keyboardRect: keyboardFrameValue)
@@ -91,6 +94,21 @@ class AutomaticKeyboardResponder {
         }
 
         return iterator.first { $0 is UIViewController } as? UIViewController
+    }
+
+    private var presentationContainerView: UIView? {
+        var currentView = parentViewController?.view
+        let iterator = AnyIterator { () -> UIView? in
+            let next = currentView?.superview
+            currentView = next
+            return next
+        }
+
+        // Find the container view that private `_UIFormSheetPresentationController` moves
+        // along with the keyboard.
+        return iterator.first { (view) -> Bool in
+            return view.description.starts(with: "<UIDropShadowView")
+        }
     }
 
     private var isFormSheetPresentation: Bool {

--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -118,6 +118,11 @@ class LoginViewController: UIViewController, RootContainment {
                                        object: contentView.accountTextField)
     }
 
+    override var disablesAutomaticKeyboardDismissal: Bool {
+        // Allow dismissing the keyboard in .formSheet presentation style
+        return false
+    }
+
     // MARK: - Public
 
     func reset() {

--- a/ios/MullvadVPN/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/ProblemReportViewController.swift
@@ -165,6 +165,11 @@ class ProblemReportViewController: UIViewController, UITextFieldDelegate, Condit
 
     // MARK: - View lifecycle
 
+    override var disablesAutomaticKeyboardDismissal: Bool {
+        // Allow dismissing the keyboard in .formSheet presentation style
+        return false
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Fix the support for automatic adjustment of UIScrollView content insets to account for keyboard overlay when in form sheet presentation style on iOS 14. This kind of presentation style is iPad specific and behaves slightly different in different versions of iOS. 
  
    Most recent versions of iOS move the controller along with the keyboard which makes it impossible to determine the part of the view that's being covered by the keyboard at the time when keyboard is about to appear. The only solution to that problem that I could find was to track the container's `frame`. 
  
    This works fine, however it seems that on iOS 14 the `presentationController?.containerView` is `nil` at the time when keyboard appears so the only way to fix this was to traverse back up and fine the container view that's being moved along the keyboard manually. This solution was tested across iOS 12 - 14.

2. on iPad, the form sheet presentation (by default) prevents the keyboard dismissal, so hitting the dismiss button in the keyboard does nothing. To address this, the view controllers that present the keyboard should return `false` from `disablesAutomaticKeyboardDismissal`. Note that in all other presentation styles the default implementation of `disablesAutomaticKeyboardDismissal` returns false as per documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2706)
<!-- Reviewable:end -->
