### PR TITLE
Don't fetch new API addresses if `MULLVAD_API_ADDRESS` is set

### DIFF
--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -629,6 +629,10 @@ impl MullvadRestHandle {
             factory,
             availability,
         };
+        #[cfg(feature = "api-override")]
+        if *super::DISABLE_ADDRESS_ROTATION {
+            return handle;
+        }
         handle.spawn_api_address_fetcher(address_cache);
 
         handle


### PR DESCRIPTION
New addresses were still being fetched from the API even if `MULLVAD_API_ADDRESS` was set. I think it's safe to assume that this is unwanted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3149)
<!-- Reviewable:end -->
