### PR TITLE
Fix Windows double tray icon on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Fix app size after changing display scale.
 - Fix daemon not starting if all excluded app paths reside on non-existent/unmounted volumes.
+- Remove tray icon of current running app version when upgrading.
 
 
 ## [2021.6] - 2021-11-17


### PR DESCRIPTION
This PR fixes the issue where the tray icon of the app running before upgrade remains until hovered. It's fixed by:
* Adding support for quitting the app without disconnecting.
* Quit without disconnecting from `installer.nsh` if the old version is 2021.2 or older.

The kill/quit in `customRemoveFiles` had to be moved to an earlier stage of the uninstallation to prevent the app from changing the tray icon to the disconnected one when it loses connection to the daemon.

The solution for checkign the version in `installer.nsh` has the drawback that it assumes that we won't release more than 9 versions during 2021.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3107)
<!-- Reviewable:end -->
