### PR TITLE
Fix potential race when initializing interfaces/addresses in the ST driver

### DIFF
--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -434,52 +434,29 @@ impl SplitTunnel {
             }
         }
 
-        // Identify IP address that gives us Internet access
-        let internet_ipv4 = get_best_default_route(WinNetAddrFamily::IPV4)
-            .map_err(Error::ObtainDefaultRoute)?
-            .map(|route| interface_luid_to_ip(WinNetAddrFamily::IPV4, route.interface_luid))
-            .transpose()
-            .map_err(Error::LuidToIp)?
-            .flatten();
-        let internet_ipv6 = get_best_default_route(WinNetAddrFamily::IPV6)
-            .map_err(Error::ObtainDefaultRoute)?
-            .map(|route| interface_luid_to_ip(WinNetAddrFamily::IPV6, route.interface_luid))
-            .transpose()
-            .map_err(Error::LuidToIp)?
-            .flatten();
-
         let tunnel_ipv4 = Some(tunnel_ipv4.unwrap_or(RESERVED_IP_V4));
-        let internet_ipv4 = internet_ipv4
-            .map(|addr| Ipv4Addr::try_from(addr).map_err(|_| Error::IpParseError))
-            .transpose()?;
-        let internet_ipv6 = internet_ipv6
-            .map(|addr| Ipv6Addr::try_from(addr).map_err(|_| Error::IpParseError))
-            .transpose()?;
+        let context_mutex = Arc::new(Mutex::new(
+            SplitTunnelDefaultRouteChangeHandlerContext::new(
+                self.request_tx.clone(),
+                self.daemon_tx.clone(),
+                tunnel_ipv4,
+                tunnel_ipv6,
+            ),
+        ));
 
-        let context = SplitTunnelDefaultRouteChangeHandlerContext::new(
-            self.request_tx.clone(),
-            self.daemon_tx.clone(),
-            tunnel_ipv4,
-            tunnel_ipv6,
-            internet_ipv4,
-            internet_ipv6,
-        );
 
         self._route_change_callback = None;
-
-        self.send_request(Request::RegisterIps(
-            tunnel_ipv4,
-            tunnel_ipv6,
-            internet_ipv4,
-            internet_ipv6,
-        ))?;
-
-        self._route_change_callback = winnet::add_default_route_change_callback(
+        let mut context = context_mutex.lock().unwrap();
+        let callback = winnet::add_default_route_change_callback(
             Some(split_tunnel_default_route_change_handler),
-            context,
+            context_mutex.clone(),
         )
         .map(Some)
         .map_err(|_| Error::RegisterRouteChangeCallback)?;
+
+        context.initialize_internet_addresses()?;
+        context.register_ips()?;
+        self._route_change_callback = callback;
 
         Ok(())
     }
@@ -526,16 +503,14 @@ impl SplitTunnelDefaultRouteChangeHandlerContext {
         daemon_tx: Weak<mpsc::UnboundedSender<TunnelCommand>>,
         tunnel_ipv4: Option<Ipv4Addr>,
         tunnel_ipv6: Option<Ipv6Addr>,
-        internet_ipv4: Option<Ipv4Addr>,
-        internet_ipv6: Option<Ipv6Addr>,
     ) -> Self {
         SplitTunnelDefaultRouteChangeHandlerContext {
             request_tx,
             daemon_tx,
             tunnel_ipv4,
             tunnel_ipv6,
-            internet_ipv4,
-            internet_ipv6,
+            internet_ipv4: None,
+            internet_ipv6: None,
         }
     }
 
@@ -550,6 +525,30 @@ impl SplitTunnelDefaultRouteChangeHandlerContext {
             ),
         )
     }
+
+    pub fn initialize_internet_addresses(&mut self) -> Result<(), Error> {
+        // Identify IP address that gives us Internet access
+        let internet_ipv4 = get_best_default_route(WinNetAddrFamily::IPV4)
+            .map_err(Error::ObtainDefaultRoute)?
+            .map(|route| interface_luid_to_ip(WinNetAddrFamily::IPV4, route.interface_luid))
+            .transpose()
+            .map_err(Error::LuidToIp)?
+            .flatten();
+        let internet_ipv6 = get_best_default_route(WinNetAddrFamily::IPV6)
+            .map_err(Error::ObtainDefaultRoute)?
+            .map(|route| interface_luid_to_ip(WinNetAddrFamily::IPV6, route.interface_luid))
+            .transpose()
+            .map_err(Error::LuidToIp)?
+            .flatten();
+
+        self.internet_ipv4 = internet_ipv4
+            .map(|addr| Ipv4Addr::try_from(addr).map_err(|_| Error::IpParseError))
+            .transpose()?;
+        self.internet_ipv6 = internet_ipv6
+            .map(|addr| Ipv6Addr::try_from(addr).map_err(|_| Error::IpParseError))
+            .transpose()?;
+        Ok(())
+    }
 }
 
 unsafe extern "system" fn split_tunnel_default_route_change_handler(
@@ -559,7 +558,8 @@ unsafe extern "system" fn split_tunnel_default_route_change_handler(
     ctx: *mut libc::c_void,
 ) {
     // Update the "internet interface" IP when best default route changes
-    let ctx = &mut *(ctx as *mut SplitTunnelDefaultRouteChangeHandlerContext);
+    let ctx_mutex = &mut *(ctx as *mut Arc<Mutex<SplitTunnelDefaultRouteChangeHandlerContext>>);
+    let mut ctx = ctx_mutex.lock().expect("ST route handler mutex poisoned");
 
     let daemon_tx = ctx.daemon_tx.upgrade();
     let maybe_send = move |content| {

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -570,7 +570,7 @@ unsafe extern "system" fn split_tunnel_default_route_change_handler(
 
     let result = match event_type {
         winnet::WinNetDefaultRouteChangeEventType::DefaultRouteChanged => {
-            match interface_luid_to_ip(address_family.clone(), default_route.interface_luid) {
+            match interface_luid_to_ip(address_family, default_route.interface_luid) {
                 Ok(Some(ip)) => match IpAddr::from(ip) {
                     IpAddr::V4(addr) => ctx.internet_ipv4 = Some(addr),
                     IpAddr::V6(addr) => ctx.internet_ipv6 = Some(addr),

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -86,7 +86,7 @@ pub fn ensure_best_metric_for_interface(interface_alias: &str) -> Result<bool, E
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 #[repr(u32)]
 pub enum WinNetAddrFamily {


### PR DESCRIPTION
Previously, route changes _could_ occur after the initial interfaces had been registered with the driver but before the default route change callback was created. To fix this, the callback is now created before the initial interfaces have been set, but a mutex prevents any change event from being handled until `set_tunnel_addresses` has returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/2999)
<!-- Reviewable:end -->
