### PR TITLE
Ignore excluded paths on non-existent drives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
   monitor may have falsely reported the machine to be online due to a race condition.
 - Recover firewall state correctly when restarting the service after a crash. This would fail when
   paths were excluded.
+- Fix daemon not starting when a path is excluded on a drive that has since been removed.
 
 
 ## [2021.4] - 2021-06-30

--- a/talpid-core/src/split_tunnel/windows/windows.rs
+++ b/talpid-core/src/split_tunnel/windows/windows.rs
@@ -107,20 +107,13 @@ impl Iterator for ProcessSnapshotEntries<'_> {
 
 /// Obtains a device path without resolving links or mount points.
 pub fn get_device_path<T: AsRef<Path>>(path: T) -> Result<OsString, io::Error> {
-    if !path.as_ref().is_absolute() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "path must be absolute",
-        ));
-    }
-
     let drive_comp = path.as_ref().components().next();
     let drive = match drive_comp {
         Some(std::path::Component::Prefix(prefix)) => prefix.as_os_str(),
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "invalid drive label",
+                "path must be absolute",
             ))
         }
     };


### PR DESCRIPTION
The settings may contain excluded paths on drives that no longer exist (e.g., USB drives). This causes the daemon to fail to add new paths and to set them when starting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2832)
<!-- Reviewable:end -->
