### PR TITLE
Remove 'blocking internet' notification shown while (re)connecting

### DIFF
--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -4,13 +4,11 @@ import log from '../../shared/logging';
 import {
   BlockWhenDisconnectedNotificationProvider,
   CloseToAccountExpiryNotificationProvider,
-  ConnectingNotificationProvider,
   ErrorNotificationProvider,
   InAppNotificationProvider,
   InconsistentVersionNotificationProvider,
   NotificationAction,
   NoValidKeyNotificationProvider,
-  ReconnectingNotificationProvider,
   UnsupportedVersionNotificationProvider,
   UpdateAvailableNotificationProvider,
 } from '../../shared/notifications/notification';
@@ -46,8 +44,6 @@ export default function NotificationArea(props: IProps) {
   const wireGuardKey = useSelector((state: IReduxState) => state.settings.wireguardKeyState);
 
   const notificationProviders: InAppNotificationProvider[] = [
-    new ConnectingNotificationProvider({ tunnelState }),
-    new ReconnectingNotificationProvider(tunnelState),
     new BlockWhenDisconnectedNotificationProvider({ tunnelState, blockWhenDisconnected }),
     new ErrorNotificationProvider({ tunnelState, accountExpiry }),
     new NoValidKeyNotificationProvider({ tunnelProtocol, wireGuardKey }),

--- a/gui/src/shared/notifications/connecting.ts
+++ b/gui/src/shared/notifications/connecting.ts
@@ -1,19 +1,14 @@
 import { sprintf } from 'sprintf-js';
 import { messages } from '../../shared/gettext';
 import { TunnelState } from '../daemon-rpc-types';
-import {
-  InAppNotification,
-  InAppNotificationProvider,
-  SystemNotificationProvider,
-} from './notification';
+import { SystemNotificationProvider } from './notification';
 
 interface ConnectingNotificationContext {
   tunnelState: TunnelState;
   reconnecting?: boolean;
 }
 
-export class ConnectingNotificationProvider
-  implements SystemNotificationProvider, InAppNotificationProvider {
+export class ConnectingNotificationProvider implements SystemNotificationProvider {
   public constructor(private context: ConnectingNotificationContext) {}
 
   public mayDisplay() {
@@ -43,11 +38,5 @@ export class ConnectingNotificationProvider
     } else {
       return undefined;
     }
-  }
-
-  public getInAppNotification(): InAppNotification {
-    return {
-      title: messages.pgettext('in-app-notifications', 'BLOCKING INTERNET'),
-    };
   }
 }

--- a/gui/src/shared/notifications/reconnecting.ts
+++ b/gui/src/shared/notifications/reconnecting.ts
@@ -1,13 +1,8 @@
 import { messages } from '../../shared/gettext';
 import { TunnelState } from '../daemon-rpc-types';
-import {
-  InAppNotification,
-  InAppNotificationProvider,
-  SystemNotificationProvider,
-} from './notification';
+import { SystemNotificationProvider } from './notification';
 
-export class ReconnectingNotificationProvider
-  implements SystemNotificationProvider, InAppNotificationProvider {
+export class ReconnectingNotificationProvider implements SystemNotificationProvider {
   public constructor(private context: TunnelState) {}
 
   public mayDisplay() {
@@ -18,12 +13,6 @@ export class ReconnectingNotificationProvider
     return {
       message: messages.pgettext('notifications', 'Reconnecting'),
       critical: false,
-    };
-  }
-
-  public getInAppNotification(): InAppNotification {
-    return {
-      title: messages.pgettext('in-app-notifications', 'BLOCKING INTERNET'),
     };
   }
 }


### PR DESCRIPTION
While connecting, the frontend shows a "blocking internet" notification. This is not necessarily true anymore. While packets outside the tunnel are dropped (except to the relay), traffic in the tunnel is permitted as soon as the tunnel state machine is told that the device is up. This can occur before entering the connected state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2750)
<!-- Reviewable:end -->
