### PR TITLE
Make sure fetchLocation is always called

### DIFF
--- a/gui/src/renderer/components/CustomDnsSettings.tsx
+++ b/gui/src/renderer/components/CustomDnsSettings.tsx
@@ -58,17 +58,20 @@ export default function CustomDnsSettings() {
     setConfirmAction(undefined);
   }, [confirmAction]);
 
-  const setCustomDnsEnabled = useCallback(async (enabled: boolean) => {
-    if (dns.customOptions.addresses.length > 0) {
-      await setDnsOptions({ ...dns, state: enabled ? 'custom' : 'default' });
-    }
-    if (enabled && dns.customOptions.addresses.length === 0) {
-      showInput();
-    }
-    if (!enabled) {
-      hideInput();
-    }
-  }, []);
+  const setCustomDnsEnabled = useCallback(
+    async (enabled: boolean) => {
+      if (dns.customOptions.addresses.length > 0) {
+        await setDnsOptions({ ...dns, state: enabled ? 'custom' : 'default' });
+      }
+      if (enabled && dns.customOptions.addresses.length === 0) {
+        showInput();
+      }
+      if (!enabled) {
+        hideInput();
+      }
+    },
+    [dns],
+  );
 
   // The input field should be hidden when it loses focus unless something on the same row or the
   // add-button is the new focused element.


### PR DESCRIPTION
This PR corrects a mistake I made in https://github.com/mullvad/mullvadvpn-app/pull/2940. The out-ip wasn't available since `fetchLocation` wasn't called.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2951)
<!-- Reviewable:end -->
