### PR TITLE
Add multi-hop, optional entry location constraint for WireGuard (CLI only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 - Support WireGuard over TCP for custom VPN relays in the CLI.
 - Make app native on Apple Silicon.
 - Add DNS options for ad and tracker blocking to the CLI.
+- Support WireGuard multihop using an entry endpoint constraint.
 
 ### Changed
 - Upgrade OpenVPN from 2.5.0 to 2.5.1.

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -218,7 +218,7 @@ impl Bridge {
     }
 
     async fn handle_set_bridge_location(matches: &clap::ArgMatches<'_>) -> Result<()> {
-        Self::update_bridge_settings(Some(location::get_constraint(matches)), None).await
+        Self::update_bridge_settings(Some(location::get_constraint_from_args(matches)), None).await
     }
 
     async fn handle_set_bridge_provider(matches: &clap::ArgMatches<'_>) -> Result<()> {

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -2,6 +2,7 @@ use crate::{location, new_rpc_client, Command, Error, Result};
 use clap::{value_t, values_t};
 use itertools::Itertools;
 use std::{
+    fmt::Write,
     io::{self, BufRead},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
@@ -733,7 +734,7 @@ impl Relay {
 
     fn format_wireguard_constraints(constraints: Option<&WireguardConstraints>) -> String {
         if let Some(constraints) = constraints {
-            format!(
+            let mut out = format!(
                 "{} over {}",
                 Self::format_port(constraints.port),
                 Self::format_ip_version(
@@ -742,7 +743,18 @@ impl Relay {
                         .clone()
                         .map(|protocol| IpVersion::from_i32(protocol.protocol).unwrap())
                 )
-            )
+            );
+
+            if let Some(ref entry) = constraints.entry_location {
+                write!(
+                    &mut out,
+                    " (via {})",
+                    location::format_location(Some(entry))
+                )
+                .unwrap();
+            }
+
+            out
         } else {
             "any port over IPv4 or IPv6".to_string()
         }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -171,6 +171,17 @@ impl Command for Relay {
                                             .default_value("any")
                                             .possible_values(&["any", "4", "6"]),
                                     )
+                                    .arg(
+                                        clap::Arg::with_name("exit location")
+                                            .help("Exit endpoint to use. This can be 'any', 'none', or \
+                                                any location that is valid with 'set location', \
+                                                such as 'se got'.")
+                                            .default_value("none")
+                                            .long("exit-location")
+                                            .multiple(true)
+                                            .min_values(1)
+                                            .max_values(3),
+                                    )
                             )
                     )
                     .subcommand(clap::SubCommand::with_name("tunnel-protocol")
@@ -415,7 +426,7 @@ impl Relay {
     }
 
     async fn set_location(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
-        let location_constraint = location::get_constraint(matches);
+        let location_constraint = location::get_constraint_from_args(matches);
         let mut found = false;
 
         if !location_constraint.country.is_empty() {
@@ -517,6 +528,8 @@ impl Relay {
     async fn set_wireguard_constraints(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let port = parse_port_constraint(matches.value_of("port").unwrap())?;
         let ip_version = parse_ip_version_constraint(matches.value_of("ip version").unwrap());
+        let exit_location =
+            parse_exit_location_constraint(matches.values_of("exit location").unwrap());
 
         self.update_constraints(RelaySettingsUpdate {
             r#type: Some(relay_settings_update::Type::Normal(
@@ -526,7 +539,7 @@ impl Relay {
                         ip_version: ip_version.option().map(|protocol| IpVersionConstraint {
                             protocol: protocol as i32,
                         }),
-                        exit_location: None,
+                        exit_location,
                     }),
                     ..Default::default()
                 },
@@ -800,4 +813,20 @@ fn parse_ip_version_constraint(raw_protocol: &str) -> Constraint<IpVersion> {
         "6" => Constraint::Only(IpVersion::V6),
         _ => unreachable!(),
     }
+}
+
+fn parse_exit_location_constraint<'a, T: Iterator<Item = &'a str>>(
+    mut location: T,
+) -> Option<RelayLocation> {
+    let country = location.next().unwrap();
+
+    if country == "none" {
+        return None;
+    }
+
+    Some(location::get_constraint(
+        country,
+        location.next(),
+        location.next(),
+    ))
 }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -526,6 +526,7 @@ impl Relay {
                         ip_version: ip_version.option().map(|protocol| IpVersionConstraint {
                             protocol: protocol as i32,
                         }),
+                        exit_location: None,
                     }),
                     ..Default::default()
                 },

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -172,12 +172,12 @@ impl Command for Relay {
                                             .possible_values(&["any", "4", "6"]),
                                     )
                                     .arg(
-                                        clap::Arg::with_name("exit location")
-                                            .help("Exit endpoint to use. This can be 'any', 'none', or \
-                                                any location that is valid with 'set location', \
-                                                such as 'se got'.")
+                                        clap::Arg::with_name("entry location")
+                                            .help("Entry endpoint to use. This can be 'any', 'none', or \
+                                                   any location that is valid with 'set location', \
+                                                   such as 'se got'.")
                                             .default_value("none")
-                                            .long("exit-location")
+                                            .long("entry-location")
                                             .multiple(true)
                                             .min_values(1)
                                             .max_values(3),
@@ -528,8 +528,8 @@ impl Relay {
     async fn set_wireguard_constraints(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
         let port = parse_port_constraint(matches.value_of("port").unwrap())?;
         let ip_version = parse_ip_version_constraint(matches.value_of("ip version").unwrap());
-        let exit_location =
-            parse_exit_location_constraint(matches.values_of("exit location").unwrap());
+        let entry_location =
+            parse_entry_location_constraint(matches.values_of("entry location").unwrap());
 
         self.update_constraints(RelaySettingsUpdate {
             r#type: Some(relay_settings_update::Type::Normal(
@@ -539,7 +539,7 @@ impl Relay {
                         ip_version: ip_version.option().map(|protocol| IpVersionConstraint {
                             protocol: protocol as i32,
                         }),
-                        exit_location,
+                        entry_location,
                     }),
                     ..Default::default()
                 },
@@ -815,7 +815,7 @@ fn parse_ip_version_constraint(raw_protocol: &str) -> Constraint<IpVersion> {
     }
 }
 
-fn parse_exit_location_constraint<'a, T: Iterator<Item = &'a str>>(
+fn parse_entry_location_constraint<'a, T: Iterator<Item = &'a str>>(
     mut location: T,
 ) -> Option<RelayLocation> {
     let country = location.next().unwrap();

--- a/mullvad-cli/src/location.rs
+++ b/mullvad-cli/src/location.rs
@@ -22,11 +22,22 @@ pub fn get_subcommand() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn get_constraint(matches: &clap::ArgMatches<'_>) -> RelayLocation {
-    let country_original = matches.value_of("country").unwrap();
+pub fn get_constraint_from_args(matches: &clap::ArgMatches<'_>) -> RelayLocation {
+    let country = matches.value_of("country").unwrap();
+    let city = matches.value_of("city");
+    let hostname = matches.value_of("hostname");
+    get_constraint(country, city, hostname)
+}
+
+pub fn get_constraint<T: AsRef<str>>(
+    country: T,
+    city: Option<T>,
+    hostname: Option<T>,
+) -> RelayLocation {
+    let country_original = country.as_ref();
     let country = country_original.to_lowercase();
-    let city = matches.value_of("city").map(str::to_lowercase);
-    let hostname = matches.value_of("hostname").map(str::to_lowercase);
+    let city = city.map(|s| s.as_ref().to_lowercase());
+    let hostname = hostname.map(|s| s.as_ref().to_lowercase());
 
     match (country_original, city, hostname) {
         ("any", None, None) => RelayLocation::default(),
@@ -81,16 +92,16 @@ pub fn format_providers(providers: &Vec<String>) -> String {
     }
 }
 
-fn country_code_validator(code: String) -> std::result::Result<(), String> {
-    if code.len() == 2 || code == "any" {
+pub fn country_code_validator<T: AsRef<str>>(code: T) -> std::result::Result<(), String> {
+    if code.as_ref().len() == 2 || code.as_ref() == "any" {
         Ok(())
     } else {
         Err(String::from("Country codes must be two letters, or 'any'."))
     }
 }
 
-fn city_code_validator(code: String) -> std::result::Result<(), String> {
-    if code.len() == 3 {
+pub fn city_code_validator<T: AsRef<str>>(code: T) -> std::result::Result<(), String> {
+    if code.as_ref().len() == 3 {
         Ok(())
     } else {
         Err(String::from("City codes must be three letters"))

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1094,7 +1094,7 @@ where
                     connection: wireguard::ConnectionConfig {
                         tunnel,
                         peer,
-                        additional_peers: exit_peer.map(|peer| vec![peer]).unwrap_or(vec![]),
+                        exit_peer,
                         ipv4_gateway,
                         ipv6_gateway: Some(ipv6_gateway),
                     },

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -323,6 +323,40 @@ impl RelaySelector {
         relay_constraints
     }
 
+    pub fn get_tunnel_exit_endpoint(
+        &mut self,
+        relay_constraints: &RelayConstraints,
+    ) -> Option<(Relay, MullvadEndpoint)> {
+        if relay_constraints.tunnel_protocol != Constraint::Only(TunnelType::Wireguard)
+            && relay_constraints.tunnel_protocol != Constraint::Any
+        {
+            return None;
+        }
+        if relay_constraints
+            .wireguard_constraints
+            .exit_location
+            .is_none()
+        {
+            return None;
+        }
+
+        let exit_constraints = RelayConstraints {
+            location: relay_constraints
+                .wireguard_constraints
+                .exit_location
+                .clone()
+                .unwrap(),
+            tunnel_protocol: Constraint::Only(TunnelType::Wireguard),
+            providers: relay_constraints.providers.clone(),
+            wireguard_constraints: WireguardConstraints {
+                exit_location: None,
+                ..WireguardConstraints::default()
+            },
+            ..RelayConstraints::default()
+        };
+        self.get_tunnel_endpoint_internal(&exit_constraints)
+    }
+
     pub fn get_auto_proxy_settings(
         &mut self,
         bridge_constraints: &InternalBridgeConstraints,

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -310,7 +310,7 @@ impl RelaySelector {
             }
             Constraint::Only(TunnelType::Wireguard) => {
                 relay_constraints.wireguard_constraints =
-                    original_constraints.wireguard_constraints;
+                    original_constraints.wireguard_constraints.clone();
                 // This ensures that if after the first 2 failed attempts the daemon does not
                 // connect, then afterwards 2 of each 4 successive attempts will try to connect on
                 // port 53.
@@ -493,7 +493,7 @@ impl RelaySelector {
                 relay.tunnels = RelayTunnels {
                     wireguard: Self::matching_wireguard_tunnels(
                         &relay.tunnels,
-                        constraints.wireguard_constraints,
+                        &constraints.wireguard_constraints,
                     ),
                     openvpn: Self::matching_openvpn_tunnels(
                         &relay.tunnels,
@@ -507,7 +507,7 @@ impl RelaySelector {
                 relay.tunnels = RelayTunnels {
                     wireguard: Self::matching_wireguard_tunnels(
                         &relay.tunnels,
-                        constraints.wireguard_constraints,
+                        &constraints.wireguard_constraints,
                     ),
                     openvpn: vec![],
                 };
@@ -580,7 +580,7 @@ impl RelaySelector {
 
     fn matching_wireguard_tunnels(
         tunnels: &RelayTunnels,
-        constraints: WireguardConstraints,
+        constraints: &WireguardConstraints,
     ) -> Vec<WireguardEndpointData> {
         tunnels
             .wireguard
@@ -660,7 +660,7 @@ impl RelaySelector {
                 .choose(&mut self.rng)
                 .cloned()
                 .and_then(|wg_tunnel| {
-                    self.wg_data_to_endpoint(relay, wg_tunnel, constraints.wireguard_constraints)
+                    self.wg_data_to_endpoint(relay, wg_tunnel, &constraints.wireguard_constraints)
                 })
         };
 
@@ -689,7 +689,7 @@ impl RelaySelector {
         &mut self,
         relay: &Relay,
         data: WireguardEndpointData,
-        constraints: WireguardConstraints,
+        constraints: &WireguardConstraints,
     ) -> Option<MullvadEndpoint> {
         let host = self.get_address_for_wireguard_relay(relay, constraints)?;
         let port = self.get_port_for_wireguard_relay(&data, constraints)?;
@@ -709,7 +709,7 @@ impl RelaySelector {
     fn get_address_for_wireguard_relay(
         &mut self,
         relay: &Relay,
-        constraints: WireguardConstraints,
+        constraints: &WireguardConstraints,
     ) -> Option<IpAddr> {
         match constraints.ip_version {
             Constraint::Any | Constraint::Only(IpVersion::V4) => Some(relay.ipv4_addr_in.into()),
@@ -720,7 +720,7 @@ impl RelaySelector {
     fn get_port_for_wireguard_relay(
         &mut self,
         data: &WireguardEndpointData,
-        constraints: WireguardConstraints,
+        constraints: &WireguardConstraints,
     ) -> Option<u16> {
         match constraints.port {
             Constraint::Any => {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -317,6 +317,7 @@ message WireguardConstraints {
 	// NOTE: optional
 	uint32 port = 1;
 	IpVersionConstraint ip_version = 2;
+	RelayLocation exit_location = 3;
 }
 
 message CustomRelaySettings {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -170,11 +170,17 @@ message TunnelEndpoint {
 	TransportProtocol protocol = 2;
 	TunnelType tunnel_type = 3;
 	ProxyEndpoint proxy = 4;
+	Endpoint entry_endpoint = 5;
 }
 
 enum ProxyType {
 	SHADOWSOCKS = 0;
 	CUSTOM = 1;
+}
+
+message Endpoint {
+	string address = 1;
+	TransportProtocol protocol = 2;
 }
 
 message ProxyEndpoint {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -317,7 +317,7 @@ message WireguardConstraints {
 	// NOTE: optional
 	uint32 port = 1;
 	IpVersionConstraint ip_version = 2;
-	RelayLocation exit_location = 3;
+	RelayLocation entry_location = 3;
 }
 
 message CustomRelaySettings {

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -773,6 +773,7 @@ impl TryFrom<RelaySettingsUpdate> for mullvad_types::relay_constraints::RelaySet
                                     ))?
                                     .into(),
                             },
+                            additional_peers: vec![],
                             ipv4_gateway,
                             ipv6_gateway,
                         })

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -315,6 +315,25 @@ impl From<IpVersion> for IpVersionConstraint {
     }
 }
 
+impl
+    From<
+        mullvad_types::relay_constraints::Constraint<
+            mullvad_types::relay_constraints::LocationConstraint,
+        >,
+    > for RelayLocation
+{
+    fn from(
+        location: mullvad_types::relay_constraints::Constraint<
+            mullvad_types::relay_constraints::LocationConstraint,
+        >,
+    ) -> Self {
+        location
+            .option()
+            .map(RelayLocation::from)
+            .unwrap_or_default()
+    }
+}
+
 impl From<mullvad_types::relay_constraints::LocationConstraint> for RelayLocation {
     fn from(location: mullvad_types::relay_constraints::LocationConstraint) -> Self {
         use mullvad_types::relay_constraints::LocationConstraint;
@@ -457,7 +476,7 @@ impl From<mullvad_types::relay_constraints::RelaySettings> for RelaySettings {
                         entry_location: constraints
                             .wireguard_constraints
                             .entry_location
-                            .and_then(|constraint| constraint.option().map(RelayLocation::from)),
+                            .map(RelayLocation::from),
                     }),
 
                     openvpn_constraints: Some(OpenvpnConstraints {

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -776,7 +776,7 @@ impl TryFrom<RelaySettingsUpdate> for mullvad_types::relay_constraints::RelaySet
                                     ))?
                                     .into(),
                             },
-                            additional_peers: vec![],
+                            exit_peer: None,
                             ipv4_gateway,
                             ipv6_gateway,
                         })

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -450,9 +450,9 @@ impl From<mullvad_types::relay_constraints::RelaySettings> for RelaySettings {
                             .option()
                             .map(IpVersion::from)
                             .map(IpVersionConstraint::from),
-                        exit_location: constraints
+                        entry_location: constraints
                             .wireguard_constraints
-                            .exit_location
+                            .entry_location
                             .and_then(|constraint| constraint.option().map(RelayLocation::from)),
                     }),
 
@@ -886,9 +886,11 @@ impl TryFrom<RelaySettingsUpdate> for mullvad_types::relay_constraints::RelaySet
                                     Constraint::Any
                                 },
                                 ip_version: Constraint::from(ip_version),
-                                exit_location: constraints
-                                    .exit_location
-                                    .map(Constraint::<mullvad_types::relay_constraints::LocationConstraint>::from),
+                                entry_location: constraints.entry_location.map(
+                                    Constraint::<
+                                        mullvad_types::relay_constraints::LocationConstraint,
+                                    >::from,
+                                ),
                             }
                         }),
                         openvpn_constraints: settings.openvpn_constraints.map(|constraints| {

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -40,6 +40,10 @@ impl From<talpid_types::net::TunnelEndpoint> for TunnelEndpoint {
                     net::proxy::ProxyType::Custom => i32::from(ProxyType::Custom),
                 },
             }),
+            entry_endpoint: endpoint.entry_endpoint.map(|entry| Endpoint {
+                address: entry.address.to_string(),
+                protocol: i32::from(TransportProtocol::from(entry.protocol)),
+            }),
         }
     }
 }

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -450,7 +450,10 @@ impl From<mullvad_types::relay_constraints::RelaySettings> for RelaySettings {
                             .option()
                             .map(IpVersion::from)
                             .map(IpVersionConstraint::from),
-                        exit_location: None,
+                        exit_location: constraints
+                            .wireguard_constraints
+                            .exit_location
+                            .and_then(|constraint| constraint.option().map(RelayLocation::from)),
                     }),
 
                     openvpn_constraints: Some(OpenvpnConstraints {
@@ -883,7 +886,9 @@ impl TryFrom<RelaySettingsUpdate> for mullvad_types::relay_constraints::RelaySet
                                     Constraint::Any
                                 },
                                 ip_version: Constraint::from(ip_version),
-                                exit_location: None,
+                                exit_location: constraints
+                                    .exit_location
+                                    .map(Constraint::<mullvad_types::relay_constraints::LocationConstraint>::from),
                             }
                         }),
                         openvpn_constraints: settings.openvpn_constraints.map(|constraints| {

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -450,6 +450,7 @@ impl From<mullvad_types::relay_constraints::RelaySettings> for RelaySettings {
                             .option()
                             .map(IpVersion::from)
                             .map(IpVersionConstraint::from),
+                        exit_location: None,
                     }),
 
                     openvpn_constraints: Some(OpenvpnConstraints {
@@ -881,6 +882,7 @@ impl TryFrom<RelaySettingsUpdate> for mullvad_types::relay_constraints::RelaySet
                                     Constraint::Any
                                 },
                                 ip_version: Constraint::from(ip_version),
+                                exit_location: None,
                             }
                         }),
                         openvpn_constraints: settings.openvpn_constraints.map(|constraints| {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -434,11 +434,12 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 }
 
 /// [`Constraint`]s applicable to WireGuard relay servers.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct WireguardConstraints {
     pub port: Constraint<u16>,
     pub ip_version: Constraint<IpVersion>,
+    pub exit_location: Option<LocationConstraint>,
 }
 
 impl fmt::Display for WireguardConstraints {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -450,8 +450,13 @@ impl fmt::Display for WireguardConstraints {
         }
         write!(f, " over ")?;
         match self.ip_version {
-            Constraint::Any => write!(f, "IPv4 or IPv6"),
-            Constraint::Only(protocol) => write!(f, "{}", protocol),
+            Constraint::Any => write!(f, "IPv4 or IPv6")?,
+            Constraint::Only(protocol) => write!(f, "{}", protocol)?,
+        }
+        if let Some(Constraint::Only(ref entry)) = self.entry_location {
+            write!(f, " (via {})", entry)
+        } else {
+            Ok(())
         }
     }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -439,7 +439,7 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 pub struct WireguardConstraints {
     pub port: Constraint<u16>,
     pub ip_version: Constraint<IpVersion>,
-    pub exit_location: Option<LocationConstraint>,
+    pub exit_location: Option<Constraint<LocationConstraint>>,
 }
 
 impl fmt::Display for WireguardConstraints {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -439,7 +439,7 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 pub struct WireguardConstraints {
     pub port: Constraint<u16>,
     pub ip_version: Constraint<IpVersion>,
-    pub exit_location: Option<Constraint<LocationConstraint>>,
+    pub entry_location: Option<Constraint<LocationConstraint>>,
 }
 
 impl fmt::Display for WireguardConstraints {

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -47,10 +47,11 @@ impl Config {
     /// Constructs a Config from parameters
     pub fn from_parameters(params: &wireguard::TunnelParameters) -> Result<Config, Error> {
         let tunnel = params.connection.tunnel.clone();
-        let peer = vec![params.connection.peer.clone()];
+        let mut peers = vec![params.connection.peer.clone()];
+        peers.append(&mut params.connection.additional_peers.clone());
         Self::new(
             tunnel,
-            peer,
+            peers,
             &params.connection,
             &params.options,
             &params.generic_options,

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -48,7 +48,9 @@ impl Config {
     pub fn from_parameters(params: &wireguard::TunnelParameters) -> Result<Config, Error> {
         let tunnel = params.connection.tunnel.clone();
         let mut peers = vec![params.connection.peer.clone()];
-        peers.append(&mut params.connection.additional_peers.clone());
+        if let Some(exit_peer) = &params.connection.exit_peer {
+            peers.push(exit_peer.clone());
+        }
         Self::new(
             tunnel,
             peers,

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -1,9 +1,9 @@
 use self::config::Config;
-use cfg_if::cfg_if;
 #[cfg(not(windows))]
 use super::tun_provider;
 use super::{tun_provider::TunProvider, TunnelEvent, TunnelMetadata};
 use crate::routing::{self, RequiredRoute};
+use cfg_if::cfg_if;
 use futures::future::abortable;
 #[cfg(target_os = "linux")]
 use lazy_static::lazy_static;

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -31,7 +31,10 @@ impl TunnelParameters {
             },
             TunnelParameters::Wireguard(params) => TunnelEndpoint {
                 tunnel_type: TunnelType::Wireguard,
-                endpoint: params.connection.get_endpoint(),
+                endpoint: params
+                    .connection
+                    .get_exit_endpoint()
+                    .unwrap_or(params.connection.get_endpoint()),
                 proxy: None,
             },
         }
@@ -49,10 +52,11 @@ impl TunnelParameters {
         }
     }
 
-    pub fn get_proxy_endpoint(&self) -> Option<openvpn::ProxySettings> {
+    // Returns the exit endpoint, if it differs from the next hop endpoint
+    pub fn get_exit_hop_endpoint(&self) -> Option<Endpoint> {
         match self {
-            TunnelParameters::OpenVpn(params) => params.proxy.clone(),
-            _ => None,
+            TunnelParameters::OpenVpn(_params) => None,
+            TunnelParameters::Wireguard(params) => params.connection.get_exit_endpoint(),
         }
     }
 

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -28,6 +28,7 @@ impl TunnelParameters {
                 tunnel_type: TunnelType::OpenVpn,
                 endpoint: params.config.endpoint,
                 proxy: params.proxy.as_ref().map(|proxy| proxy.get_endpoint()),
+                entry_endpoint: None,
             },
             TunnelParameters::Wireguard(params) => TunnelEndpoint {
                 tunnel_type: TunnelType::Wireguard,
@@ -36,6 +37,10 @@ impl TunnelParameters {
                     .get_exit_endpoint()
                     .unwrap_or(params.connection.get_endpoint()),
                 proxy: None,
+                entry_endpoint: params
+                    .connection
+                    .get_exit_endpoint()
+                    .map(|_| params.connection.get_endpoint()),
             },
         }
     }
@@ -112,17 +117,28 @@ pub struct TunnelEndpoint {
     pub tunnel_type: TunnelType,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub proxy: Option<proxy::ProxyEndpoint>,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub entry_endpoint: Option<Endpoint>,
 }
 
 impl fmt::Display for TunnelEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{} - {}", self.tunnel_type, self.endpoint)?;
-        if let Some(ref proxy) = self.proxy {
-            write!(
-                f,
-                " via {} {} over {}",
-                proxy.proxy_type, proxy.endpoint.address, proxy.endpoint.protocol
-            )?;
+        match self.tunnel_type {
+            TunnelType::OpenVpn => {
+                if let Some(ref proxy) = self.proxy {
+                    write!(
+                        f,
+                        " via {} {} over {}",
+                        proxy.proxy_type, proxy.endpoint.address, proxy.endpoint.protocol
+                    )?;
+                }
+            }
+            TunnelType::Wireguard => {
+                if let Some(ref entry_endpoint) = self.entry_endpoint {
+                    write!(f, " via {}", entry_endpoint)?;
+                }
+            }
         }
         Ok(())
     }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -25,7 +25,7 @@ pub struct TunnelParameters {
 pub struct ConnectionConfig {
     pub tunnel: TunnelConfig,
     pub peer: PeerConfig,
-    pub additional_peers: Vec<PeerConfig>,
+    pub exit_peer: Option<PeerConfig>,
     /// Gateway used by the tunnel (a private address).
     pub ipv4_gateway: Ipv4Addr,
     pub ipv6_gateway: Option<Ipv6Addr>,

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -38,6 +38,13 @@ impl ConnectionConfig {
             protocol: self.peer.protocol,
         }
     }
+
+    pub fn get_exit_endpoint(&self) -> Option<Endpoint> {
+        self.exit_peer.as_ref().map(|peer| Endpoint {
+            address: peer.endpoint,
+            protocol: peer.protocol,
+        })
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug, Hash)]

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -41,7 +41,7 @@ impl ConnectionConfig {
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug, Hash)]
 pub struct PeerConfig {
-    /// Public key corresponding to the private key in [`TunnelConfig`].
+    /// Peer's public key.
     pub public_key: PublicKey,
     /// Addresses that may be routed to the peer. Use `0.0.0.0/0` to route everything.
     pub allowed_ips: Vec<IpNetwork>,

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -25,6 +25,7 @@ pub struct TunnelParameters {
 pub struct ConnectionConfig {
     pub tunnel: TunnelConfig,
     pub peer: PeerConfig,
+    pub additional_peers: Vec<PeerConfig>,
     /// Gateway used by the tunnel (a private address).
     pub ipv4_gateway: Ipv4Addr,
     pub ipv6_gateway: Option<Ipv6Addr>,

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -178,6 +178,7 @@ bool FwContext::applyPolicyConnecting
 	const WinFwSettings &settings,
 	const WinFwEndpoint &relay,
 	const std::wstring &relayClient,
+	const std::optional<std::wstring> &tunnelInterfaceAlias,
 	const std::optional<PingableHosts> &pingableHosts,
 	const std::optional<WinFwEndpoint> &allowedEndpoint
 )
@@ -191,6 +192,17 @@ bool FwContext::applyPolicyConnecting
 	if (allowedEndpoint.has_value())
 	{
 		AppendAllowedEndpointRules(ruleset, allowedEndpoint.value());
+	}
+
+	if (tunnelInterfaceAlias.has_value())
+	{
+		ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+			*tunnelInterfaceAlias
+		));
+
+		ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+			*tunnelInterfaceAlias
+		));
 	}
 
 	//

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -35,6 +35,7 @@ public:
 		const WinFwSettings &settings,
 		const WinFwEndpoint &relay,
 		const std::wstring &relayClient,
+		const std::optional<std::wstring> &tunnelInterfaceAlias,
 		const std::optional<PingableHosts> &pingableHosts,
 		const std::optional<WinFwEndpoint> &allowedEndpoint
 	);

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -260,6 +260,7 @@ WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
 	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
+	const wchar_t *tunnelInterfaceAlias,
 	const PingableHosts *pingableHosts,
 	const WinFwEndpoint *allowedEndpoint
 )
@@ -290,6 +291,7 @@ WinFw_ApplyPolicyConnecting(
 			*settings,
 			*relay,
 			relayClient,
+			tunnelInterfaceAlias != nullptr ? std::make_optional(tunnelInterfaceAlias) : std::nullopt,
 			ConvertPingableHosts(pingableHosts),
 			MakeOptional(allowedEndpoint)
 		) ? WINFW_POLICY_STATUS_SUCCESS : WINFW_POLICY_STATUS_GENERAL_FAILURE;

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -158,6 +158,7 @@ WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
 	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
+	const wchar_t *tunnelInterfaceAlias,
 	const PingableHosts *pingableHosts,
 	const WinFwEndpoint *allowedEndpoint
 );

--- a/windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -55,14 +55,14 @@
     <ClCompile Include="rules\shared.cpp">
       <Filter>rules</Filter>
     </ClCompile>
-    <ClCompile Include="rules\multi\permitvpnrelay.cpp">
-      <Filter>rules\multi</Filter>
-    </ClCompile>
     <ClCompile Include="rules\persistent\blockall.cpp">
       <Filter>rules\persistent</Filter>
     </ClCompile>
     <ClCompile Include="rules\baseline\permitendpoint.cpp">
       <Filter>rules\baseline</Filter>
+    </ClCompile>
+    <ClCompile Include="rules\multi\permitvpnrelay.cpp">
+      <Filter>rules\multi</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -129,14 +129,14 @@
     <ClInclude Include="rules\shared.h">
       <Filter>rules</Filter>
     </ClInclude>
-    <ClInclude Include="rules\multi\permitvpnrelay.h">
-      <Filter>rules\multi</Filter>
-    </ClInclude>
     <ClInclude Include="rules\persistent\blockall.h">
       <Filter>rules\persistent</Filter>
     </ClInclude>
     <ClInclude Include="rules\baseline\permitendpoint.h">
       <Filter>rules\baseline</Filter>
+    </ClInclude>
+    <ClInclude Include="rules\multi\permitvpnrelay.h">
+      <Filter>rules\multi</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This allows an entry endpoint to be set for WireGuard. Meaning that the user only sends/receives traffic from the entry, but all traffic eventually comes in or out at the exit endpoint (controlled by the normal location constraint). Two WireGuard peers are added: Traffic to the exit endpoint (e.g. `185.213.154.69` below) is sent via an "entry peer" (e.g. `185.213.154.67` below), and all other traffic is sent to the exit endpoint (via the entry peer):

```
peer: veGD6/aEY6sMfN3Ls7YWPmNgu3AheO7nQqsFT47YSws=
  endpoint: 185.213.154.69:56783
  allowed ips: 0.0.0.0/0, ::/0
  latest handshake: 5 seconds ago
  transfer: 235.45 KiB received, 214.04 KiB sent

peer: AtvE5KdPeQtOcE2QyXaPt9eQoBV3GBxzimQ2FIuGQ2U=
  endpoint: 185.213.154.67:24343
  allowed ips: 185.213.154.69/32
  latest handshake: 5 seconds ago
  transfer: 288.55 KiB received, 274.24 KiB sent
```

It can be enabled by setting the entry to some valid location constraint, e.g. `mullvad relay set tunnel wireguard any --entry-location se got se5-wireguard`. Run `mullvad status` or `mullvad relay get` to show whether it is enabled:
```
# mullvad status
Tunnel status: Connected to WireGuard 185.213.154.68:32062 over UDP via 185.213.154.67:32899 over UDP
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2712)
<!-- Reviewable:end -->
