### PR TITLE
Replace recursive rmdir with rm

### DIFF
--- a/gui/gulpfile.js
+++ b/gui/gulpfile.js
@@ -7,7 +7,7 @@ const watch = require('./tasks/watch');
 const dist = require('./tasks/distribution');
 
 task('clean', function (done) {
-  fs.rmdir('./build', { recursive: true }, done);
+  fs.rm('./build', { recursive: true, force: true }, done);
 });
 task('build-proto', scripts.buildProto);
 task('build', series('clean', parallel(assets.copyAll, scripts.buildProto), scripts.build));

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -233,7 +233,7 @@ function packMac() {
           await notarizeMac(buildResult.artifactPaths[0]);
         }
         // remove the folder that contains the unpacked app
-        return fs.promises.rmdir(appOutDir, { recursive: true });
+        return fs.promises.rm(appOutDir, { recursive: true });
       },
       afterSign: noAppleNotarization
         ? undefined


### PR DESCRIPTION
Recursive `rmdir` is deprecated in Node 15. This PR replaces recursive `rmdir` calls with recursive `rm`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2887)
<!-- Reviewable:end -->
