### PR TITLE
Use HTTP caching when requesting relay list

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -26,6 +26,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Enable option to "Select all" when viewing app logs.
 - Split view interface for iPad.
+- Reduce network traffic consumption by leveraging HTTP caching via ETag HTTP header to avoid 
+  re-downloading the relay list if it hasn't changed.
 
 ### Fixed
 - Fix bug which caused the tunnel manager to become unresponsive in the rare event of failure to

--- a/ios/MullvadVPN/Account.swift
+++ b/ios/MullvadVPN/Account.swift
@@ -102,7 +102,7 @@ class Account {
         case exclusive
     }
 
-    private let rest = MullvadRest(session: URLSession(configuration: .ephemeral))
+    private let rest = MullvadRest()
     private let operationQueue = OperationQueue()
     private lazy var exclusivityController = ExclusivityController<ExclusivityCategory>(operationQueue: operationQueue)
 

--- a/ios/MullvadVPN/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager.swift
@@ -127,7 +127,7 @@ class AppStorePaymentManager: NSObject, SKPaymentTransactionObserver {
     private let operationQueue = OperationQueue()
     private lazy var exclusivityController = ExclusivityController<ExlcusivityCategory>(operationQueue: operationQueue)
 
-    private let rest = MullvadRest(session: URLSession(configuration: .ephemeral))
+    private let rest = MullvadRest()
     private let queue: SKPaymentQueue
 
     private var observerList = ObserverList<AnyAppStorePaymentObserver>()

--- a/ios/MullvadVPN/AutomaticKeyRotationManager.swift
+++ b/ios/MullvadVPN/AutomaticKeyRotationManager.swift
@@ -48,7 +48,7 @@ class AutomaticKeyRotationManager {
 
     private let logger = Logger(label: "AutomaticKeyRotationManager")
 
-    private let rest = MullvadRest(session: URLSession(configuration: .ephemeral))
+    private let rest = MullvadRest()
     private let persistentKeychainReference: Data
 
     /// A dispatch queue used for synchronization

--- a/ios/MullvadVPN/MullvadRest.swift
+++ b/ios/MullvadVPN/MullvadRest.swift
@@ -23,8 +23,24 @@ enum HttpMethod: String {
     case delete = "DELETE"
 }
 
+// HTTP status codes
+enum HttpStatus {
+    static let ok = 200
+    static let created = 201
+    static let noContent = 204
+    static let notModified = 304
+}
+
+/// HTTP headers
+enum HttpHeader {
+    static let authorization = "Authorization"
+    static let contentType = "Content-Type"
+    static let etag = "ETag"
+    static let ifNoneMatch = "If-None-Match"
+}
+
 /// A struct that represents a server response in case of error (any HTTP status code except 2xx).
-struct ServerErrorResponse: LocalizedError, Decodable, RestResponse, Equatable {
+struct ServerErrorResponse: LocalizedError, Decodable, Equatable {
     /// A list of known server error codes
     enum Code: String, Equatable {
         case invalidAccount = "INVALID_ACCOUNT"
@@ -113,29 +129,6 @@ protocol RestPayload {
     func inject(into request: inout URLRequest) throws
 }
 
-/// Types conforming to this protocol can act as REST response types.
-protocol RestResponse {
-    associatedtype Output
-
-    static func decodeResponse(_ data: Data) throws -> Output
-}
-
-/// Any `Decodable` can be REST response
-extension Decodable where Self: RestResponse {
-    static func decodeResponse(_ data: Data) throws -> Self {
-        try MullvadRest.makeJSONDecoder().decode(Self.self, from: data)
-    }
-}
-
-/// An empty REST response type that cannot be instantiated and is only used to produce an empty
-/// output.
-enum EmptyResponse {}
-extension EmptyResponse: RestResponse {
-    static func decodeResponse(_ data: Data) throws -> () {
-        return ()
-    }
-}
-
 /// Any `Encodable` type can be injected as JSON payload
 extension RestPayload where Self: Encodable {
     func inject(into request: inout URLRequest) throws {
@@ -146,9 +139,9 @@ extension RestPayload where Self: Encodable {
 // MARK: - Operations
 
 final class RestOperation<Input, Response>: AsyncOperation, InputOperation, OutputOperation
-    where Input: RestPayload, Response: RestResponse
+    where Input: RestPayload
 {
-    typealias Output = Result<Response.Output, RestError>
+    typealias Output = Result<Response, RestError>
 
     private let endpoint: RestEndpoint<Input, Response>
     private let session: URLSession
@@ -187,24 +180,140 @@ final class RestOperation<Input, Response>: AsyncOperation, InputOperation, Outp
     }
 }
 
+// MARK: - Response handlers
+
+/// Types conforming to this protocol can be used as response handlers to decode the raw server response to the data
+/// type expected by the caller.
+protocol ResponseHandler {
+    associatedtype Response
+
+    /// Decode the response.
+    /// The implementation is expected to throw `BadResponseError` in case of failure to handle the HTTP response,
+    /// or any other `Error` in case of failure to decode the data.
+    func decodeResponse(_ httpResponse: HTTPURLResponse, data: Data) -> Result<Response, ResponseHandlerError>
+}
+
+enum ResponseHandlerError: Error {
+    /// A failure to handle the response due to unexpected status code
+    case badResponse(_ statusCode: Int)
+
+    /// A failure to decode data
+    case decodeData(Error)
+}
+
+/// A placeholder error used to indicate that the server returned unexpected response.
+fileprivate struct BadResponseError: Error {
+    let statusCode: Int
+}
+
+/// Type-erasing response handler.
+struct AnyResponseHandler<Response>: ResponseHandler {
+    private let decodeResponseBlock: (HTTPURLResponse, Data) -> Result<Response, ResponseHandlerError>
+
+    init<T: ResponseHandler>(_ wrappedHandler: T) where T.Response == Response {
+        self.decodeResponseBlock = { (response, data) -> Result<Response, ResponseHandlerError> in
+            return wrappedHandler.decodeResponse(response, data: data)
+        }
+    }
+
+    func decodeResponse(_ httpResponse: HTTPURLResponse, data: Data) -> Result<Response, ResponseHandlerError> {
+        return self.decodeResponseBlock(httpResponse, data)
+    }
+}
+
+/// A REST response handler that decides when response contains the successful result based on the given status code and
+/// decodes the value in response.
+struct DecodingResponseHandler<Response: Decodable>: ResponseHandler {
+    private let expectedStatus: Int
+
+    init(expectedStatus: Int) {
+        self.expectedStatus = expectedStatus
+    }
+
+    func decodeResponse(_ httpResponse: HTTPURLResponse, data: Data) -> Result<Response, ResponseHandlerError> {
+        if httpResponse.statusCode == expectedStatus {
+            return Result { try MullvadRest.makeJSONDecoder().decode(Response.self, from: data) }
+                .mapError { (error) -> ResponseHandlerError in
+                    return .decodeData(error)
+                }
+        } else {
+            return .failure(.badResponse(httpResponse.statusCode))
+        }
+    }
+}
+
+/// A REST response handler that decides when response contains the successful result based on the given status code but
+/// never decodes the value in response as it anticipates it to be empty.
+struct EmptyResponseHandler: ResponseHandler {
+    private let expectedStatus: Int
+
+    init(expectedStatus: Int) {
+        self.expectedStatus = expectedStatus
+    }
+
+    func decodeResponse(_ httpResponse: HTTPURLResponse, data: Data) -> Result<(), ResponseHandlerError> {
+        if httpResponse.statusCode == expectedStatus {
+            return .success(())
+        } else {
+            return .failure(.badResponse(httpResponse.statusCode))
+        }
+    }
+}
+
+/// A REST response handler that takes into account ETag and 200 and 304 response codes to produce the output result.
+struct HttpCacheDecodingResponseHandler<WrappedType: Decodable>: ResponseHandler {
+    typealias Response = HttpResourceCacheResponse<WrappedType>
+
+    private let etag: String?
+
+    init(etag: String?) {
+        self.etag = etag
+    }
+
+    func decodeResponse(_ httpResponse: HTTPURLResponse, data: Data) -> Result<Response, ResponseHandlerError> {
+        switch httpResponse.statusCode {
+        case HttpStatus.ok:
+            return Result { try MullvadRest.makeJSONDecoder().decode(WrappedType.self, from: data) }
+                .mapError { (error) -> ResponseHandlerError in
+                    return .decodeData(error)
+                }.map { (relays) -> Response in
+                    let etag = httpResponse.value(forCaseInsensitiveHTTPHeaderField: HttpHeader.etag)
+
+                    return .newContent(etag, relays)
+                }
+
+        case HttpStatus.notModified where etag != nil:
+            return .success(.notModified)
+
+        case let statusCode:
+            return .failure(.badResponse(statusCode))
+        }
+    }
+}
+
 // MARK: - Endpoints
 
 /// A struct that describes the REST endpoint, including the expected input and output
-struct RestEndpoint<Input, Response> where Input: RestPayload, Response: RestResponse {
+struct RestEndpoint<Input, Response> where Input: RestPayload {
     let endpointURL: URL
     let httpMethod: HttpMethod
+    let makeResponseHandler: (Input) -> AnyResponseHandler<Response>
 
-    init(endpointURL: URL, httpMethod: HttpMethod) {
+    init<Handler: ResponseHandler>(endpointURL: URL, httpMethod: HttpMethod, responseHandlerFactory: @escaping (Input) -> Handler) where Handler.Response == Response {
         self.endpointURL = endpointURL
         self.httpMethod = httpMethod
+        self.makeResponseHandler = { (input) -> AnyResponseHandler<Response> in
+            return AnyResponseHandler(responseHandlerFactory(input))
+        }
     }
 
     /// Create `URLSessionDataTask` that automatically parses the HTTP response and returns the
     /// expected response type or error upon completion.
-    func dataTask(session: URLSession, payload: Input, completionHandler: @escaping (Result<Response.Output, RestError>) -> Void) -> Result<URLSessionDataTask, RestError> {
+    func dataTask(session: URLSession, payload: Input, completionHandler: @escaping (Result<Response, RestError>) -> Void) -> Result<URLSessionDataTask, RestError> {
         return makeURLRequest(payload: payload).map { (request) -> URLSessionDataTask in
             return session.dataTask(with: request) { (responseData, urlResponse, error) in
-                let result = Self.handleURLResponse(urlResponse, data: responseData, error: error)
+                let handler = self.makeResponseHandler(payload)
+                let result = Self.handleURLResponse(urlResponse, data: responseData, error: error, responseHandler: handler)
                 completionHandler(result)
             }
         }
@@ -236,13 +345,13 @@ struct RestEndpoint<Input, Response> where Input: RestPayload, Response: RestRes
             timeoutInterval: kNetworkTimeout
         )
         request.httpShouldHandleCookies = false
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: HttpHeader.contentType)
         request.httpMethod = httpMethod.rawValue
         return request
     }
 
     /// A private HTTP response handler
-    private static func handleURLResponse(_ urlResponse: URLResponse?, data: Data?, error: Error?) -> Result<Response.Output, RestError> {
+    private static func handleURLResponse(_ urlResponse: URLResponse?, data: Data?, error: Error?, responseHandler: AnyResponseHandler<Response>) -> Result<Response, RestError> {
         if let error = error {
             let networkError = error as? URLError ?? URLError(.unknown)
 
@@ -255,30 +364,26 @@ struct RestEndpoint<Input, Response> where Input: RestPayload, Response: RestRes
 
         let data = data ?? Data()
 
-        // Treat all 2xx responses as success despite the subtle meaning they may convey
-        if (200..<300).contains(httpResponse.statusCode) {
-            return Self.decodeSuccessResponse(data)
-        } else {
-            return Self.decodeErrorResponse(data)
-                .flatMap { (serverErrorResponse) -> Result<Response.Output, RestError> in
-                    return .failure(.server(serverErrorResponse))
-            }
-        }
-    }
+        return responseHandler.decodeResponse(httpResponse, data: data)
+            .flatMapError { (error) -> Result<Response, RestError> in
+                switch error {
+                case .badResponse:
+                    // Try decoding the server error response in case when unexpected response is returned
+                    return Self.decodeErrorResponse(httpResponse: httpResponse, data: data)
+                        .flatMap { (serverErrorResponse) -> Result<Response, RestError> in
+                            return .failure(.server(serverErrorResponse))
+                        }
 
-    /// A private helper that parses the JSON response in case of success (HTTP 2xx)
-    private static func decodeSuccessResponse(_ responseData: Data) -> Result<Response.Output, RestError> {
-        return Result { () -> Response.Output in
-            return try Response.decodeResponse(responseData)
-        }.mapError({ (error) -> RestError in
-            return .decodeSuccessResponse(error)
-        })
+                case .decodeData(let decodingError):
+                    return .failure(.decodeSuccessResponse(decodingError))
+                }
+            }
     }
 
     /// A private helper that parses the JSON response in case of error (Any HTTP code except 2xx)
-    private static func decodeErrorResponse(_ responseData: Data) -> Result<ServerErrorResponse, RestError> {
+    private static func decodeErrorResponse(httpResponse: HTTPURLResponse, data: Data) -> Result<ServerErrorResponse, RestError> {
         return Result { () -> ServerErrorResponse in
-            return try ServerErrorResponse.decodeResponse(responseData)
+            return try MullvadRest.makeJSONDecoder().decode(ServerErrorResponse.self, from: data)
         }.mapError({ (error) -> RestError in
             return .decodeErrorResponse(error)
         })
@@ -286,7 +391,7 @@ struct RestEndpoint<Input, Response> where Input: RestPayload, Response: RestRes
 }
 
 /// A convenience class for `RestEndpoint` that transparently provides it with the `URLSession`
-struct RestSessionEndpoint<Input, Response> where Input: RestPayload, Response: RestResponse {
+struct RestSessionEndpoint<Input, Response> where Input: RestPayload {
     let session: URLSession
     let endpoint: RestEndpoint<Input, Response>
 
@@ -297,7 +402,7 @@ struct RestSessionEndpoint<Input, Response> where Input: RestPayload, Response: 
 
     /// Create `URLSessionDataTask` that automatically parses the HTTP response and returns the
     /// expected response type or error upon completion.
-    func dataTask(payload: Input, completionHandler: @escaping (Result<Response.Output, RestError>) -> Void) -> Result<URLSessionDataTask, RestError> {
+    func dataTask(payload: Input, completionHandler: @escaping (Result<Response, RestError>) -> Void) -> Result<URLSessionDataTask, RestError> {
         return endpoint.dataTask(session: session, payload: payload, completionHandler: completionHandler)
     }
 
@@ -321,7 +426,7 @@ struct MullvadRest {
         return RestSessionEndpoint(session: session, endpoint: Self.createAccount())
     }
 
-    func getRelays() -> RestSessionEndpoint<EmptyPayload, ServerRelaysResponse> {
+    func getRelays() -> RestSessionEndpoint<ETagPayload<EmptyPayload>, HttpResourceCacheResponse<ServerRelaysResponse>> {
         return RestSessionEndpoint(session: session, endpoint: Self.getRelays())
     }
 
@@ -341,7 +446,7 @@ struct MullvadRest {
         return RestSessionEndpoint(session: session, endpoint: Self.replaceWireguardKey())
     }
 
-    func deleteWireguardKey() -> RestSessionEndpoint<PublicKeyPayload<TokenPayload<EmptyPayload>>, EmptyResponse> {
+    func deleteWireguardKey() -> RestSessionEndpoint<PublicKeyPayload<TokenPayload<EmptyPayload>>, ()> {
         return RestSessionEndpoint(session: session, endpoint: Self.deleteWireguardKey())
     }
 
@@ -349,7 +454,7 @@ struct MullvadRest {
         return RestSessionEndpoint(session: session, endpoint: Self.createApplePayment())
     }
 
-    func sendProblemReport() -> RestSessionEndpoint<ProblemReportRequest, EmptyResponse> {
+    func sendProblemReport() -> RestSessionEndpoint<ProblemReportRequest, ()> {
         return RestSessionEndpoint(session: session, endpoint: Self.sendProblemReport())
     }
 }
@@ -359,15 +464,21 @@ extension MullvadRest {
     static func createAccount() -> RestEndpoint<EmptyPayload, AccountResponse> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("accounts"),
-            httpMethod: .post
+            httpMethod: .post,
+            responseHandlerFactory: { (input) in
+                return DecodingResponseHandler(expectedStatus: HttpStatus.created)
+            }
         )
     }
 
     /// GET /v1/relays
-    static func getRelays() -> RestEndpoint<EmptyPayload, ServerRelaysResponse> {
+    static func getRelays() -> RestEndpoint<ETagPayload<EmptyPayload>, HttpResourceCacheResponse<ServerRelaysResponse>> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("relays"),
-            httpMethod: .get
+            httpMethod: .get,
+            responseHandlerFactory: { (input) in
+                return HttpCacheDecodingResponseHandler(etag: input.etag)
+            }
         )
     }
 
@@ -375,14 +486,20 @@ extension MullvadRest {
     static func getAccountExpiry() -> RestEndpoint<TokenPayload<EmptyPayload>, AccountResponse> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("me"),
-            httpMethod: .get
+            httpMethod: .get,
+            responseHandlerFactory: { (input) in
+                return DecodingResponseHandler(expectedStatus: HttpStatus.ok)
+            }
         )
     }
     /// GET /v1/wireguard-keys/{pubkey}
     static func getWireguardKey() -> RestEndpoint<PublicKeyPayload<TokenPayload<EmptyPayload>>, WireguardAddressesResponse> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("wireguard-keys"),
-            httpMethod: .get
+            httpMethod: .get,
+            responseHandlerFactory: { (input) in
+                return DecodingResponseHandler(expectedStatus: HttpStatus.ok)
+            }
         )
     }
 
@@ -390,7 +507,10 @@ extension MullvadRest {
     static func pushWireguardKey() -> RestEndpoint<TokenPayload<PushWireguardKeyRequest>, WireguardAddressesResponse> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("wireguard-keys"),
-            httpMethod: .post
+            httpMethod: .post,
+            responseHandlerFactory: { (input) in
+                return DecodingResponseHandler(expectedStatus: HttpStatus.created)
+            }
         )
     }
 
@@ -398,15 +518,21 @@ extension MullvadRest {
     static func replaceWireguardKey() -> RestEndpoint<TokenPayload<ReplaceWireguardKeyRequest>, WireguardAddressesResponse> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("replace-wireguard-key"),
-            httpMethod: .post
+            httpMethod: .post,
+            responseHandlerFactory: { (input) in
+                return DecodingResponseHandler(expectedStatus: HttpStatus.created)
+            }
         )
     }
 
     /// DELETE /v1/wireguard-keys/{pubkey}
-    static func deleteWireguardKey() -> RestEndpoint<PublicKeyPayload<TokenPayload<EmptyPayload>>, EmptyResponse> {
+    static func deleteWireguardKey() -> RestEndpoint<PublicKeyPayload<TokenPayload<EmptyPayload>>, ()> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("wireguard-keys"),
-            httpMethod: .delete
+            httpMethod: .delete,
+            responseHandlerFactory: { (input) in
+                return EmptyResponseHandler(expectedStatus: HttpStatus.noContent)
+            }
         )
     }
 
@@ -414,14 +540,20 @@ extension MullvadRest {
     static func createApplePayment() -> RestEndpoint<TokenPayload<CreateApplePaymentRequest>, CreateApplePaymentResponse> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("create-apple-payment"),
-            httpMethod: .post
+            httpMethod: .post,
+            responseHandlerFactory: { (input) in
+                return DecodingResponseHandler(expectedStatus: HttpStatus.created)
+            }
         )
     }
 
-    static func sendProblemReport() -> RestEndpoint<ProblemReportRequest, EmptyResponse> {
+    static func sendProblemReport() -> RestEndpoint<ProblemReportRequest, ()> {
         return RestEndpoint(
             endpointURL: kRestBaseURL.appendingPathComponent("problem-report"),
-            httpMethod: .post
+            httpMethod: .post,
+            responseHandlerFactory: { (input) in
+                return EmptyResponseHandler(expectedStatus: HttpStatus.noContent)
+            }
         )
     }
 
@@ -458,7 +590,7 @@ struct TokenPayload<Payload: RestPayload>: RestPayload {
     }
 
     func inject(into request: inout URLRequest) throws {
-        request.addValue("Token \(token)", forHTTPHeaderField: "Authorization")
+        request.addValue("Token \(token)", forHTTPHeaderField: HttpHeader.authorization)
         try payload.inject(into: &request)
     }
 }
@@ -482,6 +614,30 @@ struct PublicKeyPayload<Payload: RestPayload>: RestPayload {
     }
 }
 
+/// A payload that adds the ETag header to the request
+struct ETagPayload<Payload: RestPayload>: RestPayload {
+    let etag: String?
+    let enforceWeakValidator: Bool
+    let payload: Payload
+
+    init(etag: String?, enforceWeakValidator: Bool, payload: Payload) {
+        self.etag = etag
+        self.enforceWeakValidator = enforceWeakValidator
+        self.payload = payload
+    }
+
+    func inject(into request: inout URLRequest) throws {
+        if var etag = etag {
+            // Enforce weak validator to account for some backend caching quirks.
+            if enforceWeakValidator && etag.starts(with: "\"") {
+                etag.insert(contentsOf: "W/", at: etag.startIndex)
+            }
+            request.setValue(etag, forHTTPHeaderField: HttpHeader.ifNoneMatch)
+        }
+        try payload.inject(into: &request)
+    }
+}
+
 /// An empty payload placeholder type.
 /// Use it in places where the payload is not expected
 struct EmptyPayload: RestPayload {
@@ -492,7 +648,7 @@ struct EmptyPayload: RestPayload {
 
 // MARK: - Response types
 
-struct AccountResponse: Decodable, RestResponse {
+struct AccountResponse: Decodable {
     let token: String
     let expires: Date
 }
@@ -524,7 +680,27 @@ struct ServerWireguardTunnels: Codable {
     let relays: [ServerRelay]
 }
 
-struct ServerRelaysResponse: Codable, RestResponse {
+private extension HTTPURLResponse {
+    func value(forCaseInsensitiveHTTPHeaderField headerField: String) -> String? {
+        if #available(iOS 13.0, *) {
+            return self.value(forHTTPHeaderField: headerField)
+        } else {
+            for case let key as String in self.allHeaderFields.keys {
+                if case .orderedSame = key.caseInsensitiveCompare(headerField) {
+                    return self.allHeaderFields[key] as? String
+                }
+            }
+            return nil
+        }
+    }
+}
+
+enum HttpResourceCacheResponse<T: Decodable> {
+    case notModified
+    case newContent(_ etag: String?, _ value: T)
+}
+
+struct ServerRelaysResponse: Codable {
     let locations: [String: ServerLocation]
     let wireguard: ServerWireguardTunnels
 }
@@ -533,7 +709,7 @@ struct PushWireguardKeyRequest: Encodable, RestPayload {
     let pubkey: Data
 }
 
-struct WireguardAddressesResponse: Decodable, RestResponse {
+struct WireguardAddressesResponse: Decodable {
     let id: String
     let pubkey: Data
     let ipv4Address: IPAddressRange
@@ -549,7 +725,7 @@ struct CreateApplePaymentRequest: Encodable, RestPayload {
     let receiptString: Data
 }
 
-struct CreateApplePaymentResponse: Decodable, RestResponse {
+struct CreateApplePaymentResponse: Decodable {
     let timeAdded: Int
     let newExpiry: Date
 

--- a/ios/MullvadVPN/MullvadRest.swift
+++ b/ios/MullvadVPN/MullvadRest.swift
@@ -416,11 +416,7 @@ struct RestSessionEndpoint<Input, Response> where Input: RestPayload {
 // MARK: - REST interface
 
 struct MullvadRest {
-    let session: URLSession
-
-    init(session: URLSession = URLSession(configuration: .ephemeral)) {
-        self.session = session
-    }
+    let session = URLSession(configuration: .ephemeral)
 
     func createAccount() -> RestSessionEndpoint<EmptyPayload, AccountResponse> {
         return RestSessionEndpoint(session: session, endpoint: Self.createAccount())

--- a/ios/MullvadVPN/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/ProblemReportViewController.swift
@@ -13,7 +13,7 @@ class ProblemReportViewController: UIViewController, UITextFieldDelegate, Condit
     private var textViewKeyboardResponder: AutomaticKeyboardResponder?
     private var scrollViewKeyboardResponder: AutomaticKeyboardResponder?
 
-    private let mullvadRest = MullvadRest(session: URLSession(configuration: .ephemeral))
+    private let mullvadRest = MullvadRest()
     private lazy var consolidatedLog: ConsolidatedApplicationLog = {
         let securityGroupIdentifier = ApplicationConfiguration.securityGroupIdentifier
 

--- a/ios/MullvadVPN/RelayCache.swift
+++ b/ios/MullvadVPN/RelayCache.swift
@@ -69,7 +69,7 @@ class RelayCache {
     private let logger = Logger(label: "RelayCache")
 
     /// Mullvad REST client
-    private let rest: MullvadRest
+    private let rest = MullvadRest()
 
     /// The cache location used by the class instance
     private let cacheFileURL: URL
@@ -103,10 +103,9 @@ class RelayCache {
     private let observerList = ObserverList<AnyRelayCacheObserver>()
 
     /// A shared instance of `RelayCache`
-    static let shared = RelayCache(cacheFileURL: defaultCacheFileURL, networkSession: URLSession(configuration: .ephemeral))
+    static let shared = RelayCache(cacheFileURL: defaultCacheFileURL)
 
-    private init(cacheFileURL: URL, networkSession: URLSession) {
-        rest = MullvadRest(session: networkSession)
+    private init(cacheFileURL: URL) {
         self.cacheFileURL = cacheFileURL
     }
 

--- a/ios/MullvadVPN/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager.swift
@@ -243,7 +243,7 @@ class TunnelManager {
     private let logger = Logger(label: "TunnelManager")
     private let dispatchQueue = DispatchQueue(label: "net.mullvad.MullvadVPN.TunnelManager")
 
-    private let rest = MullvadRest(session: URLSession(configuration: .ephemeral))
+    private let rest = MullvadRest()
     private var tunnelProvider: TunnelProviderManagerType?
     private var tunnelIpc: PacketTunnelIpc?
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Tidy up the HTTP status code handling in the Rest API by replacing the `RestResponse` type with `ResponseHandler` protocol and moving the response handling outside of the response types.
2. Add HTTP caching support via ETag. Stored in `CachedRelays` on disk for further cache validation.
3. Add HTTP header and status code types to reuse as constants across the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2733)
<!-- Reviewable:end -->
