### PR TITLE
Prevent login form from submitting when clearing history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix link to download page not always using the beta URL when it should.
 - Fix deadlock that may occur when the API cannot be reached while entering the connecting state.
+- Fix bug causing desktop app to log in if account number field was filled when removing account
+  history.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/gui/src/renderer/components/Login.tsx
+++ b/gui/src/renderer/components/Login.tsx
@@ -276,8 +276,7 @@ export default class Login extends React.Component<IProps, IState> {
               aria-label={
                 // TRANSLATORS: This is used by screenreaders to communicate the login button.
                 messages.pgettext('accessibility', 'Login')
-              }
-              onClick={this.onSubmit}>
+              }>
               <StyledInputSubmitIcon
                 visible={this.props.loginState.type !== 'logging in'}
                 source="icon-arrow"
@@ -351,9 +350,14 @@ function AccountDropdownItem(props: IAccountDropdownItemProps) {
     props.onSelect(props.value);
   }, [props.onSelect, props.value]);
 
-  const handleRemove = useCallback(() => {
-    props.onRemove(props.value);
-  }, [props.onRemove, props.value]);
+  const handleRemove = useCallback(
+    (event) => {
+      // Prevent login form from submitting
+      event.preventDefault();
+      props.onRemove(props.value);
+    },
+    [props.onRemove, props.value],
+  );
 
   return (
     <>


### PR DESCRIPTION
Since the remove button in the account history is located in a form it submits the form when clicked. This PR solves this by calling `event.preventDefault()` in the callback. I've also removed the `onClick` on the submit button since that automatically submits the form and the form already has `onSubmit` specified.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2825)
<!-- Reviewable:end -->
