### PR TITLE
Disable GUI notification for newer version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Added possibility to filter locations by provider in the desktop app.
 - Add WireGuard over TCP CLI option for all relays.
+- New GUI environment variable `DISABLE_VERSION_CHECK` has been added. If set to `1`, latest
+  version check will be disabled in the GUI, preventing a notification from occuring when a
+  newer version is available.
 
 #### Android
 - Added toggle for Split tunneling view to be able to show system apps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Added possibility to filter locations by provider in the desktop app.
 - Add WireGuard over TCP CLI option for all relays.
-- New GUI environment variable `DISABLE_VERSION_CHECK` has been added. If set to `1`, latest
-  version check will be disabled in the GUI, preventing a notification from occuring when a
-  newer version is available.
+- Add GUI environment variable `MULLVAD_DISABLE_UPDATE_NOTIFICATION`. If set to `1`, GUI
+  notification will be disabled when an update is available.
 
 #### Android
 - Added toggle for Split tunneling view to be able to show system apps

--- a/README.md
+++ b/README.md
@@ -509,8 +509,8 @@ to do that before starting the GUI.
 
 1. `MULLVAD_PATH` - Allows changing the path to the folder with the `mullvad-problem-report` tool
     when running in development mode. Defaults to: `<repo>/target/debug/`.
-2. `DISABLE_VERSION_CHECK` - If set to `1`, latest version check will be disabled in the GUI,
-    preventing a notification from occuring when a newer version is available.
+2. `MULLVAD_DISABLE_UPDATE_NOTIFICATION` - If set to `1`, GUI notification will be disabled when
+    an update is available.
 
 
 ## Making a release

--- a/README.md
+++ b/README.md
@@ -509,6 +509,8 @@ to do that before starting the GUI.
 
 1. `MULLVAD_PATH` - Allows changing the path to the folder with the `mullvad-problem-report` tool
     when running in development mode. Defaults to: `<repo>/target/debug/`.
+2. `DISABLE_VERSION_CHECK` - If set to `1`, latest version check will be disabled in the GUI,
+    preventing a notification from occuring when a newer version is available.
 
 
 ## Making a release

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -88,6 +88,8 @@ const GUI_VERSION = app.getVersion().replace('.0', '');
 /// Mirrors the beta check regex in the daemon. Matches only well formed beta versions
 const IS_BETA = /^(\d{4})\.(\d+)-beta(\d+)$/;
 
+const VERSION_CHECK_DISABLED = process.env.DISABLE_VERSION_CHECK === '1';
+
 const SANDBOX_DISABLED = app.commandLine.hasSwitch('no-sandbox');
 
 enum AppQuitStage {
@@ -585,7 +587,9 @@ class ApplicationMain {
     }
 
     // fetch the latest version info in background
-    void this.fetchLatestVersion();
+    if (!VERSION_CHECK_DISABLED) {
+      void this.fetchLatestVersion();
+    }
 
     // reset the reconnect backoff when connection established.
     this.reconnectBackoff.reset();
@@ -922,6 +926,10 @@ class ApplicationMain {
   }
 
   private setLatestVersion(latestVersionInfo: IAppVersionInfo) {
+    if (VERSION_CHECK_DISABLED) {
+      return;
+    }
+
     const suggestedIsBeta =
       latestVersionInfo.suggestedUpgrade !== undefined &&
       IS_BETA.test(latestVersionInfo.suggestedUpgrade);

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -88,7 +88,7 @@ const GUI_VERSION = app.getVersion().replace('.0', '');
 /// Mirrors the beta check regex in the daemon. Matches only well formed beta versions
 const IS_BETA = /^(\d{4})\.(\d+)-beta(\d+)$/;
 
-const VERSION_CHECK_DISABLED = process.env.DISABLE_VERSION_CHECK === '1';
+const UPDATE_NOTIFICATION_DISABLED = process.env.MULLVAD_DISABLE_UPDATE_NOTIFICATION === '1';
 
 const SANDBOX_DISABLED = app.commandLine.hasSwitch('no-sandbox');
 
@@ -587,7 +587,7 @@ class ApplicationMain {
     }
 
     // fetch the latest version info in background
-    if (!VERSION_CHECK_DISABLED) {
+    if (!UPDATE_NOTIFICATION_DISABLED) {
       void this.fetchLatestVersion();
     }
 
@@ -926,7 +926,7 @@ class ApplicationMain {
   }
 
   private setLatestVersion(latestVersionInfo: IAppVersionInfo) {
-    if (VERSION_CHECK_DISABLED) {
+    if (UPDATE_NOTIFICATION_DISABLED) {
       return;
     }
 


### PR DESCRIPTION
I'm packaging Mullvad for [Solus OS](https://getsol.us/) and it'd be nice to disable the version check and GUI notification. Package updates are shipped to users every Friday, so the notice is really unnecessary, especially because they can't just "update" via a `.deb` or `.rpm`.

I've added a feature flag on the daemon, `disable-version-check`, which just replaces the app version request with an "empty" response that won't show as an update.

This seemed like the best place to disable this, as the `VersionUpdater` is pretty well tied into the daemon.

I've tested by patching this against 2021.3 and successfully did not see any version update notification. The output of `mullvad version` is:

```
Current version: 2021.3
	Is supported: false
	No newer version is available
```

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2931)
<!-- Reviewable:end -->
