### PR TITLE
Handle early cancellation in operation subclasses

### DIFF
--- a/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
@@ -10,16 +10,13 @@ import Foundation
 
 /// Asynchronous block operation
 class AsyncBlockOperation: AsyncOperation {
-    private let block: ((@escaping () -> Void) -> Void)
+    private let block: ((AsyncBlockOperation) -> Void)
 
-    init(_ block: @escaping (@escaping () -> Void) -> Void) {
+    init(block: @escaping (AsyncBlockOperation) -> Void) {
         self.block = block
-        super.init()
     }
 
     override func main() {
-        block { [weak self] in
-            self?.finish()
-        }
+        block(self)
     }
 }

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -36,15 +36,10 @@ class AsyncOperation: Operation {
     }
 
     final override func start() {
-        stateLock.lock()
-        if _isCancelled {
-            finish()
-            stateLock.unlock()
-        } else {
+        stateLock.withCriticalBlock {
             setExecuting(true)
-            stateLock.unlock()
-            main()
         }
+        main()
     }
 
     override func main() {

--- a/ios/MullvadVPN/Operations/PresentAlertOperation.swift
+++ b/ios/MullvadVPN/Operations/PresentAlertOperation.swift
@@ -26,6 +26,9 @@ class PresentAlertOperation: AsyncOperation {
             // Guard against executing cancellation more than once.
             guard !self.isCancelled else { return }
 
+            // Call super implementation to toggle isCancelled flag
+            super.cancel()
+
             // Guard against trying to dismiss the alert when operation hasn't started yet.
             guard self.isExecuting else { return }
 
@@ -33,14 +36,16 @@ class PresentAlertOperation: AsyncOperation {
             if !self.alertController.isBeingPresented && !self.alertController.isBeingDismissed {
                 self.dismissAndFinish()
             }
-
-            // Call super implementation to toggle isCancelled flag
-            super.cancel()
         }
     }
 
     override func main() {
         DispatchQueue.main.async {
+            guard !self.isCancelled else {
+                self.finish()
+                return
+            }
+
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(self.alertControllerDidDismiss(_:)),

--- a/ios/MullvadVPN/Promise/Promise+OperationQueue.swift
+++ b/ios/MullvadVPN/Promise/Promise+OperationQueue.swift
@@ -13,10 +13,10 @@ extension Promise {
     /// Returns a promise that adds operation that finishes along with the upstream.
     func run(on operationQueue: OperationQueue) -> Promise<Value> {
         return Promise { resolver in
-            let operation = AsyncBlockOperation { finish in
+            let operation = AsyncBlockOperation { operation in
                 self.observe { completion in
                     resolver.resolve(completion: completion)
-                    finish()
+                    operation.finish()
                 }
             }
 
@@ -31,10 +31,10 @@ extension Promise {
     /// Returns a promise that adds a mutually exclusive operation that finishes along with the upstream.
     func run(on operationQueue: OperationQueue, categories: [String]) -> Promise<Value> {
         return Promise { resolver in
-            let operation = AsyncBlockOperation { finish in
+            let operation = AsyncBlockOperation { operation in
                 self.observe { completion in
                     resolver.resolve(completion: completion)
-                    finish()
+                    operation.finish()
                 }
             }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [X] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR changes the former behaviour of `AsyncOperation` subclass, where it used to ignore calling `main()` and `finish()` itself automatically,  if it was cancelled prior to the call to `start()`. 

The new behaviour lays the responsibility of handling early cancellations on `Operation` subclasses.

This is particularly important for operations, that accept a callback and want to provide a guarantee that it will always be called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2989)
<!-- Reviewable:end -->
