### PR TITLE
Upgrade tokio due to RUSTSEC-2021-0124

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2664,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
RUSTSEC-2021-0124 was just submitted. Looks like there is a race condition in their `oneshot` implementation. As far as I can see we don't use it. We use `oneshot` channels provided by the `futures` crate. So I think we should be fine. But upgrading to get rid of the audit warning and to not accidentally use this broken channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3118)
<!-- Reviewable:end -->
