### PR TITLE
Fix broken prepare_release.sh. Don't pass args to env.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -242,7 +242,7 @@ function buildTargets() {
             build "$t"
         done
     else
-        source env.sh
+        source env.sh ""
         build
     fi
 }

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -57,7 +57,7 @@ echo "Updating version in metadata files..."
 ./version-metadata.sh inject $PRODUCT_VERSION $VERSION_METADATA_ARGS
 
 echo "Syncing Cargo.lock with new version numbers"
-source env.sh
+source env.sh ""
 # If cargo exits with a non zero exit status and it's not a timeout (exit code 124) it's an error
 set +e
 timeout 5s cargo +stable build


### PR DESCRIPTION
Just doing `source env.sh` automatically passes all command line arguments from the parent script down to `env.sh`. This does not work as `env.sh` expects the target as the first argument, which is not what we have as arguments to `prepare_release.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2792)
<!-- Reviewable:end -->
