### PR TITLE
Fix RTL layouts

### DIFF
--- a/ios/MullvadVPN/AppButton.swift
+++ b/ios/MullvadVPN/AppButton.swift
@@ -50,7 +50,7 @@ private extension UIControl.State {
 }
 
 /// A subclass that implements the button that visually look like URL links on the web
-@IBDesignable class LinkButton: CustomButton {
+class LinkButton: CustomButton {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -97,7 +97,7 @@ private extension UIControl.State {
 }
 
 /// A subclass that implements action buttons used across the app
-@IBDesignable class AppButton: CustomButton {
+class AppButton: CustomButton {
 
     var defaultContentInsets: UIEdgeInsets {
         switch traitCollection.userInterfaceIdiom {
@@ -145,7 +145,7 @@ private extension UIControl.State {
         }
     }
 
-    @IBInspectable var interfaceBuilderStyle: Int {
+    var interfaceBuilderStyle: Int {
         get {
             return self.style.rawValue
         }
@@ -228,7 +228,7 @@ private extension UIControl.State {
 }
 
 /// A custom `UIButton` subclass that implements additional layouts for the image
-@IBDesignable class CustomButton: UIButton {
+class CustomButton: UIButton {
 
     var imageAlignment: ButtonImageAlignment = .leading {
         didSet {

--- a/ios/MullvadVPN/AppButton.swift
+++ b/ios/MullvadVPN/AppButton.swift
@@ -353,6 +353,20 @@ class CustomButton: UIButton {
             titleRect.origin.x = contentRect.midX - titleRect.width * 0.5
             imageRect.origin.x = titleRect.maxX + inlineImageSpacing
 
+        case (.right, .left):
+            titleRect.origin.x = contentRect.maxX - titleRect.width
+            imageRect.origin.x = titleRect.minX - imageRect.width - inlineImageSpacing
+
+        case (.right, .leftFixed):
+            imageRect.origin.x = contentRect.minX
+            titleRect.origin.x = contentRect.maxX - titleRect.width
+
+        case (.right, .rightFixed):
+            imageRect.origin.x = contentRect.maxX - imageRect.width
+            titleRect.origin.x = imageRect.width > 0
+                ? imageRect.minX - inlineImageSpacing - titleRect.width
+                : contentRect.maxX - titleRect.width
+
         default:
             fatalError()
         }

--- a/ios/MullvadVPN/AppButton.swift
+++ b/ios/MullvadVPN/AppButton.swift
@@ -132,9 +132,9 @@ class AppButton: CustomButton {
             case .translucentNeutral:
                 return UIImage(named: "TranslucentNeutralButton")
             case .translucentDangerSplitLeft:
-                return UIImage(named: "TranslucentDangerSplitLeftButton")
+                return UIImage(named: "TranslucentDangerSplitLeftButton")?.imageFlippedForRightToLeftLayoutDirection()
             case .translucentDangerSplitRight:
-                return UIImage(named: "TranslucentDangerSplitRightButton")
+                return UIImage(named: "TranslucentDangerSplitRightButton")?.imageFlippedForRightToLeftLayoutDirection()
             }
         }
     }

--- a/ios/MullvadVPN/AppButton.swift
+++ b/ios/MullvadVPN/AppButton.swift
@@ -145,17 +145,6 @@ class AppButton: CustomButton {
         }
     }
 
-    var interfaceBuilderStyle: Int {
-        get {
-            return self.style.rawValue
-        }
-        set {
-            if let style = Style(rawValue: newValue) {
-                self.style = style
-            }
-        }
-    }
-
     var overrideContentEdgeInsets = false
 
     init(style: Style) {
@@ -170,10 +159,8 @@ class AppButton: CustomButton {
         commonInit()
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        style = .default
-        super.init(coder: aDecoder)
-        commonInit()
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     private func commonInit() {

--- a/ios/MullvadVPN/Assets.xcassets/IconArrow.imageset/Contents.json
+++ b/ios/MullvadVPN/Assets.xcassets/IconArrow.imageset/Contents.json
@@ -1,13 +1,14 @@
 {
   "images" : [
     {
+      "filename" : "IconArrow.pdf",
       "idiom" : "universal",
-      "filename" : "IconArrow.pdf"
+      "language-direction" : "left-to-right"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
     "preserves-vector-representation" : true

--- a/ios/MullvadVPN/Assets.xcassets/IconExtlink.imageset/Contents.json
+++ b/ios/MullvadVPN/Assets.xcassets/IconExtlink.imageset/Contents.json
@@ -1,16 +1,17 @@
 {
   "images" : [
     {
+      "filename" : "IconExtlink.pdf",
       "idiom" : "universal",
-      "filename" : "IconExtlink.pdf"
+      "language-direction" : "left-to-right"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
-    "template-rendering-intent" : "template",
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/ios/MullvadVPN/DisconnectSplitButton.swift
+++ b/ios/MullvadVPN/DisconnectSplitButton.swift
@@ -42,7 +42,7 @@ class DisconnectSplitButton: UIView {
         stackView.alignment = .fill
         stackView.spacing = 1
 
-        secondaryButton.setImage(UIImage(named: "IconReload"), for: .normal)
+        secondaryButton.setImage(UIImage(named: "IconReload")?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
 
         primaryButton.overrideContentEdgeInsets = true
         secondaryButtonWidthConstraint = secondaryButton.widthAnchor.constraint(equalToConstant: 0)
@@ -86,8 +86,16 @@ class DisconnectSplitButton: UIView {
 
     private func adjustTitleLabelPosition() {
         var contentInsets = primaryButton.defaultContentInsets
-        contentInsets.left = stackView.spacing + self.secondaryButtonSize.width
-        contentInsets.right = 0
+
+        let offset = stackView.spacing + self.secondaryButtonSize.width
+
+        if case .leftToRight = effectiveUserInterfaceLayoutDirection {
+            contentInsets.left = offset
+            contentInsets.right = 0
+        } else {
+            contentInsets.left = 0
+            contentInsets.right = offset
+        }
 
         primaryButton.contentEdgeInsets = contentInsets
     }

--- a/ios/MullvadVPN/SettingsCell.swift
+++ b/ios/MullvadVPN/SettingsCell.swift
@@ -104,6 +104,7 @@ class SettingsCell: UITableViewCell {
             let configuration = UIImage.SymbolConfiguration(pointSize: 11, weight: .bold)
             let chevron = UIImage(systemName: "chevron.right", withConfiguration: configuration)?
                 .withTintColor(.white, renderingMode: .alwaysOriginal)
+                .imageFlippedForRightToLeftLayoutDirection()
 
             button.setImage(chevron, for: .normal)
         } else {

--- a/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
+++ b/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
@@ -11,7 +11,7 @@ import UIKit
 private let kRotationAnimationKey = "rotation"
 private let kAnimationDuration = 0.6
 
-@IBDesignable class SpinnerActivityIndicatorView: UIView {
+class SpinnerActivityIndicatorView: UIView {
 
     enum Style {
         case small, medium, large
@@ -38,7 +38,7 @@ private let kAnimationDuration = 0.6
     }
 
     /// Thickness of the front and back circles
-    @IBInspectable var thickness: CGFloat = 6 {
+    var thickness: CGFloat = 6 {
         didSet {
             setLayersThickness()
         }

--- a/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
+++ b/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
@@ -82,9 +82,8 @@ class SpinnerActivityIndicatorView: UIView {
         commonInit()
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        commonInit()
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     deinit {

--- a/ios/MullvadVPN/TranslucentButtonBlurView.swift
+++ b/ios/MullvadVPN/TranslucentButtonBlurView.swift
@@ -28,7 +28,7 @@ class TranslucentButtonBlurView: UIVisualEffectView {
         ])
 
         layer.cornerRadius = kButtonCornerRadius
-        layer.maskedCorners = button.style.cornerMask
+        layer.maskedCorners = button.style.cornerMask(effectiveUserInterfaceLayoutDirection)
         layer.masksToBounds = true
     }
 
@@ -38,11 +38,11 @@ class TranslucentButtonBlurView: UIVisualEffectView {
 }
 
 private extension AppButton.Style {
-    var cornerMask: CACornerMask {
-        switch self {
-        case .translucentDangerSplitLeft:
+    func cornerMask(_ userInterfaceLayoutDirection: UIUserInterfaceLayoutDirection) -> CACornerMask {
+        switch (self, userInterfaceLayoutDirection) {
+        case (.translucentDangerSplitLeft, .leftToRight), (.translucentDangerSplitRight, .rightToLeft):
             return [.layerMinXMinYCorner, .layerMinXMaxYCorner]
-        case .translucentDangerSplitRight:
+        case (.translucentDangerSplitRight, .leftToRight), (.translucentDangerSplitLeft, .rightToLeft):
             return [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
         default:
             return [


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Although we don't support right-to-left per se, I figured to keep the codebase future-proof, it wouldn't hurt to fix a few outstanding issues related to supporting RTL environment in the future which as of now result in a crash `fatalError`, which is not nice.

1. Add implementation of `AppButton` layout in right-to-left languages. We're not supporting any yet but I figured to keep our code future proof, it would be great to have it in place to avoid `fatalError()` instead.
2. Remove all Interface Builder released attributes such as `@IBDesignable` and `@ IBInspectable`.
3. Remove `init(withCoder:)` initializers primarily used when loading views built with Interface Builder.
4. Flip chevron ➡️, 🔄, IconExtlink icons for right-to-left environment.

<table>
<tr>
<td>
<img width="376" alt="Screenshot 2021-11-03 at 14 05 47" src="https://user-images.githubusercontent.com/704044/140065265-88dc9bc2-445b-41d3-8dc0-b321acc4cda7.png"></td>
<td>
<img width="381" alt="Screenshot 2021-11-03 at 14 06 13" src="https://user-images.githubusercontent.com/704044/140065319-50d8bd8b-fd3e-46e4-819f-07e1b5486360.png"></td>
<td><img width="187" alt="Screenshot 2021-11-03 at 14 07 46" src="https://user-images.githubusercontent.com/704044/140065524-a340e7bb-a0d0-45af-ac3b-0025d69cf672.png"></td>
<td><img width="357" alt="Screenshot 2021-11-03 at 14 08 06" src="https://user-images.githubusercontent.com/704044/140065565-e346fe6b-f5e6-4112-bf26-f8bd5e7a00b2.png">
</td>
</tr>
</table>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3083)
<!-- Reviewable:end -->
