### PR TITLE
Fix reconnect on app resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix erasing wireguard MTU value in some scenarious.
 - Fix initial state of Split tunneling excluded apps list. Previously it was not notified the daemon
 properly after initialization.
+- Fix reconnect on app resume.
 
 #### macOS
 - Prevent app from showing when dragging tray icon on macOS.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SplitTunneling.kt
@@ -9,9 +9,11 @@ import net.mullvad.talpid.util.EventNotifier
 class SplitTunneling(persistence: SplitTunnelingPersistence, endpoint: ServiceEndpoint) {
     private val excludedApps = persistence.excludedApps.toMutableSet()
 
-    private var enabled by observable(persistence.enabled) { _, _, isEnabled ->
-        persistence.enabled = isEnabled
-        update()
+    private var enabled by observable(persistence.enabled) { _, wasEnabled, isEnabled ->
+        if (wasEnabled != isEnabled) {
+            persistence.enabled = isEnabled
+            update()
+        }
     }
 
     val onChange = EventNotifier<List<String>?>(excludedApps.toList())


### PR DESCRIPTION
Fixes an issue with the app automatically reconnecting
each time it's resumed from the background.

The issue was caused by the app and service being out-of-sync
in terms of split tunneling state during app resume, which was
fixed by comparing the new and old state in the service before
notifying other components.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3016)
<!-- Reviewable:end -->
