### PR TITLE
Add script that detects bidirectional Unicode text

### DIFF
--- a/.github/workflows/unicode-check.yml
+++ b/.github/workflows/unicode-check.yml
@@ -1,0 +1,17 @@
+name: Bidirectional Unicode scan
+on:
+    push:
+    # Request manually from the Actions tab
+    workflow_dispatch:
+jobs:
+    build-linux:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Checkout submodules
+              run: git submodule update --init
+
+            - name: Scan for code points
+              run: ./ci/check-trojan-source.sh

--- a/ci/check-trojan-source.sh
+++ b/ci/check-trojan-source.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This script scans text and source code for bidirectional Unicode characters.
+# See CVE-2021-42574. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
+# UTF-8 encoding is assumed.
+
+set -eu
+
+export LC_ALL=en_US.UTF-8
+
+cd "$( dirname "${BASH_SOURCE[0]}" )/.."
+
+FILES=()
+while IFS='' read -r line; do FILES+=("$line"); done < <( find . -type f -exec grep -Il . {} + )
+
+CODEPOINT_REGEX=$( printf "\u202a\|\u202b\|\u202c\|\u202d\|\u202e\|\u2066\|\u2067\|\u2068\|\u2069" )
+
+matched=0
+
+echo "Scanning files: ${FILES[*]}"
+
+for file in "${FILES[@]}"; do
+    if grep -q "${CODEPOINT_REGEX}" "$file"; then
+        echo "Found code points in $file"
+        matched=1
+    fi
+done
+
+exit $matched


### PR DESCRIPTION
Certain Unicode characters can be used to produce code that looks innocuous when rendered in editors, but that contains malicious code. Specifically, they may change the order in which characters appear. Details here: https://www.trojansource.codes/trojan-source.pdf.

This PR includes a script that scans all text and source code for these code points. Rust 1.56.1 already includes lints that [reject](https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html) them, but other compilers may not. The PR also adds a GitHub actions workflow that runs this script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3097)
<!-- Reviewable:end -->
