### PR TITLE
Use a new `Flow`-based approach to configure IPC in `MullvadTileService`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -162,6 +162,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:1.1.2"
     androidTestImplementation "io.mockk:mockk-android:$mockkVersion"
     androidTestImplementation "org.koin:koin-test:$koinVersion"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     // debugImplementation because LeakCanary should only run in debug builds.
     // debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
 }

--- a/android/src/androidTest/kotlin/net/mullvad/mullvadvpn/ipc/HandlerFlowTest.kt
+++ b/android/src/androidTest/kotlin/net/mullvad/mullvadvpn/ipc/HandlerFlowTest.kt
@@ -1,0 +1,48 @@
+package net.mullvad.mullvadvpn.ipc
+
+import android.os.Bundle
+import android.os.Looper
+import android.os.Message
+import android.os.Parcelable
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.parcelize.Parcelize
+import org.junit.Test
+
+class HandlerFlowTest {
+    val looper by lazy { Looper.getMainLooper() }
+
+    val handler: HandlerFlow<Data?> by lazy {
+        HandlerFlow(looper) { message ->
+            message.data.getParcelable(DATA_KEY)
+        }
+    }
+
+    @Test
+    fun test_message_extraction() {
+        sendMessage(Data(1))
+        sendMessage(Data(2))
+        sendMessage(Data(3))
+
+        val extractedData = runBlocking { handler.take(3).toList() }
+
+        assertEquals(listOf(Data(1), Data(2), Data(3)), extractedData)
+    }
+
+    private fun sendMessage(messageData: Data) {
+        val message = Message().apply {
+            data = Bundle().apply { putParcelable(DATA_KEY, messageData) }
+        }
+
+        handler.handleMessage(message)
+    }
+
+    companion object {
+        const val DATA_KEY = "data"
+
+        @Parcelize
+        data class Data(val id: Int) : Parcelable
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.ipc
 
 import android.os.Message as RawMessage
+import android.os.Messenger
 import kotlinx.parcelize.Parcelize
 import net.mullvad.mullvadvpn.model.AppVersionInfo as AppVersionInfoData
 import net.mullvad.mullvadvpn.model.GeoIpLocation
@@ -28,7 +29,7 @@ sealed class Event : Message.EventMessage() {
     data class CurrentVersion(val version: String?) : Event()
 
     @Parcelize
-    object ListenerReady : Event()
+    data class ListenerReady(val connection: Messenger) : Event()
 
     @Parcelize
     data class LoginStatus(val status: LoginStatusData?) : Event()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -29,7 +29,7 @@ sealed class Event : Message.EventMessage() {
     data class CurrentVersion(val version: String?) : Event()
 
     @Parcelize
-    data class ListenerReady(val connection: Messenger) : Event()
+    data class ListenerReady(val connection: Messenger, val listenerId: Int) : Event()
 
     @Parcelize
     data class LoginStatus(val status: LoginStatusData?) : Event()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/HandlerFlow.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/HandlerFlow.kt
@@ -1,0 +1,45 @@
+package net.mullvad.mullvadvpn.ipc
+
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onCompletion
+
+class HandlerFlow<T>(
+    looper: Looper,
+    private val extractor: (Message) -> T
+) : Handler(looper), Flow<T> {
+    private val channel = Channel<T>(Channel.UNLIMITED)
+    private val flow = channel.consumeAsFlow().onCompletion {
+        removeCallbacksAndMessages(null)
+    }
+
+    @InternalCoroutinesApi
+    override suspend fun collect(collector: FlowCollector<T>) = flow.collect(collector)
+
+    override fun handleMessage(message: Message) {
+        val extractedData = extractor(message)
+
+        try {
+            channel.sendBlocking(extractedData)
+        } catch (exception: Exception) {
+            when (exception) {
+                is ClosedSendChannelException, is CancellationException -> {
+                    Log.w("mullvad", "Received a message after HandlerFlow was closed", exception)
+                    removeCallbacksAndMessages(null)
+                }
+                else -> throw exception
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -90,6 +90,9 @@ sealed class Request : Message.RequestMessage() {
     data class SubmitVoucher(val voucher: String) : Request()
 
     @Parcelize
+    data class UnregisterListener(val listenerId: Int) : Request()
+
+    @Parcelize
     data class VpnPermissionResponse(val isGranted: Boolean) : Request()
 
     @Parcelize

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/ServiceConnection.kt
@@ -7,13 +7,13 @@ import android.os.Looper
 import android.os.Messenger
 import kotlin.reflect.KClass
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.service.MullvadVpnService
@@ -21,31 +21,34 @@ import net.mullvad.mullvadvpn.util.DispatchingFlow
 import net.mullvad.mullvadvpn.util.bindServiceFlow
 import net.mullvad.mullvadvpn.util.dispatchTo
 
-@InternalCoroutinesApi
 class ServiceConnection(context: Context, scope: CoroutineScope) {
-    private val connection = MutableStateFlow<Messenger?>(null)
+    private val activeListeners = MutableStateFlow<Pair<Messenger, Int>?>(null)
     private val handler = HandlerFlow(Looper.getMainLooper(), Event::fromMessage)
     private val listener = Messenger(handler)
+    private val listenerId = MutableStateFlow<Int?>(null)
 
-    private lateinit var requestSinks: StateFlow<Messenger?>
+    private lateinit var listenerRegistrations: StateFlow<Pair<Messenger, Int>?>
 
     init {
         val dispatcher = handler
             .filterNotNull()
             .dispatchTo {
-                requestSinks = subscribeToState(Event.ListenerReady::class, scope) { connection }
+                listenerRegistrations = subscribeToState(Event.ListenerReady::class, scope) {
+                    Pair(connection, listenerId)
+                }
             }
 
         scope.launch { connect(context) }
         scope.launch { dispatcher.collect() }
-        scope.launch { requestSinks.collect { connection.value = it } }
+        scope.launch { unregisterOldListeners() }
+        scope.launch { listenerRegistrations.collect { activeListeners.value = it } }
     }
 
     private suspend fun connect(context: Context) {
         val intent = Intent(context, MullvadVpnService::class.java)
 
         context.bindServiceFlow(intent).collect { binder ->
-            connection.value = null
+            activeListeners.value = null
             binder?.let(::registerListener)
         }
     }
@@ -53,6 +56,24 @@ class ServiceConnection(context: Context, scope: CoroutineScope) {
     private fun registerListener(binder: IBinder) {
         val request = Request.RegisterListener(listener)
         val messenger = Messenger(binder)
+
+        messenger.send(request.message)
+    }
+
+    private suspend fun unregisterOldListeners() {
+        var oldListener: Pair<Messenger, Int>? = null
+
+        activeListeners
+            .onCompletion { oldListener?.let(::unregisterListener) }
+            .collect { newListener ->
+                oldListener?.let(::unregisterListener)
+                oldListener = newListener
+            }
+    }
+
+    private fun unregisterListener(registration: Pair<Messenger, Int>) {
+        val (messenger, listenerId) = registration
+        val request = Request.UnregisterListener(listenerId)
 
         messenger.send(request.message)
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/ServiceConnection.kt
@@ -1,0 +1,65 @@
+package net.mullvad.mullvadvpn.ipc
+
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import android.os.Looper
+import android.os.Messenger
+import kotlin.reflect.KClass
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.service.MullvadVpnService
+import net.mullvad.mullvadvpn.util.DispatchingFlow
+import net.mullvad.mullvadvpn.util.bindServiceFlow
+import net.mullvad.mullvadvpn.util.dispatchTo
+
+@InternalCoroutinesApi
+class ServiceConnection(context: Context, scope: CoroutineScope) {
+    private val connection = MutableStateFlow<Messenger?>(null)
+    private val handler = HandlerFlow(Looper.getMainLooper(), Event::fromMessage)
+    private val listener = Messenger(handler)
+
+    private lateinit var requestSinks: StateFlow<Messenger?>
+
+    init {
+        val dispatcher = handler
+            .filterNotNull()
+            .dispatchTo {
+                requestSinks = subscribeToState(Event.ListenerReady::class, scope) { connection }
+            }
+
+        scope.launch { connect(context) }
+        scope.launch { dispatcher.collect() }
+        scope.launch { requestSinks.collect { connection.value = it } }
+    }
+
+    private suspend fun connect(context: Context) {
+        val intent = Intent(context, MullvadVpnService::class.java)
+
+        context.bindServiceFlow(intent).collect { binder ->
+            connection.value = null
+            binder?.let(::registerListener)
+        }
+    }
+
+    private fun registerListener(binder: IBinder) {
+        val request = Request.RegisterListener(listener)
+        val messenger = Messenger(binder)
+
+        messenger.send(request.message)
+    }
+
+    private fun <V : Any, D> DispatchingFlow<in V>.subscribeToState(
+        event: KClass<V>,
+        scope: CoroutineScope,
+        dataExtractor: suspend V.() -> D
+    ) = subscribe(event).map(dataExtractor).stateIn(scope, SharingStarted.Lazily, null)
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -121,7 +121,7 @@ class ServiceEndpoint(
                 Event.AppVersionInfo(appVersionInfoCache.appVersionInfo),
                 Event.NewRelayList(relayListListener.relayList),
                 Event.AuthToken(authTokenCache.authToken),
-                Event.ListenerReady
+                Event.ListenerReady(messenger)
             )
 
             if (vpnPermission.waitingForResponse) {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -32,6 +32,8 @@ class ServiceEndpoint(
         Request.fromMessage(message)
     }
 
+    private var listenerIdCounter = 0
+
     val messenger = Messenger(dispatcher)
 
     val vpnPermission = VpnPermission(context, this)
@@ -107,6 +109,8 @@ class ServiceEndpoint(
 
     private fun registerListener(listener: Messenger) {
         synchronized(this) {
+            val listenerId = newListenerId()
+
             listeners.add(listener)
 
             val initialEvents = mutableListOf(
@@ -121,7 +125,7 @@ class ServiceEndpoint(
                 Event.AppVersionInfo(appVersionInfoCache.appVersionInfo),
                 Event.NewRelayList(relayListListener.relayList),
                 Event.AuthToken(authTokenCache.authToken),
-                Event.ListenerReady(messenger)
+                Event.ListenerReady(messenger, listenerId)
             )
 
             if (vpnPermission.waitingForResponse) {
@@ -132,5 +136,13 @@ class ServiceEndpoint(
                 listener.send(event.message)
             }
         }
+    }
+
+    private fun newListenerId(): Int {
+        val listenerId = listenerIdCounter
+
+        listenerIdCounter += 1
+
+        return listenerId
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/DispatchingFlow.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/DispatchingFlow.kt
@@ -1,0 +1,49 @@
+package net.mullvad.mullvadvpn.util
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+
+class DispatchingFlow<T : Any>(private val upstream: Flow<T>) : Flow<T> {
+    private val subscribers = ConcurrentHashMap<KClass<out T>, SendChannel<T>>()
+
+    fun <V : T> subscribe(
+        variant: KClass<V>,
+        capacity: Int = Channel.CONFLATED
+    ): Flow<V> {
+        val channel = Channel<V>(capacity)
+
+        // This is safe because `collect` will only send to this channel if the instance class is V
+        @Suppress("UNCHECKED_CAST")
+        subscribers[variant] = channel as SendChannel<T>
+
+        return channel.consumeAsFlow()
+    }
+
+    fun <V : T> unsubscribe(variant: KClass<V>) = subscribers.remove(variant)
+
+    @InternalCoroutinesApi
+    override suspend fun collect(collector: FlowCollector<T>) {
+        upstream.collect { event ->
+            try {
+                subscribers[event::class]?.send(event)
+            } catch (closedException: ClosedSendChannelException) {
+                subscribers.remove(event::class)
+            }
+
+            collector.emit(event)
+        }
+
+        subscribers.clear()
+    }
+}
+
+fun <T : Any> Flow<T>.dispatchTo(configureSubscribers: DispatchingFlow<T>.() -> Unit) =
+    DispatchingFlow(this).also(configureSubscribers)


### PR DESCRIPTION
This PR refactors the `MullvadTileService` to use a new `Flow` based setup for the IPC channel to the `MullvadVpnService`. A new `ServiceConnection` class was created inside the `ipc` package, with the purpose of being shared between the UI and the tile service later. As part of the refactoring of the tile service, the `Handler` used for receiving messages now must be unregistered from the service in order to stop receiving messages.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal refactor, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2727)
<!-- Reviewable:end -->
