### PR TITLE
Drop support for Android 7/7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Line wrap the file at 100 chars.                                              Th
 - Upgrade Wintun from 0.10.4 to 0.13.
 - Reduce tunnel setup time for OpenVPN by disabling DAD.
 
+#### Android
+- Drop support for Android 7/7.1 (Android 8/API level 26 or later is now required).
+
 ### Fixed
 - Fix link to download page not always using the beta URL when it should.
 - Fix deadlock that may occur when the API cannot be reached while entering the connecting state.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
 
     defaultConfig {
         applicationId "net.mullvad.mullvadvpn"
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 30
         versionCode 21010099
         versionName "2021.1"


### PR DESCRIPTION
Android 8/API level 26 or later is now required.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3030)
<!-- Reviewable:end -->
