### PR TITLE
Add ad/tracker blocking settings to desktop app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 - Make app native on Apple Silicon.
 - Add DNS options for ad and tracker blocking to the CLI.
 - Support WireGuard multihop using an entry endpoint constraint.
+- Add DNS options for ad and tracker blocking to the desktop app.
 
 ### Changed
 - Upgrade OpenVPN from 2.5.0 to 2.5.1.

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -714,6 +714,34 @@ msgid "Beta program"
 msgstr ""
 
 msgctxt "preferences-view"
+msgid "Block ads"
+msgstr ""
+
+msgctxt "preferences-view"
+msgid "Block trackers"
+msgstr ""
+
+#. This is displayed when either or both of the block ads/trackers settings are
+#. turned on which makes the custom DNS setting disabled. The text enclosed in "**"
+#. will appear bold.
+#. Available placeholders:
+#. %(blockAdsFeatureName)s - The name displayed next to the "Block ads" toggle.
+#. %(blockTrackersFeatureName)s - The name displayed next to the "Block trackers" toggle.
+#. %(preferencesPageName)s - The page title showed on top in the preferences page.
+msgctxt "preferences-view"
+msgid "Disable **%(blockAdsFeatureName)s** and **%(blockTrackersFeatureName)s** (under %(preferencesPageName)s) to activate this setting."
+msgstr ""
+
+#. This is displayed when the custom DNS setting is turned on which makes the block
+#. ads/trackers settings disabled. The text enclosed in "**" will appear bold.
+#. Advanced settings refer to the name of the page with the title "Advanced".
+#. Available placeholders:
+#. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
+msgctxt "preferences-view"
+msgid "Disable **%(customDnsFeatureName)s** (under Advanced settings) to activate these settings."
+msgstr ""
+
+msgctxt "preferences-view"
 msgid "Enable or disable system notifications. The critical notifications will always be displayed."
 msgstr ""
 

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -449,15 +449,15 @@ export class DaemonRpc {
     const dnsOptions = new grpcTypes.DnsOptions();
 
     const defaultOptions = new grpcTypes.DefaultDnsOptions();
-    defaultOptions.setBlockAds(false);
-    defaultOptions.setBlockTrackers(false);
+    defaultOptions.setBlockAds(dns.defaultOptions.blockAds);
+    defaultOptions.setBlockTrackers(dns.defaultOptions.blockTrackers);
     dnsOptions.setDefaultOptions(defaultOptions);
 
     const customOptions = new grpcTypes.CustomDnsOptions();
-    customOptions.setAddressesList(dns.addresses);
+    customOptions.setAddressesList(dns.customOptions.addresses);
     dnsOptions.setCustomOptions(customOptions);
 
-    if (dns.custom) {
+    if (dns.state === 'custom') {
       dnsOptions.setState(grpcTypes.DnsOptions.DnsState.CUSTOM);
     } else {
       dnsOptions.setState(grpcTypes.DnsOptions.DnsState.DEFAULT);
@@ -1042,8 +1042,17 @@ function convertFromTunnelOptions(tunnelOptions: grpcTypes.TunnelOptions.AsObjec
       enableIpv6: tunnelOptions.generic!.enableIpv6,
     },
     dns: {
-      custom: tunnelOptions.dnsOptions!.state! === grpcTypes.DnsOptions.DnsState.CUSTOM,
-      addresses: tunnelOptions.dnsOptions?.customOptions?.addressesList ?? [],
+      state:
+        tunnelOptions.dnsOptions?.state === grpcTypes.DnsOptions.DnsState.CUSTOM
+          ? 'custom'
+          : 'default',
+      defaultOptions: {
+        blockAds: tunnelOptions.dnsOptions?.defaultOptions?.blockAds ?? false,
+        blockTrackers: tunnelOptions.dnsOptions?.defaultOptions?.blockTrackers ?? false,
+      },
+      customOptions: {
+        addresses: tunnelOptions.dnsOptions?.customOptions?.addressesList ?? [],
+      },
     },
   };
 }

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -152,8 +152,14 @@ class ApplicationMain {
         mtu: undefined,
       },
       dns: {
-        custom: false,
-        addresses: [],
+        state: 'default',
+        defaultOptions: {
+          blockAds: false,
+          blockTrackers: false,
+        },
+        customOptions: {
+          addresses: [],
+        },
       },
     },
   };

--- a/gui/src/renderer/components/PreferencesStyles.tsx
+++ b/gui/src/renderer/components/PreferencesStyles.tsx
@@ -13,6 +13,6 @@ export const StyledContent = styled.div({
   marginBottom: '2px',
 });
 
-export const StyledSeparator = styled.div({
-  height: '1px',
-});
+export const StyledSeparator = styled.div((props: { height?: number }) => ({
+  height: `${props.height ?? 1}px`,
+}));

--- a/gui/src/renderer/containers/PreferencesPage.tsx
+++ b/gui/src/renderer/containers/PreferencesPage.tsx
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router';
+import { IDnsOptions } from '../../shared/daemon-rpc-types';
 import log from '../../shared/logging';
 import consumePromise from '../../shared/promise';
 import Preferences from '../components/Preferences';
@@ -16,6 +17,7 @@ const mapStateToProps = (state: IReduxState) => ({
   monochromaticIcon: state.settings.guiSettings.monochromaticIcon,
   startMinimized: state.settings.guiSettings.startMinimized,
   unpinnedWindow: state.settings.guiSettings.unpinnedWindow,
+  dns: state.settings.dns,
 });
 
 const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps & IAppContext) => {
@@ -50,6 +52,9 @@ const mapDispatchToProps = (_dispatch: ReduxDispatch, props: RouteComponentProps
     },
     setUnpinnedWindow: (unpinnedWindow: boolean) => {
       props.app.setUnpinnedWindow(unpinnedWindow);
+    },
+    setDnsOptions: (dns: IDnsOptions) => {
+      return props.app.setDnsOptions(dns);
     },
   };
 };

--- a/gui/src/renderer/markdown-formatter.tsx
+++ b/gui/src/renderer/markdown-formatter.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const boldSyntax = '**';
+const Bold = styled.span({ fontWeight: 'bold' });
+
+export function formatMarkdown(inputString: string): React.ReactElement {
+  const formattedString = inputString
+    .split(boldSyntax)
+    .map((value, index) =>
+      index % 2 === 0 ? (
+        <React.Fragment key={index}>{value}</React.Fragment>
+      ) : (
+        <Bold key={index}>{value}</Bold>
+      ),
+    );
+
+  return <>{formattedString}</>;
+}

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -6,6 +6,7 @@ import {
   RelayLocation,
   RelayProtocol,
   TunnelProtocol,
+  IDnsOptions,
 } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
 import log from '../../../shared/logging';
@@ -133,10 +134,7 @@ export interface ISettingsReduxState {
   wireguard: {
     mtu?: number;
   };
-  dns: {
-    custom: boolean;
-    addresses: string[];
-  };
+  dns: IDnsOptions;
   wireguardKeyState: WgKeyState;
 }
 
@@ -180,8 +178,14 @@ const initialState: ISettingsReduxState = {
     type: 'key-not-set',
   },
   dns: {
-    custom: false,
-    addresses: [],
+    state: 'default',
+    defaultOptions: {
+      blockAds: false,
+      blockTrackers: false,
+    },
+    customOptions: {
+      addresses: [],
+    },
   },
 };
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -261,8 +261,14 @@ export interface ITunnelOptions {
 }
 
 export interface IDnsOptions {
-  custom: boolean;
-  addresses: string[];
+  state: 'custom' | 'default';
+  customOptions: {
+    addresses: string[];
+  };
+  defaultOptions: {
+    blockAds: boolean;
+    blockTrackers: boolean;
+  };
 }
 
 export type ProxySettings = ILocalProxySettings | IRemoteProxySettings | IShadowsocksProxySettings;


### PR DESCRIPTION
This PR adds the ad and tracker blocking settings to the desktop app. To be able to show bold text in the translations I added support for the markdown syntax for making text bold, and a very simple implementation.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2755)
<!-- Reviewable:end -->
