### PR TITLE
Rsync built artifacts to releases.mullvad.net

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -26,12 +26,12 @@ while true; do
 
     ssh build.mullvad.net mkdir -p "app/$version" || continue
     scp -pB "$f" build.mullvad.net:app/$version/ || continue
-    rsync -av --rsh='ssh -p 1122' "$f" build@releases.mullvad.net:$upload_path/$version/ || continue
+    rsync -av --rsh='ssh -p 1122' "$f" "build@releases.mullvad.net:$upload_path/$version/" || continue
 
     rm -f "$f.asc"
     gpg -u A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF --pinentry-mode loopback --sign --armor --detach-sign "$f"
     scp -pB "$f.asc" build.mullvad.net:app/$version/ || true
-    rsync -av --rsh='ssh -p 1122' "$f.asc" build@releases.mullvad.net:$upload_path/$version/ || continue
+    rsync -av --rsh='ssh -p 1122' "$f.asc" "build@releases.mullvad.net:$upload_path/$version/" || continue
     yes | rm "$f" "$f_checksum" "$f.asc"
   done
   for f_checksum in pdb-*.sha256; do

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -18,12 +18,20 @@ while true; do
     fi
 
     version=$(echo $f | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm|\.apk|\.aab)/\1/g')
+    if [[ $version == *"-dev-"* ]]; then
+        upload_path="builds"
+    else
+        upload_path="releases"
+    fi
+
     ssh build.mullvad.net mkdir -p "app/$version" || continue
     scp -pB "$f" build.mullvad.net:app/$version/ || continue
+    rsync -av --rsh='ssh -p 1122' "$f" build@releases.mullvad.net:$upload_path/$version/ || continue
 
     rm -f "$f.asc"
     gpg -u A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF --pinentry-mode loopback --sign --armor --detach-sign "$f"
     scp -pB "$f.asc" build.mullvad.net:app/$version/ || true
+    rsync -av --rsh='ssh -p 1122' "$f.asc" build@releases.mullvad.net:$upload_path/$version/ || continue
     yes | rm "$f" "$f_checksum" "$f.asc"
   done
   for f_checksum in pdb-*.sha256; do


### PR DESCRIPTION
We have a new artifact server at `releases.mullvad.net`. This patch to our upload script pushes artifacts there as well as to the older `build.mullvad.net`. When the new server has been confirmed to work well we'll deprecate `build.mullvad.net` and remove the upload to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2889)
<!-- Reviewable:end -->
