### PR TITLE
Remove beta label for split tunneling on Windows

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -15,7 +15,6 @@ import {
   StyledCustomDnsFooter,
   StyledAddCustomDnsLabel,
   StyledAddCustomDnsButton,
-  StyledBetaLabel,
 } from './AdvancedSettingsStyles';
 import * as AppButton from './AppButton';
 import { AriaDescription, AriaInput, AriaInputGroup, AriaLabel } from './AriaGroup';
@@ -160,7 +159,6 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                   <Cell.CellButtonGroup>
                     <Cell.CellButton onClick={this.props.onViewSplitTunneling}>
                       <Cell.Label>
-                        {window.env.platform === 'win32' && <StyledBetaLabel />}
                         {messages.pgettext('advanced-settings-view', 'Split tunneling')}
                       </Cell.Label>
                       <Cell.Icon height={12} width={7} source="icon-chevron" />

--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { colors } from '../../config.json';
-import BetaLabel from './BetaLabel';
 import * as Cell from './cell';
 import { NavigationScrollbars } from './NavigationBar';
 import Selector from './cell/Selector';
@@ -59,8 +58,3 @@ export const StyledAddCustomDnsLabel = styled(Cell.Label)(
     marginRight: '25px',
   }),
 );
-
-export const StyledBetaLabel = styled(BetaLabel)({
-  marginRight: '8px',
-  verticalAlign: 'bottom',
-});

--- a/gui/src/renderer/components/SplitTunnelingSettings.tsx
+++ b/gui/src/renderer/components/SplitTunnelingSettings.tsx
@@ -45,7 +45,6 @@ import {
   StyledNoResult,
   StyledNoResultSearchTerm,
   StyledDisabledWarning,
-  StyledBetaLabel,
 } from './SplitTunnelingSettingsStyles';
 
 export default function SplitTunneling() {
@@ -398,10 +397,7 @@ export function WindowsSplitTunnelingSettings(props: IPlatformSplitTunnelingSett
   return (
     <>
       <SettingsHeader>
-        <HeaderTitle>
-          {messages.pgettext('split-tunneling-view', 'Split tunneling')}
-          <StyledBetaLabel />
-        </HeaderTitle>
+        <HeaderTitle>{messages.pgettext('split-tunneling-view', 'Split tunneling')}</HeaderTitle>
         <HeaderSubTitle>
           {messages.pgettext(
             'split-tunneling-view',

--- a/gui/src/renderer/components/SplitTunnelingSettingsStyles.tsx
+++ b/gui/src/renderer/components/SplitTunnelingSettingsStyles.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { colors } from '../../config.json';
 import * as AppButton from './AppButton';
-import BetaLabel from './BetaLabel';
 import * as Cell from './cell';
 import { mediumText, smallText } from './common-styles';
 import ImageView from './ImageView';
@@ -162,9 +161,4 @@ export const StyledNoResultSearchTerm = styled.span({
 export const StyledDisabledWarning = styled.span(smallText, {
   margin: '0 22px 18px',
   color: colors.red,
-});
-
-export const StyledBetaLabel = styled(BetaLabel)({
-  marginLeft: '8px',
-  verticalAlign: 'middle',
 });


### PR DESCRIPTION
This PR removes the yellow "BETA" icon in the split tunneling title and navigation cell.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2923)
<!-- Reviewable:end -->
