### PR TITLE
Improve resource table parsing

### DIFF
--- a/gui/src/main/windows-split-tunneling.ts
+++ b/gui/src/main/windows-split-tunneling.ts
@@ -453,15 +453,12 @@ async function getResourceTreeLeafOffsets(
 
   const leaves: number[] = [];
 
-  let offset = tableOffset + table.size;
-  for (let i = 0; i < numberOfNameEntries + numberOfIdEntries; i++) {
-    const entryOffset = offset;
-    const entry = await Value.fromFile(fileHandle, entryOffset, IMAGE_RESOURCE_DIRECTORY_ID_ENTRY);
-    offset += entry.size;
-
-    if (i < numberOfNameEntries) {
-      continue;
-    }
+  for (let i = numberOfNameEntries; i < numberOfNameEntries + numberOfIdEntries; i++) {
+    const offset =
+      tableOffset +
+      Value.sizeOf(IMAGE_RESOURCE_DIRECTORY) +
+      i * Value.sizeOf(IMAGE_RESOURCE_DIRECTORY_ID_ENTRY);
+    const entry = await Value.fromFile(fileHandle, offset, IMAGE_RESOURCE_DIRECTORY_ID_ENTRY);
 
     const id = entry.get('Id').value();
     if (!ids.includes(id)) {


### PR DESCRIPTION
This PR improves the offset calculation while iterating over the resource tree nodes. This was brought up here: https://github.com/mullvad/mullvadvpn-app/pull/2720#pullrequestreview-660190665.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2834)
<!-- Reviewable:end -->
