### PR TITLE
Make trojan source check script more universally usable

### DIFF
--- a/.github/workflows/unicode-check.yml
+++ b/.github/workflows/unicode-check.yml
@@ -14,4 +14,4 @@ jobs:
               run: git submodule update --init
 
             - name: Scan for code points
-              run: ./ci/check-trojan-source.sh
+              run: ./ci/check-trojan-source.sh .

--- a/ci/check-trojan-source.sh
+++ b/ci/check-trojan-source.sh
@@ -4,11 +4,17 @@
 # See CVE-2021-42574. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
 # UTF-8 encoding is assumed.
 
+# Pass the path to the directory to check as the first argument
+
 set -eu
 
 export LC_ALL=en_US.UTF-8
 
-cd "$( dirname "${BASH_SOURCE[0]}" )/.."
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <path>"
+    exit 1
+fi
+cd "$1"
 
 FILES=()
 while IFS='' read -r line; do FILES+=("$line"); done < <( find . -type f -exec grep -Il . {} + )
@@ -16,14 +22,15 @@ while IFS='' read -r line; do FILES+=("$line"); done < <( find . -type f -exec g
 CODEPOINT_REGEX=$( printf "\u202a\|\u202b\|\u202c\|\u202d\|\u202e\|\u2066\|\u2067\|\u2068\|\u2069" )
 
 matched=0
-
-echo "Scanning files: ${FILES[*]}"
-
 for file in "${FILES[@]}"; do
     if grep -q "${CODEPOINT_REGEX}" "$file"; then
-        echo "Found code points in $file"
+        echo "Found potentially malicious unicode code points in $file"
         matched=1
     fi
 done
+
+if [[ "$matched" == 0 ]]; then
+    echo "No potentially malicious unicode found"
+fi
 
 exit $matched


### PR DESCRIPTION
Make the script take the path to the dir to check as argument instead of being self aware.

This makes it simpler to use this script in other places. And the script is less hardcoded on where it's placed. That's instead up to the CI job to define.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3117)
<!-- Reviewable:end -->
