### PR TITLE
Update OpenVPN to 2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 - Update the out of time-view and new account-view to make it more user friendly.
 - Change the app update notification when the suggested version is a beta, to include that it's a
   beta.
+- Upgrade OpenVPN from 2.5.1 to 2.5.3.
 
 ### Fixed
 - Fix link to download page not always using the beta URL when it should.
@@ -45,6 +46,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix failure to restart the daemon when resuming from "fast startup" hibernation.
+- Fix OpenVPN not responding to shutdown signals when they are sent early on, causing it to close
+  after 30 seconds.
 - Disable notification actions for persistent notifications since they were called when pressing
   close.
 - Remove deleted network devices from consideration in the offline monitor. Previously, the offline


### PR DESCRIPTION
Upgrade OpenVPN to 2.5.3. This also includes a patch that fixes an issue where OpenVPN would not shut down gracefully, which mostly caused issues on Windows when the daemon tried to restart itself after resuming from hibernation. See https://github.com/mullvad/mullvadvpn-app-binaries/pull/86.

Related: #2793

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2846)
<!-- Reviewable:end -->
