### PR TITLE
Don't explicitly pass Tokio runtime handles to async functions or methods

### DIFF
--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -279,7 +279,6 @@ pub fn send_problem_report(
 
     let mut rpc_manager = runtime
         .block_on(mullvad_rpc::MullvadRpcRuntime::with_cache(
-            runtime.handle().clone(),
             None,
             cache_dir,
             false,

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -128,12 +128,12 @@ impl MullvadRpcRuntime {
     /// Try to use the cache directory first, and fall back on the resource directory
     /// if it fails.
     pub async fn with_cache(
-        handle: tokio::runtime::Handle,
         resource_dir: Option<&Path>,
         cache_dir: &Path,
         write_changes: bool,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> Result<Self, Error> {
+        let handle = tokio::runtime::Handle::current();
         #[cfg(feature = "api-override")]
         if *DISABLE_ADDRESS_ROTATION {
             return Self::new_inner(

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -173,14 +173,9 @@ async fn remove_wireguard_key() -> Result<(), Error> {
 
     if let Some(token) = settings.get_account_token() {
         if let Some(wg_data) = settings.get_wireguard() {
-            let mut rpc_runtime = MullvadRpcRuntime::with_cache(
-                tokio::runtime::Handle::current(),
-                None,
-                &cache_path,
-                false,
-            )
-            .await
-            .map_err(Error::RpcInitializationError)?;
+            let mut rpc_runtime = MullvadRpcRuntime::with_cache(None, &cache_path, false)
+                .await
+                .map_err(Error::RpcInitializationError)?;
             let mut key_proxy =
                 mullvad_rpc::WireguardKeyProxy::new(rpc_runtime.mullvad_rest_handle());
             retry_future_n(

--- a/talpid-core/src/dns/macos.rs
+++ b/talpid-core/src/dns/macos.rs
@@ -132,6 +132,10 @@ pub struct DnsMonitor {
     state: Arc<Mutex<Option<State>>>,
 }
 
+/// SAFETY: The `SCDynamicStore` can be sent to other threads since it doesn't share mutable state
+/// with anything else.
+unsafe impl Send for DnsMonitor {}
+
 impl super::DnsMonitorT for DnsMonitor {
     type Error = Error;
 

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -256,12 +256,6 @@ impl RouteManager {
             Err(Error::RouteManagerDown)
         }
     }
-
-    /// Exposes runtime handle
-    #[cfg(target_os = "linux")]
-    pub fn runtime_handle(&self) -> tokio::runtime::Handle {
-        self.runtime.clone()
-    }
 }
 
 impl Drop for RouteManager {

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -173,16 +173,13 @@ impl RouteManager {
     /// Constructs a RouteManager and applies the required routes.
     /// Takes a set of network destinations and network nodes as an argument, and applies said
     /// routes.
-    pub async fn new(
-        runtime: tokio::runtime::Handle,
-        required_routes: HashSet<RequiredRoute>,
-    ) -> Result<Self, Error> {
+    pub async fn new(required_routes: HashSet<RequiredRoute>) -> Result<Self, Error> {
         let (manage_tx, manage_rx) = mpsc::unbounded();
         let manager = imp::RouteManagerImpl::new(required_routes).await?;
-        runtime.spawn(manager.run(manage_rx));
+        tokio::spawn(manager.run(manage_rx));
 
         Ok(Self {
-            runtime,
+            runtime: tokio::runtime::Handle::current(),
             manage_tx: Some(manage_tx),
         })
     }

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -105,6 +105,7 @@ pub struct SplitTunnel {
     daemon_tx: Weak<mpsc::UnboundedSender<TunnelCommand>>,
     async_path_update_in_progress: Arc<AtomicBool>,
 }
+unsafe impl Send for SplitTunnel {}
 
 enum Request {
     SetPaths(Vec<OsString>),

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -30,13 +30,7 @@ use futures::{
 };
 #[cfg(target_os = "android")]
 use std::os::unix::io::RawFd;
-use std::{
-    collections::HashSet,
-    io,
-    net::IpAddr,
-    path::PathBuf,
-    sync::{mpsc as sync_mpsc, Arc},
-};
+use std::{collections::HashSet, io, net::IpAddr, path::PathBuf, sync::Arc};
 #[cfg(target_os = "android")]
 use talpid_types::{android::AndroidContext, ErrorExt};
 use talpid_types::{
@@ -120,43 +114,28 @@ pub async fn spawn(
         initial_settings.dns_servers.clone(),
     );
 
-    let (startup_result_tx, startup_result_rx) = sync_mpsc::channel();
     let weak_command_tx = Arc::downgrade(&command_tx);
-    let runtime = tokio::runtime::Handle::current();
-    std::thread::spawn(move || {
-        let state_machine = runtime.block_on(TunnelStateMachine::new(
-            initial_settings,
-            weak_command_tx,
-            offline_state_listener,
-            tunnel_parameters_generator,
-            tun_provider,
-            log_dir,
-            resource_dir,
-            command_rx,
-            #[cfg(target_os = "android")]
-            android_context,
-        ));
-        let state_machine = match state_machine {
-            Ok(state_machine) => {
-                startup_result_tx.send(Ok(())).unwrap();
-                state_machine
-            }
-            Err(error) => {
-                startup_result_tx.send(Err(error)).unwrap();
-                return;
-            }
-        };
+    let state_machine = TunnelStateMachine::new(
+        initial_settings,
+        weak_command_tx,
+        offline_state_listener,
+        tunnel_parameters_generator,
+        tun_provider,
+        log_dir,
+        resource_dir,
+        command_rx,
+        #[cfg(target_os = "android")]
+        android_context,
+    )
+    .await?;
 
+    tokio::task::spawn_blocking(move || {
         state_machine.run(state_change_listener);
-
         if shutdown_tx.send(()).is_err() {
             log::error!("Can't send shutdown completion to daemon");
         }
     });
 
-    startup_result_rx
-        .recv()
-        .expect("Failed to start tunnel state machine thread")?;
     Ok(command_tx)
 }
 


### PR DESCRIPTION
Instead, simply use [`Handle::current()`](https://docs.rs/tokio/1.14.0/tokio/runtime/struct.Handle.html#method.current). I decided to only do this for async functions, and not just any function that happens to be called in an async context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3144)
<!-- Reviewable:end -->
