### PR TITLE
Use port from URI instead of always using 443 when connecting to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix relay selection failing to pick a WireGuard relay when no tunnel protocol is specified.
 - Fix time left not always being translated in desktop app settings.
+- Fix API address cache to use the supplied ports instead of always using port 443.
 
 #### Windows
 - Prevent tray icons from being extraced to `%TEMP%` directory.


### PR DESCRIPTION
The hostname part of a URI would always be parsed as a socket address, or when that inevitably fails, it'd be parsed into an IP address and then combined with port 443 to be turned into a socket address. URI is actually already properly parsed by hyper, thus the port is already separated and parsed, so that is now used. If a port isn't a part of the specified URI, only then is 443 used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2773)
<!-- Reviewable:end -->
