### PR TITLE
Improve gettext message escaping

### DIFF
--- a/android/translations-converter/src/gettext/msg_string.rs
+++ b/android/translations-converter/src/gettext/msg_string.rs
@@ -17,9 +17,17 @@ impl MsgString {
 
     /// Create a new `MsgString` from string without any escaped characters.
     ///
-    /// This will ensure that the string has the double quotes characters properly escaped.
+    /// This will ensure that the string has common C escape sequences properly created for special
+    /// characters. It will not attempt to escape non-ASCII characters and will just keep them as
+    /// UTF-8 characters.
     pub fn from_unescaped(string: &str) -> Self {
-        MsgString(string.replace(r#"""#, r#"\""#))
+        let string = string.replace(r"\", r"\\");
+        let string = string.replace("\n", r"\n");
+        let string = string.replace("\r", r"\r");
+        let string = string.replace("\t", r"\t");
+        let string = string.replace(r#"""#, r#"\""#);
+
+        MsgString(string)
     }
 
     /// Create a new `MsgString` from string that already has proper escaping.
@@ -56,9 +64,19 @@ mod tests {
 
     #[test]
     fn escaping() {
-        let input = MsgString::from_unescaped(r#""Inside double quotes""#);
+        let input = MsgString::from_unescaped(concat!(
+            r#""Inside double quotes""#,
+            r"'Inside single quotes'",
+            r"Back-slash character: \",
+            "Whitespace characters: \n\r\t",
+        ));
 
-        let expected = r#"\"Inside double quotes\""#;
+        let expected = concat!(
+            r#"\"Inside double quotes\""#,
+            "'Inside single quotes'",
+            r"Back-slash character: \\",
+            r"Whitespace characters: \n\r\t",
+        );
 
         assert_eq!(input.to_string(), expected);
     }

--- a/android/translations-converter/src/normalize.rs
+++ b/android/translations-converter/src/normalize.rs
@@ -75,7 +75,7 @@ mod tests {
         ));
 
         let expected = concat!(
-            "\'Inside single quotes\'",
+            "'Inside single quotes'",
             r#""Inside double quotes""#,
             "With parameters: %d, %s",
         );
@@ -87,14 +87,16 @@ mod tests {
     fn normalize_gettext_msg_string() {
         use crate::gettext::MsgString;
 
-        let input = MsgString::from_unescaped(concat!(
+        let input = MsgString::from_escaped(concat!(
             "'Inside single quotes'",
-            r#""Inside double quotes""#,
+            r"\'Inside escaped single quotes\'",
+            r#"\"Inside double quotes\""#,
             "With parameters: %(number)d, %(string)s",
         ));
 
         let expected = concat!(
-            "\'Inside single quotes\'",
+            "'Inside single quotes'",
+            "'Inside escaped single quotes'",
             r#""Inside double quotes""#,
             "With parameters: %d, %s",
         );

--- a/android/translations-converter/src/normalize.rs
+++ b/android/translations-converter/src/normalize.rs
@@ -39,6 +39,7 @@ mod gettext {
 
     lazy_static! {
         static ref APOSTROPHE_VARIATION: Regex = Regex::new("’").unwrap();
+        static ref ESCAPED_SINGLE_QUOTES: Regex = Regex::new(r"\\'").unwrap();
         static ref ESCAPED_DOUBLE_QUOTES: Regex = Regex::new(r#"\\""#).unwrap();
         static ref PARAMETERS: Regex = Regex::new(r"%\([^)]*\)").unwrap();
     }
@@ -49,6 +50,8 @@ mod gettext {
             let string = APOSTROPHE_VARIATION.replace_all(&*self, "'");
             // Mark where parameters are positioned, removing the parameter name
             let string = PARAMETERS.replace_all(&string, "%");
+            // Remove escaped single-quotes
+            let string = ESCAPED_SINGLE_QUOTES.replace_all(&string, r"'");
             // Remove escaped double-quotes
             let string = ESCAPED_DOUBLE_QUOTES.replace_all(&string, r#"""#);
 


### PR DESCRIPTION
My initial plan for this PR was to implement the full escape sequences supported by gettext to make this future proof, but as I dug into the details I realized that's more complicated than what initially expected. So this PR just improves the escaping to cover "most" cases.

Gettext messages follow the same escape rules as C strings. That leads to some weird situations, because C strings aren't exactly UTF-8, and things can get weird, like `"\x1FF"` is undefined behavior, `'\e'` is not standardized, and `"\u00C1"` can become one or two bytes, depending on the implementation. (Examples taken from [Wikipedia](https://en.wikipedia.org/wiki/Escape_sequences_in_C)).

Therefore, this PR only handles escaping some of the most common character sequences. The PR also improves handling single quotes, because they don't have to be escaped, but can. The `MsgString` therefore stores it as unescaped when escaping, but allows creating an instance where it is escaped and normalization will then remove any escaped single quotes to avoid any issues.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **Internal tool changes, no user visible changes.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2756)
<!-- Reviewable:end -->
