### PR TITLE
Switch to connecting state when receiving reconnect disconnecting event

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -737,7 +737,12 @@ export default class AppRenderer {
         break;
 
       case 'disconnecting':
-        actions.connection.disconnecting(tunnelState.details);
+        if (tunnelState.details === 'reconnect') {
+          this.optimisticTunnelState = 'connecting';
+          this.reduxActions.connection.connecting();
+        } else {
+          actions.connection.disconnecting(tunnelState.details);
+        }
         break;
 
       case 'disconnected':
@@ -750,7 +755,9 @@ export default class AppRenderer {
     }
 
     // Update the location when entering a new tunnel state since it's likely changed.
-    void this.updateLocation();
+    void this.updateLocation(
+      this.optimisticTunnelState === undefined ? undefined : { state: this.optimisticTunnelState },
+    );
   }
 
   private setSettings(newSettings: ISettings) {


### PR DESCRIPTION
This PR makes the renderer process handle the `disconnect(reconnect)` tunnel state event as a `connecting` event.

When the disconnecting event is received with "reconnect"  in `details`
we want the app to act like it's already reconnecting to prevent it from
showing the disconnecting state.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3018)
<!-- Reviewable:end -->
