### PR TITLE
Improve OpenVPN event handling

### DIFF
--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -112,7 +112,11 @@ impl TunnelMonitor {
         route_manager: &mut RouteManager,
     ) -> Result<Self>
     where
-        L: Fn(TunnelEvent) + Send + Clone + Sync + 'static,
+        L: (Fn(TunnelEvent) -> Box<dyn std::future::Future<Output = ()> + Unpin + Send>)
+            + Send
+            + Clone
+            + Sync
+            + 'static,
     {
         Self::ensure_ipv6_can_be_used_if_enabled(&tunnel_parameters)?;
         let log_file = Self::prepare_tunnel_log_file(&tunnel_parameters, log_dir)?;
@@ -165,7 +169,11 @@ impl TunnelMonitor {
         route_manager: &mut RouteManager,
     ) -> Result<Self>
     where
-        L: Fn(TunnelEvent) + Send + Sync + Clone + 'static,
+        L: (Fn(TunnelEvent) -> Box<dyn std::future::Future<Output = ()> + Unpin + Send>)
+            + Send
+            + Sync
+            + Clone
+            + 'static,
     {
         let config = wireguard::config::Config::from_parameters(&params)?;
         let monitor = wireguard::WireguardMonitor::start(
@@ -190,7 +198,10 @@ impl TunnelMonitor {
         route_manager: &mut RouteManager,
     ) -> Result<Self>
     where
-        L: Fn(TunnelEvent) + Send + Sync + 'static,
+        L: (Fn(TunnelEvent) -> Box<dyn std::future::Future<Output = ()> + Unpin + Send>)
+            + Send
+            + Sync
+            + 'static,
     {
         let monitor =
             openvpn::OpenVpnMonitor::start(on_event, config, log, resource_dir, route_manager)?;

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -1,7 +1,5 @@
 use self::tun_provider::TunProvider;
 use crate::{logging, routing::RouteManager};
-#[cfg(not(target_os = "android"))]
-use std::collections::HashMap;
 use std::{
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -94,54 +92,6 @@ pub struct TunnelMetadata {
     pub ipv6_gateway: Option<Ipv6Addr>,
 }
 
-#[cfg(not(target_os = "android"))]
-impl TunnelEvent {
-    /// Converts an `openvpn_plugin::EventType` to a `TunnelEvent`.
-    /// Returns `None` if there is no corresponding `TunnelEvent`.
-    fn from_openvpn_event(
-        event: openvpn_plugin::EventType,
-        env: &HashMap<String, String>,
-    ) -> Option<TunnelEvent> {
-        match event {
-            openvpn_plugin::EventType::AuthFailed => {
-                let reason = env.get("auth_failed_reason").cloned();
-                Some(TunnelEvent::AuthFailed(reason))
-            }
-            openvpn_plugin::EventType::RouteUp => {
-                let interface = env
-                    .get("dev")
-                    .expect("No \"dev\" in tunnel up event")
-                    .to_owned();
-                let mut ips = vec![env
-                    .get("ifconfig_local")
-                    .expect("No \"ifconfig_local\" in tunnel up event")
-                    .parse()
-                    .expect("Tunnel IP not in valid format")];
-                if let Some(ipv6_address) = env.get("ifconfig_ipv6_local") {
-                    ips.push(ipv6_address.parse().expect("Tunnel IP not in valid format"));
-                }
-                let ipv4_gateway = env
-                    .get("route_vpn_gateway")
-                    .expect("No \"route_vpn_gateway\" in tunnel up event")
-                    .parse()
-                    .expect("Tunnel gateway IP not in valid format");
-                let ipv6_gateway = env.get("route_ipv6_gateway_1").map(|v6_str| {
-                    v6_str
-                        .parse()
-                        .expect("V6 Tunnel gateway IP not in valid format")
-                });
-                Some(TunnelEvent::Up(TunnelMetadata {
-                    interface,
-                    ips,
-                    ipv4_gateway,
-                    ipv6_gateway,
-                }))
-            }
-            openvpn_plugin::EventType::RoutePredown => Some(TunnelEvent::Down),
-            _ => None,
-        }
-    }
-}
 /// Abstraction for monitoring a generic VPN tunnel.
 pub struct TunnelMonitor {
     monitor: InternalTunnelMonitor,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -99,9 +99,11 @@ impl ConnectingState {
         retry_attempt: u32,
     ) -> crate::tunnel::Result<Self> {
         let (event_tx, event_rx) = mpsc::unbounded();
-        let on_tunnel_event = move |event| {
-            let _ = event_tx.unbounded_send(event);
-        };
+        let on_tunnel_event =
+            move |event| -> Box<dyn std::future::Future<Output = ()> + Unpin + Send> {
+                let _ = event_tx.unbounded_send(event);
+                Box::new(futures::future::ready(()))
+            };
 
         let monitor = TunnelMonitor::start(
             runtime,

--- a/talpid-openvpn-plugin/proto/openvpn_plugin.proto
+++ b/talpid-openvpn-plugin/proto/openvpn_plugin.proto
@@ -5,10 +5,11 @@ package talpid_openvpn_plugin;
 import "google/protobuf/empty.proto";
 
 service OpenvpnEventProxy {
-    rpc Event(EventType) returns (google.protobuf.Empty) {}
+    rpc AuthFailed(EventDetails) returns (google.protobuf.Empty) {}
+    rpc RouteUp(EventDetails) returns (google.protobuf.Empty) {}
+    rpc RoutePredown(EventDetails) returns (google.protobuf.Empty) {}
 }
 
-message EventType {
-    int32 event = 1;
-    map<string, string> env = 2;
+message EventDetails {
+    map<string, string> env = 1;
 }

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -28,6 +28,9 @@ pub enum Error {
 
     #[error(display = "Unable to parse arguments from OpenVPN")]
     ParseArgsFailed(#[error(source)] std::str::Utf8Error),
+
+    #[error(display = "Unhandled event type: {:?}", _0)]
+    UnhandledEvent(openvpn_plugin::EventType),
 }
 
 
@@ -35,8 +38,6 @@ pub enum Error {
 /// events.
 pub static INTERESTING_EVENTS: &'static [EventType] = &[
     EventType::AuthFailed,
-    #[cfg(target_os = "linux")]
-    EventType::Up,
     EventType::RouteUp,
     EventType::RoutePredown,
 ];


### PR DESCRIPTION
This PR updates the OpenVPN tunnel monitor to stop relying on panics for error handling and execute async/sync code correctly.

Implementing all event handling in the service trait (with async methods) was a simple improvement over using a sync callback function.

Instead of panicking, errors are returned to `talpid-openvpn-plugin`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2797)
<!-- Reviewable:end -->
