### PR TITLE
Fix disappearing in-app notifications after re-login

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -153,7 +153,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             fatalError()
         }
 
-        notificationManager.delegate = connectController?.notificationController
         notificationManager.notificationProviders = [
             AccountExpiryNotificationProvider()
         ]
@@ -245,6 +244,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func makeConnectViewController() -> ConnectViewController {
         let connectController = ConnectViewController()
         connectController.delegate = self
+        notificationManager.delegate = connectController.notificationController
 
         return connectController
     }

--- a/ios/MullvadVPN/NotificationManager.swift
+++ b/ios/MullvadVPN/NotificationManager.swift
@@ -83,6 +83,13 @@ class NotificationManager: NotificationProviderDelegate {
         willSet {
             assert(Thread.isMainThread)
         }
+
+        didSet {
+            // Pump in-app notifications when changing delegate.
+            if !inAppNotificationDescriptors.isEmpty {
+                delegate?.notificationManagerDidUpdateInAppNotifications(self, notifications: inAppNotificationDescriptors)
+            }
+        }
     }
 
     func updateNotifications() {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Fix a bug where `NotificationManager.delegate` was left unset after re-login.
2. Immediately deliver all existing in-app notifications when assigning the `NotificationManager.delegate`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2995)
<!-- Reviewable:end -->
