### PR TITLE
Fix account text field height in compact environment

### DIFF
--- a/ios/MullvadVPN/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/AccountInputGroupView.swift
@@ -47,9 +47,8 @@ class AccountInputGroupView: UIView {
         let textField = AccountTextField()
         textField.font = UIFont.systemFont(ofSize: 20)
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.attributedPlaceholder = NSAttributedString(
-            string: "0000 0000 0000 0000",
-            attributes: [.foregroundColor: UIColor.lightGray])
+        textField.placeholder = "0000 0000 0000 0000"
+        textField.placeholderTextColor = .lightGray
         textField.textContentType = .username
         textField.clearButtonMode = .never
         textField.autocapitalizationType = .none

--- a/ios/MullvadVPN/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/AccountInputGroupView.swift
@@ -128,6 +128,9 @@ class AccountInputGroupView: UIView {
         contentView.addSubview(privateTextField)
         contentView.addSubview(sendButton)
 
+        privateTextField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        sendButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: topAnchor),
             contentView.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/ios/MullvadVPN/AccountTextField.swift
+++ b/ios/MullvadVPN/AccountTextField.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class AccountTextField: UITextField, UITextFieldDelegate {
+class AccountTextField: CustomTextField, UITextFieldDelegate {
 
     private let input = AccountTokenInput()
 
@@ -17,7 +17,8 @@ class AccountTextField: UITextField, UITextFieldDelegate {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        backgroundColor = UIColor.clear
+        backgroundColor = .clear
+        cornerRadius = 0
 
         delegate = self
         pasteDelegate = input
@@ -52,14 +53,6 @@ class AccountTextField: UITextField, UITextFieldDelegate {
         didSet {
             updateKeyboardReturnKey()
         }
-    }
-
-    override func textRect(forBounds bounds: CGRect) -> CGRect {
-        return bounds.insetBy(dx: 14, dy: 12)
-    }
-
-    override func editingRect(forBounds bounds: CGRect) -> CGRect {
-        return textRect(forBounds: bounds)
     }
 
     // MARK: - UITextFieldDelegate

--- a/ios/MullvadVPN/CustomTextField.swift
+++ b/ios/MullvadVPN/CustomTextField.swift
@@ -11,13 +11,13 @@ import UIKit
 
 class CustomTextField: UITextField {
 
-    var cornerRadius: CGFloat = 4 {
+    var cornerRadius: CGFloat = UIMetrics.controlCornerRadius {
         didSet {
             layer.cornerRadius = cornerRadius
         }
     }
 
-    var textMargins = UIEdgeInsets(top: 12, left: 14, bottom: 12, right: 14) {
+    var textMargins = UIMetrics.textFieldMargins {
         didSet {
             setNeedsLayout()
         }

--- a/ios/MullvadVPN/TranslucentButtonBlurView.swift
+++ b/ios/MullvadVPN/TranslucentButtonBlurView.swift
@@ -8,8 +8,6 @@
 
 import UIKit
 
-private let kButtonCornerRadius = CGFloat(4)
-
 class TranslucentButtonBlurView: UIVisualEffectView {
     init(button: AppButton) {
         let effect = UIBlurEffect(style: button.style.blurEffectStyle)
@@ -27,7 +25,7 @@ class TranslucentButtonBlurView: UIVisualEffectView {
             button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
 
-        layer.cornerRadius = kButtonCornerRadius
+        layer.cornerRadius = UIMetrics.controlCornerRadius
         layer.maskedCorners = button.style.cornerMask(effectiveUserInterfaceLayoutDirection)
         layer.masksToBounds = true
     }

--- a/ios/MullvadVPN/UIMetrics.swift
+++ b/ios/MullvadVPN/UIMetrics.swift
@@ -33,6 +33,12 @@ extension UIMetrics {
     /// Spacing used between distinct sections of views
     static var sectionSpacing: CGFloat = 24
 
+    /// Text field margins
+    static let textFieldMargins = UIEdgeInsets(top: 12, left: 14, bottom: 12, right: 14)
+
+    /// Corner radius used for controls such as buttons and text fields
+    static let controlCornerRadius: CGFloat = 4
+
     /// Maximum width of the split view content container on iPad
     static var maximumSplitViewContentContainerWidth: CGFloat = 810 * 0.7
 

--- a/ios/MullvadVPN/UIMetrics.swift
+++ b/ios/MullvadVPN/UIMetrics.swift
@@ -13,25 +13,25 @@ enum UIMetrics {}
 extension UIMetrics {
 
     /// Common layout margins for content presentation
-    static var contentLayoutMargins = UIEdgeInsets(top: 24, left: 24, bottom: 24, right: 24)
+    static let contentLayoutMargins = UIEdgeInsets(top: 24, left: 24, bottom: 24, right: 24)
 
     /// Common layout margins for settings cell presentation
-    static var settingsCellLayoutMargins = UIEdgeInsets(top: 16, left: 24, bottom: 16, right: 12)
+    static let settingsCellLayoutMargins = UIEdgeInsets(top: 16, left: 24, bottom: 16, right: 12)
 
     /// Common layout margins for location cell presentation
-    static var selectLocationCellLayoutMargins = UIEdgeInsets(top: 16, left: 28, bottom: 16, right: 12)
+    static let selectLocationCellLayoutMargins = UIEdgeInsets(top: 16, left: 28, bottom: 16, right: 12)
 
     /// Common cell indentation width
-    static var cellIndentationWidth: CGFloat = 16
+    static let cellIndentationWidth: CGFloat = 16
 
     /// Layout margins for in-app notification banner presentation
-    static var inAppBannerNotificationLayoutMargins = UIEdgeInsets(top: 16, left: 24, bottom: 16, right: 24)
+    static let inAppBannerNotificationLayoutMargins = UIEdgeInsets(top: 16, left: 24, bottom: 16, right: 24)
 
     /// Spacing used in stack views of buttons
-    static var interButtonSpacing: CGFloat = 16
+    static let interButtonSpacing: CGFloat = 16
 
     /// Spacing used between distinct sections of views
-    static var sectionSpacing: CGFloat = 24
+    static let sectionSpacing: CGFloat = 24
 
     /// Text field margins
     static let textFieldMargins = UIEdgeInsets(top: 12, left: 14, bottom: 12, right: 14)
@@ -40,12 +40,12 @@ extension UIMetrics {
     static let controlCornerRadius: CGFloat = 4
 
     /// Maximum width of the split view content container on iPad
-    static var maximumSplitViewContentContainerWidth: CGFloat = 810 * 0.7
+    static let maximumSplitViewContentContainerWidth: CGFloat = 810 * 0.7
 
     /// Minimum sidebar width in points
-    static var minimumSplitViewSidebarWidth: CGFloat = 300
+    static let minimumSplitViewSidebarWidth: CGFloat = 300
 
     /// Maximum sidebar width in percentage points (0...1)
-    static var maximumSplitViewSidebarWidthFraction: CGFloat = 0.3
+    static let maximumSplitViewSidebarWidthFraction: CGFloat = 0.3
 
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Inherit account token input field from `CustomTextField` to avoid code repetition.
1. Set horizontal compression priority on account input field and submit button to prevent text field from collapsing in compact horizontal environment.
1. Extract couple of dimensions into `UIMetrics` such as common corner radius and text field margins.
1. Fix leftover whitespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3146)
<!-- Reviewable:end -->
