### PR TITLE
Change "UNSECURE" into "UNSECURED"

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -165,7 +165,7 @@ msgstr ""
 msgid "UDP"
 msgstr ""
 
-msgid "UNSECURE CONNECTION"
+msgid "UNSECURED CONNECTION"
 msgstr ""
 
 msgctxt "accessibility"
@@ -1389,9 +1389,6 @@ msgid "This device is offline, no tunnels can be established"
 msgstr ""
 
 msgid "Too many WireGuard keys registered to account"
-msgstr ""
-
-msgid "UNSECURED CONNECTION"
 msgstr ""
 
 msgid "Unsecured"

--- a/gui/src/renderer/components/SecuredLabel.tsx
+++ b/gui/src/renderer/components/SecuredLabel.tsx
@@ -51,7 +51,7 @@ function getLabelText(displayStyle: SecuredDisplayStyle) {
       return messages.gettext('CREATING SECURE CONNECTION');
 
     case SecuredDisplayStyle.unsecured:
-      return messages.gettext('UNSECURE CONNECTION');
+      return messages.gettext('UNSECURED CONNECTION');
 
     case SecuredDisplayStyle.unsecuring:
       return '';


### PR DESCRIPTION
This PR changes the connectivity status label for the disconnected state from "UNSECURE CONNECTION" to "UNSECURE**D** CONNECTION".

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2974)
<!-- Reviewable:end -->
