### PR TITLE
Fix small into-tunnel leak window for excluded apps

### DIFF
--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -177,8 +177,6 @@ impl WireguardMonitor {
         #[cfg(windows)]
         let iface_luid = tunnel.get_interface_luid();
 
-        (on_event)(TunnelEvent::InterfaceUp(iface_name.clone()));
-
         #[cfg(target_os = "windows")]
         let callback_handle = route_manager
             .add_default_route_callback(Some(WgGoTunnel::default_route_changed_callback), ())
@@ -206,7 +204,6 @@ impl WireguardMonitor {
             _callback_handle: callback_handle,
         };
 
-        let metadata = Self::tunnel_metadata(&iface_name, &config);
         let gateway = config.ipv4_gateway;
         let close_sender = monitor.close_msg_sender.clone();
         let mut connectivity_monitor = connectivity_check::ConnectivityMonitor::new(
@@ -221,7 +218,11 @@ impl WireguardMonitor {
         #[cfg(windows)]
         let runtime = route_manager.runtime_handle();
 
+        let metadata = Self::tunnel_metadata(&iface_name, &config);
+
         std::thread::spawn(move || {
+            (on_event)(TunnelEvent::InterfaceUp(metadata.clone()));
+
             #[cfg(windows)]
             {
                 let iface_close_sender = close_sender.clone();

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -307,28 +307,6 @@ impl TunnelState for ConnectedState {
         let connected_state = ConnectedState::from(bootstrap);
         let tunnel_endpoint = connected_state.tunnel_parameters.get_tunnel_endpoint();
 
-        #[cfg(target_os = "windows")]
-        if let Err(error) = shared_values
-            .split_tunnel
-            .set_tunnel_addresses(Some(&connected_state.metadata))
-        {
-            log::error!(
-                "{}",
-                error.display_chain_with_msg(
-                    "Failed to register addresses with split tunnel driver"
-                )
-            );
-
-            return DisconnectingState::enter(
-                shared_values,
-                (
-                    connected_state.close_handle,
-                    connected_state.tunnel_close_event,
-                    AfterDisconnect::Block(ErrorStateCause::SplitTunnelError),
-                ),
-            );
-        }
-
         if let Err(error) = connected_state.set_firewall_policy(shared_values) {
             DisconnectingState::enter(
                 shared_values,

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -323,7 +323,7 @@ impl TunnelState for ConnectedState {
                 (
                     connected_state.close_handle,
                     connected_state.tunnel_close_event,
-                    AfterDisconnect::Block(ErrorStateCause::StartTunnelError),
+                    AfterDisconnect::Block(ErrorStateCause::SplitTunnelError),
                 ),
             );
         }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -446,7 +446,7 @@ impl TunnelState for ConnectingState {
                         )
                     );
 
-                    return ErrorState::enter(shared_values, ErrorStateCause::StartTunnelError);
+                    return ErrorState::enter(shared_values, ErrorStateCause::SplitTunnelError);
                 }
 
                 if let Err(error) =

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -20,6 +20,7 @@ use log::{debug, error, info, trace, warn};
 use std::{
     net::IpAddr,
     path::{Path, PathBuf},
+    sync::mpsc as sync_mpsc,
     thread,
     time::{Duration, Instant},
 };
@@ -47,7 +48,7 @@ const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
 pub struct ConnectingState {
     tunnel_events: TunnelEventsReceiver,
     tunnel_parameters: TunnelParameters,
-    tunnel_interface: Option<String>,
+    tunnel_metadata: Option<TunnelMetadata>,
     tunnel_close_event: TunnelCloseEvent,
     close_handle: Option<CloseHandle>,
     retry_attempt: u32,
@@ -57,7 +58,7 @@ impl ConnectingState {
     fn set_firewall_policy(
         shared_values: &mut SharedTunnelStateValues,
         params: &TunnelParameters,
-        tunnel_interface: &Option<String>,
+        tunnel_metadata: &Option<TunnelMetadata>,
     ) -> Result<(), FirewallPolicyError> {
         #[cfg(target_os = "linux")]
         shared_values.disable_connectivity_check();
@@ -66,7 +67,9 @@ impl ConnectingState {
 
         let policy = FirewallPolicy::Connecting {
             peer_endpoint,
-            tunnel_interface: tunnel_interface.clone(),
+            tunnel_interface: tunnel_metadata
+                .as_ref()
+                .map(|metadata| metadata.interface.clone()),
             pingable_hosts: gateway_list_from_params(params),
             allow_lan: shared_values.allow_lan,
             allowed_endpoint: shared_values.allowed_endpoint.clone(),
@@ -102,7 +105,14 @@ impl ConnectingState {
     ) -> crate::tunnel::Result<Self> {
         let (event_tx, event_rx) = mpsc::unbounded();
         let on_tunnel_event = move |event| {
-            let _ = event_tx.unbounded_send(event);
+            let (tx, rx) = sync_mpsc::channel();
+            let _ = event_tx.unbounded_send((event, tx));
+            match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+                Err(sync_mpsc::RecvTimeoutError::Timeout) => {
+                    log::error!("Tunnel event callback timeout");
+                }
+                _ => (),
+            }
         };
 
         let monitor = TunnelMonitor::start(
@@ -120,7 +130,7 @@ impl ConnectingState {
         Ok(ConnectingState {
             tunnel_events: event_rx.fuse(),
             tunnel_parameters: parameters,
-            tunnel_interface: None,
+            tunnel_metadata: None,
             tunnel_close_event,
             close_handle,
             retry_attempt,
@@ -238,7 +248,7 @@ impl ConnectingState {
                     match Self::set_firewall_policy(
                         shared_values,
                         &self.tunnel_parameters,
-                        &self.tunnel_interface,
+                        &self.tunnel_metadata,
                     ) {
                         Ok(()) => {
                             cfg_if! {
@@ -261,7 +271,7 @@ impl ConnectingState {
                     if let Err(error) = Self::set_firewall_policy(
                         shared_values,
                         &self.tunnel_parameters,
-                        &self.tunnel_interface,
+                        &self.tunnel_metadata,
                     ) {
                         return self.disconnect(
                             shared_values,
@@ -319,22 +329,22 @@ impl ConnectingState {
 
     fn handle_tunnel_events(
         mut self,
-        event: Option<tunnel::TunnelEvent>,
+        event: Option<(tunnel::TunnelEvent, sync_mpsc::Sender<()>)>,
         shared_values: &mut SharedTunnelStateValues,
     ) -> EventConsequence {
         use self::EventConsequence::*;
 
         match event {
-            Some(TunnelEvent::AuthFailed(reason)) => self.disconnect(
+            Some((TunnelEvent::AuthFailed(reason), _)) => self.disconnect(
                 shared_values,
                 AfterDisconnect::Block(ErrorStateCause::AuthFailed(reason)),
             ),
-            Some(TunnelEvent::InterfaceUp(interface)) => {
-                self.tunnel_interface = Some(interface);
+            Some((TunnelEvent::InterfaceUp(metadata), _done_tx)) => {
+                self.tunnel_metadata = Some(metadata);
                 match Self::set_firewall_policy(
                     shared_values,
                     &self.tunnel_parameters,
-                    &self.tunnel_interface,
+                    &self.tunnel_metadata,
                 ) {
                     Ok(()) => SameState(self.into()),
                     Err(error) => self.disconnect(
@@ -343,11 +353,11 @@ impl ConnectingState {
                     ),
                 }
             }
-            Some(TunnelEvent::Up(metadata)) => NewState(ConnectedState::enter(
+            Some((TunnelEvent::Up(metadata), _)) => NewState(ConnectedState::enter(
                 shared_values,
                 self.into_connected_state_bootstrap(metadata),
             )),
-            Some(TunnelEvent::Down) => SameState(self.into()),
+            Some((TunnelEvent::Down, _)) => SameState(self.into()),
             None => {
                 // The channel was closed
                 debug!("The tunnel disconnected unexpectedly");

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -200,7 +200,7 @@ type TunnelCommandReceiver = stream::Fuse<mpsc::UnboundedReceiver<TunnelCommand>
 
 enum EventResult {
     Command(Option<TunnelCommand>),
-    Event(Option<TunnelEvent>),
+    Event(Option<(TunnelEvent, sync_mpsc::Sender<()>)>),
     Close(Result<Option<ErrorStateCause>, oneshot::Canceled>),
 }
 

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -35,7 +35,6 @@ pub enum Error {
 /// events.
 pub static INTERESTING_EVENTS: &'static [EventType] = &[
     EventType::AuthFailed,
-    #[cfg(target_os = "linux")]
     EventType::Up,
     EventType::RouteUp,
     EventType::RoutePredown,


### PR DESCRIPTION
Previously, the driver was not given the IP address of the tunnel interface until it had reached the `Connected` state. This is usually fine: All TCP connections where the destination addresses is a public IP address are redirected to the specified non-tunnel interface. Also, non-TCP (eg UDP) sockets that are bound to 0.0.0.0 (or implicitly bound) are rebound correctly. UDP sockets that were explicitly bound to the tunnel interface could still communicate inside the tunnel, though.

This PR addresses this by registering tunnel address with the driver in the `InterfaceUp`  tunnel event, before routes are set up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2785)
<!-- Reviewable:end -->
