### PR TITLE
Promise: add doNotPropagateCancellation()

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -215,6 +215,7 @@ class TunnelManager {
             .schedule(on: stateQueue)
             .run(on: operationQueue, categories: [OperationCategory.manageTunnelProvider, OperationCategory.changeTunnelSettings])
             .requestBackgroundTime(taskName: "TunnelManager.loadAccount")
+            .doNotPropagateCancellation()
     }
 
     func startTunnel() {
@@ -342,6 +343,7 @@ class TunnelManager {
             .schedule(on: stateQueue)
             .run(on: operationQueue, categories: [OperationCategory.manageTunnelProvider, OperationCategory.changeTunnelSettings])
             .requestBackgroundTime(taskName: "TunnelManager.setAccount")
+            .doNotPropagateCancellation()
     }
 
     /// Remove the account token and remove the active tunnel
@@ -404,6 +406,7 @@ class TunnelManager {
             .schedule(on: stateQueue)
             .run(on: operationQueue, categories: [OperationCategory.manageTunnelProvider, OperationCategory.changeTunnelSettings])
             .requestBackgroundTime(taskName: "TunnelManager.unsetAccount")
+            .doNotPropagateCancellation()
     }
 
     func regeneratePrivateKey() -> Result<(), TunnelManager.Error>.Promise {
@@ -430,6 +433,7 @@ class TunnelManager {
             .schedule(on: stateQueue)
             .run(on: operationQueue, categories: [OperationCategory.changeTunnelSettings])
             .requestBackgroundTime(taskName: "TunnelManager.regeneratePrivateKey")
+            .doNotPropagateCancellation()
     }
 
     func rotatePrivateKey() -> Result<KeyRotationResult, TunnelManager.Error>.Promise {
@@ -461,6 +465,7 @@ class TunnelManager {
             .schedule(on: stateQueue)
             .run(on: operationQueue, categories: [OperationCategory.changeTunnelSettings])
             .requestBackgroundTime(taskName: "TunnelManager.rotatePrivateKey")
+            .doNotPropagateCancellation()
     }
 
     func setRelayConstraints(_ newConstraints: RelayConstraints) -> Result<(), TunnelManager.Error>.Promise {
@@ -479,6 +484,7 @@ class TunnelManager {
             .schedule(on: stateQueue)
             .run(on: operationQueue, categories: [OperationCategory.changeTunnelSettings])
             .requestBackgroundTime(taskName: "TunnelManager.setRelayConstraints")
+            .doNotPropagateCancellation()
     }
 
     func setDNSSettings(_ newDNSSettings: DNSSettings) -> Result<(), TunnelManager.Error>.Promise {
@@ -497,6 +503,7 @@ class TunnelManager {
             .schedule(on: stateQueue)
             .run(on: operationQueue, categories: [OperationCategory.changeTunnelSettings])
             .requestBackgroundTime(taskName: "TunnelManager.setDNSSettings")
+            .doNotPropagateCancellation()
     }
 
     // MARK: - Tunnel observeration

--- a/ios/MullvadVPNTests/PromiseTests.swift
+++ b/ios/MullvadVPNTests/PromiseTests.swift
@@ -295,38 +295,4 @@ class PromiseTests: XCTestCase {
         wait(for: [expectCancelHandler, expectResolve, expectObserve], timeout: 1, enforceOrder: true)
     }
 
-    func testShouldNotPropagateCancellation() {
-        let expectParentCancel = expectation(description: "Parent cancellation handler should never trigger")
-        expectParentCancel.isInverted = true
-
-        let expectChildCompletion = expectation(description: "Wait for child to complete")
-
-        let parent = Promise<Int> { resolver in
-            resolver.setCancelHandler {
-                expectParentCancel.fulfill()
-            }
-
-            DispatchQueue.main.async {
-                resolver.resolve(value: 1)
-            }
-        }
-
-        let child = Promise<Int>(parent: parent) { resolver in
-            parent.observe { completion in
-                resolver.resolve(completion: completion)
-            }
-        }
-
-        _ = child.setShouldPropagateCancellation(false)
-
-        child.observe { completion in
-            XCTAssertEqual(completion, .cancelled)
-            expectChildCompletion.fulfill()
-        }
-
-        child.cancel()
-
-        wait(for: [expectParentCancel, expectChildCompletion], timeout: 1)
-    }
-
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add `doNotPropagateCancellation()` helper that returns a `Promise` that does not propagate cancellation to the parent and instead awaits the parent to complete before passing `.cancelled` to observers.
2. Use `doNotPropagateCancellation()` in critical parts of the `TunnelManager`, especially where we push new key and then save it to Keychain, these kinds of operations should execute as transactions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3012)
<!-- Reviewable:end -->
