### PR TITLE
Avoid firewall issues on macOS 12 Beta 9 and up.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### macOS
 - Prevent app from showing when dragging tray icon on macOS.
+- Fix issue with getting PF status due to an ABI change on macOS 12 Beta 9.
 
 
 ## [2021.5-beta1] - 2021-10-12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "subslice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a8e4809a3bb02de01f1f7faf1ba01a83af9e8eabcd4d31dd6e413d14d56aae"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2498,7 @@ dependencies = [
  "rtnetlink",
  "shell-escape",
  "socket2",
+ "subslice",
  "system-configuration",
  "talpid-dbus",
  "talpid-platform-metadata",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -71,6 +71,7 @@ internet-checksum = "0.2"
 pfctl = "0.4.4"
 system-configuration = "0.4"
 tun = "0.5.1"
+subslice = "0.2"
 
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Due to the ABI change, PF status seemingly can't be queried nicely. Since we query the status to check if the firewall should remain enabled when the firewall is being shut down, this breaks the daemon. As a workaround, the status can be queried by running `pfctl -s info` instead of calling the ioctl directly, which is what I've done here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3046)
<!-- Reviewable:end -->
