### PR TITLE
Improve account data fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix deadlock that may occur when the API cannot be reached while entering the connecting state.
 - Fix bug causing desktop app to log in if account number field was filled when removing account
   history.
+- Fix lack of account expiry updates when using the app in unpinned mode and improve updating of
+  account expiry overall.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/gui/src/main/account-data-cache.ts
+++ b/gui/src/main/account-data-cache.ts
@@ -1,12 +1,10 @@
-import { closeToExpiry, hasExpired } from '../shared/account-expiry';
+import { closeToExpiry } from '../shared/account-expiry';
 import { AccountToken, IAccountData, VoucherResponse } from '../shared/daemon-rpc-types';
 import { DateComponent, dateByAddingComponent } from '../shared/date-helper';
 import log from '../shared/logging';
 import consumePromise from '../shared/promise';
 import { Scheduler } from '../shared/scheduler';
 import { InvalidAccountError } from './errors';
-
-const EXPIRED_ACCOUNT_REFRESH_PERIOD = 60_000;
 
 interface IAccountFetchWatcher {
   onFinish: () => void;
@@ -113,9 +111,7 @@ export default class AccountDataCache {
     const currentDate = new Date();
     const oneMinuteBeforeExpiry = dateByAddingComponent(accountExpiry, DateComponent.minute, -1);
 
-    if (hasExpired(accountExpiry)) {
-      return EXPIRED_ACCOUNT_REFRESH_PERIOD;
-    } else if (oneMinuteBeforeExpiry >= currentDate && closeToExpiry(accountExpiry)) {
+    if (oneMinuteBeforeExpiry >= currentDate && closeToExpiry(accountExpiry)) {
       return oneMinuteBeforeExpiry.getTime() - currentDate.getTime();
     } else {
       return undefined;

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1180,6 +1180,7 @@ class ApplicationMain {
 
       return response;
     });
+    IpcMainEventChannel.account.handleUpdateData(() => this.updateAccountData());
 
     IpcMainEventChannel.accountHistory.handleClear(async () => {
       await this.daemonRpc.clearAccountHistory();

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1049,12 +1049,10 @@ class ApplicationMain {
   }
 
   private registerWindowListener(windowController: WindowController) {
-    windowController.window?.on('show', () => {
+    windowController.window?.on('focus', () => {
       // cancel notifications when window appears
       this.notificationController.cancelPendingNotifications();
-    });
 
-    windowController.window?.on('focus', () => {
       if (
         !this.accountData ||
         closeToExpiry(this.accountData.expiry, 4) ||
@@ -1064,7 +1062,7 @@ class ApplicationMain {
       }
     });
 
-    windowController.window?.on('hide', () => {
+    windowController.window?.on('blur', () => {
       // ensure notification guard is reset
       this.notificationController.resetTunnelStateAnnouncements();
     });

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 import { sprintf } from 'sprintf-js';
 import * as uuid from 'uuid';
 import config from '../config.json';
-import { hasExpired } from '../shared/account-expiry';
+import { closeToExpiry, hasExpired } from '../shared/account-expiry';
 import { IApplication } from '../shared/application-types';
 import BridgeSettingsBuilder from '../shared/bridge-settings-builder';
 import {
@@ -1052,8 +1052,16 @@ class ApplicationMain {
     windowController.window?.on('show', () => {
       // cancel notifications when window appears
       this.notificationController.cancelPendingNotifications();
+    });
 
-      this.updateAccountData();
+    windowController.window?.on('focus', () => {
+      if (
+        !this.accountData ||
+        closeToExpiry(this.accountData.expiry, 4) ||
+        hasExpired(this.accountData.expiry)
+      ) {
+        this.updateAccountData();
+      }
     });
 
     windowController.window?.on('hide', () => {

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -318,6 +318,10 @@ export default class AppRenderer {
     return IpcRendererEventChannel.account.submitVoucher(voucherCode);
   }
 
+  public updateAccountData(): void {
+    IpcRendererEventChannel.account.updateData();
+  }
+
   public async connectTunnel(): Promise<void> {
     const state = this.tunnelState.state;
 

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -31,9 +31,14 @@ interface IProps {
   onLogout: () => void;
   onClose: () => void;
   onBuyMore: () => Promise<void>;
+  updateAccountData: () => void;
 }
 
 export default class Account extends React.Component<IProps> {
+  public componentDidMount() {
+    this.props.updateAccountData();
+  }
+
   public render() {
     return (
       <ModalContainer>

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { colors, links } from '../../config.json';
 import { hasExpired, formatRemainingTime } from '../../shared/account-expiry';
 import { messages } from '../../shared/gettext';
+import History from '../lib/history';
 import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import * as Cell from './cell';
 import { Layout } from './Layout';
@@ -42,9 +43,17 @@ export interface IProps {
   onViewPreferences: () => void;
   onViewAdvancedSettings: () => void;
   onExternalLink: (url: string) => void;
+  updateAccountData: () => void;
+  history: History;
 }
 
 export default class Settings extends React.Component<IProps> {
+  public componentDidMount() {
+    if (this.props.history.action === 'PUSH') {
+      this.props.updateAccountData();
+    }
+  }
+
   public render() {
     const showLargeTitle = this.props.loginState.type !== 'ok';
 

--- a/gui/src/renderer/containers/AccountPage.tsx
+++ b/gui/src/renderer/containers/AccountPage.tsx
@@ -22,6 +22,7 @@ const mapDispatchToProps = (_dispatch: ReduxDispatch, props: IHistoryProps & IAp
       props.history.pop();
     },
     onBuyMore: () => props.app.openLinkWithAuth(links.purchase),
+    updateAccountData: () => props.app.updateAccountData(),
   };
 };
 

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -26,6 +26,7 @@ const mapDispatchToProps = (_dispatch: ReduxDispatch, props: IHistoryProps & IAp
     onViewPreferences: () => props.history.push('/settings/preferences'),
     onViewAdvancedSettings: () => props.history.push('/settings/advanced'),
     onExternalLink: (url: string) => props.app.openUrl(url),
+    updateAccountData: () => props.app.updateAccountData(),
   };
 };
 

--- a/gui/src/shared/account-expiry.ts
+++ b/gui/src/shared/account-expiry.ts
@@ -5,10 +5,10 @@ export function hasExpired(expiry: DateType): boolean {
   return new Date(expiry).getTime() < Date.now();
 }
 
-export function closeToExpiry(expiry: DateType): boolean {
+export function closeToExpiry(expiry: DateType, days = 3): boolean {
   return (
     !hasExpired(expiry) &&
-    new Date(expiry) <= dateByAddingComponent(new Date(), DateComponent.day, 3)
+    new Date(expiry) <= dateByAddingComponent(new Date(), DateComponent.day, days)
   );
 }
 

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -164,6 +164,7 @@ export const ipcSchema = {
     logout: invoke<void, void>(),
     getWwwAuthToken: invoke<void, string>(),
     submitVoucher: invoke<string, VoucherResponse>(),
+    updateData: send<void>(),
   },
   accountHistory: {
     '': notifyRenderer<AccountToken | undefined>(),

--- a/gui/test/account-data-cache.spec.ts
+++ b/gui/test/account-data-cache.spec.ts
@@ -135,41 +135,6 @@ describe('IAccountData cache', () => {
     });
   });
 
-  it('should refetch if account has expired', async () => {
-    const expiredSpy = spy();
-    const nonExpiredSpy = spy();
-
-    const update = new Promise<void>((resolve, reject) => {
-      let firstAttempt = true;
-      const fetch = () => {
-        if (firstAttempt) {
-          expiredSpy();
-          firstAttempt = false;
-          setTimeout(() => clock.tick(60_000), 0);
-          return Promise.resolve({
-            expiry: new Date('1969-01-01').toISOString(),
-          });
-        } else {
-          nonExpiredSpy();
-          resolve();
-          return Promise.resolve(dummyAccountData);
-        }
-      };
-
-      const cache = new AccountDataCache(fetch, () => {});
-
-      cache.fetch(dummyAccountToken, {
-        onFinish: () => {},
-        onError: (_error: Error) => reject(),
-      });
-    });
-
-    return expect(update).to.eventually.be.fulfilled.then(() => {
-      expect(expiredSpy).to.have.been.called.once;
-      expect(nonExpiredSpy).to.have.been.called.once;
-    });
-  });
-
   it('should clear scheduled retry if another fetch is performed', async () => {
     const firstError = spy();
     const secondSuccess = spy();


### PR DESCRIPTION
This PR improves the logic behind when we update the account data expiry. The changes include:
* Fetch account data on `focus` event instead of `show` since `show` isn't called in unpinned mode
* Only fetch on `focus` if less than 4 days left
* Lower cache validity duration to 10 seconds when out of time
* Fetch account data when opening settings and account page
* Stop fetching every minute when account has expired
* Stop using term `expiry` for cache and instead describe it as validity to avoid confusion with account `expiry`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2843)
<!-- Reviewable:end -->
