### PR TITLE
Fix `TcpStream` reset

### DIFF
--- a/mullvad-rpc/src/tcp_stream.rs
+++ b/mullvad-rpc/src/tcp_stream.rs
@@ -92,7 +92,10 @@ impl AsyncWrite for TcpStream {
     ) -> Poll<io::Result<usize>> {
         self.do_stream(
             |stream| Pin::new(stream).poll_write(cx, buf),
-            Poll::Ready(Ok(0)),
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "socket is closed",
+            ))),
         )
     }
 
@@ -119,7 +122,10 @@ impl AsyncRead for TcpStream {
     ) -> Poll<io::Result<()>> {
         self.do_stream(
             |stream| Pin::new(stream).poll_read(cx, buf),
-            Poll::Ready(Ok(())),
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "socket is closed",
+            ))),
         )
     }
 }


### PR DESCRIPTION
A [previous PR](#2848) caused `poll_write` to be called even after a TCP stream had been shut down. Returning `Ok(0)` from `poll_write` does not seem to tell the caller that the stream is closed. Returning an error fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2853)
<!-- Reviewable:end -->
