### PR TITLE
Fix tunnel protocol preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Line wrap the file at 100 chars.                                              Th
 - Recover firewall state correctly when restarting the service after a crash. This would fail when
   paths were excluded.
 - Fix daemon not starting when a path is excluded on a drive that has since been removed.
+- Prefer WireGuard if the constraints preclude OpenVPN and the tunnel protocol is "auto", instead
+  of failing due to "no matching relays".
 
 #### Android
 - Fix erasing wireguard MTU value in some scenarious.


### PR DESCRIPTION
Previously, on Windows, the relay selector would fail to pick a relay if the tunnel protocol constraint was `any` and the location constraint didn't match any OpenVPN relays, e.g. if a specific WireGuard hostname was used. This PR fixes that, and adds some tests for tunneling protocol preference/selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2915)
<!-- Reviewable:end -->
