### PR TITLE
Add `TransportPort` OpenVPN constraint

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -13,8 +13,7 @@ use mullvad_management_interface::types::{
     relay_settings, relay_settings_update, ConnectionConfig, CustomRelaySettings, IpVersion,
     IpVersionConstraint, NormalRelaySettingsUpdate, OpenvpnConstraints, ProviderUpdate,
     RelayListCountry, RelayLocation, RelaySettingsUpdate, TransportPort, TransportProtocol,
-    TransportProtocolConstraint, TunnelType, TunnelTypeConstraint, TunnelTypeUpdate,
-    WireguardConstraints,
+    TunnelType, TunnelTypeConstraint, TunnelTypeUpdate, WireguardConstraints,
 };
 use mullvad_types::relay_constraints::Constraint;
 use talpid_types::net::all_of_the_internet;
@@ -149,13 +148,15 @@ impl Command for Relay {
                                     .arg(
                                         clap::Arg::with_name("port")
                                             .help("Port to use. Either 'any' or a specific port")
-                                            .required(true)
+                                            .long("port")
+                                            .default_value("any"),
                                     )
                                     .arg(
                                         clap::Arg::with_name("transport protocol")
+                                            .help("Transport protocol")
                                             .long("protocol")
-                                            .default_value("any")
-                                            .possible_values(&["any", "udp", "tcp"]),
+                                            .possible_values(&["any", "udp", "tcp"])
+                                            .default_value("any"),
                                     )
                             )
                             .subcommand(
@@ -165,17 +166,15 @@ impl Command for Relay {
                                         clap::Arg::with_name("port")
                                             .help("Port to use. Either 'any' or a specific port")
                                             .long("port")
-                                            .takes_value(true)
-                                            .requires("transport protocol"),
+                                            .default_value("any"),
                                     )
                                     .arg(
                                         clap::Arg::with_name("transport protocol")
                                             .help("Transport protocol. If TCP is selected, traffic is \
                                                    sent over TCP using a udp-over-tcp proxy")
                                             .long("protocol")
-                                            .takes_value(true)
-                                            .possible_values(&["udp", "tcp"])
-                                            .requires("port"),
+                                            .possible_values(&["any", "udp", "tcp"])
+                                            .default_value("any"),
                                     )
                                     .arg(
                                         clap::Arg::with_name("ip version")
@@ -516,20 +515,11 @@ impl Relay {
     }
 
     async fn set_openvpn_constraints(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
-        let port = parse_port_constraint(matches.value_of("port").unwrap())?;
-        let protocol = parse_protocol_constraint(matches.value_of("transport protocol").unwrap());
-
+        let port = parse_transport_port(matches)?;
         self.update_constraints(RelaySettingsUpdate {
             r#type: Some(relay_settings_update::Type::Normal(
                 NormalRelaySettingsUpdate {
-                    openvpn_constraints: Some(OpenvpnConstraints {
-                        port: port.unwrap_or(0) as u32,
-                        protocol: protocol
-                            .option()
-                            .map(|protocol| TransportProtocolConstraint {
-                                protocol: protocol as i32,
-                            }),
-                    }),
+                    openvpn_constraints: Some(OpenvpnConstraints { port }),
                     ..Default::default()
                 },
             )),
@@ -538,19 +528,7 @@ impl Relay {
     }
 
     async fn set_wireguard_constraints(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
-        let protocol = matches.value_of("transport protocol").map(parse_protocol);
-        let port = match matches.value_of("port").map(parse_port_constraint) {
-            None => None,
-            Some(Err(error)) => return Err(error),
-            Some(Ok(Constraint::Any)) => Some(TransportPort {
-                protocol: protocol.unwrap() as i32,
-                port: 0,
-            }),
-            Some(Ok(Constraint::Only(port))) => Some(TransportPort {
-                protocol: protocol.unwrap() as i32,
-                port: u32::from(port),
-            }),
-        };
+        let port = parse_transport_port(matches)?;
         let ip_version = parse_ip_version_constraint(matches.value_of("ip version").unwrap());
         let entry_location =
             parse_entry_location_constraint(matches.values_of("entry location").unwrap());
@@ -722,26 +700,12 @@ impl Relay {
         }
     }
 
-    fn format_port(port: u32) -> String {
-        if port != 0 {
-            format!("port {}", port)
-        } else {
-            "any port".to_string()
-        }
-    }
-
     fn format_openvpn_constraints(constraints: Option<&OpenvpnConstraints>) -> String {
         if let Some(constraints) = constraints {
-            format!(
-                "{} over {}",
-                Self::format_port(constraints.port),
-                Self::format_transport_protocol(
-                    constraints
-                        .protocol
-                        .clone()
-                        .map(|protocol| TransportProtocol::from_i32(protocol.protocol).unwrap())
-                )
-            )
+            let ovpn_constraints =
+                mullvad_types::relay_constraints::OpenVpnConstraints::try_from(constraints)
+                    .unwrap();
+            format!("{}", ovpn_constraints)
         } else {
             "any port over any transport protocol".to_string()
         }
@@ -805,19 +769,11 @@ fn parse_port_constraint(raw_port: &str) -> Result<Constraint<u16>> {
     }
 }
 
-/// Parses a protocol constraint string. Can be infallible because the possible values are limited
-/// with clap.
-fn parse_protocol_constraint(raw_protocol: &str) -> Constraint<TransportProtocol> {
+fn parse_protocol(raw_protocol: &str) -> Constraint<TransportProtocol> {
     match raw_protocol {
         "any" => Constraint::Any,
-        protocol => Constraint::Only(parse_protocol(protocol)),
-    }
-}
-
-fn parse_protocol(raw_protocol: &str) -> TransportProtocol {
-    match raw_protocol {
-        "udp" => TransportProtocol::Udp,
-        "tcp" => TransportProtocol::Tcp,
+        "udp" => Constraint::Only(TransportProtocol::Udp),
+        "tcp" => Constraint::Only(TransportProtocol::Tcp),
         _ => unreachable!(),
     }
 }
@@ -845,4 +801,23 @@ fn parse_entry_location_constraint<'a, T: Iterator<Item = &'a str>>(
         location.next(),
         location.next(),
     ))
+}
+
+fn parse_transport_port(matches: &clap::ArgMatches<'_>) -> Result<Option<TransportPort>> {
+    let port = parse_port_constraint(matches.value_of("port").unwrap())?;
+    let protocol = parse_protocol(matches.value_of("transport protocol").unwrap());
+    match (port, protocol) {
+        (Constraint::Any, Constraint::Any) => Ok(None),
+        (Constraint::Any, Constraint::Only(protocol)) => Ok(Some(TransportPort {
+            protocol: protocol as i32,
+            ..TransportPort::default()
+        })),
+        (Constraint::Only(port), Constraint::Only(protocol)) => Ok(Some(TransportPort {
+            protocol: protocol as i32,
+            port: u32::from(port),
+        })),
+        (Constraint::Only(_), Constraint::Any) => Err(Error::InvalidCommand(
+            "a transport protocol must be given to select a specific port",
+        )),
+    }
 }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -313,18 +313,13 @@ message TunnelTypeUpdate {
 	TunnelTypeConstraint tunnel_type = 2;
 }
 
-message TransportProtocolConstraint {
-	TransportProtocol protocol = 1;
-}
-
 message TransportPort {
 	TransportProtocol protocol = 1;
 	uint32 port = 2;
 }
 
 message OpenvpnConstraints {
-	uint32 port = 1;
-	TransportProtocolConstraint protocol = 2;
+	TransportPort port = 1;
 }
 
 enum IpVersion {

--- a/mullvad-types/src/settings/migrations/v2.rs
+++ b/mullvad-types/src/settings/migrations/v2.rs
@@ -128,10 +128,12 @@ mod test {
       },
       "openvpn_constraints": {
         "port": {
-          "only": 53
-        },
-        "protocol": {
-          "only": "udp"
+          "only": {
+            "protocol": "udp",
+            "port": {
+              "only": 53
+            }
+          }
         }
       }
     }

--- a/mullvad-types/src/settings/migrations/v3.rs
+++ b/mullvad-types/src/settings/migrations/v3.rs
@@ -128,10 +128,12 @@ mod test {
       },
       "openvpn_constraints": {
         "port": {
-          "only": 53
-        },
-        "protocol": {
-          "only": "udp"
+          "only": {
+            "protocol": "udp",
+            "port": {
+              "only": 53
+            }
+          }
         }
       }
     }

--- a/mullvad-types/src/settings/migrations/v3.rs
+++ b/mullvad-types/src/settings/migrations/v3.rs
@@ -50,7 +50,7 @@ impl super::SettingsMigration for Migration {
 
 #[cfg(test)]
 mod test {
-    use super::super::try_migrate_settings;
+    use super::{super::SettingsMigration, Migration};
     use serde_json;
 
     pub const V3_SETTINGS: &str = r#"
@@ -69,7 +69,7 @@ mod test {
       },
       "openvpn_constraints": {
         "port": {
-          "only": 53
+          "only": 1195
         },
         "protocol": {
           "only": "udp"
@@ -112,7 +112,7 @@ mod test {
 }
 "#;
 
-    pub const NEW_SETTINGS: &str = r#"
+    pub const V4_SETTINGS: &str = r#"
 {
   "account_token": "1234",
   "relay_settings": {
@@ -128,12 +128,10 @@ mod test {
       },
       "openvpn_constraints": {
         "port": {
-          "only": {
-            "protocol": "udp",
-            "port": {
-              "only": 53
-            }
-          }
+          "only": 1195
+        },
+        "protocol": {
+          "only": "udp"
         }
       }
     }
@@ -175,17 +173,21 @@ mod test {
       }
     }
   },
-  "settings_version": 5
+  "settings_version": 4
 }
 "#;
 
 
     #[test]
     fn test_v3_migration() {
-        let migrated_settings =
-            try_migrate_settings(V3_SETTINGS.as_bytes()).expect("Migration failed");
-        let new_settings = serde_json::from_str(NEW_SETTINGS).unwrap();
+        let mut old_settings = serde_json::from_str(V3_SETTINGS).unwrap();
 
-        assert_eq!(&migrated_settings, &new_settings);
+        let migration = Migration;
+        assert!(migration.version_matches(&mut old_settings));
+
+        migration.migrate(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = serde_json::from_str(V4_SETTINGS).unwrap();
+
+        assert_eq!(&old_settings, &new_settings);
     }
 }

--- a/mullvad-types/src/settings/migrations/v4.rs
+++ b/mullvad-types/src/settings/migrations/v4.rs
@@ -4,6 +4,7 @@ use talpid_types::net::TransportProtocol;
 
 
 const WIREGUARD_TCP_PORTS: [u16; 3] = [80, 443, 5001];
+const OPENVPN_TCP_PORTS: [u16; 2] = [80, 443];
 
 
 pub(super) struct Migration;
@@ -55,13 +56,69 @@ impl super::SettingsMigration for Migration {
                 .remove("protocol");
         }
 
+        let openvpn_constraints = || -> Option<&serde_json::Value> {
+            settings
+                .get("relay_settings")?
+                .get("normal")?
+                .get("openvpn_constraints")
+        }();
+
+        if let Some(constraints) = openvpn_constraints {
+            let port: Constraint<u16> = if let Some(port) = constraints.get("port") {
+                serde_json::from_value(port.clone()).map_err(Error::ParseError)?
+            } else {
+                Constraint::Any
+            };
+            let transport_constraint: Constraint<TransportProtocol> =
+                if let Some(protocol) = constraints.get("protocol") {
+                    serde_json::from_value(protocol.clone()).map_err(Error::ParseError)?
+                } else {
+                    Constraint::Any
+                };
+
+            let port = match (port, transport_constraint) {
+                (Constraint::Only(port), Constraint::Any) => Constraint::Only(TransportPort {
+                    protocol: openvpn_protocol_from_port(port),
+                    port: Constraint::Only(port),
+                }),
+                (Constraint::Only(port), Constraint::Only(protocol)) => {
+                    Constraint::Only(TransportPort {
+                        protocol,
+                        port: Constraint::Only(port),
+                    })
+                }
+                (Constraint::Any, Constraint::Only(protocol)) => Constraint::Only(TransportPort {
+                    protocol,
+                    port: Constraint::Any,
+                }),
+                (Constraint::Any, Constraint::Any) => Constraint::Any,
+            };
+
+            settings["relay_settings"]["normal"]["openvpn_constraints"]["port"] =
+                serde_json::json!(port);
+            settings["relay_settings"]["normal"]["openvpn_constraints"]
+                .as_object_mut()
+                .ok_or(Error::NoMatchingVersion)?
+                .remove("protocol");
+        }
+
         settings["settings_version"] = serde_json::json!(SettingsVersion::V5);
 
         Ok(())
     }
 }
 
+fn openvpn_protocol_from_port(port: u16) -> TransportProtocol {
+    log::warn!("Inferring transport protocol from port constraint");
+    if OPENVPN_TCP_PORTS.contains(&port) {
+        TransportProtocol::Tcp
+    } else {
+        TransportProtocol::Udp
+    }
+}
+
 fn wg_protocol_from_port(port: u16) -> TransportProtocol {
+    log::warn!("Inferring transport protocol from port constraint");
     if WIREGUARD_TCP_PORTS.contains(&port) {
         TransportProtocol::Tcp
     } else {
@@ -93,11 +150,9 @@ mod test {
       },
       "openvpn_constraints": {
         "port": {
-          "only": 53
+          "only": 1195
         },
-        "protocol": {
-          "only": "udp"
-        }
+        "protocol": "any"
       }
     }
   },
@@ -165,10 +220,12 @@ mod test {
       },
       "openvpn_constraints": {
         "port": {
-          "only": 53
-        },
-        "protocol": {
-          "only": "udp"
+          "only": {
+            "protocol": "udp",
+            "port": {
+              "only": 1195
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This refactors the OpenVPN relay constraints to use the `TransportPort` type introduced in #2856.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2919)
<!-- Reviewable:end -->
