### PR TITLE
Read application name from exe-file

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1224,7 +1224,9 @@ class ApplicationMain {
         // that we want to add to the list of additional applications.
         if (typeof application === 'string') {
           this.guiSettings.addBrowsedForSplitTunnelingApplications(application);
-          const applicationPath = windowsSplitTunneling.addApplicationPathToCache(application);
+          const applicationPath = await windowsSplitTunneling.addApplicationPathToCache(
+            application,
+          );
           await this.daemonRpc.addSplitTunnelingApplication(applicationPath);
         } else {
           await this.daemonRpc.addSplitTunnelingApplication(application.absolutepath);

--- a/gui/src/main/windows-pe-parser.ts
+++ b/gui/src/main/windows-pe-parser.ts
@@ -196,6 +196,9 @@ export const ULONGLONG = {
     },
   },
 };
+export const WCHAR = {
+  primitive: { size: 2, reader: (buffer: Buffer) => buffer.readUInt16LE(0) },
+};
 export const WORD = {
   primitive: { size: 2, reader: (buffer: Buffer) => buffer.readUInt16LE(0) },
 };
@@ -371,7 +374,104 @@ export const IMAGE_IMPORT_MODULE_DIRECTORY = {
   ],
 };
 
+export const IMAGE_RESOURCE_DIRECTORY = {
+  struct: [
+    { name: 'Characteristics', datatype: DWORD },
+    { name: 'TimeDateStamp', datatype: DWORD },
+    { name: 'MajorVersion', datatype: WORD },
+    { name: 'MinorVersion', datatype: WORD },
+    { name: 'NumberOfNameEntries', datatype: WORD },
+    { name: 'NumberOfIdEntries', datatype: WORD },
+  ],
+};
+
+export const IMAGE_RESOURCE_DIRECTORY_ID_ENTRY = {
+  struct: [
+    { name: 'Id', datatype: DWORD },
+    { name: 'OffsetToData', datatype: DWORD },
+  ],
+};
+
+export const IMAGE_RESOURCE_DIRECTORY_DATA_ENTRY = {
+  struct: [
+    { name: 'DataRVA', datatype: DWORD },
+    { name: 'Size', datatype: DWORD },
+    { name: 'CodePage', datatype: DWORD },
+    { name: '_Reserved', datatype: DWORD },
+  ],
+};
+
+export const VS_FIXEDFILEINFO = {
+  struct: [
+    { name: 'dwSignature', datatype: DWORD },
+    { name: 'dwStrucVersion', datatype: DWORD },
+    { name: 'dwFileVersionMS', datatype: DWORD },
+    { name: 'dwFileVersionLS', datatype: DWORD },
+    { name: 'dwProductVersionMS', datatype: DWORD },
+    { name: 'dwProductVersionLS', datatype: DWORD },
+    { name: 'dwFileFlagsMask', datatype: DWORD },
+    { name: 'dwFileFlags', datatype: DWORD },
+    { name: 'dwFileOS', datatype: DWORD },
+    { name: 'dwFileType', datatype: DWORD },
+    { name: 'dwFileSubtype', datatype: DWORD },
+    { name: 'dwFileDateMS', datatype: DWORD },
+    { name: 'dwFileDateLS', datatype: DWORD },
+  ],
+};
+
+// This structure can't be expressed with this format since Padding1 and Padding2 has a variable
+// size.
+export const VS_VERSIONINFO = {
+  struct: [
+    { name: 'wLength', datatype: WORD },
+    { name: 'wValueLength', datatype: WORD },
+    { name: 'wType', datatype: WORD },
+    // { name: 'szKey', datatype: ARRAY(?, WCHAR) },
+    // { name: 'Padding1', datatype: WORD },
+    // { name: 'Value', datatype: VS_FIXEDFILEINFO },
+    // { name: 'Padding2', datatype: WORD },
+    // { name: 'Children', datatype: WORD },
+  ],
+};
+
+// This structure can't be expressed with this format since Padding has a variable size.
+export const STRING_FILE_INFO = {
+  struct: [
+    { name: 'wLength', datatype: WORD },
+    { name: 'wValueLength', datatype: WORD },
+    { name: 'wType', datatype: WORD },
+    // { name: 'szKey', datatype: ARRAY(?, WCHAR) },
+    // { name: 'Padding', datatype: WORD },
+    // { name: 'Children', datatype: WORD },
+  ],
+};
+
+// This structure can't be expressed with this format since Padding has a variable size.
+export const STRING_TABLE = {
+  struct: [
+    { name: 'wLength', datatype: WORD },
+    { name: 'wValueLength', datatype: WORD },
+    { name: 'wType', datatype: WORD },
+    // { name: 'szKey', datatype: ARRAY(?, WCHAR) },
+    // { name: 'Padding', datatype: WORD },
+    // { name: 'Children', datatype: WORD },
+  ],
+};
+
+// This structure can't be expressed with this format since Padding has a variable size.
+export const STRING_TABLE_STRING = {
+  struct: [
+    { name: 'wLength', datatype: WORD },
+    { name: 'wValueLength', datatype: WORD },
+    { name: 'wType', datatype: WORD },
+    // { name: 'szKey', datatype: ARRAY(?, WCHAR) },
+    // { name: 'Padding', datatype: WORD },
+    // { name: 'Value', datatype: WORD },
+  ],
+};
+
 export const IMAGE_DIRECTORY_ENTRY_IMPORT = 1;
+export const IMAGE_DIRECTORY_ENTRY_RESOURCE = 2;
 
 export type ImageNtHeadersUnion = typeof IMAGE_NT_HEADERS | typeof IMAGE_NT_HEADERS64;
 export type ImageOptionalHeaderUnion =

--- a/gui/src/main/windows-split-tunneling.ts
+++ b/gui/src/main/windows-split-tunneling.ts
@@ -16,10 +16,19 @@ import {
   IMAGE_OPTIONAL_HEADER32,
   ImageOptionalHeaderUnion,
   PrimitiveValue,
-  rvaToOffset,
+  rvaToOffset as rvaToOffsetImpl,
   StructValue,
   Value,
   DWORD,
+  IMAGE_DIRECTORY_ENTRY_RESOURCE,
+  IMAGE_RESOURCE_DIRECTORY,
+  IMAGE_RESOURCE_DIRECTORY_DATA_ENTRY,
+  VS_VERSIONINFO,
+  STRING_FILE_INFO,
+  STRING_TABLE,
+  StructWrapper,
+  STRING_TABLE_STRING,
+  IMAGE_RESOURCE_DIRECTORY_ID_ENTRY,
 } from './windows-pe-parser';
 
 interface ShortcutDetails {
@@ -27,6 +36,8 @@ interface ShortcutDetails {
   name: string;
   args?: string;
 }
+
+type RvaToOffset = (rva: number) => Promise<number>;
 
 // Applications are found by scanning the start menu directories
 const APPLICATION_PATHS = [
@@ -65,7 +76,9 @@ export async function getApplications(options: {
   }
 
   // Add excluded apps that are missing from the shortcut cache to it
-  options.applicationPaths?.forEach(addApplicationToAdditionalShortcuts);
+  if (options.applicationPaths) {
+    await Promise.all(options.applicationPaths.map(addApplicationToAdditionalShortcuts));
+  }
 
   await updateApplicationCache();
   // If applicationPaths is supplied the returnvalue should only contain the applications
@@ -88,14 +101,14 @@ export async function getApplications(options: {
 }
 
 // Adds either a shortcut or an executable to the additionalShortcuts list
-export function addApplicationPathToCache(applicationPath: string): string {
+export async function addApplicationPathToCache(applicationPath: string): Promise<string> {
   const parsedPath = path.parse(applicationPath);
   if (parsedPath.ext === '.lnk') {
     const shortcutDetiails = shell.readShortcutLink(path.resolve(applicationPath));
     additionalShortcuts.push({ ...shortcutDetiails, name: path.parse(applicationPath).name });
     return shortcutDetiails.target;
   } else {
-    addApplicationToAdditionalShortcuts(applicationPath);
+    await addApplicationToAdditionalShortcuts(applicationPath);
     return applicationPath;
   }
 }
@@ -135,7 +148,7 @@ async function updateApplicationCache(): Promise<void> {
 }
 
 // Add excluded apps that are missing from the shortcut cache to it
-function addApplicationToAdditionalShortcuts(applicationPath: string): void {
+async function addApplicationToAdditionalShortcuts(applicationPath: string): Promise<void> {
   if (
     shortcutCache[applicationPath.toLowerCase()] === undefined &&
     !additionalShortcuts.some(
@@ -144,7 +157,7 @@ function addApplicationToAdditionalShortcuts(applicationPath: string): void {
   ) {
     additionalShortcuts.push({
       target: applicationPath,
-      name: path.parse(applicationPath).name,
+      name: (await getProgramName(applicationPath)) ?? path.parse(applicationPath).name,
     });
   }
 }
@@ -173,18 +186,26 @@ function resolveLinks(linkPaths: string[]): ShortcutDetails[] {
           ...shell.readShortcutLink(path.resolve(link)),
           name: path.parse(link).name,
         };
-      } catch (_e) {
+      } catch {
         return null;
       }
     })
     .filter(
       (shortcut): shortcut is ShortcutDetails =>
         shortcut !== null &&
-        shortcut.name !== 'Mullvad VPN' &&
+        !shortcut.target.endsWith('Mullvad VPN.exe') &&
         shortcut.target.endsWith('.exe') &&
-        !shortcut.target.toLowerCase().includes('uninstall') &&
-        !shortcut.name.toLowerCase().includes('uninstall'),
+        !shortcut.target.toLowerCase().includes('install') && // Covers "uninstall" as well.
+        !shortcut.name.toLowerCase().includes('install'),
     );
+}
+
+async function getProgramName(exePath: string): Promise<string | undefined> {
+  try {
+    return await getProductName(exePath);
+  } catch {
+    return undefined;
+  }
 }
 
 // Removes all duplicate shortcuts.
@@ -229,7 +250,6 @@ async function importsDll(path: string, dllName: string): Promise<boolean> {
   try {
     fileHandle = await fs.promises.open(path, fs.constants.O_RDONLY);
   } catch (e) {
-    log.error('Failed to create file handle.', e);
     return false;
   }
 
@@ -240,42 +260,14 @@ async function importsDll(path: string, dllName: string): Promise<boolean> {
 
 async function getExeImports(fileHandle: fs.promises.FileHandle, path: string): Promise<string[]> {
   try {
-    const ntHeader = await getNtHeader(fileHandle);
-    const fileHeader = ntHeader.get<StructValue<typeof IMAGE_FILE_HEADER>>('FileHeader');
-    const optionalHeader = ntHeader.get<StructValue<ImageOptionalHeaderUnion>>('OptionalHeader');
-
-    const importTableRva = optionalHeader
-      .get<ArrayValue<typeof IMAGE_DATA_DIRECTORY>>('DataDirectory')
-      .nth(IMAGE_DIRECTORY_ENTRY_IMPORT)
-      .get('VirtualAddress')
-      .value();
-
-    if (importTableRva === 0x0) {
+    const tableOffsetResult = await getTableOffset(fileHandle, IMAGE_DIRECTORY_ENTRY_IMPORT);
+    if (tableOffsetResult) {
+      const { offset: importTableOffset, rvaToOffset } = tableOffsetResult;
+      const moduleNames = await getImportModuleNames(fileHandle, importTableOffset, rvaToOffset);
+      return moduleNames;
+    } else {
       return [];
     }
-
-    const numberOfSections = fileHeader.get<PrimitiveValue>('NumberOfSections').value<number>();
-    const ntHeaderEndOffset =
-      ntHeader.offset +
-      ntHeader.get<PrimitiveValue<typeof DWORD>>('Signature').size +
-      fileHeader.size +
-      fileHeader.get<PrimitiveValue>('SizeOfOptionalHeader').value();
-
-    const importTableOffset = await rvaToOffset(
-      fileHandle,
-      importTableRva,
-      numberOfSections,
-      ntHeaderEndOffset,
-    );
-
-    const moduleNames = await getImportModuleNames(
-      fileHandle,
-      importTableOffset,
-      ntHeader.endOffset,
-      numberOfSections,
-    );
-
-    return moduleNames;
   } catch (e) {
     log.error(`Failed to read .exe import table for ${path}.`, e);
     return [];
@@ -285,14 +277,28 @@ async function getExeImports(fileHandle: fs.promises.FileHandle, path: string): 
 async function readString(
   fileHandle: fs.promises.FileHandle,
   offset: number,
-  buffer = Buffer.alloc(1000),
-  index = 0,
-): Promise<string> {
-  await fileHandle.read(buffer, index, 1, offset + index);
-  if (buffer[index] === 0x0) {
-    return buffer.slice(0, index).toString('ascii');
+  encoding: 'ascii' | 'ucs2',
+): Promise<{ value: string; endOffset: number }> {
+  const characterSize = getCharacterSize(encoding);
+  const buffer = Buffer.alloc(characterSize);
+  await fileHandle.read(buffer, 0, characterSize, offset);
+
+  const nextOffset = offset + characterSize;
+  if (buffer.every((value) => value === 0)) {
+    return { value: '', endOffset: nextOffset };
   } else {
-    return readString(fileHandle, offset, buffer, index + 1);
+    const { value: nextValue, endOffset } = await readString(fileHandle, nextOffset, encoding);
+    const value = buffer.toString(encoding) + nextValue;
+    return { value, endOffset };
+  }
+}
+
+function getCharacterSize(encoding: 'ascii' | 'ucs2'): number {
+  switch (encoding) {
+    case 'ascii':
+      return 1;
+    case 'ucs2':
+      return 2;
   }
 }
 
@@ -302,12 +308,12 @@ async function getNtHeader(
 ): Promise<StructValue<ImageNtHeadersUnion>> {
   // Check whether or not the file follows the PE format.
   const dosHeader = await Value.fromFile(fileHandle, 0, DOS_HEADER);
-  const eMagic = dosHeader.get<PrimitiveValue>('e_magic').value<number>();
+  const eMagic = dosHeader.get<PrimitiveValue>('e_magic').value();
   if (eMagic !== 0x5a4d) {
     throw new Error('Not a PE file');
   }
 
-  const ntHeaderOffset = dosHeader.get<PrimitiveValue>('e_lfanew').value<number>();
+  const ntHeaderOffset = dosHeader.get<PrimitiveValue>('e_lfanew').value();
 
   // Check if this is a 32- or 64-bit exe-file and return the correct datatype.
   const ntHeader32 = await Value.fromFile(fileHandle, ntHeaderOffset, IMAGE_NT_HEADERS);
@@ -319,7 +325,7 @@ async function getNtHeader(
   const magic = ntHeader32
     .get<StructValue<typeof IMAGE_OPTIONAL_HEADER32>>('OptionalHeader')
     .get<PrimitiveValue>('Magic')
-    .value<number>();
+    .value();
 
   // magic is 0x20b for 64-bit executables.
   return magic === 0x20b
@@ -331,8 +337,7 @@ async function getNtHeader(
 async function getImportModuleNames(
   fileHandle: fs.promises.FileHandle,
   importTableOffset: number,
-  firstSectionHeaderOffset: number,
-  numberOfSections: number,
+  rvaToOffset: RvaToOffset,
 ): Promise<string[]> {
   const moduleNames: string[] = [];
   const entrySize = Value.sizeOf(IMAGE_IMPORT_MODULE_DIRECTORY);
@@ -347,17 +352,262 @@ async function getImportModuleNames(
     const nameRva = importEntry.get('ModuleName').value();
 
     if (nameRva !== 0x0) {
-      const offset = await rvaToOffset(
-        fileHandle,
-        nameRva,
-        numberOfSections,
-        firstSectionHeaderOffset,
-      );
+      const offset = await rvaToOffset(nameRva);
 
-      const name = await readString(fileHandle, offset);
+      const { value: name } = await readString(fileHandle, offset, 'ascii');
       moduleNames.push(name);
     } else {
       return moduleNames;
     }
   }
+}
+
+async function getProductName(path: string): Promise<string | undefined> {
+  let fileHandle: fs.promises.FileHandle;
+  try {
+    fileHandle = await fs.promises.open(path, fs.constants.O_RDONLY);
+  } catch {
+    return undefined;
+  }
+
+  try {
+    const getTableOffsetResult = await getTableOffset(fileHandle, IMAGE_DIRECTORY_ENTRY_RESOURCE);
+
+    if (getTableOffsetResult) {
+      const { offset: resourceTableOffset, rvaToOffset } = getTableOffsetResult;
+      const leafOffsets = await getResourceTreeLeafOffsets(
+        fileHandle,
+        resourceTableOffset,
+        resourceTableOffset,
+        rvaToOffset,
+        [[16], [1], [0, 1033]],
+      );
+
+      const productName = await leafOffsets.reduce(async (alreadyFoundValue, leafOffset) => {
+        const value = await alreadyFoundValue;
+        if (value) {
+          return value;
+        } else {
+          const strings = await getVsVersionInfoStrings(fileHandle, leafOffset);
+          return strings.get('FileDescription') ?? strings.get('ProductName');
+        }
+      }, Promise.resolve() as Promise<string | undefined>);
+
+      return productName;
+    } else {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  } finally {
+    await fileHandle.close();
+  }
+}
+
+async function getTableOffset(
+  fileHandle: fs.promises.FileHandle,
+  tableIndex: number,
+): Promise<{ offset: number; rvaToOffset: RvaToOffset } | undefined> {
+  const ntHeader = await getNtHeader(fileHandle);
+  const fileHeader = ntHeader.get<StructValue<typeof IMAGE_FILE_HEADER>>('FileHeader');
+  const optionalHeader = ntHeader.get<StructValue<ImageOptionalHeaderUnion>>('OptionalHeader');
+
+  const tableRva = optionalHeader
+    .get<ArrayValue<typeof IMAGE_DATA_DIRECTORY>>('DataDirectory')
+    .nth(tableIndex)
+    .get('VirtualAddress')
+    .value();
+
+  if (tableRva === 0x0) {
+    return undefined;
+  }
+
+  const numberOfSections = fileHeader.get<PrimitiveValue>('NumberOfSections').value();
+  const ntHeaderEndOffset =
+    ntHeader.offset +
+    ntHeader.get<PrimitiveValue<typeof DWORD>>('Signature').size +
+    fileHeader.size +
+    fileHeader.get<PrimitiveValue>('SizeOfOptionalHeader').value();
+
+  const rvaToOffset = (rva: number) =>
+    rvaToOffsetImpl(fileHandle, rva, numberOfSections, ntHeaderEndOffset);
+
+  const tableOffset = await rvaToOffset(tableRva);
+
+  return { offset: tableOffset, rvaToOffset };
+}
+
+// Searches the resource tree for the supplied paths and returns the leaves at the end of those
+// paths.
+async function getResourceTreeLeafOffsets(
+  fileHandle: fs.promises.FileHandle,
+  sectionOffset: number,
+  tableOffset: number,
+  rvaToOffset: (rva: number) => Promise<number>,
+  [ids, ...path]: number[][],
+): Promise<number[]> {
+  const table = await Value.fromFile(fileHandle, tableOffset, IMAGE_RESOURCE_DIRECTORY);
+
+  const numberOfNameEntries = table.get('NumberOfNameEntries').value();
+  const numberOfIdEntries = table.get('NumberOfIdEntries').value();
+
+  const leaves: number[] = [];
+
+  let offset = tableOffset + table.size;
+  for (let i = 0; i < numberOfNameEntries + numberOfIdEntries; i++) {
+    const entryOffset = offset;
+    const entry = await Value.fromFile(fileHandle, entryOffset, IMAGE_RESOURCE_DIRECTORY_ID_ENTRY);
+    offset += entry.size;
+
+    if (i < numberOfNameEntries) {
+      continue;
+    }
+
+    const id = entry.get('Id').value();
+    if (!ids.includes(id)) {
+      continue;
+    }
+
+    let offsetToData = entry.get('OffsetToData').value();
+    // If the first bit is 1 then the offset points to another node, otherwise it point to a leaf.
+    const isLeaf = (offsetToData & 0x80000000) === 0;
+
+    if (isLeaf && path.length === 0) {
+      const leafDataOffset = await getResourceTreeLeafValueOffset(
+        fileHandle,
+        sectionOffset + offsetToData,
+        rvaToOffset,
+      );
+
+      leaves.push(leafDataOffset);
+    } else if (!isLeaf) {
+      offsetToData &= 0x7fffffff;
+
+      const subTreeLeaves = await getResourceTreeLeafOffsets(
+        fileHandle,
+        sectionOffset,
+        sectionOffset + offsetToData,
+        rvaToOffset,
+        path,
+      );
+
+      leaves.push(...subTreeLeaves);
+    } else {
+      continue;
+    }
+  }
+
+  return leaves;
+}
+
+// Finds the Strings structures within the VS_VERSIONINFO structure and returns the contents.
+async function getVsVersionInfoStrings(
+  fileHandle: fs.promises.FileHandle,
+  offset: number,
+): Promise<Map<string, string>> {
+  try {
+    const stringFileInfoOffset = await getVsVersionInfoChildrenOffset(fileHandle, offset);
+
+    const stringTableOffset = await getChildrenOffset(
+      fileHandle,
+      stringFileInfoOffset,
+      STRING_FILE_INFO,
+      (szKey) => szKey === 'StringFileInfo',
+    );
+    const stringTable = await Value.fromFile(fileHandle, stringTableOffset, STRING_TABLE);
+    const stringTableLength = stringTable.get<PrimitiveValue>('wLength').value();
+
+    const stringsOffset = await getChildrenOffset(
+      fileHandle,
+      stringTableOffset,
+      STRING_TABLE,
+      (szKey) => szKey.substr(4).toLowerCase() === '04b0',
+    );
+
+    const strings = await parseStrings(
+      fileHandle,
+      stringsOffset,
+      stringTableOffset + stringTableLength,
+    );
+
+    return strings;
+  } catch {
+    return new Map();
+  }
+}
+
+// Loops through the list of strings and returns a map with the contents.
+async function parseStrings(
+  fileHandle: fs.promises.FileHandle,
+  stringsOffset: number,
+  stringTableEnd: number,
+): Promise<Map<string, string>> {
+  const strings = new Map<string, string>();
+
+  let currentStringOffset = stringsOffset;
+  while (currentStringOffset < stringTableEnd) {
+    const stringValue = await Value.fromFile(fileHandle, currentStringOffset, STRING_TABLE_STRING);
+    const valueSize = (stringValue.get('wValueLength').value() - 1) * 2;
+
+    const szKeyOffset = currentStringOffset + stringValue.size;
+    const { value: szKey, endOffset } = await readString(fileHandle, szKeyOffset, 'ucs2');
+
+    const valueOffset = alignDword(endOffset);
+    const { buffer } = await fileHandle.read(Buffer.alloc(valueSize), 0, valueSize, valueOffset);
+    const value = buffer.toString('ucs2');
+
+    strings.set(szKey, value);
+    currentStringOffset += alignDword(stringValue.get<PrimitiveValue>('wLength').value());
+  }
+
+  return strings;
+}
+
+async function getResourceTreeLeafValueOffset(
+  fileHandle: fs.promises.FileHandle,
+  offset: number,
+  rvaToOffset: (rva: number) => Promise<number>,
+): Promise<number> {
+  const leaf = await Value.fromFile(fileHandle, offset, IMAGE_RESOURCE_DIRECTORY_DATA_ENTRY);
+  const valueRva = leaf.get<PrimitiveValue>('DataRVA').value();
+  const valueOffset = await rvaToOffset(valueRva);
+
+  return valueOffset;
+}
+
+// Finds the offset to the Children field in the VS_VERSIONINFO structure.
+async function getVsVersionInfoChildrenOffset(fileHandle: fs.promises.FileHandle, offset: number) {
+  const valueValueOffset = await getChildrenOffset(
+    fileHandle,
+    offset,
+    VS_VERSIONINFO,
+    (szKey) => szKey === 'VS_VERSION_INFO',
+  );
+  const versionInfo = await Value.fromFile(fileHandle, offset, VS_VERSIONINFO);
+  const versionInfoValueLength = versionInfo.get<PrimitiveValue>('wValueLength').value();
+  const valuePadding2Offset = valueValueOffset + versionInfoValueLength;
+  const valueChildrenOffset = alignDword(valuePadding2Offset);
+
+  return valueChildrenOffset;
+}
+
+// Finds the offset to the Children field in any of the STRING_FILE_INFO, STRING_TABLE and
+// STRING_TABLE_STRING structures.
+async function getChildrenOffset(
+  fileHandle: fs.promises.FileHandle,
+  offset: number,
+  datatype: StructWrapper,
+  validateSzKey?: (szKey: string) => boolean,
+) {
+  const szKeyOffset = offset + Value.sizeOf(datatype);
+  const { value, endOffset } = await readString(fileHandle, szKeyOffset, 'ucs2');
+  if (validateSzKey && !validateSzKey(value)) {
+    throw new Error(`Invalid szKey "${value}"`);
+  }
+
+  return alignDword(endOffset);
+}
+
+function alignDword(offset: number): number {
+  return Math.ceil(offset / 4) * 4;
 }


### PR DESCRIPTION
This PR contains code for retrieving an applications name from the resource tree within the exe-file. This is used when displaying the name of excluded applications that has been added with the file-picker.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2720)
<!-- Reviewable:end -->
