### PR TITLE
Switch to always using icon-close-down for dismiss navigations

### DIFF
--- a/gui/src/renderer/components/NavigationBar.tsx
+++ b/gui/src/renderer/components/NavigationBar.tsx
@@ -194,16 +194,12 @@ interface ICloseBarItemProps {
 }
 
 export function CloseBarItem(props: ICloseBarItemProps) {
-  // Use the arrow down icon on Linux, to avoid confusion with the close button in the window
-  // title bar.
-  const unpinnedWindow = useSelector((state) => state.settings.guiSettings.unpinnedWindow);
-  const iconName = unpinnedWindow ? 'icon-close-down' : 'icon-close';
   return (
     <StyledCloseBarItemButton aria-label={messages.gettext('Close')} onClick={props.action}>
       <StyledCloseBarItemIcon
         height={24}
         width={24}
-        source={iconName}
+        source={'icon-close-down'}
         tintColor={colors.white60}
         tintHoverColor={colors.white80}
       />


### PR DESCRIPTION
This PR changes the "close"-icon in the navigation bar to always be the down arrow since we didn't see a reason to have different icons when this one works in all situations.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2916)
<!-- Reviewable:end -->
