### PR TITLE
Fix CLI bug not allowing the openvpn and wireguard `relay` subcommands to work properly.

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -139,7 +139,7 @@ impl Command for Relay {
                             .subcommand(
                                 clap::SubCommand::with_name("openvpn")
                                     .about("Set OpenVPN-specific constraints")
-                                    .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+                                    .setting(clap::AppSettings::ArgRequiredElseHelp)
                                     .arg(
                                         clap::Arg::with_name("port")
                                             .help("Port to use. Either 'any' or a specific port")
@@ -157,7 +157,7 @@ impl Command for Relay {
                             .subcommand(
                                 clap::SubCommand::with_name("wireguard")
                                     .about("Set WireGuard-specific constraints")
-                                    .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+                                    .setting(clap::AppSettings::ArgRequiredElseHelp)
                                     .arg(
                                         clap::Arg::with_name("port")
                                             .help("Port to use. Either 'any' or a specific port")


### PR DESCRIPTION
Fixes bugs in #3108.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3114)
<!-- Reviewable:end -->
