### PR TITLE
Remove login item in uninstall script on macOS

### DIFF
--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -38,6 +38,9 @@ echo "Removing app from /Applications ..."
 sudo rm -rf /Applications/Mullvad\ VPN.app
 sudo pkgutil --forget net.mullvad.vpn || true
 
+echo "Removing login item ..."
+osascript -e 'tell application "System Events" to delete login item "Mullvad VPN"' 2>/dev/null || true
+
 read -p "Do you want to delete the log and cache files the app has created? (y/n) "
 if [[ "$REPLY" =~ [Yy]$ ]]; then
     sudo rm -rf /var/log/mullvad-vpn /var/root/Library/Caches/mullvad-vpn /Library/Caches/mullvad-vpn


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR updates uninstall script for macOS with command to remove the login item from autostart on macOS. If the item is not there, the `osascript` command emits the following error:

> 36:67: execution error: System Events got an error: Can’t get login item "Mullvad VPN". (-1728)

If desired we could send the output to `/dev/null` as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3135)
<!-- Reviewable:end -->
