### PR TITLE
REST: handle HTTP 200 and 201 in /v1/create-apple-payment

### DIFF
--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -395,13 +395,17 @@ private extension CreateApplePaymentResponse {
                 formattedTimeAdded ?? ""
             )
         case .restoration:
-            return timeAdded == 0
-                ? NSLocalizedString(
+            switch self {
+            case .noTimeAdded:
+                return NSLocalizedString(
                     "Your previous purchases have already been added to this account.",
                     comment: "")
-                : String(
+            case .timeAdded:
+                return String(
                     format: NSLocalizedString("%@ have been added to your account", comment: ""),
-                    formattedTimeAdded ?? "")
+                    self.formattedTimeAdded ?? ""
+                )
+            }
         }
     }
 }

--- a/ios/MullvadVPN/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager.swift
@@ -257,11 +257,13 @@ class AppStorePaymentManager: NSObject, SKPaymentTransactionObserver {
                 createApplePaymentOperation.addDidFinishBlockObserver { (operation, result) in
                     switch result {
                     case .success(let response):
-                        self.logger.info("AppStore Receipt was processed. Time added: \(response.timeAdded), New expiry: \(response.newExpiry)")
+                        self.logger.info("AppStore receipt was processed. Time added: \(response.timeAdded), New expiry: \(response.newExpiry)")
 
                         completionHandler(.success(response))
 
                     case .failure(let error):
+                        self.logger.error(chainedError: error, message: "Failed to upload the AppStore receipt")
+
                         completionHandler(.failure(.sendReceipt(error)))
                     }
                 }
@@ -270,6 +272,7 @@ class AppStorePaymentManager: NSObject, SKPaymentTransactionObserver {
 
             case .failure(let error):
                 self.logger.error(chainedError: error, message: "Failed to fetch the AppStore receipt")
+
                 completionHandler(.failure(.readReceipt(error)))
             }
         }
@@ -354,8 +357,6 @@ class AppStorePaymentManager: NSObject, SKPaymentTransactionObserver {
                     }
 
                 case .failure(let error):
-                    self.logger.error(chainedError: error, message: "Failed to upload the AppStore receipt")
-
                     self.observerList.forEach { (observer) in
                         observer.appStorePaymentManager(
                             self,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR fixes the regression in REST API handling where `/v1/create-apple-payment` was not properly handling both `200` and `201` responses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2757)
<!-- Reviewable:end -->
