### PR TITLE
Add missing hook dependency for setCustomDnsEnabled

### DIFF
--- a/gui/src/renderer/components/CustomDnsSettings.tsx
+++ b/gui/src/renderer/components/CustomDnsSettings.tsx
@@ -58,17 +58,20 @@ export default function CustomDnsSettings() {
     setConfirmAction(undefined);
   }, [confirmAction]);
 
-  const setCustomDnsEnabled = useCallback(async (enabled: boolean) => {
-    if (dns.customOptions.addresses.length > 0) {
-      await setDnsOptions({ ...dns, state: enabled ? 'custom' : 'default' });
-    }
-    if (enabled && dns.customOptions.addresses.length === 0) {
-      showInput();
-    }
-    if (!enabled) {
-      hideInput();
-    }
-  }, []);
+  const setCustomDnsEnabled = useCallback(
+    async (enabled: boolean) => {
+      if (dns.customOptions.addresses.length > 0) {
+        await setDnsOptions({ ...dns, state: enabled ? 'custom' : 'default' });
+      }
+      if (enabled && dns.customOptions.addresses.length === 0) {
+        showInput();
+      }
+      if (!enabled) {
+        hideInput();
+      }
+    },
+    [dns],
+  );
 
   // The input field should be hidden when it loses focus unless something on the same row or the
   // add-button is the new focused element.


### PR DESCRIPTION
This PR adds a missing dependency to the `setCustomDnsEnabled` hook. It being missing made it use old data resulting in unexpected behavior hen disabling the feature after enabling it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2950)
<!-- Reviewable:end -->
