### PR TITLE
Somewhat unify logic for writing structs to byte buffers.

### DIFF
--- a/talpid-core/src/windows.rs
+++ b/talpid-core/src/windows.rs
@@ -451,6 +451,12 @@ pub fn try_socketaddr_from_inet_sockaddr(addr: SOCKADDR_INET) -> Result<SocketAd
     }
 }
 
+/// Casts a struct to a slice of possibly uninitialized bytes.
+#[cfg(target_os = "windows")]
+pub fn as_uninit_byte_slice<T: Copy + Sized>(value: &T) -> &[mem::MaybeUninit<u8>] {
+    unsafe { std::slice::from_raw_parts(value as *const _ as *const _, mem::size_of::<T>()) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
There actually isn't overlap between Windows and Linux use cases, as I have not verified that any of the WireGuardNT structs use padding. But for cases where structs have padding, the only reasonable choice is to only ever treat the bytes as `MaybeUninit<u8>` all the way through to the syscall.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3027)
<!-- Reviewable:end -->
