### PR TITLE
Fix empty account history error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix relay selection failing to pick a WireGuard relay when no tunnel protocol is specified.
 - Fix time left not always being translated in desktop app settings.
 - Fix API address cache to use the supplied ports instead of always using port 443.
+- Do not try to parse an empty account history.
 
 #### Windows
 - Prevent tray icons from being extraced to `%TEMP%` directory.


### PR DESCRIPTION
Previously, starting the daemon with a non-existent account history file resulted in the following error:

```
[2021-06-01 17:21:53.771][mullvad_daemon::account_history][WARN] Error: Failed to read+deserialize account history
Caused by: EOF while parsing a value at line 1 column 0
```

This was because it tried to parse newly created history files. The error is pretty harmless as it is ignored, though.

This PR fixes it by not trying to parse a newly created history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2780)
<!-- Reviewable:end -->
