### PR TITLE
Simplify tunnel state machine arguments

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -540,13 +540,15 @@ where
         let (tunnel_state_machine_shutdown_tx, tunnel_state_machine_shutdown_signal) =
             oneshot::channel();
 
+        let runtime = tokio::runtime::Handle::current();
+
         let (internal_event_tx, internal_event_rx) = command_channel.destructure();
         let (address_change_tx, mut address_change_rx) = mpsc::channel(0);
         let address_change_tx = std::sync::Mutex::new(address_change_tx);
-        let address_change_runtime = tokio::runtime::Handle::current();
+        let address_change_runtime = runtime.clone();
 
         let mut rpc_runtime = mullvad_rpc::MullvadRpcRuntime::with_cache(
-            tokio::runtime::Handle::current(),
+            runtime.clone(),
             Some(&resource_dir),
             &cache_dir,
             true,
@@ -666,21 +668,24 @@ where
         };
 
         let tunnel_command_tx = tunnel_state_machine::spawn(
-            settings.allow_lan,
-            settings.block_when_disconnected,
-            Self::get_dns_resolvers(&settings.tunnel_options.dns_options),
-            initial_api_endpoint,
+            runtime,
+            tunnel_state_machine::InitialTunnelState::new(
+                settings.allow_lan,
+                settings.block_when_disconnected,
+                Self::get_dns_resolvers(&settings.tunnel_options.dns_options),
+                initial_api_endpoint,
+                initial_target_state != TargetState::Secured,
+                #[cfg(windows)]
+                exclude_apps,
+            ),
             tunnel_parameters_generator,
             log_dir,
             resource_dir,
             cache_dir.clone(),
             internal_event_tx.to_specialized_sender(),
             tunnel_state_machine_shutdown_tx,
-            initial_target_state != TargetState::Secured,
             #[cfg(target_os = "android")]
             android_context,
-            #[cfg(windows)]
-            exclude_apps,
         )
         .await
         .map_err(Error::TunnelError)?;

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -77,21 +77,50 @@ pub enum Error {
     SendStateChange,
 }
 
-/// Spawn the tunnel state machine thread, returning a channel for sending tunnel commands.
-pub async fn spawn(
+/// Settings used to initialize the tunnel state machine.
+pub struct InitialTunnelState {
     allow_lan: bool,
     block_when_disconnected: bool,
     dns_servers: Option<Vec<IpAddr>>,
     allowed_endpoint: Endpoint,
+    reset_firewall: bool,
+    #[cfg(windows)]
+    exclude_paths: Vec<OsString>,
+}
+
+impl InitialTunnelState {
+    /// Settings used to initialize the tunnel state machine.
+    pub fn new(
+        allow_lan: bool,
+        block_when_disconnected: bool,
+        dns_servers: Option<Vec<IpAddr>>,
+        allowed_endpoint: Endpoint,
+        reset_firewall: bool,
+        #[cfg(windows)] exclude_paths: Vec<OsString>,
+    ) -> Self {
+        Self {
+            allow_lan,
+            block_when_disconnected,
+            dns_servers,
+            allowed_endpoint,
+            reset_firewall,
+            #[cfg(windows)]
+            exclude_paths,
+        }
+    }
+}
+
+/// Spawn the tunnel state machine thread, returning a channel for sending tunnel commands.
+pub async fn spawn(
+    runtime: tokio::runtime::Handle,
+    initial_settings: InitialTunnelState,
     tunnel_parameters_generator: impl TunnelParametersGenerator,
     log_dir: Option<PathBuf>,
     resource_dir: PathBuf,
     cache_dir: impl AsRef<Path> + Send + 'static,
     state_change_listener: impl Sender<TunnelStateTransition> + Send + 'static,
     shutdown_tx: oneshot::Sender<()>,
-    reset_firewall: bool,
     #[cfg(target_os = "android")] android_context: AndroidContext,
-    #[cfg(windows)] exclude_paths: Vec<OsString>,
 ) -> Result<Arc<mpsc::UnboundedSender<TunnelCommand>>, Error> {
     let (command_tx, command_rx) = mpsc::unbounded();
     let command_tx = Arc::new(command_tx);
@@ -107,29 +136,21 @@ pub async fn spawn(
         dns_servers.clone(),
     );
 
-    let runtime = tokio::runtime::Handle::current();
-
     let (startup_result_tx, startup_result_rx) = sync_mpsc::channel();
     let weak_command_tx = Arc::downgrade(&command_tx);
     std::thread::spawn(move || {
         let state_machine = runtime.block_on(TunnelStateMachine::new(
             runtime.clone(),
+            initial_settings,
             weak_command_tx,
-            allow_lan,
-            block_when_disconnected,
-            dns_servers,
-            allowed_endpoint,
             tunnel_parameters_generator,
             tun_provider,
             log_dir,
             resource_dir,
             cache_dir,
             command_rx,
-            reset_firewall,
             #[cfg(target_os = "android")]
             android_context,
-            #[cfg(windows)]
-            exclude_paths,
         ));
         let state_machine = match state_machine {
             Ok(state_machine) => {
@@ -208,29 +229,24 @@ struct TunnelStateMachine {
 impl TunnelStateMachine {
     async fn new(
         runtime: tokio::runtime::Handle,
+        settings: InitialTunnelState,
         command_tx: std::sync::Weak<mpsc::UnboundedSender<TunnelCommand>>,
-        allow_lan: bool,
-        block_when_disconnected: bool,
-        dns_servers: Option<Vec<IpAddr>>,
-        allowed_endpoint: Endpoint,
         tunnel_parameters_generator: impl TunnelParametersGenerator,
         tun_provider: TunProvider,
         log_dir: Option<PathBuf>,
         resource_dir: PathBuf,
         cache_dir: impl AsRef<Path>,
         commands_rx: mpsc::UnboundedReceiver<TunnelCommand>,
-        reset_firewall: bool,
         #[cfg(target_os = "android")] android_context: AndroidContext,
-        #[cfg(windows)] exclude_paths: Vec<OsString>,
     ) -> Result<Self, Error> {
         #[cfg(windows)]
         let split_tunnel = split_tunnel::SplitTunnel::new(command_tx.clone())
             .map_err(Error::InitSplitTunneling)?;
 
         let args = FirewallArguments {
-            initialize_blocked: block_when_disconnected || !reset_firewall,
-            allow_lan,
-            allowed_endpoint: Some(allowed_endpoint),
+            initialize_blocked: settings.block_when_disconnected || !settings.reset_firewall,
+            allow_lan: settings.allow_lan,
+            allowed_endpoint: Some(settings.allowed_endpoint),
         };
 
         let firewall = Firewall::new(args).map_err(Error::InitFirewallError)?;
@@ -272,11 +288,11 @@ impl TunnelStateMachine {
             dns_monitor,
             route_manager,
             _offline_monitor: offline_monitor,
-            allow_lan,
-            block_when_disconnected,
+            allow_lan: settings.allow_lan,
+            block_when_disconnected: settings.block_when_disconnected,
             is_offline,
-            dns_servers,
-            allowed_endpoint,
+            dns_servers: settings.dns_servers,
+            allowed_endpoint: settings.allowed_endpoint,
             tunnel_parameters_generator: Box::new(tunnel_parameters_generator),
             tun_provider,
             log_dir,
@@ -285,7 +301,8 @@ impl TunnelStateMachine {
             connectivity_check_was_enabled: None,
         };
 
-        let (initial_state, _) = DisconnectedState::enter(&mut shared_values, reset_firewall);
+        let (initial_state, _) =
+            DisconnectedState::enter(&mut shared_values, settings.reset_firewall);
 
         Ok(TunnelStateMachine {
             current_state: Some(initial_state),


### PR DESCRIPTION
Minor PR to reduce the number of arguments given to `tunnel_state_machine::spawn` by four. I grouped all the "stateful" settings used for initialization into `InitialTunnelState`.