### PR TITLE
Reset next tunnel state in renderer on update

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -731,6 +731,9 @@ export default class AppRenderer {
     log.debug(`Tunnel state: ${tunnelState.state}`);
 
     this.tunnelState = tunnelState;
+    // The main process doesn't notify the tunnel state while waiting for a new one (unless it times
+    // out). Therefore the first tunnel state update will be the one we're waiting for.
+    this.optimisticTunnelState = undefined;
 
     switch (tunnelState.state) {
       case 'connecting':


### PR DESCRIPTION
Previously the next tunnel state variable wasn't reset which caused prevented the connect button from working after connecting/disconnecting from another frontend/instance.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2949)
<!-- Reviewable:end -->
