### PR TITLE
Fix new settings views contexts

### DIFF
--- a/gui/locales/da/messages.po
+++ b/gui/locales/da/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Bemærk: aktivering af dette medfører, at der altid kræves en Mullvad VPN-forbindelse for at oprette forbindelse til internettet."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatisk"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Brotilstand"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Standard"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Hvis du afbryder forbindelsen eller lukker appen, blokerer denne indstilling dit internet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Fra"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Til"
 
@@ -287,7 +283,7 @@ msgstr "OpenVPN-transportprotokol"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Indstil OpenVPN MSS-værdi. Gyldigt interval: %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Indstil OpenVPN MSS-værdi. Gyldigt interval: %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Indstil WireGuard MTU-værdi. Gyldigt interval: %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Split tunneling"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Appens indbyggede kill-switch er altid slået til. Denne indstilling blokerer desuden internettet, hvis du klikker på Afbryd forbindelse eller Afslut"
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Den automatiske indstilling vil vælge tilfældigt mellem en lang række porte."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tunnelprotokol"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard-nøgle"
 

--- a/gui/locales/de/messages.po
+++ b/gui/locales/de/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Achtung: Wenn Sie diese Einstellung aktivieren, wird immer eine Mullvad VPN-Verbindung erfordert, um das Internet zu erreichen."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatisch"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Brückenmodus"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Standard"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Wenn Sie die Verbindung trennen oder die App beenden, wird diese Einstellung Ihr Internet sperren."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Aus"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Ein"
 
@@ -287,7 +283,7 @@ msgstr "OpenVPN-Transportprotokoll"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "OpenVPN MSS-Wert einstellen. Gültiger Bereich: %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "OpenVPN MSS-Wert einstellen. Gültiger Bereich: %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "WireGuard MTU-Wert einstellen. Gültiger Bereich: %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Split Tunneling"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Der integrierte Killswitch der App ist immer an. Diese Einstellung wird außerdem das Internet sperren, wenn Sie auf Trennen oder Beenden klicken."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Die automatische Einstellung wählt willkürlich aus einer Vielzahl von Ports."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tunnelprotokoll"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard-Schlüssel"
 

--- a/gui/locales/es/messages.po
+++ b/gui/locales/es/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Atención: Si activa esta opción, se exigirá siempre el uso de una conexión de Mullvad VPN para conectarse a Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automático"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Modo puente"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Predeterminado"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Si se desconecta o sale de la aplicación, esta configuración bloqueará el acceso a Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Desactivado"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Activado"
 
@@ -287,7 +283,7 @@ msgstr "Protocolo de transporte de OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Establezca el valor de MSS de OpenVPN. Intervalo válido: %(min)d-%(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Establezca el valor de MSS de OpenVPN. Intervalo válido: %(min)d-%(max)
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Establezca el valor de MTU de WireGuard. Intervalo válido: %(min)d-%(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Tunelización dividida"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "La función de desconexión de seguridad integrada en la aplicación siempre está activada. Esta configuración bloqueará también el acceso a Internet si hace clic en Desconectar o Salir."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Si se activa la opción de configuración automática, se elegirá entre un gran número de puertos al azar."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Protocolo de tunelización"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "Clave de WireGuard"
 

--- a/gui/locales/fi/messages.po
+++ b/gui/locales/fi/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Huomio: jos tämä otetaan käyttöön, verkkoon yhdistäminen vaatii aina Mullvad VPN -yhteyden."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automaattinen"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Siltaus"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Oletus"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Jos katkaiset sovellusyhteyden tai suljet sovelluksen, tämä asetus estää verkkoyhteyden."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Pois"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Päällä"
 
@@ -287,7 +283,7 @@ msgstr "OpenVPN-siirtoprotokolla"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Aseta OpenVPN MSS -arvo asteikolla %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Aseta OpenVPN MSS -arvo asteikolla %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Aseta WireGuardin MTU-arvo väliltä %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Sovelluskohtainen yhdistäminen"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Sovelluksen sisäänrakennettu tappokytkin on aina käytössä. Tämä asetus estää lisäksi verkkoyhteyden, jos katkaiset sovellusyhteyden tai suljet sovelluksen."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Automaattinen asetus valitsee satunnaisesti laajasta määrästä portteja."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tunneliprotokolla"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard-avain"
 

--- a/gui/locales/fr/messages.po
+++ b/gui/locales/fr/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Attention : si vous activez cette option, les connexions à Internet nécessiteront toujours une connexion Mullvad VPN."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatique"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Mode pont"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Par défaut"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Si vous vous déconnectez ou quittez l'application, ce paramètre bloquera votre connexion internet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Désactivé"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Activé"
 
@@ -287,7 +283,7 @@ msgstr "Protocole de transport OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Définir la valeur MSS OpenVPN. Plage valide : %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Définir la valeur MSS OpenVPN. Plage valide : %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Définir la valeur MTU WireGuard. Plage valide : %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Split tunneling"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Le kill switch intégré à l'application est toujours activé. Ce paramètre bloquera en plus Internet si vous cliquez sur Déconnecter ou Quitter."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Le réglage automatique choisira au hasard parmi un large éventail de ports."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Protocole de tunnel"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "Clé WireGuard"
 

--- a/gui/locales/it/messages.po
+++ b/gui/locales/it/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Attenzione: abilitando questa opzione, si richiederà sempre una connessione Mullvad VPN per navigare in Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatico"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Modalità bridge"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Predefinito"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Se l'utente si scollega o esce dall'app, l'impostazione bloccherà Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Off"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "On"
 
@@ -287,7 +283,7 @@ msgstr "Protocollo di trasporto OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Imposta valore OpenVPN MSS. Intervallo valido: %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Imposta valore OpenVPN MSS. Intervallo valido: %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Imposta il valore MTU WireGuard. Intervallo valido: %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Split tunneling"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Il kill switch integrato dell'app è sempre attivo. Questa impostazione serve inoltre a bloccare Internet quando si clicca su Disconnetti o Esci."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "L'impostazione automatica sceglierà in modo casuale da un ampio intervallo porte."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Protocollo di tunneling"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "Chiave WireGuard"
 

--- a/gui/locales/ja/messages.po
+++ b/gui/locales/ja/messages.po
@@ -216,16 +216,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "注意：この設定を有効化すると、インターネットにアクセスするために常にMullvad VPNへの接続が必要になります。"
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "自動"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "ブリッジモード"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "デフォルト"
 
@@ -253,11 +251,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "アプリを接続解除したり終了したりすると、この設定によってインターネットアクセスがブロックされます。"
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "オフ"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "オン"
 
@@ -284,7 +280,7 @@ msgstr "OpenVPN転送プロトコル"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "OpenVPN MSS の値を設定します。有効範囲：%(min)d ～ %(max)d。"
 
@@ -292,7 +288,7 @@ msgstr "OpenVPN MSS の値を設定します。有効範囲：%(min)d ～ %(max)
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "WireGuard MTU の値を設定します。有効範囲：%(min)d ～ %(max)d"
 
@@ -300,7 +296,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "スプリットトンネリング"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -309,7 +304,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "アプリに組み込まれているキルスイッチは常にオンになっています。この設定を有効にすると、「接続解除」または「終了」をクリックした場合にインターネットが補助的にブロックされます。"
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "自動設定では、さまざまなポートからランダムに選択されます。"
 
@@ -325,7 +320,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "トンネルプロトコル"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -337,7 +331,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard鍵"
 

--- a/gui/locales/ko/messages.po
+++ b/gui/locales/ko/messages.po
@@ -208,16 +208,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "주의: 이 기능을 사용하려면 인터넷 연결을 위해 항상 Mullvad VPN 연결이 필요합니다."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "자동"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "브리지 모드"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "기본값"
 
@@ -245,11 +243,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "앱 연결을 끊거나 종료하면 이 설정으로 인해 인터넷이 차단됩니다."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "끄기"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "켜기"
 
@@ -276,7 +272,7 @@ msgstr "OpenVPN 전송 프로토콜"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "OpenVPN MSS 값을 설정하세요. 유효 범위: %(min)d ~ %(max)d."
 
@@ -284,7 +280,7 @@ msgstr "OpenVPN MSS 값을 설정하세요. 유효 범위: %(min)d ~ %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "WireGuard MTU 값을 설정하세요. 유효 범위: %(min)d ~ %(max)d."
 
@@ -292,7 +288,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "분할 터널링"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -301,7 +296,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "앱에서 기본 제공되는 중단 스위치는 항상 켜져 있습니다. 연결 끊기 또는 종료를 클릭하면 이 설정으로 인해 인터넷이 추가로 차단됩니다."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "자동 설정은 다양한 포트에서 임의로 선택합니다."
 
@@ -317,7 +312,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "터널 프로토콜"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -329,7 +323,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard 키"
 

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -63,6 +63,9 @@ msgstr[1] ""
 msgid "Apply"
 msgstr ""
 
+msgid "Automatic"
+msgstr ""
+
 msgid "Back"
 msgstr ""
 
@@ -96,6 +99,9 @@ msgstr ""
 msgid "CREATING SECURE CONNECTION"
 msgstr ""
 
+msgid "Default"
+msgstr ""
+
 msgid "Disconnect"
 msgstr ""
 
@@ -126,6 +132,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+msgid "Off"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
 msgid "Open URL"
 msgstr ""
 
@@ -139,6 +151,12 @@ msgid "Settings"
 msgstr ""
 
 msgid "System default"
+msgstr ""
+
+msgid "TCP"
+msgstr ""
+
+msgid "UDP"
 msgstr ""
 
 msgid "UNSECURE CONNECTION"
@@ -227,17 +245,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr ""
 
-msgid "Automatic"
-msgstr ""
-
-#. The title for the shadowsocks bridge selector section.
-msgctxt "openvpn-settings-view"
-msgid "Bridge mode"
-msgstr ""
-
-msgid "Default"
-msgstr ""
-
 msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr ""
@@ -262,61 +269,24 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr ""
 
-msgid "Off"
-msgstr ""
-
-msgid "On"
+msgctxt "advanced-settings-view"
+msgid "missing key"
 msgstr ""
 
 msgctxt "advanced-settings-view"
 msgid "OpenVPN"
 msgstr ""
 
-#. The title for the port selector section.
-#. Available placeholders:
-#. %(portType)s - a selected protocol (either TCP or UDP)
 msgctxt "advanced-settings-view"
-msgid "OpenVPN %(portType)s port"
-msgstr ""
-
-msgctxt "advanced-settings-view"
-msgid "OpenVPN Mssfix"
-msgstr ""
-
-msgctxt "advanced-settings-view"
-msgid "OpenVPN transport protocol"
-msgstr ""
-
-#. The hint displayed below the Mssfix input field.
-#. Available placeholders:
-#. %(max)d - the maximum possible mssfix value
-#. %(min)d - the minimum possible mssfix value
-msgctxt "openvpn-settings-view"
-msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
-msgstr ""
-
-#. The hint displayed below the WireGuard MTU input field.
-#. Available placeholders:
-#. %(max)d - the maximum possible wireguard mtu value
-#. %(min)d - the minimum possible wireguard mtu value
-msgctxt "wireguard-settings-view"
-msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
+msgid "OpenVPN settings"
 msgstr ""
 
 msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr ""
 
-msgid "TCP"
-msgstr ""
-
 msgctxt "advanced-settings-view"
 msgid "The app’s built-in kill switch is always on. This setting will additionally block the internet if clicking Disconnect or Quit."
-msgstr ""
-
-#. The hint displayed below the WireGuard port selector.
-msgctxt "wireguard-settings-view"
-msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -331,9 +301,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr ""
 
-msgid "UDP"
-msgstr ""
-
 msgctxt "advanced-settings-view"
 msgid "Use custom DNS server"
 msgstr ""
@@ -342,20 +309,8 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr ""
 
-msgctxt "wireguard-settings-view"
-msgid "WireGuard key"
-msgstr ""
-
 msgctxt "advanced-settings-view"
-msgid "WireGuard MTU"
-msgstr ""
-
-msgctxt "advanced-settings-view"
-msgid "WireGuard port"
-msgstr ""
-
-msgctxt "advanced-settings-view-wireguard"
-msgid "missing key"
+msgid "WireGuard settings"
 msgstr ""
 
 msgctxt "auth-failure"
@@ -772,6 +727,43 @@ msgstr ""
 
 msgctxt "notifications"
 msgid "Your selected server and tunnel protocol don't match. Please adjust your settings."
+msgstr ""
+
+#. Title label in navigation bar
+msgctxt "openvpn-settings-nav"
+msgid "OpenVPN settings"
+msgstr ""
+
+#. The title for the port selector section.
+#. Available placeholders:
+#. %(portType)s - a selected protocol (either TCP or UDP)
+msgctxt "openvpn-settings-view"
+msgid "%(portType)s port"
+msgstr ""
+
+#. The title for the shadowsocks bridge selector section.
+msgctxt "openvpn-settings-view"
+msgid "Bridge mode"
+msgstr ""
+
+msgctxt "openvpn-settings-view"
+msgid "Mssfix"
+msgstr ""
+
+msgctxt "openvpn-settings-view"
+msgid "OpenVPN settings"
+msgstr ""
+
+#. The hint displayed below the Mssfix input field.
+#. Available placeholders:
+#. %(max)d - the maximum possible mssfix value
+#. %(min)d - the minimum possible mssfix value
+msgctxt "openvpn-settings-view"
+msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
+msgstr ""
+
+msgctxt "openvpn-settings-view"
+msgid "Transport protocol"
 msgstr ""
 
 #. Title label in navigation bar
@@ -1235,14 +1227,48 @@ msgctxt "wireguard-key-view"
 msgid "Verify key"
 msgstr ""
 
-#. Back button in navigation bar
-msgctxt "wireguard-keys-nav"
-msgid "Advanced"
-msgstr ""
-
 #. Title label in navigation bar
 msgctxt "wireguard-keys-nav"
 msgid "WireGuard key"
+msgstr ""
+
+#. Back button in navigation bar
+msgctxt "wireguard-keys-nav"
+msgid "WireGuard settings"
+msgstr ""
+
+#. Title label in navigation bar
+msgctxt "wireguard-settings-nav"
+msgid "WireGuard settings"
+msgstr ""
+
+msgctxt "wireguard-settings-view"
+msgid "MTU"
+msgstr ""
+
+msgctxt "wireguard-settings-view"
+msgid "Port"
+msgstr ""
+
+#. The hint displayed below the WireGuard MTU input field.
+#. Available placeholders:
+#. %(max)d - the maximum possible wireguard mtu value
+#. %(min)d - the minimum possible wireguard mtu value
+msgctxt "wireguard-settings-view"
+msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
+msgstr ""
+
+#. The hint displayed below the WireGuard port selector.
+msgctxt "wireguard-settings-view"
+msgid "The automatic setting will randomly choose from a wide range of ports."
+msgstr ""
+
+msgctxt "wireguard-settings-view"
+msgid "WireGuard key"
+msgstr ""
+
+msgctxt "wireguard-settings-view"
+msgid "WireGuard settings"
 msgstr ""
 
 msgid "Account authentication failed."
@@ -1369,6 +1395,9 @@ msgid "Virtual adapter error"
 msgstr ""
 
 msgid "While connected, your real location is masked with a private and secure location in the selected region."
+msgstr ""
+
+msgid "WireGuard MTU"
 msgstr ""
 
 msgid "WireGuard error"

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -227,16 +227,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr ""
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr ""
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr ""
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr ""
 
@@ -264,11 +262,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr ""
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr ""
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr ""
 
@@ -295,7 +291,7 @@ msgstr ""
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr ""
 
@@ -303,7 +299,7 @@ msgstr ""
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr ""
 
@@ -311,7 +307,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr ""
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr ""
 
@@ -320,7 +315,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr ""
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr ""
 
@@ -336,7 +331,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr ""
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr ""
 
@@ -348,7 +342,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr ""
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr ""
 

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -63,9 +63,6 @@ msgstr[1] ""
 msgid "Apply"
 msgstr ""
 
-msgid "Automatic"
-msgstr ""
-
 msgid "Back"
 msgstr ""
 
@@ -99,9 +96,6 @@ msgstr ""
 msgid "CREATING SECURE CONNECTION"
 msgstr ""
 
-msgid "Default"
-msgstr ""
-
 msgid "Disconnect"
 msgstr ""
 
@@ -132,12 +126,6 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-msgid "Off"
-msgstr ""
-
-msgid "On"
-msgstr ""
-
 msgid "Open URL"
 msgstr ""
 
@@ -151,12 +139,6 @@ msgid "Settings"
 msgstr ""
 
 msgid "System default"
-msgstr ""
-
-msgid "TCP"
-msgstr ""
-
-msgid "UDP"
 msgstr ""
 
 msgid "UNSECURE CONNECTION"
@@ -249,6 +231,15 @@ msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr ""
 
+#. The title for the shadowsocks bridge selector section.
+msgctxt "advanced-settings-view"
+msgid "Bridge mode"
+msgstr ""
+
+msgctxt "advanced-settings-view"
+msgid "Default"
+msgstr ""
+
 msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr ""
@@ -274,15 +265,46 @@ msgid "If you disconnect or quit the app, this setting will block your internet.
 msgstr ""
 
 msgctxt "advanced-settings-view"
-msgid "missing key"
+msgid "Off"
+msgstr ""
+
+msgctxt "advanced-settings-view"
+msgid "On"
 msgstr ""
 
 msgctxt "advanced-settings-view"
 msgid "OpenVPN"
 msgstr ""
 
+#. The title for the port selector section.
+#. Available placeholders:
+#. %(portType)s - a selected protocol (either TCP or UDP)
 msgctxt "advanced-settings-view"
-msgid "OpenVPN settings"
+msgid "OpenVPN %(portType)s port"
+msgstr ""
+
+msgctxt "advanced-settings-view"
+msgid "OpenVPN Mssfix"
+msgstr ""
+
+msgctxt "advanced-settings-view"
+msgid "OpenVPN transport protocol"
+msgstr ""
+
+#. The hint displayed below the Mssfix input field.
+#. Available placeholders:
+#. %(max)d - the maximum possible mssfix value
+#. %(min)d - the minimum possible mssfix value
+msgctxt "advanced-settings-view"
+msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
+msgstr ""
+
+#. The hint displayed below the WireGuard MTU input field.
+#. Available placeholders:
+#. %(max)d - the maximum possible wireguard mtu value
+#. %(min)d - the minimum possible wireguard mtu value
+msgctxt "advanced-settings-view"
+msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -290,7 +312,16 @@ msgid "Split tunneling"
 msgstr ""
 
 msgctxt "advanced-settings-view"
+msgid "TCP"
+msgstr ""
+
+msgctxt "advanced-settings-view"
 msgid "The app’s built-in kill switch is always on. This setting will additionally block the internet if clicking Disconnect or Quit."
+msgstr ""
+
+#. The hint displayed below the WireGuard port selector.
+msgctxt "advanced-settings-view"
+msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -306,6 +337,10 @@ msgid "Tunnel protocol"
 msgstr ""
 
 msgctxt "advanced-settings-view"
+msgid "UDP"
+msgstr ""
+
+msgctxt "advanced-settings-view"
 msgid "Use custom DNS server"
 msgstr ""
 
@@ -314,7 +349,19 @@ msgid "WireGuard"
 msgstr ""
 
 msgctxt "advanced-settings-view"
-msgid "WireGuard settings"
+msgid "WireGuard key"
+msgstr ""
+
+msgctxt "advanced-settings-view"
+msgid "WireGuard MTU"
+msgstr ""
+
+msgctxt "advanced-settings-view"
+msgid "WireGuard port"
+msgstr ""
+
+msgctxt "advanced-settings-view-wireguard"
+msgid "missing key"
 msgstr ""
 
 msgctxt "auth-failure"
@@ -731,43 +778,6 @@ msgstr ""
 
 msgctxt "notifications"
 msgid "Your selected server and tunnel protocol don't match. Please adjust your settings."
-msgstr ""
-
-#. Title label in navigation bar
-msgctxt "openvpn-settings-nav"
-msgid "OpenVPN settings"
-msgstr ""
-
-#. The title for the port selector section.
-#. Available placeholders:
-#. %(portType)s - a selected protocol (either TCP or UDP)
-msgctxt "openvpn-settings-view"
-msgid "%(portType)s port"
-msgstr ""
-
-#. The title for the shadowsocks bridge selector section.
-msgctxt "openvpn-settings-view"
-msgid "Bridge mode"
-msgstr ""
-
-msgctxt "openvpn-settings-view"
-msgid "Mssfix"
-msgstr ""
-
-msgctxt "openvpn-settings-view"
-msgid "OpenVPN settings"
-msgstr ""
-
-#. The hint displayed below the Mssfix input field.
-#. Available placeholders:
-#. %(max)d - the maximum possible mssfix value
-#. %(min)d - the minimum possible mssfix value
-msgctxt "openvpn-settings-view"
-msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
-msgstr ""
-
-msgctxt "openvpn-settings-view"
-msgid "Transport protocol"
 msgstr ""
 
 #. Title label in navigation bar
@@ -1231,48 +1241,14 @@ msgctxt "wireguard-key-view"
 msgid "Verify key"
 msgstr ""
 
-#. Title label in navigation bar
-msgctxt "wireguard-keys-nav"
-msgid "WireGuard key"
-msgstr ""
-
 #. Back button in navigation bar
 msgctxt "wireguard-keys-nav"
-msgid "WireGuard settings"
+msgid "Advanced"
 msgstr ""
 
 #. Title label in navigation bar
-msgctxt "wireguard-settings-nav"
-msgid "WireGuard settings"
-msgstr ""
-
-msgctxt "wireguard-settings-view"
-msgid "MTU"
-msgstr ""
-
-msgctxt "wireguard-settings-view"
-msgid "Port"
-msgstr ""
-
-#. The hint displayed below the WireGuard MTU input field.
-#. Available placeholders:
-#. %(max)d - the maximum possible wireguard mtu value
-#. %(min)d - the minimum possible wireguard mtu value
-msgctxt "wireguard-settings-view"
-msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
-msgstr ""
-
-#. The hint displayed below the WireGuard port selector.
-msgctxt "wireguard-settings-view"
-msgid "The automatic setting will randomly choose from a wide range of ports."
-msgstr ""
-
-msgctxt "wireguard-settings-view"
+msgctxt "wireguard-keys-nav"
 msgid "WireGuard key"
-msgstr ""
-
-msgctxt "wireguard-settings-view"
-msgid "WireGuard settings"
 msgstr ""
 
 msgid "Account authentication failed."
@@ -1399,9 +1375,6 @@ msgid "Virtual adapter error"
 msgstr ""
 
 msgid "While connected, your real location is masked with a private and secure location in the selected region."
-msgstr ""
-
-msgid "WireGuard MTU"
 msgstr ""
 
 msgid "WireGuard error"

--- a/gui/locales/my/messages.po
+++ b/gui/locales/my/messages.po
@@ -208,16 +208,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "သတိပြုရန်- ၎င်းကို ဖွင့်ခြင်းဖြင့် အင်တာနက် သုံးရန်အတွက် Mullvad VPN ချိတ်ဆက်မှုကို အမြဲ လိုအပ်ပါမည်။"
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "အော်တိုမက်တစ်"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "ပေါင်းကူး မုဒ်"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "မူလအတိုင်း"
 
@@ -245,11 +243,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "ဤအက်ပ်နှင့် ချိတ်ဆက်မှုပြတ်သွားပါက သို့မဟုတ် ထွက်လိုက်ပါက ဤဆက်တင်သည် သင့်အင်တာနက်ကို ပိတ်ဆို့သွားပါလိမ့်မည်။"
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "ပိတ်"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "ဖွင့်"
 
@@ -276,7 +272,7 @@ msgstr "OpenVPN ပို့ဆောင်ရေး ပရိုတိုကေ
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "OpenVPN MSS တန်ဖိုးကို သတ်မှတ်ပါ။ အကျုံးဝင်သည့် အပိုင်းအခြား- %(min)d - %(max)d"
 
@@ -284,7 +280,7 @@ msgstr "OpenVPN MSS တန်ဖိုးကို သတ်မှတ်ပါ�
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "WireGuard MTU တန်ဖိုးကို သတ်မှတ်ပါ။ အကျုံးဝင်သည့် အပိုင်းအခြား- %(min)d - %(max)d"
 
@@ -292,7 +288,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Split Tunneling"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -301,7 +296,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "ဤအက်ပ်၏ မူလပါရှိသော Kill Switch ကို အမြဲဖွင့်ထားပါ။ ထို့အပြင် ချိတ်ဆက်မှုဖြုတ်ရန် သို့မဟုတ် ထွက်ရန်ကို နှိပ်ခြင်းဖြင့် ဤဆက်တင်သည် အင်တာနက်ကို ပိတ်ဆို့သွားပါလိမ့်မည်။"
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "အော်တိုဆက်တင်သည် ပို့တ်များစွာမှ ကျပန်းရွေးသွားပါလိမ့်မည်။"
 
@@ -317,7 +312,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tunnel ပရိုတိုကောလ်"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -329,7 +323,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard ကီး"
 

--- a/gui/locales/nb/messages.po
+++ b/gui/locales/nb/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Advarsel: Hvis du aktiverer dette, må du alltid ha en Mullvad VPN-tilkobling for å være tilkoblet internett."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatisk"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Bromodus"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Standard"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Hvis du kobler fra eller lukker appen, vil denne innstillingen blokkere tilgangen til internettet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Av"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "På"
 
@@ -287,7 +283,7 @@ msgstr "Transportprotokoll for OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Angi OpenVPN MSS-verdi. Verdiområde: %(min)d-%(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Angi OpenVPN MSS-verdi. Verdiområde: %(min)d-%(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Angi WireGuard MTU-verdi. Verdiområde: %(min)d-%(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Delt tunnel"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Appens innebygde «Kill Switch» er alltid på. Innstillingen bil også blokkere tilgangen til internettet hvis du trykker på Koble fra eller Lukk."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Den automatiske innstillingen vil tilfeldig velge fra en rekke porter."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tunnelprotokoll"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard-nøkkel"
 

--- a/gui/locales/nl/messages.po
+++ b/gui/locales/nl/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Opgelet: dit inschakelen vereist altijd een Mullvad VPN-verbinding om het internet te bereiken."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatisch"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Bridge-modus"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Standaard"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Als u de verbinding verbreekt of de app verlaat, blokkeert deze instelling uw internet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Uit"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Aan"
 
@@ -287,7 +283,7 @@ msgstr "OpenVPN transportprotocol"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Stel OpenVPN MMS-waarde in. Geldig bereik: %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Stel OpenVPN MMS-waarde in. Geldig bereik: %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Stel de WireGuard MTU-waarde in. Geldig bereik: %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Split tunneling"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "De ingebouwde killswitch van de app staat altijd aan. Deze instelling blokkeert het internet bovendien als men op Verbinding verbreken of Afsluiten klikt."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "De automatische instelling kiest willekeurig uit een ruim aantal poorten."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tunnelprotocol"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard-sleutel"
 

--- a/gui/locales/pl/messages.po
+++ b/gui/locales/pl/messages.po
@@ -241,16 +241,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Uwaga: wskutek włączenia tej opcji w celu uzyskania dostępu do Internetu zawsze wymagane będzie połączenie przez Mullvad VPN."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatycznie"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Tryb mostu"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Domyślnie"
 
@@ -278,11 +276,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Jeśli rozłączysz się lub zamkniesz aplikację, to ustawienie będzie blokować dostęp do Internetu."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Wył."
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Wł."
 
@@ -309,7 +305,7 @@ msgstr "Protokół transportowy OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Ustaw wartość MSS OpenVPN. Prawidłowy zakres: %(min)d - %(max)d."
 
@@ -317,7 +313,7 @@ msgstr "Ustaw wartość MSS OpenVPN. Prawidłowy zakres: %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Ustaw wartość MTU WireGuard. Prawidłowy zakres: %(min)d - %(max)d."
 
@@ -325,7 +321,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Dzielone tunelowanie"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -334,7 +329,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Wbudowany kill switch aplikacji jest zawsze włączony. To ustawienie dodatkowo blokuje dostęp do Internetu w razie kliknięcia przycisku Rozłącz lub Zamknij."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Ustawienie automatyczne skutkuje wyborem losowym z szerokiego zakresu portów."
 
@@ -350,7 +345,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Protokół tunelowania"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -362,7 +356,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "Klucz WireGuard"
 

--- a/gui/locales/pt/messages.po
+++ b/gui/locales/pt/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Atenção: ativar esta opção exige sempre uma ligação através de Mullvad VPN para aceder à Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automático"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Modo de ponte"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Padrão"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Se o utilizador se desligar ou sair da aplicação, esta configuração bloqueará a sua Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Desligado"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Ligado"
 
@@ -287,7 +283,7 @@ msgstr "Protocolo de transporte OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Definir o valor OpenVPN MSS. Intervalo válido: %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Definir o valor OpenVPN MSS. Intervalo válido: %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Definir o valor WireGuard MTU. Intervalo válido: %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Divisão do túnel"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "O kill switch integrado da aplicação está sempre ligado. Esta configuração bloqueará adicionalmente a Internet caso o utilizador se desligue ou saia da aplicação."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "As definições automáticas escolhem aleatoriamente a partir de uma vasta gama de portas."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Protocolo do túnel"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "Chave WireGuard"
 

--- a/gui/locales/ru/messages.po
+++ b/gui/locales/ru/messages.po
@@ -241,16 +241,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Внимание: при активации этого параметра для выхода в Интернет необходимо будет обязательно подключиться через Mullvad VPN."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Автоматически"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Режим моста"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "По умолчанию"
 
@@ -278,11 +276,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Если разорвать соединение или закрыть приложение, то выход в Интернет будет заблокирован."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Выключен"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Включен"
 
@@ -309,7 +305,7 @@ msgstr "Транспортный протокол OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Установить значение MSS для OpenVPN. Диапазон значений: %(min)d — %(max)d."
 
@@ -317,7 +313,7 @@ msgstr "Установить значение MSS для OpenVPN. Диапазо
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Установить значение MTU для WireGuard. Диапазон значений: %(min)d–%(max)d."
 
@@ -325,7 +321,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Раздельное туннелирование"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -334,7 +329,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Функция аварийного отключения, встроенная в приложение, всегда включена. Этот параметр дополнительно блокирует Интернет при нажатии \"Отключить\" или \"Выход\"."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "При автоматической настройке порт будет выбираться случайным образом из доступного диапазона портов."
 
@@ -350,7 +345,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Протокол туннелирования"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -362,7 +356,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "Ключ WireGuard"
 

--- a/gui/locales/sv/messages.po
+++ b/gui/locales/sv/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Obs! Om du aktiverar detta kommer det alltid att krävas en Mullvad VPN-anslutning för att nå internet."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Automatisk"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Broläge"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Standard"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Om du kopplar från eller avslutar appen kommer den här inställningen att blockera ditt internet."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Av"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "På"
 
@@ -287,7 +283,7 @@ msgstr "OpenVPN-överföringsprotokoll"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "Ange värde för OpenVPN MSS. Giltigt intervall: %(min)d-%(max)d."
 
@@ -295,7 +291,7 @@ msgstr "Ange värde för OpenVPN MSS. Giltigt intervall: %(min)d-%(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "Ange WireGuard MTU-värde. Giltigt intervall: %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Delade tunnlar"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Appens inbyggda Kill Switch är alltid på. Den här inställningen kommer dessutom blockera internet när du klickar på Koppla från eller Avsluta."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Den automatiska inställningen väljer automatiskt från en mängd olika portar."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tunnelprotokoll"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard-nyckel"
 

--- a/gui/locales/th/messages.po
+++ b/gui/locales/th/messages.po
@@ -208,16 +208,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "โปรดทราบ: การเปิดใช้งานสิ่งนี้จะทำให้คุณจำเป็นต้องเชื่อมต่อ Mullvad VPN ไว้ตลอดเวลา เพื่อที่จะเข้าถึงอินเทอร์เน็ต"
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "อัตโนมัติ"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "โหมดบริดจ์"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "ค่าเริ่มต้น"
 
@@ -245,11 +243,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "หากคุณตัดการเชื่อมต่อหรือออกจากแอป การตั้งค่านี้จะบล็อกการเข้าถึงอินเทอร์เน็ตของคุณ"
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "ปิด"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "เปิด"
 
@@ -276,7 +272,7 @@ msgstr "โพรโทคอลการส่งผ่าน OpenVPN"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "ตั้งค่า OpenVPN MSS ช่วงที่ใช้ได้: %(min)d - %(max)d"
 
@@ -284,7 +280,7 @@ msgstr "ตั้งค่า OpenVPN MSS ช่วงที่ใช้ได�
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "ตั้งค่า WireGuard MTU ช่วงที่ใช้ได้: %(min)d - %(max)d"
 
@@ -292,7 +288,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "แยกช่องทาง"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -301,7 +296,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "คิลสวิตช์ภายในแอปจะเปิดใช้งานอยู่เสมอ การตั้งค่านี้จะบล็อกการเข้าถึงอินเทอร์เน็ต หากคุณคลิกไปที่ตัดการเชื่อมต่อ หรือออก"
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "การตั้งค่าอัตโนมัติจะเป็นการสุ่มเลือกจากพอร์ตต่างๆ"
 
@@ -317,7 +312,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "โพรโทคอลช่องทางการเชื่อมต่อ"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -329,7 +323,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "คีย์ WireGuard"
 

--- a/gui/locales/tr/messages.po
+++ b/gui/locales/tr/messages.po
@@ -219,16 +219,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Dikkat: bu seçeneğin etkinleştirilmesi, internete erişim için her zaman bir Mullvad VPN bağlantısı gerektirir."
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "Otomatik"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "Köprü modu"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "Varsayılan"
 
@@ -256,11 +254,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "Uygulamanın bağlantısını keserseniz veya uygulamadan çıkarsanız, bu ayar İnternet'e bağlanmanızı engeller."
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "Kapalı"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "Açık"
 
@@ -287,7 +283,7 @@ msgstr "OpenVPN taşıma protokolü"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "OpenVPN MSS değerini belirleyin. Geçerli aralık: %(min)d - %(max)d."
 
@@ -295,7 +291,7 @@ msgstr "OpenVPN MSS değerini belirleyin. Geçerli aralık: %(min)d - %(max)d."
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "WireGuard MTU değerini ayarlayın. Geçerli aralık: %(min)d - %(max)d."
 
@@ -303,7 +299,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "Bölünmüş tünelleme"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -312,7 +307,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "Uygulamanın dahili Kill Switch seçeneği her zaman açıktır. Bu ayar, Bağlantıyı Kes veya Çık seçeneklerini tıklamanız durumunda ayrıca İnternet'i de engeller."
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "Otomatik ayar, çeşitli bağlantı noktaları arasından rastgele seçim yapacaktır."
 
@@ -328,7 +323,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "Tünel protokolü"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -340,7 +334,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard anahtarı"
 

--- a/gui/locales/zh-CN/messages.po
+++ b/gui/locales/zh-CN/messages.po
@@ -208,16 +208,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "注意：启用此选项后，将始终需要 Mullvad VPN 才能连接到网络。"
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "自动"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "桥接模式"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "默认"
 
@@ -245,11 +243,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "如果断开连接或退出应用，此设置将阻止您的网络连接。"
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "关"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "开"
 
@@ -276,7 +272,7 @@ msgstr "OpenVPN 传输协议"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "设置 OpenVPN MSS 值。值范围：%(min)d - %(max)d。"
 
@@ -284,7 +280,7 @@ msgstr "设置 OpenVPN MSS 值。值范围：%(min)d - %(max)d。"
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "设置 WireGuard MTU 值。有效范围：%(min)d - %(max)d。"
 
@@ -292,7 +288,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "拆分隧道"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -301,7 +296,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "应用的内置切断开关始终处于开启状态。如果点击“断开连接”或“退出”，此设置还将阻止您的网络连接。"
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "自动设置将从一系列端口中随机选择。"
 
@@ -317,7 +312,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "隧道协议"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -329,7 +323,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard 密钥"
 

--- a/gui/locales/zh-TW/messages.po
+++ b/gui/locales/zh-TW/messages.po
@@ -208,16 +208,14 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "注意：啟用此功能，皆需 Mullvad VPN 連線才能上網。"
 
-msgctxt "advanced-settings-view"
 msgid "Automatic"
 msgstr "自動"
 
 #. The title for the shadowsocks bridge selector section.
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr "橋接模式"
 
-msgctxt "advanced-settings-view"
 msgid "Default"
 msgstr "預設"
 
@@ -245,11 +243,9 @@ msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
 msgstr "如果您中斷連線或退出應用程式，此設定將會封鎖您的網路。"
 
-msgctxt "advanced-settings-view"
 msgid "Off"
 msgstr "關閉"
 
-msgctxt "advanced-settings-view"
 msgid "On"
 msgstr "開啟"
 
@@ -276,7 +272,7 @@ msgstr "OpenVPN 傳輸通訊協定"
 #. Available placeholders:
 #. %(max)d - the maximum possible mssfix value
 #. %(min)d - the minimum possible mssfix value
-msgctxt "advanced-settings-view"
+msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr "設定 OpenVPN MSS 值。有效範圍：%(min)d - %(max)d。"
 
@@ -284,7 +280,7 @@ msgstr "設定 OpenVPN MSS 值。有效範圍：%(min)d - %(max)d。"
 #. Available placeholders:
 #. %(max)d - the maximum possible wireguard mtu value
 #. %(min)d - the minimum possible wireguard mtu value
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "Set WireGuard MTU value. Valid range: %(min)d - %(max)d."
 msgstr "設定 WireGuard MTU 值。有效範圍：%(min)d - %(max)d。"
 
@@ -292,7 +288,6 @@ msgctxt "advanced-settings-view"
 msgid "Split tunneling"
 msgstr "分割通道"
 
-msgctxt "advanced-settings-view"
 msgid "TCP"
 msgstr "TCP"
 
@@ -301,7 +296,7 @@ msgid "The app’s built-in kill switch is always on. This setting will addition
 msgstr "應用程式內建緊停開關 (Kill Switch) 始終處於開啟狀態。如果按一下「中斷連線」或「退出」，此設定還將封鎖您的網路。"
 
 #. The hint displayed below the WireGuard port selector.
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
 msgstr "自動設定會隨機從各種連線埠中進行選擇。"
 
@@ -317,7 +312,6 @@ msgctxt "advanced-settings-view"
 msgid "Tunnel protocol"
 msgstr "通道通訊協定"
 
-msgctxt "advanced-settings-view"
 msgid "UDP"
 msgstr "UDP"
 
@@ -329,7 +323,7 @@ msgctxt "advanced-settings-view"
 msgid "WireGuard"
 msgstr "WireGuard"
 
-msgctxt "advanced-settings-view"
+msgctxt "wireguard-settings-view"
 msgid "WireGuard key"
 msgstr "WireGuard 金鑰"
 

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -206,7 +206,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
   ): Array<ISelectorItem<OptionalTunnelProtocol>> => {
     return [
       {
-        label: messages.pgettext('advanced-settings-view', 'Automatic'),
+        label: messages.gettext('Automatic'),
         value: undefined,
       },
       {


### PR DESCRIPTION
This PR reverts the changes to `messages.pot` made in https://github.com/mullvad/mullvadvpn-app/pull/2909 and moves the existing translations instead.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2944)
<!-- Reviewable:end -->
