### PR TITLE
Fix tunnel manager settings migration

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix bug which caused the tunnel manager to become unresponsive in the rare event of failure to
   disable on-demand when stopping the tunnel from within the app.
+- Fix bug that caused the app to skip tunnel settings migration from older versions of the app.
 
 
 ## [2021.1] - 2021-03-16

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -315,7 +315,7 @@ class TunnelManager {
                     if let error = error {
                         finish(.failure(.loadAllVPNConfigurations(error)))
                     } else {
-                        if let accountToken = self.accountToken {
+                        if let accountToken = accountToken {
                             // Migrate the tunnel settings if needed
                             self.migrateTunnelSettings(accountToken: accountToken)
 

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -216,7 +216,7 @@ class TunnelManager {
             case .removeTunnelSettings:
                 return "Failed to remove the tunnel settings"
             case .obtainPersistentKeychainReference:
-                return "Failed to obtain the persistent keychain refrence"
+                return "Failed to obtain the persistent keychain reference"
             case .pushWireguardKey:
                 return "Failed to push the WireGuard key to server"
             case .replaceWireguardKey:


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes a small bug in `TunnelManager` code that caused the app to skip the tunnel settings migration from older versions of the app.

The bug boils down to the use of wrong variable (instance variable) instead of the argument to the function. Both variables carry the same name so it was easily missed during reviews. I believe this bug was introduced in one of recent refactorings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2724)
<!-- Reviewable:end -->
