### PR TITLE
Include `api-override` feature when building dev versions in release mode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,6 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --dev-build)
             BUILD_MODE="dev"
-            CARGO_ARGS+=(--features api-override)
             ;;
         --target)
             TARGET=("$2")
@@ -93,6 +92,7 @@ if [[ "$BUILD_MODE" == "dev" || $product_version_commit_hash != "$current_head_c
 
     echo "Disabling Apple notarization (macOS only) of installer in this dev build"
     NPM_PACK_ARGS+=(--no-apple-notarization)
+    CARGO_ARGS+=(--features api-override)
 else
     echo "Removing old Rust build artifacts"
     cargo +stable clean


### PR DESCRIPTION
Previously, the feature was only added when passing `--dev-build` to `build.sh`. The build server builds everything in release mode, but it should also be included there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3110)
<!-- Reviewable:end -->
