### PR TITLE
Remove workaround for TAP adapter alias bug

### DIFF
--- a/windows/libshared/src/libshared/network/interfaceutils.cpp
+++ b/windows/libshared/src/libshared/network/interfaceutils.cpp
@@ -9,7 +9,6 @@ namespace shared::network
 {
 
 InterfaceUtils::NetworkAdapter::NetworkAdapter(
-	const common::network::Nci &nci,
 	const std::shared_ptr<std::vector<uint8_t>> addressesBuffer,
 	const IP_ADAPTER_ADDRESSES &entry
 )
@@ -17,38 +16,7 @@ InterfaceUtils::NetworkAdapter::NetworkAdapter(
 	, m_entry(entry)
 {
 	m_guid = common::string::ToWide(entry.AdapterName);
-
-	try
-	{
-		//
-		// FIXME:
-		// Work around incorrect alias sometimes
-		// being returned on Windows 8.
-		//
-		// Steps to reproduce:
-		// 1. Install NDIS 6 TAP driver v9.00.00.21.
-		// 2. Update driver to v9.24.2.601.
-		// 3. Rename TAP adapter.
-		//
-		// GetAdaptersAddresses() returns a generic name
-		// for the *first* adapter instead of the correct
-		// one, whereas ConvertInterfaceAliasToLuid() and
-		// ConvertInterfaceLuidToAlias() yield correct values.
-		//
-
-		IID guidObj = { 0 };
-		if (S_OK != IIDFromString(&m_guid[0], &guidObj))
-		{
-			THROW_ERROR("IIDFromString() failed");
-		}
-
-		m_alias = nci.getConnectionName(guidObj);
-	}
-	catch (const std::exception &)
-	{
-		m_alias = entry.FriendlyName;
-	}
-
+	m_alias = entry.FriendlyName;
 	m_name = entry.Description;
 }
 
@@ -79,11 +47,9 @@ std::set<InterfaceUtils::NetworkAdapter> InterfaceUtils::GetAllAdapters(ULONG fa
 
 	std::set<NetworkAdapter> adapters;
 
-	common::network::Nci nci;
-
 	for (auto it = addresses; nullptr != it; it = it->Next)
 	{
-		adapters.emplace(NetworkAdapter(nci, buffer, *it));
+		adapters.emplace(NetworkAdapter(buffer, *it));
 	}
 
 	return adapters;

--- a/windows/libshared/src/libshared/network/interfaceutils.h
+++ b/windows/libshared/src/libshared/network/interfaceutils.h
@@ -16,8 +16,6 @@
 #include <netioapi.h>
 // end
 
-#include <libcommon/network/nci.h>
-
 namespace shared::network
 {
 
@@ -49,7 +47,6 @@ public:
 	private:
 
 		NetworkAdapter(
-			const common::network::Nci &nci,
 			const std::shared_ptr<std::vector<uint8_t>> addressesBuffer,
 			const IP_ADAPTER_ADDRESSES &entry
 		);

--- a/windows/windns/src/windns/windns.cpp
+++ b/windows/windns/src/windns/windns.cpp
@@ -94,9 +94,17 @@ AdapterDnsAddresses GetAdapterDnsAddresses(const std::wstring &adapterAlias)
 		GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST
 	);
 
+	NET_LUID luid;
+	if (NO_ERROR != ConvertInterfaceAliasToLuid(adapterAlias.c_str(), &luid))
+	{
+		const auto err = std::wstring(L"Could not resolve LUID of interface: \"")
+			.append(adapterAlias).append(L"\"");
+		THROW_ERROR(common::string::ToAnsi(err).c_str());
+	}
+
 	for (const auto adapter : adapters)
 	{
-		if (0 != _wcsicmp(adapter.alias().c_str(), adapterAlias.c_str()))
+		if (luid.Value != adapter.raw().Luid.Value)
 		{
 			continue;
 		}

--- a/windows/windns/src/windns/windns.cpp
+++ b/windows/windns/src/windns/windns.cpp
@@ -96,8 +96,6 @@ AdapterDnsAddresses GetAdapterDnsAddresses(const std::wstring &adapterAlias)
 
 	for (const auto adapter : adapters)
 	{
-		const auto guidObj = common::Guid::FromString(adapter.guid());
-
 		if (0 != _wcsicmp(adapter.alias().c_str(), adapterAlias.c_str()))
 		{
 			continue;


### PR DESCRIPTION
We previously couldn't rely on `FriendlyName` in `IP_ADAPTER_ADDRESSES_LH` to provide the correct alias on Windows 8. This PR removes that workaround since the affected driver is no longer used. Also, the interfaces are now compared using LUIDs instead of aliases, which should work regardless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3127)
<!-- Reviewable:end -->
