### PR TITLE
Freeze API requests made before the TSM has spawned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix desktop app showing a future date for when WireGuard key was generated.
 - Fix desktop app split tunneling view to not overflow on very long application names.
+- Prevent API requests from being made prior to the tunnel state machine being set up.
+  Rarely, failed requests could result in a deadlock.
 
 #### Windows
 - Fix detection of Windows 11. Problem reports will now correctly report Windows 11 instead

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.7"
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.8", features =  [ "fs", "rt-multi-thread", "sync" ] }
+tokio = { version = "1.8", features =  [ "fs", "rt-multi-thread", "sync", "time" ] }
 tokio-stream = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/mullvad-daemon/src/account.rs
+++ b/mullvad-daemon/src/account.rs
@@ -86,7 +86,7 @@ impl AccountHandle {
         .await;
         if result.is_ok() {
             self.initial_check_abort_handle.abort();
-            self.api_availability.resume();
+            self.api_availability.resume_background();
         }
         result
     }
@@ -107,7 +107,7 @@ impl Account {
         api_availability: ApiAvailabilityHandle,
     ) -> AccountHandle {
         let accounts_proxy = AccountsProxy::new(rpc_handle);
-        api_availability.pause();
+        api_availability.pause_background();
 
         let api_availability_copy = api_availability.clone();
         let accounts_proxy_copy = accounts_proxy.clone();
@@ -116,7 +116,7 @@ impl Account {
             let token = if let Some(token) = token {
                 token
             } else {
-                api_availability.pause();
+                api_availability.pause_background();
                 return;
             };
 
@@ -155,16 +155,16 @@ fn handle_expiry_result_inner(
 ) -> bool {
     match result {
         Ok(_expiry) if *_expiry >= chrono::Utc::now() => {
-            api_availability.resume();
+            api_availability.resume_background();
             true
         }
         Ok(_expiry) => {
-            api_availability.pause();
+            api_availability.pause_background();
             true
         }
         Err(mullvad_rpc::rest::Error::ApiError(_status, code)) => {
             if code == mullvad_rpc::INVALID_ACCOUNT || code == mullvad_rpc::INVALID_AUTH {
-                api_availability.pause();
+                api_availability.pause_background();
                 return true;
             }
             false

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -588,6 +588,7 @@ where
         .map_err(Error::InitRpcFactory)?;
         let rpc_handle = rpc_runtime.mullvad_rest_handle();
         let api_availability = rpc_runtime.availability_handle();
+        api_availability.suspend();
 
         let relay_list_listener = event_listener.clone();
         let on_relay_list_update = move |relay_list: &RelayList| {
@@ -717,6 +718,8 @@ where
         )
         .await
         .map_err(Error::TunnelError)?;
+
+        api_availability.unsuspend();
 
         Self::forward_offline_state(&runtime, api_availability.clone(), offline_state_rx).await;
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -24,7 +24,7 @@ mod version_check;
 use futures::{
     channel::{mpsc, oneshot},
     future::{abortable, AbortHandle, Future},
-    SinkExt, StreamExt,
+    StreamExt,
 };
 use log::{debug, error, info, warn};
 use mullvad_rpc::availability::ApiAvailabilityHandle;
@@ -559,50 +559,6 @@ where
         let runtime = tokio::runtime::Handle::current();
 
         let (internal_event_tx, internal_event_rx) = command_channel.destructure();
-        let (address_change_tx, mut address_change_rx) = mpsc::channel(0);
-        let address_change_tx = std::sync::Mutex::new(address_change_tx);
-        let address_change_runtime = runtime.clone();
-
-        let mut rpc_runtime = mullvad_rpc::MullvadRpcRuntime::with_cache(
-            runtime.clone(),
-            Some(&resource_dir),
-            &cache_dir,
-            true,
-            move |address| {
-                let (result_tx, result_rx) = oneshot::channel();
-
-                let mut tx = address_change_tx.lock().unwrap().clone();
-                address_change_runtime.block_on(async move {
-                    let tunnel_command = TunnelCommand::AllowEndpoint(
-                        Endpoint::from_socket_address(address, TransportProtocol::Tcp),
-                        result_tx,
-                    );
-                    let _ = tx.send(tunnel_command).await;
-                    result_rx.await.map_err(|_| ())
-                })
-            },
-            #[cfg(target_os = "android")]
-            Self::create_bypass_tx(&internal_event_tx),
-        )
-        .await
-        .map_err(Error::InitRpcFactory)?;
-        let rpc_handle = rpc_runtime.mullvad_rest_handle();
-        let api_availability = rpc_runtime.availability_handle();
-        api_availability.suspend();
-
-        let relay_list_listener = event_listener.clone();
-        let on_relay_list_update = move |relay_list: &RelayList| {
-            relay_list_listener.notify_relay_list(relay_list.clone());
-        };
-
-        let relay_selector = relays::RelaySelector::new(
-            rpc_handle.clone(),
-            on_relay_list_update,
-            &resource_dir,
-            &cache_dir,
-            api_availability.clone(),
-        );
-
 
         if let Err(error) = migrations::migrate_all(&cache_dir, &settings_dir).await {
             log::error!(
@@ -615,21 +571,6 @@ where
         if version::is_beta_version() {
             let _ = settings.set_show_beta_releases(true).await;
         }
-
-        let app_version_info = version_check::load_cache(&cache_dir).await;
-        let (version_updater, version_updater_handle) = version_check::VersionUpdater::new(
-            rpc_handle.clone(),
-            api_availability.clone(),
-            cache_dir.clone(),
-            internal_event_tx.to_specialized_sender(),
-            app_version_info.clone(),
-            settings.show_beta_releases,
-        );
-        tokio::spawn(version_updater.run());
-        let account_history =
-            account_history::AccountHistory::new(&settings_dir, settings.get_account_token())
-                .await
-                .map_err(Error::LoadAccountHistory)?;
 
         // Restore the tunnel to a previous state
         let target_cache = cache_dir.join(TARGET_START_STATE_FILE);
@@ -677,10 +618,6 @@ where
         };
         Self::cache_target_state(&cache_dir, initial_target_state).await;
 
-        let initial_api_endpoint = Endpoint::from_socket_address(
-            rpc_runtime.address_cache.peek_address(),
-            TransportProtocol::Tcp,
-        );
         #[cfg(windows)]
         let exclude_paths = if settings.split_tunnel.enable_exclusions {
             settings
@@ -693,8 +630,26 @@ where
             vec![]
         };
 
-        let (offline_state_tx, offline_state_rx) = mpsc::unbounded();
+        let mut rpc_runtime = mullvad_rpc::MullvadRpcRuntime::with_cache(
+            runtime.clone(),
+            Some(&resource_dir),
+            &cache_dir,
+            true,
+            #[cfg(target_os = "android")]
+            Self::create_bypass_tx(&internal_event_tx),
+        )
+        .await
+        .map_err(Error::InitRpcFactory)?;
 
+        let api_availability = rpc_runtime.availability_handle();
+        api_availability.suspend();
+
+        let initial_api_endpoint = Endpoint::from_socket_address(
+            rpc_runtime.address_cache.peek_address(),
+            TransportProtocol::Tcp,
+        );
+
+        let (offline_state_tx, offline_state_rx) = mpsc::unbounded();
         let tunnel_command_tx = tunnel_state_machine::spawn(
             runtime.clone(),
             tunnel_state_machine::InitialTunnelState {
@@ -708,7 +663,7 @@ where
             },
             tunnel_parameters_generator,
             log_dir,
-            resource_dir,
+            resource_dir.clone(),
             cache_dir.clone(),
             internal_event_tx.to_specialized_sender(),
             offline_state_tx,
@@ -719,20 +674,55 @@ where
         .await
         .map_err(Error::TunnelError)?;
 
-        api_availability.unsuspend();
+        let address_change_runtime = runtime.clone();
+        let tunnel_cmd_weak_tx = Arc::downgrade(&tunnel_command_tx);
+        rpc_runtime.set_address_change_listener(move |address| {
+            let (result_tx, result_rx) = oneshot::channel();
+            let tx = tunnel_cmd_weak_tx.clone();
+            address_change_runtime.block_on(async move {
+                if let Some(tx) = tx.upgrade() {
+                    let _ = tx.unbounded_send(TunnelCommand::AllowEndpoint(
+                        Endpoint::from_socket_address(address, TransportProtocol::Tcp),
+                        result_tx,
+                    ));
+                    result_rx.await.map_err(|_| ())
+                } else {
+                    Err(())
+                }
+            })
+        });
+
+        let rpc_handle = rpc_runtime.mullvad_rest_handle();
 
         Self::forward_offline_state(&runtime, api_availability.clone(), offline_state_rx).await;
 
-        let tsm_api_address_change_tx = Arc::downgrade(&tunnel_command_tx);
-        tokio::spawn(async move {
-            while let Some(address_change) = address_change_rx.next().await {
-                if let Some(tx) = tsm_api_address_change_tx.upgrade() {
-                    let _ = tx.unbounded_send(address_change);
-                } else {
-                    return;
-                }
-            }
-        });
+        let relay_list_listener = event_listener.clone();
+        let on_relay_list_update = move |relay_list: &RelayList| {
+            relay_list_listener.notify_relay_list(relay_list.clone());
+        };
+
+        let relay_selector = relays::RelaySelector::new(
+            rpc_handle.clone(),
+            on_relay_list_update,
+            &resource_dir,
+            &cache_dir,
+            api_availability.clone(),
+        );
+
+        let app_version_info = version_check::load_cache(&cache_dir).await;
+        let (version_updater, version_updater_handle) = version_check::VersionUpdater::new(
+            rpc_handle.clone(),
+            api_availability.clone(),
+            cache_dir.clone(),
+            internal_event_tx.to_specialized_sender(),
+            app_version_info.clone(),
+            settings.show_beta_releases,
+        );
+        tokio::spawn(version_updater.run());
+        let account_history =
+            account_history::AccountHistory::new(&settings_dir, settings.get_account_token())
+                .await
+                .map_err(Error::LoadAccountHistory)?;
 
         let wireguard_key_manager = wireguard::KeyManager::new(
             internal_event_tx.clone(),
@@ -783,6 +773,8 @@ where
         };
 
         daemon.ensure_wireguard_keys_for_current_account().await;
+
+        api_availability.unsuspend();
 
         Ok(daemon)
     }

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -1046,10 +1046,12 @@ impl RelayListUpdater {
     }
 
     async fn run(mut self, mut cmd_rx: mpsc::Receiver<bool>) {
-        let mut check_interval = tokio_stream::wrappers::IntervalStream::new(
-            tokio::time::interval(UPDATE_CHECK_INTERVAL),
-        )
-        .fuse();
+        let mut check_interval =
+            tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(
+                (Instant::now() + UPDATE_CHECK_INTERVAL).into(),
+                UPDATE_CHECK_INTERVAL,
+            ))
+            .fuse();
         let mut download_future = Box::pin(Fuse::terminated());
         loop {
             futures::select! {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -1129,7 +1129,7 @@ impl RelayListUpdater {
         tag: Option<String>,
     ) -> impl Future<Output = Result<Option<RelayList>, mullvad_rpc::Error>> + 'static {
         let download_futures = move || {
-            let available = api_handle.wait_available();
+            let available = api_handle.wait_background();
             let req = rpc_handle.relay_list(tag.clone());
             async move {
                 available.await?;

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -233,7 +233,7 @@ impl VersionUpdater {
         let version_proxy = self.version_proxy.clone();
         let platform_version = self.platform_version.clone();
         let download_future_factory = move || {
-            let when_available = api_handle.wait_available();
+            let when_available = api_handle.wait_background();
             let request = version_proxy.version_check(
                 PRODUCT_VERSION.to_owned(),
                 PLATFORM,

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -229,7 +229,7 @@ impl KeyManager {
         let availability_handle = self.availability_handle.clone();
 
         let future_generator = move || {
-            let wait_available = availability_handle.wait_available();
+            let wait_available = availability_handle.wait_background();
             let fut = inner_future_generator();
             let error_tx = error_tx.clone();
             let error_account = error_account.clone();
@@ -381,7 +381,7 @@ impl KeyManager {
 
         let rotate_key_for_account =
             move |old_key: &PublicKey| -> Pin<Box<dyn Future<Output = Result<PublicKey>> + Send>> {
-                let wait_available = availability_handle.wait_available();
+                let wait_available = availability_handle.wait_background();
                 let rotate = Self::rotate_key(
                     daemon_tx.clone(),
                     http_handle.clone(),

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -283,7 +283,6 @@ pub fn send_problem_report(
             None,
             cache_dir,
             false,
-            |_| Ok(()),
             #[cfg(target_os = "android")]
             None,
         ))

--- a/mullvad-rpc/src/availability.rs
+++ b/mullvad-rpc/src/availability.rs
@@ -18,21 +18,17 @@ pub enum Error {
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
 pub struct State {
-    pause_automatic: bool,
+    pause_background: bool,
     offline: bool,
 }
 
 impl State {
-    pub fn is_paused(&self) -> bool {
-        self.pause_automatic
+    pub fn is_background_paused(&self) -> bool {
+        self.pause_background
     }
 
     pub fn is_offline(&self) -> bool {
         self.offline
-    }
-
-    pub fn is_available(&self) -> bool {
-        !self.is_paused() && !self.is_offline()
     }
 }
 
@@ -67,18 +63,18 @@ pub struct ApiAvailabilityHandle {
 }
 
 impl ApiAvailabilityHandle {
-    pub fn pause(&self) {
+    pub fn pause_background(&self) {
         let mut state = self.state.lock().unwrap();
-        if !state.pause_automatic {
-            state.pause_automatic = true;
+        if !state.pause_background {
+            state.pause_background = true;
             let _ = self.tx.send(*state);
         }
     }
 
-    pub fn resume(&self) {
+    pub fn resume_background(&self) {
         let mut state = self.state.lock().unwrap();
-        if state.pause_automatic {
-            state.pause_automatic = false;
+        if state.pause_background {
+            state.pause_background = false;
             let _ = self.tx.send(*state);
         }
     }
@@ -95,8 +91,8 @@ impl ApiAvailabilityHandle {
         *self.state.lock().unwrap()
     }
 
-    pub fn wait_available(&self) -> impl Future<Output = Result<(), Error>> {
-        self.wait_for_state(|state| state.is_available())
+    pub fn wait_background(&self) -> impl Future<Output = Result<(), Error>> {
+        self.wait_for_state(|state| !state.is_offline() && !state.is_background_paused())
     }
 
     pub fn wait_online(&self) -> impl Future<Output = Result<(), Error>> {

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -646,7 +646,7 @@ impl MullvadRestHandle {
             loop {
                 interval.tick().await;
                 if next_check < Instant::now() {
-                    if let Err(error) = availability.wait_available().await {
+                    if let Err(error) = availability.wait_background().await {
                         log::error!("Failed while waiting for API: {}", error);
                         next_check = next_error_check();
                         continue;

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -178,7 +178,6 @@ async fn remove_wireguard_key() -> Result<(), Error> {
                 None,
                 &cache_path,
                 false,
-                |_| Ok(()),
             )
             .await
             .map_err(Error::RpcInitializationError)?;


### PR DESCRIPTION
Supersedes #3065. Main changes:
* All requests are frozen (although they can still time out) until after the TSM has been constructed.
* The listener for handling address changes is set *after* the TSM is created, and the REST client is created immediately before the TSM is created.
* The relay list updater doesn't immediately check if the relay list is outdated. This was likely the thing that triggered the deadlock in the first place, when the subsequent list updated failed, although it was pretty racy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3066)
<!-- Reviewable:end -->
