### PR TITLE
Replace "unsecured" with "unsecure"

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -120,7 +120,7 @@ msgstr ""
 msgid "System default"
 msgstr ""
 
-msgid "UNSECURED CONNECTION"
+msgid "UNSECURE CONNECTION"
 msgstr ""
 
 msgctxt "accessibility"
@@ -401,7 +401,7 @@ msgid "Remember, turning it off will allow network traffic while the VPN is disc
 msgstr ""
 
 msgctxt "connect-view"
-msgid "To add more, you will need to disconnect and access the Internet with an unsecured connection."
+msgid "To add more, you will need to disconnect and access the Internet with an unsecure connection."
 msgstr ""
 
 msgctxt "connect-view"
@@ -624,7 +624,7 @@ msgid "Could not configure IPv6. Disable it in the app or enable it on your devi
 msgstr ""
 
 msgctxt "notifications"
-msgid "Disconnected and unsecured"
+msgid "Disconnected and unsecure"
 msgstr ""
 
 msgctxt "notifications"
@@ -1187,6 +1187,9 @@ msgid "This device is offline, no tunnels can be established"
 msgstr ""
 
 msgid "Too many WireGuard keys registered to account"
+msgstr ""
+
+msgid "UNSECURED CONNECTION"
 msgstr ""
 
 msgid "Unsecured"

--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -155,7 +155,7 @@ export default class ExpiredAccountErrorView extends React.Component<
       case RecoveryAction.disconnect:
         return messages.pgettext(
           'connect-view',
-          'To add more, you will need to disconnect and access the Internet with an unsecured connection.',
+          'To add more, you will need to disconnect and access the Internet with an unsecure connection.',
         );
     }
   }

--- a/gui/src/renderer/components/SecuredLabel.tsx
+++ b/gui/src/renderer/components/SecuredLabel.tsx
@@ -48,7 +48,7 @@ function getLabelText(displayStyle: SecuredDisplayStyle) {
       return messages.gettext('CREATING SECURE CONNECTION');
 
     case SecuredDisplayStyle.unsecured:
-      return messages.gettext('UNSECURED CONNECTION');
+      return messages.gettext('UNSECURE CONNECTION');
 
     case SecuredDisplayStyle.failedToSecure:
       return messages.gettext('FAILED TO SECURE CONNECTION');

--- a/gui/src/shared/notifications/disconnected.ts
+++ b/gui/src/shared/notifications/disconnected.ts
@@ -15,7 +15,7 @@ export class DisconnectedNotificationProvider implements SystemNotificationProvi
 
   public getSystemNotification() {
     return {
-      message: messages.pgettext('notifications', 'Disconnected and unsecured'),
+      message: messages.pgettext('notifications', 'Disconnected and unsecure'),
       critical: false,
     };
   }


### PR DESCRIPTION
This PR replaces the word "unsecured" with "unsecure" in user facing texts.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2731)
<!-- Reviewable:end -->
