### PR TITLE
Select location: reorder accessibility elements

### DIFF
--- a/ios/MullvadVPN/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/SelectLocationViewController.swift
@@ -67,6 +67,7 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
 
         self.tableView = tableView
 
+        view.accessibilityElements = [tableHeaderFooterView, tableView]
         view.backgroundColor = .secondaryColor
         view.addSubview(tableView)
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR reorders accessibility elements in "Select Location" controller to ensure that the table header or footer receives the accessibility focus first before the relay list. 

This is especially important on iPad where the description is displayed at the bottom of the view before the list of relays. 

The rationale behind is that it would be really difficult to reach the description label using only horizontal swipe gesture, when it's located at the bottom, it would require going through all of the relay locations first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2883)
<!-- Reviewable:end -->
