### PR TITLE
CI: suppress verbose output from xcodebuild

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -39,7 +39,9 @@ jobs:
 
             - name: Build and test
               run: |
-                  xcodebuild test -project MullvadVPN.xcodeproj \
+                  xcodebuild test \
+                      -quiet \
+                      -project MullvadVPN.xcodeproj \
                       -scheme MullvadVPNTests \
                       -destination "${destination}" \
                       -clonedSourcePackagesDirPath "${SOURCE_PACKAGES_PATH}" \


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR suppresses an overly verbose output from Xcodebuild that makes it nearly impossible to spot errors in the CI output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2988)
<!-- Reviewable:end -->
