### PR TITLE
Update NSEventMonitor to 1.0.1 and dependencies with vulnerabilities

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -85,7 +85,7 @@
       },
       "optionalDependencies": {
         "grpc-tools": "^1.10.0",
-        "nseventmonitor": "^1.0.0"
+        "nseventmonitor": "^1.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9661,9 +9661,9 @@
       }
     },
     "node_modules/nseventmonitor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-1.0.0.tgz",
-      "integrity": "sha512-qqctMJ8NIO3KB87LTO+thmJBADOa4s+pTpBKobajzZpOBBGNqAxxhxXdDV7MnaERozAlMvtp54I6nHCYbIjQfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-1.0.1.tgz",
+      "integrity": "sha512-k/jayTdKn/9FRSR51i6VZERSaibaif0h02iTSlVXAYnIKG/1Y4gYLo9vc9B8YjMvoQC2bNjwfD0VMgzEf4UaLw==",
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -21587,9 +21587,9 @@
       }
     },
     "nseventmonitor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-1.0.0.tgz",
-      "integrity": "sha512-qqctMJ8NIO3KB87LTO+thmJBADOa4s+pTpBKobajzZpOBBGNqAxxhxXdDV7MnaERozAlMvtp54I6nHCYbIjQfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nseventmonitor/-/nseventmonitor-1.0.1.tgz",
+      "integrity": "sha512-k/jayTdKn/9FRSR51i6VZERSaibaif0h02iTSlVXAYnIKG/1Y4gYLo9vc9B8YjMvoQC2bNjwfD0VMgzEf4UaLw==",
       "optional": true,
       "requires": {
         "nan": "^2.14.2",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -5457,9 +5457,9 @@
       }
     },
     "node_modules/eslint/node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -8152,9 +8152,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
       "dependencies": {
         "lie": "~3.3.0",
@@ -9025,9 +9025,9 @@
       }
     },
     "node_modules/mocha/node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -10138,9 +10138,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-platform": {
@@ -10278,15 +10278,14 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
-      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.4.tgz",
+      "integrity": "sha512-ksrr8y9+nXOxQB2osVNqrgvX/XQPOXaU4BQMKjYq8PvaY1U18mo+fKgBSwzK+luSyinOuPae956lSVcBwxlAMg==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "base64-js": "^1.5.1",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "^0.5.0"
+        "xmlbuilder": "^9.0.7"
       },
       "engines": {
         "node": ">=6"
@@ -12210,22 +12209,42 @@
       }
     },
     "node_modules/tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "optional": true,
       "dependencies": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
       },
       "engines": {
         "node": ">=4.5"
       }
+    },
+    "node_modules/tar/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
     },
     "node_modules/temp-file": {
       "version": "3.4.0",
@@ -13498,16 +13517,6 @@
       "optional": true,
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/xtend": {
@@ -18121,9 +18130,9 @@
           "dev": true
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -20334,9 +20343,9 @@
       }
     },
     "jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -21057,9 +21066,9 @@
           "dev": true
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -21956,9 +21965,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-platform": {
@@ -22063,15 +22072,14 @@
       }
     },
     "plist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
-      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.4.tgz",
+      "integrity": "sha512-ksrr8y9+nXOxQB2osVNqrgvX/XQPOXaU4BQMKjYq8PvaY1U18mo+fKgBSwzK+luSyinOuPae956lSVcBwxlAMg==",
       "dev": true,
       "optional": true,
       "requires": {
         "base64-js": "^1.5.1",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "^0.5.0"
+        "xmlbuilder": "^9.0.7"
       },
       "dependencies": {
         "xmlbuilder": {
@@ -23655,18 +23663,26 @@
       }
     },
     "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "optional": true,
       "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "optional": true
+        }
       }
     },
     "temp-file": {
@@ -24678,13 +24694,6 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-      "dev": true,
-      "optional": true
-    },
-    "xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
       "dev": true,
       "optional": true
     },

--- a/gui/package.json
+++ b/gui/package.json
@@ -31,7 +31,7 @@
   },
   "optionalDependencies": {
     "grpc-tools": "^1.10.0",
-    "nseventmonitor": "^1.0.0"
+    "nseventmonitor": "^1.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
This PR updates NSEventMonitor to 1.0.1 and updates dependencies with known vulnerabilities. `npm audit fix` was used to update transitive dependencies.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2978)
<!-- Reviewable:end -->
