### PR TITLE
Select location: move instruction text to footer on iPad

### DIFF
--- a/ios/MullvadVPN/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/SelectLocationViewController.swift
@@ -29,6 +29,12 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
     private var setScrollPositionOnViewDidLoad: UITableView.ScrollPosition = .none
     private var isViewAppeared = false
 
+    private var showHeaderViewAtTheBottom = false {
+        didSet {
+            setTableHeaderFooterDimensions()
+        }
+    }
+
     weak var delegate: SelectLocationViewControllerDelegate?
     var scrollToSelectedRelayOnViewWillAppear = true
 
@@ -52,13 +58,15 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
         tableView.separatorColor = .secondaryColor
         tableView.separatorInset = .zero
         tableView.estimatedRowHeight = 53
-        tableView.estimatedSectionHeaderHeight = 109
         tableView.indicatorStyle = .white
 
         tableView.register(SelectLocationHeaderView.self, forHeaderFooterViewReuseIdentifier: ReuseIdentifiers.header.rawValue)
         tableView.register(SelectLocationCell.self, forCellReuseIdentifier: ReuseIdentifiers.cell.rawValue)
 
         self.tableView = tableView
+
+        setTableHeaderFooterDimensions()
+
         view.backgroundColor = .secondaryColor
         view.addSubview(tableView)
 
@@ -102,6 +110,10 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // Show header view at the bottom when controller is presented inline and show header view
+        // at the top of the view when controller is presented modally.
+        showHeaderViewAtTheBottom = self.presentingViewController == nil
 
         if let indexPath = dataSource?.indexPathForSelectedRelay(), scrollToSelectedRelayOnViewWillAppear, !isViewAppeared {
             self.tableView?.scrollToRow(at: indexPath, at: .middle, animated: false)
@@ -164,15 +176,27 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         assert(section == 0)
 
-        let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: ReuseIdentifiers.header.rawValue) as! SelectLocationHeaderView
+        if showHeaderViewAtTheBottom {
+            return nil
+        } else {
+            let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: ReuseIdentifiers.header.rawValue) as! SelectLocationHeaderView
+            updateTopLayoutMargin(forHeaderView: view)
 
-        // When contained within the navigation controller, we want the distance between the navigation title
-        // and the table header label to be exactly 24pt.
-        if let navigationBar = navigationController?.navigationBar as? CustomNavigationBar {
-            view.topLayoutMarginAdjustmentForNavigationBarTitle = navigationBar.titleLabelBottomInset
+            return view
         }
+    }
 
-        return view
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        assert(section == 0)
+
+        if showHeaderViewAtTheBottom {
+            let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: ReuseIdentifiers.header.rawValue) as! SelectLocationHeaderView
+            view.topLayoutMarginAdjustmentForNavigationBarTitle = 0
+
+            return view
+        } else {
+            return nil
+        }
     }
 
     // MARK: - Public
@@ -209,5 +233,29 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
         }
 
         dataSource.toggleChildren(location, animated: true)
+    }
+
+    // MARK: - Private
+
+    private func updateTopLayoutMargin(forHeaderView view: SelectLocationHeaderView) {
+        // When contained within the navigation controller, we want the distance between the navigation title
+        // and the table header label to be exactly 24pt.
+        if let navigationBar = navigationController?.navigationBar as? CustomNavigationBar {
+            view.topLayoutMarginAdjustmentForNavigationBarTitle = navigationBar.titleLabelBottomInset
+        } else {
+            view.topLayoutMarginAdjustmentForNavigationBarTitle = 0
+        }
+    }
+
+    private func setTableHeaderFooterDimensions() {
+        let headerFooterHeight: CGFloat = 109
+
+        if showHeaderViewAtTheBottom {
+            self.tableView?.estimatedSectionHeaderHeight = 0
+            self.tableView?.estimatedSectionFooterHeight = headerFooterHeight
+        } else {
+            self.tableView?.estimatedSectionHeaderHeight = headerFooterHeight
+            self.tableView?.estimatedSectionFooterHeight = 0
+        }
     }
 }

--- a/ios/MullvadVPN/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/SelectLocationViewController.swift
@@ -20,22 +20,7 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
         case header
     }
 
-    private lazy var tableView: UITableView = {
-        let tableView = UITableView(frame: view.bounds, style: .plain)
-        tableView.translatesAutoresizingMaskIntoConstraints = true
-        tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        tableView.backgroundColor = .clear
-        tableView.separatorColor = .secondaryColor
-        tableView.separatorInset = .zero
-        tableView.estimatedRowHeight = 53
-        tableView.estimatedSectionHeaderHeight = 109
-        tableView.indicatorStyle = .white
-
-        tableView.register(SelectLocationHeaderView.self, forHeaderFooterViewReuseIdentifier: ReuseIdentifiers.header.rawValue)
-        tableView.register(SelectLocationCell.self, forCellReuseIdentifier: ReuseIdentifiers.cell.rawValue)
-
-        return tableView
-    }()
+    private var tableView: UITableView?
 
     private let logger = Logger(label: "SelectLocationController")
     private var dataSource: LocationDataSource?
@@ -60,11 +45,25 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        let tableView = UITableView(frame: view.bounds, style: .plain)
+        tableView.translatesAutoresizingMaskIntoConstraints = true
+        tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        tableView.backgroundColor = .clear
+        tableView.separatorColor = .secondaryColor
+        tableView.separatorInset = .zero
+        tableView.estimatedRowHeight = 53
+        tableView.estimatedSectionHeaderHeight = 109
+        tableView.indicatorStyle = .white
+
+        tableView.register(SelectLocationHeaderView.self, forHeaderFooterViewReuseIdentifier: ReuseIdentifiers.header.rawValue)
+        tableView.register(SelectLocationCell.self, forCellReuseIdentifier: ReuseIdentifiers.cell.rawValue)
+
+        self.tableView = tableView
         view.backgroundColor = .secondaryColor
         view.addSubview(tableView)
 
         dataSource = LocationDataSource(
-            tableView: self.tableView,
+            tableView: tableView,
             cellProvider: { [weak self] (tableView, indexPath, item) -> UITableViewCell? in
                 guard let self = self else { return nil }
 
@@ -105,7 +104,7 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
         super.viewWillAppear(animated)
 
         if let indexPath = dataSource?.indexPathForSelectedRelay(), scrollToSelectedRelayOnViewWillAppear, !isViewAppeared {
-            self.tableView.scrollToRow(at: indexPath, at: .middle, animated: false)
+            self.tableView?.scrollToRow(at: indexPath, at: .middle, animated: false)
         }
     }
 
@@ -114,7 +113,7 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
 
         isViewAppeared = true
 
-        tableView.flashScrollIndicators()
+        tableView?.flashScrollIndicators()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -128,7 +127,7 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
 
         coordinator.animate { (context) in
             if let indexPath = self.dataSource?.indexPathForSelectedRelay() {
-                self.tableView.scrollToRow(at: indexPath, at: .middle, animated: false)
+                self.tableView?.scrollToRow(at: indexPath, at: .middle, animated: false)
             }
         }
     }
@@ -204,7 +203,7 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
     // MARK: - Collapsible cells
 
     private func collapseCell(_ cell: SelectLocationCell) {
-        guard let cellIndexPath = tableView.indexPath(for: cell),
+        guard let cellIndexPath = tableView?.indexPath(for: cell),
               let dataSource = dataSource, let location = dataSource.relayLocation(for: cellIndexPath) else {
             return
         }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR moves the instruction text in "Select Location" controller from being displayed at the top to the bottom on iPad when the controller is displayed as a child inside of the main controller, in all other instances the instruction text is displayed at the top (i.e modal presentation).

![Footer b](https://user-images.githubusercontent.com/704044/116573641-47405700-a90d-11eb-8ea9-2d661c0e6af7.png)
![Footer a](https://user-images.githubusercontent.com/704044/116573650-4a3b4780-a90d-11eb-8c5f-ad3470b68bef.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2707)
<!-- Reviewable:end -->
