### PR TITLE
Upgrade Wintun to 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Prevent tray icons from being extraced to `%TEMP%` directory.
+- Fix failure to create Wintun adapter due to a residual network interface by upgrading Wintun to
+  0.10.4.
 
 #### Linux
 - Fix find `mullvad-vpn.desktop` in `XDG_DATA_DIRS` instead of using hardcoded path.

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -64,7 +64,7 @@
 !macro ExtractWintun
 
 	SetOutPath "$TEMP"
-	File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\wintun.dll"
+	File "${BUILD_RESOURCES_DIR}\binaries\x86_64-pc-windows-msvc\wintun\wintun.dll"
 	File "${BUILD_RESOURCES_DIR}\..\windows\driverlogic\bin\x64-Release\driverlogic.exe"
 
 !macroend

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -113,7 +113,7 @@ const config = {
       { from: distAssets('binaries/x86_64-pc-windows-msvc/openvpn.exe'), to: '.' },
       { from: distAssets('binaries/x86_64-pc-windows-msvc/sslocal.exe'), to: '.' },
       { from: root('build/lib/x86_64-pc-windows-msvc/libwg.dll'), to: '.' },
-      { from: distAssets('binaries/x86_64-pc-windows-msvc/wintun.dll'), to: '.' },
+      { from: distAssets('binaries/x86_64-pc-windows-msvc/wintun/wintun.dll'), to: '.' },
     ],
   },
 

--- a/windows/driverlogic/src/driverlogic.cpp
+++ b/windows/driverlogic/src/driverlogic.cpp
@@ -21,7 +21,7 @@
 #include <cfgmgr32.h>
 #include <io.h>
 #include <fcntl.h>
-#include <wintun.h>
+#include <wintun/wintun.h>
 
 
 namespace


### PR DESCRIPTION
This fixes occasional failures to reuse GUIDs for Wintun interfaces:
```
[2021-05-05 11:38:07.830][talpid_core::tunnel::openvpn::windows][INFO] [Wintun] CreateAdapter: Creating adapter
[2021-05-05 11:38:08.632][talpid_core::tunnel::openvpn::windows][ERROR] [Wintun] CreateAdapter: Failed to setup adapter: Åtgärden har slutförts. (Code 0x00000000)
```
It was caused by Windows not cleaning up after itself: https://git.zx2c4.com/wintun/commit/?id=747ba7121d1d94dac982b9148076d7006e2c170f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2725)
<!-- Reviewable:end -->
