### PR TITLE
Fix notification foreground state

### DIFF
--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -101,6 +101,9 @@ sealed class Request : Message.RequestMessage() {
     @Parcelize
     object WireGuardVerifyKey : Request()
 
+    @Parcelize
+    data class SetForcedForeground(val doForceForeground: Boolean) : Request()
+
     companion object {
         private const val MESSAGE_KEY = "request"
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ipc/ServiceConnection.kt
@@ -55,7 +55,9 @@ class ServiceConnection(context: Context, scope: CoroutineScope) {
     }
 
     private suspend fun connect(context: Context) {
-        val intent = Intent(context, MullvadVpnService::class.java)
+        val intent = Intent(context, MullvadVpnService::class.java).also {
+            it.putExtra("ui-flag", true)
+        }
 
         context.bindServiceFlow(intent).collect { binder ->
             activeListeners.value = null

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -68,7 +68,7 @@ class ForegroundNotificationManager(
     var onForeground = false
         private set
 
-    private var lockedToForeground by observable(false) { _, _, _ ->
+    var lockedToForeground by observable(false) { _, _, _ ->
         updater.sendBlocking(UpdaterMessage.UpdateNotification())
     }
 

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -158,6 +158,14 @@ class MullvadVpnService : TalpidVpnService() {
 
     override fun onUnbind(intent: Intent): Boolean {
         Log.d(TAG, "Closed all connections to service")
+
+        // The intent extras 'ui-flag' is used to distinguish unbinds of the ut (app/tile) from
+        // unbinds of the system. It's expected that the service is already in background once
+        // the ui (app/tile) unbinds, so this is a safeguard in case the app crashes etc.
+        if (notificationManager.lockedToForeground && intent.hasExtra("ui-flag")) {
+            notificationManager.lockedToForeground = false
+        }
+
         if (state != State.Running) {
             stop()
         }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ForegroundRequestHandler.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ForegroundRequestHandler.kt
@@ -1,0 +1,18 @@
+package net.mullvad.mullvadvpn.service.endpoint
+
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import net.mullvad.mullvadvpn.ipc.Request
+import net.mullvad.mullvadvpn.util.safeOffer
+
+class ForegroundRequestHandler(val endpoint: ServiceEndpoint) {
+    fun foregroundRequests(): Flow<Boolean> = callbackFlow {
+        endpoint.dispatcher.registerHandler(Request.SetForcedForeground::class) { request ->
+            safeOffer(request.doForceForeground)
+        }
+        awaitClose {
+            // TODO: Not able to unregister...
+        }
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -57,6 +57,7 @@ class ServiceEndpoint(
     val relayListListener = RelayListListener(this)
     val splitTunneling = SplitTunneling(SplitTunnelingPersistence(context), this)
     val voucherRedeemer = VoucherRedeemer(this)
+    val foregroundRequestHandler = ForegroundRequestHandler(this)
 
     init {
         dispatcher.apply {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -99,7 +99,9 @@ open class MainActivity : FragmentActivity() {
 
         isUiVisible = true
 
-        val intent = Intent(this, MullvadVpnService::class.java)
+        val intent = Intent(this, MullvadVpnService::class.java).also {
+            it.putExtra("ui-flag", true)
+        }
 
         startForegroundService(intent)
         bindService(intent, serviceConnectionManager, 0)

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ForegroundController.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ForegroundController.kt
@@ -1,0 +1,10 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import net.mullvad.mullvadvpn.ipc.Request
+
+class ForegroundController(val messenger: Messenger) {
+    fun requestForcedForeground(doForceForeground: Boolean) {
+        messenger.send(Request.SetForcedForeground(doForceForeground).message)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -41,6 +41,7 @@ class ServiceConnection(
     val splitTunneling = get<SplitTunneling>(parameters = { parametersOf(connection, dispatcher) })
     val voucherRedeemer = VoucherRedeemer(connection, dispatcher)
     val vpnPermission = VpnPermission(connection, dispatcher)
+    val foregroundController = ForegroundController(connection)
 
     val appVersionInfoCache = AppVersionInfoCache(dispatcher, settingsListener)
     val customDns = CustomDns(connection, settingsListener)


### PR DESCRIPTION
Fixes issues with the notification sometimes
not being in the correct state (foreground)
resulting an a notification that behaves the
wrong way.

The issue is fixed by re-adding state communication
between the app and service, where the app notifies
the service whenever it's visible.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3105)
<!-- Reviewable:end -->
