### PR TITLE
Fix showing outdated connection information

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -338,12 +338,28 @@ export default class AppRenderer {
     }
   }
 
-  public disconnectTunnel(): Promise<void> {
-    return IpcRendererEventChannel.tunnel.disconnect();
+  public async disconnectTunnel(): Promise<void> {
+    const state = this.tunnelState.state;
+
+    // disconnect only if tunnel is connected, connecting or blocked.
+    if (state === 'connecting' || state === 'connected' || state === 'error') {
+      // switch to the disconnecting state ahead of time to make the app look more responsive
+      this.reduxActions.connection.disconnecting('nothing');
+
+      return IpcRendererEventChannel.tunnel.disconnect();
+    }
   }
 
-  public reconnectTunnel(): Promise<void> {
-    return IpcRendererEventChannel.tunnel.reconnect();
+  public async reconnectTunnel(): Promise<void> {
+    const state = this.tunnelState.state;
+
+    // reconnect only if tunnel is connected or connecting.
+    if (state === 'connecting' || state === 'connected') {
+      // switch to the connecting state ahead of time to make the app look more responsive
+      this.reduxActions.connection.connecting();
+
+      return IpcRendererEventChannel.tunnel.reconnect();
+    }
   }
 
   public updateRelaySettings(relaySettings: RelaySettingsUpdate) {

--- a/gui/src/renderer/redux/connection/actions.ts
+++ b/gui/src/renderer/redux/connection/actions.ts
@@ -31,7 +31,7 @@ interface IBlockedAction {
 
 interface INewLocationAction {
   type: 'NEW_LOCATION';
-  newLocation: ILocation;
+  newLocation: Partial<ILocation>;
 }
 
 interface IUpdateBlockStateAction {
@@ -82,7 +82,7 @@ function blocked(errorState: IErrorState): IBlockedAction {
   };
 }
 
-function newLocation(location: ILocation): INewLocationAction {
+function newLocation(location: Partial<ILocation>): INewLocationAction {
   return {
     type: 'NEW_LOCATION',
     newLocation: location,


### PR DESCRIPTION
This PR replaces the outdated location information, that is displayed between pressing `connect` and receiving the daemon event with the new location, with the country, city and hostname in the location constraints. Another thing that has been changed is that the disconnect and reconnect buttons now also update the renderer state immediately to make the app feel more responsive.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2934)
<!-- Reviewable:end -->
