### PR TITLE
Fix issue of daemon not restarting when "fast startup" is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Line wrap the file at 100 chars.                                              Th
 - Make offline monitor aware of routing table changes.
 - Assign local DNS servers to more appropriate interfaces when using systemd-resolved.
 
+#### Windows
+- Fix failure to restart the daemon when resuming from "fast startup" hibernation.
+
 
 ## [2021.4-beta1] - 2021-06-09
 This release is for desktop only.

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub log_stdout_timestamps: bool,
     pub run_as_service: bool,
     pub register_service: bool,
+    pub restart_service: bool,
 }
 
 pub fn get_config() -> &'static Config {
@@ -32,6 +33,7 @@ pub fn create_config() -> Config {
 
     let run_as_service = cfg!(windows) && matches.is_present("run_as_service");
     let register_service = cfg!(windows) && matches.is_present("register_service");
+    let restart_service = cfg!(windows) && matches.is_present("restart_service");
 
     Config {
         log_level,
@@ -39,6 +41,7 @@ pub fn create_config() -> Config {
         log_stdout_timestamps,
         run_as_service,
         register_service,
+        restart_service,
     }
 }
 
@@ -91,10 +94,16 @@ fn create_app() -> App<'static, 'static> {
             Arg::with_name("run_as_service")
                 .long("run-as-service")
                 .help("Run as a system service. On Windows this option must be used when running a system service"),
-        ).arg(
+        )
+        .arg(
             Arg::with_name("register_service")
                 .long("register-service")
                 .help("Register itself as a system service"),
+        )
+        .arg(
+            Arg::with_name("restart_service")
+                .long("restart-service")
+                .help("Restarts the existing system service"),
         )
     }
     app

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -75,6 +75,12 @@ fn get_log_dir(config: &cli::Config) -> Result<Option<PathBuf>, String> {
 async fn run_platform(config: &cli::Config, log_dir: Option<PathBuf>) -> Result<(), String> {
     if config.run_as_service {
         system_service::run()
+    } else if config.restart_service {
+        let restart_result = system_service::restart_service().map_err(|e| e.display_chain());
+        if restart_result.is_ok() {
+            log::info!("Restarted the service.");
+        }
+        restart_result
     } else {
         if config.register_service {
             let install_result = system_service::install_service().map_err(|e| e.display_chain());

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -521,7 +521,10 @@ impl HibernationDetector {
             .parent()
             .ok_or("Failed to obtain resource directory".to_string())?
             .to_path_buf();
-        let args = vec!["--restart-service".to_string()];
+        let args = vec![
+            "--restart-service".to_string(),
+            "--disable-log-to-file".to_string(),
+        ];
         duct::cmd(daemon_path, args)
             .dir(working_dir)
             .stdin_null()


### PR DESCRIPTION
Sometimes, e.g. when `openvpn.exe` cannot be killed gracefully, it can take around 30 seconds to stop the service. `net stop mullvadvpn`, which was used to restart the service after resuming from "hibernation", has a timeout that is approximately 30 seconds as well, so it sometimes fails before the daemon has stopped. Rather than relying on `cmd /c "net stop mullvadvpn & net start mullvadvpn"`, a `--restart-service` option was added, and `mullvad-daemon --restart-service` is run instead. This has a timeout of two minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2793)
<!-- Reviewable:end -->
