### PR TITLE
Update to tokio 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "urlencoding",
  "webpki",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,11 +467,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
- "atty",
- "humantime 1.3.0",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -481,7 +478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -730,7 +727,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -795,7 +792,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.8.1",
+ "tokio",
  "tokio-util",
  "tracing",
 ]
@@ -859,7 +856,7 @@ checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes 1.0.1",
  "http",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -873,15 +870,6 @@ name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
 
 [[package]]
 name = "humantime"
@@ -905,9 +893,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "socket2 0.4.0",
- "tokio 1.8.1",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -925,7 +913,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 1.8.1",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -1278,7 +1266,7 @@ dependencies = [
  "natord",
  "serde",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
  "winapi 0.3.9",
  "winres",
 ]
@@ -1316,7 +1304,7 @@ dependencies = [
  "talpid-core",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "triggered",
  "uuid",
@@ -1354,7 +1342,7 @@ dependencies = [
  "rand 0.7.3",
  "talpid-core",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -1372,7 +1360,7 @@ dependencies = [
  "prost",
  "prost-types",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
  "tonic",
  "tonic-build",
  "tower",
@@ -1403,7 +1391,7 @@ dependencies = [
  "regex",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
  "uuid",
  "winapi 0.3.9",
  "winres",
@@ -1431,7 +1419,7 @@ dependencies = [
  "socket2 0.3.19",
  "talpid-types",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "tokio-rustls",
  "urlencoding",
  "webpki",
@@ -1452,7 +1440,7 @@ dependencies = [
  "mullvad-types",
  "talpid-core",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
  "widestring",
  "winapi 0.3.9",
  "winres",
@@ -1546,7 +1534,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "tokio 1.8.1",
+ "tokio",
  "tokio-util",
 ]
 
@@ -1559,7 +1547,7 @@ dependencies = [
  "futures",
  "libc",
  "log",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -1726,7 +1714,7 @@ dependencies = [
  "libc",
  "log",
  "rand 0.7.3",
- "tokio 1.8.1",
+ "tokio",
  "winapi 0.3.9",
 ]
 
@@ -1874,12 +1862,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -2224,7 +2206,7 @@ dependencies = [
  "netlink-proto",
  "nix 0.19.1",
  "thiserror",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -2586,7 +2568,7 @@ dependencies = [
  "talpid-platform-metadata",
  "talpid-types",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "tonic",
  "tonic-build",
@@ -2611,7 +2593,7 @@ dependencies = [
  "libc",
  "log",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -2625,7 +2607,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost",
  "talpid-types",
- "tokio 1.8.1",
+ "tokio",
  "tonic",
  "tonic-build",
  "tower",
@@ -2728,23 +2710,6 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "iovec",
- "lazy_static",
- "memchr",
- "mio 0.6.23",
- "num_cpus",
- "pin-project-lite 0.1.12",
- "slab",
- "tokio-macros 0.2.6",
-]
-
-[[package]]
-name = "tokio"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
@@ -2757,21 +2722,10 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "signal-hook-registry",
- "tokio-macros 1.3.0",
+ "tokio-macros",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2792,7 +2746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.8.1",
+ "tokio",
  "webpki",
 ]
 
@@ -2803,8 +2757,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.6",
- "tokio 1.8.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2817,8 +2771,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.6",
- "tokio 1.8.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2850,7 +2804,7 @@ dependencies = [
  "pin-project 1.0.5",
  "prost",
  "prost-derive",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -2883,7 +2837,7 @@ dependencies = [
  "pin-project 1.0.5",
  "rand 0.8.3",
  "slab",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tower-layer",
@@ -2911,7 +2865,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2990,15 +2944,16 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 [[package]]
 name = "udp-over-tcp"
 version = "0.1.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=3d1abafe112ee8c2db47ca401f8e286756454e7a#3d1abafe112ee8c2db47ca401f8e286756454e7a"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=1e27324362ed123b61fa2062b1599e5f9d569796#1e27324362ed123b61fa2062b1599e5f9d569796"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger 0.8.2",
  "err-context",
  "futures",
+ "lazy_static",
  "log",
  "nix 0.20.0",
  "structopt",
- "tokio 0.2.25",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -127,12 +127,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -268,7 +262,17 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys 0.8.2",
  "libc",
 ]
 
@@ -279,10 +283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
-name = "ct-logs"
-version = "0.7.0"
+name = "core-foundation-sys"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8e13110a84b6315df212c045be706af261fd364791cad863285439ebba672e"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
  "sct",
 ]
@@ -773,11 +783,11 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -785,10 +795,9 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util 0.3.1",
+ "tokio 1.8.1",
+ "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -844,25 +853,26 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "http",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -881,11 +891,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.13.10"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -895,9 +905,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
- "socket2",
- "tokio",
+ "pin-project-lite 0.2.6",
+ "socket2 0.4.0",
+ "tokio 1.8.1",
  "tower-service",
  "tracing",
  "want",
@@ -905,18 +915,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
- "bytes 0.5.6",
  "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio",
+ "tokio 1.8.1",
  "tokio-rustls",
  "webpki",
 ]
@@ -1001,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -1100,9 +1109,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libdbus-sys"
@@ -1185,6 +1194,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,31 +1214,8 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log",
- "mio",
+ "mio 0.6.23",
  "slab",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio",
- "miow 0.3.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio",
 ]
 
 [[package]]
@@ -1237,7 +1236,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi 0.3.9",
 ]
 
@@ -1266,7 +1265,7 @@ dependencies = [
 name = "mullvad-cli"
 version = "2021.4.0"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "chrono",
  "clap",
  "env_logger 0.8.2",
@@ -1279,7 +1278,7 @@ dependencies = [
  "natord",
  "serde",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
  "winapi 0.3.9",
  "winres",
 ]
@@ -1317,7 +1316,8 @@ dependencies = [
  "talpid-core",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
+ "tokio-stream",
  "triggered",
  "uuid",
  "winapi 0.3.9",
@@ -1354,7 +1354,7 @@ dependencies = [
  "rand 0.7.3",
  "talpid-core",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ dependencies = [
  "prost",
  "prost-types",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
  "tonic",
  "tonic-build",
  "tower",
@@ -1403,7 +1403,7 @@ dependencies = [
  "regex",
  "talpid-platform-metadata",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
  "uuid",
  "winapi 0.3.9",
  "winres",
@@ -1428,10 +1428,10 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.3.19",
  "talpid-types",
  "tempfile",
- "tokio",
+ "tokio 1.8.1",
  "tokio-rustls",
  "urlencoding",
  "webpki",
@@ -1452,7 +1452,7 @@ dependencies = [
  "mullvad-types",
  "talpid-core",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
  "widestring",
  "winapi 0.3.9",
  "winres",
@@ -1511,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2253105e60b35a3fb6cf342b56a45ee1c76ef4b1e68c59b08f813f24c3b7b469"
+checksum = "4c92a86a6528fe6d0a811c48d28213ca896a2b8bf2f6cadf2ab5bb12d32ec0f1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1537,40 +1537,29 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31dfd4f1653ba8e1e2410b3def2313f3399d9b9f7ec3a8a6a8f2f670c3e58d71"
+checksum = "ddd06e90449ae973fe3888c1ff85949604ef5189b4ac9a2ae39518da1e00762d"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures",
  "log",
  "netlink-packet-core",
- "netlink-sys 0.5.0",
- "tokio",
- "tokio-util 0.2.0",
+ "netlink-sys",
+ "tokio 1.8.1",
+ "tokio-util",
 ]
 
 [[package]]
 name = "netlink-sys"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9e9df13fd91bdd4b92bea93d5d2848c8035677c60fc3fee5dabddc02c3012e"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf10c3ab67b9c09b42abb5a53ecb8ffdad160d6485b140a6f21f53ba5362042d"
+checksum = "f48ea34ea0678719815c3753155067212f853ad2d8ef4a49167bae7f7c254188"
 dependencies = [
  "futures",
  "libc",
  "log",
- "mio",
- "tokio",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -1644,9 +1633,18 @@ dependencies = [
  "fsevent-sys",
  "inotify",
  "libc",
- "mio",
+ "mio 0.6.23",
  "mio-extras",
  "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -1720,17 +1718,15 @@ dependencies = [
 
 [[package]]
 name = "parity-tokio-ipc"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7f6c69d7687501b2205fe51ade1d7b8797bb3aa141fe5bf13dd78c0483bc89"
+checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
  "futures",
  "libc",
  "log",
- "mio-named-pipes",
- "miow 0.3.6",
  "rand 0.7.3",
- "tokio",
+ "tokio 1.8.1",
  "winapi 0.3.9",
 ]
 
@@ -1956,40 +1952,40 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "heck",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
  "prost",
  "prost-types",
  "tempfile",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1997,11 +1993,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "prost",
 ]
 
@@ -2217,16 +2213,18 @@ checksum = "d4a874cf4a0b9bc283edaa65d81d62368b84b1a8e56196e4885ca4701fd49972"
 
 [[package]]
 name = "rtnetlink"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c942df3c7725a0500971d857a080d6dc537e257e19ccb352f80b2c726ef7007"
+checksum = "279f7e9a312496b3e726e776cbd1f3102bd5ffe66503c3f44d642f7327995919"
 dependencies = [
  "byteordered",
  "futures",
  "log",
  "netlink-packet-route",
  "netlink-proto",
+ "nix 0.19.1",
  "thiserror",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -2237,11 +2235,11 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "log",
  "ring",
  "sct",
@@ -2250,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
  "rustls",
@@ -2309,24 +2307,24 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "1.0.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.9.1",
+ "core-foundation-sys 0.8.2",
  "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "1.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.2",
  "libc",
 ]
 
@@ -2438,6 +2436,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4bc0637a2b8c0b1a5145cca3e21b707865edc7e32285771536af1ade129468"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.7.0",
  "system-configuration-sys",
 ]
 
@@ -2525,7 +2533,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269e271436d8e4bb2621c535a11fe03d5d012f74b19af72f80288f3a72f6180a"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.7.0",
  "libc",
 ]
 
@@ -2555,7 +2563,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-packet-utils",
  "netlink-proto",
- "netlink-sys 0.4.0",
+ "netlink-sys",
  "nftnl",
  "nix 0.19.1",
  "notify",
@@ -2572,20 +2580,21 @@ dependencies = [
  "resolv-conf",
  "rtnetlink",
  "shell-escape",
- "socket2",
+ "socket2 0.3.19",
  "system-configuration",
  "talpid-dbus",
  "talpid-platform-metadata",
  "talpid-types",
  "tempfile",
- "tokio",
+ "tokio 1.8.1",
+ "tokio-stream",
  "tonic",
  "tonic-build",
  "triggered",
  "tun",
  "udp-over-tcp",
  "uuid",
- "which 4.0.2",
+ "which",
  "widestring",
  "winapi 0.3.9",
  "winreg",
@@ -2602,7 +2611,7 @@ dependencies = [
  "libc",
  "log",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -2616,7 +2625,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost",
  "talpid-types",
- "tokio",
+ "tokio 1.8.1",
  "tonic",
  "tonic-build",
  "tower",
@@ -2637,7 +2646,7 @@ dependencies = [
 name = "talpid-types"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "err-derive 0.3.0",
  "ipnetwork",
  "jnix",
@@ -2724,20 +2733,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes 0.5.6",
- "fnv",
- "futures-core",
  "iovec",
  "lazy_static",
- "libc",
  "memchr",
- "mio",
- "mio-named-pipes",
- "mio-uds",
+ "mio 0.6.23",
  "num_cpus",
  "pin-project-lite 0.1.12",
- "signal-hook-registry",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.6",
+]
+
+[[package]]
+name = "tokio"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.13",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite 0.2.6",
+ "signal-hook-registry",
+ "tokio-macros 1.3.0",
  "winapi 0.3.9",
 ]
 
@@ -2753,43 +2775,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.14.1"
+name = "tokio-macros"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
- "futures-core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
  "rustls",
- "tokio",
+ "tokio 1.8.1",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.2.0"
+name = "tokio-stream"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
- "bytes 0.5.6",
  "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.12",
- "tokio",
+ "pin-project-lite 0.2.6",
+ "tokio 1.8.1",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.12",
- "tokio",
+ "pin-project-lite 0.2.6",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -2803,29 +2832,28 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.3.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
+checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.12.3",
- "bytes 0.5.6",
+ "base64",
+ "bytes 1.0.1",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
  "percent-encoding",
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "prost",
  "prost-derive",
- "tokio",
- "tokio-util 0.3.1",
+ "tokio 1.8.1",
+ "tokio-stream",
+ "tokio-util",
  "tower",
- "tower-balance",
- "tower-load",
- "tower-make",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -2833,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19970cf58f3acc820962be74c4021b8bbc8e8a1c4e3a02095d0aa60cde5f3633"
+checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -2845,67 +2873,22 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.3.1"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3169017c090b7a28fce80abaad0ab4f5566423677c9331bb320af7e49cfe62"
-dependencies = [
- "futures-core",
- "tower-buffer",
- "tower-discover",
- "tower-layer",
- "tower-limit",
- "tower-load-shed",
- "tower-retry",
- "tower-service",
- "tower-timeout",
- "tower-util",
-]
-
-[[package]]
-name = "tower-balance"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
+checksum = "f60422bc7fefa2f3ec70359b8ff1caff59d785877eb70595904605bcc412470f"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.27",
- "rand 0.7.3",
+ "pin-project 1.0.5",
+ "rand 0.8.3",
  "slab",
- "tokio",
- "tower-discover",
- "tower-layer",
- "tower-load",
- "tower-make",
- "tower-ready-cache",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio",
+ "tokio 1.8.1",
+ "tokio-stream",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tower-service",
 ]
 
 [[package]]
@@ -2915,111 +2898,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
-name = "tower-limit"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio",
- "tower-layer",
- "tower-load",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
-dependencies = [
- "futures-core",
- "log",
- "pin-project 0.4.27",
- "tokio",
- "tower-discover",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-make"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-dependencies = [
- "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "tower-ready-cache"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap",
- "log",
- "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
-
-[[package]]
-name = "tower-timeout"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
-dependencies = [
- "pin-project 0.4.27",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.27",
- "tower-service",
-]
 
 [[package]]
 name = "tracing"
@@ -3116,7 +2998,7 @@ dependencies = [
  "log",
  "nix 0.20.0",
  "structopt",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3290,15 +3172,6 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,15 +1006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1259,7 +1262,7 @@ dependencies = [
  "env_logger 0.8.2",
  "err-derive 0.3.0",
  "futures",
- "itertools 0.10.0",
+ "itertools",
  "mullvad-management-interface",
  "mullvad-paths",
  "mullvad-types",
@@ -1935,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
  "prost-derive",
@@ -1945,13 +1948,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.9.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -1963,12 +1966,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -1976,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
  "prost",
@@ -2730,6 +2733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2801,6 +2814,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.5",
  "prost",
@@ -2809,6 +2823,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -2816,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+checksum = "25db9a497663a9a779693ef67b6e6aef8345b3d3ff8d50ef92eae6c88cb1e386"
 dependencies = [
  "proc-macro2",
  "prost-build",

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -27,7 +27,7 @@ mullvad-paths = { path = "../mullvad-paths" }
 talpid-types = { path = "../talpid-types" }
 
 mullvad-management-interface = { path = "../mullvad-management-interface" }
-tokio = { version = "0.2", features =  [ "rt-threaded" ] }
+tokio = { version = "1.8", features =  [ "rt-multi-thread" ] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -24,7 +24,8 @@ rand = "0.7"
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "0.2", features =  [ "fs", "rt-threaded", "stream", "sync" ] }
+tokio = { version = "1.8", features =  [ "fs", "rt-multi-thread", "sync" ] }
+tokio-stream = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1141,7 +1141,7 @@ where
     async fn schedule_reconnect(&mut self, delay: Duration) {
         let tunnel_command_tx = self.tx.to_specialized_sender();
         let (future, abort_handle) = abortable(Box::pin(async move {
-            tokio::time::delay_for(delay).await;
+            tokio::time::sleep(delay).await;
             log::debug!("Attempting to reconnect");
             let (tx, _) = oneshot::channel();
             let _ = tunnel_command_tx.send(DaemonCommand::Reconnect(tx));

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
         std::process::exit(1)
     });
 
-    let mut runtime = new_runtime_builder().build().unwrap_or_else(|error| {
+    let runtime = new_runtime_builder().build().unwrap_or_else(|error| {
         eprintln!("{}", error.display_chain());
         std::process::exit(1);
     });

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -908,7 +908,10 @@ impl RelayListUpdater {
     }
 
     async fn run(mut self, mut cmd_rx: mpsc::Receiver<()>) {
-        let mut check_interval = tokio::time::interval(UPDATE_CHECK_INTERVAL).fuse();
+        let mut check_interval = tokio_stream::wrappers::IntervalStream::new(
+            tokio::time::interval(UPDATE_CHECK_INTERVAL),
+        )
+        .fuse();
         let mut download_future = Box::pin(Fuse::terminated());
         loop {
             futures::select! {

--- a/mullvad-daemon/src/runtime.rs
+++ b/mullvad-daemon/src/runtime.rs
@@ -1,11 +1,7 @@
 use tokio::runtime;
 
 pub fn new_runtime_builder() -> runtime::Builder {
-    let mut builder = runtime::Builder::new();
-    builder
-        .threaded_scheduler()
-        .core_threads(4)
-        .max_threads(8)
-        .enable_all();
+    let mut builder = runtime::Builder::new_multi_thread();
+    builder.worker_threads(4).enable_all();
     builder
 }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -149,7 +149,6 @@ impl SettingsPersister {
         let mut options = fs::OpenOptions::new();
         #[cfg(unix)]
         {
-            use fs::os::unix::OpenOptionsExt;
             options.mode(0o600);
         }
         let mut file = options

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -105,7 +105,7 @@ pub fn handle_service_main(_arguments: Vec<OsString>) {
     let log_dir = crate::get_log_dir(cli::get_config()).expect("Log dir should be available here");
 
     let runtime = new_runtime_builder().build();
-    let mut runtime = match runtime {
+    let runtime = match runtime {
         Err(error) => {
             log::error!("{}", error.display_chain());
             persistent_service_status

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -269,7 +269,7 @@ impl VersionUpdater {
 
     pub async fn run(mut self) {
         let mut rx = self.rx.take().unwrap().fuse();
-        let next_delay = || tokio::time::sleep(UPDATE_CHECK_INTERVAL).fuse();
+        let next_delay = || Box::pin(tokio::time::sleep(UPDATE_CHECK_INTERVAL)).fuse();
         let mut check_delay = next_delay();
         let mut version_check = futures::future::Fuse::terminated();
 

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -269,7 +269,7 @@ impl VersionUpdater {
 
     pub async fn run(mut self) {
         let mut rx = self.rx.take().unwrap().fuse();
-        let next_delay = || tokio::time::delay_for(UPDATE_CHECK_INTERVAL).fuse();
+        let next_delay = || tokio::time::sleep(UPDATE_CHECK_INTERVAL).fuse();
         let mut check_delay = next_delay();
         let mut version_check = futures::future::Fuse::terminated();
 

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -304,7 +304,7 @@ impl KeyManager {
         rotation_interval_secs: u64,
         account_token: AccountToken,
     ) {
-        tokio::time::delay_for(ROTATION_START_DELAY).await;
+        tokio::time::sleep(ROTATION_START_DELAY).await;
 
         let rotate_key_for_account = move |old_key: &PublicKey| {
             Self::rotate_key(

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 log-panics = "2"
 nix = "0.19"
 rand = "0.7"
-tokio = "0.2"
+tokio = "1.8"
 
 mullvad-daemon = { path = "../mullvad-daemon" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -231,7 +231,7 @@ fn spawn_daemon(
         .map_err(Error::CreateGlobalReference)?;
     let (tx, rx) = mpsc::channel();
 
-    let mut runtime = new_runtime_builder()
+    let runtime = new_runtime_builder()
         .build()
         .map_err(Error::InitializeTokioRuntime)?;
 

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -12,10 +12,10 @@ err-derive = "0.3.0"
 mullvad-types = { path = "../mullvad-types" }
 mullvad-paths = { path = "../mullvad-paths" }
 talpid-types = { path = "../talpid-types" }
-tonic = "0.4"
+tonic = "0.5"
 tower = "0.4"
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.8"
+prost-types = "0.8"
 parity-tokio-ipc = "0.9"
 futures = "0.3"
 tokio = { version = "1.8", features =  [ "rt" ] }
@@ -27,4 +27,4 @@ nix = "0.19"
 lazy_static = "1.0"
 
 [build-dependencies]
-tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"] }

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -12,13 +12,13 @@ err-derive = "0.3.0"
 mullvad-types = { path = "../mullvad-types" }
 mullvad-paths = { path = "../mullvad-paths" }
 talpid-types = { path = "../talpid-types" }
-tonic = "0.3.1"
-tower = "0.3"
-prost = "0.6"
-prost-types = "0.6"
-parity-tokio-ipc = "0.8"
+tonic = "0.4"
+tower = "0.4"
+prost = "0.7"
+prost-types = "0.7"
+parity-tokio-ipc = "0.9"
 futures = "0.3"
-tokio = { version = "0.2", features =  [ "rt-util" ] }
+tokio = { version = "1.8", features =  [ "rt" ] }
 triggered = "0.1.1"
 log = "0.4"
 
@@ -27,4 +27,4 @@ nix = "0.19"
 lazy_static = "1.0"
 
 [build-dependencies]
-tonic-build = { version = "0.3", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }

--- a/mullvad-management-interface/src/lib.rs
+++ b/mullvad-management-interface/src/lib.rs
@@ -106,7 +106,13 @@ pub async fn spawn_rpc_server<T: ManagementService>(
 
 #[derive(Debug)]
 struct StreamBox<T: AsyncRead + AsyncWrite>(pub T);
-impl<T: AsyncRead + AsyncWrite> Connected for StreamBox<T> {}
+impl<T: AsyncRead + AsyncWrite> Connected for StreamBox<T> {
+    type ConnectInfo = Option<()>;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        None
+    }
+}
 impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for StreamBox<T> {
     fn poll_read(
         mut self: Pin<&mut Self>,

--- a/mullvad-management-interface/src/lib.rs
+++ b/mullvad-management-interface/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tonic::transport::{server::Connected, Endpoint, Server, Uri};
 use tower::service_fn;
 
@@ -111,8 +111,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for StreamBox<T> {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<std::io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
         Pin::new(&mut self.0).poll_read(cx, buf)
     }
 }

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -15,7 +15,7 @@ err-derive = "0.3.0"
 lazy_static = "1.0"
 regex = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
-tokio = { version = "0.2", features = [ "rt-core" ] }
+tokio = { version = "1.8", features = [ "rt" ] }
 
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-rpc = { path = "../mullvad-rpc" }

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -310,7 +310,7 @@ pub fn send_problem_report(
                     )
                 }
             }
-            tokio::time::delay_for(RETRY_INTERVAL).await;
+            tokio::time::sleep(RETRY_INTERVAL).await;
         }
         Err(Error::SendProblemReportError)
     })

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -273,9 +273,8 @@ pub fn send_problem_report(
     let metadata =
         ProblemReport::parse_metadata(&report_content).unwrap_or_else(|| metadata::collect());
 
-    let mut runtime = tokio::runtime::Builder::new()
-        .threaded_scheduler()
-        .core_threads(2)
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
         .enable_all()
         .build()
         .map_err(Error::CreateRuntime)?;

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -36,6 +36,9 @@ tempfile = "3.0"
 [target.'cfg(target_os="android")'.dependencies]
 socket2 = "0.3"
 
+[target.'cfg(target_os="macos")'.dependencies]
+tokio-stream = { version = "0.1", features = ["io-util"] }
+
 [[bin]]
 name = "relay_list"
 

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -13,16 +13,16 @@ chrono = { version = "0.4", features = ["serde"] }
 err-derive = "0.3.0"
 futures = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = { version = "0.14", features = ["client", "stream"] }
 ipnetwork = "0.16"
 log = "0.4"
 rand = "0.7"
 regex = "1"
 serde = "1"
 serde_json = "1.0"
-hyper-rustls = "0.21"
-tokio = { version = "0.2", features = [ "macros", "time", "rt-threaded", "net", "io-std", "io-driver", "fs" ] }
-tokio-rustls = "0.14"
+hyper-rustls = "0.22"
+tokio = { version = "1.8", features = [ "macros", "time", "rt-multi-thread", "net", "io-std", "fs" ] }
+tokio-rustls = "0.22"
 urlencoding = "1"
 webpki = { version = "0.21", features =  [] }
 

--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -164,7 +164,7 @@ impl HttpsConnectorWithSni {
         let addr = addrs
             .next()
             .ok_or(io::Error::new(io::ErrorKind::Other, "Empty DNS response"))?;
-        Ok(SocketAddr::new(addr, port))
+        Ok(SocketAddr::new(addr.ip(), port))
     }
 }
 

--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -24,7 +24,9 @@ use std::{
     time::Duration,
 };
 
-use tokio::{net::TcpStream as TokioTcpStream, runtime::Handle, time::timeout};
+#[cfg(not(target_os = "android"))]
+use tokio::time::timeout;
+use tokio::{net::TcpStream as TokioTcpStream, runtime::Handle};
 use tokio_rustls::rustls::{self, ProtocolVersion};
 use webpki::DNSNameRef;
 
@@ -123,11 +125,12 @@ impl HttpsConnectorWithSni {
         socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> std::io::Result<TokioTcpStream> {
         use socket2::{Domain, Protocol, Socket, Type};
+        use std::os::unix::io::{FromRawFd, IntoRawFd};
         let domain = match addr {
             SocketAddr::V4(_) => Domain::ipv4(),
             SocketAddr::V6(_) => Domain::ipv6(),
         };
-        let socket = Socket::new(domain, Type::stream(), Some(Protocol::tcp()))?.into_tcp_stream();
+        let socket = Socket::new(domain, Type::stream(), Some(Protocol::tcp()))?;
 
         if let Some(mut tx) = socket_bypass_tx {
             let (done_tx, done_rx) = oneshot::channel();
@@ -137,9 +140,15 @@ impl HttpsConnectorWithSni {
             }
         }
 
-        timeout(CONNECT_TIMEOUT, TokioTcpStream::connect_std(socket, &addr))
-            .await
-            .map_err(|err| io::Error::new(io::ErrorKind::TimedOut, err))?
+        tokio::task::spawn_blocking(move || {
+            socket.connect_timeout(&addr.into(), CONNECT_TIMEOUT)?;
+            socket.set_nonblocking(true)?;
+            TokioTcpStream::from_std(unsafe {
+                std::net::TcpStream::from_raw_fd(socket.into_raw_fd())
+            })
+        })
+        .await
+        .expect("connect task panicked")
     }
 
     async fn resolve_address(uri: &Uri) -> io::Result<SocketAddr> {

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -54,7 +54,7 @@ pub enum Error {
     HttpError(#[error(source)] http::Error),
 
     #[error(display = "Request timed out")]
-    TimeoutError(#[error(source)] tokio::time::Elapsed),
+    TimeoutError(#[error(source)] tokio::time::error::Elapsed),
 
     #[error(display = "Failed to deserialize data")]
     DeserializeError(#[error(source)] serde_json::Error),

--- a/mullvad-rpc/src/tcp_stream.rs
+++ b/mullvad-rpc/src/tcp_stream.rs
@@ -14,17 +14,21 @@ use tokio::{
 
 #[derive(Debug)]
 pub struct TcpStreamHandle {
-    inner: Weak<Mutex<StreamInner>>,
+    inner: Weak<Mutex<Option<StreamInner>>>,
 }
 
 impl TcpStreamHandle {
     pub fn close(self) {
         if let Some(inner_lock) = self.inner.upgrade() {
-            if let Ok(mut inner) = inner_lock.lock() {
-                if let Err(err) = inner.stream.shutdown(Shutdown::Both) {
+            if let Ok(Some(inner)) = inner_lock.lock().map(|mut inner| inner.take()) {
+                if let Err(err) = flatten_result(
+                    inner
+                        .stream
+                        .into_std()
+                        .map(|stream| stream.shutdown(Shutdown::Both)),
+                ) {
                     log::error!("Failed to shut down TCP socket: {}", err);
                 }
-                let _ = inner.shutdown_tx.take();
             }
         }
     }
@@ -32,7 +36,7 @@ impl TcpStreamHandle {
 
 
 pub struct TcpStream {
-    inner: Arc<Mutex<StreamInner>>,
+    inner: Arc<Mutex<Option<StreamInner>>>,
 }
 
 impl TcpStream {
@@ -41,30 +45,34 @@ impl TcpStream {
         id: usize,
         shutdown_tx: Option<oneshot::Sender<()>>,
     ) -> (Self, TcpStreamHandle) {
-        let inner = Arc::new(Mutex::new(StreamInner {
+        let inner = Arc::new(Mutex::new(Some(StreamInner {
             id,
             stream,
             shutdown_tx,
-        }));
-        (
-            Self {
-                inner: inner.clone(),
-            },
-            TcpStreamHandle {
-                inner: Arc::downgrade(&inner),
-            },
-        )
+        })));
+        let stream_handle = TcpStreamHandle {
+            inner: Arc::downgrade(&inner),
+        };
+        (Self { inner }, stream_handle)
     }
 
-    fn do_stream<T>(&self, mut stream_fn: impl FnMut(&mut TokioTcpStream) -> T) -> T {
+    fn do_stream<T>(
+        &self,
+        mut stream_fn: impl FnMut(&mut TokioTcpStream) -> T,
+        closed_value: T,
+    ) -> T {
         let mut inner = self.inner.lock().expect("TCP lock poisoned");
-        stream_fn(&mut inner.stream)
+        if let Some(inner) = &mut *inner {
+            stream_fn(&mut inner.stream)
+        } else {
+            closed_value
+        }
     }
 }
 
 impl Drop for TcpStream {
     fn drop(&mut self) {
-        if let Ok(mut inner) = self.inner.lock() {
+        if let Ok(Some(mut inner)) = self.inner.lock().map(|mut inner| inner.take()) {
             if let Some(tx) = inner.shutdown_tx.take() {
                 let _ = tx.send(());
             }
@@ -79,15 +87,24 @@ impl AsyncWrite for TcpStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
-        self.do_stream(|stream| Pin::new(stream).poll_write(cx, buf))
+        self.do_stream(
+            |stream| Pin::new(stream).poll_write(cx, buf),
+            Poll::Ready(Ok(0)),
+        )
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        self.do_stream(|stream| Pin::new(stream).poll_flush(cx))
+        self.do_stream(
+            |stream| Pin::new(stream).poll_flush(cx),
+            Poll::Ready(Ok(())),
+        )
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        self.do_stream(|stream| Pin::new(stream).poll_shutdown(cx))
+        self.do_stream(
+            |stream| Pin::new(stream).poll_shutdown(cx),
+            Poll::Ready(Ok(())),
+        )
     }
 }
 
@@ -97,7 +114,10 @@ impl AsyncRead for TcpStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<Result<(), io::Error>> {
-        self.do_stream(|stream| Pin::new(stream).poll_read(cx, buf))
+        self.do_stream(
+            |stream| Pin::new(stream).poll_read(cx, buf),
+            Poll::Ready(Ok(())),
+        )
     }
 }
 
@@ -112,4 +132,11 @@ struct StreamInner {
     id: usize,
     stream: TokioTcpStream,
     shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+fn flatten_result<T, E>(result: Result<Result<T, E>, E>) -> Result<T, E> {
+    match result {
+        Ok(value) => value,
+        Err(err) => Err(err),
+    }
 }

--- a/mullvad-rpc/src/tcp_stream.rs
+++ b/mullvad-rpc/src/tcp_stream.rs
@@ -1,4 +1,3 @@
-use bytes::buf::Buf;
 use futures::channel::oneshot;
 use hyper::client::connect::{Connected, Connection};
 use std::{
@@ -9,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::{
-    io::{AsyncRead, AsyncWrite},
+    io::{AsyncRead, AsyncWrite, ReadBuf},
     net::TcpStream as TokioTcpStream,
 };
 
@@ -83,14 +82,6 @@ impl AsyncWrite for TcpStream {
         self.do_stream(|stream| Pin::new(stream).poll_write(cx, buf))
     }
 
-    fn poll_write_buf<B: Buf>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<Result<usize, io::Error>> {
-        self.do_stream(|stream| Pin::new(stream).poll_write_buf(cx, buf))
-    }
-
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         self.do_stream(|stream| Pin::new(stream).poll_flush(cx))
     }
@@ -104,8 +95,8 @@ impl AsyncRead for TcpStream {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize, io::Error>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<(), io::Error>> {
         self.do_stream(|stream| Pin::new(stream).poll_read(cx, buf))
     }
 }

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.1.0"
 
 mullvad-management-interface = { path = "../mullvad-management-interface" }
 
-tokio = { version = "0.2", features =  [ "rt-threaded" ] }
+tokio = { version = "1.8", features =  [ "rt-multi-thread" ] }
 
 mullvad-daemon = { path = "../mullvad-daemon" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -26,13 +26,13 @@ futures = "0.1.23"
 tokio01 = { package = "tokio", version = "0.1" }
 tokio-timer = "0.1"
 tokio = { version = "1.8", features =  [ "io-util", "process", "rt", "rt-multi-thread", "fs"] }
-tonic = "0.4"
+tonic = "0.5"
 tower = "0.4"
-prost = "0.7"
+prost = "0.8"
 parity-tokio-ipc = "0.9"
 
 [build-dependencies]
-tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -25,14 +25,14 @@ jsonrpc-client-pubsub = { git = "https://github.com/mullvad/jsonrpc-client-rs", 
 futures = "0.1.23"
 tokio01 = { package = "tokio", version = "0.1" }
 tokio-timer = "0.1"
-tokio = { version = "0.2", features =  [ "io-util", "process", "rt-core", "rt-threaded", "stream", "fs"] }
-tonic = "0.3.1"
-tower = "0.3"
-prost = "0.6"
-parity-tokio-ipc = "0.8"
+tokio = { version = "1.8", features =  [ "io-util", "process", "rt", "rt-multi-thread", "fs"] }
+tonic = "0.4"
+tower = "0.4"
+prost = "0.7"
+parity-tokio-ipc = "0.9"
 
 [build-dependencies]
-tonic-build = { version = "0.3", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -30,7 +30,7 @@ chrono = "0.4"
 tokio = { version = "1.8", features = [ "process", "rt-multi-thread", "fs" ] }
 tokio-stream = "0.1"
 rand = "0.7"
-udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "3d1abafe112ee8c2db47ca401f8e286756454e7a" }
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "1e27324362ed123b61fa2062b1599e5f9d569796" }
 
 
 [target.'cfg(not(target_os="android"))'.dependencies]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -37,8 +37,8 @@ udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "1e27324
 openvpn-plugin = { version = "0.4", features = ["serde", "auth-failed-event"] }
 parity-tokio-ipc = "0.9"
 triggered = "0.1.1"
-tonic = "0.4"
-prost = "0.7"
+tonic = "0.5"
+prost = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.19"
@@ -85,7 +85,7 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 memoffset = "0.6"
 
 [build-dependencies]
-tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"] }
 
 
 [dev-dependencies]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -27,17 +27,18 @@ talpid-types = { path = "../talpid-types" }
 uuid = { version = "0.8", features = ["v4"] }
 zeroize = "1"
 chrono = "0.4"
-tokio = { version = "0.2", features = [ "process", "rt-threaded", "stream", "fs" ] }
+tokio = { version = "1.8", features = [ "process", "rt-multi-thread", "fs" ] }
+tokio-stream = "0.1"
 rand = "0.7"
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "3d1abafe112ee8c2db47ca401f8e286756454e7a" }
 
 
 [target.'cfg(not(target_os="android"))'.dependencies]
 openvpn-plugin = { version = "0.4", features = ["serde", "auth-failed-event"] }
-parity-tokio-ipc = "0.8"
+parity-tokio-ipc = "0.9"
 triggered = "0.1.1"
-tonic = "0.3.1"
-prost = "0.6"
+tonic = "0.4"
+prost = "0.7"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.19"
@@ -51,12 +52,12 @@ jnix = { version = "0.4", features = ["derive"] }
 failure = "0.1"
 notify = "4.0"
 resolv-conf = "0.7"
-rtnetlink = "0.6"
+rtnetlink = "0.8"
 netlink-packet-core = "0.2"
 netlink-packet-utils = "0.4"
-netlink-packet-route = "0.6"
-netlink-proto = "0.5"
-netlink-sys = "0.4"
+netlink-packet-route = "0.7"
+netlink-proto = "0.7"
+netlink-sys = "0.7"
 byteorder = "1"
 nftnl = { version = "0.6", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2.0", features = ["mnl-1-0-4"] }
@@ -84,7 +85,7 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 memoffset = "0.6"
 
 [build-dependencies]
-tonic-build = { version = "0.3", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }
 
 
 [dev-dependencies]

--- a/talpid-core/src/future_retry.rs
+++ b/talpid-core/src/future_retry.rs
@@ -32,10 +32,10 @@ pub async fn retry_future_with_backoff<
 async fn sleep(mut delay: Duration) {
     while delay > MAX_SINGLE_DELAY {
         delay -= MAX_SINGLE_DELAY;
-        tokio::time::delay_for(MAX_SINGLE_DELAY).await;
+        tokio::time::sleep(MAX_SINGLE_DELAY).await;
     }
 
-    tokio::time::delay_for(delay).await;
+    tokio::time::sleep(delay).await;
 }
 
 /// Provides an exponential back-off timer to delay the next retry of a failed operation.

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -826,7 +826,7 @@ mod test {
     /// Tests if dropping inside a tokio runtime panics
     #[test]
     fn test_drop_in_executor() {
-        let mut runtime = tokio::runtime::Runtime::new().expect("Failed to initialize runtime");
+        let runtime = tokio::runtime::Runtime::new().expect("Failed to initialize runtime");
         runtime.block_on(async {
             let manager = RouteManagerImpl::new(HashSet::new())
                 .await
@@ -838,7 +838,7 @@ mod test {
     /// Tests if dropping outside a runtime panics
     #[test]
     fn test_drop() {
-        let mut runtime = tokio::runtime::Runtime::new().expect("Failed to initialize runtime");
+        let runtime = tokio::runtime::Runtime::new().expect("Failed to initialize runtime");
         let manager = runtime.block_on(async {
             RouteManagerImpl::new(HashSet::new())
                 .await

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -629,7 +629,8 @@ impl RouteManagerImpl {
                 let mut add_message = self
                     .handle
                     .route()
-                    .add_v4()
+                    .add()
+                    .v4()
                     .destination_prefix(v4_prefix.ip(), v4_prefix.prefix());
 
                 if v4_prefix.prefix() > 0 && v4_prefix.prefix() < 32 {
@@ -653,7 +654,8 @@ impl RouteManagerImpl {
                 let mut add_message = self
                     .handle
                     .route()
-                    .add_v6()
+                    .add()
+                    .v6()
                     .destination_prefix(v6_prefix.ip(), v6_prefix.prefix());
 
                 if v6_prefix.prefix() > 0 && v6_prefix.prefix() < 128 {

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -13,6 +13,7 @@ use std::{
     process::{ExitStatus, Stdio},
 };
 use tokio::{io::AsyncBufReadExt, process::Command};
+use tokio_stream::wrappers::LinesStream;
 
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -332,7 +333,7 @@ async fn listen_for_default_route_changes() -> Result<impl Stream<Item = std::io
     let mut add_or_delete_message = false;
     let mut contains_default = false;
 
-    let monitor = lines.try_filter_map(move |line| {
+    let monitor = LinesStream::new(lines).try_filter_map(move |line| {
         if add_or_delete_message {
             if line.contains("default") {
                 contains_default = true;

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -528,9 +528,8 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
             format!("/tmp/talpid-openvpn-{}", uuid)
         };
 
-        let mut runtime = tokio::runtime::Builder::new()
-            .threaded_scheduler()
-            .core_threads(1)
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
             .enable_all()
             .build()
             .map_err(Error::RuntimeError)?;

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -1200,7 +1200,13 @@ mod event_server {
 
     #[derive(Debug)]
     pub struct StreamBox<T: AsyncRead + AsyncWrite>(pub T);
-    impl<T: AsyncRead + AsyncWrite> Connected for StreamBox<T> {}
+    impl<T: AsyncRead + AsyncWrite> Connected for StreamBox<T> {
+        type ConnectInfo = Option<()>;
+
+        fn connect_info(&self) -> Self::ConnectInfo {
+            None
+        }
+    }
     impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for StreamBox<T> {
         fn poll_read(
             mut self: Pin<&mut Self>,

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -954,7 +954,7 @@ mod event_server {
     };
     #[cfg(any(target_os = "linux", windows))]
     use talpid_types::ErrorExt;
-    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use tonic::{
         self,
         transport::{server::Connected, Server},
@@ -1205,8 +1205,8 @@ mod event_server {
         fn poll_read(
             mut self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-            buf: &mut [u8],
-        ) -> Poll<std::io::Result<usize>> {
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
             Pin::new(&mut self.0).poll_read(cx, buf)
         }
     }

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -123,11 +123,11 @@ impl TcpProxy {
             .block_on(Udp2Tcp::new(
                 listen_addr,
                 endpoint,
-                Some(&TcpOptions {
+                TcpOptions {
                     #[cfg(target_os = "linux")]
                     fwmark: Some(crate::linux::TUNNEL_FW_MARK),
                     ..TcpOptions::default()
-                }),
+                },
             ))
             .map_err(Error::Udp2TcpError)?;
 

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
@@ -15,7 +15,7 @@ use netlink_proto::{
     ConnectionHandle, Error as NetlinkError,
 };
 use std::{ffi::CString, net::IpAddr};
-use tokio::stream::StreamExt;
+use tokio_stream::StreamExt;
 
 mod parsers;
 

--- a/talpid-dbus/Cargo.toml
+++ b/talpid-dbus/Cargo.toml
@@ -12,4 +12,4 @@ lazy_static = "1.0"
 log = "0.4"
 libc = "0.2"
 talpid-types = { path = "../talpid-types" }
-tokio = { version = "0.2", features = [ "blocking" ] }
+tokio = { version = "1.8", features = [ "full" ] }

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -20,12 +20,12 @@ tokio = { version = "1.8", features =  [ "rt" ] }
 openvpn-plugin = { version = "0.4", features = ["serde", "log", "auth-failed-event"] }
 talpid-types = { path = "../talpid-types" }
 
-tonic = "0.4"
+tonic = "0.5"
 tower = "0.4"
-prost = "0.7"
+prost = "0.8"
 
 [build-dependencies]
-tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"] }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -14,18 +14,18 @@ crate-type = ["cdylib"]
 err-derive = "0.3.0"
 log = "0.4"
 env_logger = "0.8.2"
-parity-tokio-ipc = "0.8"
-tokio = { version = "0.2", features =  [ "rt-core" ] }
+parity-tokio-ipc = "0.9"
+tokio = { version = "1.8", features =  [ "rt" ] }
 
 openvpn-plugin = { version = "0.4", features = ["serde", "log", "auth-failed-event"] }
 talpid-types = { path = "../talpid-types" }
 
-tonic = "0.3.1"
-tower = "0.3"
-prost = "0.6"
+tonic = "0.4"
+tower = "0.4"
+prost = "0.7"
 
 [build-dependencies]
-tonic-build = { version = "0.3", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"] }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -25,10 +25,7 @@ pub struct EventProcessor {
 impl EventProcessor {
     pub fn new(arguments: Arguments) -> Result<EventProcessor, Error> {
         log::trace!("Creating EventProcessor");
-        let mut runtime = runtime::Builder::new()
-            .basic_scheduler()
-            .core_threads(1)
-            .max_threads(1)
+        let runtime = runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(Error::CreateRuntime)?;


### PR DESCRIPTION
As above. This is a fairly small update. The number of changes that had to be made was not very large, so little refactoring was done. One major benefit of upgrading is the switch to mio 0.7, as there are some elusive panics on Windows caused by bugs in mio 0.6.

All direct dependency updates:
* tokio: 0.2.25 to 1.8.1.
* hyper: 0.13 to 0.14.
* hyper-rustls: 0.21 to 0.22.
* rustls: 0.18 to 0.19.
* tower: 0.3.1 to 0.4.8.
* tokio-rustls: 0.14.1 to 0.22.
* tonic: 0.3.1 to 0.5.
* tonic-build: 0.3.1 to 0.5.
* prost: 0.6 to 0.8.
* prost-types: 0.6 to 0.8.
* netlink-packet-route: 0.6 to 0.7.
* netlink-proto: 0.5 to 0.7.
* netlink-sys: 0.4 to 0.7.
* rtnetlink: 0.6 to 0.8.
* parity-tokio-ipc: 0.8 to 0.9.
* udp-over-tcp: `tokio02` branch to `master` branch.