### PR TITLE
Don't purge DNS options if v3 settings are invalid

### DIFF
--- a/mullvad-types/src/settings/migrations/v3.rs
+++ b/mullvad-types/src/settings/migrations/v3.rs
@@ -20,26 +20,28 @@ impl super::SettingsMigration for Migration {
         }();
 
         if let Some(options) = dns_options {
-            let new_state = if options
-                .get("custom")
-                .map(|custom| custom.as_bool().unwrap_or(false))
-                .unwrap_or(false)
-            {
-                DnsState::Custom
-            } else {
-                DnsState::Default
-            };
-            let addresses = if let Some(addrs) = options.get("addresses") {
-                serde_json::from_value(addrs.clone()).map_err(Error::ParseError)?
-            } else {
-                vec![]
-            };
+            if options.get("state").is_none() {
+                let new_state = if options
+                    .get("custom")
+                    .map(|custom| custom.as_bool().unwrap_or(false))
+                    .unwrap_or(false)
+                {
+                    DnsState::Custom
+                } else {
+                    DnsState::Default
+                };
+                let addresses = if let Some(addrs) = options.get("addresses") {
+                    serde_json::from_value(addrs.clone()).map_err(Error::ParseError)?
+                } else {
+                    vec![]
+                };
 
-            settings["tunnel_options"]["dns_options"] = serde_json::json!(DnsOptions {
-                state: new_state,
-                default_options: DefaultDnsOptions::default(),
-                custom_options: CustomDnsOptions { addresses },
-            });
+                settings["tunnel_options"]["dns_options"] = serde_json::json!(DnsOptions {
+                    state: new_state,
+                    default_options: DefaultDnsOptions::default(),
+                    custom_options: CustomDnsOptions { addresses },
+                });
+            }
         }
 
         settings["settings_version"] = serde_json::json!(SettingsVersion::V4);


### PR DESCRIPTION
Previously, the current settings version number was incorrectly set to `v3`, even though it should have been `v4`. https://github.com/mullvad/mullvadvpn-app/commit/53374768f9ac5b51c9a0830bc1d339aefa09c947 fixes this, but the last release still produces flawed settings. On master, all DNS options are reset if such a file is "migrated" to the newer format.

This PR updates the old migration code to not overwrite the newer fields if they exist, making it safe to run anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2933)
<!-- Reviewable:end -->
