### PR TITLE
Update platform support for Ubuntu and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ security.
 |-------------|--------------------|
 | Windows     | 7, 8.1 and 10      |
 | macOS       | The three latest major releases |
-| Linux (Ubuntu)| The two newest LTS releases and the two newest non-LTS releases |
+| Linux (Ubuntu)| The two latest LTS releases and the latest non-LTS releases |
 | Linux (Fedora) | The versions that are not yet [EOL](https://fedoraproject.org/wiki/End_of_life) |
 | Linux (Debian) | The versions that are not yet [EOL](https://wiki.debian.org/DebianReleases) |
 | Android | The four latest major releases|
-| iOS         | 13 and newer       |
+| iOS         | 12 and newer       |
 
 On Linux we test using the Gnome desktop environment. The app should, and probably does work
 in other DEs, but we don't regularly test those.


### PR DESCRIPTION
iOS was simply outdated. We have supported iOS 12 for a long time now. We will likely drop it sometime relatively soon, but this table should be correct until then.

For Ubuntu there was a disconnect between the readme and the support team. In practice we only support the latest non-LTS release of Ubuntu, and not the two latest ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2941)
<!-- Reviewable:end -->
