### PR TITLE
Fix deadlock when entering the connecting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix link to download page not always using the beta URL when it should.
+- Fix deadlock that may occur when the API cannot be reached while entering the connecting state.
 
 #### Linux
 - Make offline monitor aware of routing table changes.


### PR DESCRIPTION
When an API request fails while the tunnel state machine is entering the connecting state, the API address cache tries to switch to a different address. It waits for the tunnel state machine to handle `TunnelCommand::AllowEndpoint`. At the same time, the tunnel state machine waits for the daemon to provide it with tunnel parameters (via `GenerateTunnelParameters`). This results in a deadlock.

To fix this, the REST request handler spawns a separate task for updating the address cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2809)
<!-- Reviewable:end -->
