### PR TITLE
Prevent multiple reconnects from being scheduled

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1151,12 +1151,16 @@ where
     }
 
     async fn schedule_reconnect(&mut self, delay: Duration) {
+        self.unschedule_reconnect();
+
         let tunnel_command_tx = self.tx.to_specialized_sender();
         let (future, abort_handle) = abortable(Box::pin(async move {
             tokio::time::sleep(delay).await;
             log::debug!("Attempting to reconnect");
-            let (tx, _) = oneshot::channel();
+            let (tx, rx) = oneshot::channel();
             let _ = tunnel_command_tx.send(DaemonCommand::Reconnect(tx));
+            // suppress "unable to send" warning:
+            let _ = rx.await;
         }));
 
         tokio::spawn(future);


### PR DESCRIPTION
`schedule_reconnect` did not abort the previous task, if there was one. Moreover, since the receiver for the reconnect command was (reasonably) dropped, `oneshot_send` logged a warning (`Unable to send reconnect issued to the daemon command sender`) which is now suppressed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2986)
<!-- Reviewable:end -->
