### PR TITLE
Handle empty (filtered) ST paths correctly on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 #### Windows
 - Fix app size after changing display scale.
+- Fix daemon not starting if all excluded app paths reside on non-existent/unmounted volumes.
 
 
 ## [2021.6] - 2021-11-17

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -328,6 +328,10 @@ impl DeviceHandle {
             }
         }
 
+        if device_paths.is_empty() {
+            return self.clear_config();
+        }
+
         log::debug!("Excluded device paths:");
         for path in &device_paths {
             log::debug!("    {:?}", path);


### PR DESCRIPTION
The daemon filters out paths on non-existent volumes. Previously, the daemon failed to start if this resulted in an empty list. This PR fixes this by clearing the config in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3126)
<!-- Reviewable:end -->
