### PR TITLE
Prevent app from showing when dragging icon on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix initial state of Split tunneling excluded apps list. Previously it was not notified the daemon
 properly after initialization.
 
+#### macOS
+- Prevent app from showing when dragging tray icon on macOS.
+
 ## [2021.4] - 2021-06-30
 This release is for desktop only.
 

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1932,17 +1932,21 @@ class ApplicationMain {
       }
       this.tray?.on('click', () => this.windowController?.show());
     } else {
-      this.tray?.on('click', () => {
-        const isMacOsBigSur = process.platform === 'darwin' && parseInt(os.release(), 10) >= 20;
-        if (isMacOsBigSur && !this.windowController?.isVisible()) {
-          // This is a workaround for this Electron issue, when it's resolved
-          // `this.windowController?.toggle()` should do the trick on all platforms:
-          // https://github.com/electron/electron/issues/28776
-          const contextMenu = Menu.buildFromTemplate([]);
-          contextMenu.on('menu-will-show', () => this.windowController?.show());
-          this.tray?.popUpContextMenu(contextMenu);
-        } else {
-          this.windowController?.toggle();
+      this.tray?.on('click', (event) => {
+        // The app shouldn't become visible if the user is reordering the tray icons on macOS. The
+        // tray icon becomes draggable when holding the command key (meta).
+        if (process.platform !== 'darwin' || !event.metaKey) {
+          const isMacOsBigSur = process.platform === 'darwin' && parseInt(os.release(), 10) >= 20;
+          if (isMacOsBigSur && !this.windowController?.isVisible()) {
+            // This is a workaround for this Electron issue, when it's resolved
+            // `this.windowController?.toggle()` should do the trick on all platforms:
+            // https://github.com/electron/electron/issues/28776
+            const contextMenu = Menu.buildFromTemplate([]);
+            contextMenu.on('menu-will-show', () => this.windowController?.show());
+            this.tray?.popUpContextMenu(contextMenu);
+          } else {
+            this.windowController?.toggle();
+          }
         }
       });
       this.tray?.on('right-click', () => this.windowController?.hide());


### PR DESCRIPTION
This PR prevents the app from showing when dragging the tray icon on macOS.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3011)
<!-- Reviewable:end -->
