### PR TITLE
Root container accessibility

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -382,6 +382,18 @@ extension AppDelegate: RootContainerViewControllerDelegate {
             return controller.supportedInterfaceOrientations
         }
     }
+
+    func rootContainerViewAccessibilityPerformMagicTap(_ controller: RootContainerViewController) -> Bool {
+        guard Account.shared.isLoggedIn else { return false }
+
+        switch TunnelManager.shared.tunnelState {
+        case .connected, .connecting, .reconnecting:
+            reconnectTunnel()
+        case .disconnecting, .disconnected:
+            connectTunnel()
+        }
+        return true
+    }
 }
 
 // MARK: - LoginViewControllerDelegate
@@ -517,9 +529,7 @@ extension AppDelegate: ConnectViewControllerDelegate {
     }
 
     func connectViewControllerShouldReconnectTunnel(_ controller: ConnectViewController) {
-        TunnelManager.shared.reconnectTunnel {
-            self.logger?.debug("Re-connected VPN tunnel")
-        }
+        reconnectTunnel()
     }
 
     @objc private func handleDismissSelectLocationController(_ sender: Any) {
@@ -551,6 +561,12 @@ extension AppDelegate: ConnectViewControllerDelegate {
                 self.logger?.error(chainedError: error, message: "Failed to stop the VPN tunnel")
                 self.presentTunnelError(error, alertTitle: NSLocalizedString("Failed to stop the VPN tunnel", comment: ""))
             }
+        }
+    }
+
+    private func reconnectTunnel() {
+        TunnelManager.shared.reconnectTunnel {
+            self.logger?.debug("Re-connected VPN tunnel")
         }
     }
 

--- a/ios/MullvadVPN/ConnectMainContentView.swift
+++ b/ios/MullvadVPN/ConnectMainContentView.swift
@@ -84,6 +84,10 @@ class ConnectMainContentView: UIView {
         backgroundColor = .primaryColor
         layoutMargins = UIMetrics.contentLayoutMargins
 
+        if #available(iOS 13.0, *) {
+            accessibilityContainerType = .semanticGroup
+        }
+
         addSubviews()
     }
 

--- a/ios/MullvadVPN/HeaderBarView.swift
+++ b/ios/MullvadVPN/HeaderBarView.swift
@@ -63,6 +63,10 @@ class HeaderBarView: UIView {
             right: UIMetrics.contentLayoutMargins.right
         )
 
+        if #available(iOS 13.0, *) {
+            accessibilityContainerType = .semanticGroup
+        }
+
         let constraints = [
             logoImageView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
             logoImageView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),

--- a/ios/MullvadVPN/RootContainerViewController.swift
+++ b/ios/MullvadVPN/RootContainerViewController.swift
@@ -49,6 +49,8 @@ protocol RootContainerViewControllerDelegate: AnyObject {
     func rootContainerViewControllerShouldShowSettings(_ controller: RootContainerViewController, navigateTo route: SettingsNavigationRoute?, animated: Bool)
 
     func rootContainerViewSupportedInterfaceOrientations(_ controller: RootContainerViewController) -> UIInterfaceOrientationMask
+
+    func rootContainerViewAccessibilityPerformMagicTap(_ controller: RootContainerViewController) -> Bool
 }
 
 /// A root container view controller
@@ -269,6 +271,12 @@ class RootContainerViewController: UIViewController {
         } else {
             updateHeaderBarHiddenFromChildPreferences(animated: animated)
         }
+    }
+
+    // MARK: - Accessibility
+
+    override func accessibilityPerformMagicTap() -> Bool {
+        return delegate?.rootContainerViewAccessibilityPerformMagicTap(self) ?? super.accessibilityPerformMagicTap()
     }
 
     // MARK: - Private

--- a/ios/MullvadVPN/RootContainerViewController.swift
+++ b/ios/MullvadVPN/RootContainerViewController.swift
@@ -107,8 +107,6 @@ class RootContainerViewController: UIViewController {
         addTransitionView()
         addHeaderBarView()
         updateHeaderBarBackground()
-
-        accessibilityElements = [headerBarView, transitionContainer]
     }
 
     override func viewDidLayoutSubviews() {
@@ -361,6 +359,7 @@ class RootContainerViewController: UIViewController {
             }
 
             self.updateInterfaceOrientation(attemptRotateToDeviceOrientation: true)
+            self.updateAccessibilityElementsAndNotifyScreenChange()
 
             completion?()
         }
@@ -550,6 +549,14 @@ class RootContainerViewController: UIViewController {
             disappearingController = nil
             controller.endAppearanceTransition()
         }
+    }
+
+    private func updateAccessibilityElementsAndNotifyScreenChange() {
+        // Update accessibility elements to define the correct navigation order: header bar, content view.
+        view.accessibilityElements = [headerBarView, topViewController?.view].compactMap { $0 }
+
+        // Tell accessibility that the significant part of screen was changed.
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
 
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Properly update `accessibilityElements` on the `RootContainer` view to set the order in which voice over navigates between child views.
2. Post`Accessibility.screenChanged` notification when changing view controllers in `RootContainer`. This tells accessibility runtime to update the accessibility tree and note new views etc..
3. Set `accessibilityContainerType` to `semanticGroup` on header bar and main content view (with tunnel status), which includes the marked views into "Containers" group in rotor control and enables quick navigation between them.
   _Note: as the case with many standard controls, `UITableView` with relay locations is automatically marked as container so we don't need to mark it explicitly._
4. Add magic tap implementation (double tap with two fingers), which secures connection when disconnected and reconnects when connected, but never disconnects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2858)
<!-- Reviewable:end -->
