### PR TITLE
Kill sslocal if setting up the tunnel monitor fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Line wrap the file at 100 chars.                                              Th
   instead of setting them to default values.
 
 ### Fixed
+- Always kill `sslocal` if the tunnel monitor fails to start when using bridges.
+
 #### Windows
 - Fix app size after changing display scale.
 - Fix daemon not starting if all excluded app paths reside on non-existent/unmounted volumes.


### PR DESCRIPTION
Previously, `sslocal` would sometimes continue running even after the daemon had been killed. This resulted in the uninstaller failing on Windows. As the process is only explicitly killed in `OpenVpnMonitor::wait`, if anything in `OpenVpnMonitor::start` failed *after* the proxy monitor had started, the process would keep running. To fix this and to make it less likely to occur in the future, the process is now killed when a `ShadowsocksProxyMonitor` is dropped, even if `ShadowsocksProxyMonitorCloseHandle::close()` is never called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3124)
<!-- Reviewable:end -->
