### PR TITLE
Improve connection info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix in-app notification button not working for some notifications.
 - Fix incorrectly positioned navigation bar title when navigating back to a scrolled down view.
 - Fix connectivity check for WireGuard multihop when the exit hop is down.
+- Fix incorrect location and connection status while disconnecting and incorrect location in the
+  beginning while connecting in the desktop app.
+- Improve responsiveness of the controls and status text in the main view in the desktop app.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -612,16 +612,25 @@ export default class AppRenderer {
       if (location !== 'any' && 'only' in location) {
         const constraint = location.only;
 
-        const relayLocations = this.reduxStore.getState().settings.relayLocations;
+        const state = this.reduxStore.getState();
+        const coordinates = {
+          longitude: state.connection.longitude,
+          latitude: state.connection.latitude,
+        };
+        const relayLocations = state.settings.relayLocations;
         if ('country' in constraint) {
           const country = relayLocations.find(({ code }) => constraint.country === code);
 
-          this.reduxActions.connection.newLocation({ country: country?.name });
+          this.reduxActions.connection.newLocation({ country: country?.name, ...coordinates });
         } else if ('city' in constraint) {
           const country = relayLocations.find(({ code }) => constraint.city[0] === code);
           const city = country?.cities.find(({ code }) => constraint.city[1] === code);
 
-          this.reduxActions.connection.newLocation({ country: country?.name, city: city?.name });
+          this.reduxActions.connection.newLocation({
+            country: country?.name,
+            city: city?.name,
+            ...coordinates,
+          });
         } else if ('hostname' in constraint) {
           const country = relayLocations.find(({ code }) => constraint.hostname[0] === code);
           const city = country?.cities.find((location) => location.code === constraint.hostname[1]);
@@ -630,6 +639,7 @@ export default class AppRenderer {
             country: country?.name,
             city: city?.name,
             hostname: constraint.hostname[2],
+            ...coordinates,
           });
         }
       }

--- a/gui/src/renderer/components/Connect.tsx
+++ b/gui/src/renderer/components/Connect.tsx
@@ -213,9 +213,6 @@ export default class Connect extends React.Component<IProps, IState> {
   private showMarkerOrSpinner(): MarkerOrSpinner {
     const status = this.props.connection.status;
 
-    return status.state === 'connecting' ||
-      (status.state === 'disconnecting' && status.details === 'reconnect')
-      ? 'spinner'
-      : 'marker';
+    return status.state === 'connecting' || status.state === 'disconnecting' ? 'spinner' : 'marker';
   }
 }

--- a/gui/src/renderer/components/SecuredLabel.tsx
+++ b/gui/src/renderer/components/SecuredLabel.tsx
@@ -8,11 +8,13 @@ export enum SecuredDisplayStyle {
   blocked,
   securing,
   unsecured,
+  unsecuring,
   failedToSecure,
 }
 
 const securedDisplayStyleColorMap = {
   [SecuredDisplayStyle.securing]: colors.white,
+  [SecuredDisplayStyle.unsecuring]: colors.white,
   [SecuredDisplayStyle.secured]: colors.green,
   [SecuredDisplayStyle.blocked]: colors.green,
   [SecuredDisplayStyle.unsecured]: colors.red,
@@ -20,6 +22,8 @@ const securedDisplayStyleColorMap = {
 };
 
 const StyledSecuredLabel = styled.span((props: { displayStyle: SecuredDisplayStyle }) => ({
+  display: 'inline-block',
+  minHeight: '22px',
   color: securedDisplayStyleColorMap[props.displayStyle],
 }));
 
@@ -49,6 +53,9 @@ function getLabelText(displayStyle: SecuredDisplayStyle) {
 
     case SecuredDisplayStyle.unsecured:
       return messages.gettext('UNSECURE CONNECTION');
+
+    case SecuredDisplayStyle.unsecuring:
+      return '';
 
     case SecuredDisplayStyle.failedToSecure:
       return messages.gettext('FAILED TO SECURE CONNECTION');

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -163,7 +163,7 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
         return (
           <Wrapper>
             <Body>
-              <Secured displayStyle={SecuredDisplayStyle.secured} />
+              <Secured displayStyle={SecuredDisplayStyle.unsecuring} />
               <Location>{this.renderCountry()}</Location>
             </Body>
             <Footer>

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -46,7 +46,6 @@ export interface IAppStateSnapshot {
   accountHistory?: AccountToken;
   tunnelState: TunnelState;
   settings: ISettings;
-  location?: ILocation;
   relayListPair: IRelayListPair;
   currentVersion: ICurrentAppVersionInfo;
   upgradeVersion: IAppVersionInfo;
@@ -112,9 +111,6 @@ export const ipcSchema = {
     connected: notifyRenderer<void>(),
     disconnected: notifyRenderer<void>(),
   },
-  location: {
-    '': notifyRenderer<ILocation>(),
-  },
   relays: {
     '': notifyRenderer<IRelayListPair>(),
   },
@@ -128,6 +124,9 @@ export const ipcSchema = {
     quit: send<void>(),
     openUrl: invoke<string, void>(),
     showOpenDialog: invoke<Electron.OpenDialogOptions, Electron.OpenDialogReturnValue>(),
+  },
+  location: {
+    get: invoke<void, ILocation>(),
   },
   tunnel: {
     '': notifyRenderer<TunnelState>(),


### PR DESCRIPTION
This PR contains fixes for a bunch of issues relating to the connection info in the main view:
* Showing "SECURE CONNECTION" while disconnecting
* Showing the location of the previously connected server while disconnecting
* Showing information about the previous connection before receiving new information while connecting and reconnecting
* Having a delay when entering the disconnecting state (disconnect and reconnect). This is due to the time it takes before the frontend receives the daemon event with the new tunnel status.

To fix these issues I've made the following changes:
* Remove the status label while disconnecting
* Move all location handling code to the renderer since that's where it's used
* Use the location from when last disconnected while disconnecting
* Use location constraints when starting a new connection/reconnection
* Update the renderer state immediately when pressing disconnect/reconnect
* Ignore tunnel state updates that doesn't correspond to the latest action. E.g. Pressing `Connect` followed by `Cancel` before the `connecting` event has arrived ignores the `connecting` event since we've already requested a disconnect.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2940)
<!-- Reviewable:end -->
