### PR TITLE
Remove split tunnel button margin on macOS

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -22,7 +22,7 @@ import {
   StyledSelectorForFooter,
   StyledTunnelProtocolContainer,
   StyledCustomDnsSwitchContainer,
-  StyledCustomDnsFotter,
+  StyledCustomDnsFooter,
   StyledAddCustomDnsLabel,
   StyledAddCustomDnsButton,
   StyledBetaLabel,
@@ -441,8 +441,8 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                   </Cell.CellButton>
                 </StyledButtonCellGroup>
 
-                <StyledButtonCellGroup>
-                  {(window.platform === 'linux' || window.platform === 'win32') && (
+                {(window.platform === 'linux' || window.platform === 'win32') && (
+                  <StyledButtonCellGroup>
                     <Cell.CellButton onClick={this.props.onViewSplitTunneling}>
                       <Cell.Label>
                         {window.platform === 'win32' && <StyledBetaLabel />}
@@ -450,8 +450,8 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                       </Cell.Label>
                       <Cell.Icon height={12} width={7} source="icon-chevron" />
                     </Cell.CellButton>
-                  )}
-                </StyledButtonCellGroup>
+                  </StyledButtonCellGroup>
+                )}
 
                 <StyledCustomDnsSwitchContainer disabled={!this.customDnsAvailable()}>
                   <AriaInputGroup>
@@ -509,7 +509,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                   </StyledAddCustomDnsButton>
                 </Accordion>
 
-                <StyledCustomDnsFotter>
+                <StyledCustomDnsFooter>
                   <Cell.FooterText>
                     {this.customDnsAvailable() ? (
                       messages.pgettext(
@@ -520,7 +520,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                       <CustomDnsDisabledMessage />
                     )}
                   </Cell.FooterText>
-                </StyledCustomDnsFotter>
+                </StyledCustomDnsFooter>
               </StyledNavigationScrollbars>
             </NavigationContainer>
           </StyledContainer>

--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -50,7 +50,7 @@ export const StyledCustomDnsSwitchContainer = styled(Cell.Container)({
   marginBottom: '1px',
 });
 
-export const StyledCustomDnsFotter = styled(Cell.Footer)({
+export const StyledCustomDnsFooter = styled(Cell.Footer)({
   marginBottom: '2px',
 });
 


### PR DESCRIPTION
This PR removes the margin below the "Split Tunneling" navigation cell in advanced settings when the option isn't available. I also fixed a typo.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2836)
<!-- Reviewable:end -->
