### PR TITLE
Change settings button opacity to 60%

### DIFF
--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -115,8 +115,8 @@ export function HeaderBarSettingsButton() {
         height={24}
         width={24}
         source="icon-settings"
-        tintColor={colors.white80}
-        tintHoverColor={colors.white}
+        tintColor={colors.white60}
+        tintHoverColor={colors.white80}
       />
     </HeaderBarSettingsButtonContainer>
   );

--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -66,7 +66,7 @@ export const StyledBackBarItemButton = styled.button({
 export const StyledBackBarItemIcon = styled(ImageView)({
   marginRight: '8px',
   [StyledBackBarItemButton + ':hover &']: {
-    backgroundColor: colors.white80,
+    backgroundColor: colors.white60,
   },
 });
 

--- a/gui/src/renderer/components/SelectLocation.tsx
+++ b/gui/src/renderer/components/SelectLocation.tsx
@@ -140,8 +140,8 @@ export default class SelectLocation extends React.Component<IProps, IState> {
                     aria-label={messages.gettext('Filter')}>
                     <ImageView
                       source="icon-filter-round"
-                      tintColor={colors.white60}
-                      tintHoverColor={colors.white80}
+                      tintColor={colors.white40}
+                      tintHoverColor={colors.white60}
                       height={24}
                       width={24}
                     />


### PR DESCRIPTION
* Change settings button opacity to 60% which is closer to what it was before https://github.com/mullvad/mullvadvpn-app/pull/2906
* Correct incorrect opacity for some navigation bar icons.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2930)
<!-- Reviewable:end -->
