### PR TITLE
Fix splittunneling initial list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Fix erasing wireguard MTU value in some scenarious.
+- Fix initial state of Split tunneling excluded apps list. Previously it was not notified the daemon
+properly after initialization.
 
 ## [2021.4] - 2021-06-30
 This release is for desktop only.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
@@ -14,7 +14,7 @@ class SplitTunneling(persistence: SplitTunnelingPersistence, endpoint: ServiceEn
         update()
     }
 
-    val onChange = EventNotifier<List<String>?>(null)
+    val onChange = EventNotifier<List<String>?>(excludedApps.toList())
 
     init {
         onChange.subscribe(this) { excludedApps ->


### PR DESCRIPTION
In this PR we fix issue when after initialisation the daemon was not aware about restored excluded apps list, because it was initialised with the null. So, by default all apps were navigate thru the tunnel unless you open Split tunnel view in the app.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
