### PR TITLE
Handle deleted devices in the offline monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix failure to restart the daemon when resuming from "fast startup" hibernation.
 - Disable notification actions for persistent notifications since they were called when pressing
   close.
+- Remove deleted network devices from consideration in the offline monitor. Previously, the offline
+  monitor may have falsely reported the machine to be online due to a race condition.
 
 
 ## [2021.4-beta1] - 2021-06-09

--- a/windows/winnet/src/winnet/networkadaptermonitor.h
+++ b/windows/winnet/src/winnet/networkadaptermonitor.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <vector>
 #include <mutex>
+#include <optional>
 
 class NetworkAdapterMonitor
 {
@@ -61,7 +62,7 @@ private:
 
 	std::mutex m_callbackLock;
 
-	MIB_IF_ROW2 getAdapter(NET_LUID luid) const;
+	std::optional<MIB_IF_ROW2> getAdapter(NET_LUID luid) const;
 
 	bool hasIPv4Interface(NET_LUID luid) const;
 	bool hasIPv6Interface(NET_LUID luid) const;
@@ -69,7 +70,7 @@ private:
 	std::map<ULONG64, MIB_IF_ROW2> m_adapters;
 	std::vector<MIB_IF_ROW2> m_filteredAdapters;
 
-	std::vector<MIB_IF_ROW2>::iterator findFilteredAdapter(const MIB_IF_ROW2 &adapter);
+	std::vector<MIB_IF_ROW2>::iterator findFilteredAdapter(const NET_LUID adapter);
 
 	HANDLE m_notificationHandle;
 	static void __stdcall Callback(void *context, MIB_IPINTERFACE_ROW *hint, MIB_NOTIFICATION_TYPE updateType);


### PR DESCRIPTION
`NotifyIpInterfaceChange` is used to monitor changes to network interfaces and determine whether any of them are online. `GetIfEntry2` is then used to look up network adapter details given a LUID.

Sometimes `GetIfEntry2` is called after a network adapter has already been deleted, which logs an error and might leave behind a "ghost" adapter. If the last state of the adapter indicated that it was connected, this might cause the offline monitor to always believe that the machine is online.

The PR fixes this by handling the case where an adapter has been deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2812)
<!-- Reviewable:end -->
