### PR TITLE
Handle uninstaller errors correctly

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -688,10 +688,6 @@
 #
 !macro customInstall
 
-	Var /GLOBAL BlockFilterResult
-	Var /GLOBAL PersistentBlockFilterResult
-
-	Push $1
 	Push $R0
 
 	log::SetLogTarget ${LOG_INSTALL}
@@ -759,29 +755,14 @@
 	#
 	Delete "$INSTDIR\mullvad vpn.exe"
 
-	nsExec::ExecToStack '"$SYSDIR\netsh.exe" wfp show security FILTER ${BLOCK_OUTBOUND_IPV4_FILTER_GUID}'
-	Pop $BlockFilterResult
-	Pop $1
-
-	nsExec::ExecToStack '"$SYSDIR\netsh.exe" wfp show security FILTER ${PERSISTENT_BLOCK_OUTBOUND_IPV4_FILTER_GUID}'
-	Pop $PersistentBlockFilterResult
-	Pop $1
-
-	${If} $BlockFilterResult == 0
-	${OrIf} $PersistentBlockFilterResult == 0
-		MessageBox MB_ICONEXCLAMATION|MB_YESNO "Do you wish to unblock your internet access? Doing so will leave you with an unsecure connection." IDNO customInstall_abort_installation_skip_firewall_revert
-		${ExtractMullvadSetup}
-		${ClearFirewallRules}
-	${EndIf}
-
-	customInstall_abort_installation_skip_firewall_revert:
+	${ExtractMullvadSetup}
+	${ClearFirewallRules}
 
 	Abort
 
 	customInstall_skip_abort:
 
 	Pop $R0
-	Pop $1
 
 !macroend
 


### PR DESCRIPTION
#2813 gives the option to decide what to do if the uninstaller returns an error or refuses to run. The default behavior is to ignore any errors, so we checked for the presence of "uninstall.log" to infer that it failed. Aside from getting rid of that hack, the installer can now always refuse to continue if some old files could not be deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2814)
<!-- Reviewable:end -->
