### PR TITLE
Promise extensions

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		581CBCEE229826FD00727D7F /* StaticTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581CBCED229826FD00727D7F /* StaticTableViewDataSource.swift */; };
 		581FC4FA2695ACE100AA97BA /* Account.strings in Resources */ = {isa = PBXBuildFile; fileRef = 581FC4F82695ACE100AA97BA /* Account.strings */; };
 		5823FA5026CA690600283BF8 /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5823FA4F26CA690600283BF8 /* OSLogHandler.swift */; };
+		5820674926E63EC900655B05 /* Promise+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5820674826E63EC800655B05 /* Promise+BackgroundTask.swift */; };
 		58293FAE2510CA58005D0BB5 /* ProblemReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58293FAC2510CA58005D0BB5 /* ProblemReportViewController.swift */; };
 		58293FB125124117005D0BB5 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58293FB025124117005D0BB5 /* CustomTextField.swift */; };
 		58293FB3251241B4005D0BB5 /* CustomTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58293FB2251241B3005D0BB5 /* CustomTextView.swift */; };
@@ -312,6 +313,7 @@
 		581503A524D6F4AE00C9C50E /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		581CBCED229826FD00727D7F /* StaticTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticTableViewDataSource.swift; sourceTree = "<group>"; };
 		581FC4F92695ACE100AA97BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Account.strings; sourceTree = "<group>"; };
+		5820674826E63EC800655B05 /* Promise+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+BackgroundTask.swift"; sourceTree = "<group>"; };
 		5823FA4F26CA690600283BF8 /* OSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogHandler.swift; sourceTree = "<group>"; };
 		58293FAC2510CA58005D0BB5 /* ProblemReportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemReportViewController.swift; sourceTree = "<group>"; };
 		58293FB025124117005D0BB5 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
@@ -771,6 +773,7 @@
 				58E1337426D2BEC400CC316B /* Promise+Optional.swift */,
 				58E1337826D2BEDD00CC316B /* Promise+ReceiveOn.swift */,
 				58E1338026D2BF5C00CC316B /* Promise+Result.swift */,
+				5820674826E63EC800655B05 /* Promise+BackgroundTask.swift */,
 			);
 			path = Promise;
 			sourceTree = "<group>";
@@ -1160,6 +1163,7 @@
 				5873884D239E6D7E00E96C4E /* EmbeddedViewContainerView.swift in Sources */,
 				583BC70724FE4DC500C9DE04 /* Optional+DispatchQueue.swift in Sources */,
 				58F3C0A4249CB069003E76BE /* HeaderBarView.swift in Sources */,
+				5820674926E63EC900655B05 /* Promise+BackgroundTask.swift in Sources */,
 				58B9EB132488ED2100095626 /* AlertPresenter.swift in Sources */,
 				587A01FC23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift in Sources */,
 				5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -26,8 +26,8 @@
 		581503A724D6F4AE00C9C50E /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581503A524D6F4AE00C9C50E /* Logging.swift */; };
 		581CBCEE229826FD00727D7F /* StaticTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581CBCED229826FD00727D7F /* StaticTableViewDataSource.swift */; };
 		581FC4FA2695ACE100AA97BA /* Account.strings in Resources */ = {isa = PBXBuildFile; fileRef = 581FC4F82695ACE100AA97BA /* Account.strings */; };
-		5823FA5026CA690600283BF8 /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5823FA4F26CA690600283BF8 /* OSLogHandler.swift */; };
 		5820674926E63EC900655B05 /* Promise+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5820674826E63EC800655B05 /* Promise+BackgroundTask.swift */; };
+		5823FA5026CA690600283BF8 /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5823FA4F26CA690600283BF8 /* OSLogHandler.swift */; };
 		58293FAE2510CA58005D0BB5 /* ProblemReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58293FAC2510CA58005D0BB5 /* ProblemReportViewController.swift */; };
 		58293FB125124117005D0BB5 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58293FB025124117005D0BB5 /* CustomTextField.swift */; };
 		58293FB3251241B4005D0BB5 /* CustomTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58293FB2251241B3005D0BB5 /* CustomTextView.swift */; };
@@ -52,6 +52,8 @@
 		584592612639B4A200EF967F /* ConsentContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584592602639B4A200EF967F /* ConsentContentView.swift */; };
 		5845F842236CBACD00B2D93C /* PacketTunnelIpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */; };
 		5845F843236CBDAB00B2D93C /* PacketTunnelIpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */; };
+		5846226726E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846226626E0DF960035F7C2 /* Promise+OperationQueue.swift */; };
+		5846226826E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846226626E0DF960035F7C2 /* Promise+OperationQueue.swift */; };
 		584789B8264D4A2A000E45FB /* old_le_root_cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = 584789B4264D4A2A000E45FB /* old_le_root_cert.cer */; };
 		584789B9264D4A2A000E45FB /* old_le_root_cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = 584789B4264D4A2A000E45FB /* old_le_root_cert.cer */; };
 		584789BE264D4A2A000E45FB /* new_le_root_cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = 584789B7264D4A2A000E45FB /* new_le_root_cert.cer */; };
@@ -133,6 +135,7 @@
 		589AB4F7227B64450039131E /* BasicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589AB4F6227B64450039131E /* BasicTableViewCell.swift */; };
 		58A1AA8C23F5584C009F7EA6 /* ConnectionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A1AA8B23F5584B009F7EA6 /* ConnectionPanelView.swift */; };
 		58A8BE81239FBE62006B74AC /* IPEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58561C98239A5D1500BD6B5E /* IPEndpoint.swift */; };
+		58A94AE626D23C3D001CB97C /* PromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A94AE526D23C3D001CB97C /* PromiseTests.swift */; };
 		58A99ED3240014A0006599E9 /* ConsentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A99ED2240014A0006599E9 /* ConsentViewController.swift */; };
 		58ACF6492655365700ACE4B7 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACF6482655365700ACE4B7 /* PreferencesViewController.swift */; };
 		58ACF64B26553C3F00ACE4B7 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACF64A26553C3F00ACE4B7 /* SettingsSwitchCell.swift */; };
@@ -161,6 +164,7 @@
 		58BA693223EAE1AE009DC256 /* SimulatorTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */; };
 		58BA791B2578F092006FAEA0 /* WireGuardKit in Frameworks */ = {isa = PBXBuildFile; productRef = 58BA791A2578F092006FAEA0 /* WireGuardKit */; };
 		58BA7947257901A5006FAEA0 /* WireGuardKit in Frameworks */ = {isa = PBXBuildFile; productRef = 58BA7946257901A5006FAEA0 /* WireGuardKit */; };
+		58BF345E26F09F3C002A6CAA /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580EE20524B3222200F9D8A1 /* ExclusivityController.swift */; };
 		58BFA5C622A7C97F00A6173D /* RelayCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5C522A7C97F00A6173D /* RelayCache.swift */; };
 		58BFA5C722A7C97F00A6173D /* RelayCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5C522A7C97F00A6173D /* RelayCache.swift */; };
 		58BFA5CC22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
@@ -334,6 +338,7 @@
 		5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadEndpoint.swift; sourceTree = "<group>"; };
 		584592602639B4A200EF967F /* ConsentContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentContentView.swift; sourceTree = "<group>"; };
 		5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelIpc.swift; sourceTree = "<group>"; };
+		5846226626E0DF960035F7C2 /* Promise+OperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+OperationQueue.swift"; sourceTree = "<group>"; };
 		584789B4264D4A2A000E45FB /* old_le_root_cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = old_le_root_cert.cer; sourceTree = "<group>"; };
 		584789B7264D4A2A000E45FB /* new_le_root_cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = new_le_root_cert.cer; sourceTree = "<group>"; };
 		584789DF26529D72000E45FB /* SSLPinningURLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningURLSessionDelegate.swift; sourceTree = "<group>"; };
@@ -773,6 +778,7 @@
 				58E1337426D2BEC400CC316B /* Promise+Optional.swift */,
 				58E1337826D2BEDD00CC316B /* Promise+ReceiveOn.swift */,
 				58E1338026D2BF5C00CC316B /* Promise+Result.swift */,
+				5846226626E0DF960035F7C2 /* Promise+OperationQueue.swift */,
 				5820674826E63EC800655B05 /* Promise+BackgroundTask.swift */,
 			);
 			path = Promise;
@@ -1065,14 +1071,17 @@
 				584E96BE240FD4DB00D3334F /* Location.swift in Sources */,
 				5857F23F24C844AD00CF6F47 /* Locking.swift in Sources */,
 				5857F23424C8443700CF6F47 /* AsyncOperation.swift in Sources */,
+				58BF345E26F09F3C002A6CAA /* ExclusivityController.swift in Sources */,
 				58E1338326D2BF5C00CC316B /* Promise+Result.swift in Sources */,
 				58B0A2AC238EE6D500BC001D /* IPAddress+Codable.swift in Sources */,
 				58B0A2AD238EE6EC00BC001D /* MullvadEndpoint.swift in Sources */,
+				5846226826E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */,
 				5860392B26DCEE6300554C79 /* PromiseCompletion.swift in Sources */,
 				58FAEDF4245088B300CB0F5B /* KeychainError.swift in Sources */,
 				5860392726D91B8400554C79 /* PromiseTests.swift in Sources */,
 				58E1337326D2BE9C00CC316B /* AnyOptional.swift in Sources */,
 				5896AE88246D7FAF005B36CB /* CustomDateComponentsFormatting.swift in Sources */,
+				58A94AE626D23C3D001CB97C /* PromiseTests.swift in Sources */,
 				58C3478B26C1094F0060838B /* Promise.swift in Sources */,
 				5857F23824C8446700CF6F47 /* AsyncBlockOperation.swift in Sources */,
 				582AE3122440CA0D00E6733A /* AccountTokenInputTests.swift in Sources */,
@@ -1155,6 +1164,7 @@
 				584E96BC240FD4DA00D3334F /* Location.swift in Sources */,
 				581503A124D6F01F00C9C50E /* LogRotation.swift in Sources */,
 				58B8743222B25A7600015324 /* WireguardAssociatedAddresses.swift in Sources */,
+				5846226726E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */,
 				5850368C25A49E2200A43E93 /* PrivateKeyWithMetadata.swift in Sources */,
 				58B67B482602079E008EF58E /* RelaySelector.swift in Sources */,
 				58DF28A52417CB4B00E836B0 /* AppStorePaymentManager.swift in Sources */,
@@ -1235,6 +1245,8 @@
 				5850368D25A49E2200A43E93 /* PrivateKeyWithMetadata.swift in Sources */,
 				580EE20724B3222400F9D8A1 /* ExclusivityController.swift in Sources */,
 				58F840B02464382C0044E708 /* KeychainItemRevision.swift in Sources */,
+				58E1337A26D2BEDD00CC316B /* Promise+ReceiveOn.swift in Sources */,
+				58B93A2526C683B300A55733 /* Promise.swift in Sources */,
 				58E1337A26D2BEDD00CC316B /* Promise+ReceiveOn.swift in Sources */,
 				58B93A2526C683B300A55733 /* Promise.swift in Sources */,
 				587AD7C723421D8600E93A53 /* TunnelSettings.swift in Sources */,

--- a/ios/MullvadVPN/Promise/Promise+BackgroundTask.swift
+++ b/ios/MullvadVPN/Promise/Promise+BackgroundTask.swift
@@ -1,0 +1,57 @@
+//
+//  Promise+BackgroundTask.swift
+//  Promise+BackgroundTask
+//
+//  Created by pronebird on 06/09/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+extension Promise {
+
+    /// Start the background task for the duration of the upstream execution.
+    func requestBackgroundTime(taskName: String? = nil) -> Promise<Value> {
+        return Promise<Value> { resolver in
+            var backgroundTaskIdentifier: UIBackgroundTaskIdentifier?
+
+            let beginBackgroundTask = {
+                backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: taskName) {
+                    resolver.resolve(completion: .cancelled)
+                }
+            }
+
+            let endBackgroundTask = {
+                guard let taskIdentifier = backgroundTaskIdentifier,
+                      taskIdentifier != .invalid else { return }
+
+                UIApplication.shared.endBackgroundTask(taskIdentifier)
+                backgroundTaskIdentifier = nil
+            }
+
+            let endBackgroundTaskOnMainQueue = {
+                if Thread.isMainThread {
+                    endBackgroundTask()
+                } else {
+                    DispatchQueue.main.async(execute: endBackgroundTask)
+                }
+            }
+
+            if Thread.isMainThread {
+                beginBackgroundTask()
+            } else {
+                DispatchQueue.main.async(execute: beginBackgroundTask)
+            }
+
+            resolver.setCancelHandler {
+                endBackgroundTaskOnMainQueue()
+            }
+
+            self.observe { completion in
+                resolver.resolve(completion: completion)
+
+                endBackgroundTaskOnMainQueue()
+            }
+        }
+    }
+}

--- a/ios/MullvadVPN/Promise/Promise+OperationQueue.swift
+++ b/ios/MullvadVPN/Promise/Promise+OperationQueue.swift
@@ -1,0 +1,49 @@
+//
+//  Promise+OperationQueue.swift
+//  Promise+OperationQueue
+//
+//  Created by pronebird on 02/09/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension Promise {
+
+    /// Returns a promise that adds operation that finishes along with the upstream.
+    func run(on operationQueue: OperationQueue) -> Promise<Value> {
+        return Promise { resolver in
+            let operation = AsyncBlockOperation { finish in
+                self.observe { completion in
+                    resolver.resolve(completion: completion)
+                    finish()
+                }
+            }
+
+            resolver.setCancelHandler {
+                operation.cancel()
+            }
+
+            operationQueue.addOperation(operation)
+        }
+    }
+
+    /// Returns a promise that adds a mutually exclusive operation that finishes along with the upstream.
+    func run(on operationQueue: OperationQueue, categories: [String]) -> Promise<Value> {
+        return Promise { resolver in
+            let operation = AsyncBlockOperation { finish in
+                self.observe { completion in
+                    resolver.resolve(completion: completion)
+                    finish()
+                }
+            }
+
+            resolver.setCancelHandler {
+                operation.cancel()
+            }
+
+            ExclusivityController.shared.addOperation(operation, categories: categories)
+            operationQueue.addOperation(operation)
+        }
+    }
+}

--- a/ios/MullvadVPN/Promise/Promise+Optional.swift
+++ b/ios/MullvadVPN/Promise/Promise+Optional.swift
@@ -28,4 +28,11 @@ extension Promise where Value: AnyOptional {
             return value.asConcreteType().map(producePromise) ?? .resolved(defaultValue)
         }
     }
+
+    /// Map contained value to result providing failure when the value is `nil`.
+    func some<Failure: Error>(or failure: Failure) -> Result<Value.Wrapped, Failure>.Promise {
+        return then { value -> Result<Value.Wrapped, Failure> in
+            return value.asConcreteType().map { .success($0) } ?? .failure(failure)
+        }
+    }
 }

--- a/ios/MullvadVPN/Promise/Promise+ReceiveOn.swift
+++ b/ios/MullvadVPN/Promise/Promise+ReceiveOn.swift
@@ -9,23 +9,47 @@
 import Foundation
 
 extension Promise {
+    /// A type of timer.
+    enum TimerType {
+        case deadline
+        case walltime
+    }
+
     /// Dispatch the upstream value on another queue.
     func receive(on queue: DispatchQueue) -> Promise<Value> {
         return Promise<Value> { resolver in
-            _ = self.observe { completion in
-                queue.async {
+            self.observe { completion in
+                let work = DispatchWorkItem {
                     resolver.resolve(completion: completion, queue: queue)
                 }
+
+                resolver.setCancelHandler {
+                    work.cancel()
+                }
+
+                queue.async(execute: work)
             }
         }
     }
 
     /// Dispatch the upstream value on another queue after delay.
-    func receive(on queue: DispatchQueue, after deadline: DispatchTime) -> Promise<Value> {
+    func receive(on queue: DispatchQueue, after timeInterval: DispatchTimeInterval, timerType: TimerType) -> Promise<Value> {
         return Promise<Value> { resolver in
-            _ = self.observe { completion in
-                queue.asyncAfter(deadline: deadline) {
+            self.observe { completion in
+                let work = DispatchWorkItem {
                     resolver.resolve(completion: completion, queue: queue)
+                }
+
+                resolver.setCancelHandler {
+                    work.cancel()
+                }
+
+                switch timerType {
+                case .deadline:
+                    queue.asyncAfter(deadline: .now() + timeInterval, execute: work)
+
+                case .walltime:
+                    queue.asyncAfter(wallDeadline: .now() + timeInterval, execute: work)
                 }
             }
         }

--- a/ios/MullvadVPN/Promise/Promise+Result.swift
+++ b/ios/MullvadVPN/Promise/Promise+Result.swift
@@ -51,21 +51,19 @@ extension Promise where Value: AnyResult {
         }
     }
 
-    /// Perform actiion on success.
-    func onSuccess(_ onResolve: @escaping (Success) -> Void) -> Self {
-        return observe { completion in
-            if case .success(let value) = completion.unwrappedValue?.asConcreteType() {
-                onResolve(value)
-            }
+    /// Perform action on success.
+    func onSuccess(_ onResolve: @escaping (Success) -> Void) -> Result<Success, Failure>.Promise {
+        return map { value -> Success in
+            onResolve(value)
+            return value
         }
     }
 
     /// Perform action on failure.
-    func onFailure(_ onResolve: @escaping (Failure) -> Void) -> Self {
-        return observe { completion in
-            if case .failure(let error) = completion.unwrappedValue?.asConcreteType() {
-                onResolve(error)
-            }
+    func onFailure(_ onResolve: @escaping (Failure) -> Void) -> Result<Success, Failure>.Promise {
+        return mapError { error -> Failure in
+            onResolve(error)
+            return error
         }
     }
 

--- a/ios/MullvadVPN/Promise/Promise+Result.swift
+++ b/ios/MullvadVPN/Promise/Promise+Result.swift
@@ -96,7 +96,7 @@ extension Promise where Value: AnyResult {
     /// Map failure to Result. Passes successful result downstream.
     func flatMapError<NewFailure>(_ transform: @escaping (Failure) -> Result<Success, NewFailure>) -> Result<Success, NewFailure>.Promise {
         return then { result in
-            result.asConcreteType().flatMapError(transform)
+            return result.asConcreteType().flatMapError(transform)
         }
     }
 }

--- a/ios/MullvadVPN/Promise/Promise+Result.swift
+++ b/ios/MullvadVPN/Promise/Promise+Result.swift
@@ -144,3 +144,10 @@ extension Result {
         }
     }
 }
+
+extension Result where Success: AnyOptional {
+    /// Same as `value` except it flattens `T??` producing single Optional (`T?`)
+    var flattenValue: Success.Wrapped? {
+        return value?.asConcreteType().flatMap { $0 }
+    }
+}

--- a/ios/MullvadVPN/Promise/Promise+Result.swift
+++ b/ios/MullvadVPN/Promise/Promise+Result.swift
@@ -99,6 +99,18 @@ extension Promise where Value: AnyResult {
             return result.asConcreteType().flatMapError(transform)
         }
     }
+
+    /// Map failure to Result producing Promise. Passes successful result downstream.
+    func flatMapErrorThen<NewFailure>(_ transform: @escaping (Failure) -> Result<Success, NewFailure>.Promise) -> Result<Success, NewFailure>.Promise {
+        return then { result in
+            switch result.asConcreteType() {
+            case .success(let value):
+                return .success(value)
+            case .failure(let error):
+                return transform(error)
+            }
+        }
+    }
 }
 
 extension Promise where Value: AnyResult {

--- a/ios/MullvadVPN/Promise/Promise.swift
+++ b/ios/MullvadVPN/Promise/Promise.swift
@@ -208,13 +208,22 @@ final class Promise<Value> {
 }
 
 final class PromiseCancellationToken {
-    private let handler: () -> Void
+    private var handler: (() -> Void)?
+    private let lock = NSLock()
+
     fileprivate init(_ handler: @escaping () -> Void) {
         self.handler = handler
     }
 
+    func cancel() {
+        lock.withCriticalBlock {
+            self.handler?()
+            self.handler = nil
+        }
+    }
+
     deinit {
-        handler()
+        cancel()
     }
 }
 

--- a/ios/MullvadVPN/Promise/Promise.swift
+++ b/ios/MullvadVPN/Promise/Promise.swift
@@ -26,6 +26,13 @@ final class Promise<Value> {
         return Self.init(value: value)
     }
 
+    /// Returns Promise with lazily resolved value.
+    class func deferred(_ producer: @escaping () -> Value) -> Self {
+        return Self.init { resolver in
+            resolver.resolve(value: producer())
+        }
+    }
+
     /// Initialize Promise with the execution block.
     init(body: @escaping (PromiseResolver<Value>) -> Void) {
         state = .pending(body, nil)

--- a/ios/MullvadVPN/Promise/PromiseCompletion.swift
+++ b/ios/MullvadVPN/Promise/PromiseCompletion.swift
@@ -37,6 +37,13 @@ enum PromiseCompletion<Value> {
     }
 }
 
+extension PromiseCompletion where Value: AnyOptional {
+    /// Same as `unwrappedValue` except it flattens `T??` producing single Optional (`T?`)
+    var flattenUnwrappedValue: Value.Wrapped? {
+        return unwrappedValue?.asConcreteType().flatMap { $0 }
+    }
+}
+
 extension PromiseCompletion: Equatable where Value: Equatable {
     static func == (lhs: PromiseCompletion<Value>, rhs: PromiseCompletion<Value>) -> Bool {
         switch (lhs, rhs) {

--- a/ios/MullvadVPN/Promise/PromiseCompletion.swift
+++ b/ios/MullvadVPN/Promise/PromiseCompletion.swift
@@ -26,6 +26,16 @@ enum PromiseCompletion<Value> {
         }
     }
 
+    /// Returns `true` when the completion is `.cancelled`.
+    var isCancelled: Bool {
+        switch self {
+        case .cancelled:
+            return true
+        case .finished:
+            return false
+        }
+    }
+
     /// Map the contained value, producing new `PromiseCompletion` type.
     func map<NewValue>(_ transform: (Value) throws -> NewValue) rethrows -> PromiseCompletion<NewValue> {
         switch self {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add `Promise.deferred`  to be able to pass lazily resolved value
2. `Promise` won't throw exception when dropped while in `pending` state, but will continue to warn when dropped while `executing`.
3. Calls to `onSuccess` and `onFailure` will chain as any other calls to avoid calling `observe()` which triggers execution.
4. `Promise.observe()` returns `Void` and is meant to be used as the final call when composing a promise chain.
5. Add extension to request background execution time from the system. `Promise+BackgroundTask`
6. Make calls to `Promise.receive(on:)` cancellable and introduce timer type.
7. Add extension to schedule work on `OperationQueue`.
8. Add `Promise<T?>.some<Failure>(or: Failure)` containing `T?` value into `T` or `Failure`. Useful when unpacking promises containing `nullable` value.
9. Add helpers to further improve ergonomics of `PromiseCompletion`: `isCancelled` and `flattenUnwrappedValue`
10. Rework `ExclusivityController` for `Operation`s. The primary difference that it doesn't add `Operation`s to the `OperationQueue`, instead simply wires them up and installs the observer to observe `isFinished` property of the given `Operation`. Unregisters observer once `Operation` finished.
11. Add `Result<T?>.flattenValue` to turn otherwise `T??` when unpacking the value via `Result.value`, into `T?`. The similar result can be achieved by using `flatMap { $0 }`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2953)
<!-- Reviewable:end -->
