### PR TITLE
Disable Electron sandbox on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Line wrap the file at 100 chars.                                              Th
 - Disable DNS over TLS for tunnel's DNS config when using systemd-resolved.
 - Fix DNS when combining a static resolv.conf with ad blocking DNS.
 - Check connectivity correctly on IPv6-only networks.
+- Disable Electron renderer sandbox to make app work with newer versions of glibc.
 
 #### Windows
 - Fix failure to restart the daemon when resuming from "fast startup" hibernation.

--- a/dist-assets/linux/mullvad-gui-launcher.sh
+++ b/dist-assets/linux/mullvad-gui-launcher.sh
@@ -4,13 +4,11 @@ set -eu
 UNPRIVILEGED_USERNS_PATH="/proc/sys/kernel/unprivileged_userns_clone"
 if [ -e $UNPRIVILEGED_USERNS_PATH ] && grep -q 0 $UNPRIVILEGED_USERNS_PATH; then
     SANDBOX_FLAG="--no-sandbox"
-elif command -v lsb_release > /dev/null && \
-    [[ "$(lsb_release -i | awk -F : '{print $2}' | xargs echo)" == "Ubuntu" ]] && \
-    [[ "$(lsb_release -r | awk -F : '{print $2}' | xargs echo)" == "21.10" ]]; then
+elif [[ "$OSTYPE" == "linux"* ]]; then
     SANDBOX_FLAG="--no-sandbox"
 else
     SANDBOX_FLAG=""
 fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-exec "$SCRIPT_DIR/mullvad-gui" $SANDBOX_FLAG "$@"
+exec "$SCRIPT_DIR/mullvad-gui" "$SANDBOX_FLAG" "$@"


### PR DESCRIPTION
This PR disables the Electron sandbox on Linux

Recently the Electron sandbox was disabled on Ubuntu 21.10 beta since it
didn't work in combination with newer versions of glibc. This issue is
present in beta versions of Fedora and Kubuntu as well. This is planned
to be reverted in 2021.6 since the upgrade to Electron 15 also fixes
this issue.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3010)
<!-- Reviewable:end -->
