### PR TITLE
Give Windows more time to init IP interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@ Line wrap the file at 100 chars.                                              Th
 - Prevent tray icons from being extraced to `%TEMP%` directory.
 - Fix failure to create Wintun adapter due to a residual network interface by upgrading Wintun to
   0.10.4.
-- Wait for IP interfaces to be added to the Wintun adapter before setting metrics on them.
+- Wait indefinitely for IP interfaces to attach to the tunnel device to prevent early timeouts,
+  and errors setting interface metrics.
 - Prevent Microsoft Store from dropping packets in WireGuard tunnels.
 
 #### Linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,6 +2524,7 @@ dependencies = [
 name = "talpid-core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "atty",
  "byteorder",
  "cfg-if 1.0.0",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+async-trait = "0.1"
 atty = "0.2"
 cfg-if = "1.0"
 duct = "0.13"

--- a/talpid-core/src/routing/windows.rs
+++ b/talpid-core/src/routing/windows.rs
@@ -98,6 +98,11 @@ impl RouteManager {
         }
     }
 
+    /// Retrieve handle for the tokio runtime.
+    pub fn runtime_handle(&self) -> tokio::runtime::Handle {
+        self.runtime.clone()
+    }
+
     async fn listen(mut manage_rx: UnboundedReceiver<RouteManagerCommand>) {
         while let Some(command) = manage_rx.next().await {
             match command {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -24,6 +24,9 @@ pub mod wireguard;
 /// A module for low level platform specific tunnel device management.
 pub(crate) mod tun_provider;
 
+#[cfg(target_os = "windows")]
+mod windows;
+
 const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
 const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";
 

--- a/talpid-core/src/tunnel/openvpn/windows.rs
+++ b/talpid-core/src/tunnel/openvpn/windows.rs
@@ -4,8 +4,7 @@ use std::{
     os::windows::{ffi::OsStrExt, io::RawHandle},
     path::Path,
     ptr,
-    sync::{Arc, Mutex},
-    time::Duration,
+    sync::Arc,
 };
 use talpid_types::ErrorExt;
 use widestring::{U16CStr, U16CString};
@@ -14,13 +13,8 @@ use winapi::{
         guiddef::GUID,
         ifdef::NET_LUID,
         minwindef::{BOOL, FARPROC, HINSTANCE, HMODULE},
-        netioapi::{
-            CancelMibChangeNotify2, ConvertInterfaceLuidToGuid, GetIpInterfaceEntry,
-            MibAddInstance, NotifyIpInterfaceChange, MIB_IPINTERFACE_ROW,
-        },
-        ntdef::FALSE,
+        netioapi::ConvertInterfaceLuidToGuid,
         winerror::NO_ERROR,
-        ws2def::{AF_INET, AF_INET6, AF_UNSPEC},
     },
     um::{
         libloaderapi::{
@@ -34,8 +28,6 @@ use winreg::{enums::HKEY_LOCAL_MACHINE, RegKey};
 
 /// Longest possible adapter name (in characters), including null terminator
 const MAX_ADAPTER_NAME: usize = 128;
-
-const INTERFACE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 type WintunOpenAdapterFn =
     unsafe extern "stdcall" fn(pool: *const u16, name: *const u16) -> RawHandle;
@@ -142,6 +134,7 @@ impl fmt::Debug for WintunAdapter {
 }
 
 unsafe impl Send for WintunAdapter {}
+unsafe impl Sync for WintunAdapter {}
 
 impl WintunAdapter {
     pub fn open(dll_handle: Arc<WintunDll>, pool: &U16CStr, name: &U16CStr) -> io::Result<Self> {
@@ -406,6 +399,7 @@ pub fn string_from_guid(guid: &GUID) -> String {
     }
 }
 
+/// Returns the registry key for a network device identified by its GUID.
 pub fn find_adapter_registry_key(find_guid: &str, permissions: REGSAM) -> io::Result<RegKey> {
     let net_devs = RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey_with_flags(
         r"SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}",
@@ -431,124 +425,6 @@ pub fn find_adapter_registry_key(find_guid: &str, permissions: REGSAM) -> io::Re
     }
 
     Err(io::Error::new(io::ErrorKind::NotFound, "device not found"))
-}
-
-pub struct IpNotifierHandle<'a> {
-    mutex: Mutex<()>,
-    callback: Option<Box<dyn FnMut(&MIB_IPINTERFACE_ROW, u32) + Send + 'a>>,
-    handle: RawHandle,
-}
-
-impl<'a> Drop for IpNotifierHandle<'a> {
-    fn drop(&mut self) {
-        // Inner callback may be called while destructing
-        unsafe { CancelMibChangeNotify2(self.handle as *mut _) };
-
-        let _ = self
-            .mutex
-            .lock()
-            .expect("NotifyIpInterfaceChange mutex poisoned");
-        let _ = self.callback.take();
-    }
-}
-
-unsafe extern "system" fn inner_callback(
-    context: *mut winapi::ctypes::c_void,
-    row: *mut MIB_IPINTERFACE_ROW,
-    notify_type: u32,
-) {
-    let context = &mut *(context as *mut IpNotifierHandle<'_>);
-    let _ = context
-        .mutex
-        .lock()
-        .expect("NotifyIpInterfaceChange mutex poisoned");
-
-    if let Some(ref mut callback) = context.callback {
-        callback(&*row, notify_type);
-    }
-}
-
-pub fn notify_ip_interface_change<'a, T: FnMut(&MIB_IPINTERFACE_ROW, u32) + Send + 'a>(
-    callback: T,
-    family: u16,
-) -> io::Result<Box<IpNotifierHandle<'a>>> {
-    let mut context = Box::new(IpNotifierHandle {
-        mutex: Mutex::default(),
-        callback: Some(Box::new(callback)),
-        handle: std::ptr::null_mut(),
-    });
-
-    let status = unsafe {
-        NotifyIpInterfaceChange(
-            family,
-            Some(inner_callback),
-            &mut *context as *mut _ as *mut _,
-            FALSE,
-            (&mut context.handle) as *mut _,
-        )
-    };
-
-    if status != NO_ERROR {
-        return Err(io::Error::last_os_error());
-    }
-
-    Ok(context)
-}
-
-pub fn get_ip_interface_entry(family: u16, luid: &NET_LUID) -> io::Result<MIB_IPINTERFACE_ROW> {
-    let mut row: MIB_IPINTERFACE_ROW = unsafe { mem::zeroed() };
-    row.Family = family;
-    row.InterfaceLuid = *luid;
-
-    let result = unsafe { GetIpInterfaceEntry(&mut row as *mut _) };
-    if result != NO_ERROR {
-        return Err(io::Error::last_os_error());
-    }
-
-    Ok(row)
-}
-
-pub fn wait_for_interfaces(luid: &NET_LUID, ipv4: bool, ipv6: bool) -> io::Result<()> {
-    let (tx, rx) = std::sync::mpsc::channel();
-
-    let mut found_ipv4 = if ipv4 { false } else { true };
-    let mut found_ipv6 = if ipv6 { false } else { true };
-
-    let _handle = notify_ip_interface_change(
-        move |row, notification_type| {
-            if found_ipv4 && found_ipv6 {
-                return;
-            }
-            if notification_type != MibAddInstance {
-                return;
-            }
-            if row.InterfaceLuid.Value != luid.Value {
-                return;
-            }
-            match row.Family as i32 {
-                AF_INET => found_ipv4 = true,
-                AF_INET6 => found_ipv6 = true,
-                _ => (),
-            }
-            if found_ipv4 && found_ipv6 {
-                let _ = tx.send(());
-            }
-        },
-        AF_UNSPEC as u16,
-    )?;
-
-    // Make sure they don't already exist
-    if (!ipv4 || get_ip_interface_entry(AF_INET as u16, luid).is_ok())
-        && (!ipv6 || get_ip_interface_entry(AF_INET6 as u16, luid).is_ok())
-    {
-        return Ok(());
-    }
-
-    let _ = rx
-        .recv_timeout(INTERFACE_WAIT_TIMEOUT)
-        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "timed out waiting on interfaces"))?;
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/talpid-core/src/tunnel/windows.rs
+++ b/talpid-core/src/tunnel/windows.rs
@@ -1,0 +1,133 @@
+use std::{io, mem, os::windows::io::RawHandle, sync::Mutex};
+use winapi::shared::{
+    ifdef::NET_LUID,
+    netioapi::{
+        CancelMibChangeNotify2, GetIpInterfaceEntry, MibAddInstance, NotifyIpInterfaceChange,
+        MIB_IPINTERFACE_ROW,
+    },
+    ntdef::FALSE,
+    winerror::{ERROR_NOT_FOUND, NO_ERROR},
+    ws2def::{AF_INET, AF_INET6, AF_UNSPEC},
+};
+
+/// Context for [`notify_ip_interface_change`]. When it is dropped,
+/// the callback is unregistered.
+pub struct IpNotifierHandle<'a> {
+    callback: Mutex<Box<dyn FnMut(&MIB_IPINTERFACE_ROW, u32) + Send + 'a>>,
+    handle: RawHandle,
+}
+
+unsafe impl Send for IpNotifierHandle<'_> {}
+
+impl<'a> Drop for IpNotifierHandle<'a> {
+    fn drop(&mut self) {
+        unsafe { CancelMibChangeNotify2(self.handle as *mut _) };
+    }
+}
+
+unsafe extern "system" fn inner_callback(
+    context: *mut winapi::ctypes::c_void,
+    row: *mut MIB_IPINTERFACE_ROW,
+    notify_type: u32,
+) {
+    let context = &mut *(context as *mut IpNotifierHandle<'_>);
+    context
+        .callback
+        .lock()
+        .expect("NotifyIpInterfaceChange mutex poisoned")(&*row, notify_type);
+}
+
+/// Registers a callback function that is invoked when an interface is added, removed,
+/// or changed.
+pub fn notify_ip_interface_change<'a, T: FnMut(&MIB_IPINTERFACE_ROW, u32) + Send + 'a>(
+    callback: T,
+    family: u16,
+) -> io::Result<Box<IpNotifierHandle<'a>>> {
+    let mut context = Box::new(IpNotifierHandle {
+        callback: Mutex::new(Box::new(callback)),
+        handle: std::ptr::null_mut(),
+    });
+
+    let status = unsafe {
+        NotifyIpInterfaceChange(
+            family,
+            Some(inner_callback),
+            &mut *context as *mut _ as *mut _,
+            FALSE,
+            (&mut context.handle) as *mut _,
+        )
+    };
+
+    if status == NO_ERROR {
+        Ok(context)
+    } else {
+        Err(io::Error::from_raw_os_error(status as i32))
+    }
+}
+
+/// Returns information about a network IP interface.
+pub fn get_ip_interface_entry(family: u16, luid: &NET_LUID) -> io::Result<MIB_IPINTERFACE_ROW> {
+    let mut row: MIB_IPINTERFACE_ROW = unsafe { mem::zeroed() };
+    row.Family = family;
+    row.InterfaceLuid = *luid;
+
+    let result = unsafe { GetIpInterfaceEntry(&mut row as *mut _) };
+    if result == NO_ERROR {
+        Ok(row)
+    } else {
+        Err(io::Error::from_raw_os_error(result as i32))
+    }
+}
+
+fn ip_interface_entry_exists(family: u16, luid: &NET_LUID) -> io::Result<bool> {
+    match get_ip_interface_entry(family, luid) {
+        Ok(_) => Ok(true),
+        Err(error) if error.raw_os_error() == Some(ERROR_NOT_FOUND as i32) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+/// Waits until the specified IP interfaces have attached to a given network interface.
+pub async fn wait_for_interfaces(luid: NET_LUID, ipv4: bool, ipv6: bool) -> io::Result<()> {
+    let (tx, rx) = futures::channel::oneshot::channel();
+
+    let mut found_ipv4 = if ipv4 { false } else { true };
+    let mut found_ipv6 = if ipv6 { false } else { true };
+
+    let mut tx = Some(tx);
+
+    let _handle = notify_ip_interface_change(
+        move |row, notification_type| {
+            if found_ipv4 && found_ipv6 {
+                return;
+            }
+            if notification_type != MibAddInstance {
+                return;
+            }
+            if row.InterfaceLuid.Value != luid.Value {
+                return;
+            }
+            match row.Family as i32 {
+                AF_INET => found_ipv4 = true,
+                AF_INET6 => found_ipv6 = true,
+                _ => (),
+            }
+            if found_ipv4 && found_ipv6 {
+                if let Some(tx) = tx.take() {
+                    let _ = tx.send(());
+                }
+            }
+        },
+        AF_UNSPEC as u16,
+    )?;
+
+    // Make sure they don't already exist
+    if (!ipv4 || ip_interface_entry_exists(AF_INET as u16, &luid)?)
+        && (!ipv6 || ip_interface_entry_exists(AF_INET6 as u16, &luid)?)
+    {
+        return Ok(());
+    }
+
+    let _ = rx.await;
+    Ok(())
+}

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -524,6 +524,11 @@ mod test {
             "mock-tunnel".to_string()
         }
 
+        #[cfg(windows)]
+        fn get_interface_luid(&self) -> u64 {
+            0
+        }
+
         fn stop(self: Box<Self>) -> Result<(), TunnelError> {
             Ok(())
         }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -167,6 +167,15 @@ impl ConnectingState {
                     log::debug!("WireGuard tunnel timed out");
                     None
                 }
+                error @ tunnel::Error::WireguardTunnelMonitoringError(..)
+                    if !should_retry(&error) =>
+                {
+                    error!(
+                        "{}",
+                        error.display_chain_with_msg("Tunnel has stopped unexpectedly")
+                    );
+                    Some(ErrorStateCause::StartTunnelError)
+                }
                 error => {
                     warn!(
                         "{}",


### PR DESCRIPTION
Previously, the daemon had a five-second timeout for waiting on the `MibAddInstance` event (i.e., for IP interfaces to attach to the tunnel device) after setting up a new Wintun device. Early after a reboot, this can take considerably more time to occur on some machines (30 seconds or more), causing some machines to get stuck in the error state, especially with auto-connect enabled.

The previous code blocked the tunnel state machine, so it had to time out quickly. To extend/remove the timeout, the tunnel monitors were updated to do this asynchronously/on a separate thread. The blocking code was also removed from `libwg` and now uses the same code as the openvpn tunnel monitor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2778)
<!-- Reviewable:end -->
