### PR TITLE
Wait before reconnecting with a new WireGuard key

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -78,7 +78,7 @@ const TUNNEL_STATE_MACHINE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const FIRST_KEY_PUSH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Delay between generating a new WireGuard key and reconnecting
-const WG_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+const WG_RECONNECT_DELAY: Duration = Duration::from_secs(4 * 60);
 
 pub type ResponseTx<T, E> = oneshot::Sender<Result<T, E>>;
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1997,7 +1997,7 @@ where
                     .await
                     .map_err(Error::AccountHistory)?;
                 if let Some(TunnelType::Wireguard) = self.get_target_tunnel_type() {
-                    self.reconnect_tunnel();
+                    self.schedule_reconnect(WG_RECONNECT_DELAY).await;
                 }
                 let keygen_event = KeygenEvent::NewKey(public_key);
                 self.event_listener.notify_key_event(keygen_event.clone());


### PR DESCRIPTION
The waiting behavior was already there for automatic key rotation. The only changes are that the interval is now 4 minutes, and that the same thing is done for manual key rotation.