### PR TITLE
Fix suggestedIsBeta propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 
 ### Fixed
+- Fix link to download page not always using the beta URL when it should.
+
 #### Linux
 - Make offline monitor aware of routing table changes.
 - Assign local DNS servers to more appropriate interfaces when using systemd-resolved.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -892,10 +892,13 @@ class ApplicationMain {
     const suggestedIsBeta =
       latestVersionInfo.suggestedUpgrade !== undefined &&
       IS_BETA.test(latestVersionInfo.suggestedUpgrade);
-    this.upgradeVersion = {
+
+    const upgradeVersion = {
       ...latestVersionInfo,
       suggestedIsBeta,
     };
+
+    this.upgradeVersion = upgradeVersion;
 
     // notify user to update the app if it became unsupported
     const notificationProviders = [
@@ -918,10 +921,7 @@ class ApplicationMain {
     }
 
     if (this.windowController) {
-      IpcMainEventChannel.upgradeVersion.notify(
-        this.windowController.webContents,
-        latestVersionInfo,
-      );
+      IpcMainEventChannel.upgradeVersion.notify(this.windowController.webContents, upgradeVersion);
     }
   }
 


### PR DESCRIPTION
`suggestedIsBeta` wasn't always sent to the renderer resulting in the GUI sometimes using the wrong update-URL.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2800)
<!-- Reviewable:end -->
