### PR TITLE
Declare localizations used in system notifications 

### DIFF
--- a/ios/MullvadVPN/Notifications/AccountExpiryNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/AccountExpiryNotificationProvider.swift
@@ -55,6 +55,15 @@ class AccountExpiryNotificationProvider: NotificationProvider, SystemNotificatio
     var notificationRequest: UNNotificationRequest? {
         guard let trigger = trigger else { return nil }
 
+        _ = NSLocalizedString(
+            "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE",
+            comment: "Title for system account expiry notification, fired 3 days prior to account expiry."
+        )
+        _ = NSLocalizedString(
+            "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY",
+            comment: "Message for system account expiry notification, fired 3 days prior to account expiry."
+        )
+
         let content = UNMutableNotificationContent()
         content.title = NSString.localizedUserNotificationString(forKey: "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE", arguments: nil)
         content.body = NSString.localizedUserNotificationString(forKey: "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY", arguments: nil)
@@ -100,8 +109,16 @@ class AccountExpiryNotificationProvider: NotificationProvider, SystemNotificatio
         return InAppNotificationDescriptor(
             identifier: self.identifier,
             style: .warning,
-            title: NSLocalizedString("ACCOUNT_EXPIRY_INAPP_NOTIFICATION_TITLE", comment: ""),
-            body: String(format: NSLocalizedString("ACCOUNT_EXPIRY_INAPP_NOTIFICATION_BODY", comment: ""), duration)
+            title: NSLocalizedString(
+                "ACCOUNT_EXPIRY_INAPP_NOTIFICATION_TITLE",
+                comment: "Title for in-app notification, displayed within the last 3 days until account expiry."
+            ),
+            body: String(
+                format: NSLocalizedString(
+                    "ACCOUNT_EXPIRY_INAPP_NOTIFICATION_BODY",
+                    comment: "Message for in-app notification, displayed within the last 3 days until account expiry."
+                ), duration
+            )
         )
     }
 

--- a/ios/MullvadVPN/en.lproj/Localizable.strings
+++ b/ios/MullvadVPN/en.lproj/Localizable.strings
@@ -1,20 +1,11 @@
-/* 
-  Localizable.strings
-  MullvadVPN
-
-  Created by pronebird on 31/05/2021.
-  Copyright © 2021 Mullvad VPN AB. All rights reserved.
-*/
-
-"HEADER_BAR_SETTINGS_BUTTON_ACCESSIBILITY_LABEL" = "Settings";
-"RECONNECT_BUTTON_ACCESSIBILITY_LABEL" = "Reconnect";
-
-"SELECT_LOCATION_COLLAPSE_ACCESSIBILITY_ACTION" = "Collapse location";
-"SELECT_LOCATION_EXPAND_ACCESSIBILITY_ACTION" = "Expand location";
-
-"ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE" = "Account credit expires soon";
-"ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY" = "Account credit expires in 3 days. Buy more credit.";
-"ACCOUNT_EXPIRY_INAPP_NOTIFICATION_TITLE" = "ACCOUNT CREDIT EXPIRES SOON";
+/* Message for in-app notification, displayed within the last 3 days until account expiry. */
 "ACCOUNT_EXPIRY_INAPP_NOTIFICATION_BODY" = "%@ left. Buy more credit.";
 
-"ACCOUNT_INPUT_LOGIN_BUTTON_ACCESSIBILITY_LABEL" = "Log in";
+/* Title for in-app notification, displayed within the last 3 days until account expiry. */
+"ACCOUNT_EXPIRY_INAPP_NOTIFICATION_TITLE" = "ACCOUNT CREDIT EXPIRES SOON";
+
+/* Message for system account expiry notification, fired 3 days prior to account expiry. */
+"ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY" = "Account credit expires in 3 days. Buy more credit.";
+
+/* Title for system account expiry notification, fired 3 days prior to account expiry. */
+"ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE" = "Account credit expires soon";


### PR DESCRIPTION
Genstrings tool does not automatically pick up NSString.localizedUserNotificationString

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Add no-op `NSLocalizedString` calls for the parser to pick up the translations for system notifications. `NSString.localizedUserNotificationString` marks the string IDs for the system to pick up from `Localizable.strings` but the parser itself does not extract the identifiers from these calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2881)
<!-- Reviewable:end -->
