### PR TITLE
Make settings button accessible in formsheet presentation on iPad

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -434,6 +434,9 @@ extension AppDelegate: LoginViewControllerDelegate {
     func loginViewControllerDidLogin(_ controller: LoginViewController) {
         self.window?.isUserInteractionEnabled = false
 
+        // Move the settings button back into header bar
+        self.rootContainer?.removeSettingsButtonFromPresentationContainer()
+
         TunnelManager.shared.getRelayConstraints { [weak self] (result) in
             guard let self = self else { return }
 
@@ -650,6 +653,28 @@ extension AppDelegate: UIAdaptivePresentationControllerDelegate {
         // Force hide header bar in .formSheet presentation and show it in .fullScreen presentation
         if let wrapper = presentationController.presentedViewController as? RootContainerViewController {
             wrapper.setOverrideHeaderBarHidden(style == .formSheet, animated: false)
+        }
+
+        guard style == .formSheet else {
+            // Move the settings button back into header bar
+            self.rootContainer?.removeSettingsButtonFromPresentationContainer()
+
+            return
+        }
+
+        // Add settings button into the modal container to make it accessible by user
+        if let transitionCoordinator = transitionCoordinator {
+            transitionCoordinator.animate(alongsideTransition: { (context) in
+                self.rootContainer?.addSettingsButtonToPresentationContainer(context.containerView)
+            }, completion: { (context) in
+                // no-op
+            })
+        } else {
+            if let containerView = presentationController.containerView {
+                self.rootContainer?.addSettingsButtonToPresentationContainer(containerView)
+            } else {
+                logger?.warning("Cannot obtain the containerView for presentation controller when presenting with adaptive style \(style.rawValue) and missing transition coordinator.")
+            }
         }
     }
 }

--- a/ios/MullvadVPN/HeaderBarView.swift
+++ b/ios/MullvadVPN/HeaderBarView.swift
@@ -10,22 +10,30 @@ import Foundation
 import UIKit
 
 class HeaderBarView: UIView {
-    let logoImageView = UIImageView(image: UIImage(named: "LogoIcon"))
+    let logoImageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(named: "LogoIcon"))
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
 
     lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = "MULLVAD VPN"
         titleLabel.font = UIFont.boldSystemFont(ofSize: 24)
         titleLabel.textColor = UIColor.white.withAlphaComponent(0.8)
         return titleLabel
     }()
 
-    lazy var settingsButton: UIButton = {
+    let settingsButton = makeSettingsButton()
+
+    class func makeSettingsButton() -> UIButton {
         let settingsButton = UIButton(type: .custom)
         settingsButton.setImage(UIImage(named: "IconSettings"), for: .normal)
+        settingsButton.translatesAutoresizingMaskIntoConstraints = false
         settingsButton.accessibilityIdentifier = "SettingsButton"
         return settingsButton
-    }()
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -52,10 +60,7 @@ class HeaderBarView: UIView {
             settingsButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor)
         ]
 
-        for view in [logoImageView, titleLabel, settingsButton] {
-            view.translatesAutoresizingMaskIntoConstraints = false
-            addSubview(view)
-        }
+        [logoImageView, titleLabel, settingsButton].forEach { addSubview($0) }
 
         NSLayoutConstraint.activate(constraints)
     }

--- a/ios/MullvadVPN/RootContainerViewController.swift
+++ b/ios/MullvadVPN/RootContainerViewController.swift
@@ -49,6 +49,7 @@ class RootContainerViewController: UIViewController {
 
     private let headerBarView = HeaderBarView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
     private let transitionContainer = UIView(frame: UIScreen.main.bounds)
+    private var presentationContainerSettingsButton: UIButton?
 
     private(set) var headerBarStyle = HeaderBarStyle.default
     private(set) var headerBarHidden = false
@@ -200,6 +201,39 @@ class RootContainerViewController: UIViewController {
     /// Enable or disable the settings bar button displayed in the header bar
     func setEnableSettingsButton(_ isEnabled: Bool) {
         headerBarView.settingsButton.isEnabled = isEnabled
+        presentationContainerSettingsButton?.isEnabled = isEnabled
+    }
+
+    /// Add settings bar button into the presentation container to make settings accessible even
+    /// when the root container is covered with modal.
+    func addSettingsButtonToPresentationContainer(_ presentationContainer: UIView) {
+        let settingsButton: UIButton
+
+        if let transitionViewSettingsButton = presentationContainerSettingsButton {
+            transitionViewSettingsButton.removeFromSuperview()
+            settingsButton = transitionViewSettingsButton
+        } else {
+            settingsButton = HeaderBarView.makeSettingsButton()
+            settingsButton.isEnabled = headerBarView.settingsButton.isEnabled
+            settingsButton.addTarget(self, action: #selector(handleSettingsButtonTap), for: .touchUpInside)
+
+            presentationContainerSettingsButton = settingsButton
+        }
+
+        // Hide the settings button inside the header bar to avoid color blending issues
+        headerBarView.settingsButton.alpha = 0
+
+        presentationContainer.addSubview(settingsButton)
+
+        NSLayoutConstraint.activate([
+            settingsButton.centerXAnchor.constraint(equalTo: headerBarView.settingsButton.centerXAnchor),
+            settingsButton.centerYAnchor.constraint(equalTo: headerBarView.settingsButton.centerYAnchor),
+        ])
+    }
+
+    func removeSettingsButtonFromPresentationContainer() {
+        presentationContainerSettingsButton?.removeFromSuperview()
+        headerBarView.settingsButton.alpha = 1
     }
 
     func setOverrideHeaderBarHidden(_ isHidden: Bool?, animated: Bool) {
@@ -240,11 +274,7 @@ class RootContainerViewController: UIViewController {
         // Prevent automatic layout margins adjustment as we manually control them.
         headerBarView.insetsLayoutMarginsFromSafeArea = false
 
-        headerBarView.settingsButton.addTarget(
-            self,
-            action: #selector(handleSettingsButtonTap),
-            for: .touchUpInside
-        )
+        headerBarView.settingsButton.addTarget(self, action: #selector(handleSettingsButtonTap), for: .touchUpInside)
 
         view.addSubview(headerBarView)
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

When presenting the login controller in form-sheet presentation, the UIKit presents the controller in the middle of the screen and adds semi-transparent overlay beneath it, covering the header bar and settings button, effectively blocking the interaction with it and preventing user from accessing settings.

This PR adds capabilities to duplicate the settings button inside the semi-transparent overlay while in form-sheet presentation and make the settings button appear exactly above the original button inside of header bar, however enabling user interaction since the cloned button is now above the overlay.

Couple of 3D screenshots below explain the idea:

<img width="1119" alt="Screenshot 2021-05-05 at 14 33 18" src="https://user-images.githubusercontent.com/704044/117859506-6042f380-b28f-11eb-810a-1e05ddbd16bd.png">

<img width="833" alt="Screenshot 2021-05-05 at 14 39 53" src="https://user-images.githubusercontent.com/704044/117859554-70f36980-b28f-11eb-8502-ea3bcb5d0e50.png">

(the white rectangle on screenshots, just above the semi-transparent black overlay is actually invisible to the user, however is rendered in UI inspection mode)

Final screenshot:

![Simulator Screen Shot - iPad mini (5th generation) - 2021-05-11 at 19 34 31](https://user-images.githubusercontent.com/704044/117859947-faa33700-b28f-11eb-96ff-2c4f0d4cd82f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2736)
<!-- Reviewable:end -->
