### PR TITLE
Simplify management interface server shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,6 @@ dependencies = [
  "talpid-types",
  "tokio",
  "tokio-stream",
- "triggered",
  "uuid",
  "winapi 0.3.9",
  "windows-service",
@@ -1312,7 +1311,6 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
- "triggered",
 ]
 
 [[package]]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -36,7 +36,6 @@ talpid-types = { path = "../talpid-types" }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-triggered = "0.1.1"
 mullvad-management-interface = { path = "../mullvad-management-interface" }
 
 [target.'cfg(target_os="android")'.dependencies]

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -735,11 +735,7 @@ where
         );
 
         // Attempt to download a fresh relay list
-        let mut relay_handle = relay_selector.updater_handle();
-        relay_handle
-            .update_relay_list_deferred()
-            .await
-            .expect("Relay list updated thread has stopped unexpectedly");
+        relay_selector.update().await;
 
         let mut daemon = Daemon {
             tunnel_command_tx,

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -157,15 +157,13 @@ async fn create_daemon(
 async fn spawn_management_interface(
     command_sender: DaemonCommandSender,
 ) -> Result<ManagementInterfaceEventBroadcaster, String> {
-    let server = ManagementInterfaceServer::start(command_sender)
+    let (socket_path, event_broadcaster) = ManagementInterfaceServer::start(command_sender)
         .await
         .map_err(|error| {
-            error.display_chain_with_msg("Unable to start management interface server")
-        })?;
-    let event_broadcaster = server.event_broadcaster();
+        error.display_chain_with_msg("Unable to start management interface server")
+    })?;
 
-    info!("Management interface listening on {}", server.socket_path());
-    tokio::spawn(server.run());
+    info!("Management interface listening on {}", socket_path);
 
     Ok(event_broadcaster)
 }

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -19,7 +19,6 @@ prost-types = "0.8"
 parity-tokio-ipc = "0.9"
 futures = "0.3"
 tokio = { version = "1.8", features =  [ "rt" ] }
-triggered = "0.1.1"
 log = "0.4"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Previously, any instance of `ManagementInterfaceEventBroadcaster` stopped the server when dropped, i.e., it would stop after the first handle was dropped. This PR updates the code so that the server is stopped when all handles have been dropped instead, as this is more idiomatic. Other small improvements were made as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3086)
<!-- Reviewable:end -->
