### PR TITLE
Fix location line height

### DIFF
--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -66,6 +66,7 @@ const Location = styled.div({
 
 const StyledMarquee = styled(Marquee)({
   ...bigText,
+  lineHeight: '36px',
   overflow: 'hidden',
 });
 

--- a/gui/src/renderer/components/common-styles.ts
+++ b/gui/src/renderer/components/common-styles.ts
@@ -34,6 +34,6 @@ export const buttonText = {
 export const bigText = {
   ...sourceSansPro,
   fontSize: '32px',
-  lineHeight: '35px',
+  lineHeight: '34px',
   color: colors.white,
 };


### PR DESCRIPTION
In https://github.com/mullvad/mullvadvpn-app/pull/3100 the `line-height` of `bigText` was increased from `34px` to `35px` to fit the lowest row of pixels on some letters. It turns out that this wasn't enough on HiDPI displays so this PR reverts the last one and instead increases the `line-height` of the location info.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3140)
<!-- Reviewable:end -->
