### PR TITLE
Add WireGuard IP version setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add WireGuard over TCP CLI option for all relays.
 - Add GUI environment variable `MULLVAD_DISABLE_UPDATE_NOTIFICATION`. If set to `1`, GUI
   notification will be disabled when an update is available.
+- Add setting for changing between IPv4 and IPv6 for the connection to WireGuard servers on desktop.
 
 #### Android
 - Added toggle for Split tunneling view to be able to show system apps

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -120,6 +120,12 @@ msgstr ""
 msgid "Invalid account number"
 msgstr ""
 
+msgid "IPv4"
+msgstr ""
+
+msgid "IPv6"
+msgstr ""
+
 msgid "less than a day"
 msgstr ""
 
@@ -1243,6 +1249,10 @@ msgid "WireGuard settings"
 msgstr ""
 
 msgctxt "wireguard-settings-view"
+msgid "IP version"
+msgstr ""
+
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr ""
 
@@ -1261,6 +1271,11 @@ msgstr ""
 #. The hint displayed below the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
+msgstr ""
+
+#. The hint displayed below the WireGuard IP version selector.
+msgctxt "wireguard-settings-view"
+msgid "This allows access to WireGuard for devices that only support IPv6."
 msgstr ""
 
 msgctxt "wireguard-settings-view"

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -152,6 +152,7 @@ class ApplicationMain {
         },
         wireguardConstraints: {
           port: 'any',
+          ipVersion: 'any',
         },
       },
     },

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -644,7 +644,10 @@ export default class AppRenderer {
             port: liftConstraint(openvpnConstraints.port),
             protocol: liftConstraint(openvpnConstraints.protocol),
           },
-          wireguard: { port: liftConstraint(wireguardConstraints.port) },
+          wireguard: {
+            port: liftConstraint(wireguardConstraints.port),
+            ipVersion: liftConstraint(wireguardConstraints.ipVersion),
+          },
           tunnelProtocol: liftConstraint(tunnelProtocol),
         },
       });

--- a/gui/src/renderer/containers/WireguardSettingsPage.tsx
+++ b/gui/src/renderer/containers/WireguardSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { IpVersion } from '../../shared/daemon-rpc-types';
 import log from '../../shared/logging';
 import RelaySettingsBuilder from '../../shared/relay-settings-builder';
 import WireguardSettings from '../components/WireguardSettings';
@@ -21,7 +22,13 @@ const mapStateToProps = (state: IReduxState) => {
 const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) => {
   if ('normal' in relaySettings) {
     const port = relaySettings.normal.wireguard.port;
-    return { wireguard: { port: port === 'any' ? undefined : port } };
+    const ipVersion = relaySettings.normal.wireguard.ipVersion;
+    return {
+      wireguard: {
+        port: port === 'any' ? undefined : port,
+        ipVersion: ipVersion === 'any' ? undefined : ipVersion,
+      },
+    };
     // since the GUI doesn't display custom settings, just display the default ones.
     // If the user sets any settings, then those will be applied.
   } else if ('customTunnelEndpoint' in relaySettings) {
@@ -39,13 +46,19 @@ const mapDispatchToProps = (_dispatch: ReduxDispatch, props: IHistoryProps & IAp
       props.history.pop();
     },
 
-    setWireguardRelayPort: async (port?: number) => {
+    setWireguardRelayPortAndIpVersion: async (port?: number, ipVersion?: IpVersion) => {
       const relayUpdate = RelaySettingsBuilder.normal()
         .tunnel.wireguard((wireguard) => {
           if (port) {
             wireguard.port.exact(port);
           } else {
             wireguard.port.any();
+          }
+
+          if (ipVersion) {
+            wireguard.ipVersion.exact(ipVersion);
+          } else {
+            wireguard.ipVersion.any();
           }
         })
         .build();

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -8,6 +8,7 @@ import {
   RelayProtocol,
   TunnelProtocol,
   IDnsOptions,
+  IpVersion,
 } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
 import log from '../../../shared/logging';
@@ -25,6 +26,7 @@ export type RelaySettingsRedux =
         };
         wireguard: {
           port: LiftedConstraint<number>;
+          ipVersion: LiftedConstraint<IpVersion>;
         };
       };
     }
@@ -159,7 +161,7 @@ const initialState: ISettingsReduxState = {
       location: 'any',
       tunnelProtocol: 'any',
       providers: [],
-      wireguard: { port: 'any' },
+      wireguard: { port: 'any', ipVersion: 'any' },
       openvpn: {
         port: 'any',
         protocol: 'any',

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -130,9 +130,12 @@ export interface IOpenVpnConstraints {
 
 export interface IWireguardConstraints {
   port: Constraint<number>;
+  ipVersion: Constraint<IpVersion>;
 }
 
 export type TunnelProtocol = 'wireguard' | 'openvpn';
+
+export type IpVersion = 'ipv4' | 'ipv6';
 
 interface IRelaySettingsNormal<OpenVpn, Wireguard> {
   location: Constraint<RelayLocation>;

--- a/gui/src/shared/relay-settings-builder.ts
+++ b/gui/src/shared/relay-settings-builder.ts
@@ -1,6 +1,7 @@
 import {
   Constraint,
   IOpenVpnConstraints,
+  IpVersion,
   IWireguardConstraints,
   RelayProtocol,
   RelaySettingsNormalUpdate,
@@ -21,6 +22,7 @@ interface IOpenVPNConfigurator {
 
 interface IWireguardConfigurator {
   port: IExactOrAny<number, IWireguardConfigurator>;
+  ipVersion: IExactOrAny<IpVersion, IWireguardConfigurator>;
 }
 
 interface ITunnelProtocolConfigurator {
@@ -122,6 +124,16 @@ class NormalRelaySettingsBuilder {
             };
             return {
               exact: (value: number) => apply({ only: value }),
+              any: () => apply('any'),
+            };
+          },
+          get ipVersion() {
+            const apply = (ipVersion: Constraint<IpVersion>) => {
+              updateWireguard({ ipVersion });
+              return this;
+            };
+            return {
+              exact: (value: IpVersion) => apply({ only: value }),
               any: () => apply('any'),
             };
           },


### PR DESCRIPTION
This PR adds the WireGuard IP version setting to the frontend.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2946)
<!-- Reviewable:end -->
