### PR TITLE
Fix statusbar appearance

### DIFF
--- a/ios/MullvadVPN/CustomNavigationBar.swift
+++ b/ios/MullvadVPN/CustomNavigationBar.swift
@@ -59,6 +59,7 @@ class CustomNavigationBar: UINavigationBar {
     }
 
     private func setupNavigationBarAppearance() {
+        tintColor = .white
         backgroundColor = .secondaryColor
         isTranslucent = false
 

--- a/ios/MullvadVPN/CustomNavigationBar.swift
+++ b/ios/MullvadVPN/CustomNavigationBar.swift
@@ -69,7 +69,10 @@ class CustomNavigationBar: UINavigationBar {
             backIndicatorImage = customBackIndicatorImage
             backIndicatorTransitionMaskImage = customBackIndicatorTransitionMask
             barTintColor = .secondaryColor
-            titleTextAttributes = [.foregroundColor: UIColor.white]
+
+            let titleAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.white]
+            titleTextAttributes = titleAttributes
+            largeTitleTextAttributes = titleAttributes
             shadowImage = UIImage()
         }
     }

--- a/ios/MullvadVPN/CustomSplitViewController.swift
+++ b/ios/MullvadVPN/CustomSplitViewController.swift
@@ -32,6 +32,22 @@ class CustomSplitViewController: UISplitViewController, RootContainment {
         }
     }
 
+    override var childForStatusBarStyle: UIViewController? {
+        if #available(iOS 13, *) {
+            return super.childForStatusBarStyle
+        } else {
+            return viewControllers.last
+        }
+    }
+
+    override var childForStatusBarHidden: UIViewController? {
+        if #available(iOS 13, *) {
+            return super.childForStatusBarHidden
+        } else {
+            return viewControllers.last
+        }
+    }
+
     override var shouldAutomaticallyForwardAppearanceMethods: Bool {
         // iOS 12: force split view controller to forward appearance events.
         return true

--- a/ios/MullvadVPN/CustomSplitViewController.swift
+++ b/ios/MullvadVPN/CustomSplitViewController.swift
@@ -32,6 +32,11 @@ class CustomSplitViewController: UISplitViewController, RootContainment {
         }
     }
 
+    override var shouldAutomaticallyForwardAppearanceMethods: Bool {
+        // iOS 12: force split view controller to forward appearance events.
+        return true
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 

--- a/ios/MullvadVPN/SelectLocationNavigationController.swift
+++ b/ios/MullvadVPN/SelectLocationNavigationController.swift
@@ -11,12 +11,18 @@ import UIKit
 
 class SelectLocationNavigationController: UINavigationController {
 
+    override var childForStatusBarStyle: UIViewController? {
+        return topViewController
+    }
+
+    override var childForStatusBarHidden: UIViewController? {
+        return topViewController
+    }
+
     init(contentController: SelectLocationViewController) {
         super.init(navigationBarClass: CustomNavigationBar.self, toolbarClass: nil)
 
         viewControllers = [contentController]
-        navigationBar.barStyle = .black
-        navigationBar.tintColor = .white
     }
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {

--- a/ios/MullvadVPN/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/SelectLocationViewController.swift
@@ -36,6 +36,10 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
         }
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
     weak var delegate: SelectLocationViewControllerDelegate?
     var scrollToSelectedRelayOnViewWillAppear = true
 

--- a/ios/MullvadVPN/SettingsNavigationController.swift
+++ b/ios/MullvadVPN/SettingsNavigationController.swift
@@ -29,6 +29,14 @@ class SettingsNavigationController: CustomNavigationController, SettingsViewCont
 
     weak var settingsDelegate: SettingsNavigationControllerDelegate?
 
+    override var childForStatusBarStyle: UIViewController? {
+        return topViewController
+    }
+
+    override var childForStatusBarHidden: UIViewController? {
+        return topViewController
+    }
+
     init() {
         super.init(navigationBarClass: CustomNavigationBar.self, toolbarClass: nil)
 
@@ -51,8 +59,6 @@ class SettingsNavigationController: CustomNavigationController, SettingsViewCont
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationBar.barStyle = .black
-        navigationBar.tintColor = .white
         navigationBar.prefersLargeTitles = true
 
         // Update account expiry


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

#### `CustomSplitViewController`

1. Forward appearance events (viewWillAppear, viewDidAppear, etc...) on iOS 12
2. Handle statusbar style on iOS 12. Resort to default behaviour on iOS 13 and newer, which works as expected.
3. Implement `preferredStatusBarStyle` in `SelectLocationViewController`. This fixes the issue where the statusbar is half black and half white on iOS 15, when using split view controller.

#### Custom navigation controllers

1. Delegate statusbar style to the child controllers. The system queries the status bar style via `preferredStatusBarStyle` property.
2. Add missing `largeTitleTextAttributes` appearance configuration in `CustomNavigationBar`. Also default `tintColor` to `.white`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3091)
<!-- Reviewable:end -->
