### PR TITLE
Increase line height with 1px on big text to fit lowercase "g"

### DIFF
--- a/gui/src/renderer/components/common-styles.ts
+++ b/gui/src/renderer/components/common-styles.ts
@@ -34,6 +34,6 @@ export const buttonText = {
 export const bigText = {
   ...sourceSansPro,
   fontSize: '32px',
-  lineHeight: '34px',
+  lineHeight: '35px',
   color: colors.white,
 };


### PR DESCRIPTION
This PR increases the line height of text with font size `32px` from `34px` to `35px` since lowercase "g" didn't fit in that line height. It was for example cut of when displaying "Gothenburg" in the connection info.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3100)
<!-- Reviewable:end -->
