### PR TITLE
Fix android multi process lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Line wrap the file at 100 chars.                                              Th
 - Keep unspecified constraints unchanged in the CLI when providing specific tunnel constraints
   instead of setting them to default values.
 
+#### Android
+- Avoid running in foreground when not connected.
+- Avoid removing notification when service is stopped.
+- Change so that swiping the notification no longer kills the service since that isn't a common way of handling the 
+  lifecycle in Android. Instead rely on the following mechanisms to kill the service:
+  * Swiping to remove from the Recents/Overview screen.
+  * Android Background Execution Limits.
+  * The System Settings way of killing apps ("Force Stop").
+
 ### Fixed
 - Always kill `sslocal` if the tunnel monitor fails to start when using bridges.
 
@@ -35,6 +44,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix daemon not starting if all excluded app paths reside on non-existent/unmounted volumes.
 - Remove tray icon of current running app version when upgrading.
 
+#### Android
+- Fix Quick Settings tile showing wrong state in certain scenarios.
 
 ## [2021.6] - 2021-11-17
 ### Fixed

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/model/ServiceResult.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/model/ServiceResult.kt
@@ -1,0 +1,25 @@
+package net.mullvad.mullvadvpn.model
+
+import android.os.IBinder
+
+data class ServiceResult(
+    val binder: IBinder?
+) {
+    enum class ConnectionState {
+        CONNECTED,
+        DISCONNECTED;
+    }
+
+    val connectionState: ConnectionState
+        get() {
+            return if (binder == null) {
+                ConnectionState.DISCONNECTED
+            } else {
+                ConnectionState.CONNECTED
+            }
+        }
+
+    companion object {
+        val NOT_CONNECTED = ServiceResult(null)
+    }
+}

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -92,19 +92,7 @@ class ForegroundNotificationManager(
         service.unregisterReceiver(deviceLockListener)
 
         updater.close()
-
         tunnelStateNotification.visible = false
-    }
-
-    fun acknowledgeStartForegroundService() {
-        // When sending start commands to the service, it is necessary to request the service to be
-        // on the foreground. With such request, when the service is started it must be placed on
-        // the foreground with a call to startForeground before a timeout expires, otherwise Android
-        // kills the app.
-        showOnForeground()
-
-        // Restore the notification to its correct state.
-        updateNotification()
     }
 
     private fun runUpdater() = GlobalScope.actor<UpdaterMessage>(
@@ -132,7 +120,7 @@ class ForegroundNotificationManager(
         onForeground = true
     }
 
-    private fun updateNotification() {
+    fun updateNotification() {
         if (shouldBeOnForeground != onForeground) {
             if (shouldBeOnForeground) {
                 showOnForeground()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -92,7 +92,6 @@ class ForegroundNotificationManager(
         service.unregisterReceiver(deviceLockListener)
 
         updater.close()
-        tunnelStateNotification.visible = false
     }
 
     private fun runUpdater() = GlobalScope.actor<UpdaterMessage>(

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -51,11 +51,11 @@ class MullvadTileService : TileService() {
 
         if (secured) {
             intent.action = MullvadVpnService.KEY_DISCONNECT_ACTION
+            startService(intent)
         } else {
             intent.action = MullvadVpnService.KEY_CONNECT_ACTION
+            startForegroundService(intent)
         }
-
-        startForegroundService(intent)
     }
 
     override fun onStopListening() {

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -61,14 +61,6 @@ class MullvadVpnService : TalpidVpnService() {
         }
     }
 
-    private var isBound: Boolean by observable(false) { _, _, isBound ->
-        notificationManager.lockedToForeground = isUiVisible or isBound
-    }
-
-    private var isUiVisible: Boolean by observable(false) { _, _, isUiVisible ->
-        notificationManager.lockedToForeground = isUiVisible or isBound
-    }
-
     override fun onCreate() {
         super.onCreate()
         Log.d(TAG, "Initializing service")
@@ -91,7 +83,6 @@ class MullvadVpnService : TalpidVpnService() {
 
         notificationManager =
             ForegroundNotificationManager(this, connectionProxy, keyguardManager).apply {
-                acknowledgeStartForegroundService()
                 accountNumberEvents = endpoint.settingsListener.accountNumberNotifier
             }
 
@@ -121,7 +112,7 @@ class MullvadVpnService : TalpidVpnService() {
         val startResult = super.onStartCommand(intent, flags, startId)
         var quitCommand = false
 
-        notificationManager.acknowledgeStartForegroundService()
+        notificationManager.updateNotification()
 
         if (!keyguardManager.isDeviceLocked) {
             val action = intent?.action
@@ -145,15 +136,11 @@ class MullvadVpnService : TalpidVpnService() {
 
     override fun onBind(intent: Intent): IBinder {
         Log.d(TAG, "New connection to service")
-        isBound = true
-
         return super.onBind(intent) ?: endpoint.messenger.binder
     }
 
     override fun onRebind(intent: Intent) {
         Log.d(TAG, "Connection to service restored")
-        isBound = true
-
         if (state == State.Stopping) {
             restart()
         }
@@ -165,7 +152,6 @@ class MullvadVpnService : TalpidVpnService() {
 
     override fun onUnbind(intent: Intent): Boolean {
         Log.d(TAG, "Closed all connections to service")
-        isBound = false
 
         if (state != State.Running) {
             stop()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -9,7 +9,6 @@ import androidx.core.app.NotificationCompat
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.service.MullvadVpnService
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
@@ -90,15 +89,13 @@ class TunnelStateNotification(val context: Context) {
         val pendingIntent =
             PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
-        val deleteIntent = buildDeleteIntent()
-
         val actions = if (showAction) {
             listOf(buildAction())
         } else {
             emptyList()
         }
 
-        return channel.buildNotification(pendingIntent, notificationText, actions, deleteIntent)
+        return channel.buildNotification(pendingIntent, notificationText, actions)
     }
 
     private fun buildAction(): NotificationCompat.Action {
@@ -111,11 +108,5 @@ class TunnelStateNotification(val context: Context) {
         val pendingIntent = PendingIntent.getForegroundService(context, 1, intent, flags)
 
         return NotificationCompat.Action(action.icon, label, pendingIntent)
-    }
-
-    private fun buildDeleteIntent(): PendingIntent {
-        val intent = Intent(MullvadVpnService.KEY_QUIT_ACTION).setPackage("net.mullvad.mullvadvpn")
-        val flags = PendingIntent.FLAG_UPDATE_CURRENT
-        return PendingIntent.getForegroundService(context, 1, intent, flags)
     }
 }

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -26,7 +26,6 @@ open class MainActivity : FragmentActivity() {
     val problemReport = MullvadProblemReport()
     val serviceNotifier = EventNotifier<ServiceConnection?>(null)
 
-    private var isUiVisible = false
     private var visibleSecureScreens = HashSet<Fragment>()
 
     private val deviceIsTv by lazy {
@@ -87,11 +86,9 @@ open class MainActivity : FragmentActivity() {
         android.util.Log.d("mullvad", "Starting main activity")
         super.onStart()
 
-        isUiVisible = true
-
         val intent = Intent(this, MullvadVpnService::class.java)
 
-        startForegroundService(intent)
+        startService(intent)
         bindService(intent, serviceConnectionManager, 0)
     }
 
@@ -109,7 +106,6 @@ open class MainActivity : FragmentActivity() {
 
     override fun onStop() {
         android.util.Log.d("mullvad", "Stoping main activity")
-        isUiVisible = false
         unbindService(serviceConnectionManager)
 
         super.onStop()

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.take
+import net.mullvad.mullvadvpn.model.ServiceResult
 
 fun <T> SendChannel<T>.safeOffer(element: T): Boolean {
     return runCatching { offer(element) }.getOrDefault(false)
@@ -32,21 +33,22 @@ fun Animation.transitionFinished(): Flow<Unit> = callbackFlow<Unit> {
     }
 }.take(1)
 
-fun Context.bindServiceFlow(intent: Intent, flags: Int = 0): Flow<IBinder?> = callbackFlow {
+fun Context.bindServiceFlow(intent: Intent, flags: Int = 0): Flow<ServiceResult> = callbackFlow {
     val connectionCallback = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
-            safeOffer(binder)
+            safeOffer(ServiceResult(binder))
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
-            safeOffer(null)
+            safeOffer(ServiceResult.NOT_CONNECTED)
+            bindService(intent, this, flags)
         }
     }
 
     bindService(intent, connectionCallback, flags)
 
     awaitClose {
-        safeOffer(null)
+        safeOffer(ServiceResult.NOT_CONNECTED)
 
         Dispatchers.Default.dispatch(EmptyCoroutineContext) {
             unbindService(connectionCallback)


### PR DESCRIPTION
This PR aims to improve lifecycle issues introduced as part of when the following were split into to separate processes: app ui, VPN service and tile service.

- Fix Quick Settings tile showing wrong state in certain scenarios.
- Avoid running in foreground when not connected.
- Avoid removing notification when service is stopped.
- Change so that swiping the notification no longer kills the service
  since that isn't a common way of handling the lifecycle in Android.
  Instead rely on the following mechanisms to kill the service:
  * Swiping to remove from the Recents/Overview screen.
  * Android Background Execution Limits.
  * The System Settings way of killing apps ("Force Stop").

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3142)
<!-- Reviewable:end -->
