### PR TITLE
Add missing 'fs' feature to tokio

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -27,7 +27,7 @@ talpid-types = { path = "../talpid-types" }
 uuid = { version = "0.8", features = ["v4"] }
 zeroize = "1"
 chrono = "0.4"
-tokio = { version = "0.2", features = [ "process", "rt-threaded", "stream" ] }
+tokio = { version = "0.2", features = [ "process", "rt-threaded", "stream", "fs" ] }
 rand = "0.7"
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "3d1abafe112ee8c2db47ca401f8e286756454e7a" }
 


### PR DESCRIPTION
Some recent OpenVPN changes to `talpid-core` relied on the `fs` feature of `tokio`, but the crate manifest wasn't updated to reflect these changes, so `cargo build -p talpid-core` would fail. I've added the `fs` feature now, so it should all just work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2815)
<!-- Reviewable:end -->
