### PR TITLE
Clarify custom dns hint

### DIFF
--- a/android/src/main/res/layout/edit_custom_dns_server.xml
+++ b/android/src/main/res/layout/edit_custom_dns_server.xml
@@ -17,7 +17,7 @@
               android:textColorHint="@color/blue60"
               android:textColor="@color/blue"
               android:textSize="@dimen/text_medium"
-              android:hint="@string/custom_dns_example" />
+              android:hint="@string/custom_dns_hint" />
     <ImageButton android:id="@+id/save"
                  android:layout_width="wrap_content"
                  android:layout_height="match_parent"

--- a/android/src/main/res/values-da/strings.xml
+++ b/android/src/main/res/values-da/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Opretter konto...</string>
     <string name="creating_secure_connection">OPRETTER SIKKER FORBINDELSE</string>
     <string name="critical_error">Kritisk fejl (som kræver din opmærksomhed)</string>
-    <string name="custom_dns_example">f.eks. 10.0.0.4</string>
     <string name="custom_dns_footer">Aktiver for at tilføje mindst én DNS-server.</string>
+    <string name="custom_dns_hint">Indtast IP</string>
     <string name="custom_tunnel_host_resolution_error">Kunne ikke fortolke værtsnavnet på den tilpassede server</string>
     <string name="disconnect">Afbryd forbindelse</string>
     <string name="disconnecting">Afbryder</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Konto wird erstellt ...</string>
     <string name="creating_secure_connection">SICHERE VERBINDUNG WIRD ERSTELLT</string>
     <string name="critical_error">Kritischer Fehler (Ihre Aufmerksamkeit wird erfordert)</string>
-    <string name="custom_dns_example">z. B. 10.0.0.4</string>
     <string name="custom_dns_footer">Aktivieren, um mindestens einen DNS-Server hinzuzufügen.</string>
+    <string name="custom_dns_hint">IP eingeben</string>
     <string name="custom_tunnel_host_resolution_error">Der Hostname des benutzerdefinierten Servers konnte nicht aufgelöst werden</string>
     <string name="disconnect">Verbindung trennen</string>
     <string name="disconnecting">Verbindung wird getrennt</string>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Creando cuenta…</string>
     <string name="creating_secure_connection">CREANDO CONEXIÓN SEGURA</string>
     <string name="critical_error">Error crítico (precisa su atención)</string>
-    <string name="custom_dns_example">Por ejemplo, «10.0.0.4»</string>
     <string name="custom_dns_footer">Active esta opción para agregar como mínimo un servidor DNS.</string>
+    <string name="custom_dns_hint">Escriba la IP</string>
     <string name="custom_tunnel_host_resolution_error">No se puede resolver el nombre de host del servidor personalizado</string>
     <string name="disconnect">Desconectar</string>
     <string name="disconnecting">Desconectando</string>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Luodaan tiliä...</string>
     <string name="creating_secure_connection">LUODAAN SUOJATTU YHTEYS</string>
     <string name="critical_error">Vakava virhe (vaatii huomiotasi)</string>
-    <string name="custom_dns_example">esim. 10.0.0.4</string>
     <string name="custom_dns_footer">Ota käyttöön lisätäksesi vähintään yhden DNS-palvelimen.</string>
+    <string name="custom_dns_hint">Anna IP-osoite</string>
     <string name="custom_tunnel_host_resolution_error">Mukautetun palvelimen isäntänimen selvittäminen epäonnistui</string>
     <string name="disconnect">Katkaise yhteys</string>
     <string name="disconnecting">Katkaistaan yhteyttä</string>

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Création du compte…</string>
     <string name="creating_secure_connection">CRÉATION D\'UNE CONNEXION SÉCURISÉE</string>
     <string name="critical_error">Erreur critique (votre attention est requise)</string>
-    <string name="custom_dns_example">par ex 10.0.0.4</string>
     <string name="custom_dns_footer">Activez pour ajouter au moins un serveur DNS.</string>
+    <string name="custom_dns_hint">Saisir l\'IP</string>
     <string name="custom_tunnel_host_resolution_error">Échec de la résolution du nom d\'hôte du serveur personnalisé</string>
     <string name="disconnect">Déconnexion</string>
     <string name="disconnecting">Déconnexion en cours</string>

--- a/android/src/main/res/values-it/strings.xml
+++ b/android/src/main/res/values-it/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Creazione account...</string>
     <string name="creating_secure_connection">CREAZIONE CONNESSIONE PROTETTA</string>
     <string name="critical_error">Errore critico (è necessario intervenire)</string>
-    <string name="custom_dns_example">esempio 10.0.0.4</string>
     <string name="custom_dns_footer">Abilita per aggiungere almeno un server DNS.</string>
+    <string name="custom_dns_hint">Inserisci IP</string>
     <string name="custom_tunnel_host_resolution_error">Impossibile risolvere il nome host del server personalizzato</string>
     <string name="disconnect">Disconnetti</string>
     <string name="disconnecting">Disconnessione</string>

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">アカウントを作成中...</string>
     <string name="creating_secure_connection">セキュリティ保護接続を確立中</string>
     <string name="critical_error">重大なエラー (ご注意ください)</string>
-    <string name="custom_dns_example">例: 10.0.0.4</string>
     <string name="custom_dns_footer">1つ以上のDNSサーバーを追加できるようにします。</string>
+    <string name="custom_dns_hint">IP を入力</string>
     <string name="custom_tunnel_host_resolution_error">カスタムサーバーのホスト名を解決できませんでした</string>
     <string name="disconnect">接続解除</string>
     <string name="disconnecting">接続解除中</string>

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">계정 생성 중...</string>
     <string name="creating_secure_connection">보안 연결 생성 중</string>
     <string name="critical_error">심각한 오류(주의가 필요함)</string>
-    <string name="custom_dns_example">예: 10.0.0.4</string>
     <string name="custom_dns_footer">하나 이상의 DNS 서버를 추가할 수 있습니다.</string>
+    <string name="custom_dns_hint">IP 입력</string>
     <string name="custom_tunnel_host_resolution_error">사용자 지정 서버의 호스트 이름을 확인하지 못했습니다.</string>
     <string name="disconnect">연결 끊기</string>
     <string name="disconnecting">연결 해제 중</string>

--- a/android/src/main/res/values-my/strings.xml
+++ b/android/src/main/res/values-my/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">အကောင့် ဖန်တီးနေဆဲ...</string>
     <string name="creating_secure_connection">လုံခြုံသည့် ချိတ်ဆက်မှုကို ဖန်တီးနေပါသည်</string>
     <string name="critical_error">အလွန်အရေးပါသည့် ချို့ယွင်းချက် (သင့်အာရုံစိုက်မှု လိုအပ်ပါသည်)</string>
-    <string name="custom_dns_example">ဥပမာ- 10.0.0.4</string>
     <string name="custom_dns_footer">အနည်းဆုံး DNS ဆာဗာတစ်ခုကို ပေါင်းထည့်ပါ။</string>
+    <string name="custom_dns_hint">IP ဖြည့်ပါ</string>
     <string name="custom_tunnel_host_resolution_error">စိတ်ကြိုက် ဆာဗာ၏ Hostname ကို ဖြေရှင်း၍ မရနိုင်ပါ</string>
     <string name="disconnect">ချိတ်ဆက်မှုဖြုတ်ရန်</string>
     <string name="disconnecting">ချိတ်ဆက်မှုဖြုတ်နေပါသည်</string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Oppretter konto ...</string>
     <string name="creating_secure_connection">OPPRETTER SIKKER TILKOBLING</string>
     <string name="critical_error">Kritisk feil (krever din oppmerksomhet)</string>
-    <string name="custom_dns_example">f.eks. 10.0.0.4</string>
     <string name="custom_dns_footer">Aktiver for å legge til minst én DNS-server.</string>
+    <string name="custom_dns_hint">Angi IP</string>
     <string name="custom_tunnel_host_resolution_error">Kunne ikke løse vertsnavnet til den egendefinerte serveren</string>
     <string name="disconnect">Koble fra</string>
     <string name="disconnecting">Kobler fra</string>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Account aanmaken...</string>
     <string name="creating_secure_connection">BEVEILIGDE VERBINDING AANMAKEN</string>
     <string name="critical_error">Kritieke fout (uw aandacht is vereist)</string>
-    <string name="custom_dns_example">bijv. 10.0.0.4</string>
     <string name="custom_dns_footer">Schakel in om minimaal één DNS-server toe te voegen.</string>
+    <string name="custom_dns_hint">Voer IP-adres in</string>
     <string name="custom_tunnel_host_resolution_error">Kon de hostnaam van de aangepaste server niet omzetten</string>
     <string name="disconnect">Verbinding verbreken</string>
     <string name="disconnecting">Verbinding wordt verbroken</string>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Tworzenie konta...</string>
     <string name="creating_secure_connection">TWORZENIE BEZPIECZNEGO POŁĄCZENIA</string>
     <string name="critical_error">Błąd krytyczny (wymagana uwaga)</string>
-    <string name="custom_dns_example">np. 10.0.0.4</string>
     <string name="custom_dns_footer">Włącz, aby dodać co najmniej jeden serwer DNS.</string>
+    <string name="custom_dns_hint">Wprowadź adres IP</string>
     <string name="custom_tunnel_host_resolution_error">Nie można rozpoznać nazwy hosta serwera niestandardowego</string>
     <string name="disconnect">Rozłącz</string>
     <string name="disconnecting">Rozłączanie</string>

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">A criar conta...</string>
     <string name="creating_secure_connection">A CRIAR LIGAÇÃO SEGURA</string>
     <string name="critical_error">Erro crítico (é necessária a sua atenção)</string>
-    <string name="custom_dns_example">ex.: 10.0.0.4</string>
     <string name="custom_dns_footer">Ativar para adicionar pelo menos um servidor DNS.</string>
+    <string name="custom_dns_hint">Introduzir IP</string>
     <string name="custom_tunnel_host_resolution_error">Não foi possível resolver o nome do anfitrião do servidor personalizado</string>
     <string name="disconnect">Desligar</string>
     <string name="disconnecting">A desligar</string>

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Создание учетной записи...</string>
     <string name="creating_secure_connection">СОЗДАНИЕ ЗАЩИЩЕННОГО ПОДКЛЮЧЕНИЯ</string>
     <string name="critical_error">Критическая ошибка (требуется ваше участие)</string>
-    <string name="custom_dns_example">напр., 10.0.0.4</string>
     <string name="custom_dns_footer">Чтобы добавить как минимум один DNS-сервер, включите этот параметр.</string>
+    <string name="custom_dns_hint">Введите IP-адрес</string>
     <string name="custom_tunnel_host_resolution_error">Не удалось преобразовать имя узла пользовательского сервера</string>
     <string name="disconnect">Отключить</string>
     <string name="disconnecting">Отключение</string>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Skapar konto...</string>
     <string name="creating_secure_connection">SKAPAR SÄKER ANSLUTNING</string>
     <string name="critical_error">Kritiskt fel (kräver din uppmärksamhet)</string>
-    <string name="custom_dns_example">t.ex. 10.0.0.4</string>
     <string name="custom_dns_footer">Aktivera för att lägga till minst en DNS-server.</string>
+    <string name="custom_dns_hint">Ange IP</string>
     <string name="custom_tunnel_host_resolution_error">Det gick inte att lösa värdnamnet för den anpassade servern</string>
     <string name="disconnect">Koppla från</string>
     <string name="disconnecting">Kopplar från</string>

--- a/android/src/main/res/values-th/strings.xml
+++ b/android/src/main/res/values-th/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">กำลังสร้างบัญชี...</string>
     <string name="creating_secure_connection">กำลังสร้างการเชื่อมต่อที่ปลอดภัย</string>
     <string name="critical_error">ข้อผิดพลาดร้ายแรง (คุณจำเป็นต้องตรวจสอบ)</string>
-    <string name="custom_dns_example">เช่น 10.0.0.4</string>
     <string name="custom_dns_footer">เปิดเพื่อเพิ่มเซิร์ฟเวอร์ DNS อย่างน้อยหนึ่งรายการ</string>
+    <string name="custom_dns_hint">ป้อน IP</string>
     <string name="custom_tunnel_host_resolution_error">ไม่พบชื่อโฮสต์ของเซิร์ฟเวอร์แบบกำหนดเอง</string>
     <string name="disconnect">ตัดการเชื่อมต่อ</string>
     <string name="disconnecting">กำลังตัดการเชื่อมต่อ</string>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">Hesap oluşturuluyor...</string>
     <string name="creating_secure_connection">GÜVENLİ BAĞLANTI OLUŞTURULUYOR</string>
     <string name="critical_error">Kritik hata (lütfen dikkatli olun)</string>
-    <string name="custom_dns_example">ör. 10.0.0.4</string>
     <string name="custom_dns_footer">En az bir DNS sunucusu eklemek için etkinleştirin.</string>
+    <string name="custom_dns_hint">IP\'yi girin</string>
     <string name="custom_tunnel_host_resolution_error">Özel sunucu ana bilgisayar adı çözülemiyor</string>
     <string name="disconnect">Bağlantıyı Kes</string>
     <string name="disconnecting">Bağlantı kesiliyor</string>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -37,8 +37,8 @@
     <string name="creating_new_account">正在创建帐户…</string>
     <string name="creating_secure_connection">正在创建安全连接</string>
     <string name="critical_error">严重错误（需要注意）</string>
-    <string name="custom_dns_example">例如 10.0.0.4</string>
     <string name="custom_dns_footer">启用以添加至少一个 DNS 服务器。</string>
+    <string name="custom_dns_hint">输入 IP</string>
     <string name="custom_tunnel_host_resolution_error">无法解析自定义服务器的主机名</string>
     <string name="disconnect">断开连接</string>
     <string name="disconnecting">正在断开连接</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -39,8 +39,8 @@
     <string name="creating_new_account">正在建立帳戶…</string>
     <string name="creating_secure_connection">建立安全連線</string>
     <string name="critical_error">嚴重錯誤 (需注意)</string>
-    <string name="custom_dns_example">例如 10.0.0.4</string>
     <string name="custom_dns_footer">啟用以新增至少一個 DNS 伺服器。</string>
+    <string name="custom_dns_hint">輸入 IP</string>
     <string name="custom_tunnel_host_resolution_error">無法解析自訂伺服器的主機名稱</string>
     <string name="disconnect">中斷連線</string>
     <string name="disconnecting">正在中斷連線</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -168,7 +168,7 @@
     <string name="enable">Enable</string>
     <string name="enable_custom_dns">Use custom DNS server</string>
     <string name="add_a_server">Add a server</string>
-    <string name="custom_dns_example">e.g. 10.0.0.4</string>
+    <string name="custom_dns_hint">Enter IP</string>
     <string name="custom_dns_footer">Enable to add at least one DNS server.</string>
     <string name="confirm_local_dns">The local DNS server will not work unless you enable \"Local
     Network Sharing\" under Preferences.</string>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1430,9 +1430,6 @@ msgstr ""
 msgid "You may need to go back to the app's main screen and click Disconnect before trying again. Don't worry, the information you entered will remain in the form."
 msgstr ""
 
-msgid "e.g. 10.0.0.4"
-msgstr ""
-
 msgid "Account credit expires in a day"
 msgid_plural "Account credit expires in %d days"
 msgstr[0] ""


### PR DESCRIPTION
When the user adds a custom dns, the input field hint
will say "Enter IP" rather than "e.g. 10.0.0.4" to avoid
confusion.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **SKIPPED as it's a minor tweak.**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3019)
<!-- Reviewable:end -->
