### PR TITLE
Fix segfault while closing app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix desktop app split tunneling view to not overflow on very long application names.
 - Prevent API requests from being made prior to the tunnel state machine being set up.
   Rarely, failed requests could result in a deadlock.
+- Fix segmentation fault when closing app.
 
 #### Windows
 - Fix detection of Windows 11. Problem reports will now correctly report Windows 11 instead

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -569,7 +569,10 @@ export class DaemonRpc {
           throw error;
         }
       });
-      subscription.cancel();
+      // setImmediate is required due to https://github.com/grpc/grpc-node/issues/1464. Should be
+      // possible to remove it again after upgrading to Electron 16 which is using a node version
+      // where this is fixed.
+      setImmediate(() => subscription.cancel());
     }
   }
 


### PR DESCRIPTION
This is a workaround for a bug in node which causes a segfault when we close a gRPC stream. The workaround is to wrap the `.cancel()` call in a `setImmediate()`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3074)
<!-- Reviewable:end -->
