### PR TITLE
Move platform version checks to it's own file

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -13,7 +13,6 @@ import {
   systemPreferences,
   Tray,
 } from 'electron';
-import os from 'os';
 import * as path from 'path';
 import { sprintf } from 'sprintf-js';
 import util from 'util';
@@ -71,6 +70,7 @@ import {
 } from './logging';
 import { loadTranslations } from './load-translations';
 import NotificationController from './notification-controller';
+import { isMacOs11OrNewer } from './platform-version';
 import { resolveBin } from './proc';
 import ReconnectionBackoff from './reconnection-backoff';
 import TrayIconController, { TrayIconType } from './tray-icon-controller';
@@ -1947,8 +1947,7 @@ class ApplicationMain {
           if (event.metaKey) {
             setImmediate(() => this.windowController?.updatePosition());
           } else {
-            const isBigSurOrNewer = parseInt(os.release(), 10) >= 20;
-            if (isBigSurOrNewer && !this.windowController?.isVisible()) {
+            if (isMacOs11OrNewer() && !this.windowController?.isVisible()) {
               // This is a workaround for this Electron issue, when it's resolved
               // `this.windowController?.toggle()` should do the trick on all platforms:
               // https://github.com/electron/electron/issues/28776

--- a/gui/src/main/platform-version.ts
+++ b/gui/src/main/platform-version.ts
@@ -1,0 +1,21 @@
+import os from 'os';
+
+export function isMacOs11OrNewer() {
+  const [major] = parseVersion();
+  return process.platform === 'darwin' && major >= 20;
+}
+
+// Windows 11 has the internal version 10.0.22000+.
+export function isWindows11OrNewer() {
+  const [major, minor, patch] = parseVersion();
+  return (
+    process.platform === 'win32' && (major > 10 || (major === 10 && (minor > 0 || patch >= 22000)))
+  );
+}
+
+function parseVersion() {
+  return os
+    .release()
+    .split('.')
+    .map((value) => parseInt(value, 10));
+}

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -1,8 +1,8 @@
 import { BrowserWindow, Display, screen, Tray, WebContents } from 'electron';
-import os from 'os';
 import { IWindowShapeParameters } from '../shared/ipc-types';
 import { Scheduler } from '../shared/scheduler';
 import { IpcMainEventChannel } from './ipc-event-channel';
+import { isWindows11OrNewer } from './platform-version';
 
 interface IPosition {
   x: number;
@@ -14,10 +14,8 @@ interface IWindowPositioning {
   getWindowShapeParameters(window: BrowserWindow): IWindowShapeParameters;
 }
 
-// Tray applications are positioned aproximately 10px from the tray in Windows 11. Windows 11 has
-// the internal version 10.0.22000+.
-const MARGIN =
-  process.platform === 'win32' && parseInt(os.release().split('.').at(-1)!) >= 22000 ? 10 : 0;
+// Tray applications are positioned aproximately 10px from the tray in Windows 11.
+const MARGIN = isWindows11OrNewer() ? 10 : 0;
 
 class StandaloneWindowPositioning implements IWindowPositioning {
   public getPosition(window: BrowserWindow): IPosition {


### PR DESCRIPTION
This PR moves the macOS 11+ and Windows 11+ checks to it's own file.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3132)
<!-- Reviewable:end -->
