### PR TITLE
Refactor AppStoreReceipt

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		5845F843236CBDAB00B2D93C /* PacketTunnelIpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */; };
 		5846226726E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846226626E0DF960035F7C2 /* Promise+OperationQueue.swift */; };
 		5846226826E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846226626E0DF960035F7C2 /* Promise+OperationQueue.swift */; };
+		5846226A26E0E6FA0035F7C2 /* ReceiptRefreshOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846226926E0E6FA0035F7C2 /* ReceiptRefreshOperation.swift */; };
 		584789B8264D4A2A000E45FB /* old_le_root_cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = 584789B4264D4A2A000E45FB /* old_le_root_cert.cer */; };
 		584789B9264D4A2A000E45FB /* old_le_root_cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = 584789B4264D4A2A000E45FB /* old_le_root_cert.cer */; };
 		584789BE264D4A2A000E45FB /* new_le_root_cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = 584789B7264D4A2A000E45FB /* new_le_root_cert.cer */; };
@@ -339,6 +340,7 @@
 		584592602639B4A200EF967F /* ConsentContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentContentView.swift; sourceTree = "<group>"; };
 		5845F841236CBACD00B2D93C /* PacketTunnelIpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelIpc.swift; sourceTree = "<group>"; };
 		5846226626E0DF960035F7C2 /* Promise+OperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+OperationQueue.swift"; sourceTree = "<group>"; };
+		5846226926E0E6FA0035F7C2 /* ReceiptRefreshOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptRefreshOperation.swift; sourceTree = "<group>"; };
 		584789B4264D4A2A000E45FB /* old_le_root_cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = old_le_root_cert.cer; sourceTree = "<group>"; };
 		584789B7264D4A2A000E45FB /* new_le_root_cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = new_le_root_cert.cer; sourceTree = "<group>"; };
 		584789DF26529D72000E45FB /* SSLPinningURLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningURLSessionDelegate.swift; sourceTree = "<group>"; };
@@ -530,6 +532,7 @@
 				580EE22324B3243100F9D8A1 /* AsyncBlockOperation.swift */,
 				58E973DD24850EB600096F90 /* AsyncOperation.swift */,
 				580EE20524B3222200F9D8A1 /* ExclusivityController.swift */,
+				5846226926E0E6FA0035F7C2 /* ReceiptRefreshOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -1135,6 +1138,7 @@
 				58FEEB58260B662E00A621A8 /* AutomaticKeyboardResponder.swift in Sources */,
 				58FAEDEF245069C700CB0F5B /* KeychainAttributes.swift in Sources */,
 				58CB0EE024B86751001EF0D8 /* MullvadRest.swift in Sources */,
+				5846226A26E0E6FA0035F7C2 /* ReceiptRefreshOperation.swift in Sources */,
 				58E1337526D2BEC400CC316B /* Promise+Optional.swift in Sources */,
 				58293FB125124117005D0BB5 /* CustomTextField.swift in Sources */,
 				582AE3102440A6CA00E6733A /* AccountTokenInput.swift in Sources */,

--- a/ios/MullvadVPN/AppStoreReceipt.swift
+++ b/ios/MullvadVPN/AppStoreReceipt.swift
@@ -66,7 +66,7 @@ enum AppStoreReceipt {
 
         return Result { try Data(contentsOf: appStoreReceiptURL) }
             .mapError { (error) -> Error in
-                if let ioError = error as? CocoaError, ioError.code == .fileNoSuchFile {
+                if let cocoaError = error as? CocoaError, cocoaError.code == .fileReadNoSuchFile || cocoaError.code == .fileNoSuchFile {
                     return .doesNotExist
                 } else {
                     return .io(error)

--- a/ios/MullvadVPN/AppStoreReceipt.swift
+++ b/ios/MullvadVPN/AppStoreReceipt.swift
@@ -33,7 +33,12 @@ enum AppStoreReceipt {
     }
 
     /// An operation queue used to run receipt refresh requests
-    private static let operationQueue = OperationQueue()
+    private static let operationQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "AppStoreReceiptQueue"
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
 
     /// Read AppStore receipt from disk
     static func readFromDisk() -> Result<Data, Error> {

--- a/ios/MullvadVPN/Operations/ReceiptRefreshOperation.swift
+++ b/ios/MullvadVPN/Operations/ReceiptRefreshOperation.swift
@@ -1,0 +1,46 @@
+//
+//  ReceiptRefreshOperation.swift
+//  ReceiptRefreshOperation
+//
+//  Created by pronebird on 02/09/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import StoreKit
+
+class ReceiptRefreshOperation: AsyncOperation, SKRequestDelegate {
+    private let request: SKReceiptRefreshRequest
+    private let completionHandler: (Result<(), Error>) -> Void
+
+    init(receiptProperties: [String: Any]?, completionHandler: @escaping (Result<(), Error>) -> Void) {
+        request = SKReceiptRefreshRequest(receiptProperties: receiptProperties)
+        self.completionHandler = completionHandler
+
+        super.init()
+
+        request.delegate = self
+    }
+
+    override func main() {
+        request.start()
+    }
+
+    override func cancel() {
+        super.cancel()
+
+        request.cancel()
+    }
+
+    // - MARK: SKRequestDelegate
+
+    func requestDidFinish(_ request: SKRequest) {
+        completionHandler(.success(()))
+        finish()
+    }
+
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        completionHandler(.failure(error))
+        finish()
+    }
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Make sure that `ReceiptRefreshOperation` runs on a serial `OperationQueue`, since that call triggers system Apple ID sign in prompt.
2. Handle `CocoaError.fileReadNoSuchFile` when reading AppStore receipt from disk. I am pretty sure that in the past `fileNoSuchFile` was thrown instead. Map both to `AppStoreReceipt.Error.doesNotExist`.
3. Move `ReceiptRefreshOperation` to separate source file.
4. Simplify `ReceiptRefreshOperation` since I am moving away from more complex operations for many reasons, but essentially trying to reduce complexity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2957)
<!-- Reviewable:end -->
