### PR TITLE
Fix/improve window proportion after display scale factor change on windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Line wrap the file at 100 chars.                                              Th
 - Keep unspecified constraints unchanged in the CLI when providing specific tunnel constraints
   instead of setting them to default values.
 
+### Fixed
+#### Windows
+- Fix app size after changing display scale.
+
 
 ## [2021.6-beta1] - 2021-11-03
 ### Added

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1693,45 +1693,13 @@ class ApplicationMain {
     }
   }
 
-  // On both Linux and Windows the app height is applied incorrectly:
-  // https://github.com/electron/electron/issues/28777
-  private getContentHeight(): number {
-    // The height we want achieve.
-    const contentHeight = 568;
-
-    switch (process.platform) {
-      case 'darwin': {
-        // The size of transparent area around arrow on macOS.
-        const headerBarArrowHeight = 12;
-
-        return this.guiSettings.unpinnedWindow
-          ? contentHeight
-          : contentHeight + headerBarArrowHeight;
-      }
-      case 'win32':
-        // On Windows the app height ends up slightly lower than we set it to if running in unpinned
-        // mode and the app becomes a tiny bit taller when pinned to task bar.
-        return this.guiSettings.unpinnedWindow ? contentHeight + 19 : contentHeight - 1;
-      case 'linux':
-        // On Linux the app ends up slightly lower than we set it to.
-        return contentHeight - 25;
-      default:
-        return contentHeight;
-    }
-  }
-
   private async createWindow(): Promise<BrowserWindow> {
-    const height = this.getContentHeight();
-    const width = 320;
+    const { width, height } = WindowController.getContentSize(this.guiSettings.unpinnedWindow);
 
     const options: Electron.BrowserWindowConstructorOptions = {
       useContentSize: true,
       width,
-      minWidth: width,
-      maxWidth: width,
       height,
-      minHeight: height,
-      maxHeight: height,
       resizable: false,
       maximizable: false,
       fullscreenable: false,

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -263,7 +263,7 @@ export default class WindowController {
       }
     }
 
-    // On linux, the window won't be properly rescaled back to it's original
+    // On Linux and Windows, the window won't be properly rescaled back to it's original
     // size if the DPI scaling factor is changed.
     // https://github.com/electron/electron/issues/11050
     if (process.platform === 'linux' && changedMetrics.includes('scaleFactor')) {

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -135,8 +135,6 @@ class AttachedToTrayWindowPositioning implements IWindowPositioning {
 }
 
 export default class WindowController {
-  private width: number;
-  private height: number;
   private windowValue: BrowserWindow;
   private webContentsValue: WebContents;
   private windowPositioning: IWindowPositioning;
@@ -151,10 +149,7 @@ export default class WindowController {
     return this.webContentsValue.isDestroyed() ? undefined : this.webContentsValue;
   }
 
-  constructor(windowValue: BrowserWindow, tray: Tray, unpinnedWindow: boolean) {
-    const [width, height] = windowValue.getSize();
-    this.width = width;
-    this.height = height;
+  constructor(windowValue: BrowserWindow, tray: Tray, private unpinnedWindow: boolean) {
     this.windowValue = windowValue;
     this.webContentsValue = windowValue.webContents;
     this.windowPositioning = unpinnedWindow
@@ -202,6 +197,13 @@ export default class WindowController {
     if (this.window && !this.window.isDestroyed()) {
       this.window.destroy();
     }
+  }
+
+  public static getContentSize(unpinnedWindow: boolean): { width: number; height: number } {
+    return {
+      width: 320,
+      height: WindowController.getContentHeight(unpinnedWindow),
+    };
   }
 
   private installHideHandler() {
@@ -266,7 +268,10 @@ export default class WindowController {
     // On Linux and Windows, the window won't be properly rescaled back to it's original
     // size if the DPI scaling factor is changed.
     // https://github.com/electron/electron/issues/11050
-    if (process.platform === 'linux' && changedMetrics.includes('scaleFactor')) {
+    if (
+      changedMetrics.includes('scaleFactor') &&
+      (process.platform === 'win32' || process.platform === 'linux')
+    ) {
       this.forceResizeWindow();
     }
   };
@@ -276,7 +281,8 @@ export default class WindowController {
   }
 
   private forceResizeWindow() {
-    this.window?.setSize(this.width, this.height);
+    const { width, height } = WindowController.getContentSize(this.unpinnedWindow);
+    this.window?.setContentSize(width, height);
   }
 
   private executeWhenWindowIsReady(closure: () => void) {
@@ -286,6 +292,31 @@ export default class WindowController {
       this.webContents?.once('did-stop-loading', () => {
         closure();
       });
+    }
+  }
+
+  // On both Linux and Windows the app height is applied incorrectly:
+  // https://github.com/electron/electron/issues/28777
+  private static getContentHeight(unpinnedWindow: boolean): number {
+    // The height we want to achieve.
+    const contentHeight = 568;
+
+    switch (process.platform) {
+      case 'darwin': {
+        // The size of transparent area around arrow on macOS.
+        const headerBarArrowHeight = 12;
+
+        return unpinnedWindow ? contentHeight : contentHeight + headerBarArrowHeight;
+      }
+      case 'win32':
+        // On Windows the app height ends up slightly lower than we set it to if running in unpinned
+        // mode and the app becomes a tiny bit taller when pinned to task bar.
+        return unpinnedWindow ? contentHeight + 19 : contentHeight - 1;
+      case 'linux':
+        // On Linux the app ends up slightly lower than we set it to.
+        return contentHeight - 25;
+      default:
+        return contentHeight;
     }
   }
 }

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -224,7 +224,10 @@ export default class AppRenderer {
       void this.onDaemonConnected();
     }
 
-    this.checkContentHeight();
+    this.checkContentHeight(false);
+    window.addEventListener('resize', () => {
+      this.checkContentHeight(true);
+    });
 
     if (initialState.windowsSplitTunnelingApplications) {
       this.reduxActions.settings.setSplitTunnelingApplications(
@@ -577,7 +580,7 @@ export default class AppRenderer {
   // purposes since there's a bug in Electron that causes the app height to be another value than
   // the one we have set.
   // https://github.com/electron/electron/issues/28777
-  private checkContentHeight(): void {
+  private checkContentHeight(resize: boolean): void {
     let expectedContentHeight = 568;
 
     // The app content is 12px taller on macOS to fit the top arrow.
@@ -587,7 +590,10 @@ export default class AppRenderer {
 
     const contentHeight = window.innerHeight;
     if (contentHeight !== expectedContentHeight) {
-      log.error(`Wrong content height ${contentHeight}, expected ${expectedContentHeight}`);
+      log.debug(
+        resize ? 'Resize:' : 'Initial:',
+        `Wrong content height: ${contentHeight}, expected ${expectedContentHeight}`,
+      );
     }
   }
 


### PR DESCRIPTION
This PR improves (almost fixes) the issue where the app window isn't always resized properly after changing display scale factor. I still managed to reproduce the issue once with this fix active but compared to before it happens *way* less. I was able to reproduce it easily and now I've tried a lot and only managed to reproduce it once.

The fix is to resize the window when the display scale changes. I also had to switch to `setContentSize` instead of `setSize`, since `setSize` sometimes used the wrong scale factor. Always settings content size seems like a better fit for us since our UI is designed in relation to these measurements.

I also improved the debug logging for when the window is the wrong size. And we no longer need to set `minHeight`, `minWidth`, `maxHeight` and `maxWidth` since those doesn't seem to make a difference.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3094)
<!-- Reviewable:end -->
