### PR TITLE
Make sure time since key was generated is positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Line wrap the file at 100 chars.                                              Th
 - Improve responsiveness of the controls and status text in the main view in the desktop app.
 - Read macOS scrollbar visibility settings to decide wheter or not the scrollbars should hide when
   not scrolling.
+- Fix desktop app showing a future date for when WireGuard key was generated.
 
 #### Linux
 - Make offline monitor aware of routing table changes.

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -279,7 +279,8 @@ export default class WireguardKeys extends React.Component<IProps, IState> {
     switch (keyState.type) {
       case 'key-set':
       case 'being-verified': {
-        return formatRelativeDate(new Date(), keyState.key.created, true);
+        const createdDate = Math.min(Date.parse(keyState.key.created), Date.now());
+        return formatRelativeDate(new Date(), createdDate, true);
       }
       default:
         return '-';

--- a/gui/src/shared/date-helper.ts
+++ b/gui/src/shared/date-helper.ts
@@ -1,7 +1,7 @@
 import { sprintf } from 'sprintf-js';
 import { messages } from './gettext';
 
-export type DateType = Date | string;
+export type DateType = Date | string | number;
 
 export enum DateComponent {
   day,


### PR DESCRIPTION
This PR fixes a bug where the app said that a WireGuard key was generated "less than a day left". This was solved by making sure that the key generated date can't be in the future.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3009)
<!-- Reviewable:end -->
