### PR TITLE
Fix split tunneling support for TV-only apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Line wrap the file at 100 chars.                                              Th
   isn't granted to the app. The app will now show the UI to ask for the permission and correctly
   connect after it is granted.
 - Fix quick-settings tile sometimes showing the wrong tunnel state.
+- Fix TV-only apps not appearing in the Split Tunneling screen.
 
 
 ## [2021.3] - 2021-04-28

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProvider.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProvider.kt
@@ -30,7 +30,8 @@ class ApplicationsProvider(
     }
 
     private fun isLaunchable(packageName: String): Boolean {
-        return packageManager.getLaunchIntentForPackage(packageName) != null
+        return packageManager.getLaunchIntentForPackage(packageName) != null ||
+            packageManager.getLeanbackLaunchIntentForPackage(packageName) != null
     }
 
     private fun isSelfApplication(packageName: String): Boolean {


### PR DESCRIPTION
Previously, the Split Tunneling screen wasn't showing TV-only apps, like Netflix or Prime Video. The reason was that since these apps are TV-only, they don't have normal launch intents, and have leanback launch intents instead. The filtering code to determine which apps to show filtered out apps without normal launch intents.

This PR changes the filtering code to only filter out apps that have neither a normal launch intent nor a leanback launch intent.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2772)
<!-- Reviewable:end -->
