### PR TITLE
Stop uploading to build.mullvad.net

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -24,16 +24,15 @@ while true; do
         upload_path="releases"
     fi
 
-    ssh build.mullvad.net mkdir -p "app/$version" || continue
-    scp -pB "$f" build.mullvad.net:app/$version/ || continue
     rsync -av --rsh='ssh -p 1122' "$f" "build@releases.mullvad.net:$upload_path/$version/" || continue
 
     rm -f "$f.asc"
     gpg -u A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF --pinentry-mode loopback --sign --armor --detach-sign "$f"
-    scp -pB "$f.asc" build.mullvad.net:app/$version/ || true
     rsync -av --rsh='ssh -p 1122' "$f.asc" "build@releases.mullvad.net:$upload_path/$version/" || continue
     yes | rm "$f" "$f_checksum" "$f.asc"
   done
+
+  # Upload PDB files (Windows debugging info)
   for f_checksum in pdb-*.sha256; do
     sleep 1
     f="${f_checksum/.sha256/}"
@@ -42,9 +41,7 @@ while true; do
       continue
     fi
 
-    ssh build.mullvad.net mkdir -p app/pdb || continue
-    scp -pB "$f" build.mullvad.net:app/pdb/ || continue
-
+    rsync -av --rsh='ssh -p 1122' "$f" "build@releases.mullvad.net:builds/pdb/" || continue
     yes | rm "$f" "$f_checksum"
   done
 done

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -17,7 +17,7 @@ while true; do
       continue
     fi
 
-    version=$(echo $f | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm|\.apk|\.aab)/\1/g')
+    version=$(echo "$f" | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm|\.apk|\.aab)/\1/g')
     if [[ $version == *"-dev-"* ]]; then
         upload_path="builds"
     else


### PR DESCRIPTION
Removing the last traces of `build.mullvad.net` in this repository. For a while we have been uploading build artifacts to two servers. But it's time to stop doing it to the old one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3080)
<!-- Reviewable:end -->
