### PR TITLE
Disable sandbox on Ubuntu 21.10

### DIFF
--- a/dist-assets/linux/mullvad-gui-launcher.sh
+++ b/dist-assets/linux/mullvad-gui-launcher.sh
@@ -4,6 +4,10 @@ set -eu
 UNPRIVILEGED_USERNS_PATH="/proc/sys/kernel/unprivileged_userns_clone"
 if [ -e $UNPRIVILEGED_USERNS_PATH ] && grep -q 0 $UNPRIVILEGED_USERNS_PATH; then
     SANDBOX_FLAG="--no-sandbox"
+elif command -v lsb_release > /dev/null && \
+    [[ "$(lsb_release -i | awk -F : '{print $2}' | xargs echo)" == "Ubuntu" ]] && \
+    [[ "$(lsb_release -r | awk -F : '{print $2}' | xargs echo)" == "21.10" ]]; then
+    SANDBOX_FLAG="--no-sandbox"
 else
     SANDBOX_FLAG=""
 fi


### PR DESCRIPTION
This PR disables the Electron renderer sandbox on Ubuntu 21.10 since it doesn't work. After upgrading to Electron 15 this workaround will no longer be needed.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2997)
<!-- Reviewable:end -->
