### PR TITLE
More idiomatic bash in build_windows_modules.sh

### DIFF
--- a/build_windows_modules.sh
+++ b/build_windows_modules.sh
@@ -70,12 +70,8 @@ function get_solution_output_path {
     local build_mode=$3
 
     case $build_target in
-        "x86")
-            echo "$solution_root/bin/Win32-$build_mode"
-            ;;
-        "x64")
-            echo "$solution_root/bin/x64-$build_mode"
-            ;;
+        "x86") echo "$solution_root/bin/Win32-$build_mode";;
+        "x64") echo "$solution_root/bin/x64-$build_mode";;
         *)
             echo Unkown build target $build_target
             exit 1
@@ -125,15 +121,9 @@ function arch_from_build_target {
     local build_target=$1
 
     case    $build_target in
-        "x86")
-            echo "i686"
-            ;;
-        "x64")
-            echo "x86_64"
-            ;;
-        *)
-            echo $build_target
-            ;;
+        "x86") echo "i686";;
+        "x64") echo "x86_64";;
+        *) echo $build_target;;
     esac
 }
 

--- a/build_windows_modules.sh
+++ b/build_windows_modules.sh
@@ -12,173 +12,162 @@ CPP_BUILD_TARGETS=${CPP_BUILD_TARGETS:-"x64"}
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"./target/"}
 
 if [[ "${1:-""}" == "--dev-build" ]]; then
-  DEV_BUILD=true
+    DEV_BUILD=true
 fi
 
-function clean_solution
-{
-  local path="$1"
-  
-  if [[ -z "${DEV_BUILD+x}" ]]; then
-    # Clean all intermediate and output files
-    rm -r $path/bin/* || true
-  else
-    echo "Will NOT clean intermediate files in $path/bin/"
-  fi
+function clean_solution {
+    local path="$1"
+
+    if [[ -z ${DEV_BUILD+x} ]]; then
+        # Clean all intermediate and output files
+        rm -r $path/bin/* || true
+    else
+        echo "Will NOT clean intermediate files in $path/bin/"
+    fi
 }
 
-function build_solution_config
-{
-  local sln="$1"
-  local config="$2"
-  local platform="$3"
+function build_solution_config {
+    local sln="$1"
+    local config="$2"
+    local platform="$3"
 
-  set -x
-  cmd.exe "/c msbuild.exe /m $(to_win_path $sln) /p:Configuration=$config /p:Platform=$platform"
-  set +x
+    set -x
+    cmd.exe "/c msbuild.exe /m $(to_win_path $sln) /p:Configuration=$config /p:Platform=$platform"
+    set +x
 }
 
 # Builds visual studio solution in all (specified) configurations
-function build_solution
-{
-  local path="$1"
-  local sln="$1/$2"
+function build_solution {
+    local path="$1"
+    local sln="$1/$2"
 
-  clean_solution $path
+    clean_solution $path
 
-  for mode in $CPP_BUILD_MODES; do
-    for target in $CPP_BUILD_TARGETS; do
-      build_solution_config $sln $mode $target
+    for mode in $CPP_BUILD_MODES; do
+        for target in $CPP_BUILD_TARGETS; do
+            build_solution_config $sln $mode $target
+        done
     done
-  done
 }
 
-function to_win_path
-{
-  local unixpath=$1
-  # if it's a relative path and starts with a dot (.), don't transform the
-  # drive prefix (/c/ -> C:\)
-  if echo $unixpath | grep '^\.' >/dev/null; then
-    echo $unixpath | sed -e 's/^\///' -e 's/\//\\/g'
-  # if it's an absolute path, transform the drive prefix
-  else
-    # remove the cygrdive prefix if it's there
-    unixpath=$(echo $1 | sed -e 's/^\/cygdrive//')
-    echo $unixpath | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/'
-  fi
+function to_win_path {
+    local unixpath=$1
+    # if it's a relative path and starts with a dot (.), don't transform the
+    # drive prefix (/c/ -> C:\)
+    if echo $unixpath | grep '^\.' >/dev/null; then
+        echo $unixpath | sed -e 's/^\///' -e 's/\//\\/g'
+    # if it's an absolute path, transform the drive prefix
+    else
+        # remove the cygrdive prefix if it's there
+        unixpath=$(echo $1 | sed -e 's/^\/cygdrive//')
+        echo $unixpath | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/'
+    fi
 }
 
-function get_solution_output_path
-{
-  local solution_root=$1
-  local build_target=$2
-  local build_mode=$3
+function get_solution_output_path {
+    local solution_root=$1
+    local build_target=$2
+    local build_mode=$3
 
-  case $build_target in
-    "x86")
-      echo "$solution_root/bin/Win32-$build_mode"
-      ;;
-    "x64")
-      echo "$solution_root/bin/x64-$build_mode"
-      ;;
-    *)
-      echo Unkown build target $build_target
-      exit 1
-      ;;
-  esac
+    case $build_target in
+        "x86")
+            echo "$solution_root/bin/Win32-$build_mode"
+            ;;
+        "x64")
+            echo "$solution_root/bin/x64-$build_mode"
+            ;;
+        *)
+            echo Unkown build target $build_target
+            exit 1
+            ;;
+    esac
 }
 
 # builds an appropriate cargo target path for the specified build target and
 # build mode
-function get_cargo_target_dir
-{
-  local build_target=$1
-  local build_mode=$2
+function get_cargo_target_dir {
+    local build_target=$1
+    local build_mode=$2
 
-  local host_arch=$(rustc_host_arch)
-  local host_target_arch=$(arch_from_build_target $host_arch)
-  local build_target_arch=$(arch_from_build_target $build_target)
-  # if the target is the same as the host, cargo omits the platform triplet
-  if [ "$host_target_arch" == "$build_target_arch" ]; then
-    platform_triplet=""
-  # otherwise, the cargo target path is build with the platform triplet
-  else
-    platform_triplet="$build_target_arch-pc-windows-msvc"
-  fi
+    local host_arch=$(rustc_host_arch)
+    local host_target_arch=$(arch_from_build_target $host_arch)
+    local build_target_arch=$(arch_from_build_target $build_target)
+    # if the target is the same as the host, cargo omits the platform triplet
+    if [ "$host_target_arch" == "$build_target_arch" ]; then
+        platform_triplet=""
+    # otherwise, the cargo target path is build with the platform triplet
+    else
+        platform_triplet="$build_target_arch-pc-windows-msvc"
+    fi
 
-  echo "$CARGO_TARGET_DIR/$platform_triplet/${build_mode,,}"
+    echo "$CARGO_TARGET_DIR/$platform_triplet/${build_mode,,}"
 }
 
-function copy_outputs
-{
-  local solution_path=$1
-  local artifacts=$2
+function copy_outputs {
+    local solution_path=$1
+    local artifacts=$2
 
-  for mode in $CPP_BUILD_MODES; do
-    for target in $CPP_BUILD_TARGETS; do
-      local dll_path=$(get_solution_output_path $solution_path $target $mode)
-      local cargo_target=$(get_cargo_target_dir $target $mode)
-      mkdir -p $cargo_target
-      for artifact in $artifacts; do
-        cp "$dll_path/$artifact" "$cargo_target"
-      done
+    for mode in $CPP_BUILD_MODES; do
+        for target in $CPP_BUILD_TARGETS; do
+            local dll_path=$(get_solution_output_path $solution_path $target $mode)
+            local cargo_target=$(get_cargo_target_dir $target $mode)
+            mkdir -p $cargo_target
+            for artifact in $artifacts; do
+                cp "$dll_path/$artifact" "$cargo_target"
+            done
+        done
     done
-  done
 }
 
 # Since Microsoft likes to name their architectures differently from Rust, this
 # function tries to match microsoft names to Rust names.
-function arch_from_build_target
-{
-  local build_target=$1
+function arch_from_build_target {
+    local build_target=$1
 
-  case  $build_target in
-    "x86")
-      echo "i686"
-      ;;
-    "x64")
-      echo "x86_64"
-      ;;
-    *)
-      echo $build_target
-      ;;
-  esac
+    case    $build_target in
+        "x86")
+            echo "i686"
+            ;;
+        "x64")
+            echo "x86_64"
+            ;;
+        *)
+            echo $build_target
+            ;;
+    esac
 }
 
-function rustc_host_arch
-{
-  rustc.exe --print cfg \
-   | grep '^target_arch=' \
-   | cut -d'=' -f2 \
-   | tr -d '"'
+function rustc_host_arch {
+    rustc.exe --print cfg \
+     | grep '^target_arch=' \
+     | cut -d'=' -f2 \
+     | tr -d '"'
 }
 
-function build_nsis_plugins
-{
-  local nsis_root_path=${CPP_ROOT_PATH:-"./windows/nsis-plugins"}
+function build_nsis_plugins {
+    local nsis_root_path=${CPP_ROOT_PATH:-"./windows/nsis-plugins"}
 
-  clean_solution "$nsis_root_path"
-  build_solution_config "$nsis_root_path/nsis-plugins.sln" "Release" "x86"
+    clean_solution "$nsis_root_path"
+    build_solution_config "$nsis_root_path/nsis-plugins.sln" "Release" "x86"
 }
 
-function main
-{
-  local winfw_root_path=${CPP_ROOT_PATH:-"./windows/winfw"}
-  local windns_root_path=${CPP_ROOT_PATH:-"./windows/windns"}
-  local winnet_root_path=${CPP_ROOT_PATH:-"./windows/winnet"}
-  
-  build_solution "$winfw_root_path" "winfw.sln"
-  build_solution "$windns_root_path" "windns.sln"
-  build_solution "$winnet_root_path" "winnet.sln"
+function main {
+    local winfw_root_path=${CPP_ROOT_PATH:-"./windows/winfw"}
+    local windns_root_path=${CPP_ROOT_PATH:-"./windows/windns"}
+    local winnet_root_path=${CPP_ROOT_PATH:-"./windows/winnet"}
 
-  copy_outputs $winfw_root_path "winfw.dll"
-  copy_outputs $windns_root_path "windns.dll"
-  copy_outputs $winnet_root_path "winnet.dll"
+    build_solution "$winfw_root_path" "winfw.sln"
+    build_solution "$windns_root_path" "windns.sln"
+    build_solution "$winnet_root_path" "winnet.sln"
 
-  local driverlogic_root_path=${CPP_ROOT_PATH:-"./windows/driverlogic"}
-  build_solution "$driverlogic_root_path" "driverlogic.sln"
+    copy_outputs $winfw_root_path "winfw.dll"
+    copy_outputs $windns_root_path "windns.dll"
+    copy_outputs $winnet_root_path "winnet.dll"
 
-  build_nsis_plugins
+    local driverlogic_root_path=${CPP_ROOT_PATH:-"./windows/driverlogic"}
+    build_solution "$driverlogic_root_path" "driverlogic.sln"
+
+    build_nsis_plugins
 }
 
 main

--- a/build_windows_modules.sh
+++ b/build_windows_modules.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -eu
 
 # List of solution configurations to build.


### PR DESCRIPTION
Some changes to adapt a bit towards the [coding guidelines](https://github.com/mullvad/coding-guidelines/blob/master/bash.md). This script was largely written before those existed.

* Add a shebang at the start
* Change indentation to four spaces
* Compress `case` branches in some places where I felt they were more verbose than needed. This is not part of the written style guideline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3119)
<!-- Reviewable:end -->
