### PR TITLE
REST: handle 200 in POST to v1/wireguard-keys

### DIFF
--- a/ios/MullvadVPN/MullvadRest.swift
+++ b/ios/MullvadVPN/MullvadRest.swift
@@ -514,7 +514,15 @@ extension MullvadRest {
             endpointURL: kRestBaseURL.appendingPathComponent("wireguard-keys"),
             httpMethod: .post,
             responseHandlerFactory: { (input) in
-                return DecodingResponseHandler(expectedStatus: HttpStatus.created)
+                return AnyResponseHandler { (httpResponse, data) -> Result<WireguardAddressesResponse, ResponseHandlerError> in
+                    switch httpResponse.statusCode {
+                    case HttpStatus.ok, HttpStatus.created:
+                        return MullvadRest.decodeSuccessResponse(WireguardAddressesResponse.self, from: data)
+
+                    default:
+                        return .failure(.badResponse(httpResponse.statusCode))
+                    }
+                }
             }
         )
     }


### PR DESCRIPTION

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Although undocumented, the API returns HTTP status `200` in response to `POST v1/wireguard-keys` if the given pubkey is already registered with the server. Since the app is not really interested in such subtle difference, we should just carry on with the returned associated addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2764)
<!-- Reviewable:end -->
