### PR TITLE
Wait for IP interfaces to be attached before setting metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Line wrap the file at 100 chars.                                              Th
 - Prevent tray icons from being extraced to `%TEMP%` directory.
 - Fix failure to create Wintun adapter due to a residual network interface by upgrading Wintun to
   0.10.4.
+- Wait for IP interfaces to be added to the Wintun adapter before setting metrics on them.
 
 #### Linux
 - Fix find `mullvad-vpn.desktop` in `XDG_DATA_DIRS` instead of using hardcoded path.

--- a/talpid-core/src/tunnel/openvpn/windows.rs
+++ b/talpid-core/src/tunnel/openvpn/windows.rs
@@ -14,8 +14,8 @@ use winapi::{
         ifdef::NET_LUID,
         minwindef::{BOOL, FARPROC, HINSTANCE, HMODULE},
         netioapi::{
-            CancelMibChangeNotify2, ConvertInterfaceLuidToGuid, NotifyIpInterfaceChange,
-            MIB_IPINTERFACE_ROW,
+            CancelMibChangeNotify2, ConvertInterfaceLuidToGuid, GetIpInterfaceEntry,
+            NotifyIpInterfaceChange, MIB_IPINTERFACE_ROW,
         },
         ntdef::FALSE,
         winerror::NO_ERROR,
@@ -489,6 +489,19 @@ pub fn notify_ip_interface_change<'a, T: FnMut(&MIB_IPINTERFACE_ROW, u32) + Send
     }
 
     Ok(context)
+}
+
+pub fn get_ip_interface_entry(family: u16, luid: &NET_LUID) -> io::Result<MIB_IPINTERFACE_ROW> {
+    let mut row: MIB_IPINTERFACE_ROW = unsafe { mem::zeroed() };
+    row.Family = family;
+    row.InterfaceLuid = *luid;
+
+    let result = unsafe { GetIpInterfaceEntry(&mut row as *mut _) };
+    if result != NO_ERROR {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(row)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`WinNet_EnsureBestMetric` sometimes fails due to `LUID [...] does not specify any IPv4 or IPv6 interfaces` (`windows/winnet/src/winnet/interfacePair.cpp:25`). The code in this PR waits for the interfaces to attach after creating the tunnel device. If the error continues to occur, it must mean that an incorrect LUID is used for setting the metric (unlikely), or that the interfaces are destroyed at some later point in time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2753)
<!-- Reviewable:end -->
