### PR TITLE
Remove timeout for updates to excluded apps on Windows

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -317,6 +317,9 @@ pub(crate) enum InternalDaemonEvent {
     NewAccountEvent(AccountToken, oneshot::Sender<Result<String, Error>>),
     /// The background job fetching new `AppVersionInfo`s got a new info object.
     NewAppVersionInfo(AppVersionInfo),
+    /// The split tunnel paths or state were updated.
+    #[cfg(target_os = "windows")]
+    ExcludedPathsEvent(bool, HashSet<PathBuf>, oneshot::Sender<Result<(), Error>>),
 }
 
 impl From<TunnelStateTransition> for InternalDaemonEvent {
@@ -909,6 +912,10 @@ where
             NewAppVersionInfo(app_version_info) => {
                 self.handle_new_app_version_info(app_version_info)
             }
+            #[cfg(windows)]
+            ExcludedPathsEvent(state, paths, tx) => {
+                self.handle_new_excluded_paths(state, paths, tx).await
+            }
         }
     }
 
@@ -1349,6 +1356,50 @@ where
     fn handle_new_app_version_info(&mut self, app_version_info: AppVersionInfo) {
         self.app_version_info = Some(app_version_info.clone());
         self.event_listener.notify_app_version(app_version_info);
+    }
+
+    #[cfg(windows)]
+    async fn handle_new_excluded_paths(
+        &mut self,
+        state: bool,
+        paths: HashSet<PathBuf>,
+        tx: ResponseTx<(), Error>,
+    ) {
+        let save_result = self
+            .settings
+            .set_split_tunnel_state(state)
+            .await
+            .map_err(Error::SettingsError);
+        match save_result {
+            Ok(true) => {
+                let _ = tx.send(Ok(()));
+                self.event_listener
+                    .notify_settings(self.settings.to_settings());
+                return;
+            }
+            Err(error) => {
+                let _ = tx.send(Err(error));
+                return;
+            }
+            Ok(false) => (),
+        }
+
+        let save_result = self
+            .settings
+            .set_split_tunnel_apps(paths)
+            .await
+            .map_err(Error::SettingsError);
+        match save_result {
+            Ok(true) => {
+                let _ = tx.send(Ok(()));
+                self.event_listener
+                    .notify_settings(self.settings.to_settings());
+            }
+            Err(error) => {
+                let _ = tx.send(Err(error));
+            }
+            Ok(false) => (),
+        }
     }
 
     async fn on_set_target_state(
@@ -1799,54 +1850,52 @@ where
         tx: ResponseTx<(), Error>,
         response_msg: &'static str,
         settings: Settings,
+        new_state: bool,
         new_list: HashSet<PathBuf>,
     ) {
-        if new_list == settings.split_tunnel.apps {
+        if new_list == settings.split_tunnel.apps
+            && new_state == settings.split_tunnel.enable_exclusions
+        {
             Self::oneshot_send(tx, Ok(()), response_msg);
             return;
         }
 
-        if settings.split_tunnel.enable_exclusions {
-            let (result_tx, result_rx) = oneshot::channel();
-            self.send_tunnel_command(TunnelCommand::SetExcludedApps(
-                result_tx,
-                new_list.iter().map(|s| OsString::from(s)).collect(),
-            ));
-            match result_rx.await {
-                Ok(Ok(_)) => (),
-                Ok(Err(error)) => {
-                    log::error!(
-                        "{}",
-                        error.display_chain_with_msg("Failed to set excluded apps list")
-                    );
-                    Self::oneshot_send(tx, Err(Error::SplitTunnelError(error)), response_msg);
-                    return;
-                }
-                Err(_) => {
-                    log::error!("The tunnel failed to return a result");
-                    return;
-                }
-            }
-        }
+        if new_state || new_state != settings.split_tunnel.enable_exclusions {
+            let tunnel_list = if new_state {
+                new_list.iter().map(|s| OsString::from(s)).collect()
+            } else {
+                vec![]
+            };
 
-        let save_result = self
-            .settings
-            .set_split_tunnel_apps(new_list)
-            .await
-            .map_err(Error::SettingsError);
-        match save_result {
-            Ok(true) => {
-                Self::oneshot_send(tx, Ok(()), response_msg);
-                self.event_listener
-                    .notify_settings(self.settings.to_settings());
-            }
-            Err(error) => {
-                Self::oneshot_send(tx, Err(error), response_msg);
-            }
-            Ok(false) => {
-                // unreachable!("new_list != settings.split_tunnel_apps")
-                error!("BUG: new_list != settings.split_tunnel_apps");
-            }
+            let (result_tx, result_rx) = oneshot::channel();
+            self.send_tunnel_command(TunnelCommand::SetExcludedApps(result_tx, tunnel_list));
+            let daemon_tx = self.tx.clone();
+
+            tokio::spawn(async move {
+                match result_rx.await {
+                    Ok(Ok(_)) => (),
+                    Ok(Err(error)) => {
+                        log::error!(
+                            "{}",
+                            error.display_chain_with_msg("Failed to set excluded apps list")
+                        );
+                        Self::oneshot_send(tx, Err(Error::SplitTunnelError(error)), response_msg);
+                        return;
+                    }
+                    Err(_) => {
+                        log::error!("The tunnel failed to return a result");
+                        return;
+                    }
+                }
+
+                let _ = daemon_tx.send(InternalDaemonEvent::ExcludedPathsEvent(
+                    new_state, new_list, tx,
+                ));
+            });
+        } else {
+            let _ = self.tx.send(InternalDaemonEvent::ExcludedPathsEvent(
+                new_state, new_list, tx,
+            ));
         }
     }
 
@@ -1856,9 +1905,16 @@ where
 
         let mut new_list = settings.split_tunnel.apps.clone();
         new_list.insert(path);
+        let state = settings.split_tunnel.enable_exclusions;
 
-        self.set_split_tunnel_paths(tx, "add_split_tunnel_app response", settings, new_list)
-            .await;
+        self.set_split_tunnel_paths(
+            tx,
+            "add_split_tunnel_app response",
+            settings,
+            state,
+            new_list,
+        )
+        .await;
     }
 
     #[cfg(windows)]
@@ -1867,82 +1923,39 @@ where
 
         let mut new_list = settings.split_tunnel.apps.clone();
         new_list.remove(&path);
+        let state = settings.split_tunnel.enable_exclusions;
 
-        self.set_split_tunnel_paths(tx, "remove_split_tunnel_app response", settings, new_list)
-            .await;
+        self.set_split_tunnel_paths(
+            tx,
+            "remove_split_tunnel_app response",
+            settings,
+            state,
+            new_list,
+        )
+        .await;
     }
 
     #[cfg(windows)]
     async fn on_clear_split_tunnel_apps(&mut self, tx: ResponseTx<(), Error>) {
         let settings = self.settings.to_settings();
         let new_list = HashSet::new();
-        self.set_split_tunnel_paths(tx, "clear_split_tunnel_apps response", settings, new_list)
-            .await;
+        let state = settings.split_tunnel.enable_exclusions;
+        self.set_split_tunnel_paths(
+            tx,
+            "clear_split_tunnel_apps response",
+            settings,
+            state,
+            new_list,
+        )
+        .await;
     }
 
     #[cfg(windows)]
-    async fn on_set_split_tunnel_state(&mut self, tx: ResponseTx<(), Error>, enabled: bool) {
+    async fn on_set_split_tunnel_state(&mut self, tx: ResponseTx<(), Error>, state: bool) {
         let settings = self.settings.to_settings();
-
-        if enabled != settings.split_tunnel.enable_exclusions {
-            let new_list = if enabled {
-                settings.split_tunnel.apps.clone()
-            } else {
-                HashSet::new()
-            };
-            if !settings.split_tunnel.apps.is_empty() {
-                let (result_tx, result_rx) = oneshot::channel();
-                self.send_tunnel_command(TunnelCommand::SetExcludedApps(
-                    result_tx,
-                    new_list.iter().map(|app| OsString::from(app)).collect(),
-                ));
-                match result_rx.await {
-                    Ok(Ok(_)) => (),
-                    Ok(Err(error)) => {
-                        log::error!(
-                            "{}",
-                            error.display_chain_with_msg("Failed to set excluded apps list")
-                        );
-                        Self::oneshot_send(
-                            tx,
-                            Err(Error::SplitTunnelError(error)),
-                            "set_split_tunnel_state response",
-                        );
-                        return;
-                    }
-                    Err(_) => {
-                        log::error!("The tunnel failed to return a result");
-                        return;
-                    }
-                }
-            }
-
-            let save_result = self
-                .settings
-                .set_split_tunnel_state(enabled)
-                .await
-                .map_err(Error::SettingsError);
-            match save_result {
-                Ok(true) => {
-                    Self::oneshot_send(tx, Ok(()), "set_split_tunnel_state response");
-                    self.event_listener
-                        .notify_settings(self.settings.to_settings());
-                }
-                Err(error) => {
-                    error!(
-                        "{}",
-                        error.display_chain_with_msg("Unable to save settings")
-                    );
-                    Self::oneshot_send(tx, Err(error), "set_split_tunnel_state response");
-                }
-                Ok(false) => {
-                    // unreachable!("enabled != settings.split_tunnel"),
-                    error!("BUG: enabled != settings.split_tunnel");
-                }
-            }
-        } else {
-            Self::oneshot_send(tx, Ok(()), "set_split_tunnel_state response");
-        }
+        let list = settings.split_tunnel.apps.clone();
+        self.set_split_tunnel_paths(tx, "set_split_tunnel_state response", settings, state, list)
+            .await;
     }
 
     #[cfg(windows)]

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -42,8 +42,6 @@ use winapi::{
 const DRIVER_SYMBOLIC_NAME: &str = "\\\\.\\MULLVADSPLITTUNNEL";
 const ST_DEVICE_TYPE: u32 = 0x8000;
 
-const DEFAULT_DRIVER_IO_TIMEOUT: Duration = Duration::from_secs(5);
-
 const fn ctl_code(device_type: u32, function: u32, method: u32, access: u32) -> u32 {
     device_type << 16 | access << 14 | function << 2 | method
 }
@@ -159,7 +157,7 @@ impl DeviceHandle {
         }
 
         log::trace!("Clearing any existing exclusion config");
-        device.clear_config(Some(DEFAULT_DRIVER_IO_TIMEOUT))?;
+        device.clear_config()?;
 
         Ok(device)
     }
@@ -170,7 +168,7 @@ impl DeviceHandle {
             DriverIoctlCode::Initialize as u32,
             None,
             0,
-            Some(DEFAULT_DRIVER_IO_TIMEOUT),
+            None,
         )?;
         Ok(())
     }
@@ -182,7 +180,7 @@ impl DeviceHandle {
             DriverIoctlCode::RegisterProcesses as u32,
             Some(&process_tree_buffer),
             0,
-            Some(DEFAULT_DRIVER_IO_TIMEOUT),
+            None,
         )?;
         Ok(())
     }
@@ -244,7 +242,7 @@ impl DeviceHandle {
             DriverIoctlCode::RegisterIpAddresses as u32,
             Some(buffer),
             0,
-            Some(DEFAULT_DRIVER_IO_TIMEOUT),
+            None,
         )?;
 
         Ok(())
@@ -256,18 +254,14 @@ impl DeviceHandle {
             DriverIoctlCode::GetState as u32,
             None,
             size_of::<u64>() as u32,
-            Some(DEFAULT_DRIVER_IO_TIMEOUT),
+            None,
         )?
         .unwrap();
 
         Ok(unsafe { deserialize_buffer(&buffer) })
     }
 
-    pub fn set_config<T: AsRef<OsStr>>(
-        &self,
-        apps: &[T],
-        io_timeout: Option<Duration>,
-    ) -> io::Result<()> {
+    pub fn set_config<T: AsRef<OsStr>>(&self, apps: &[T]) -> io::Result<()> {
         let mut device_paths = Vec::with_capacity(apps.len());
         for app in apps.as_ref() {
             match get_device_path(app.as_ref()) {
@@ -296,19 +290,19 @@ impl DeviceHandle {
             DriverIoctlCode::SetConfiguration as u32,
             Some(&config),
             0,
-            io_timeout,
+            None,
         )?;
 
         Ok(())
     }
 
-    pub fn clear_config(&self, io_timeout: Option<Duration>) -> io::Result<()> {
+    pub fn clear_config(&self) -> io::Result<()> {
         device_io_control(
             self.handle.as_raw_handle(),
             DriverIoctlCode::ClearConfiguration as u32,
             None,
             0,
-            io_timeout,
+            None,
         )?;
 
         Ok(())

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -42,7 +42,7 @@ use winapi::{
 const DRIVER_SYMBOLIC_NAME: &str = "\\\\.\\MULLVADSPLITTUNNEL";
 const ST_DEVICE_TYPE: u32 = 0x8000;
 
-const DRIVER_IO_TIMEOUT: Duration = Duration::from_secs(3);
+const DEFAULT_DRIVER_IO_TIMEOUT: Duration = Duration::from_secs(5);
 
 const fn ctl_code(device_type: u32, function: u32, method: u32, access: u32) -> u32 {
     device_type << 16 | access << 14 | function << 2 | method
@@ -159,7 +159,7 @@ impl DeviceHandle {
         }
 
         log::trace!("Clearing any existing exclusion config");
-        device.clear_config()?;
+        device.clear_config(Some(DEFAULT_DRIVER_IO_TIMEOUT))?;
 
         Ok(device)
     }
@@ -170,7 +170,7 @@ impl DeviceHandle {
             DriverIoctlCode::Initialize as u32,
             None,
             0,
-            Some(DRIVER_IO_TIMEOUT),
+            Some(DEFAULT_DRIVER_IO_TIMEOUT),
         )?;
         Ok(())
     }
@@ -182,7 +182,7 @@ impl DeviceHandle {
             DriverIoctlCode::RegisterProcesses as u32,
             Some(&process_tree_buffer),
             0,
-            Some(DRIVER_IO_TIMEOUT),
+            Some(DEFAULT_DRIVER_IO_TIMEOUT),
         )?;
         Ok(())
     }
@@ -244,7 +244,7 @@ impl DeviceHandle {
             DriverIoctlCode::RegisterIpAddresses as u32,
             Some(buffer),
             0,
-            Some(DRIVER_IO_TIMEOUT),
+            Some(DEFAULT_DRIVER_IO_TIMEOUT),
         )?;
 
         Ok(())
@@ -256,14 +256,18 @@ impl DeviceHandle {
             DriverIoctlCode::GetState as u32,
             None,
             size_of::<u64>() as u32,
-            Some(DRIVER_IO_TIMEOUT),
+            Some(DEFAULT_DRIVER_IO_TIMEOUT),
         )?
         .unwrap();
 
         Ok(unsafe { deserialize_buffer(&buffer) })
     }
 
-    pub fn set_config<T: AsRef<OsStr>>(&self, apps: &[T]) -> io::Result<()> {
+    pub fn set_config<T: AsRef<OsStr>>(
+        &self,
+        apps: &[T],
+        io_timeout: Option<Duration>,
+    ) -> io::Result<()> {
         let mut device_paths = Vec::with_capacity(apps.len());
         for app in apps.as_ref() {
             match get_device_path(app.as_ref()) {
@@ -292,19 +296,19 @@ impl DeviceHandle {
             DriverIoctlCode::SetConfiguration as u32,
             Some(&config),
             0,
-            Some(DRIVER_IO_TIMEOUT),
+            io_timeout,
         )?;
 
         Ok(())
     }
 
-    pub fn clear_config(&self) -> io::Result<()> {
+    pub fn clear_config(&self, io_timeout: Option<Duration>) -> io::Result<()> {
         device_io_control(
             self.handle.as_raw_handle(),
             DriverIoctlCode::ClearConfiguration as u32,
             None,
             0,
-            Some(DRIVER_IO_TIMEOUT),
+            io_timeout,
         )?;
 
         Ok(())

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -118,7 +118,7 @@ enum Request {
 type RequestResponseTx = sync_mpsc::Sender<Result<(), Error>>;
 type RequestTx = sync_mpsc::Sender<(Request, RequestResponseTx)>;
 
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(6);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct EventThreadContext {
     handle: Arc<driver::DeviceHandle>,
@@ -330,11 +330,9 @@ impl SplitTunnel {
                         let mut monitored_paths_guard = monitored_paths.lock().unwrap();
 
                         let result = if paths.len() > 0 {
-                            handle
-                                .set_config(&paths, None)
-                                .map_err(Error::SetConfiguration)
+                            handle.set_config(&paths).map_err(Error::SetConfiguration)
                         } else {
-                            handle.clear_config(None).map_err(Error::SetConfiguration)
+                            handle.clear_config().map_err(Error::SetConfiguration)
                         };
 
                         if result.is_ok() {
@@ -390,7 +388,7 @@ impl SplitTunnel {
                 let paths = monitored_paths_copy.lock().unwrap();
                 let result = if paths.len() > 0 {
                     log::debug!("Re-resolving excluded paths");
-                    handle_copy.set_config(&*paths, None)
+                    handle_copy.set_config(&*paths)
                 } else {
                     continue;
                 };

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         self, get_best_default_route, interface_luid_to_ip, WinNetAddrFamily, WinNetCallbackHandle,
     },
 };
-use futures::channel::mpsc;
+use futures::channel::{mpsc, oneshot};
 use std::{
     convert::TryFrom,
     ffi::{OsStr, OsString},
@@ -17,7 +17,10 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     os::windows::io::{AsRawHandle, RawHandle},
     ptr,
-    sync::{mpsc as sync_mpsc, Arc, Mutex, Weak},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc as sync_mpsc, Arc, Mutex, Weak,
+    },
     time::Duration,
 };
 use talpid_types::{tunnel::ErrorStateCause, ErrorExt};
@@ -86,15 +89,21 @@ pub enum Error {
     /// Failed to start the NTFS reparse point monitor
     #[error(display = "Failed to start path monitor")]
     StartPathMonitor(#[error(source)] io::Error),
+
+    /// A previous path update has not yet completed
+    #[error(display = "A previous update is not yet complete")]
+    AlreadySettingPaths,
 }
 
 /// Manages applications whose traffic to exclude from the tunnel.
 pub struct SplitTunnel {
+    runtime: tokio::runtime::Handle,
     request_tx: RequestTx,
     event_thread: Option<std::thread::JoinHandle<()>>,
     quit_event: RawHandle,
     _route_change_callback: Option<WinNetCallbackHandle>,
     daemon_tx: Weak<mpsc::UnboundedSender<TunnelCommand>>,
+    async_path_update_in_progress: Arc<AtomicBool>,
 }
 
 enum Request {
@@ -107,9 +116,9 @@ enum Request {
     ),
 }
 type RequestResponseTx = sync_mpsc::Sender<Result<(), Error>>;
-type RequestTx = sync_mpsc::SyncSender<(Request, RequestResponseTx)>;
+type RequestTx = sync_mpsc::Sender<(Request, RequestResponseTx)>;
 
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(6);
 
 struct EventThreadContext {
     handle: Arc<driver::DeviceHandle>,
@@ -120,7 +129,10 @@ unsafe impl Send for EventThreadContext {}
 
 impl SplitTunnel {
     /// Initialize the driver.
-    pub fn new(daemon_tx: Weak<mpsc::UnboundedSender<TunnelCommand>>) -> Result<Self, Error> {
+    pub fn new(
+        runtime: tokio::runtime::Handle,
+        daemon_tx: Weak<mpsc::UnboundedSender<TunnelCommand>>,
+    ) -> Result<Self, Error> {
         let (request_tx, handle) = Self::spawn_request_thread()?;
 
         let mut event_overlapped: OVERLAPPED = unsafe { mem::zeroed() };
@@ -277,16 +289,18 @@ impl SplitTunnel {
         });
 
         Ok(SplitTunnel {
+            runtime,
             request_tx,
             event_thread: Some(event_thread),
             quit_event,
             _route_change_callback: None,
             daemon_tx,
+            async_path_update_in_progress: Arc::new(AtomicBool::new(false)),
         })
     }
 
     fn spawn_request_thread() -> Result<(RequestTx, Arc<driver::DeviceHandle>), Error> {
-        let (tx, rx): (RequestTx, _) = sync_mpsc::sync_channel(3);
+        let (tx, rx): (RequestTx, _) = sync_mpsc::channel();
         let (init_tx, init_rx) = sync_mpsc::channel();
 
         let (path_monitor, path_change_rx) =
@@ -316,9 +330,11 @@ impl SplitTunnel {
                         let mut monitored_paths_guard = monitored_paths.lock().unwrap();
 
                         let result = if paths.len() > 0 {
-                            handle.set_config(&paths).map_err(Error::SetConfiguration)
+                            handle
+                                .set_config(&paths, None)
+                                .map_err(Error::SetConfiguration)
                         } else {
-                            handle.clear_config().map_err(Error::SetConfiguration)
+                            handle.clear_config(None).map_err(Error::SetConfiguration)
                         };
 
                         if result.is_ok() {
@@ -374,7 +390,7 @@ impl SplitTunnel {
                 let paths = monitored_paths_copy.lock().unwrap();
                 let result = if paths.len() > 0 {
                     log::debug!("Re-resolving excluded paths");
-                    handle_copy.set_config(&*paths)
+                    handle_copy.set_config(&*paths, None)
                 } else {
                     continue;
                 };
@@ -398,11 +414,8 @@ impl SplitTunnel {
         let (response_tx, response_rx) = sync_mpsc::channel();
 
         request_tx
-            .try_send((request, response_tx))
-            .map_err(|error| match error {
-                sync_mpsc::TrySendError::Disconnected(_) => Error::RequestThreadDown,
-                sync_mpsc::TrySendError::Full(_) => Error::RequestThreadStuck,
-            })?;
+            .send((request, response_tx))
+            .map_err(|_| Error::RequestThreadDown)?;
 
         response_rx
             .recv_timeout(REQUEST_TIMEOUT)
@@ -410,13 +423,48 @@ impl SplitTunnel {
     }
 
     /// Set a list of applications to exclude from the tunnel.
-    pub fn set_paths<T: AsRef<OsStr>>(&self, paths: &[T]) -> Result<(), Error> {
+    pub fn set_paths_sync<T: AsRef<OsStr>>(&self, paths: &[T]) -> Result<(), Error> {
         self.send_request(Request::SetPaths(
             paths
                 .iter()
                 .map(|path| path.as_ref().to_os_string())
                 .collect(),
         ))
+    }
+
+    /// Set a list of applications to exclude from the tunnel.
+    pub fn set_paths<T: AsRef<OsStr>>(
+        &self,
+        paths: &[T],
+        result_tx: oneshot::Sender<Result<(), Error>>,
+    ) {
+        let busy = self
+            .async_path_update_in_progress
+            .swap(true, Ordering::SeqCst);
+        if busy {
+            let _ = result_tx.send(Err(Error::AlreadySettingPaths));
+            return;
+        }
+        let (response_tx, response_rx) = sync_mpsc::channel();
+        let request = Request::SetPaths(
+            paths
+                .iter()
+                .map(|path| path.as_ref().to_os_string())
+                .collect(),
+        );
+        let request_tx = self.request_tx.clone();
+
+        let wait_task = move || {
+            request_tx
+                .send((request, response_tx))
+                .map_err(|_| Error::RequestThreadDown)?;
+            response_rx.recv().map_err(|_| Error::RequestThreadDown)?
+        };
+        let in_progress = self.async_path_update_in_progress.clone();
+        self.runtime.spawn_blocking(move || {
+            let _ = result_tx.send(wait_task());
+            in_progress.store(false, Ordering::SeqCst);
+        });
     }
 
     /// Instructs the driver to redirect traffic from sockets bound to 0.0.0.0, ::, or the
@@ -482,7 +530,7 @@ impl Drop for SplitTunnel {
         }
 
         let paths: [&OsStr; 0] = [];
-        if let Err(error) = self.set_paths(&paths) {
+        if let Err(error) = self.set_paths_sync(&paths) {
             log::error!("{}", error.display_chain());
         }
     }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -262,7 +262,7 @@ impl ConnectedState {
             }
             #[cfg(windows)]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                let _ = result_tx.send(shared_values.split_tunnel.set_paths(&paths));
+                shared_values.split_tunnel.set_paths(&paths, result_tx);
                 SameState(self.into())
             }
         }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -326,7 +326,7 @@ impl ConnectingState {
             }
             #[cfg(windows)]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                let _ = result_tx.send(shared_values.split_tunnel.set_paths(&paths));
+                shared_values.split_tunnel.set_paths(&paths, result_tx);
                 SameState(self.into())
             }
         }

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -146,7 +146,7 @@ impl TunnelState for DisconnectedState {
             }
             #[cfg(windows)]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                let _ = result_tx.send(shared_values.split_tunnel.set_paths(&paths));
+                shared_values.split_tunnel.set_paths(&paths, result_tx);
                 SameState(self.into())
             }
             Some(_) => SameState(self.into()),

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -61,7 +61,7 @@ impl DisconnectingState {
                 }
                 #[cfg(windows)]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                    let _ = result_tx.send(shared_values.split_tunnel.set_paths(&paths));
+                    shared_values.split_tunnel.set_paths(&paths, result_tx);
                     AfterDisconnect::Nothing
                 }
             },
@@ -103,7 +103,7 @@ impl DisconnectingState {
                 }
                 #[cfg(windows)]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                    let _ = result_tx.send(shared_values.split_tunnel.set_paths(&paths));
+                    shared_values.split_tunnel.set_paths(&paths, result_tx);
                     AfterDisconnect::Block(reason)
                 }
                 None => AfterDisconnect::Block(reason),
@@ -146,7 +146,7 @@ impl DisconnectingState {
                 }
                 #[cfg(windows)]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                    let _ = result_tx.send(shared_values.split_tunnel.set_paths(&paths));
+                    shared_values.split_tunnel.set_paths(&paths, result_tx);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
             },

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -168,7 +168,7 @@ impl TunnelState for ErrorState {
             }
             #[cfg(windows)]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                let _ = result_tx.send(shared_values.split_tunnel.set_paths(&paths));
+                shared_values.split_tunnel.set_paths(&paths, result_tx);
                 SameState(self.into())
             }
         }

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -228,7 +228,7 @@ impl TunnelStateMachine {
         #[cfg(target_os = "android")] android_context: AndroidContext,
     ) -> Result<Self, Error> {
         #[cfg(windows)]
-        let split_tunnel = split_tunnel::SplitTunnel::new(command_tx.clone())
+        let split_tunnel = split_tunnel::SplitTunnel::new(runtime.clone(), command_tx.clone())
             .map_err(Error::InitSplitTunneling)?;
 
         let args = FirewallArguments {
@@ -279,7 +279,7 @@ impl TunnelStateMachine {
 
         #[cfg(windows)]
         split_tunnel
-            .set_paths(&settings.exclude_paths)
+            .set_paths_sync(&settings.exclude_paths)
             .map_err(Error::InitSplitTunneling)?;
 
         let mut shared_values = SharedTunnelStateValues {


### PR DESCRIPTION
Previously, adding or removing applications from the excluded apps list blocked the TSM/daemon, so there had to be a short timeout before the request was abandoned. If the request eventually completed, the daemon was not notified, causing the settings/daemon state to be inconsistent with the driver state. This PR fixes this by removing the timeout. The daemon is not blocked while the request is being processed.