### PR TITLE
Refactor Windows code in `talpid-core`

### DIFF
--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -13,6 +13,10 @@ mod ffi;
 #[cfg(windows)]
 mod winnet;
 
+/// Windows API wrappers and utilities
+#[cfg(target_os = "windows")]
+pub mod windows;
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 /// Working with IP interface devices
 pub mod network_interface;

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -22,9 +22,6 @@ pub mod wireguard;
 /// A module for low level platform specific tunnel device management.
 pub(crate) mod tun_provider;
 
-#[cfg(target_os = "windows")]
-mod windows;
-
 const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
 const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";
 

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -243,7 +243,7 @@ impl WireguardMonitor {
                     use futures::future::FutureExt;
                     use winapi::shared::ifdef::NET_LUID;
                     let luid = NET_LUID { Value: iface_luid };
-                    let setup_future = super::windows::wait_for_interfaces(luid, true, enable_ipv6);
+                    let setup_future = crate::windows::wait_for_interfaces(luid, true, enable_ipv6);
 
                     futures::select! {
                         result = setup_future.fuse() => {


### PR DESCRIPTION
`openvpn` contains far too much Windows-specific code, and `openvpn::windows` is unnecessarily generic. Where possible, this moves code out of `openvpn` into `openvpn::wintun` and `talpid_core::windows`.