### PR TITLE
Display tunnel errors in in-app banner

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		5857F24724C882D700CF6F47 /* SelectLocationNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5857F24624C882D700CF6F47 /* SelectLocationNavigationController.swift */; };
 		585834F824D2BC1F00A8AF56 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 585834F724D2BC1F00A8AF56 /* Logging */; };
 		585834FC24D2BC9500A8AF56 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 585834FB24D2BC9500A8AF56 /* Logging */; };
+		585B4B8726D9098900555C4C /* TunnelErrorNotificationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A94AE326CFD945001CB97C /* TunnelErrorNotificationProvider.swift */; };
 		585CA70F25F8C44600B47C62 /* UIMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585CA70E25F8C44600B47C62 /* UIMetrics.swift */; };
 		585DA87726B024A600B8C587 /* CachedRelays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585DA87626B024A600B8C587 /* CachedRelays.swift */; };
 		585DA87A26B024F900B8C587 /* RelayCacheError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585DA87926B024F900B8C587 /* RelayCacheError.swift */; };
@@ -269,7 +270,6 @@
 		58F558FB2696EB1C00F630D0 /* AppStorePaymentManager.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F558F72696EB1C00F630D0 /* AppStorePaymentManager.strings */; };
 		58F558FE2696F09100F630D0 /* KeyboardNavigation.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F558FC2696F09100F630D0 /* KeyboardNavigation.strings */; };
 		58F5590B2697002100F630D0 /* CustomDateComponentsFormatting.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F558FF2697002000F630D0 /* CustomDateComponentsFormatting.strings */; };
-		58F5590C2697002100F630D0 /* AppDelegate.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F559012697002000F630D0 /* AppDelegate.strings */; };
 		58F5590D2697002100F630D0 /* AccountInput.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F559032697002000F630D0 /* AccountInput.strings */; };
 		58F5590E2697002100F630D0 /* Main.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F559052697002000F630D0 /* Main.strings */; };
 		58F5590F2697002100F630D0 /* ConnectionPanel.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F559072697002100F630D0 /* ConnectionPanel.strings */; };
@@ -449,6 +449,7 @@
 		589AB4F6227B64450039131E /* BasicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTableViewCell.swift; sourceTree = "<group>"; };
 		58A1AA8623F43901009F7EA6 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		58A1AA8B23F5584B009F7EA6 /* ConnectionPanelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionPanelView.swift; sourceTree = "<group>"; };
+		58A94AE326CFD945001CB97C /* TunnelErrorNotificationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelErrorNotificationProvider.swift; sourceTree = "<group>"; };
 		58A94AE526D23C3D001CB97C /* PromiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseTests.swift; sourceTree = "<group>"; };
 		58A99ED2240014A0006599E9 /* ConsentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentViewController.swift; sourceTree = "<group>"; };
 		58ACF6482655365700ACE4B7 /* PreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
@@ -518,7 +519,6 @@
 		58F558F82696EB1C00F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AppStorePaymentManager.strings; sourceTree = "<group>"; };
 		58F558FD2696F09100F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/KeyboardNavigation.strings; sourceTree = "<group>"; };
 		58F559002697002000F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/CustomDateComponentsFormatting.strings; sourceTree = "<group>"; };
-		58F559022697002000F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AppDelegate.strings; sourceTree = "<group>"; };
 		58F559042697002000F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AccountInput.strings; sourceTree = "<group>"; };
 		58F559062697002000F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		58F559082697002100F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ConnectionPanel.strings; sourceTree = "<group>"; };
@@ -636,7 +636,6 @@
 			children = (
 				581FC4F82695ACE100AA97BA /* Account.strings */,
 				58F559032697002000F630D0 /* AccountInput.strings */,
-				58F559012697002000F630D0 /* AppDelegate.strings */,
 				58F558F72696EB1C00F630D0 /* AppStorePaymentManager.strings */,
 				582CFEE526945FC30072883A /* AppStoreSubscriptions.strings */,
 				58F559072697002100F630D0 /* ConnectionPanel.strings */,
@@ -728,6 +727,7 @@
 			isa = PBXGroup;
 			children = (
 				587B75402668FD7700DEF7E9 /* AccountExpiryNotificationProvider.swift */,
+				58A94AE326CFD945001CB97C /* TunnelErrorNotificationProvider.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -1162,7 +1162,6 @@
 				58F5590B2697002100F630D0 /* CustomDateComponentsFormatting.strings in Resources */,
 				58F5590E2697002100F630D0 /* Main.strings in Resources */,
 				58F558FE2696F09100F630D0 /* KeyboardNavigation.strings in Resources */,
-				58F5590C2697002100F630D0 /* AppDelegate.strings in Resources */,
 				581FC4FA2695ACE100AA97BA /* Account.strings in Resources */,
 				58F558EC2695D26A00F630D0 /* RESTClient.strings in Resources */,
 				582CFEEA269463B80072883A /* Settings.strings in Resources */,
@@ -1324,6 +1323,7 @@
 				581503A124D6F01F00C9C50E /* LogRotation.swift in Sources */,
 				58B8743222B25A7600015324 /* WireguardAssociatedAddresses.swift in Sources */,
 				5820676426E771DB00655B05 /* TunnelManagerError.swift in Sources */,
+				585B4B8726D9098900555C4C /* TunnelErrorNotificationProvider.swift in Sources */,
 				5846226726E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */,
 				5850368C25A49E2200A43E93 /* PrivateKeyWithMetadata.swift in Sources */,
 				58B67B482602079E008EF58E /* RelaySelector.swift in Sources */,
@@ -1617,14 +1617,6 @@
 				58F559002697002000F630D0 /* en */,
 			);
 			name = CustomDateComponentsFormatting.strings;
-			sourceTree = "<group>";
-		};
-		58F559012697002000F630D0 /* AppDelegate.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				58F559022697002000F630D0 /* en */,
-			);
-			name = AppDelegate.strings;
 			sourceTree = "<group>";
 		};
 		58F559032697002000F630D0 /* AccountInput.strings */ = {

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -154,7 +154,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         notificationManager.notificationProviders = [
-            AccountExpiryNotificationProvider()
+            AccountExpiryNotificationProvider(),
+            TunnelErrorNotificationProvider()
         ]
         notificationManager.updateNotifications()
 

--- a/ios/MullvadVPN/Notifications/TunnelErrorNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/TunnelErrorNotificationProvider.swift
@@ -1,0 +1,58 @@
+//
+//  TunnelErrorNotificationProvider.swift
+//  TunnelErrorNotificationProvider
+//
+//  Created by pronebird on 20/08/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+class TunnelErrorNotificationProvider: NotificationProvider, InAppNotificationProvider, TunnelObserver {
+    override var identifier: String {
+        return "net.mullvad.MullvadVPN.TunnelErrorNotificationProvider"
+    }
+
+    var notificationDescriptor: InAppNotificationDescriptor? {
+        guard let lastError = lastError else { return nil }
+
+        return InAppNotificationDescriptor(
+            identifier: identifier,
+            style: .error,
+            title: NSLocalizedString("TUNNEL_ERROR_INAPP_NOTIFICATION_TITLE", comment: ""),
+            body: lastError.errorChainDescription ?? "No error description provided."
+        )
+    }
+
+    private var lastError: TunnelManager.Error?
+
+    override init() {
+        super.init()
+
+        TunnelManager.shared.addObserver(self)
+    }
+
+    func tunnelManager(_ manager: TunnelManager, didUpdateTunnelState tunnelState: TunnelState) {
+        // Reset error with each new connection attempt
+        if case .connecting = tunnelState {
+            lastError = nil
+        }
+
+        // Tell manager to refresh displayed notifications
+        invalidate()
+    }
+
+    func tunnelManager(_ manager: TunnelManager, didUpdateTunnelSettings tunnelInfo: TunnelInfo?) {
+        // no-op
+    }
+
+    func tunnelManager(_ manager: TunnelManager, didFailWithError error: TunnelManager.Error) {
+        // Save tunnel error
+        lastError = error
+
+        // Tell manager to refresh displayed notifications
+        invalidate()
+    }
+
+
+}

--- a/ios/MullvadVPN/en.lproj/AppDelegate.strings
+++ b/ios/MullvadVPN/en.lproj/AppDelegate.strings
@@ -1,8 +1,0 @@
-/* No comment provided by engineer. */
-"START_VPN_TUNNEL_ERROR_ALERT_TITLE" = "Failed to start the VPN tunnel";
-
-/* No comment provided by engineer. */
-"STOP_VPN_TUNNEL_ERROR_ALERT_TITLE" = "Failed to stop the VPN tunnel";
-
-/* Dismiss button in tunnel error alert. */
-"TUNNEL_ERROR_ALERT_OK_BUTTON" = "OK";

--- a/ios/MullvadVPN/en.lproj/Localizable.strings
+++ b/ios/MullvadVPN/en.lproj/Localizable.strings
@@ -9,3 +9,6 @@
 
 /* Title for system account expiry notification, fired 3 days prior to account expiry. */
 "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE" = "Account credit expires soon";
+
+/* No comment provided by engineer. */
+"TUNNEL_ERROR_INAPP_NOTIFICATION_TITLE" = "Tunnel error";


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Previously we used to display modal system alerts for simplicity and this functionality has been removed in one of the recent PRs. 

This PR moves the errors associated with starting or stopping the tunnel into the in-app banner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2996)
<!-- Reviewable:end -->
