### PR TITLE
Add blur to transparent buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Changed
 - Update Electron from 11.4.9 to 15.0.0.
+- Revamp main view with lower resolution maps, blurred background behind semi-transparent buttons
+  and switch to correct font for logo.
 
 #### Android
 - Drop support for Android 7/7.1 (Android 8/API level 26 or later is now required).

--- a/gui/src/renderer/components/AppButton.tsx
+++ b/gui/src/renderer/components/AppButton.tsx
@@ -3,7 +3,12 @@ import styled from 'styled-components';
 import { colors } from '../../config.json';
 import log from '../../shared/logging';
 import { useMounted } from '../lib/utilityHooks';
-import { StyledButtonContent, StyledLabel, StyledLabelContainer } from './AppButtonStyles';
+import {
+  StyledButtonContent,
+  StyledLabel,
+  StyledLabelContainer,
+  transparentButton,
+} from './AppButtonStyles';
 import ImageView from './ImageView';
 
 interface IButtonContext {
@@ -178,14 +183,14 @@ export const BlueButton = styled(BaseButton)({
   },
 });
 
-export const TransparentButton = styled(BaseButton)({
+export const TransparentButton = styled(BaseButton)(transparentButton, {
   backgroundColor: colors.white20,
   ':not(:disabled):hover': {
     backgroundColor: colors.white40,
   },
 });
 
-export const RedTransparentButton = styled(BaseButton)({
+export const RedTransparentButton = styled(BaseButton)(transparentButton, {
   backgroundColor: colors.red60,
   ':not(:disabled):hover': {
     backgroundColor: colors.red80,

--- a/gui/src/renderer/components/AppButtonStyles.tsx
+++ b/gui/src/renderer/components/AppButtonStyles.tsx
@@ -21,3 +21,7 @@ export const StyledButtonContent = styled.div({
   justifyContent: 'center',
   padding: '9px',
 });
+
+export const transparentButton = {
+  backdropFilter: 'blur(4px)',
+};


### PR DESCRIPTION
This PR makes the transparent buttons blur the background behind them.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3076)
<!-- Reviewable:end -->
