### PR TITLE
Always send DNS requests inside the tunnel for public IPs on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Line wrap the file at 100 chars.                                              Th
 - Move OpenVPN and WireGuard settings in the advanced settings view into separate settings views.
 - Return to main view in desktop app after being hidden/closed for two minutes.
 
+#### Linux
+- Always send DNS requests inside the tunnel for excluded processes when using public custom DNS.
+
 #### Windows
 - Upgrade Wintun from 0.10.4 to 0.13.
 
@@ -64,6 +67,7 @@ Line wrap the file at 100 chars.                                              Th
 - Make offline monitor aware of routing table changes.
 - Assign local DNS servers to more appropriate interfaces when using systemd-resolved.
 - Disable DNS over TLS for tunnel's DNS config when using systemd-resolved.
+- Fix DNS when combining static resolv.conf with ad blocking DNS.
 
 #### Windows
 - Fix failure to restart the daemon when resuming from "fast startup" hibernation.

--- a/docs/split-tunneling.md
+++ b/docs/split-tunneling.md
@@ -43,7 +43,7 @@ Some definitions of terms used later to describe behavior:
 *: On platforms where we have custom firewall integration. This is currently on desktop operating
   systems, and not mobile.
 
-### Windows
+### Windows and Linux
 
 | In-app DNS setting | Normal & Excluded app |
 |-|-|
@@ -51,24 +51,13 @@ Some definitions of terms used later to describe behavior:
 | **Private custom DNS** (e.g. 10.0.1.1) | LAN (to 10.0.1.1) |
 | **Public custom DNS** (e.g. 8.8.8.8) | In tunnel (to 8.8.8.8) |
 
-In other words: Normal and excluded processes always behave the same. This is due to the
-Windows DNS cache service is the single origin for all DNS requests.
+In other words: Normal and excluded processes always behave the same. This is because DNS is
+typically handled by a service, e.g. DNS cache on Windows or systemd-resolved's resolver on Linux,
+which is not an excluded process.
 
-### Linux
-
-| In-app DNS setting | Normal app | Excluded app |
-|-|-|-|
-| **Default DNS** | In tunnel (to relay) | In tunnel (to relay) |
-| **Private custom DNS** (e.g. 10.0.1.1) | LAN (to 10.0.1.1) | LAN (to 10.0.1.1) |
-| **Public custom DNS** (e.g. 8.8.8.8) | In tunnel (to 8.8.8.8) | Outside tunnel* (to 8.8.8.8) |
-
-*: Only if a local DNS resolver, such as systemd-resolved is **not in use**. Because if a
-local DNS resolver is in use the requests will go there and that resolver in turn will then
-send requests in the tunnel.
-
-In other words: Normal and excluded processes behave the same in all cases except when Custom DNS
-is enabled, pointed to a publicly available IP and the system is not set up to use a localhost DNS
-resolver.
+For the sake of simplicity and consistency, public custom DNS is also sent *in tunnel* when using a
+plain old static `resolv.conf`, even though it is technically possible to exclude public custom DNS
+in that case.
 
 ### Android
 

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -8,8 +8,12 @@ use self::{
     network_manager::NetworkManager, resolvconf::Resolvconf, static_resolv_conf::StaticResolvConf,
     systemd_resolved::SystemdResolved,
 };
-use crate::routing::RouteManagerHandle;
-use std::{env, fmt, net::IpAddr, path::Path};
+use crate::{
+    firewall::is_local_address,
+    routing::{Node, RequiredRoute, RouteManagerHandle},
+};
+use ipnetwork::IpNetwork;
+use std::{collections::HashSet, env, fmt, net::IpAddr, path::Path};
 
 
 const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
@@ -38,12 +42,21 @@ pub enum Error {
     /// No suitable DNS monitor implementation detected
     #[error(display = "No suitable DNS monitor implementation detected")]
     NoDnsMonitor,
+
+    /// Invalid DNS servers?
+    #[error(display = "Failed to construct routes for DNS servers")]
+    IpNetworkError(#[error(source)] ipnetwork::IpNetworkError),
+
+    /// Failed to add or remove routes for DNS servers
+    #[error(display = "Failed to update DNS server routes")]
+    RoutingError(crate::routing::Error),
 }
 
 pub struct DnsMonitor {
     route_manager: RouteManagerHandle,
     handle: tokio::runtime::Handle,
     inner: Option<DnsMonitorHolder>,
+    dns_routes: Option<HashSet<RequiredRoute>>,
 }
 
 impl super::DnsMonitorT for DnsMonitor {
@@ -58,11 +71,19 @@ impl super::DnsMonitorT for DnsMonitor {
             route_manager,
             handle,
             inner: None,
+            dns_routes: None,
         })
     }
 
     fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<()> {
         self.reset()?;
+
+        let routes = get_dns_routes(interface, servers)?;
+        self.handle
+            .block_on(self.route_manager.add_routes(routes.clone()))
+            .map_err(Error::RoutingError)?;
+        self.dns_routes = Some(routes);
+
         // Creating a new DNS monitor for each set, in case the system changed how it manages DNS.
         let mut inner = DnsMonitorHolder::new()?;
         inner.set(&self.handle, &self.route_manager, interface, servers)?;
@@ -71,6 +92,12 @@ impl super::DnsMonitorT for DnsMonitor {
     }
 
     fn reset(&mut self) -> Result<()> {
+        if let Some(routes) = self.dns_routes.take() {
+            self.handle
+                .block_on(self.route_manager.remove_routes(routes.clone()))
+                .map_err(Error::RoutingError)?;
+        }
+
         if let Some(mut inner) = self.inner.take() {
             inner.reset(&self.handle)?;
         }
@@ -172,4 +199,26 @@ impl DnsMonitorHolder {
 pub fn will_use_nm() -> bool {
     crate::dns::imp::SystemdResolved::new().is_err()
         && crate::dns::imp::NetworkManager::new().is_ok()
+}
+
+fn get_dns_routes(interface: &str, dns_ips: &[IpAddr]) -> Result<HashSet<RequiredRoute>> {
+    let mut routes = HashSet::new();
+    for destination in dns_ips {
+        if !is_local_address(destination) {
+            let prefix = match destination {
+                IpAddr::V4(_) => 32,
+                IpAddr::V6(_) => 128,
+            };
+            routes.insert(
+                crate::routing::RequiredRoute::new(
+                    IpNetwork::new(*destination, prefix)?,
+                    Node::device(interface.to_string()),
+                )
+                .table(u32::from(
+                    netlink_packet_route::rtnl::constants::RT_TABLE_MAIN,
+                )),
+            );
+        }
+    }
+    Ok(routes)
 }

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -345,33 +345,23 @@ impl<'a> PolicyBatch<'a> {
             self.batch.add(&rule, nftnl::MsgType::Add);
         }
 
-        // Allow some DNS requests to pass through the tunnel
+        // Allow select DNS requests to pass through the tunnel
         if let FirewallPolicy::Connected {
             tunnel,
             dns_servers,
             ..
         } = policy
         {
-            let gateway = IpAddr::V4(tunnel.ipv4_gateway);
-            if dns_servers.contains(&gateway) {
-                self.add_nat_tunnel_dns_rule(&tunnel.interface, TransportProtocol::Udp, gateway)?;
-                self.add_nat_tunnel_dns_rule(&tunnel.interface, TransportProtocol::Tcp, gateway)?;
-            }
-
-            if let Some(ref gateway) = tunnel.ipv6_gateway {
-                let gateway = IpAddr::V6(*gateway);
-                if dns_servers.contains(&gateway) {
-                    self.add_nat_tunnel_dns_rule(
-                        &tunnel.interface,
-                        TransportProtocol::Udp,
-                        gateway,
-                    )?;
-                    self.add_nat_tunnel_dns_rule(
-                        &tunnel.interface,
-                        TransportProtocol::Tcp,
-                        gateway,
-                    )?;
-                }
+            for server in dns_servers.iter().filter(|server| {
+                !super::is_local_address(server)
+                    || *server == &tunnel.ipv4_gateway
+                    || tunnel
+                        .ipv6_gateway
+                        .map(|ref gateway| *server == gateway)
+                        .unwrap_or(false)
+            }) {
+                self.add_nat_tunnel_dns_rule(&tunnel.interface, TransportProtocol::Udp, *server)?;
+                self.add_nat_tunnel_dns_rule(&tunnel.interface, TransportProtocol::Tcp, *server)?;
             }
         }
 

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -288,6 +288,20 @@ impl RouteManagerImpl {
         Ok(())
     }
 
+    async fn remove_required_routes(
+        &mut self,
+        required_routes: HashSet<RequiredRoute>,
+    ) -> Result<()> {
+        let routes = required_routes.into_iter().map(|route| match route.node {
+            NetNode::RealNode(node) => Route::new(node, route.prefix).table(route.table_id),
+        });
+        for route in routes {
+            self.delete_route_if_exists(&route).await?;
+            self.added_routes.remove(&route);
+        }
+        Ok(())
+    }
+
     async fn initialize_link_map(
         handle: &rtnetlink::Handle,
     ) -> Result<BTreeMap<u32, NetworkInterface>> {
@@ -354,7 +368,11 @@ impl RouteManagerImpl {
             }
             RouteManagerCommand::AddRoutes(routes, result_tx) => {
                 log::debug!("Adding routes: {:?}", routes);
-                let _ = result_tx.send(self.add_required_routes(routes.clone()).await);
+                let _ = result_tx.send(self.add_required_routes(routes).await);
+            }
+            RouteManagerCommand::DelRoutes(routes, result_tx) => {
+                log::debug!("Removing routes: {:?}", routes);
+                let _ = result_tx.send(self.remove_required_routes(routes).await);
             }
             RouteManagerCommand::CreateRoutingRules(enable_ipv6, result_tx) => {
                 let _ = result_tx.send(self.create_routing_rules(enable_ipv6).await);

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -70,6 +70,19 @@ impl RouteManagerHandle {
             .map_err(Error::PlatformError)
     }
 
+    /// Removes previously applied routes.
+    #[cfg(target_os = "linux")]
+    pub async fn remove_routes(&self, routes: HashSet<RequiredRoute>) -> Result<(), Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .unbounded_send(RouteManagerCommand::DelRoutes(routes, response_tx))
+            .map_err(|_| Error::RouteManagerDown)?;
+        response_rx
+            .await
+            .map_err(|_| Error::ManagerChannelDown)?
+            .map_err(Error::PlatformError)
+    }
+
     /// Ensure that packets are routed using the correct tables.
     #[cfg(target_os = "linux")]
     pub async fn create_routing_rules(&self, enable_ipv6: bool) -> Result<(), Error> {
@@ -135,6 +148,11 @@ impl RouteManagerHandle {
 #[derive(Debug)]
 pub(crate) enum RouteManagerCommand {
     AddRoutes(
+        HashSet<RequiredRoute>,
+        oneshot::Sender<Result<(), PlatformError>>,
+    ),
+    #[cfg(target_os = "linux")]
+    DelRoutes(
         HashSet<RequiredRoute>,
         oneshot::Sender<Result<(), PlatformError>>,
     ),
@@ -212,6 +230,27 @@ impl RouteManager {
             let (result_tx, result_rx) = oneshot::channel();
             if tx
                 .unbounded_send(RouteManagerCommand::AddRoutes(routes, result_tx))
+                .is_err()
+            {
+                return Err(Error::RouteManagerDown);
+            }
+
+            result_rx
+                .await
+                .map_err(|_| Error::ManagerChannelDown)?
+                .map_err(Error::PlatformError)
+        } else {
+            Err(Error::RouteManagerDown)
+        }
+    }
+
+    /// Removes the given routes.
+    #[cfg(target_os = "linux")]
+    pub async fn remove_routes(&mut self, routes: HashSet<RequiredRoute>) -> Result<(), Error> {
+        if let Some(tx) = &self.manage_tx {
+            let (result_tx, result_rx) = oneshot::channel();
+            if tx
+                .unbounded_send(RouteManagerCommand::DelRoutes(routes, result_tx))
                 .is_err()
             {
                 return Err(Error::RouteManagerDown);


### PR DESCRIPTION
Previously, whenever DNS was not managed by some system service (e.g., a simple static `resolv.conf`), excluded processes always tried to reach resolvers on public IPs _outside_ the tunnel. Ad blocking DNS servers are in the "public" range (according to the definition used by the app), so ad blocking made DNS unusable for excluded processes.

This PR ensures that public DNS requests are sent _inside_ the tunnel. This solves the problem above and overall reduces the complexity of how DNS is handled for excluded apps.