### PR TITLE
Migrate from JCenter to mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,8 +124,8 @@ play {
 }
 
 repositories {
-    jcenter()
     google()
+    mavenCentral()
 }
 
 dependencies {
@@ -142,18 +142,18 @@ dependencies {
     implementation "joda-time:joda-time:2.10.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3"
-    implementation "org.koin:koin-core:$koinVersion"
-    implementation "org.koin:koin-core-ext:$koinVersion"
-    implementation "org.koin:koin-androidx-fragment:$koinVersion"
-    implementation "org.koin:koin-androidx-scope:$koinVersion"
-    implementation "org.koin:koin-androidx-viewmodel:$koinVersion"
+    implementation "io.insert-koin:koin-core:$koinVersion"
+    implementation "io.insert-koin:koin-core-ext:$koinVersion"
+    implementation "io.insert-koin:koin-androidx-fragment:$koinVersion"
+    implementation "io.insert-koin:koin-androidx-scope:$koinVersion"
+    implementation "io.insert-koin:koin-androidx-viewmodel:$koinVersion"
 
     /* Test dependencies */
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3"
-    testImplementation "org.koin:koin-test:$koinVersion"
+    testImplementation "io.insert-koin:koin-test:$koinVersion"
 
     /* UI test dependencies */
     debugImplementation "androidx.fragment:fragment-testing:$fragmentVersion"
@@ -161,7 +161,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
     androidTestImplementation "androidx.test.ext:junit:1.1.2"
     androidTestImplementation "io.mockk:mockk-android:$mockkVersion"
-    androidTestImplementation "org.koin:koin-test:$koinVersion"
+    androidTestImplementation "io.insert-koin:koin-test:$koinVersion"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     // debugImplementation because LeakCanary should only run in debug builds.
     // debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
@@ -173,11 +173,11 @@ buildscript {
         fragmentVersion = "1.3.2"
         koinVersion = '2.2.2'
         kotlinVersion = '1.4.31'
-        mockkVersion = '1.10.6'
+        mockkVersion = '1.12.0'
     }
     repositories {
-        jcenter()
         google()
+        mavenCentral()
 
         maven {
             url "https://plugins.gradle.org/m2/"

--- a/android/src/androidTest/AndroidManifest.xml
+++ b/android/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="net.mullvad.mullvadvpn.test">
+
+    <!-- Required on certain Android versions and/or ABIs
+    https://github.com/mockk/mockk/issues/297#issuecomment-641361770 -->
+    <application android:extractNativeLibs="true" />
+</manifest>


### PR DESCRIPTION
JCenter has been sunset and should no longer be relied on as per:
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

The migration also required the following changes:
* Updated Koin maven group id as per the official documentation at:
  https://insert-koin.io/docs/setup/v2/
* Bump MockK version due to old versions of one of its dependencies'
  (dexmaker) not being available at mavenCentral.
* Fix mockK instrumentation lib issue.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **SKIPPED**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3006)
<!-- Reviewable:end -->
