### PR TITLE
Reset navigation after window being hidden for two minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Line wrap the file at 100 chars.                                              Th
 - Upgrade OpenVPN from 2.5.1 to 2.5.3.
 - Update Electron from 11.2.3 to 11.4.9.
 - Move OpenVPN and WireGuard settings in the advanced settings view into separate settings views.
+- Return to main view in desktop app after being hidden/closed for two minutes.
 
 #### Windows
 - Upgrade Wintun from 0.10.4 to 0.13.

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -205,6 +205,8 @@ export default class AppRenderer {
       this.reduxActions.userInterface.setWindowFocused(focus);
     });
 
+    IpcRendererEventChannel.navigation.listenReset(() => this.history.dismiss(true));
+
     // Request the initial state from the main process
     const initialState = IpcRendererEventChannel.state.get();
 

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -105,6 +105,9 @@ export const ipcSchema = {
   windowFocus: {
     '': notifyRenderer<boolean>(),
   },
+  navigation: {
+    reset: notifyRenderer<void>(),
+  },
   daemon: {
     connected: notifyRenderer<void>(),
     disconnected: notifyRenderer<void>(),


### PR DESCRIPTION
This PR adds a timer that resets the navigation to the main view after the window has been hidden for two minutes. Fixes https://github.com/mullvad/mullvadvpn-app/issues/2878.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2917)
<!-- Reviewable:end -->
