### PR TITLE
Upgrade to Rust 2021

### DIFF
--- a/android/translations-converter/Cargo.toml
+++ b/android/translations-converter/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 license = "GPL-3.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 derive_more = "0.99"

--- a/android/translations-converter/Cargo.toml
+++ b/android/translations-converter/Cargo.toml
@@ -3,7 +3,7 @@ name = "translations-converter"
 version = "0.1.0"
 authors = ["Mullvad VPN"]
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "2021.6.0-beta1"
 authors = ["Mullvad VPN"]
 description = "Manage the Mullvad VPN daemon via a convenient CLI"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -4,7 +4,7 @@ version = "2021.6.0-beta1"
 authors = ["Mullvad VPN"]
 description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/mullvad-exclude/Cargo.toml
+++ b/mullvad-exclude/Cargo.toml
@@ -3,7 +3,7 @@ name = "mullvad-exclude"
 version = "2021.6.0-beta1"
 authors = ["Mullvad VPN"]
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "JNI interface for the Mullvad daemon"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Mullvad VPN IPC. Contains types and functions for IPC clients and servers."
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Mullvad VPN application paths and directories"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -4,7 +4,7 @@ version = "2021.6.0-beta1"
 authors = ["Mullvad VPN"]
 description = "Collect Mullvad VPN logs into a report and send it to support"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Mullvad VPN RPC clients. Providing an interface to query our infrastructure for information."
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -4,7 +4,7 @@ version = "2021.6.0-beta1"
 authors = ["Mullvad VPN"]
 description = "Tool used to manage daemon setup"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]

--- a/mullvad-tests/Cargo.toml
+++ b/mullvad-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Mullvad test specific modules and binaries"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Common base data structures for Mullvad VPN client"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Privacy preserving and secure VPN client library"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -153,6 +153,9 @@ impl SplitTunnel {
         let event_thread = std::thread::spawn(move || {
             use driver::{EventBody, EventId};
 
+            // Take ownership of the entire struct (Rust 2021 edition change)
+            let _ = &event_context;
+
             let mut data_buffer = Vec::with_capacity(DRIVER_EVENT_BUFFER_SIZE);
             let mut returned_bytes = 0u32;
 

--- a/talpid-dbus/Cargo.toml
+++ b/talpid-dbus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "talpid-dbus"
 version = "0.1.0"
 authors = ["Mullvad VPN"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -4,7 +4,7 @@ version = "2021.6.0-beta1"
 authors = ["Mullvad VPN"]
 description = "OpenVPN shared library plugin for relaying OpenVPN events to talpid_core"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/talpid-platform-metadata/Cargo.toml
+++ b/talpid-platform-metadata/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Platform metadata detection functions"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mullvad VPN"]
 description = "Common base structures for talpid"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Rust 2021 edition has been out for a while. This repository always just targets the latest stable compiler. There is no reason not to upgrade as far as I'm aware. So this just bumps all the `edition` specifications. `cargo fix --edition` does not change anything. So I guess all our code is already compliant :ok_hand:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3098)
<!-- Reviewable:end -->
