### PR TITLE
Pass interface by LUID instead of alias to WinDns

### DIFF
--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -1,10 +1,14 @@
-use crate::logging::windows::{log_sink, LogSink};
+use crate::{
+    logging::windows::{log_sink, LogSink},
+    windows::luid_from_alias,
+};
 
 use lazy_static::lazy_static;
 use log::{error, trace, warn};
 use std::{env, io, net::IpAddr, path::Path};
 use talpid_types::ErrorExt;
 use widestring::WideCString;
+use winapi::shared::ifdef::NET_LUID;
 use winreg::{
     enums::{HKEY_LOCAL_MACHINE, REG_MULTI_SZ},
     transaction::Transaction,
@@ -22,6 +26,7 @@ lazy_static! {
 
 /// Errors that can happen when configuring DNS on Windows.
 #[derive(err_derive::Error, Debug)]
+#[error(no_from)]
 pub enum Error {
     /// Failure to initialize WinDns.
     #[error(display = "Failed to initialize WinDns")]
@@ -34,6 +39,10 @@ pub enum Error {
     /// Failure to set new DNS servers on the interface.
     #[error(display = "Failed to set new DNS servers on interface")]
     Setting,
+
+    /// Failure to obtain an interface LUID given an alias.
+    #[error(display = "Failed to obtain LUID for the interface alias")]
+    InterfaceLuidError(#[error(source)] io::Error),
 
     /// Failure to set new DNS servers.
     #[error(display = "Failed to update dnscache policy config")]
@@ -78,9 +87,11 @@ impl super::DnsMonitorT for DnsMonitor {
         trace!("ipv4 ips - {:?} - {}", ipv4, ipv4.len());
         trace!("ipv6 ips - {:?} - {}", ipv6, ipv6.len());
 
+        let luid = luid_from_alias(interface).map_err(Error::InterfaceLuidError)?;
+
         unsafe {
             WinDns_Set(
-                WideCString::from_str(interface).unwrap().as_ptr(),
+                &luid,
                 ipv4_address_ptrs.as_mut_ptr(),
                 ipv4_address_ptrs.len() as u32,
                 ipv6_address_ptrs.as_mut_ptr(),
@@ -132,20 +143,15 @@ impl Drop for DnsMonitor {
 }
 
 fn set_dns_cache_policy(servers: &[IpAddr]) -> Result<(), Error> {
-    let transaction = Transaction::new()?;
-    match set_dns_cache_policy_inner(&transaction, servers) {
-        Ok(()) => {
-            transaction.commit()?;
-            Ok(())
-        }
-        Err(error) => {
-            transaction.rollback()?;
-            Err(error)
-        }
-    }
+    let transaction = Transaction::new().map_err(Error::UpdateDnsCachePolicy)?;
+    let result = match set_dns_cache_policy_inner(&transaction, servers) {
+        Ok(()) => transaction.commit(),
+        Err(error) => transaction.rollback().and_then(|_| Err(error)),
+    };
+    result.map_err(Error::UpdateDnsCachePolicy)
 }
 
-fn set_dns_cache_policy_inner(transaction: &Transaction, servers: &[IpAddr]) -> Result<(), Error> {
+fn set_dns_cache_policy_inner(transaction: &Transaction, servers: &[IpAddr]) -> io::Result<()> {
     let (dns_cache_parameters, _) = RegKey::predef(HKEY_LOCAL_MACHINE).create_subkey_transacted(
         r#"SYSTEM\CurrentControlSet\Services\DnsCache\Parameters"#,
         transaction,
@@ -178,7 +184,8 @@ fn set_dns_cache_policy_inner(transaction: &Transaction, servers: &[IpAddr]) -> 
 
 fn reset_dns_cache_policy() -> Result<(), Error> {
     let (dns_cache_parameters, _) = RegKey::predef(HKEY_LOCAL_MACHINE)
-        .create_subkey(r#"SYSTEM\CurrentControlSet\Services\DnsCache\Parameters"#)?;
+        .create_subkey(r#"SYSTEM\CurrentControlSet\Services\DnsCache\Parameters"#)
+        .map_err(Error::UpdateDnsCachePolicy)?;
     match dns_cache_parameters.delete_value("DnsSecureNameQueryFallback") {
         Ok(()) => Ok(()),
         Err(error) => {
@@ -236,7 +243,7 @@ extern "stdcall" {
     // Configure which DNS servers should be used and start enforcing these settings.
     #[link_name = "WinDns_Set"]
     pub fn WinDns_Set(
-        interface_alias: *const u16,
+        interface_luid: *const NET_LUID,
         v4_ips: *mut *const u16,
         v4_n_ips: u32,
         v6_ips: *mut *const u16,

--- a/windows/windns/src/windns/windns.h
+++ b/windows/windns/src/windns/windns.h
@@ -56,7 +56,7 @@ WINDNS_LINKAGE
 bool
 WINDNS_API
 WinDns_Set(
-	const wchar_t *interfaceAlias,
+	const NET_LUID *interfaceLuid,
 	const wchar_t **ipv4Servers,
 	uint32_t numIpv4Servers,
 	const wchar_t **ipv6Servers,


### PR DESCRIPTION
Continuation of #3127. This simplifies WinDns to use LUIDs instead of aliases. At the moment, we still derive the LUID from the alias (in Rust). We could/should eventually just obtain it from the wintun/wg-nt API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3137)
<!-- Reviewable:end -->
