### PR TITLE
Prevent account history and Login footer from hiding

### DIFF
--- a/gui/src/renderer/components/Login.tsx
+++ b/gui/src/renderer/components/Login.tsx
@@ -82,7 +82,7 @@ export default class Login extends React.Component<IProps, IState> {
   }
 
   public render() {
-    const showFooter = this.shouldShowFooter();
+    const showFooter = this.allowInteraction();
 
     return (
       <Layout>
@@ -208,16 +208,7 @@ export default class Login extends React.Component<IProps, IState> {
   }
 
   private shouldShowAccountHistory() {
-    return (
-      this.allowInteraction() && this.state.isActive && this.props.accountHistory !== undefined
-    );
-  }
-
-  private shouldShowFooter() {
-    return (
-      (this.props.loginState.type === 'none' || this.props.loginState.type === 'failed') &&
-      !this.shouldShowAccountHistory()
-    );
+    return this.allowInteraction() && this.props.accountHistory !== undefined;
   }
 
   private onSelectAccountFromHistory = (accountToken: string) => {


### PR DESCRIPTION
This PR changes the behavior of the footer and account history on the Login page to not hide/show depending on whether or not the account number field is focused. Instead it only hides during and after log in. We talked about this long ago but since both the account history and footer didn't fit at the same time we didn't do anything then. Now when we've shortened the account history to 1 item this is much easier.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2829)
<!-- Reviewable:end -->
