### PR TITLE
Fix intermittent tunnel device errors

### DIFF
--- a/talpid-core/src/tunnel/openvpn/windows.rs
+++ b/talpid-core/src/tunnel/openvpn/windows.rs
@@ -198,7 +198,7 @@ impl WintunAdapter {
         let mut guid = mem::MaybeUninit::zeroed();
         let result = unsafe { ConvertInterfaceLuidToGuid(&self.luid(), guid.as_mut_ptr()) };
         if result != NO_ERROR {
-            return Err(io::Error::last_os_error());
+            return Err(io::Error::from_raw_os_error(result as i32));
         }
         Ok(unsafe { guid.assume_init() })
     }

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -75,26 +75,17 @@ impl WgGoTunnel {
             .map_err(TunnelError::LoggingError)?;
 
         #[cfg(not(target_os = "android"))]
+        let mtu = config.mtu as isize;
         let handle = unsafe {
             wgTurnOn(
-                config.mtu as isize,
+                #[cfg(not(target_os = "android"))]
+                mtu,
                 wg_config_str.as_ptr() as *const i8,
                 tunnel_fd,
                 Some(logging_callback),
                 logging_context.0 as *mut libc::c_void,
             )
         };
-
-        #[cfg(target_os = "android")]
-        let handle = unsafe {
-            wgTurnOn(
-                wg_config_str.as_ptr() as *const i8,
-                tunnel_fd,
-                Some(logging_callback),
-                logging_context.0 as *mut libc::c_void,
-            )
-        };
-
         check_wg_status(handle)?;
 
         #[cfg(target_os = "android")]

--- a/wireguard/libwg/libwg_windows.go
+++ b/wireguard/libwg/libwg_windows.go
@@ -13,6 +13,7 @@ import (
 	"bufio"
 	"fmt"
 	"strings"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -24,6 +25,10 @@ import (
 
 	"github.com/mullvad/mullvadvpn-app/wireguard/libwg/logging"
 	"github.com/mullvad/mullvadvpn-app/wireguard/libwg/tunnelcontainer"
+)
+
+const (
+	MAX_WINTUN_CREATION_ATTEMPTS = 3
 )
 
 // Redefined here because otherwise the compiler doesn't realize it's a type alias for a type that's safe to export.
@@ -68,11 +73,23 @@ func wgTurnOn(cIfaceName *C.char, mtu int, waitOnIpv6 bool, cSettings *C.char, c
 		tun.WintunPool = MullvadPool
 	}
 
-	wintun, err := tun.CreateTUNWithRequestedGUID(ifaceName, &networkId, mtu)
-	if err != nil {
-		logger.Errorf("Failed to create tunnel\n")
-		logger.Errorf("%s\n", err)
-		return ERROR_GENERAL_FAILURE
+	var wintun tun.Device
+	var wintunErr error
+
+	attempt := 0
+	for {
+		attempt += 1
+		wintun, wintunErr = tun.CreateTUNWithRequestedGUID(ifaceName, &networkId, mtu)
+		if wintunErr != nil {
+			logger.Errorf("Failed to create tunnel\n")
+			logger.Errorf("%s\n", wintunErr)
+			if attempt == MAX_WINTUN_CREATION_ATTEMPTS {
+				return ERROR_GENERAL_FAILURE
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
 	}
 
 	nativeTun := wintun.(*tun.NativeTun)


### PR DESCRIPTION
Changes:
* Try to create Wintun devices multiple times if an error occurs. This is to work around poorly understood races/delays that can occur when resuming from hibernation or after a reboot.
* Small amount of refactoring.
* Fix incorrect return code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2970)
<!-- Reviewable:end -->
