### PR TITLE
Retry failed API requests made indirectly by frontends

### DIFF
--- a/mullvad-daemon/src/account.rs
+++ b/mullvad-daemon/src/account.rs
@@ -2,16 +2,21 @@ use chrono::{DateTime, Utc};
 use futures::future::{abortable, AbortHandle};
 use mullvad_rpc::{
     availability::ApiAvailabilityHandle,
-    rest::{self, MullvadRestHandle},
+    rest::{self, Error as RestError, MullvadRestHandle},
     AccountsProxy,
 };
 use mullvad_types::account::{AccountToken, VoucherSubmission};
-use std::time::Duration;
-use talpid_core::future_retry::{retry_future_with_backoff, ExponentialBackoff, Jittered};
+use std::{future::Future, time::Duration};
+use talpid_core::future_retry::{
+    constant_interval, retry_future_n, retry_future_with_backoff, ExponentialBackoff, Jittered,
+};
 
-const RETRY_INTERVAL_INITIAL: Duration = Duration::from_secs(4);
-const RETRY_INTERVAL_FACTOR: u32 = 5;
-const RETRY_INTERVAL_MAX: Duration = Duration::from_secs(24 * 60 * 60);
+const RETRY_ACTION_INTERVAL: Duration = Duration::from_millis(500);
+const RETRY_ACTION_MAX_RETRIES: usize = 2;
+
+const RETRY_EXPIRY_CHECK_INTERVAL_INITIAL: Duration = Duration::from_secs(4);
+const RETRY_EXPIRY_CHECK_INTERVAL_FACTOR: u32 = 5;
+const RETRY_EXPIRY_CHECK_INTERVAL_MAX: Duration = Duration::from_secs(24 * 60 * 60);
 
 
 pub struct Account(());
@@ -20,12 +25,42 @@ pub struct Account(());
 pub struct AccountHandle {
     api_availability: ApiAvailabilityHandle,
     initial_check_abort_handle: AbortHandle,
-    pub proxy: AccountsProxy,
+    proxy: AccountsProxy,
 }
 
 impl AccountHandle {
+    pub fn create_account(&self) -> impl Future<Output = Result<AccountToken, rest::Error>> {
+        let mut proxy = self.proxy.clone();
+        retry_future_n(
+            move || proxy.create_account(),
+            Self::should_retry,
+            constant_interval(RETRY_ACTION_INTERVAL),
+            RETRY_ACTION_MAX_RETRIES,
+        )
+    }
+
+    pub fn get_www_auth_token(
+        &self,
+        account: AccountToken,
+    ) -> impl Future<Output = Result<String, rest::Error>> {
+        let proxy = self.proxy.clone();
+        retry_future_n(
+            move || proxy.get_www_auth_token(account.clone()),
+            Self::should_retry,
+            constant_interval(RETRY_ACTION_INTERVAL),
+            RETRY_ACTION_MAX_RETRIES,
+        )
+    }
+
     pub async fn check_expiry(&self, token: AccountToken) -> Result<DateTime<Utc>, rest::Error> {
-        let result = self.proxy.get_expiry(token).await;
+        let proxy = self.proxy.clone();
+        let result = retry_future_n(
+            move || proxy.get_expiry(token.clone()),
+            Self::should_retry,
+            constant_interval(RETRY_ACTION_INTERVAL),
+            RETRY_ACTION_MAX_RETRIES,
+        )
+        .await;
         if handle_expiry_result_inner(&result, &self.api_availability) {
             self.initial_check_abort_handle.abort();
         }
@@ -37,12 +72,31 @@ impl AccountHandle {
         account_token: AccountToken,
         voucher: String,
     ) -> Result<VoucherSubmission, rest::Error> {
-        let result = self.proxy.submit_voucher(account_token, voucher).await;
+        let mut proxy = self.proxy.clone();
+        let result = retry_future_n(
+            move || proxy.submit_voucher(account_token.clone(), voucher.clone()),
+            Self::should_retry,
+            constant_interval(RETRY_ACTION_INTERVAL),
+            RETRY_ACTION_MAX_RETRIES,
+        )
+        .await;
         if result.is_ok() {
             self.initial_check_abort_handle.abort();
             self.api_availability.resume();
         }
         result
+    }
+
+    fn should_retry<T>(result: &Result<T, RestError>) -> bool {
+        match result {
+            Ok(_) => false,
+            Err(RestError::ApiError(_status, code)) => {
+                code != mullvad_rpc::INVALID_ACCOUNT
+                    && code != mullvad_rpc::INVALID_AUTH
+                    && code != mullvad_rpc::VOUCHER_USED
+            }
+            _ => true,
+        }
     }
 }
 
@@ -68,8 +122,11 @@ impl Account {
             };
 
             let retry_strategy = Jittered::jitter(
-                ExponentialBackoff::new(RETRY_INTERVAL_INITIAL, RETRY_INTERVAL_FACTOR)
-                    .max_delay(RETRY_INTERVAL_MAX),
+                ExponentialBackoff::new(
+                    RETRY_EXPIRY_CHECK_INTERVAL_INITIAL,
+                    RETRY_EXPIRY_CHECK_INTERVAL_FACTOR,
+                )
+                .max_delay(RETRY_EXPIRY_CHECK_INTERVAL_MAX),
             );
             let future_generator = move || {
                 let wait_online = api_availability.wait_online();

--- a/mullvad-daemon/src/account.rs
+++ b/mullvad-daemon/src/account.rs
@@ -8,7 +8,7 @@ use mullvad_rpc::{
 use mullvad_types::account::{AccountToken, VoucherSubmission};
 use std::{future::Future, time::Duration};
 use talpid_core::future_retry::{
-    constant_interval, retry_future_n, retry_future_with_backoff, ExponentialBackoff, Jittered,
+    constant_interval, retry_future, retry_future_n, ExponentialBackoff, Jittered,
 };
 
 const RETRY_ACTION_INTERVAL: Duration = Duration::from_millis(500);
@@ -138,9 +138,7 @@ impl Account {
                 }
             };
             let should_retry = move |state_was_updated: &bool| -> bool { !*state_was_updated };
-            let retry_future =
-                retry_future_with_backoff(future_generator, should_retry, retry_strategy);
-            retry_future.await;
+            retry_future(future_generator, should_retry, retry_strategy).await;
         });
         runtime.spawn(future);
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1591,7 +1591,7 @@ where
                 {
                     let remove_key = self
                         .wireguard_key_manager
-                        .remove_key(previous_token, previous_key);
+                        .remove_key_with_backoff(previous_token, previous_key);
                     tokio::spawn(async move {
                         if let Err(error) = remove_key.await {
                             log::error!(

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1452,8 +1452,7 @@ where
 
     async fn on_create_new_account(&mut self, tx: ResponseTx<String, Error>) {
         let daemon_tx = self.tx.clone();
-        let future = self.account.proxy.create_account();
-
+        let future = self.account.create_account();
         tokio::spawn(async move {
             match future.await {
                 Ok(account_token) => {
@@ -1484,7 +1483,7 @@ where
 
     async fn on_get_www_auth_token(&mut self, tx: ResponseTx<String, Error>) {
         if let Some(account_token) = self.settings.get_account_token() {
-            let future = self.account.proxy.get_www_auth_token(account_token);
+            let future = self.account.get_www_auth_token(account_token);
             let rpc_call = async {
                 Self::oneshot_send(
                     tx,

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -29,7 +29,7 @@ use std::{
     sync::Arc,
     time::{self, Duration, Instant, SystemTime},
 };
-use talpid_core::future_retry::{retry_future_with_backoff, ExponentialBackoff, Jittered};
+use talpid_core::future_retry::{retry_future, ExponentialBackoff, Jittered};
 use talpid_types::{
     net::{
         all_of_the_internet, openvpn::ProxySettings, wireguard, IpVersion, TransportProtocol,
@@ -1141,7 +1141,7 @@ impl RelayListUpdater {
             ExponentialBackoff::new(EXPONENTIAL_BACKOFF_INITIAL, EXPONENTIAL_BACKOFF_FACTOR)
                 .max_delay(UPDATE_INTERVAL * 2);
 
-        let download_future = retry_future_with_backoff(
+        let download_future = retry_future(
             download_futures,
             |result| result.is_err(),
             Jittered::jitter(exponential_backoff),

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -204,10 +204,11 @@ impl VersionUpdater {
                 .map_err(Error::Download)
         };
 
-        Box::pin(talpid_core::future_retry::retry_future_with_backoff(
+        Box::pin(talpid_core::future_retry::retry_future_n(
             download_future_factory,
             move |result| result.is_err() && !api_handle.get_state().is_offline(),
-            std::iter::repeat(IMMEDIATE_UPDATE_INTERVAL_ERROR).take(IMMEDIATE_UPDATE_MAX_RETRIES),
+            std::iter::repeat(IMMEDIATE_UPDATE_INTERVAL_ERROR),
+            IMMEDIATE_UPDATE_MAX_RETRIES,
         ))
     }
 
@@ -232,7 +233,7 @@ impl VersionUpdater {
             }
         };
 
-        Box::pin(talpid_core::future_retry::retry_future_with_backoff(
+        Box::pin(talpid_core::future_retry::retry_future(
             download_future_factory,
             |result| result.is_err(),
             std::iter::repeat(UPDATE_INTERVAL_ERROR),

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -38,7 +38,7 @@ const UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
 /// Wait this long until next try if an update failed
 const UPDATE_INTERVAL_ERROR: Duration = Duration::from_secs(60 * 60 * 6);
 /// Retry interval for `RunVersionCheck`.
-const IMMEDIATE_UPDATE_INTERVAL_ERROR: Duration = Duration::from_secs(1);
+const IMMEDIATE_UPDATE_INTERVAL_ERROR: Duration = Duration::ZERO;
 const IMMEDIATE_UPDATE_MAX_RETRIES: usize = 2;
 
 #[cfg(target_os = "linux")]
@@ -206,10 +206,22 @@ impl VersionUpdater {
 
         Box::pin(talpid_core::future_retry::retry_future_n(
             download_future_factory,
-            move |result| result.is_err() && !api_handle.get_state().is_offline(),
+            move |result| Self::should_retry_immediate(result, &api_handle),
             std::iter::repeat(IMMEDIATE_UPDATE_INTERVAL_ERROR),
             IMMEDIATE_UPDATE_MAX_RETRIES,
         ))
+    }
+
+    fn should_retry_immediate<T>(
+        result: &Result<T, Error>,
+        api_handle: &ApiAvailabilityHandle,
+    ) -> bool {
+        match result {
+            Err(Error::Download(error)) if error.is_network_error() => {
+                !api_handle.get_state().is_offline()
+            }
+            _ => false,
+        }
     }
 
     fn create_update_background_future(

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -10,7 +10,7 @@ use std::{future::Future, pin::Pin, time::Duration};
 
 use futures::future::{abortable, AbortHandle};
 use talpid_core::{
-    future_retry::{retry_future_with_backoff, ExponentialBackoff, Jittered},
+    future_retry::{retry_future, ExponentialBackoff, Jittered},
     mpsc::Sender,
 };
 
@@ -218,8 +218,7 @@ impl KeyManager {
             }
         };
 
-        let upload_future =
-            retry_future_with_backoff(future_generator, should_retry, retry_strategy);
+        let upload_future = retry_future(future_generator, should_retry, retry_strategy);
 
 
         let (cancellable_upload, abort_handle) = abortable(Box::pin(upload_future));
@@ -417,7 +416,7 @@ impl KeyManager {
             }
         };
 
-        retry_future_with_backoff(
+        retry_future(
             move || rotate_key.clone()(&old_key),
             should_retry,
             retry_strategy,

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -492,14 +492,13 @@ impl WireguardKeyProxy {
         rest::deserialize_body(response).await
     }
 
-    pub async fn remove_wireguard_key(
+    pub fn remove_wireguard_key(
         &mut self,
         account_token: AccountToken,
-        key: &wireguard::PublicKey,
-    ) -> Result<(), rest::Error> {
+        key: wireguard::PublicKey,
+    ) -> impl Future<Output = Result<(), rest::Error>> {
         let service = self.handle.service.clone();
-
-        let _ = rest::send_request(
+        let future = rest::send_request(
             &self.handle.factory,
             service,
             &format!(
@@ -509,9 +508,11 @@ impl WireguardKeyProxy {
             Method::DELETE,
             Some(account_token),
             StatusCode::NO_CONTENT,
-        )
-        .await?;
-        Ok(())
+        );
+        async move {
+            let _ = future.await?;
+            Ok(())
+        }
     }
 }
 

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -188,7 +188,10 @@ async fn remove_wireguard_key() -> Result<(), Error> {
                 move || {
                     key_proxy.remove_wireguard_key(token.clone(), wg_data.private_key.public_key())
                 },
-                move |result| result.is_err(),
+                move |result| match result {
+                    Err(error) => error.is_network_error(),
+                    _ => false,
+                },
                 constant_interval(KEY_RETRY_INTERVAL),
                 KEY_RETRY_MAX_RETRIES,
             )

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -179,7 +179,7 @@ async fn remove_wireguard_key() -> Result<(), Error> {
             let mut key_proxy =
                 mullvad_rpc::WireguardKeyProxy::new(rpc_runtime.mullvad_rest_handle());
             key_proxy
-                .remove_wireguard_key(token, &wg_data.private_key.public_key())
+                .remove_wireguard_key(token, wg_data.private_key.public_key())
                 .await
                 .map_err(Error::RemoveKeyError)?;
             settings

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -2,8 +2,11 @@ use clap::{crate_authors, crate_description, crate_name, SubCommand};
 use mullvad_management_interface::new_rpc_client;
 use mullvad_rpc::MullvadRpcRuntime;
 use mullvad_types::version::ParsedAppVersion;
-use std::{path::PathBuf, process};
-use talpid_core::firewall::{self, Firewall, FirewallArguments};
+use std::{path::PathBuf, process, time::Duration};
+use talpid_core::{
+    firewall::{self, Firewall, FirewallArguments},
+    future_retry::{constant_interval, retry_future_n},
+};
 use talpid_types::ErrorExt;
 
 pub const PRODUCT_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
@@ -12,6 +15,9 @@ lazy_static::lazy_static! {
     static ref APP_VERSION: ParsedAppVersion = ParsedAppVersion::from_str(PRODUCT_VERSION).unwrap();
     static ref IS_DEV_BUILD: bool = APP_VERSION.is_dev();
 }
+
+const KEY_RETRY_INTERVAL: Duration = Duration::ZERO;
+const KEY_RETRY_MAX_RETRIES: usize = 2;
 
 #[repr(i32)]
 enum ExitStatus {
@@ -178,10 +184,16 @@ async fn remove_wireguard_key() -> Result<(), Error> {
             .map_err(Error::RpcInitializationError)?;
             let mut key_proxy =
                 mullvad_rpc::WireguardKeyProxy::new(rpc_runtime.mullvad_rest_handle());
-            key_proxy
-                .remove_wireguard_key(token, wg_data.private_key.public_key())
-                .await
-                .map_err(Error::RemoveKeyError)?;
+            retry_future_n(
+                move || {
+                    key_proxy.remove_wireguard_key(token.clone(), wg_data.private_key.public_key())
+                },
+                move |result| result.is_err(),
+                constant_interval(KEY_RETRY_INTERVAL),
+                KEY_RETRY_MAX_RETRIES,
+            )
+            .await
+            .map_err(Error::RemoveKeyError)?;
             settings
                 .set_wireguard(None)
                 .await

--- a/talpid-core/src/future_retry.rs
+++ b/talpid-core/src/future_retry.rs
@@ -5,7 +5,25 @@ use std::{future::Future, time::Duration};
 /// required - run a timer for 60 seconds until a delay is shorter than 5 minutes.
 const MAX_SINGLE_DELAY: Duration = Duration::from_secs(5 * 60);
 
-/// Retries a future until it should stop as determined by the retry function.
+/// Convenience function that works like [`retry_future_with_backoff`] but limits the number
+/// of retries to `max_retries`.
+pub async fn retry_future_n<
+    F: FnMut() -> O + 'static,
+    R: FnMut(&T) -> bool + 'static,
+    D: Iterator<Item = Duration> + 'static,
+    O: Future<Output = T>,
+    T,
+>(
+    factory: F,
+    should_retry: R,
+    delays: D,
+    max_retries: usize,
+) -> T {
+    retry_future_with_backoff(factory, should_retry, delays.take(max_retries)).await
+}
+
+/// Retries a future until it should stop as determined by the retry function, or when
+/// the iterator returns `None`.
 pub async fn retry_future_with_backoff<
     F: FnMut() -> O + 'static,
     R: FnMut(&T) -> bool + 'static,
@@ -22,13 +40,16 @@ pub async fn retry_future_with_backoff<
         if should_retry(&current_result) {
             if let Some(delay) = delays.next() {
                 sleep(delay).await;
-            } else {
-                return current_result;
+                continue;
             }
-        } else {
-            return current_result;
         }
+        return current_result;
     }
+}
+
+/// Returns an iterator that repeats the same interval.
+pub fn constant_interval(interval: Duration) -> impl Iterator<Item = Duration> {
+    std::iter::repeat(interval)
 }
 
 async fn sleep(mut delay: Duration) {

--- a/talpid-core/src/future_retry.rs
+++ b/talpid-core/src/future_retry.rs
@@ -5,7 +5,7 @@ use std::{future::Future, time::Duration};
 /// required - run a timer for 60 seconds until a delay is shorter than 5 minutes.
 const MAX_SINGLE_DELAY: Duration = Duration::from_secs(5 * 60);
 
-/// Convenience function that works like [`retry_future_with_backoff`] but limits the number
+/// Convenience function that works like [`retry_future`] but limits the number
 /// of retries to `max_retries`.
 pub async fn retry_future_n<
     F: FnMut() -> O + 'static,
@@ -19,12 +19,12 @@ pub async fn retry_future_n<
     delays: D,
     max_retries: usize,
 ) -> T {
-    retry_future_with_backoff(factory, should_retry, delays.take(max_retries)).await
+    retry_future(factory, should_retry, delays.take(max_retries)).await
 }
 
 /// Retries a future until it should stop as determined by the retry function, or when
 /// the iterator returns `None`.
-pub async fn retry_future_with_backoff<
+pub async fn retry_future<
     F: FnMut() -> O + 'static,
     R: FnMut(&T) -> bool + 'static,
     D: Iterator<Item = Duration> + 'static,


### PR DESCRIPTION
This primarily affects these account-related RPCs:
* `CreateNewAccount`
* `GetAccountData`
* `GetWwwAuthToken`
* `SubmitVoucher`

In general, a request is sent up to 3 times. On failure, the daemon will use a different endpoint to reach the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2982)
<!-- Reviewable:end -->
