### PR TITLE
Add workaround for closing context menus on macOS 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Line wrap the file at 100 chars.                                              Th
 #### MacOS
 - Set correct permissions for daemon's launch file in installer.
 - Fix downgrades on macOS silently keeping previous version.
+- Fix other menubar context menus not always closing when opening app on macOS 11.
 
 #### Android
 - Fix UI sometimes not updating correctly while no split screen or after having a dialog from

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   shell,
   Tray,
 } from 'electron';
+import os from 'os';
 import * as path from 'path';
 import { sprintf } from 'sprintf-js';
 import * as uuid from 'uuid';
@@ -1764,7 +1765,19 @@ class ApplicationMain {
       }
       this.tray?.on('click', () => this.windowController?.show());
     } else {
-      this.tray?.on('click', () => this.windowController?.toggle());
+      this.tray?.on('click', () => {
+        const isMacOsBigSur = process.platform === 'darwin' && parseInt(os.release(), 10) >= 20;
+        if (isMacOsBigSur && !this.windowController?.isVisible()) {
+          // This is a workaround for this Electron issue, when it's resolved
+          // `this.windowController?.toggle()` should do the trick on all platforms:
+          // https://github.com/electron/electron/issues/28776
+          const contextMenu = Menu.buildFromTemplate([]);
+          contextMenu.on('menu-will-show', () => this.windowController?.show());
+          this.tray?.popUpContextMenu(contextMenu);
+        } else {
+          this.windowController?.toggle();
+        }
+      });
       this.tray?.on('right-click', () => this.windowController?.hide());
     }
   }


### PR DESCRIPTION
This PR adds a workaround for [this Electron issue](https://github.com/electron/electron/issues/28776) which causes other menubar context menus to remain open after opening our app.

This solution doesn't allow VoiceOver to focus the window properly but VoiceOver didn't work when the other context menus were ontop of our window either. VoiceOver still works as expected if the window is opened by launching the app when already running from the dock, spotlight or other methods.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2781)
<!-- Reviewable:end -->
