### PR TITLE
Automatically disable custom dns when no added servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix reconnect on app resume. Don't reconnect the tunnel every time the app is opened.
 - Fix invalid URLs. Rely on browser locale rather than app/system language.
+- Automatically disable custom DNS when no servers have been added.
 
 #### macOS
 - Prevent app from showing when dragging tray icon on macOS.

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -152,10 +152,8 @@ class AdvancedFragment : ServiceDependentFragment(OnNoService.GoBack) {
         parentActivity.backButtonHandler = {
             if (customDnsAdapter.isEditing) {
                 customDnsAdapter.stopEditing()
-                true
-            } else {
-                false
             }
+            false
         }
     }
 


### PR DESCRIPTION
Automatically disable custom DNS when no servers have been added as this better reflect the daemon behavior (which will fallback to the default Mullvad DNS servers).

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3084)
<!-- Reviewable:end -->
