### PR TITLE
Temporarily ignore RUSTSEC-2020-0159 RUSTSEC-2020-0071 (time + chrono)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -21,4 +21,6 @@ jobs:
                   version: latest
 
             - name: Audit
-              run: cargo audit
+              # TEMP: Ignore the time/chrono segfault CVEs since there are no known
+              # good workarounds, and we want logs etc to be in local time.
+              run: cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071


### PR DESCRIPTION
As far as I'm aware, there is no known good workaround to these potential segfaults. I would assume we won't trigger them anyway. I doubt anything in our program will actually set the relevant environment variables under our feet?

We can't have broken CI (broken window principle) so we need to either fix this or mark it as ignored so we get our green CI status back.

We never use `time` directly, only indirectly via `chrono`. So we should monitor https://github.com/chronotope/chrono/issues/499 and fix this in a better way when there is a nice solution available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3063)
<!-- Reviewable:end -->
