### PR TITLE
Add system apps to split tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Line wrap the file at 100 chars.                                              Th
 - Added possibility to filter locations by provider in the desktop app.
 - Add WireGuard over TCP CLI option for all relays.
 
+#### Android
+- Added toggle for Split tunneling view to be able to show system apps
+
 ### Changed
 - Only use the account history file to store the last used account.
 - Update the out of time-view and new account-view to make it more user friendly.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppData.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppData.kt
@@ -1,3 +1,3 @@
 package net.mullvad.mullvadvpn.applist
 
-data class AppData(val packageName: String, val iconRes: Int, val name: String)
+data class AppData(val packageName: String, val iconRes: Int, val name: String, val isSystemApp: Boolean = false)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppData.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/AppData.kt
@@ -1,3 +1,8 @@
 package net.mullvad.mullvadvpn.applist
 
-data class AppData(val packageName: String, val iconRes: Int, val name: String, val isSystemApp: Boolean = false)
+data class AppData(
+    val packageName: String,
+    val iconRes: Int,
+    val name: String,
+    val isSystemApp: Boolean = false
+)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProvider.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProvider.kt
@@ -10,7 +10,6 @@ class ApplicationsProvider(
 ) {
     private val applicationFilterPredicate: (ApplicationInfo) -> Boolean = { appInfo ->
         hasInternetPermission(appInfo.packageName) &&
-            isLaunchable(appInfo.packageName) &&
             !isSelfApplication(appInfo.packageName)
     }
 
@@ -19,7 +18,12 @@ class ApplicationsProvider(
             .asSequence()
             .filter(applicationFilterPredicate)
             .map { info ->
-                AppData(info.packageName, info.icon, info.loadLabel(packageManager).toString())
+                AppData(
+                    info.packageName,
+                    info.icon,
+                    info.loadLabel(packageManager).toString(),
+                    !isLaunchable(info.packageName)
+                )
             }
             .toList()
     }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ViewIntent.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/applist/ViewIntent.kt
@@ -6,4 +6,5 @@ sealed class ViewIntent {
     // In future we will have search intent
     data class ChangeApplicationGroup(val item: ListItemData) : ViewIntent()
     object ViewIsReady : ViewIntent()
+    data class ShowSystemApps(internal val show: Boolean) : ViewIntent()
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -181,4 +181,5 @@
     <string name="download_url">https://mullvad.net/en/download</string>
     <string name="faqs_and_guides_url">https://mullvad.net/en/help/tag/mullvad-app/</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>
+    <string name="show_system_apps">Show system apps</string>
 </resources>

--- a/android/src/test/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProviderTest.kt
+++ b/android/src/test/kotlin/net/mullvad/mullvadvpn/applist/ApplicationsProviderTest.kt
@@ -51,6 +51,7 @@ class ApplicationsProviderTest {
         val result = testSubject.getAppsList()
         val expected = listOf(
             AppData(launchWithInternetPackageName, 0, launchWithInternetPackageName),
+            AppData(nonLaunchWithInternetPackageName, 0, nonLaunchWithInternetPackageName, true),
             AppData(leanbackLaunchWithInternetPackageName, 0, leanbackLaunchWithInternetPackageName)
         )
 
@@ -74,8 +75,7 @@ class ApplicationsProviderTest {
             listOf(
                 launchWithInternetPackageName,
                 nonLaunchWithInternetPackageName,
-                leanbackLaunchWithInternetPackageName,
-                selfPackageName
+                leanbackLaunchWithInternetPackageName
             ).forEach { packageName ->
                 mockedPackageManager.getLaunchIntentForPackage(packageName)
             }
@@ -93,7 +93,8 @@ class ApplicationsProviderTest {
         packageName: String,
         launch: Boolean = false,
         leanback: Boolean = false,
-        internet: Boolean = false
+        internet: Boolean = false,
+        systemApp: Boolean = false
     ): ApplicationInfo {
         val mockApplicationInfo = mockk<ApplicationInfo>()
 
@@ -104,14 +105,14 @@ class ApplicationsProviderTest {
 
         every {
             mockedPackageManager.getLaunchIntentForPackage(packageName)
-        } returns if (launch)
+        } returns if (launch || systemApp)
             mockk()
         else
             null
 
         every {
             mockedPackageManager.getLeanbackLaunchIntentForPackage(packageName)
-        } returns if (leanback)
+        } returns if (leanback || systemApp)
             mockk()
         else
             null

--- a/android/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModelTest.kt
+++ b/android/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModelTest.kt
@@ -93,6 +93,7 @@ class SplitTunnelingViewModelTest {
             createMainItem(R.string.exclude_applications),
             createApplicationItem(appExcluded, true),
             createDivider(1),
+            createSwitchItem(R.string.show_system_apps, false),
             createMainItem(R.string.all_applications),
             createApplicationItem(appNotExcluded, false),
         )
@@ -131,6 +132,7 @@ class SplitTunnelingViewModelTest {
         val expectedList = listOf(
             createTextItem(R.string.split_tunneling_description),
             createDivider(1),
+            createSwitchItem(R.string.show_system_apps, false),
             createMainItem(R.string.all_applications),
             createApplicationItem(app, false),
         )
@@ -156,6 +158,7 @@ class SplitTunnelingViewModelTest {
         val expectedListBeforeAction = listOf(
             createTextItem(R.string.split_tunneling_description),
             createDivider(1),
+            createSwitchItem(R.string.show_system_apps, false),
             createMainItem(R.string.all_applications),
             createApplicationItem(app, false),
         )
@@ -224,4 +227,12 @@ class SplitTunnelingViewModelTest {
     private fun createProgressItem(): ListItemData = ListItemData.build(identifier = "progress") {
         type = ListItemData.PROGRESS
     }
+
+    private fun createSwitchItem(@StringRes text: Int, checked: Boolean): ListItemData =
+        ListItemData.build(identifier = "switch_$text") {
+            type = ListItemData.ACTION
+            textRes = text
+            action = ListItemData.ItemAction(text.toString())
+            widget = WidgetState.SwitchState(checked)
+        }
 }

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1355,6 +1355,9 @@ msgstr ""
 msgid "Secured"
 msgstr ""
 
+msgid "Show system apps"
+msgstr ""
+
 msgid "Shows current VPN tunnel status"
 msgstr ""
 


### PR DESCRIPTION
Add possibility to show and exclude from the tunnel system apps that not shown by default. 
Linked to the #2777 

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
