### PR TITLE
Fix android vpn permission request

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -43,6 +43,11 @@ open class MainActivity : FragmentActivity() {
 
         if (newConnection == null) {
             serviceNotifier.notify(null)
+        } else {
+            newConnection.vpnPermission.onRequest = { ->
+                Unit
+                this.requestVpnPermission()
+            }
         }
     }
 


### PR DESCRIPTION
When moving to a split-process implementation, a bug was introduced due to the main activity never handling requests from the VPN service to ask for the VPN permission. I've fixed this by adding a handler for the request that does in fact ask the permission. 
Unrelatedly, I've also removed `android/.idea` because the commited config rendered my android studio unable to build anything. Since we don't rely on android studio to build our app, I've removed the config and added the directory to `.gitignore`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2807)
<!-- Reviewable:end -->
