### PR TITLE
Improve management interface error handling

### DIFF
--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -168,12 +168,7 @@ impl ManagementService for ManagementServiceImpl {
     ) -> ServiceResult<()> {
         log::debug!("update_relay_settings");
         let (tx, rx) = oneshot::channel();
-        let constraints_update =
-            RelaySettingsUpdate::try_from(request.into_inner()).map_err(|error| match error {
-                types::FromProtobufTypeError::InvalidArgument(error) => {
-                    Status::invalid_argument(error)
-                }
-            })?;
+        let constraints_update = RelaySettingsUpdate::try_from(request.into_inner())?;
 
         let message = DaemonCommand::UpdateRelaySettings(tx, constraints_update);
         self.send_command_to_daemon(message)?;
@@ -228,12 +223,7 @@ impl ManagementService for ManagementServiceImpl {
         &self,
         request: Request<types::BridgeSettings>,
     ) -> ServiceResult<()> {
-        let settings =
-            BridgeSettings::try_from(request.into_inner()).map_err(|error| match error {
-                types::FromProtobufTypeError::InvalidArgument(error) => {
-                    Status::invalid_argument(error)
-                }
-            })?;
+        let settings = BridgeSettings::try_from(request.into_inner())?;
 
         log::debug!("set_bridge_settings({:?})", settings);
 
@@ -246,12 +236,7 @@ impl ManagementService for ManagementServiceImpl {
     }
 
     async fn set_bridge_state(&self, request: Request<types::BridgeState>) -> ServiceResult<()> {
-        let bridge_state =
-            BridgeState::try_from(request.into_inner()).map_err(|error| match error {
-                types::FromProtobufTypeError::InvalidArgument(error) => {
-                    Status::invalid_argument(error)
-                }
-            })?;
+        let bridge_state = BridgeState::try_from(request.into_inner())?;
 
         log::debug!("set_bridge_state({:?})", bridge_state);
         let (tx, rx) = oneshot::channel();
@@ -362,9 +347,7 @@ impl ManagementService for ManagementServiceImpl {
 
     #[cfg(not(target_os = "android"))]
     async fn set_dns_options(&self, request: Request<types::DnsOptions>) -> ServiceResult<()> {
-        let options = DnsOptions::try_from(request.into_inner()).map_err(|error| match error {
-            types::FromProtobufTypeError::InvalidArgument(error) => Status::invalid_argument(error),
-        })?;
+        let options = DnsOptions::try_from(request.into_inner())?;
         log::debug!("set_dns_options({:?})", options);
 
         let (tx, rx) = oneshot::channel();

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -1215,3 +1215,11 @@ fn convert_providers_constraint(
         Constraint::Only(providers) => Vec::from(providers.clone()),
     }
 }
+
+impl From<FromProtobufTypeError> for crate::Status {
+    fn from(err: FromProtobufTypeError) -> Self {
+        match err {
+            FromProtobufTypeError::InvalidArgument(err) => crate::Status::invalid_argument(err),
+        }
+    }
+}


### PR DESCRIPTION
There seems to be a lot of repetition when it comes to handling errors from converting GRPC types into daemon types. I've factored the reoccuring closure into a function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2947)
<!-- Reviewable:end -->
