### PR TITLE
Use larger buffer for `ReadDirectoryChangesW`

### DIFF
--- a/talpid-core/src/split_tunnel/windows/path_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/path_monitor.rs
@@ -278,7 +278,7 @@ impl DirContext {
         Ok(DirContext {
             path: path.as_ref().to_path_buf(),
             dir_handle,
-            buffer: vec![0u8; 4096],
+            buffer: vec![0u8; 16 * 1024],
             overlapped: Box::pin(unsafe { mem::zeroed() }),
             _io_completion_port: io_completion_port,
         })
@@ -650,7 +650,7 @@ impl PathMonitor {
             ))?;
 
         let changed = if result.bytes_returned == 0 {
-            log::debug!("Change event buffer is empty");
+            log::trace!("Change event buffer is empty");
             false
         } else {
             self.process_file_notification(&self.dir_contexts[ctx_index])?


### PR DESCRIPTION
It's not uncommon for the log to be flooded with these messages:

```
[talpid_core::split_tunnel::imp::path_monitor][DEBUG] Change event buffer is empty
```

This seems to be because the buffer used by the path monitor is too small.

It's not super critical, so I've just enlarged the buffer and changed the log level to `trace`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2991)
<!-- Reviewable:end -->
