### PR TITLE
Fix display implementation for BridgeConstraints

### DIFF
--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -566,8 +566,13 @@ pub struct BridgeConstraints {
 impl fmt::Display for BridgeConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.location {
-            Constraint::Any => write!(f, "any location"),
-            Constraint::Only(ref location_constraint) => location_constraint.fmt(f),
+            Constraint::Any => write!(f, "any location")?,
+            Constraint::Only(ref location_constraint) => location_constraint.fmt(f)?,
+        }
+        write!(f, " using ")?;
+        match self.providers {
+            Constraint::Any => write!(f, "any provider"),
+            Constraint::Only(ref constraint) => constraint.fmt(f),
         }
     }
 }


### PR DESCRIPTION
Tiny fix: Include providers in the `fmt` output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2964)
<!-- Reviewable:end -->
