### PR TITLE
Hotfix for expanded title calculation

### DIFF
--- a/android/src/main/res/layout/account.xml
+++ b/android/src/main/res/layout/account.xml
@@ -39,6 +39,7 @@
                           android:layout_height="wrap_content"
                           android:layout_marginBottom="@dimen/half_vertical_space"
                           android:layout_marginHorizontal="@dimen/side_margin"
+                          android:lines="1"
                           android:text="@string/settings_account"
                           style="@style/SettingsExpandedHeader" />
                 <net.mullvad.mullvadvpn.ui.widget.CopyableInformationView android:id="@+id/account_number"

--- a/android/src/main/res/layout/advanced_header.xml
+++ b/android/src/main/res/layout/advanced_header.xml
@@ -9,6 +9,7 @@
               android:layout_height="wrap_content"
               android:layout_marginTop="2dp"
               android:layout_marginLeft="@dimen/side_margin"
+              android:lines="1"
               android:text="@string/settings_advanced"
               style="@style/SettingsExpandedHeader" />
     <net.mullvad.mullvadvpn.ui.widget.MtuCell android:id="@+id/wireguard_mtu"

--- a/android/src/main/res/layout/preferences.xml
+++ b/android/src/main/res/layout/preferences.xml
@@ -39,6 +39,7 @@
                           android:layout_height="wrap_content"
                           android:layout_marginTop="2dp"
                           android:layout_marginLeft="@dimen/side_margin"
+                          android:lines="1"
                           android:text="@string/settings_preferences"
                           style="@style/SettingsExpandedHeader" />
                 <net.mullvad.mullvadvpn.ui.widget.ToggleCell android:id="@+id/auto_connect"

--- a/android/src/main/res/layout/problem_report.xml
+++ b/android/src/main/res/layout/problem_report.xml
@@ -40,6 +40,7 @@
                           android:layout_marginTop="2dp"
                           android:layout_marginBottom="8dp"
                           android:layout_marginHorizontal="@dimen/side_margin"
+                          android:lines="1"
                           android:text="@string/report_a_problem"
                           style="@style/SettingsExpandedHeader" />
                 <ViewSwitcher android:id="@+id/body_container"

--- a/android/src/main/res/layout/select_location_header.xml
+++ b/android/src/main/res/layout/select_location_header.xml
@@ -9,6 +9,7 @@
               android:layout_weight="0"
               android:layout_marginVertical="4dp"
               android:layout_marginHorizontal="@dimen/side_margin"
+              android:lines="1"
               android:text="@string/select_location"
               style="@style/SettingsExpandedHeader" />
     <TextView android:layout_width="wrap_content"

--- a/android/src/main/res/layout/settings.xml
+++ b/android/src/main/res/layout/settings.xml
@@ -40,6 +40,7 @@
                           android:layout_height="wrap_content"
                           android:layout_marginTop="4dp"
                           android:layout_marginLeft="@dimen/side_margin"
+                          android:lines="1"
                           android:text="@string/settings"
                           style="@style/SettingsExpandedHeader" />
                 <net.mullvad.mullvadvpn.ui.widget.AccountCell android:id="@+id/account"

--- a/android/src/main/res/layout/split_tunneling_header.xml
+++ b/android/src/main/res/layout/split_tunneling_header.xml
@@ -11,6 +11,7 @@
               android:layout_marginLeft="@dimen/side_margin"
               android:layout_marginTop="2dp"
               android:layout_marginBottom="12dp"
+              android:lines="1"
               android:text="@string/split_tunneling"
               style="@style/SettingsExpandedHeader" />
     <TextView android:layout_width="match_parent"

--- a/android/src/main/res/layout/wireguard_key.xml
+++ b/android/src/main/res/layout/wireguard_key.xml
@@ -40,6 +40,7 @@
                           android:layout_marginLeft="@dimen/side_margin"
                           android:layout_marginTop="2dp"
                           android:layout_marginBottom="@dimen/half_vertical_space"
+                          android:lines="1"
                           android:text="@string/wireguard_key"
                           style="@style/SettingsExpandedHeader" />
                 <net.mullvad.mullvadvpn.ui.widget.CopyableInformationView android:id="@+id/public_key"


### PR DESCRIPTION
This PR add 1 line limitation for expanded header to prevent wrong calculation of height scale. 
Probable this component will be changed to `CoordinatorLayout` in future.
Fixes #2423


Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2715)
<!-- Reviewable:end -->
