### PR TITLE
CI: Switch to macOS 11 and iOS 13

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,10 +9,10 @@ on:
 jobs:
     test:
         name: Unit tests
-        runs-on: macos-10.15
+        runs-on: macos-11
         strategy:
             matrix:
-                destination: ['platform=iOS Simulator,OS=12.4,name=iPhone 8']
+                destination: ['platform=iOS Simulator,OS=13.7,name=iPhone 8']
         env:
             source_packages_dir: .spm
         steps:
@@ -32,10 +32,10 @@ jobs:
               with:
                   go-version: '1.16.5'
 
-            - name: Prepare iOS 12 simulator
+            - name: Prepare iOS simulator
               run: |
                   sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-                  sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
+                  sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.7.simruntime
 
             - name: Build and test
               run: |


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR migrates iOS tests to iOS 13 simulator runtime and macOS 11. The change is needed because older Xcode does not recognise API introduced in iOS 15 and fails to run tests even though all calls to newer API are guarded with availability checks. 

Xcode 13 on the other side, does not have that problem, however it does not come with iOS 12 simulator runtime, so I had to bump the test suite to use iOS 13 instead. 

[The alternative solution that preserves the iOS 12 runtime](https://github.com/mullvad/mullvadvpn-app/commit/1d647738d40fc3be58abf3049ce592f2c62423aa
), involves installing it on macOS 11 image and then caching it with `actions/cache@v2`, however that alone adds about 3 minute of extra overhead to set up the testing environment and takes 2 GB extra cache space.

Hence I favour running tests on iOS 13, partly because we'll eventually have to abandon iOS 12. The tests themselves aren't iOS 12 specific so hence even more reasons to not complicate our test setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3081)
<!-- Reviewable:end -->
