### PR TITLE
Set gateway address on WireGuard tunnel routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix failure to create Wintun adapter due to a residual network interface by upgrading Wintun to
   0.10.4.
 - Wait for IP interfaces to be added to the Wintun adapter before setting metrics on them.
+- Prevent Microsoft Store from dropping packets in WireGuard tunnels.
 
 #### Linux
 - Fix find `mullvad-vpn.desktop` in `XDG_DATA_DIRS` instead of using hardcoded path.


### PR DESCRIPTION
Microsoft Store drops packets in the tunnel if the routes have no gateway address set. This can be worked around by setting that address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2748)
<!-- Reviewable:end -->
