### PR TITLE
iOS 12 fixes for iPad app

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -633,17 +633,22 @@ extension AppDelegate: UIAdaptivePresentationControllerDelegate {
         }
     }
 
-    func presentationController(_ controller: UIPresentationController, viewControllerForAdaptivePresentationStyle style: UIModalPresentationStyle) -> UIViewController? {
-        return nil
-    }
-
     func presentationController(_ presentationController: UIPresentationController, willPresentWithAdaptiveStyle style: UIModalPresentationStyle, transitionCoordinator: UIViewControllerTransitionCoordinator?) {
-        // Force hide header bar in .formSheet presentation and show it in .fullScreen presentation
-        if let wrapper = presentationController.presentedViewController as? RootContainerViewController {
-            wrapper.setOverrideHeaderBarHidden(style == .formSheet, animated: false)
+        let actualStyle: UIModalPresentationStyle
+
+        // When adaptive presentation is not changing, the `style` is set to `.none`
+        if case .none = style {
+            actualStyle = presentationController.presentedViewController.modalPresentationStyle
+        } else {
+            actualStyle = style
         }
 
-        guard style == .formSheet else {
+        // Force hide header bar in .formSheet presentation and show it in .fullScreen presentation
+        if let wrapper = presentationController.presentedViewController as? RootContainerViewController {
+            wrapper.setOverrideHeaderBarHidden(actualStyle == .formSheet, animated: false)
+        }
+
+        guard actualStyle == .formSheet else {
             // Move the settings button back into header bar
             self.rootContainer?.removeSettingsButtonFromPresentationContainer()
 
@@ -661,7 +666,7 @@ extension AppDelegate: UIAdaptivePresentationControllerDelegate {
             if let containerView = presentationController.containerView {
                 self.rootContainer?.addSettingsButtonToPresentationContainer(containerView)
             } else {
-                logger?.warning("Cannot obtain the containerView for presentation controller when presenting with adaptive style \(style.rawValue) and missing transition coordinator.")
+                logger?.warning("Cannot obtain the containerView for presentation controller when presenting with adaptive style \(actualStyle.rawValue) and missing transition coordinator.")
             }
         }
     }

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -295,13 +295,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func makeLoginContainerController() -> RootContainerViewController {
         let rootContainerWrapper = RootContainerViewController()
         rootContainerWrapper.delegate = self
-        rootContainerWrapper.presentationController?.delegate = self
         rootContainerWrapper.preferredContentSize = CGSize(width: 480, height: 600)
 
-        if #available(iOS 13.0, *) {
-            // Prevent swiping off the login or consent controllers
-            rootContainerWrapper.isModalInPresentation = true
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            rootContainerWrapper.modalPresentationStyle = .formSheet
+            if #available(iOS 13.0, *) {
+                // Prevent swiping off the login or consent controllers
+                rootContainerWrapper.isModalInPresentation = true
+            }
         }
+
+        rootContainerWrapper.presentationController?.delegate = self
 
         return rootContainerWrapper
     }
@@ -309,14 +313,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func makeLoginController() -> LoginViewController {
         let controller = LoginViewController()
         controller.delegate = self
-
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            controller.modalPresentationStyle = .formSheet
-            if #available(iOS 13.0, *) {
-                controller.isModalInPresentation = true
-            }
-        }
-
         return controller
     }
 

--- a/ios/MullvadVPN/AutomaticKeyboardResponder.swift
+++ b/ios/MullvadVPN/AutomaticKeyboardResponder.swift
@@ -111,8 +111,24 @@ class AutomaticKeyboardResponder {
     }
 
     private var isFormSheetPresentation: Bool {
-        return UIDevice.current.userInterfaceIdiom == .pad &&
-            parentViewController?.modalPresentationStyle == .formSheet
+        // Form sheet is only supported on iPad
+        guard UIDevice.current.userInterfaceIdiom == .pad else { return false }
+
+        // Find the parent controller holding the view
+        guard let parent = parentViewController else { return false }
+
+        // Determine presentation style within the context
+        let presentationStyle: UIModalPresentationStyle
+
+        // Use the presentation style of a presented controller when parent controller is being presented as a child of
+        // other modal controller.
+        if let presented = parent.presentingViewController?.presentedViewController {
+            presentationStyle = presented.modalPresentationStyle
+        } else {
+            presentationStyle = parent.modalPresentationStyle
+        }
+
+        return presentationStyle == .formSheet
     }
 
     private func adjustContentInsets(keyboardRect: CGRect) {

--- a/ios/MullvadVPN/RootContainerViewController.swift
+++ b/ios/MullvadVPN/RootContainerViewController.swift
@@ -86,6 +86,10 @@ class RootContainerViewController: UIViewController {
         return false
     }
 
+    override var disablesAutomaticKeyboardDismissal: Bool {
+        return topViewController?.disablesAutomaticKeyboardDismissal ?? super.disablesAutomaticKeyboardDismissal
+    }
+
     // MARK: - View lifecycle
 
     override func viewDidLoad() {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- Since login controller is now being wrapped in `RootContainer`, we have to proxy `disablesAutomaticKeyboardDismissal` to the child controllers to make sure that user can dismiss the keyboard when in formsheet presentation on iPad.
- On iOS 12, the adaptive presentation call to `willPresentWithAdaptiveStyle` often receives `.none` as the adaptive presentation style, which means that no change to adaptive presentation should be made and we should carry on with the modal presentation style that was originally set on the presented view controller. This fix attempts to resolve the actual presentation style before deciding how to adapt the presentation. On iOS 13+ this call often receives the actual presentation style (i.e `.formSheet`), which either way should work fine if we handle it in the proposed way.
- On iOS 12, `modalPresentationStyle` is only consulted at the time of presentation delegate assignment. Set `modalPresentationStyle` first to fix that.
- Fix active modal presentation detection in `AutomaticKeyboardResponder` when parent controller is a child of another controller. Consult presenting controller to find the modally presented ascendant up the view controller hierarchy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2745)
<!-- Reviewable:end -->
