### PR TITLE
Store locations in english and translate for rendering

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -562,12 +562,6 @@ export default class AppRenderer {
     // load translations for new locale
     loadTranslations(messages, translations.locale, translations.messages);
     loadTranslations(relayLocations, translations.locale, translations.relayLocations);
-
-    // refresh the relay list pair with the new translations
-    this.propagateRelayListPairToRedux();
-
-    // refresh the location with the new translations
-    this.propagateLocationToRedux();
   }
 
   public getPreferredLocaleDisplayName(localeCode: string): string {
@@ -837,37 +831,19 @@ export default class AppRenderer {
 
   private propagateLocationToRedux() {
     if (this.location) {
-      this.reduxActions.connection.newLocation(this.translateLocation(this.location));
+      this.reduxActions.connection.newLocation(this.location);
     }
-  }
-
-  private translateLocation(inputLocation: Partial<ILocation>): Partial<ILocation> {
-    const location = { ...inputLocation };
-
-    if (location.city) {
-      const city = location.city;
-
-      location.city = relayLocations.gettext(city) || city;
-    }
-
-    if (location.country) {
-      const country = location.country;
-
-      location.country = relayLocations.gettext(country) || country;
-    }
-
-    return location;
   }
 
   private convertRelayListToLocationList(relayList: IRelayList): IRelayLocationRedux[] {
     return relayList.countries
       .map((country) => ({
-        name: relayLocations.gettext(country.name) || country.name,
+        name: country.name,
         code: country.code,
         hasActiveRelays: country.cities.some((city) => city.relays.some((relay) => relay.active)),
         cities: country.cities
           .map((city) => ({
-            name: relayLocations.gettext(city.name) || city.name,
+            name: city.name,
             code: city.code,
             latitude: city.latitude,
             longitude: city.longitude,

--- a/gui/src/renderer/components/LocationList.tsx
+++ b/gui/src/renderer/components/LocationList.tsx
@@ -7,6 +7,7 @@ import {
   RelayLocation,
   relayLocationComponents,
 } from '../../shared/daemon-rpc-types';
+import { relayLocations } from '../../shared/gettext';
 import { IRelayLocationRedux } from '../redux/settings/reducers';
 import * as Cell from './cell';
 import LocationRow from './LocationRow';
@@ -283,7 +284,7 @@ export class RelayLocations extends React.PureComponent<IRelayLocationsProps> {
           return (
             <LocationRow
               key={getLocationKey(countryLocation)}
-              name={relayCountry.name}
+              name={relayLocations.gettext(relayCountry.name)}
               active={relayCountry.hasActiveRelays}
               expanded={this.isExpanded(countryLocation)}
               onSelect={this.handleSelection}
@@ -299,7 +300,7 @@ export class RelayLocations extends React.PureComponent<IRelayLocationsProps> {
                 return (
                   <LocationRow
                     key={getLocationKey(cityLocation)}
-                    name={relayCity.name}
+                    name={relayLocations.gettext(relayCity.name)}
                     active={relayCity.hasActiveRelays}
                     expanded={this.isExpanded(cityLocation)}
                     onSelect={this.handleSelection}

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { sprintf } from 'sprintf-js';
 import styled from 'styled-components';
 import { TunnelState } from '../../shared/daemon-rpc-types';
-import { messages } from '../../shared/gettext';
+import { messages, relayLocations } from '../../shared/gettext';
 import ConnectionPanelContainer from '../containers/ConnectionPanelContainer';
 import * as AppButton from './AppButton';
 import { bigText } from './common-styles';
@@ -197,11 +197,14 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
   }
 
   private renderCity() {
-    return <StyledMarquee>{this.props.city}</StyledMarquee>;
+    const city = this.props.city === undefined ? '' : relayLocations.gettext(this.props.city);
+    return <StyledMarquee>{city}</StyledMarquee>;
   }
 
   private renderCountry() {
-    return <StyledMarquee>{this.props.country}</StyledMarquee>;
+    const country =
+      this.props.country === undefined ? '' : relayLocations.gettext(this.props.country);
+    return <StyledMarquee>{country}</StyledMarquee>;
   }
 
   private switchLocationButton() {


### PR DESCRIPTION
Prevent trying to translate translation of city and country name while connecting. This is accomplished by not storing translated locations in the Redux state and instead translating while rendering.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3103)
<!-- Reviewable:end -->
