### PR TITLE
Pause/defer automatic API requests while offline or the account is invalid

### DIFF
--- a/mullvad-daemon/src/account.rs
+++ b/mullvad-daemon/src/account.rs
@@ -1,0 +1,120 @@
+use chrono::{DateTime, Utc};
+use futures::future::{abortable, AbortHandle};
+use mullvad_rpc::{
+    availability::ApiAvailabilityHandle,
+    rest::{self, MullvadRestHandle},
+    AccountsProxy,
+};
+use mullvad_types::account::{AccountToken, VoucherSubmission};
+use std::time::Duration;
+use talpid_core::future_retry::{retry_future_with_backoff, ExponentialBackoff, Jittered};
+
+const RETRY_INTERVAL_INITIAL: Duration = Duration::from_secs(4);
+const RETRY_INTERVAL_FACTOR: u32 = 5;
+const RETRY_INTERVAL_MAX: Duration = Duration::from_secs(24 * 60 * 60);
+
+
+pub struct Account(());
+
+#[derive(Clone)]
+pub struct AccountHandle {
+    api_availability: ApiAvailabilityHandle,
+    initial_check_abort_handle: AbortHandle,
+    pub proxy: AccountsProxy,
+}
+
+impl AccountHandle {
+    pub async fn check_expiry(&self, token: AccountToken) -> Result<DateTime<Utc>, rest::Error> {
+        let result = self.proxy.get_expiry(token).await;
+        if handle_expiry_result_inner(&result, &self.api_availability) {
+            self.initial_check_abort_handle.abort();
+        }
+        result
+    }
+
+    pub async fn submit_voucher(
+        &mut self,
+        account_token: AccountToken,
+        voucher: String,
+    ) -> Result<VoucherSubmission, rest::Error> {
+        let result = self.proxy.submit_voucher(account_token, voucher).await;
+        if result.is_ok() {
+            self.initial_check_abort_handle.abort();
+            self.api_availability.resume();
+        }
+        result
+    }
+}
+
+impl Account {
+    pub fn new(
+        runtime: tokio::runtime::Handle,
+        rpc_handle: MullvadRestHandle,
+        token: Option<String>,
+        api_availability: ApiAvailabilityHandle,
+    ) -> AccountHandle {
+        let accounts_proxy = AccountsProxy::new(rpc_handle);
+        api_availability.pause();
+
+        let api_availability_copy = api_availability.clone();
+        let accounts_proxy_copy = accounts_proxy.clone();
+
+        let (future, initial_check_abort_handle) = abortable(async move {
+            let token = if let Some(token) = token {
+                token
+            } else {
+                api_availability.pause();
+                return;
+            };
+
+            let retry_strategy = Jittered::jitter(
+                ExponentialBackoff::new(RETRY_INTERVAL_INITIAL, RETRY_INTERVAL_FACTOR)
+                    .max_delay(RETRY_INTERVAL_MAX),
+            );
+            let future_generator = move || {
+                let wait_online = api_availability.wait_online();
+                let expiry_fut = accounts_proxy.get_expiry(token.clone());
+                let api_availability_copy = api_availability.clone();
+                async move {
+                    let _ = wait_online.await;
+                    handle_expiry_result_inner(&expiry_fut.await, &api_availability_copy)
+                }
+            };
+            let should_retry = move |state_was_updated: &bool| -> bool { !*state_was_updated };
+            let retry_future =
+                retry_future_with_backoff(future_generator, should_retry, retry_strategy);
+            retry_future.await;
+        });
+        runtime.spawn(future);
+
+        AccountHandle {
+            api_availability: api_availability_copy,
+            initial_check_abort_handle,
+            proxy: accounts_proxy_copy,
+        }
+    }
+}
+
+fn handle_expiry_result_inner(
+    result: &Result<chrono::DateTime<chrono::Utc>, mullvad_rpc::rest::Error>,
+    api_availability: &ApiAvailabilityHandle,
+) -> bool {
+    match result {
+        Ok(_expiry) if *_expiry >= chrono::Utc::now() => {
+            api_availability.resume();
+            true
+        }
+        Ok(_expiry) => {
+            api_availability.pause();
+            true
+        }
+        Err(mullvad_rpc::rest::Error::ApiError(_status, code)) => {
+            if code == mullvad_rpc::INVALID_ACCOUNT || code == mullvad_rpc::INVALID_AUTH {
+                api_availability.pause();
+                return true;
+            }
+            false
+        }
+        Err(_) => false,
+    }
+}

--- a/mullvad-rpc/src/availability.rs
+++ b/mullvad-rpc/src/availability.rs
@@ -1,0 +1,127 @@
+use std::{
+    future::Future,
+    sync::{Arc, Mutex},
+};
+use tokio::sync::broadcast;
+
+
+const CHANNEL_CAPACITY: usize = 100;
+
+
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// The [`ApiAvailability`] instance was dropped, or the receiver lagged behind.
+    #[error(display = "API availability instance was dropped")]
+    Interrupted(#[error(source)] broadcast::error::RecvError),
+}
+
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
+pub struct State {
+    pause_automatic: bool,
+    offline: bool,
+}
+
+impl State {
+    pub fn is_paused(&self) -> bool {
+        self.pause_automatic
+    }
+
+    pub fn is_offline(&self) -> bool {
+        self.offline
+    }
+
+    pub fn is_available(&self) -> bool {
+        !self.is_paused() && !self.is_offline()
+    }
+}
+
+pub struct ApiAvailability {
+    state: Arc<Mutex<State>>,
+    tx: broadcast::Sender<State>,
+}
+
+impl ApiAvailability {
+    pub fn new(initial_state: State) -> Self {
+        let (tx, _rx) = broadcast::channel(CHANNEL_CAPACITY);
+        let state = Arc::new(Mutex::new(initial_state));
+        ApiAvailability { state, tx }
+    }
+
+    pub fn get_state(&self) -> State {
+        *self.state.lock().unwrap()
+    }
+
+    pub fn handle(&self) -> ApiAvailabilityHandle {
+        ApiAvailabilityHandle {
+            state: self.state.clone(),
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ApiAvailabilityHandle {
+    state: Arc<Mutex<State>>,
+    tx: broadcast::Sender<State>,
+}
+
+impl ApiAvailabilityHandle {
+    pub fn pause(&self) {
+        let mut state = self.state.lock().unwrap();
+        if !state.pause_automatic {
+            state.pause_automatic = true;
+            let _ = self.tx.send(*state);
+        }
+    }
+
+    pub fn resume(&self) {
+        let mut state = self.state.lock().unwrap();
+        if state.pause_automatic {
+            state.pause_automatic = false;
+            let _ = self.tx.send(*state);
+        }
+    }
+
+    pub fn set_offline(&self, offline: bool) {
+        let mut state = self.state.lock().unwrap();
+        if state.offline != offline {
+            state.offline = offline;
+            let _ = self.tx.send(*state);
+        }
+    }
+
+    pub fn get_state(&self) -> State {
+        *self.state.lock().unwrap()
+    }
+
+    pub fn wait_available(&self) -> impl Future<Output = Result<(), Error>> {
+        self.wait_for_state(|state| state.is_available())
+    }
+
+    pub fn wait_online(&self) -> impl Future<Output = Result<(), Error>> {
+        self.wait_for_state(|state| !state.is_offline())
+    }
+
+    fn wait_for_state(
+        &self,
+        state_ready: impl Fn(State) -> bool,
+    ) -> impl Future<Output = Result<(), Error>> {
+        let mut rx = self.tx.subscribe();
+        let state = self.state.clone();
+
+        async move {
+            let current_state = { *state.lock().unwrap() };
+            if state_ready(current_state) {
+                return Ok(());
+            }
+
+            loop {
+                let new_state = rx.recv().await?;
+                if state_ready(new_state) {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -18,6 +18,8 @@ use std::{
 use talpid_types::{net::wireguard, ErrorExt};
 
 
+pub mod availability;
+use availability::{ApiAvailability, ApiAvailabilityHandle};
 pub mod rest;
 
 mod https_client_with_sni;
@@ -41,6 +43,9 @@ pub const INVALID_VOUCHER: &str = "INVALID_VOUCHER";
 /// Error code returned by the Mullvad API if the account token is invalid.
 pub const INVALID_ACCOUNT: &str = "INVALID_ACCOUNT";
 
+/// Error code returned by the Mullvad API if the account token is missing or invalid.
+pub const INVALID_AUTH: &str = "INVALID_AUTH";
+
 const API_HOST: &str = "api.mullvad.net";
 pub const API_IP_CACHE_FILENAME: &str = "api-ip-address.txt";
 const API_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(193, 138, 218, 78));
@@ -51,6 +56,7 @@ const API_ADDRESS: (IpAddr, u16) = (crate::API_IP, 443);
 pub struct MullvadRpcRuntime {
     handle: tokio::runtime::Handle,
     pub address_cache: AddressCache,
+    api_availability: availability::ApiAvailability,
     #[cfg(target_os = "android")]
     socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
 }
@@ -62,6 +68,9 @@ pub enum Error {
 
     #[error(display = "Failed to load address cache")]
     AddressCacheError(#[error(source)] address_cache::Error),
+
+    #[error(display = "API availability check failed")]
+    ApiCheckError(#[error(source)] availability::Error),
 }
 
 impl MullvadRpcRuntime {
@@ -74,6 +83,7 @@ impl MullvadRpcRuntime {
                 None,
                 Arc::new(Box::new(|_| Ok(()))),
             )?,
+            api_availability: ApiAvailability::new(availability::State::default()),
             #[cfg(target_os = "android")]
             socket_bypass_tx: None,
         })
@@ -139,6 +149,7 @@ impl MullvadRpcRuntime {
         Ok(MullvadRpcRuntime {
             handle,
             address_cache,
+            api_availability: ApiAvailability::new(availability::State::default()),
             #[cfg(target_os = "android")]
             socket_bypass_tx,
         })
@@ -156,6 +167,7 @@ impl MullvadRpcRuntime {
         let service = rest::RequestService::new(
             https_connector,
             self.handle.clone(),
+            self.api_availability.handle(),
             self.address_cache.clone(),
         );
         let handle = service.handle();
@@ -172,7 +184,12 @@ impl MullvadRpcRuntime {
             Some("app".to_owned()),
         );
 
-        rest::MullvadRestHandle::new(service, factory, self.address_cache.clone())
+        rest::MullvadRestHandle::new(
+            service,
+            factory,
+            self.address_cache.clone(),
+            self.availability_handle(),
+        )
     }
 
     /// Returns a new request service handle
@@ -183,8 +200,13 @@ impl MullvadRpcRuntime {
     pub fn handle(&mut self) -> &mut tokio::runtime::Handle {
         &mut self.handle
     }
+
+    pub fn availability_handle(&self) -> ApiAvailabilityHandle {
+        self.api_availability.handle()
+    }
 }
 
+#[derive(Clone)]
 pub struct AccountsProxy {
     handle: rest::MullvadRestHandle,
 }

--- a/mullvad-types/src/account.rs
+++ b/mullvad-types/src/account.rs
@@ -15,6 +15,13 @@ pub struct AccountData {
     pub expiry: DateTime<Utc>,
 }
 
+impl AccountData {
+    /// Return true if the account has no time left.
+    pub fn is_expired(&self) -> bool {
+        self.expiry >= Utc::now()
+    }
+}
+
 /// Data structure that's returned from successful invocation of the mullvad API's
 /// `/v1/submit-voucher` RPC.
 #[derive(Deserialize, Serialize, Debug)]

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -1,11 +1,8 @@
-use crate::{
-    routing::{self, RouteManagerHandle},
-    tunnel_state_machine::TunnelCommand,
-};
+use crate::routing::{self, RouteManagerHandle};
 use futures::{channel::mpsc::UnboundedSender, StreamExt};
 use std::{
     net::{IpAddr, Ipv4Addr},
-    sync::Weak,
+    sync::Arc,
 };
 use talpid_types::ErrorExt;
 
@@ -20,6 +17,7 @@ pub enum Error {
 
 pub struct MonitorHandle {
     route_manager: RouteManagerHandle,
+    _notify_tx: Arc<UnboundedSender<bool>>,
 }
 
 // Mullvad API's public IP address, correct at the time of writing, but any public IP address will
@@ -42,7 +40,7 @@ impl MonitorHandle {
 }
 
 pub async fn spawn_monitor(
-    sender: Weak<UnboundedSender<TunnelCommand>>,
+    notify_tx: UnboundedSender<bool>,
     route_manager: RouteManagerHandle,
 ) -> Result<MonitorHandle> {
     let mut is_offline = public_ip_unreachable(&route_manager).await?;
@@ -52,8 +50,11 @@ pub async fn spawn_monitor(
         .await
         .map_err(Error::RouteManagerError)?;
 
+    let notify_tx = Arc::new(notify_tx);
+    let sender = Arc::downgrade(&notify_tx);
     let monitor_handle = MonitorHandle {
         route_manager: route_manager.clone(),
+        _notify_tx: notify_tx,
     };
 
     tokio::spawn(async move {
@@ -71,7 +72,7 @@ pub async fn spawn_monitor(
                         });
                     if new_offline_state != is_offline {
                         is_offline = new_offline_state;
-                        let _ = sender.unbounded_send(TunnelCommand::IsOffline(is_offline));
+                        let _ = sender.unbounded_send(is_offline);
                     }
                 }
                 None => return,

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,8 +1,6 @@
 #[cfg(target_os = "linux")]
 use crate::routing::RouteManagerHandle;
-use crate::tunnel_state_machine::TunnelCommand;
 use futures::channel::mpsc::UnboundedSender;
-use std::sync::Weak;
 #[cfg(target_os = "android")]
 use talpid_types::android::AndroidContext;
 
@@ -43,7 +41,7 @@ impl MonitorHandle {
 }
 
 pub async fn spawn_monitor(
-    sender: Weak<UnboundedSender<TunnelCommand>>,
+    sender: UnboundedSender<bool>,
     #[cfg(target_os = "linux")] route_manager: RouteManagerHandle,
     #[cfg(target_os = "android")] android_context: AndroidContext,
 ) -> Result<MonitorHandle, Error> {


### PR DESCRIPTION
New behavior:
* When the daemon starts, the account validity is checked. If the account is non-existent, expired, or invalid, automatic requests to the API are delayed until `GetAccountData` is called with a valid account (or a valid voucher is submitted). These requests include: WireGuard key rotation, initial WireGuard key push, relay list updates, version checks, API IP cache rotations, etc.
* When offline, automatic requests are delayed until the machine is back online.
* The API IP is not rotated when offline and a request fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2937)
<!-- Reviewable:end -->
