### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,12 +163,6 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -770,7 +764,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -829,7 +823,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -840,7 +834,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
  "pin-project-lite",
 ]
@@ -869,7 +863,7 @@ version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1390,7 +1384,6 @@ dependencies = [
 name = "mullvad-rpc"
 version = "0.1.0"
 dependencies = [
- "bytes 0.5.6",
  "chrono",
  "err-derive",
  "filetime",
@@ -1518,7 +1511,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd06e90449ae973fe3888c1ff85949604ef5189b4ac9a2ae39518da1e00762d"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "log",
  "netlink-packet-core",
@@ -1927,7 +1920,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "prost-derive",
 ]
 
@@ -1937,7 +1930,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "heck",
  "itertools",
  "log",
@@ -1968,7 +1961,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "prost",
 ]
 
@@ -2704,7 +2697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
  "mio 0.7.13",
@@ -2765,7 +2758,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -2791,7 +2784,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,7 +2520,7 @@ dependencies = [
  "resolv-conf",
  "rtnetlink",
  "shell-escape",
- "socket2 0.3.19",
+ "socket2 0.4.0",
  "system-configuration",
  "talpid-dbus",
  "talpid-platform-metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,6 @@ dependencies = [
  "nftnl",
  "nix 0.19.1",
  "notify",
- "openvpn-plugin",
  "os_pipe",
  "parity-tokio-ipc",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,7 +2550,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "talpid-types",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,28 +530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fern"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,7 +2490,6 @@ dependencies = [
  "chrono",
  "duct",
  "err-derive",
- "failure",
  "futures",
  "hex",
  "internet-checksum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,20 +492,6 @@ checksum = "449aad22b1364e927ff3bf50f55404efd705c40065fb47f73f28704de707c89e"
 
 [[package]]
 name = "err-derive"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "err-derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc7f65832b62ed38939f98966824eb6294911c3629b0e9a262bfb80836d9686"
@@ -1260,7 +1246,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger 0.8.2",
- "err-derive 0.3.0",
+ "err-derive",
  "futures",
  "itertools",
  "mullvad-management-interface",
@@ -1285,7 +1271,7 @@ dependencies = [
  "ctrlc",
  "dirs-next",
  "duct",
- "err-derive 0.3.0",
+ "err-derive",
  "fern",
  "futures",
  "ipnetwork",
@@ -1320,7 +1306,7 @@ dependencies = [
 name = "mullvad-exclude"
 version = "2021.4.0"
 dependencies = [
- "err-derive 0.3.0",
+ "err-derive",
  "nix 0.19.1",
  "talpid-types",
 ]
@@ -1329,7 +1315,7 @@ dependencies = [
 name = "mullvad-jni"
 version = "0.1.0"
 dependencies = [
- "err-derive 0.3.0",
+ "err-derive",
  "futures",
  "ipnetwork",
  "jnix",
@@ -1352,7 +1338,7 @@ dependencies = [
 name = "mullvad-management-interface"
 version = "0.1.0"
 dependencies = [
- "err-derive 0.3.0",
+ "err-derive",
  "futures",
  "lazy_static",
  "log",
@@ -1375,7 +1361,7 @@ name = "mullvad-paths"
 version = "0.1.0"
 dependencies = [
  "dirs-next",
- "err-derive 0.3.0",
+ "err-derive",
  "log",
 ]
 
@@ -1387,7 +1373,7 @@ dependencies = [
  "dirs-next",
  "duct",
  "env_logger 0.8.2",
- "err-derive 0.3.0",
+ "err-derive",
  "lazy_static",
  "mullvad-paths",
  "mullvad-rpc",
@@ -1406,7 +1392,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.5.6",
  "chrono",
- "err-derive 0.3.0",
+ "err-derive",
  "filetime",
  "futures",
  "http",
@@ -1434,7 +1420,7 @@ version = "2021.4.0"
 dependencies = [
  "clap",
  "env_logger 0.8.2",
- "err-derive 0.3.0",
+ "err-derive",
  "lazy_static",
  "mullvad-daemon",
  "mullvad-management-interface",
@@ -1454,7 +1440,7 @@ name = "mullvad-types"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "err-derive 0.3.0",
+ "err-derive",
  "ipnetwork",
  "jnix",
  "lazy_static",
@@ -1560,7 +1546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2453197ab3fcf147bf0ebd193557eeffa3998e6c84670eb8c9d86393bd09011f"
 dependencies = [
  "bitflags",
- "err-derive 0.3.0",
+ "err-derive",
  "log",
  "nftnl-sys",
 ]
@@ -2532,7 +2518,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "duct",
- "err-derive 0.3.0",
+ "err-derive",
  "failure",
  "futures",
  "hex",
@@ -2591,7 +2577,7 @@ name = "talpid-dbus"
 version = "0.1.0"
 dependencies = [
  "dbus",
- "err-derive 0.3.0",
+ "err-derive",
  "lazy_static",
  "libc",
  "log",
@@ -2604,7 +2590,7 @@ name = "talpid-openvpn-plugin"
 version = "2021.4.0"
 dependencies = [
  "env_logger 0.8.2",
- "err-derive 0.3.0",
+ "err-derive",
  "log",
  "openvpn-plugin",
  "parity-tokio-ipc",
@@ -2632,7 +2618,7 @@ name = "talpid-types"
 version = "0.1.0"
 dependencies = [
  "base64",
- "err-derive 0.3.0",
+ "err-derive",
  "ipnetwork",
  "jnix",
  "rand 0.7.3",
@@ -3204,12 +3190,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-service"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdfb0437cd780b66551aa81b466470f1159b1878ed45438b738de8bc6e5012b6"
+checksum = "0c643e10139d127d30d6d753398c8a6f0a43532e8370f6c9d29ebbff29b984ab"
 dependencies = [
  "bitflags",
- "err-derive 0.2.4",
+ "err-derive",
  "widestring",
  "winapi 0.3.9",
 ]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -49,7 +49,7 @@ simple-signal = "1.1"
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"
 duct = "0.13"
-windows-service = "0.3"
+windows-service = "0.4"
 winapi = { version = "0.3", features = ["errhandlingapi", "handleapi", "libloaderapi", "ntlsa", "synchapi", "tlhelp32", "winbase", "winerror", "winuser"] }
 dirs-next = "2.0"
 

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -34,9 +34,3 @@ tempfile = "3.0"
 
 [target.'cfg(target_os="macos")'.dependencies]
 tokio-stream = { version = "0.1", features = ["io-util"] }
-
-[[bin]]
-name = "relay_list"
-
-[[bin]]
-name = "address_cache"

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-bytes = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 err-derive = "0.3.0"
 futures = "0.3"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -34,7 +34,6 @@ udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "1e27324
 
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-openvpn-plugin = { version = "0.4", features = ["serde", "auth-failed-event"] }
 parity-tokio-ipc = "0.9"
 triggered = "0.1.1"
 tonic = "0.5"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -49,7 +49,6 @@ jnix = { version = "0.4", features = ["derive"] }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]
-failure = "0.1"
 notify = "4.0"
 resolv-conf = "0.7"
 rtnetlink = "0.8"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -62,7 +62,7 @@ mnl = { version = "0.2.0", features = ["mnl-1-0-4"] }
 which = { version = "4.0", default-features = false }
 tun = "0.5.1"
 talpid-dbus = { path = "../talpid-dbus" }
-socket2 = "0.3"
+socket2 = { version = "0.4", features = ["all"] }
 internet-checksum = "0.2"
 
 
@@ -78,7 +78,7 @@ internet-checksum = "0.2"
 widestring = "0.4"
 winreg = { version = "0.7", features = ["transactions"] }
 winapi = { version = "0.3.6", features = ["combaseapi", "handleapi", "ifdef", "libloaderapi", "netioapi", "psapi", "stringapiset", "synchapi", "winbase", "winioctl", "winuser"] }
-socket2 = "0.3"
+socket2 = { version = "0.4", features = ["all"] }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 memoffset = "0.6"
 

--- a/talpid-core/src/ping_monitor/icmp.rs
+++ b/talpid-core/src/ping_monitor/icmp.rs
@@ -49,7 +49,7 @@ pub struct Pinger {
 }
 
 impl Pinger {
-    pub fn new(addr: Ipv4Addr, interface_name: String) -> Result<Self> {
+    pub fn new(addr: Ipv4Addr, #[cfg(target_os = "linux")] interface_name: String) -> Result<Self> {
         let addr = SocketAddr::new(addr.into(), 0);
         let sock = Socket::new(Domain::IPV4, Type::RAW, Some(Protocol::ICMPV4))
             .map_err(Error::OpenError)?;
@@ -58,9 +58,6 @@ impl Pinger {
         #[cfg(target_os = "linux")]
         sock.bind_device(Some(interface_name.as_bytes()))
             .map_err(Error::SocketOptError)?;
-        // Just ignore the interface name on non-Linux
-        #[cfg(not(target_os = "linux"))]
-        let _ = interface_name;
 
         Ok(Self {
             sock,

--- a/talpid-core/src/ping_monitor/mod.rs
+++ b/talpid-core/src/ping_monitor/mod.rs
@@ -20,7 +20,11 @@ pub trait Pinger: Send {
 /// Create a new pinger
 pub fn new_pinger(
     addr: std::net::Ipv4Addr,
-    interface_name: String,
+    #[cfg(not(target_os = "windows"))] interface_name: String,
 ) -> Result<Box<dyn Pinger>, Error> {
-    Ok(Box::new(imp::Pinger::new(addr, interface_name)?))
+    Ok(Box::new(imp::Pinger::new(
+        addr,
+        #[cfg(not(target_os = "windows"))]
+        interface_name,
+    )?))
 }

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -77,11 +77,16 @@ pub struct ConnectivityMonitor {
 impl ConnectivityMonitor {
     pub(super) fn new(
         addr: Ipv4Addr,
-        interface: String,
+        #[cfg(not(target_os = "windows"))] interface: String,
         tunnel_handle: Weak<Mutex<Option<Box<dyn Tunnel>>>>,
         close_receiver: mpsc::Receiver<()>,
     ) -> Result<Self, Error> {
-        let pinger = new_pinger(addr, interface).map_err(Error::PingError)?;
+        let pinger = new_pinger(
+            addr,
+            #[cfg(not(target_os = "windows"))]
+            interface,
+        )
+        .map_err(Error::PingError)?;
 
         let now = Instant::now();
 

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -221,6 +221,7 @@ impl WireguardMonitor {
         let close_sender = monitor.close_msg_sender.clone();
         let mut connectivity_monitor = connectivity_check::ConnectivityMonitor::new(
             gateway,
+            #[cfg(not(target_os = "windows"))]
             iface_name.clone(),
             Arc::downgrade(&monitor.tunnel),
             pinger_rx,

--- a/talpid-dbus/Cargo.toml
+++ b/talpid-dbus/Cargo.toml
@@ -11,5 +11,4 @@ err-derive = "0.3.0"
 lazy_static = "1.0"
 log = "0.4"
 libc = "0.2"
-talpid-types = { path = "../talpid-types" }
 tokio = { version = "1.8", features = ["rt"] }


### PR DESCRIPTION
I just published `windows-service 0.4.0`. I figured we could upgrade ourselves even if we don't really need anything from the new release. While doing so I checked other dependencies and found a bunch of unused ones. First just `bytes` by luck and then with the help of `cargo-udeps` a bunch more. This got rid of a total of four dependencies from the tree! :tada: 

I also upgraded `socket2` since `0.4` is a pretty big upgrade.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2900)
<!-- Reviewable:end -->
