### PR TITLE
Always disable DNS over TLS in systemd-resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Make offline monitor aware of routing table changes.
 - Assign local DNS servers to more appropriate interfaces when using systemd-resolved.
+- Disable DNS over TLS for tunnel's DNS config when using systemd-resolved.
 
 #### Windows
 - Fix failure to restart the daemon when resuming from "fast startup" hibernation.

--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -75,6 +75,11 @@ impl SystemdResolved {
         self.tunnel_index = tunnel_index;
         let mut last_result = Ok(());
 
+        if let Err(error) = self.dbus_interface.disable_dot(self.tunnel_index).await {
+            log::error!("Failed to disable DoT: {}", error.display_chain());
+        }
+
+
         {
             let mut initial_states = self.initial_states.lock().unwrap();
             for (iface_index, iface_config) in &initial_config {
@@ -112,6 +117,7 @@ impl SystemdResolved {
                 }
             }
         }
+
 
         if let Err(error) = last_result {
             let _ = self.reset();


### PR DESCRIPTION
If a user has enabled DNS over TLS globally in `systemd-resolved` via editing `/etc/systemd/resolved.conf` and set `DNSOverTLS` to `yes`, then our daemon will fail to configure DNS for our tunnel interface, as systemd-resolved will always try to use DoT with our interface. To remedy this, I've added a call to `SetDNSOverTLS` to disable DoT for our interface.  This should fix #2893.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2895)
<!-- Reviewable:end -->
