### PR TITLE
Hide features that require daemon connection while not connected

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -664,11 +664,13 @@ export default class AppRenderer {
 
   private onDaemonConnected() {
     this.connectedToDaemon = true;
+    this.reduxActions.userInterface.setConnectedToDaemon(true);
     this.resetNavigation();
   }
 
   private onDaemonDisconnected() {
     this.connectedToDaemon = false;
+    this.reduxActions.userInterface.setConnectedToDaemon(false);
     this.resetNavigation();
   }
 

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -29,6 +29,7 @@ import { LoginState } from '../redux/account/reducers';
 export interface IProps {
   preferredLocaleDisplayName: string;
   loginState: LoginState;
+  connectedToDaemon: boolean;
   accountExpiry?: string;
   appVersion: string;
   consistentVersion: boolean;
@@ -108,7 +109,7 @@ export default class Settings extends React.Component<IProps> {
 
   private renderTopButtons() {
     const isLoggedIn = this.props.loginState.type === 'ok';
-    if (!isLoggedIn) {
+    if (!isLoggedIn || !this.props.connectedToDaemon) {
       return null;
     }
 

--- a/gui/src/renderer/containers/SettingsPage.tsx
+++ b/gui/src/renderer/containers/SettingsPage.tsx
@@ -10,6 +10,7 @@ const mapStateToProps = (state: IReduxState, props: IAppContext) => ({
     state.settings.guiSettings.preferredLocale,
   ),
   loginState: state.account.status,
+  connectedToDaemon: state.userInterface.connectedToDaemon,
   accountExpiry: state.account.expiry,
   appVersion: state.version.current,
   consistentVersion: state.version.consistent,

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -41,6 +41,11 @@ export interface ISetMacOsScrollbarVisibility {
   visibility: MacOsScrollbarVisibility;
 }
 
+export interface ISetConnectedToDaemon {
+  type: 'SET_CONNECTED_TO_DAEMON';
+  connectedToDaemon: boolean;
+}
+
 export type UserInterfaceAction =
   | IUpdateLocaleAction
   | IUpdateWindowArrowPositionAction
@@ -49,7 +54,8 @@ export type UserInterfaceAction =
   | ISetWindowFocusedAction
   | IAddScrollPosition
   | IRemoveScrollPosition
-  | ISetMacOsScrollbarVisibility;
+  | ISetMacOsScrollbarVisibility
+  | ISetConnectedToDaemon;
 
 function updateLocale(locale: string): IUpdateLocaleAction {
   return {
@@ -109,6 +115,13 @@ function setMacOsScrollbarVisibility(
   };
 }
 
+function setConnectedToDaemon(connectedToDaemon: boolean): ISetConnectedToDaemon {
+  return {
+    type: 'SET_CONNECTED_TO_DAEMON',
+    connectedToDaemon,
+  };
+}
+
 export default {
   updateLocale,
   updateWindowArrowPosition,
@@ -118,4 +131,5 @@ export default {
   addScrollPosition,
   removeScrollPosition,
   setMacOsScrollbarVisibility,
+  setConnectedToDaemon,
 };

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -14,6 +14,7 @@ export interface IUserInterfaceReduxState {
   windowFocused: boolean;
   scrollPosition: Record<string, [number, number]>;
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
+  connectedToDaemon: boolean;
 }
 
 const initialState: IUserInterfaceReduxState = {
@@ -23,6 +24,7 @@ const initialState: IUserInterfaceReduxState = {
   windowFocused: false,
   scrollPosition: {},
   macOsScrollbarVisibility: undefined,
+  connectedToDaemon: false,
 };
 
 export default function (
@@ -59,6 +61,9 @@ export default function (
 
     case 'SET_MACOS_SCROLLBAR_VISIBILITY':
       return { ...state, macOsScrollbarVisibility: action.visibility };
+
+    case 'SET_CONNECTED_TO_DAEMON':
+      return { ...state, connectedToDaemon: action.connectedToDaemon };
 
     default:
       return state;


### PR DESCRIPTION
This PR prevents the "Account", "Preferences" and "Advanced Settings" buttons from showing in the settings view when not connected to the daemon.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3060)
<!-- Reviewable:end -->
