### PR TITLE
Fix reverting translations

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1064,7 +1064,6 @@ class ApplicationMain {
 
   private registerIpcListeners() {
     IpcMainEventChannel.state.handleGet(() => ({
-      locale: this.locale,
       isConnected: this.connectedToDaemon,
       autoStart: getOpenAtLogin(),
       accountData: this.accountData,

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -425,7 +425,7 @@ class ApplicationMain {
     // Blocks navigation since it's not needed.
     this.blockNavigation();
 
-    this.translations = this.updateCurrentLocale();
+    this.updateCurrentLocale();
 
     this.daemonRpc.addConnectionObserver(
       new ConnectionObserver(this.onDaemonConnected, this.onDaemonDisconnected),
@@ -1153,7 +1153,8 @@ class ApplicationMain {
 
     IpcMainEventChannel.guiSettings.handleSetPreferredLocale((locale: string) => {
       this.guiSettings.preferredLocale = locale;
-      return Promise.resolve(this.updateCurrentLocale());
+      this.updateCurrentLocale();
+      return Promise.resolve(this.translations);
     });
 
     IpcMainEventChannel.account.handleCreate(() => this.createNewAccount());
@@ -1526,7 +1527,8 @@ class ApplicationMain {
 
     const messagesTranslations = loadTranslations(this.locale, messages);
     const relayLocationsTranslations = loadTranslations(this.locale, relayLocations);
-    return {
+
+    this.translations = {
       locale: this.locale,
       messages: messagesTranslations,
       relayLocations: relayLocationsTranslations,

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -208,7 +208,7 @@ export default class AppRenderer {
     // Request the initial state from the main process
     const initialState = IpcRendererEventChannel.state.get();
 
-    this.setLocale(initialState.locale);
+    this.setLocale(initialState.translations.locale);
     loadTranslations(
       messages,
       initialState.translations.locale,

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -40,7 +40,6 @@ export interface IRelayListPair {
 export type LaunchApplicationResult = { success: true } | { error: string };
 
 export interface IAppStateSnapshot {
-  locale: string;
   isConnected: boolean;
   autoStart: boolean;
   accountData?: IAccountData;


### PR DESCRIPTION
This PR fixes a bug which made the translations revert after switching to/from pinned window after changing language. The translations wasn't saved when switching language and since we create a new window when switching to/from pinned window we used the old ones.

I've also removed `locale` in `initialState` since it's redundant. We have the same value in `initialState.translations.locale`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2849)
<!-- Reviewable:end -->
