### PR TITLE
Fix wireguard mtu erase value bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Line wrap the file at 100 chars.                                              Th
   paths were excluded.
 - Fix daemon not starting when a path is excluded on a drive that has since been removed.
 
+#### Android
+- Fix erasing wireguard MTU value in some scenarious.
 
 ## [2021.4] - 2021-06-30
 This release is for desktop only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/MtuCell.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/MtuCell.kt
@@ -35,10 +35,10 @@ class MtuCell : Cell {
     var onSubmit: ((Int?) -> Unit)? = null
 
     var hasFocus by observable(false) { _, oldValue, newValue ->
-        if (oldValue == true && newValue == false) {
+        if (oldValue && !newValue) {
             val mtu = value
 
-            if (mtu == null || (mtu >= MIN_MTU_VALUE && mtu <= MAX_MTU_VALUE)) {
+            if (mtu == null || (mtu in MIN_MTU_VALUE..MAX_MTU_VALUE)) {
                 onSubmit?.invoke(mtu)
             }
         }

--- a/android/src/main/res/layout/advanced_header.xml
+++ b/android/src/main/res/layout/advanced_header.xml
@@ -16,6 +16,8 @@
                                               android:layout_width="match_parent"
                                               android:layout_height="wrap_content"
                                               android:layout_marginTop="@dimen/vertical_space"
+                                              android:focusable="true"
+                                              android:focusableInTouchMode="true"
                                               mullvad:text="@string/wireguard_mtu" />
     <net.mullvad.mullvadvpn.ui.widget.NavigateCell android:id="@+id/wireguard_keys"
                                                    android:layout_width="match_parent"


### PR DESCRIPTION
This PR contains fix for wireguard MTU input field. In some scenarios the value was erased because of the wrong focused state of input field.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2911)
<!-- Reviewable:end -->
