### PR TITLE
TunnelManager: properly finish operation in stopTunnel()

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -26,6 +26,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Enable option to "Select all" when viewing app logs.
 
+### Fixed
+- Fix bug which caused the tunnel manager to become unresponsive in the rare event of failure to
+  disable on-demand when stopping the tunnel from within the app.
+
 
 ## [2021.1] - 2021-03-16
 ### Added

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -422,7 +422,7 @@ class TunnelManager {
 
             tunnelProvider.saveToPreferences { (error) in
                 if let error = error {
-                    completionHandler(.failure(.saveVPNConfiguration(error)))
+                    finish(.failure(.saveVPNConfiguration(error)))
                 } else {
                     tunnelProvider.connection.stopVPNTunnel()
                     finish(.success(()))


### PR DESCRIPTION
The operation is not being finished in the event of failure to save
tunnel configuration to system preferences.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes a small omission where the operation enqueued from `TunnelManager.stopTunnel()` wasn't properly finished in the event of failure to save the VPN configuration to preferences; which in turn caused the `TunnelManager` to become unresponsive to any further requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2722)
<!-- Reviewable:end -->
