### PR TITLE
Fix ping monitor when multiple peers are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Line wrap the file at 100 chars.                                              Th
   desktop app.
 - Fix in-app notification button not working for some notifications.
 - Fix incorrectly positioned navigation bar title when navigating back to a scrolled down view.
+- Fix connectivity check for WireGuard multihop when the exit hop is down.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -327,7 +327,10 @@ impl WireguardMonitor {
         #[cfg(target_os = "linux")]
         if !*FORCE_USERSPACE_WIREGUARD {
             if crate::dns::will_use_nm() {
-                match wireguard_kernel::NetworkManagerTunnel::new(config) {
+                match wireguard_kernel::NetworkManagerTunnel::new(
+                    route_manager.runtime_handle(),
+                    config,
+                ) {
                     Ok(tunnel) => {
                         log::debug!("Using NetworkManager to use kernel WireGuard implementation");
                         return Ok(Box::new(tunnel));
@@ -559,9 +562,7 @@ pub(crate) trait Tunnel: Send {
     #[cfg(target_os = "windows")]
     fn get_interface_luid(&self) -> u64;
     fn stop(self: Box<Self>) -> std::result::Result<(), TunnelError>;
-    fn get_tunnel_stats(&self) -> std::result::Result<stats::Stats, TunnelError>;
-    #[cfg(target_os = "linux")]
-    fn slow_stats_refresh_rate(&self) {}
+    fn get_tunnel_stats(&self) -> std::result::Result<stats::StatsMap, TunnelError>;
 }
 
 /// Errors to be returned from WireGuard implementations, namely implementers of the Tunnel trait

--- a/talpid-core/src/tunnel/wireguard/stats.rs
+++ b/talpid-core/src/tunnel/wireguard/stats.rs
@@ -4,11 +4,11 @@ use super::wireguard_kernel::wg_message::{DeviceMessage, DeviceNla, PeerNla};
 
 #[derive(err_derive::Error, Debug, PartialEq)]
 pub enum Error {
+    #[error(display = "Failed to parse peer pubkey from string \"_0\"")]
+    PubKeyParseError(String, #[error(source)] hex::FromHexError),
+
     #[error(display = "Failed to parse integer from string \"_0\"")]
     IntParseError(String, #[error(source)] std::num::ParseIntError),
-
-    #[error(display = "Config key not found")]
-    KeyNotFoundError,
 
     #[error(display = "Device no longer exists")]
     NoTunnelDevice,
@@ -21,8 +21,14 @@ pub struct Stats {
     pub rx_bytes: u64,
 }
 
+/// A map from peer pubkeys to peer stats.
+pub type StatsMap = std::collections::HashMap<[u8; 32], Stats>;
+
 impl Stats {
-    pub fn parse_config_str(config: &str) -> Result<Self, Error> {
+    pub fn parse_config_str(config: &str) -> Result<StatsMap, Error> {
+        let mut map = StatsMap::new();
+
+        let mut peer = None;
         let mut tx_bytes = None;
         let mut rx_bytes = None;
 
@@ -36,6 +42,14 @@ impl Stats {
 
         for (key, value) in parts {
             match key {
+                "public_key" => {
+                    let mut buffer = [0u8; 32];
+                    hex::decode_to_slice(value, &mut buffer)
+                        .map_err(|err| Error::PubKeyParseError(value.to_string(), err))?;
+                    peer = Some(buffer);
+                    tx_bytes = None;
+                    rx_bytes = None;
+                }
                 "rx_bytes" => {
                     rx_bytes = Some(
                         value
@@ -55,35 +69,53 @@ impl Stats {
 
                 _ => continue,
             }
-        }
 
-        match (tx_bytes, rx_bytes) {
-            (Some(tx_bytes), Some(rx_bytes)) => Ok(Self { tx_bytes, rx_bytes }),
-            _ => Err(Error::KeyNotFoundError),
+            match (peer, tx_bytes, rx_bytes) {
+                (Some(peer_val), Some(tx_bytes_val), Some(rx_bytes_val)) => {
+                    map.insert(
+                        peer_val,
+                        Self {
+                            tx_bytes: tx_bytes_val,
+                            rx_bytes: rx_bytes_val,
+                        },
+                    );
+                    peer = None;
+                    tx_bytes = None;
+                    rx_bytes = None;
+                }
+                _ => (),
+            }
         }
+        Ok(map)
     }
 
     #[cfg(target_os = "linux")]
-    pub fn parse_device_message(message: &DeviceMessage) -> Self {
-        // iterate over device attributes
-        let mut tx_bytes = 0;
-        let mut rx_bytes = 0;
+    pub fn parse_device_message(message: &DeviceMessage) -> StatsMap {
+        let mut map = StatsMap::new();
+
         for nla in &message.nlas {
             if let DeviceNla::Peers(peers) = nla {
-                // iterate over all peer attributes
-                let peer_iter = peers.iter().map(|peer| peer.0.as_slice()).flatten();
+                for msg in peers {
+                    let mut tx_bytes = 0;
+                    let mut rx_bytes = 0;
+                    let mut pub_key = None;
 
-                for peer_nla in peer_iter {
-                    match peer_nla {
-                        PeerNla::TxBytes(bytes) => tx_bytes += *bytes,
-                        PeerNla::RxBytes(bytes) => rx_bytes += *bytes,
-                        _ => continue,
-                    };
+                    for nla in &msg.0 {
+                        match nla {
+                            PeerNla::TxBytes(bytes) => tx_bytes = *bytes,
+                            PeerNla::RxBytes(bytes) => rx_bytes = *bytes,
+                            PeerNla::PublicKey(key) => pub_key = Some(*key),
+                            _ => continue,
+                        }
+                    }
+                    if let Some(key) = pub_key {
+                        map.insert(key, Stats { tx_bytes, rx_bytes });
+                    }
                 }
             }
         }
 
-        Self { tx_bytes, rx_bytes }
+        map
     }
 }
 
@@ -95,10 +127,14 @@ mod test {
     #[test]
     fn test_parsing() {
         let valid_input = "private_key=0000000000000000000000000000000000000000000000000000000000000000\npublic_key=0000000000000000000000000000000000000000000000000000000000000000\npreshared_key=0000000000000000000000000000000000000000000000000000000000000000\nprotocol_version=1\nendpoint=000.000.000.000:00000\nlast_handshake_time_sec=1578420649\nlast_handshake_time_nsec=369416131\ntx_bytes=2740\nrx_bytes=2396\npersistent_keepalive_interval=0\nallowed_ip=0.0.0.0/0\n";
+        let pubkey = [0u8; 32];
 
         let stats = Stats::parse_config_str(valid_input).expect("Failed to parse valid input");
-        assert_eq!(stats.rx_bytes, 2396);
-        assert_eq!(stats.tx_bytes, 2740);
+        assert_eq!(stats.len(), 1);
+        let actual_keys: Vec<[u8; 32]> = stats.keys().cloned().collect();
+        assert_eq!(actual_keys, [pubkey]);
+        assert_eq!(stats[&pubkey].rx_bytes, 2396);
+        assert_eq!(stats[&pubkey].tx_bytes, 2740);
     }
 
     #[test]
@@ -110,15 +146,6 @@ mod test {
         assert_eq!(
             Stats::parse_config_str(invalid_input),
             Err(Error::IntParseError(invalid_str, int_err))
-        );
-    }
-
-    #[test]
-    fn test_parsing_missing_keys() {
-        let invalid_input = "private_key=0000000000000000000000000000000000000000000000000000000000000000\npublic_key=0000000000000000000000000000000000000000000000000000000000000000\npreshared_key=0000000000000000000000000000000000000000000000000000000000000000\nprotocol_version=1\nendpoint=000.000.000.000:00000\nlast_handshake_time_sec=1578420649\nlast_handshake_time_nsec=369416131\ntx_bytes=2740\npersistent_keepalive_interval=0\nallowed_ip=0.0.0.0/0\n";
-        assert_eq!(
-            Stats::parse_config_str(invalid_input),
-            Err(Error::KeyNotFoundError)
         );
     }
 }

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -1,4 +1,7 @@
-use super::{stats::Stats, Config, Tunnel, TunnelError};
+use super::{
+    stats::{Stats, StatsMap},
+    Config, Tunnel, TunnelError,
+};
 use crate::tunnel::{
     tun_provider::TunProvider,
     wireguard::logging::{clean_up_logging, initialize_logging, logging_callback, WgLogLevel},
@@ -307,7 +310,7 @@ impl Tunnel for WgGoTunnel {
         self.interface_luid
     }
 
-    fn get_tunnel_stats(&self) -> Result<Stats> {
+    fn get_tunnel_stats(&self) -> Result<StatsMap> {
         let config_str = unsafe {
             let ptr = wgGetConfig(self.handle.unwrap());
             if ptr.is_null() {

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
@@ -1,6 +1,7 @@
 use super::{
-    super::stats::Stats, wg_message::DeviceNla, Config, Error, Handle, Tunnel, TunnelError,
-    MULLVAD_INTERFACE_NAME,
+    super::stats::{Stats, StatsMap},
+    wg_message::DeviceNla,
+    Config, Error, Handle, Tunnel, TunnelError, MULLVAD_INTERFACE_NAME,
 };
 
 
@@ -97,7 +98,7 @@ impl Tunnel for NetlinkTunnel {
         })
     }
 
-    fn get_tunnel_stats(&self) -> std::result::Result<Stats, TunnelError> {
+    fn get_tunnel_stats(&self) -> std::result::Result<StatsMap, TunnelError> {
         let mut wg = self.netlink_connections.wg_handle.clone();
         let interface_index = self.interface_index;
         let result = self.tokio_handle.block_on(async move {


### PR DESCRIPTION
Previously, the ping monitor would take any traffic received from any peer to mean that the tunnel was up. This worked poorly with multihop, since the entry hop could respond even when the exit hop could not be reached, incorrectly causing the TSM to enter the connected state.

This was fixed by requiring data to be received from every peer before considering the tunnel to be up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2943)
<!-- Reviewable:end -->
