### PR TITLE
Adapt account controller

### DIFF
--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -206,8 +206,8 @@ class AccountViewController: UIViewController, AppStorePaymentObserver, AccountO
     }
 
     private func showTimeAddedConfirmationAlert(
-        with response: CreateApplePaymentResponse,
-        context: CreateApplePaymentResponse.Context)
+        with response: REST.CreateApplePaymentResponse,
+        context: REST.CreateApplePaymentResponse.Context)
     {
         let alertController = UIAlertController(
             title: response.alertTitle(context: context),
@@ -461,7 +461,7 @@ class AccountViewController: UIViewController, AppStorePaymentObserver, AccountO
 
 }
 
-private extension CreateApplePaymentResponse {
+private extension REST.CreateApplePaymentResponse {
 
     enum Context {
         case purchase
@@ -515,7 +515,7 @@ private extension CreateApplePaymentResponse {
                         value: "%@ have been added to your account",
                         comment: "Message displayed upon successful restoration of existing purchases, containing the time duration credited to user account. Use %@ placeholder to position the localized text with duration added (i.e '30 days')"
                     ),
-                    self.formattedTimeAdded ?? ""
+                    formattedTimeAdded ?? ""
                 )
             }
         }

--- a/ios/MullvadVPN/AccountViewController.swift
+++ b/ios/MullvadVPN/AccountViewController.swift
@@ -342,43 +342,39 @@ class AccountViewController: UIViewController, AppStorePaymentObserver, AccountO
     // MARK: - AppStorePaymentObserver
 
     func appStorePaymentManager(_ manager: AppStorePaymentManager, transaction: SKPaymentTransaction, accountToken: String?, didFailWithError error: AppStorePaymentManager.Error) {
-        DispatchQueue.main.async {
-            let alertController = UIAlertController(
+        let alertController = UIAlertController(
+            title: NSLocalizedString(
+                "CANNOT_COMPLETE_PURCHASE_ALERT_TITLE",
+                tableName: "Account",
+                value: "Cannot complete the purchase",
+                comment: "Title for purchase failure dialog"
+            ),
+            message: error.errorChainDescription,
+            preferredStyle: .alert
+        )
+
+        alertController.addAction(
+            UIAlertAction(
                 title: NSLocalizedString(
-                    "CANNOT_COMPLETE_PURCHASE_ALERT_TITLE",
+                    "CANNOT_COMPLETE_PURCHASE_ALERT_OK_ACTION",
                     tableName: "Account",
-                    value: "Cannot complete the purchase",
-                    comment: "Title for purchase failure dialog"
-                ),
-                message: error.errorChainDescription,
-                preferredStyle: .alert
-            )
+                    value: "OK",
+                    comment: "Title for OK button in purchase failure dialog"
+                ), style: .cancel)
+        )
 
-            alertController.addAction(
-                UIAlertAction(
-                    title: NSLocalizedString(
-                        "CANNOT_COMPLETE_PURCHASE_ALERT_OK_ACTION",
-                        tableName: "Account",
-                        value: "OK",
-                        comment: "Title for OK button in purchase failure dialog"
-                    ), style: .cancel)
-            )
+        alertPresenter.enqueue(alertController, presentingController: self)
 
-            self.alertPresenter.enqueue(alertController, presentingController: self)
-
-            if transaction.payment == self.pendingPayment {
-                self.compoundInteractionRestriction.decrease(animated: true)
-            }
+        if transaction.payment == pendingPayment {
+            compoundInteractionRestriction.decrease(animated: true)
         }
     }
 
-    func appStorePaymentManager(_ manager: AppStorePaymentManager, transaction: SKPaymentTransaction, accountToken: String, didFinishWithResponse response: CreateApplePaymentResponse) {
-        DispatchQueue.main.async {
-            self.showTimeAddedConfirmationAlert(with: response, context: .purchase)
+    func appStorePaymentManager(_ manager: AppStorePaymentManager, transaction: SKPaymentTransaction, accountToken: String, didFinishWithResponse response: REST.CreateApplePaymentResponse) {
+        showTimeAddedConfirmationAlert(with: response, context: .purchase)
 
-            if transaction.payment == self.pendingPayment {
-                self.compoundInteractionRestriction.decrease(animated: true)
-            }
+        if transaction.payment == self.pendingPayment {
+            compoundInteractionRestriction.decrease(animated: true)
         }
     }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR introduces a couple of adjustments to the `AccountViewController`:

1. Adapt to using new promise based `AppStorePaymentObserver ` API.
2. Adapt to new `REST` types structure.
3. Stop re-dispatching all calls to `AppStorePaymentObserver` on main queue, since `AppStorePaymentObserver ` guarantees to call all delegate methods on main queue.
4. Use `Promise.delay()` instead of `DispatchQueue.asyncAfter`.
5. Adapt to using new `Account.logout()`  interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3007)
<!-- Reviewable:end -->
