### PR TITLE
Add backup logs in report

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -23,8 +23,16 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Attach log backup from previous application run to problem report.
+
+### Fixed
+- Drop leading replacement characters (`\u{FFFD}`) when decoding UTF-8 from a part of log file.
+
+## [2021.3] - 2021-08-10
 ### Added
-- Show a reminder to add more credits 3 days before account expiry via system notification and in-app message.
+- Show a reminder to add more credits 3 days before account expiry via system notification and
+  in-app message.
 - Add submit button next to account input field on login screen.
 
 ### Fixed

--- a/ios/MullvadVPN/ConsolidatedApplicationLog.swift
+++ b/ios/MullvadVPN/ConsolidatedApplicationLog.swift
@@ -142,7 +142,12 @@ class ConsolidatedApplicationLog: TextOutputStreamable {
         }
 
         let data = fileHandle.readData(ofLength: Int(kLogMaxReadBytes))
-        let lossyString = String(decoding: data, as: UTF8.self)
+        let replacementCharacter = Character(UTF8.decode(UTF8.encodedReplacementCharacter))
+        let lossyString = String(String(decoding: data, as: UTF8.self)
+            .drop { ch in
+                // Drop leading replacement characters produced when decoding data
+                return ch == replacementCharacter
+            })
 
         return .success(lossyString)
     }

--- a/ios/MullvadVPN/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/ProblemReportViewController.swift
@@ -25,7 +25,7 @@ class ProblemReportViewController: UIViewController, UITextFieldDelegate, Condit
             redactContainerPathsForSecurityGroupIdentifiers: [securityGroupIdentifier]
         )
 
-        report.addLogFiles(fileURLs: ApplicationConfiguration.logFileURLs)
+        report.addLogFiles(fileURLs: ApplicationConfiguration.logFileURLs, includeLogBackup: true)
 
         return report
     }()


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add log backups (`old.log`) to problem reports
2. We include the trailing 128k of each log file. When decoding those bytes into UTF-8, the parser replaces the malformed UTF-8 sequence with a replacement character (`\u{FFFD}`). Handle this by dropping the leading replacement characters before including the log file into the final problem report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2929)
<!-- Reviewable:end -->
