### PR TITLE
Fix issues with relay constraints in the CLI

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -792,7 +792,7 @@ fn parse_transport_port(
             }
         }
     };
-    let port = match matches.value_of("port") {
+    let mut port = match matches.value_of("port") {
         Some(port) => parse_port_constraint(port)?,
         None => {
             if let Some(ref transport_port) = current_constraint {
@@ -806,6 +806,11 @@ fn parse_transport_port(
             }
         }
     };
+    if port.is_only() && protocol.is_any() && !matches.is_present("port") {
+        // Reset the port if the transport protocol is set to any.
+        println!("The port constraint was set to 'any'");
+        port = Constraint::Any;
+    }
     match (port, protocol) {
         (Constraint::Any, Constraint::Any) => Ok(None),
         (Constraint::Any, Constraint::Only(protocol)) => Ok(Some(types::TransportPort {

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -638,7 +638,7 @@ impl Relay {
             .relay_settings
             .unwrap();
 
-        print!(
+        println!(
             "Current constraints: {}",
             RelaySettings::try_from(relay_settings).unwrap()
         );

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -796,7 +796,11 @@ fn parse_transport_port(
         Some(port) => parse_port_constraint(port)?,
         None => {
             if let Some(ref transport_port) = current_constraint {
-                Constraint::Only(transport_port.port as u16)
+                if transport_port.port != 0 {
+                    Constraint::Only(transport_port.port as u16)
+                } else {
+                    Constraint::Any
+                }
             } else {
                 Constraint::Any
             }


### PR DESCRIPTION
Changes:
* Add missing newline to `mullvad relay get`.
* The transport protocol constraint could not be set to `any`, without explicitly setting the port to `any`, if it had previously been set to a specific protocol. I.e., `mullvad relay set tunnel wireguard --protocol any` would fail. This has been fixed.
* `mullvad relay set tunnel wireguard --protocol any` now clears any existing port constraint. That is, it has the same effect as `mullvad relay set tunnel wireguard --protocol any --port any`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3134)
<!-- Reviewable:end -->
