### PR TITLE
Add WireGuard transport protocol constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Added
 - Added possibility to filter locations by provider in the desktop app.
+- Add WireGuard over TCP CLI option for all relays.
 
 ### Changed
 - Only use the account history file to store the last used account.

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -1154,8 +1154,12 @@ function convertFromOpenVpnConstraints(
 function convertFromWireguardConstraints(
   constraints: grpcTypes.WireguardConstraints,
 ): IWireguardConstraints {
-  const port = convertFromConstraint(constraints.getPort());
-  return { port };
+  const transportPort = convertFromConstraint(constraints.getPort());
+  if (transportPort !== 'any' && 'only' in transportPort) {
+    const port = convertFromConstraint(transportPort.only.getPort());
+    return { port };
+  }
+  return { port: 'any' };
 }
 
 function convertFromTunnelTypeConstraint(
@@ -1260,7 +1264,10 @@ function convertToWireguardConstraints(
     const wireguardConstraints = new grpcTypes.WireguardConstraints();
     const port = liftConstraint(constraint.port);
     if (port) {
-      wireguardConstraints.setPort(port);
+      const portConstraints = new grpcTypes.TransportPort();
+      portConstraints.setPort(port);
+      portConstraints.setProtocol(grpcTypes.TransportProtocol.UDP);
+      wireguardConstraints.setPort(portConstraints);
     }
     return wireguardConstraints;
   }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -749,8 +749,14 @@ impl Relay {
     fn format_wireguard_constraints(constraints: Option<&WireguardConstraints>) -> String {
         if let Some(constraints) = constraints {
             let mut out = format!(
-                "{} over {}",
+                "{} over {} over {}",
                 Self::format_port(constraints.port),
+                Self::format_transport_protocol(
+                    constraints
+                        .protocol
+                        .clone()
+                        .map(|protocol| TransportProtocol::from_i32(protocol.protocol).unwrap())
+                ),
                 Self::format_ip_version(
                     constraints
                         .ip_version
@@ -770,7 +776,7 @@ impl Relay {
 
             out
         } else {
-            "any port over IPv4 or IPv6".to_string()
+            "any port over any protocol over IPv4 or IPv6".to_string()
         }
     }
 

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -54,6 +54,7 @@ const EXPONENTIAL_BACKOFF_FACTOR: u32 = 8;
 const DEFAULT_WIREGUARD_PORT: u16 = 51820;
 const WIREGUARD_EXIT_CONSTRAINTS: WireguardConstraints = WireguardConstraints {
     port: Constraint::Only(DEFAULT_WIREGUARD_PORT),
+    protocol: Constraint::Only(TransportProtocol::Udp),
     ip_version: Constraint::Only(IpVersion::V4),
     entry_location: None,
 };

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -317,6 +317,11 @@ message TransportProtocolConstraint {
 	TransportProtocol protocol = 1;
 }
 
+message TransportPort {
+	TransportProtocol protocol = 1;
+	uint32 port = 2;
+}
+
 message OpenvpnConstraints {
 	uint32 port = 1;
 	TransportProtocolConstraint protocol = 2;
@@ -332,10 +337,9 @@ message IpVersionConstraint {
 }
 
 message WireguardConstraints {
-	uint32 port = 1;
-	TransportProtocolConstraint protocol = 2;
-	IpVersionConstraint ip_version = 3;
-	RelayLocation entry_location = 4;
+	TransportPort port = 1;
+	IpVersionConstraint ip_version = 2;
+	RelayLocation entry_location = 3;
 }
 
 message CustomRelaySettings {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -332,10 +332,10 @@ message IpVersionConstraint {
 }
 
 message WireguardConstraints {
-	// NOTE: optional
 	uint32 port = 1;
-	IpVersionConstraint ip_version = 2;
-	RelayLocation entry_location = 3;
+	TransportProtocolConstraint protocol = 2;
+	IpVersionConstraint ip_version = 3;
+	RelayLocation entry_location = 4;
 }
 
 message CustomRelaySettings {

--- a/mullvad-rpc/src/relay_list.rs
+++ b/mullvad-rpc/src/relay_list.rs
@@ -3,7 +3,7 @@ use crate::rest;
 
 use hyper::{header, Method, StatusCode};
 use mullvad_types::{location, relay_list};
-use talpid_types::net::wireguard;
+use talpid_types::net::{wireguard, TransportProtocol};
 
 use std::{
     collections::BTreeMap,
@@ -183,6 +183,7 @@ impl ServerRelayList {
                 ipv4_gateway,
                 ipv6_gateway,
                 public_key,
+                protocol: TransportProtocol::Udp,
             };
 
         for mut wireguard_relay in relays {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -516,13 +516,16 @@ impl Match<WireguardEndpointData> for WireguardConstraints {
     fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
         match self.port {
             Constraint::Any => true,
-            Constraint::Only(port) => match port.port {
-                Constraint::Any => true,
-                Constraint::Only(port) => endpoint
-                    .port_ranges
-                    .iter()
-                    .any(|range| (port >= range.0 && port <= range.1)),
-            },
+            Constraint::Only(transport_port) => {
+                transport_port.protocol == endpoint.protocol
+                    && match transport_port.port {
+                        Constraint::Any => true,
+                        Constraint::Only(port) => endpoint
+                            .port_ranges
+                            .iter()
+                            .any(|range| (port >= range.0 && port <= range.1)),
+                    }
+            }
         }
     }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -445,6 +445,12 @@ impl Match<WireguardEndpointData> for TunnelConstraints {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct TransportPort {
+    pub protocol: TransportProtocol,
+    pub port: Constraint<u16>,
+}
+
 /// [`Constraint`]s applicable to OpenVPN relay servers.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct OpenVpnConstraints {
@@ -476,8 +482,7 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct WireguardConstraints {
-    pub port: Constraint<u16>,
-    pub protocol: Constraint<TransportProtocol>,
+    pub port: Constraint<TransportPort>,
     pub ip_version: Constraint<IpVersion>,
     pub entry_location: Option<Constraint<LocationConstraint>>,
 }
@@ -486,12 +491,13 @@ impl fmt::Display for WireguardConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.port {
             Constraint::Any => write!(f, "any port")?,
-            Constraint::Only(port) => write!(f, "port {}", port)?,
-        }
-        write!(f, " over ")?;
-        match self.protocol {
-            Constraint::Any => write!(f, "any protocol")?,
-            Constraint::Only(protocol) => write!(f, "{}", protocol)?,
+            Constraint::Only(port) => {
+                match port.port {
+                    Constraint::Any => write!(f, "any port")?,
+                    Constraint::Only(port) => write!(f, "port {}", port)?,
+                }
+                write!(f, " over {}", port.protocol)?;
+            }
         }
         write!(f, " over ")?;
         match self.ip_version {
@@ -510,10 +516,13 @@ impl Match<WireguardEndpointData> for WireguardConstraints {
     fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
         match self.port {
             Constraint::Any => true,
-            Constraint::Only(port) => endpoint
-                .port_ranges
-                .iter()
-                .any(|range| (port >= range.0 && port <= range.1)),
+            Constraint::Only(port) => match port.port {
+                Constraint::Any => true,
+                Constraint::Only(port) => endpoint
+                    .port_ranges
+                    .iter()
+                    .any(|range| (port >= range.0 && port <= range.1)),
+            },
         }
     }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -491,6 +491,11 @@ impl fmt::Display for WireguardConstraints {
             Constraint::Only(port) => write!(f, "port {}", port)?,
         }
         write!(f, " over ")?;
+        match self.protocol {
+            Constraint::Any => write!(f, "any protocol")?,
+            Constraint::Only(protocol) => write!(f, "{}", protocol)?,
+        }
+        write!(f, " over ")?;
         match self.ip_version {
             Constraint::Any => write!(f, "IPv4 or IPv6")?,
             Constraint::Only(protocol) => write!(f, "{}", protocol)?,

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -477,6 +477,7 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 #[serde(default)]
 pub struct WireguardConstraints {
     pub port: Constraint<u16>,
+    pub protocol: Constraint<TransportProtocol>,
     pub ip_version: Constraint<IpVersion>,
     pub entry_location: Option<Constraint<LocationConstraint>>,
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -12,8 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fmt};
 use talpid_types::net::{openvpn::ProxySettings, IpVersion, TransportProtocol, TunnelType};
 
-pub const WIREGUARD_TCP_PORTS: [(u16, u16); 3] = [(80, 80), (443, 443), (5001, 5001)];
-
 
 pub trait Match<T> {
     fn matches(&self, other: &T) -> bool;
@@ -512,15 +510,10 @@ impl Match<WireguardEndpointData> for WireguardConstraints {
     fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
         match self.port {
             Constraint::Any => true,
-            Constraint::Only(port) => match self.protocol {
-                Constraint::Only(TransportProtocol::Tcp) => WIREGUARD_TCP_PORTS
-                    .iter()
-                    .any(|range| (port >= range.0 && port <= range.1)),
-                _ => endpoint
-                    .port_ranges
-                    .iter()
-                    .any(|range| (port >= range.0 && port <= range.1)),
-            },
+            Constraint::Only(port) => endpoint
+                .port_ranges
+                .iter()
+                .any(|range| (port >= range.0 && port <= range.1)),
         }
     }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fmt};
 use talpid_types::net::{openvpn::ProxySettings, IpVersion, TransportProtocol, TunnelType};
 
+pub const WIREGUARD_TCP_PORTS: [(u16, u16); 3] = [(80, 80), (443, 443), (5001, 5001)];
+
 
 pub trait Match<T> {
     fn matches(&self, other: &T) -> bool;
@@ -505,10 +507,15 @@ impl Match<WireguardEndpointData> for WireguardConstraints {
     fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
         match self.port {
             Constraint::Any => true,
-            Constraint::Only(port) => endpoint
-                .port_ranges
-                .iter()
-                .any(|range| (port >= range.0 && port <= range.1)),
+            Constraint::Only(port) => match self.protocol {
+                Constraint::Only(TransportProtocol::Tcp) => WIREGUARD_TCP_PORTS
+                    .iter()
+                    .any(|range| (port >= range.0 && port <= range.1)),
+                _ => endpoint
+                    .port_ranges
+                    .iter()
+                    .any(|range| (port >= range.0 && port <= range.1)),
+            },
         }
     }
 }

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -142,15 +142,23 @@ pub struct WireguardEndpointData {
     pub ipv6_gateway: Ipv6Addr,
     /// The peer's public key
     pub public_key: wireguard::PublicKey,
+    #[serde(default = "default_wg_transport")]
+    #[serde(skip)]
+    pub protocol: TransportProtocol,
+}
+
+fn default_wg_transport() -> TransportProtocol {
+    TransportProtocol::Udp
 }
 
 impl fmt::Display for WireguardEndpointData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "gateways {} - {} port_ranges {{ {} }} public_key {}",
+            "gateways {} - {} {} port_ranges {{ {} }} public_key {}",
             self.ipv4_gateway,
             self.ipv6_gateway,
+            self.protocol,
             self.port_ranges
                 .iter()
                 .map(|range| format!("[{} - {}]", range.0, range.1))

--- a/mullvad-types/src/settings/migrations/mod.rs
+++ b/mullvad-types/src/settings/migrations/mod.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 mod v1;
 mod v2;
 mod v3;
+mod v4;
 
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
@@ -11,9 +12,10 @@ pub enum SettingsVersion {
     V2 = 2,
     V3 = 3,
     V4 = 4,
+    V5 = 5,
 }
 
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V3;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V5;
 
 impl<'de> Deserialize<'de> for SettingsVersion {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
@@ -24,6 +26,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V2 as u32 => Ok(SettingsVersion::V2),
             v if v == SettingsVersion::V3 as u32 => Ok(SettingsVersion::V3),
             v if v == SettingsVersion::V4 as u32 => Ok(SettingsVersion::V4),
+            v if v == SettingsVersion::V5 as u32 => Ok(SettingsVersion::V5),
             v => Err(serde::de::Error::custom(format!(
                 "{} is not a valid SettingsVersion",
                 v
@@ -59,6 +62,7 @@ pub fn try_migrate_settings(mut settings_file: &[u8]) -> Result<crate::settings:
         Box::new(v1::Migration),
         Box::new(v2::Migration),
         Box::new(v3::Migration),
+        Box::new(v4::Migration),
     ];
 
     for migration in &migrations {
@@ -85,7 +89,7 @@ mod test {
     #[test]
     #[should_panic]
     fn test_deserialization_failure_version_too_big() {
-        let _version: SettingsVersion = serde_json::from_str("100").expect("Version too big");
+        let _version: SettingsVersion = serde_json::from_str("1000").expect("Version too big");
     }
 
     #[test]

--- a/mullvad-types/src/settings/migrations/v1.rs
+++ b/mullvad-types/src/settings/migrations/v1.rs
@@ -128,7 +128,7 @@ mod test {
       "enable_ipv6": false
     }
   },
-  "settings_version": 4
+  "settings_version": 5
 }
 "#;
 

--- a/mullvad-types/src/settings/migrations/v2.rs
+++ b/mullvad-types/src/settings/migrations/v2.rs
@@ -160,7 +160,7 @@ mod test {
       "enable_ipv6": false
     }
   },
-  "settings_version": 4
+  "settings_version": 5
 }
 "#;
 

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -356,7 +356,7 @@ mod test {
                   "enable_ipv6": true
                 }
               },
-              "settings_version": 3,
+              "settings_version": 5,
               "show_beta_releases": false
         }"#;
 


### PR DESCRIPTION
This previously existed only for custom relays. The PR adds the option for normal relays. Because the relay list does not currently include ports/TCP endpoints, all WireGuard relays are assumed to run `tcp2udp` on a set of hardcoded ports.

Usage:
> mullvad relay set tunnel wireguard any --protocol tcp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2856)
<!-- Reviewable:end -->
