### PR TITLE
Consent screen localization

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		58F3C0A4249CB069003E76BE /* HeaderBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3C0A3249CB069003E76BE /* HeaderBarView.swift */; };
 		58F3C0A624A50157003E76BE /* relays.json in Resources */ = {isa = PBXBuildFile; fileRef = 58F3C0A524A50155003E76BE /* relays.json */; };
 		58F3C0A724A50C02003E76BE /* relays.json in Resources */ = {isa = PBXBuildFile; fileRef = 58F3C0A524A50155003E76BE /* relays.json */; };
+		58F558DD2695B85E00F630D0 /* Consent.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F558DB2695B85E00F630D0 /* Consent.strings */; };
 		58F5590E2697002100F630D0 /* Main.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F559052697002000F630D0 /* Main.strings */; };
 		58F5590F2697002100F630D0 /* ConnectionPanel.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F559072697002100F630D0 /* ConnectionPanel.strings */; };
 		58F61F4F2692F21C00DCFC2B /* WireguardKeys.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F61F4D2692F21C00DCFC2B /* WireguardKeys.strings */; };
@@ -440,6 +441,7 @@
 		58F19E34228C15BA00C7710B /* SpinnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerActivityIndicatorView.swift; sourceTree = "<group>"; };
 		58F3C0A3249CB069003E76BE /* HeaderBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBarView.swift; sourceTree = "<group>"; };
 		58F3C0A524A50155003E76BE /* relays.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = relays.json; sourceTree = "<group>"; };
+		58F558DC2695B85E00F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Consent.strings; sourceTree = "<group>"; };
 		58F559062697002000F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		58F559082697002100F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ConnectionPanel.strings; sourceTree = "<group>"; };
 		58F61F4E2692F21C00DCFC2B /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/WireguardKeys.strings; sourceTree = "<group>"; };
@@ -549,6 +551,7 @@
 				581FC4F82695ACE100AA97BA /* Account.strings */,
 				582CFEE526945FC30072883A /* AppStoreSubscriptions.strings */,
 				58F559072697002100F630D0 /* ConnectionPanel.strings */,
+				58F558DB2695B85E00F630D0 /* Consent.strings */,
 				587B7543266922BF00DEF7E9 /* Localizable.strings */,
 				58F559052697002000F630D0 /* Main.strings */,
 				582CFEE8269463B80072883A /* Settings.strings */,
@@ -958,6 +961,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				58F3C0A624A50157003E76BE /* relays.json in Resources */,
+				58F558DD2695B85E00F630D0 /* Consent.strings in Resources */,
 				58727283265D173C00F315B2 /* LaunchScreen.storyboard in Resources */,
 				586ADD4723FC13F400CE9E87 /* countries.geo.json in Resources */,
 				58F5590F2697002100F630D0 /* ConnectionPanel.strings in Resources */,
@@ -1295,6 +1299,14 @@
 				587B7544266922BF00DEF7E9 /* en */,
 			);
 			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		58F558DB2695B85E00F630D0 /* Consent.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				58F558DC2695B85E00F630D0 /* en */,
+			);
+			name = Consent.strings;
 			sourceTree = "<group>";
 		};
 		58F559052697002000F630D0 /* Main.strings */ = {

--- a/ios/MullvadVPN/ConsentContentView.swift
+++ b/ios/MullvadVPN/ConsentContentView.swift
@@ -17,7 +17,7 @@ class ConsentContentView: UIView {
         titleLabel.numberOfLines = 0
         titleLabel.textColor = .white
         titleLabel.allowsDefaultTighteningForTruncation = true
-        titleLabel.text = NSLocalizedString("Do you agree to remaining anonymous?", comment: "")
+        titleLabel.text = NSLocalizedString("PRIVACY_NOTICE_HEADING", tableName: "Consent", comment: "Heading.")
         titleLabel.lineBreakMode = .byWordWrapping
         if #available(iOS 14.0, *) {
             // Disable the new line break strategy used by UIKit that moves at least two words
@@ -29,27 +29,23 @@ class ConsentContentView: UIView {
     }()
 
     let bodyLabel: UILabel = {
-        let localizedText = NSLocalizedString("""
-You have a right to privacy. That’s why we never store activity logs, don't ask for personal information, and encourage anonymous payments.
-
-In some situations, as outlined in our privacy policy, we might process personal data that you choose to send, for example if you email us.
-
-We strongly believe in retaining as little data as possible because we want you to remain anonymous.
-""", comment: "")
-
         let bodyLabel = UILabel()
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
         bodyLabel.font = UIFont.systemFont(ofSize: 18)
         bodyLabel.textColor = .white
         bodyLabel.numberOfLines = 0
-        bodyLabel.text = localizedText
+        bodyLabel.text = NSLocalizedString("PRIVACY_NOTICE_BODY", tableName: "Consent", comment: "Body.")
         return bodyLabel
     }()
 
     let privacyPolicyLink: LinkButton = {
         let button = LinkButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.titleString = NSLocalizedString("Privacy policy", comment: "")
+        button.titleString = NSLocalizedString(
+            "PRIVACY_POLICY_LINK_TITLE",
+            tableName: "Consent",
+            comment: "Title for link to privacy policy web page."
+        )
         button.setImage(UIImage(named: "IconExtlink"), for: .normal)
         return button
     }()
@@ -57,8 +53,12 @@ We strongly believe in retaining as little data as possible because we want you 
     let agreeButton: AppButton = {
         let button = AppButton(style: .default)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle(NSLocalizedString("Agree and continue", comment: ""), for: .normal)
         button.accessibilityIdentifier = "AgreeButton"
+        button.setTitle(NSLocalizedString(
+            "CONTINUE_BUTTON_TITLE",
+            tableName: "Consent",
+            comment: "Title for button used for agreeing with privacy notice."
+        ), for: .normal)
         return button
     }()
 

--- a/ios/MullvadVPN/en.lproj/Consent.strings
+++ b/ios/MullvadVPN/en.lproj/Consent.strings
@@ -1,0 +1,11 @@
+/* Title for button used for agreeing with privacy notice. */
+"CONTINUE_BUTTON_TITLE" = "Agree and continue";
+
+/* Body. */
+"PRIVACY_NOTICE_BODY" = "You have a right to privacy. That’s why we never store activity logs, don't ask for personal information, and encourage anonymous payments.\n\nIn some situations, as outlined in our privacy policy, we might process personal data that you choose to send, for example if you email us.\n\nWe strongly believe in retaining as little data as possible because we want you to remain anonymous.";
+
+/* Heading. */
+"PRIVACY_NOTICE_HEADING" = "Do you agree to remaining anonymous?";
+
+/* Title for link to privacy policy web page. */
+"PRIVACY_POLICY_LINK_TITLE" = "Privacy policy";


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
* 
This PR moves localizations found in a privacy controller displayed on the very first run, into a separate `Consent.strings` table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2870)
<!-- Reviewable:end -->
