### PR TITLE
Localize StoreKit errors (SKError)

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix bug which caused the tunnel manager to become unresponsive in the rare event of failure to
   disable on-demand when stopping the tunnel from within the app.
 - Fix bug that caused the app to skip tunnel settings migration from older versions of the app.
+- Localize some of well known StoreKit errors so that they look less cryptic when presented to user.
 
 
 ## [2021.1] - 2021-03-16


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

It looks like StoreKit does not provide localized error messages which results in the following error message to be displayed to user:

> The operation couldn’t be completed. (SKErrorDomain error 2.)

This PR localises some of the well known errors to display a user friendly error to the user. The messages themselves are taken verbatim from Apple documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2735)
<!-- Reviewable:end -->
