### PR TITLE
Login: set inputAccessoryView only on iPhone

### DIFF
--- a/ios/MullvadVPN/LoginViewController.swift
+++ b/ios/MullvadVPN/LoginViewController.swift
@@ -88,20 +88,23 @@ class LoginViewController: UIViewController, RootContainment {
             contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
-        contentView.accountTextField.inputAccessoryView = self.accountInputAccessoryToolbar
+        contentView.accountTextField.onReturnKey = { [weak self] _ in
+            guard let self = self else { return true }
 
-        // The return key on iPad should behave the same way as "Log in" button in the toolbar
-        if case .pad = UIDevice.current.userInterfaceIdiom {
-            contentView.accountTextField.onReturnKey = { [weak self] _ in
-                guard let self = self else { return true }
-
-                if self.canBeginLogin() {
-                    self.doLogin()
-                    return true
-                } else {
-                    return false
-                }
+            if self.canBeginLogin() {
+                self.doLogin()
+                return true
+            } else {
+                return false
             }
+        }
+
+        // There is no need to set the input accessory toolbar on iPad since it has a dedicated
+        // button to dismiss the keyboard.
+        if case .phone = UIDevice.current.userInterfaceIdiom {
+            contentView.accountTextField.inputAccessoryView = self.accountInputAccessoryToolbar
+        } else {
+            contentView.accountTextField.inputAccessoryView = nil
         }
 
         updateDisplayedMessage()


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR makes sure that the keyboard input accessory toolbar is only set on iPhone where we have a numpad-style keyboard (circled in red on screenshots), while on iPad we have a full-size keyboard which contains keys to log-in (via return key) or dismiss the keyboard via dedicated dismiss key. (See screenshots below)

![PR  iPhone](https://user-images.githubusercontent.com/704044/116990510-7a9b3100-acd3-11eb-8937-b7a180e05e7e.png)

![PR  iPad](https://user-images.githubusercontent.com/704044/116990915-1462de00-acd4-11eb-9487-9c942158065d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2719)
<!-- Reviewable:end -->
