### PR TITLE
Disable notification action on persistent notifications on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix failure to restart the daemon when resuming from "fast startup" hibernation.
+- Disable notification actions for persistent notifications since they were called when pressing
+  close.
 
 
 ## [2021.4-beta1] - 2021-06-09

--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -123,7 +123,7 @@ export default class NotificationController {
         notification.on('action', () => this.performAction(systemNotification.action));
       }
       notification.on('click', () => this.notificationControllerDelegate.openApp());
-    } else {
+    } else if (!(process.platform === 'win32' && systemNotification.critical)) {
       if (systemNotification.action) {
         notification.on('click', () => this.performAction(systemNotification.action));
       } else {


### PR DESCRIPTION
Due to [this Electron bug](https://github.com/electron/electron/issues/27088) system notifications on Windows with `timeoutType: never` calls the notification action when pressing close, e.g. pressing the "Close" button on the account expiry notification opens the account page in a browser. This PR simply disables actions for notifications with `timeoutType: never` on Windows.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2803)
<!-- Reviewable:end -->
