### PR TITLE
Make sure history is initialized with correct path and make frontend wait until fonts are loaded before showing window

### DIFF
--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -133,7 +133,6 @@ export default class WindowController {
   private windowValue: BrowserWindow;
   private webContentsValue: WebContents;
   private windowPositioning: IWindowPositioning;
-  private isWindowReady = false;
 
   get window(): BrowserWindow | undefined {
     return this.windowValue.isDestroyed() ? undefined : this.windowValue;
@@ -154,7 +153,6 @@ export default class WindowController {
       : new AttachedToTrayWindowPositioning(tray);
 
     this.installDisplayMetricsHandler();
-    this.installWindowReadyHandlers();
   }
 
   public replaceWindow(window: BrowserWindow, unpinnedWindow: boolean) {
@@ -269,17 +267,11 @@ export default class WindowController {
     this.window?.setSize(this.width, this.height);
   }
 
-  private installWindowReadyHandlers() {
-    this.window?.once('ready-to-show', () => {
-      this.isWindowReady = true;
-    });
-  }
-
   private executeWhenWindowIsReady(closure: () => void) {
-    if (this.isWindowReady) {
+    if (this.webContents?.isLoading() === false && this.webContents?.getURL() !== '') {
       closure();
     } else {
-      this.window?.once('ready-to-show', () => {
+      this.webContents?.once('did-stop-loading', () => {
         closure();
       });
     }


### PR DESCRIPTION
This PR:
* Changes the initialization of `history` to be done later and to be done with the correct path
* ~~Adds possibility to listen to ipc calls for one event only~~
* Makes main process wait until fonts are loaded before calling `show()` on renderer window.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2857)
<!-- Reviewable:end -->
