### PR TITLE
Fix WireGuard entry relay selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
   history.
 - Fix lack of account expiry updates when using the app in unpinned mode and improve updating of
   account expiry overall.
+- Fix incorrect WireGuard relay filtering when exit and entry locations overlap.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -818,7 +818,8 @@ impl RelaySelector {
                     }
                     port_index -= ports_in_range;
                 }
-                panic!("Port selection algorithm is broken")
+                error!("Port selection algorithm is broken!");
+                None
             }
             Constraint::Only(port) => {
                 if data

--- a/mullvad-types/src/endpoint.rs
+++ b/mullvad-types/src/endpoint.rs
@@ -14,6 +14,7 @@ pub enum MullvadEndpoint {
     OpenVpn(Endpoint),
     Wireguard {
         peer: wireguard::PeerConfig,
+        exit_peer: Option<wireguard::PeerConfig>,
         ipv4_gateway: Ipv4Addr,
         ipv6_gateway: Ipv6Addr,
     },

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -160,6 +160,10 @@ impl<'de> Deserialize<'de> for PrivateKey {
 #[derive(Clone)]
 pub struct PublicKey(x25519_dalek::PublicKey);
 
+/// Error returned if a base64 string represents an invalid key
+#[derive(Debug)]
+pub struct InvalidKeyError(());
+
 impl PublicKey {
     /// Get the public key as bytes
     pub fn as_bytes(&self) -> &[u8; 32] {
@@ -168,6 +172,16 @@ impl PublicKey {
 
     pub fn to_base64(&self) -> String {
         base64::encode(self.as_bytes())
+    }
+
+    pub fn from_base64(key: &str) -> Result<Self, InvalidKeyError> {
+        let bytes = base64::decode(key).map_err(|_| InvalidKeyError(()))?;
+        if bytes.len() != 32 {
+            return Err(InvalidKeyError(()));
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes);
+        Ok(From::from(key))
     }
 }
 


### PR DESCRIPTION
Previously, the WireGuard "entry peer" was always obtained after the exit (i.e., "normal") relay was decided. This could be an issue if a specific entry relay constraint were set, e.g. a hostname, that was a subset of the exit location constraint. The same peer could be selected for both exit and entry.

To fix this, the entry relay is now selected before the exit relay if the entry location constraint is more specific than the exit location constraint, and vice versa if the exit location constraint is more specific than the entry relay constraint. For example, if the entry location constraint is a city and the entry location constraint is a country, the exit peer is decided first.

Some unit tests were also added to test the changes in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2841)
<!-- Reviewable:end -->
