### PR TITLE
 Position navbar content with css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix wrong translations when switching to/from unpinned window after changing language in the
   desktop app.
 - Fix in-app notification button not working for some notifications.
+- Fix incorrectly positioned navigation bar title when navigating back to a scrolled down view.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -12,9 +12,10 @@ export const StyledNavigationBarSeparator = styled.div({
 });
 
 export const StyledNavigationItems = styled.div({
-  display: 'flex',
   flex: 1,
-  flexDirection: 'row',
+  display: 'grid',
+  gridTemplateColumns: '1fr auto 1fr',
+  alignItems: 'center',
 });
 
 export const StyledNavigationBar = styled.nav((props: { unpinnedWindow: boolean }) => ({
@@ -23,49 +24,22 @@ export const StyledNavigationBar = styled.nav((props: { unpinnedWindow: boolean 
   paddingTop: window.env.platform === 'darwin' && !props.unpinnedWindow ? '24px' : '12px',
 }));
 
-export const StyledNavigationBarWrapper = styled.div({
-  display: 'flex',
-  flex: 1,
-  flexDirection: 'column',
-  overflow: 'hidden',
-});
-
-export const StyledTitleBarItemContainer = styled.div({
-  display: 'flex',
-  flex: 1,
-  minWidth: 0,
-  flexDirection: 'column',
-  justifyContent: 'center',
-  overflow: 'hidden',
-});
-
-interface ITitleBarItemLabelProps {
-  titleAdjustment: number;
-  visible?: boolean;
-}
-
-export const StyledTitleBarItemLabel = styled.h1({}, (props: ITitleBarItemLabelProps) => ({
+export const StyledTitleBarItemLabel = styled.h1({}, (props: { visible?: boolean }) => ({
   fontFamily: 'Open Sans',
   fontSize: '16px',
   fontWeight: 600,
   lineHeight: '22px',
   color: colors.white,
   padding: '0 5px',
-  textAlign: 'center',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  marginLeft: props.titleAdjustment + 'px',
   opacity: props.visible ? 1 : 0,
   transition: 'opacity 250ms ease-in-out',
 }));
 
-export const StyledTitleBarItemMeasuringLabel = styled(StyledTitleBarItemLabel)({
-  position: 'absolute',
-  opacity: 0,
-});
-
 export const StyledCloseBarItemButton = styled.button({
+  justifySelf: 'start',
   borderWidth: 0,
   padding: 0,
   margin: 0,
@@ -78,7 +52,7 @@ export const StyledCloseBarItemIcon = styled(ImageView)({
 });
 
 export const StyledBackBarItemButton = styled.button({
-  position: 'relative',
+  justifySelf: 'start',
   borderWidth: 0,
   padding: 0,
   margin: 0,

--- a/gui/src/renderer/components/SelectLocationStyles.tsx
+++ b/gui/src/renderer/components/SelectLocationStyles.tsx
@@ -27,6 +27,7 @@ export const StyledNavigationBarAttachment = styled.div({
 
 export const StyledFilterContainer = styled.div({
   position: 'relative',
+  justifySelf: 'end',
 });
 
 export const StyledFilterIconButton = styled.button({


### PR DESCRIPTION
This PR changes how the navigation bar title is positioned. Previously it was done by having refs for each element in the navigation bar and then calculating the correct position of the title and updating it. With this solution we had some positioning issues that occasionally happened due to the code running before the browser had finished painting. The new solution is much simpler and only consists of CSS.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2914)
<!-- Reviewable:end -->
