### PR TITLE
Remove last translation of 'Mullvad VPN'

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -467,10 +467,6 @@ msgctxt "filter-by-provider-view"
 msgid "All providers"
 msgstr ""
 
-msgctxt "generic"
-msgid "Mullvad VPN"
-msgstr ""
-
 msgctxt "in-app-notifications"
 msgid "\"Always require VPN\" is enabled."
 msgstr ""
@@ -1337,6 +1333,9 @@ msgid "If needed we will contact you on %s"
 msgstr ""
 
 msgid "Install Mullvad VPN (%s) to stay up to date"
+msgstr ""
+
+msgid "Mullvad VPN"
 msgstr ""
 
 msgid "Mullvad account number"

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1761,7 +1761,7 @@ class ApplicationMain {
     const template: Electron.MenuItemConstructorOptions[] = [
       {
         label: sprintf(messages.pgettext('tray-icon-context-menu', 'Open %(mullvadVpn)s'), {
-          mullvadVpn: messages.pgettext('generic', 'Mullvad VPN'),
+          mullvadVpn: 'Mullvad VPN',
         }),
         click: () => this.windowController?.show(),
       },

--- a/gui/src/shared/localization-contexts.ts
+++ b/gui/src/shared/localization-contexts.ts
@@ -1,5 +1,4 @@
 export type LocalizationContexts =
-  | 'generic'
   | 'accessibility'
   | 'login-view'
   | 'auth-failure'


### PR DESCRIPTION
This PR removes the last instance of `Mullvad VPN` being translated since we don't want to have that translated.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2908)
<!-- Reviewable:end -->
