### PR TITLE
Kill openvpn correctly early on

### DIFF
--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -770,6 +770,7 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
         };
 
         if self.closed.load(Ordering::SeqCst) {
+            let _ = child.kill();
             return WaitResult::Preparation(Ok(()));
         }
 


### PR DESCRIPTION
The daemon closes OpenVPN by dropping a handle. OpenVPN spawns a thread that waits for this to occur, and sets a "signal" variable when it does: https://github.com/mullvad/openvpn/blob/f38b92ee84af4d3581307c3b0f13591a52c1ca3c/src/openvpn/openvpn.c#L144. Sometimes this may occur before that variable is cleared, though, causing the released handle to be ignored.

This PR works around the issue. The changes can be reverted once the patch has been fixed and OpenVPN rebuilt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2794)
<!-- Reviewable:end -->
