### PR TITLE
Fix banner sometimes incorrectly showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Fix Quick Settings tile showing wrong state in certain scenarios.
+- Fix banner sometimes incorrectly showing (e.g. "BLOCKING INTERNET").
 
 ## [2021.6] - 2021-11-17
 ### Fixed

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.view.isVisible
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.notification.InAppNotification
 import net.mullvad.mullvadvpn.ui.notification.InAppNotificationController
@@ -158,19 +159,15 @@ class NotificationBanner : FrameLayout {
 
     private fun animateChange() {
         val notification = notifications.current
+        val hasOngoingHideAnimation = animation.isRunning && reversedAnimation
 
-        if (notification != null && visibility == View.INVISIBLE) {
-            // Banner is not currently shown but must be shown
+        if (isVisible.not() && notification != null) {
             reversedAnimation = false
             update(notification)
             animation.start()
-        } else if (visibility == View.VISIBLE && (!animation.isRunning() || !reversedAnimation)) {
-            // Either the banner is shown or it is in the process of being shown, but the
-            // notification must be hidden or replaced
+        } else if (hasOngoingHideAnimation.not()) {
             reversedAnimation = true
             animation.reverse()
         }
-        // If the banner is animating to be hidden, it will automatically start showing when the
-        // hide animation ends
     }
 }


### PR DESCRIPTION
Fixes the the issue present on master and the last release where the banner sometimes didn't hide after showing information to the user. For instance, while establishing a connection the banner shows "BLOCKING CONNECTION", however the banner wasn't removed/hidden after the connection was successfully established.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3148)
<!-- Reviewable:end -->
