### PR TITLE
Fix IPv6 firewall filters on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ Line wrap the file at 100 chars.                                              Th
 - Prefer WireGuard if the constraints preclude OpenVPN and the tunnel protocol is "auto", instead
   of failing due to "no matching relays".
 - Retry tunnel device creation multiple times to work around issues early after boot or hibernation.
+- Fix IPv6 connections to WireGuard servers by not dropping select neighbor advertisements and
+  solicitations in WFP.
 
 #### Android
 - Fix erasing wireguard MTU value in some scenarious.

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,6 +100,12 @@ forwarded. All other forward traffic is rejected.
 * The app does not look at ICMPv6 type and code headers. So all ICMPv6 is allowed between the
   specified IP networks.
 
+#### Windows deviations
+An additional subset of NDP is permitted in addition to the traffic above:
+* Outgoing to `ff02::1:ff00:0/104` and `fe80::/10`, but only ICMPv6 with type 135 and code 0 (Neighbor solicitation).
+* Outgoing to `fe80::/10`, but only ICMPv6 with type 136 and code 0 (Neighbor advertisement).
+* Incoming from `*`, but only ICMPv6 with type 136 and code 0 (Neighbor advertisement).
+
 ### Disconnected
 
 This is the default state that the `mullvad-daemon` starts in when the device boots, unless

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -136,6 +136,9 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Router_Solicitation()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Inbound_Router_Advertisement()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Neighbor_Solicitation()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Neighbor_Advertisement()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Inbound_Neighbor_Advertisement()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Inbound_Redirect()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDns_Outbound_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDns_Outbound_Ipv6()));
@@ -735,6 +738,48 @@ const GUID &MullvadGuids::Filter_Baseline_PermitNdp_Inbound_Router_Advertisement
 		0x4915,
 		0x4a6a,
 		{ 0xbd, 0xf5, 0xb5, 0x1a, 0x2d, 0xbc, 0xb8, 0xe9 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitNdp_Outbound_Neighbor_Solicitation()
+{
+	static const GUID g =
+	{
+		0x8cc5348a,
+		0xf736,
+		0x4ec4,
+		{ 0x8e, 0x8f, 0xd7, 0x13, 0x17, 0xd4, 0xc2, 0xb8 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitNdp_Outbound_Neighbor_Advertisement()
+{
+	static const GUID g =
+	{
+		0x932042c4,
+		0x2275,
+		0x4c3e,
+		{ 0x85, 0xe8, 0xf9, 0xa2, 0x77, 0x18, 0x19, 0x5c }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitNdp_Inbound_Neighbor_Advertisement()
+{
+	static const GUID g =
+	{
+		0xc0e39478,
+		0x7920,
+		0x4632,
+		{ 0x82, 0x12, 0x2a, 0xe5, 0xd2, 0x6f, 0x39, 0x5c }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -79,6 +79,9 @@ public:
 
 	static const GUID &Filter_Baseline_PermitNdp_Outbound_Router_Solicitation();
 	static const GUID &Filter_Baseline_PermitNdp_Inbound_Router_Advertisement();
+	static const GUID &Filter_Baseline_PermitNdp_Outbound_Neighbor_Solicitation();
+	static const GUID &Filter_Baseline_PermitNdp_Outbound_Neighbor_Advertisement();
+	static const GUID &Filter_Baseline_PermitNdp_Inbound_Neighbor_Advertisement();
 	static const GUID &Filter_Baseline_PermitNdp_Inbound_Redirect();
 
 	static const GUID &Filter_Baseline_PermitDns_Outbound_Ipv4();

--- a/windows/winfw/src/winfw/rules/baseline/permitndp.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitndp.cpp
@@ -18,6 +18,7 @@ bool PermitNdp::apply(IObjectInstaller &objectInstaller)
 {
 	const wfp::IpNetwork linkLocal(wfp::IpAddress::Literal6({ 0xFE80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }), 10);
 	const wfp::IpAddress::Literal6 linkLocalRouterMulticast{ 0xFF02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2 };
+	const wfp::IpNetwork solicitedNodeMulticast(wfp::IpAddress::Literal6({ 0xFF02, 0, 0, 0, 0, 1, 0xFF00, 0 }), 104);
 
 	wfp::FilterBuilder filterBuilder;
 
@@ -81,12 +82,91 @@ bool PermitNdp::apply(IObjectInstaller &objectInstaller)
 		.name(L"Permit inbound NDP redirect")
 		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
 
+	{
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+
+		conditionBuilder.add_condition(ConditionProtocol::IcmpV6());
+		conditionBuilder.add_condition(ConditionIcmp::Type(137));
+		conditionBuilder.add_condition(ConditionIcmp::Code(0));
+		conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
+
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
+	}
+
+	//
+	// #4 Permit outbound neighbor solicitation.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitNdp_Outbound_Neighbor_Solicitation())
+		.name(L"Permit outbound NDP neighbor solicitation")
+		.description(L"This filter is part of a rule that permits the most central parts of NDP")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Medium)
+		.permit();
+
+	{
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+		conditionBuilder.add_condition(ConditionProtocol::IcmpV6());
+		conditionBuilder.add_condition(ConditionIcmp::Type(135));
+		conditionBuilder.add_condition(ConditionIcmp::Code(0));
+		conditionBuilder.add_condition(ConditionIp::Remote(solicitedNodeMulticast));
+		conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
+
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
+	}
+
+	//
+	// #5 Permit outbound neighbor advertisement.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitNdp_Outbound_Neighbor_Advertisement())
+		.name(L"Permit outbound NDP neighbor advertisement")
+		.description(L"This filter is part of a rule that permits the most central parts of NDP")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Medium)
+		.permit();
+
+	{
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+		conditionBuilder.add_condition(ConditionProtocol::IcmpV6());
+		conditionBuilder.add_condition(ConditionIcmp::Type(136));
+		conditionBuilder.add_condition(ConditionIcmp::Code(0));
+		conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
+
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
+	}
+
+	//
+	// #6 Permit inbound neighbor advertisement.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitNdp_Inbound_Neighbor_Advertisement())
+		.name(L"Permit inbound NDP neighbor advertisement")
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
 
 	conditionBuilder.add_condition(ConditionProtocol::IcmpV6());
-	conditionBuilder.add_condition(ConditionIcmp::Type(137));
+	conditionBuilder.add_condition(ConditionIcmp::Type(136));
 	conditionBuilder.add_condition(ConditionIcmp::Code(0));
-	conditionBuilder.add_condition(ConditionIp::Remote(linkLocal));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }


### PR DESCRIPTION
IPv6 currently doesn't work (for long) on Windows if parts of NDP (used for DAD and neighbor reachability) are blocked. To fix this, this PR permits certain neighbor advertisement and neighbor solicitation messages.