### PR TITLE
Prevent header bar title from being translated

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -495,10 +495,6 @@ msgctxt "generic"
 msgid "Mullvad VPN"
 msgstr ""
 
-msgctxt "generic"
-msgid "MULLVAD VPN"
-msgstr ""
-
 msgctxt "in-app-notifications"
 msgid "\"Always require VPN\" is enabled."
 msgstr ""

--- a/gui/src/renderer/components/ErrorBoundary.tsx
+++ b/gui/src/renderer/components/ErrorBoundary.tsx
@@ -78,7 +78,7 @@ export default class ErrorBoundary extends React.Component<IProps, IState> {
           <Layout>
             <StyledContainer>
               <Logo height={106} width={106} source="logo-icon" />
-              <Title>{messages.pgettext('generic', 'MULLVAD VPN')}</Title>
+              <Title>MULLVAD VPN</Title>
               <Subtitle role="alert">{reachBackMessage}</Subtitle>
             </StyledContainer>
           </Layout>

--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -86,7 +86,7 @@ export function Brand(props: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <BrandContainer {...props}>
       <Logo width={44} height={44} source="logo-icon" />
-      <Title>{messages.pgettext('generic', 'MULLVAD VPN')}</Title>
+      <Title>MULLVAD VPN</Title>
     </BrandContainer>
   );
 }

--- a/gui/src/renderer/components/Launch.tsx
+++ b/gui/src/renderer/components/Launch.tsx
@@ -44,7 +44,7 @@ export default function Launch() {
       </Header>
       <StyledContainer>
         <Logo height={106} width={106} source="logo-icon" />
-        <Title>{messages.pgettext('generic', 'MULLVAD VPN')}</Title>
+        <Title>MULLVAD VPN</Title>
         <Subtitle role="alert">
           {messages.pgettext('launch-view', 'Connecting to Mullvad system service...')}
         </Subtitle>


### PR DESCRIPTION
This PR prevents `MULLVAD VPN` in the header bar from being translated. This aligns the text with Android and iOS.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2880)
<!-- Reviewable:end -->
