### PR TITLE
Retry when WireGuard over TCP fails

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -409,6 +409,8 @@ fn should_retry(error: &tunnel::Error) -> bool {
     use tunnel::wireguard::TunnelError;
 
     match error {
+        tunnel::Error::WireguardTunnelMonitoringError(Error::Udp2TcpError(_)) => true,
+
         #[cfg(not(windows))]
         tunnel::Error::WireguardTunnelMonitoringError(Error::TunnelError(
             TunnelError::RecoverableStartWireguardError,


### PR DESCRIPTION
Currently, the daemon does not retry if connecting to a WireGuard relay via `udp2tcp` fails. You can see this by trying to connect to a server that isn't running `tcp2udp`. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2928)
<!-- Reviewable:end -->
