### PR TITLE
Remove filters added by the ST driver before initializing the firewall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Line wrap the file at 100 chars.                                              Th
   close.
 - Remove deleted network devices from consideration in the offline monitor. Previously, the offline
   monitor may have falsely reported the machine to be online due to a race condition.
+- Recover firewall state correctly when restarting the service after a crash. This would fail when
+  paths were excluded.
 
 
 ## [2021.4] - 2021-06-30

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -157,6 +157,9 @@ impl DeviceHandle {
             device.register_processes()?;
         }
 
+        log::trace!("Clearing any existing exclusion config");
+        device.clear_config()?;
+
         Ok(device)
     }
 


### PR DESCRIPTION
Previously, firewall initialization would fail if there filters left by the ST driver. This occurred when the daemon hadn't stopped as expected and cleaned them up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2831)
<!-- Reviewable:end -->
