### PR TITLE
Update the app update notification to specify if it's a beta version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Changed
 - Only use the account history file to store the last used account.
-- Updated the out of time-view and new account-view to make it more user friendly.
+- Update the out of time-view and new account-view to make it more user friendly.
+- Change the app update notification when the suggested version is a beta, to include that it's a
+  beta.
 
 ### Fixed
 - Fix link to download page not always using the beta URL when it should.

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -513,9 +513,14 @@ msgid "APP IS OUT OF SYNC"
 msgstr ""
 
 msgctxt "in-app-notifications"
+msgid "BETA UPDATE AVAILABLE"
+msgstr ""
+
+msgctxt "in-app-notifications"
 msgid "BLOCKING INTERNET"
 msgstr ""
 
+#. The in-app banner displayed to the user when the app update is available.
 msgctxt "in-app-notifications"
 msgid "Install the latest app version to stay up to date."
 msgstr ""
@@ -530,6 +535,14 @@ msgstr ""
 
 msgctxt "in-app-notifications"
 msgid "Please quit and restart the app."
+msgstr ""
+
+#. The in-app banner displayed to the user when the app beta update is
+#. available.
+#. Available placeholders:
+#. %(version)s - The version number of the new beta version.
+msgctxt "in-app-notifications"
+msgid "Try out the newest beta version (%(version)s)."
 msgstr ""
 
 msgctxt "in-app-notifications"
@@ -632,6 +645,14 @@ msgstr ""
 
 msgctxt "notifications"
 msgid "App is out of sync. Please quit and restart."
+msgstr ""
+
+#. The system notification that notifies the user when a beta update is
+#. available.
+#. Available placeholders:
+#. %(version)s - The version number of the new beta version.
+msgctxt "notifications"
+msgid "Beta update available. Try out the newest beta version (%(version)s)."
 msgstr ""
 
 msgctxt "notifications"

--- a/gui/src/shared/notifications/update-available.ts
+++ b/gui/src/shared/notifications/update-available.ts
@@ -1,3 +1,4 @@
+import { sprintf } from 'sprintf-js';
 import { links } from '../../config.json';
 import { messages } from '../../shared/gettext';
 import {
@@ -23,12 +24,10 @@ export class UpdateAvailableNotificationProvider
   public getInAppNotification(): InAppNotification {
     return {
       indicator: 'warning',
-      title: messages.pgettext('in-app-notifications', 'UPDATE AVAILABLE'),
-      // TRANSLATORS: The in-app banner displayed to the user when the app update is available.
-      subtitle: messages.pgettext(
-        'in-app-notifications',
-        'Install the latest app version to stay up to date.',
-      ),
+      title: this.context.suggestedIsBeta
+        ? messages.pgettext('in-app-notifications', 'BETA UPDATE AVAILABLE')
+        : messages.pgettext('in-app-notifications', 'UPDATE AVAILABLE'),
+      subtitle: this.inAppMessage(),
       action: {
         type: 'open-url',
         url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
@@ -38,10 +37,7 @@ export class UpdateAvailableNotificationProvider
 
   public getSystemNotification(): SystemNotification {
     return {
-      message: messages.pgettext(
-        'notifications',
-        'Update available. Install the latest app version to stay up to date',
-      ),
+      message: this.systemMessage(),
       critical: false,
       action: {
         type: 'open-url',
@@ -51,5 +47,45 @@ export class UpdateAvailableNotificationProvider
       presentOnce: { value: true, name: this.constructor.name },
       suppressInDevelopment: true,
     };
+  }
+
+  private inAppMessage(): string {
+    if (this.context.suggestedIsBeta) {
+      return sprintf(
+        // TRANSLATORS: The in-app banner displayed to the user when the app beta update is
+        // TRANSLATORS: available.
+        // TRANSLATORS: Available placeholders:
+        // TRANSLATORS: %(version)s - The version number of the new beta version.
+        messages.pgettext('in-app-notifications', 'Try out the newest beta version (%(version)s).'),
+        { version: this.context.suggestedUpgrade },
+      );
+    } else {
+      // TRANSLATORS: The in-app banner displayed to the user when the app update is available.
+      return messages.pgettext(
+        'in-app-notifications',
+        'Install the latest app version to stay up to date.',
+      );
+    }
+  }
+
+  private systemMessage(): string {
+    if (this.context.suggestedIsBeta) {
+      return sprintf(
+        // TRANSLATORS: The system notification that notifies the user when a beta update is
+        // TRANSLATORS: available.
+        // TRANSLATORS: Available placeholders:
+        // TRANSLATORS: %(version)s - The version number of the new beta version.
+        messages.pgettext(
+          'notifications',
+          'Beta update available. Try out the newest beta version (%(version)s).',
+        ),
+        { version: this.context.suggestedUpgrade },
+      );
+    } else {
+      return messages.pgettext(
+        'notifications',
+        'Update available. Install the latest app version to stay up to date',
+      );
+    }
   }
 }


### PR DESCRIPTION
This PR changes the app update notification when the suggested version is a beta version. It then adds the fact that it's a beta and displays the version number as well.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2821)
<!-- Reviewable:end -->
