### PR TITLE
Make linux offline monitor aware of routing table changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - Fix find `mullvad-vpn.desktop` in `XDG_DATA_DIRS` instead of using hardcoded path.
+- Make offline monitor aware of routing table changes.
 
 #### MacOS
 - Set correct permissions for daemon's launch file in installer.

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -8,7 +8,7 @@ use netlink_packet_route::{
     rtnl::route::nlas::Nla as RouteNla, NetlinkMessage, RouteFlags, RouteMessage, RtnlMessage,
 };
 use rtnetlink::{
-    constants::{RTMGRP_IPV4_IFADDR, RTMGRP_IPV6_IFADDR, RTMGRP_LINK, RTMGRP_NOTIFY},
+    constants::{RTMGRP_IPV4_IFADDR, RTMGRP_IPV4_ROUTE, RTMGRP_IPV6_IFADDR, RTMGRP_IPV6_ROUTE, RTMGRP_LINK, RTMGRP_NOTIFY},
     sys::SocketAddr,
     Handle, IpVersion,
 };
@@ -82,7 +82,7 @@ pub async fn spawn_monitor(sender: Weak<UnboundedSender<TunnelCommand>>) -> Resu
     let (mut connection, handle, mut messages) =
         rtnetlink::new_connection().map_err(Error::NetlinkConnectionError)?;
 
-    let mgroup_flags = RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR | RTMGRP_LINK | RTMGRP_NOTIFY;
+    let mgroup_flags = RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_IFADDR | RTMGRP_IPV6_ROUTE | RTMGRP_LINK | RTMGRP_NOTIFY;
     let addr = SocketAddr::new(0, mgroup_flags);
 
     connection
@@ -187,7 +187,7 @@ pub fn execute_route_get_request(
 mod test {
     use super::*;
     use rtnetlink::{
-        constants::{RTMGRP_IPV4_IFADDR, RTMGRP_IPV6_IFADDR, RTMGRP_LINK, RTMGRP_NOTIFY},
+        constants::{RTMGRP_IPV4_IFADDR, RTMGRP_IPV4_ROUTE, RTMGRP_IPV6_IFADDR, RTMGRP_IPV6_ROUTE, RTMGRP_LINK, RTMGRP_NOTIFY},
         sys::SocketAddr,
     };
 
@@ -200,7 +200,7 @@ mod test {
                 .expect("Failed to create a netlink connection")
         });
 
-        let mgroup_flags = RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR | RTMGRP_LINK | RTMGRP_NOTIFY;
+        let mgroup_flags = RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_IFADDR | RTMGRP_IPV6_ROUTE | RTMGRP_LINK | RTMGRP_NOTIFY;
         let addr = SocketAddr::new(0, mgroup_flags);
 
         connection.socket_mut().bind(&addr).unwrap();


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

This change causes the Linux offline monitor to evaluate the offline status in response to more events, namely routing table changes. This is necessary due to how the offline monitor currently responds to a suspend/resume cycle. On the affected system (Arch Linux using systemd-networkd), before suspending, the network connection is disabled which causes the offline monitor to go into a blocked state. When resuming, the network connection is restored, and the routing table recreated, which should cause the offline monitor to reevaluate the offline status and unblock. Before this change, the offline monitor does not receive these events and remains blocked.

Specifically, this PR adds `RTMGRP_IPV4_ROUTE` and `RTMGRP_IPV6_ROUTE` to the events that trigger an offline status check. I also added the flags to the test, even though it's only checking for the presence of a route. I'm not sure how this change could be tested without making changes to the routing table in the test environment.

Fixes #2744

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2791)
<!-- Reviewable:end -->
