### PR TITLE
Keep unspecified constraints unchanged in the CLI when providing protocol-specific constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Keep unspecified constraints unchanged in the CLI when providing specific tunnel constraints
+  instead of setting them to default values.
 
 
 ## [2021.6-beta1] - 2021-11-03

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -139,6 +139,7 @@ impl Command for Relay {
                             .subcommand(
                                 clap::SubCommand::with_name("openvpn")
                                     .about("Set OpenVPN-specific constraints")
+                                    .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                                     .arg(
                                         clap::Arg::with_name("port")
                                             .help("Port to use. Either 'any' or a specific port")
@@ -156,6 +157,7 @@ impl Command for Relay {
                             .subcommand(
                                 clap::SubCommand::with_name("wireguard")
                                     .about("Set WireGuard-specific constraints")
+                                    .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                                     .arg(
                                         clap::Arg::with_name("port")
                                             .help("Port to use. Either 'any' or a specific port")


### PR DESCRIPTION
This is a tweak to make the CLI more intuitive. Previously, setting protocol-specific constraints would clear/set to default any options that weren't provided. E.g., the second command would reset the port and entry locations (to `any` and `none`, respectively) in this example:

```
mullvad relay set tunnel wireguard --protocol udp --port 1234 --entry-location se
mullvad relay set tunnel wireguard --protocol tcp
```

The updated behavior in this PR is to leave those settings alone and only change the transport protocol constraint (or whatever constraints are provided).

To avoid modifying the proto file/gRPC service, the old constraints are simply obtained from the gRPC server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3108)
<!-- Reviewable:end -->
