### PR TITLE
Make openLinkWithAuth arrow function to preserve this

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix incorrect WireGuard relay filtering when exit and entry locations overlap.
 - Fix wrong translations when switching to/from unpinned window after changing language in the
   desktop app.
+- Fix in-app notification button not working for some notifications.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -361,7 +361,7 @@ export default class AppRenderer {
     return IpcRendererEventChannel.accountHistory.clear();
   }
 
-  public async openLinkWithAuth(link: string): Promise<void> {
+  public openLinkWithAuth = async (link: string): Promise<void> => {
     let token = '';
     try {
       token = await IpcRendererEventChannel.account.getWwwAuthToken();
@@ -369,7 +369,7 @@ export default class AppRenderer {
       log.error(`Failed to get the WWW auth token: ${e.message}`);
     }
     void this.openUrl(`${link}?token=${token}`);
-  }
+  };
 
   public async setAllowLan(allowLan: boolean) {
     const actions = this.reduxActions;


### PR DESCRIPTION
This PR fixes the issue where the notification button didn't work for some notifications. The problem was that `openLinkWithAuth` didn't have the correct `this`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2907)
<!-- Reviewable:end -->
