### PR TITLE
Set up OpenVPN tunnels more quickly on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Upgrade Wintun from 0.10.4 to 0.13.
+- Reduce tunnel setup time for OpenVPN by disabling DAD.
 
 ### Fixed
 - Fix link to download page not always using the beta URL when it should.

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -41,7 +41,6 @@ use winapi::shared::{
     netioapi::{GetUnicastIpAddressEntry, MIB_UNICASTIPADDRESS_ROW},
     nldef::{IpDadStatePreferred, IpDadStateTentative, NL_DAD_STATE},
     winerror::NO_ERROR,
-    ws2def::AF_UNSPEC,
 };
 #[cfg(windows)]
 use winreg::enums::{KEY_READ, KEY_WRITE};
@@ -1244,7 +1243,7 @@ fn wait_for_ready_device(alias: &str) -> Result<()> {
 
     // Obtain unicast IP addresses
     let mut unicast_rows: Vec<MIB_UNICASTIPADDRESS_ROW> =
-        crate::tunnel::windows::get_unicast_table(AF_UNSPEC as u16)
+        crate::tunnel::windows::get_unicast_table(None)
             .map_err(Error::ObtainUnicastAddress)?
             .into_iter()
             .filter(|row| row.InterfaceLuid.Value == luid.Value)

--- a/talpid-core/src/tunnel/openvpn/windows.rs
+++ b/talpid-core/src/tunnel/openvpn/windows.rs
@@ -1,4 +1,4 @@
-use crate::tunnel::windows::{get_ip_interface_entry, set_ip_interface_entry};
+use crate::tunnel::windows::{get_ip_interface_entry, set_ip_interface_entry, AddressFamily};
 use std::{
     ffi::CStr,
     fmt, io, iter, mem,
@@ -18,7 +18,6 @@ use winapi::{
         nldef::RouterDiscoveryDisabled,
         ntdef::FALSE,
         winerror::NO_ERROR,
-        ws2def::{AF_INET, AF_INET6},
     },
     um::{
         libloaderapi::{
@@ -161,8 +160,8 @@ impl WintunAdapter {
     pub fn try_disable_unused_features(&self) {
         // Disable DAD, DHCP, and router discovery
         let luid = self.luid();
-        for family in &[AF_INET, AF_INET6] {
-            if let Ok(mut row) = get_ip_interface_entry(*family as u16, &luid) {
+        for family in &[AddressFamily::Ipv4, AddressFamily::Ipv6] {
+            if let Ok(mut row) = get_ip_interface_entry(*family, &luid) {
                 row.SitePrefixLength = 0;
                 row.RouterDiscoveryBehavior = RouterDiscoveryDisabled;
                 row.DadTransmits = 0;

--- a/talpid-core/src/tunnel/windows.rs
+++ b/talpid-core/src/tunnel/windows.rs
@@ -8,8 +8,8 @@ use winapi::shared::{
     ifdef::NET_LUID,
     netioapi::{
         CancelMibChangeNotify2, ConvertInterfaceAliasToLuid, FreeMibTable, GetIpInterfaceEntry,
-        GetUnicastIpAddressTable, MibAddInstance, NotifyIpInterfaceChange, MIB_IPINTERFACE_ROW,
-        MIB_UNICASTIPADDRESS_ROW, MIB_UNICASTIPADDRESS_TABLE,
+        GetUnicastIpAddressTable, MibAddInstance, NotifyIpInterfaceChange, SetIpInterfaceEntry,
+        MIB_IPINTERFACE_ROW, MIB_UNICASTIPADDRESS_ROW, MIB_UNICASTIPADDRESS_TABLE,
     },
     ntdef::FALSE,
     winerror::{ERROR_NOT_FOUND, NO_ERROR},
@@ -77,9 +77,19 @@ pub fn get_ip_interface_entry(family: u16, luid: &NET_LUID) -> io::Result<MIB_IP
     row.Family = family;
     row.InterfaceLuid = *luid;
 
-    let result = unsafe { GetIpInterfaceEntry(&mut row as *mut _) };
+    let result = unsafe { GetIpInterfaceEntry(&mut row) };
     if result == NO_ERROR {
         Ok(row)
+    } else {
+        Err(io::Error::from_raw_os_error(result as i32))
+    }
+}
+
+/// Set the properties of an IP interface.
+pub fn set_ip_interface_entry(row: &MIB_IPINTERFACE_ROW) -> io::Result<()> {
+    let result = unsafe { SetIpInterfaceEntry(row as *const _ as *mut _) };
+    if result == NO_ERROR {
+        Ok(())
     } else {
         Err(io::Error::from_raw_os_error(result as i32))
     }


### PR DESCRIPTION
Changes:
* Disable DAD on Wintun interfaces. On my machine, this reduces the time it takes to connect by about **2.5** seconds.
* Refactor general networking code on Windows. I've moved some generic functions to `talpid_core::tunnel::windows`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2966)
<!-- Reviewable:end -->
