### PR TITLE
Make redeem voucher button always enabled

### DIFF
--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -83,9 +83,7 @@ export default class ExpiredAccountErrorView extends React.Component<
 
                 {this.renderExternalPaymentButton()}
 
-                <AppButton.GreenButton
-                  disabled={this.getRecoveryAction() === RecoveryAction.disconnect}
-                  onClick={this.props.navigateToRedeemVoucher}>
+                <AppButton.GreenButton onClick={this.props.navigateToRedeemVoucher}>
                   {messages.pgettext('connect-view', 'Redeem voucher')}
                 </AppButton.GreenButton>
               </StyledFooter>


### PR DESCRIPTION
This PR removes the `disabled` prop on the redeem voucher button on the out of time view since API calls won't be blocked. This one was forgotten when changing the same thing on other buttons.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2840)
<!-- Reviewable:end -->
