### PR TITLE
Fix filter button alignment in Select Location view

### DIFF
--- a/gui/src/renderer/components/SelectLocationStyles.tsx
+++ b/gui/src/renderer/components/SelectLocationStyles.tsx
@@ -29,6 +29,7 @@ export const StyledNavigationBarAttachment = styled.div({}, (props: { top: numbe
 }));
 
 export const StyledFilterContainer = styled.div({
+  display: 'flex',
   position: 'relative',
   justifySelf: 'end',
 });


### PR DESCRIPTION
This PR changes the filter button wrapper display property to `display: flex` to make it have the same height as the content.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
