### PR TITLE
Replace window controller instead of window

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1585,7 +1585,13 @@ class ApplicationMain {
       this.tray.removeAllListeners();
 
       const window = await this.createWindow();
-      this.windowController.replaceWindow(window, unpinnedWindow);
+
+      this.windowController.destroy();
+      this.windowController = new WindowController(
+        window,
+        this.tray,
+        this.guiSettings.unpinnedWindow,
+      );
 
       await this.initializeWindow();
       this.windowController.show();

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -151,7 +151,7 @@ export default class WindowController {
     return this.webContentsValue.isDestroyed() ? undefined : this.webContentsValue;
   }
 
-  constructor(windowValue: BrowserWindow, private tray: Tray, unpinnedWindow: boolean) {
+  constructor(windowValue: BrowserWindow, tray: Tray, unpinnedWindow: boolean) {
     const [width, height] = windowValue.getSize();
     this.width = width;
     this.height = height;
@@ -163,24 +163,6 @@ export default class WindowController {
 
     this.installDisplayMetricsHandler();
     this.installHideHandler();
-  }
-
-  public replaceWindow(windowValue: BrowserWindow, unpinnedWindow: boolean) {
-    this.window?.destroy();
-
-    const [width, height] = windowValue.getSize();
-    this.width = width;
-    this.height = height;
-    this.windowValue = windowValue;
-    this.webContentsValue = windowValue.webContents;
-
-    this.windowPositioning = unpinnedWindow
-      ? new StandaloneWindowPositioning()
-      : new AttachedToTrayWindowPositioning(this.tray);
-
-    this.installDisplayMetricsHandler();
-    this.installHideHandler();
-    this.updatePosition();
   }
 
   public show(whenReady = true) {
@@ -214,6 +196,12 @@ export default class WindowController {
     }
 
     this.notifyUpdateWindowShape();
+  }
+
+  public destroy() {
+    if (this.window && !this.window.isDestroyed()) {
+      this.window.destroy();
+    }
   }
 
   private installHideHandler() {


### PR DESCRIPTION
This PR switches to replacing the whole `WindowController` instead of just the `BrowserWindow` when switch between pinned and unpinned mode. It lowers the complexity and removes duplicated code as a result.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3101)
<!-- Reviewable:end -->
