### PR TITLE
Remove blank_lines_upper_bound from rustfmt.toml

### DIFF
--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -66,7 +66,6 @@ fn create_bridge_set_subcommand() -> clap::App<'static, 'static> {
         ))
 }
 
-
 fn create_set_custom_settings_subcommand() -> clap::App<'static, 'static> {
     #[allow(unused_mut)]
     let mut local_subcommand = clap::SubCommand::with_name("local")

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -732,7 +732,6 @@ impl Relay {
     }
 }
 
-
 fn parse_port_constraint(raw_port: &str) -> Result<Constraint<u16>> {
     match raw_port.to_lowercase().as_str() {
         "any" => Ok(Constraint::Any),

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -96,7 +96,6 @@ fn create_wireguard_keys_rotation_interval_subcommand() -> clap::App<'static, 's
         )
 }
 
-
 fn create_openvpn_subcommand() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("openvpn")
         .about("Manage options for OpenVPN tunnels")

--- a/mullvad-daemon/src/account.rs
+++ b/mullvad-daemon/src/account.rs
@@ -18,7 +18,6 @@ const RETRY_EXPIRY_CHECK_INTERVAL_INITIAL: Duration = Duration::from_secs(4);
 const RETRY_EXPIRY_CHECK_INTERVAL_FACTOR: u32 = 5;
 const RETRY_EXPIRY_CHECK_INTERVAL_MAX: Duration = Duration::from_secs(24 * 60 * 60);
 
-
 pub struct Account(());
 
 #[derive(Clone)]

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -36,7 +36,6 @@ lazy_static::lazy_static! {
     static ref ACCOUNT_REGEX: Regex = Regex::new(r"^[0-9]+$").unwrap();
 }
 
-
 impl AccountHistory {
     pub async fn new(
         settings_dir: &Path,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -4,7 +4,6 @@
 #[macro_use]
 extern crate serde;
 
-
 mod account;
 pub mod account_history;
 pub mod exception_logging;
@@ -602,7 +601,6 @@ where
             tx: internal_event_tx.clone(),
         };
 
-
         let initial_target_state = if settings.get_account_token().is_some() {
             if settings.auto_connect {
                 // Note: Auto-connect overrides the cached target state
@@ -891,7 +889,6 @@ where
         )
     }
 
-
     async fn handle_event(&mut self, event: InternalDaemonEvent) {
         use self::InternalDaemonEvent::*;
         match event {
@@ -937,7 +934,6 @@ where
             }
             TunnelStateTransition::Error(error_state) => TunnelState::Error(error_state),
         };
-
 
         self.unschedule_reconnect();
 
@@ -1176,7 +1172,6 @@ where
             job.abort();
         }
     }
-
 
     async fn handle_command(&mut self, command: DaemonCommand) {
         use self::DaemonCommand::*;
@@ -2165,7 +2160,6 @@ where
         Self::oneshot_send(tx, result, "on_set_bridge_state response");
     }
 
-
     async fn on_set_enable_ipv6(&mut self, tx: ResponseTx<(), settings::Error>, enable_ipv6: bool) {
         let save_result = self.settings.set_enable_ipv6(enable_ipv6).await;
         match save_result {
@@ -2594,7 +2588,6 @@ where
             result
         }
     }
-
 
     pub fn shutdown_handle(&self) -> DaemonShutdownHandle {
         DaemonShutdownHandle {

--- a/mullvad-daemon/src/migrations/account_history.rs
+++ b/mullvad-daemon/src/migrations/account_history.rs
@@ -8,13 +8,11 @@ use tokio::{
     io::{self, AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
 };
 
-
 const ACCOUNT_HISTORY_FILE: &str = "account-history.json";
 
 lazy_static::lazy_static! {
     static ref ACCOUNT_REGEX: Regex = Regex::new(r"^[0-9]+$").unwrap();
 }
-
 
 pub async fn migrate_location(old_dir: &Path, new_dir: &Path) {
     let old_path = old_dir.join(ACCOUNT_HISTORY_FILE);
@@ -312,7 +310,6 @@ mod test {
   "settings_version": 5
 }
 "#;
-
 
     // Test whether the current format is parsed correctly
     #[test]

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -46,7 +46,6 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-
 pub async fn migrate_all(cache_dir: &Path, settings_dir: &Path) -> Result<()> {
     #[cfg(windows)]
     windows::migrate_after_windows_update(settings_dir)

--- a/mullvad-daemon/src/migrations/v1.rs
+++ b/mullvad-daemon/src/migrations/v1.rs
@@ -2,7 +2,6 @@ use super::Result;
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
 use talpid_types::net::TunnelType;
 
-
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {
         return Ok(());

--- a/mullvad-daemon/src/migrations/v2.rs
+++ b/mullvad-daemon/src/migrations/v2.rs
@@ -3,7 +3,6 @@ use crate::wireguard::{MAX_ROTATION_INTERVAL, MIN_ROTATION_INTERVAL};
 use mullvad_types::settings::SettingsVersion;
 use std::time::Duration;
 
-
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {
         return Ok(());
@@ -169,7 +168,6 @@ mod test {
   "settings_version": 3
 }
 "#;
-
 
     #[test]
     fn test_v2_migration() {

--- a/mullvad-daemon/src/migrations/v3.rs
+++ b/mullvad-daemon/src/migrations/v3.rs
@@ -3,7 +3,6 @@ use mullvad_types::settings::{
     CustomDnsOptions, DefaultDnsOptions, DnsOptions, DnsState, SettingsVersion,
 };
 
-
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {
         return Ok(());
@@ -179,7 +178,6 @@ mod test {
   "settings_version": 4
 }
 "#;
-
 
     #[test]
     fn test_v3_migration() {

--- a/mullvad-daemon/src/migrations/v4.rs
+++ b/mullvad-daemon/src/migrations/v4.rs
@@ -5,10 +5,8 @@ use mullvad_types::{
 };
 use talpid_types::net::TransportProtocol;
 
-
 const WIREGUARD_TCP_PORTS: [u16; 3] = [80, 443, 5001];
 const OPENVPN_TCP_PORTS: [u16; 2] = [80, 443];
-
 
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {
@@ -265,7 +263,6 @@ mod test {
   "settings_version": 5
 }
 "#;
-
 
     #[test]
     fn test_v4_migration() {

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -62,7 +62,6 @@ const WIREGUARD_EXIT_CONSTRAINTS: WireguardConstraints = WireguardConstraints {
 };
 const WIREGUARD_TCP_PORTS: [(u16, u16); 3] = [(80, 80), (443, 443), (5001, 5001)];
 
-
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
 pub enum Error {
@@ -214,7 +213,6 @@ impl RelaySelector {
             Box::new(on_update),
             api_availability,
         );
-
 
         RelaySelector {
             parsed_relays,
@@ -376,7 +374,6 @@ impl RelaySelector {
             } else {
                 (Constraint::Any, TransportProtocol::Tcp, TunnelType::OpenVpn)
             };
-
 
         let mut relay_constraints = original_constraints.clone();
         relay_constraints.openvpn_constraints = Default::default();
@@ -625,7 +622,6 @@ impl RelaySelector {
         }
     }
 
-
     /// Returns a random relay endpoint if any is matching the given constraints.
     fn get_tunnel_endpoint_internal(
         &mut self,
@@ -722,7 +718,6 @@ impl RelaySelector {
                 relay
             }
         };
-
 
         let relay_matches = match constraints.tunnel_protocol {
             Constraint::Any => {
@@ -1166,7 +1161,6 @@ impl RelayListUpdater {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1442,7 +1436,6 @@ mod test {
             .map_err(|error| error.to_string())?;
 
         assert_ne!(exit_relay.hostname, specific_hostname);
-
 
         relay_constraints.location = Constraint::Only(location_specific);
         relay_constraints.wireguard_constraints.entry_location =

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -17,9 +17,7 @@ use tokio::{
     io::{self, AsyncWriteExt},
 };
 
-
 const SETTINGS_FILE: &str = "settings.json";
-
 
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
@@ -43,7 +41,6 @@ pub enum Error {
     #[error(display = "Unable to set settings file permissions")]
     SetPermissions(#[error(source)] io::Error),
 }
-
 
 #[derive(Debug)]
 pub struct SettingsPersister {

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -197,7 +197,6 @@ fn start_event_monitor(
     })
 }
 
-
 /// Service status helper with persistent checkpoint counter.
 #[derive(Debug, Clone)]
 struct PersistentServiceStatus {

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -50,7 +50,6 @@ const PLATFORM: &str = "windows";
 #[cfg(target_os = "android")]
 const PLATFORM: &str = "android";
 
-
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 struct CachedAppVersionInfo {
     #[serde(flatten)]
@@ -97,7 +96,6 @@ pub enum Error {
     #[error(display = "Version cache update was aborted")]
     UpdateAborted,
 }
-
 
 pub(crate) struct VersionUpdater {
     version_proxy: AppVersionProxy,

--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -111,7 +111,6 @@ impl KeyManager {
             .map_err(Self::map_rpc_error)
     }
 
-
     /// Replace a key for an account synchronously
     pub async fn replace_key(
         &mut self,
@@ -210,7 +209,6 @@ impl KeyManager {
         }
     }
 
-
     /// Generate a new private key asynchronously. The new keys will be sent to the daemon channel.
     pub async fn spawn_key_generation_task(
         &mut self,
@@ -271,7 +269,6 @@ impl KeyManager {
 
         let upload_future = retry_future(future_generator, should_retry, retry_strategy);
 
-
         let (cancellable_upload, abort_handle) = abortable(Box::pin(upload_future));
         let daemon_tx = self.daemon_tx.clone();
         let future = async move {
@@ -289,11 +286,9 @@ impl KeyManager {
             }
         };
 
-
         tokio::spawn(Box::pin(future));
         self.current_job = Some(abort_handle);
     }
-
 
     fn push_future_generator(
         &self,

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -515,7 +515,6 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_getAcco
     }
 }
 
-
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_getAccountData<'env>(

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -13,7 +13,6 @@ use std::{
 };
 use talpid_types::ErrorExt;
 
-
 pub mod metadata;
 
 /// Maximum number of bytes to read from each log file
@@ -21,7 +20,6 @@ const LOG_MAX_READ_BYTES: usize = 128 * 1024;
 const EXTRA_BYTES: usize = 32 * 1024;
 /// Fit five logs plus some system information in the report.
 const REPORT_MAX_SIZE: usize = (5 * LOG_MAX_READ_BYTES) + EXTRA_BYTES;
-
 
 /// Field delimeter in generated problem report
 const LOG_DELIMITER: &str = "====================";

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -5,7 +5,6 @@ use mullvad_problem_report::{collect_report, metadata, send_problem_report, Erro
 use std::{env, path::Path, process};
 use talpid_types::ErrorExt;
 
-
 fn main() {
     process::exit(match run() {
         Ok(()) => 0,

--- a/mullvad-rpc/src/address_cache.rs
+++ b/mullvad-rpc/src/address_cache.rs
@@ -246,7 +246,6 @@ impl crate::rest::AddressProvider for AddressCache {
     }
 }
 
-
 #[derive(Clone, PartialEq, Eq)]
 struct AddressCacheInner {
     addresses: Vec<SocketAddr>,

--- a/mullvad-rpc/src/availability.rs
+++ b/mullvad-rpc/src/availability.rs
@@ -4,9 +4,7 @@ use std::{
 };
 use tokio::sync::broadcast;
 
-
 const CHANNEL_CAPACITY: usize = 100;
-
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
@@ -14,7 +12,6 @@ pub enum Error {
     #[error(display = "API availability instance was dropped")]
     Interrupted(#[error(source)] broadcast::error::RecvError),
 }
-
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
 pub struct State {

--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -91,7 +91,6 @@ impl HttpsConnectorWithSni {
         cert_store
     }
 
-
     /// Set a channel to register sockets with the request service.
     pub(crate) fn set_service_tx(&mut self, service_tx: mpsc::Sender<RequestCommand>) {
         self.service_tx = Some(service_tx);
@@ -144,7 +143,6 @@ impl HttpsConnectorWithSni {
             return Ok(SocketAddr::new(addr, port));
         }
 
-
         let mut addrs = GaiResolver::new()
             .call(
                 Name::from_str(&hostname)
@@ -164,7 +162,6 @@ impl fmt::Debug for HttpsConnectorWithSni {
         f.debug_struct("HttpsConnectorWithSni").finish()
     }
 }
-
 
 impl Service<Uri> for HttpsConnectorWithSni {
     type Response = MaybeHttpsStream<TcpStream>;
@@ -214,7 +211,6 @@ impl Service<Uri> for HttpsConnectorWithSni {
 
             let (socket_shutdown_tx, socket_shutdown_rx) = oneshot::channel();
 
-
             let (tcp_stream, socket_handle) =
                 TcpStream::new(tokio_connection, Some(socket_shutdown_tx));
             if let Some(mut service_tx) = service_tx {
@@ -237,17 +233,14 @@ impl Service<Uri> for HttpsConnectorWithSni {
                 });
             }
 
-
             let tls_connection = tls_connector.connect(host, tcp_stream).await?;
 
             Ok(MaybeHttpsStream::Https(tls_connection))
         };
 
-
         Box::pin(fut)
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/mullvad-rpc/src/lib.rs
+++ b/mullvad-rpc/src/lib.rs
@@ -17,7 +17,6 @@ use std::{
 };
 use talpid_types::{net::wireguard, ErrorExt};
 
-
 pub mod availability;
 use availability::{ApiAvailability, ApiAvailabilityHandle};
 pub mod rest;
@@ -78,7 +77,6 @@ lazy_static::lazy_static! {
     static ref API_HOST: String = API_HOST_DEFAULT.to_string();
     static ref API_ADDRESS: SocketAddr = SocketAddr::new(API_IP_DEFAULT, API_PORT_DEFAULT);
 }
-
 
 /// A type that helps with the creation of RPC connections.
 pub struct MullvadRpcRuntime {
@@ -437,14 +435,12 @@ impl AppVersionProxy {
     }
 }
 
-
 /// Error code for when an account has too many keys. Returned when trying to push a new key.
 pub const KEY_LIMIT_REACHED: &str = "KEY_LIMIT_REACHED";
 #[derive(Clone)]
 pub struct WireguardKeyProxy {
     handle: rest::MullvadRestHandle,
 }
-
 
 impl WireguardKeyProxy {
     pub fn new(handle: rest::MullvadRestHandle) -> Self {

--- a/mullvad-rpc/src/relay_list.rs
+++ b/mullvad-rpc/src/relay_list.rs
@@ -71,7 +71,6 @@ impl RelayListProxy {
     }
 }
 
-
 #[derive(Debug, serde::Deserialize)]
 struct ServerRelayList {
     locations: BTreeMap<String, Location>,
@@ -106,7 +105,6 @@ impl ServerRelayList {
                 }
             }
         }
-
 
         Self::add_openvpn_relays(&mut countries, openvpn);
         Self::add_wireguard_relays(&mut countries, wireguard);
@@ -275,7 +273,6 @@ impl ServerRelayList {
         }
     }
 }
-
 
 /// Splits a location code into a country code and a city code. The input is expected to be in a
 /// format like `se-mma`, with `se` being the country code, `mma` being the city code.

--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -35,7 +35,6 @@ const API_IP_CHECK_DELAY: Duration = Duration::from_secs(15 * 60);
 const API_IP_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const API_IP_CHECK_ERROR_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
-
 pub type Result<T> = std::result::Result<T, Error>;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -187,7 +186,6 @@ impl RequestService {
                         }
                     }
 
-
                     if completion_tx.send(response).is_err() {
                         log::trace!(
                             "Failed to send response to caller, caller channel is shut down"
@@ -195,7 +193,6 @@ impl RequestService {
                     }
                     let _ = tx.send(RequestCommand::RequestFinished(id)).await;
                 };
-
 
                 self.handle.spawn(future);
                 self.in_flight_requests.insert(id, abort_handle);
@@ -258,7 +255,6 @@ fn get_request_socket_addr(request: &Request) -> Option<SocketAddr> {
     Some(SocketAddr::new(host_addr, port))
 }
 
-
 #[derive(Clone)]
 /// A handle to interact with a spawned `RequestService`.
 pub struct RequestServiceHandle {
@@ -284,7 +280,6 @@ impl RequestServiceHandle {
             .await
             .map_err(|_| Error::SendError)?;
 
-
         completion_rx.await.map_err(|_| Error::ReceiveError)?
     }
 
@@ -305,7 +300,6 @@ pub(crate) enum RequestCommand {
     SocketClosed(usize),
     Reset(oneshot::Sender<()>),
 }
-
 
 /// A REST request that is sent to the RequestService to be executed.
 #[derive(Debug)]
@@ -331,7 +325,6 @@ impl RestRequest {
             .uri(uri)
             .body(hyper::Body::empty())
             .map_err(Error::HttpError)?;
-
 
         Ok(RestRequest {
             timeout: DEFAULT_TIMEOUT,
@@ -409,7 +402,6 @@ pub struct RequestFactory {
     path_prefix: Option<String>,
     pub timeout: Duration,
 }
-
 
 impl RequestFactory {
     pub fn new(
@@ -515,7 +507,6 @@ impl AddressProvider for IpAddr {
     }
 }
 
-
 pub fn get_request<T: serde::de::DeserializeOwned>(
     factory: &RequestFactory,
     service: RequestServiceHandle,
@@ -567,7 +558,6 @@ pub fn post_request_with_json<B: serde::Serialize>(
     }
 }
 
-
 pub async fn deserialize_body<T: serde::de::DeserializeOwned>(mut response: Response) -> Result<T> {
     let body_length: usize = response
         .headers()
@@ -595,7 +585,6 @@ pub async fn parse_rest_response(
 
     Ok(response)
 }
-
 
 pub async fn handle_error_response<T>(response: Response) -> Result<T> {
     let error_message = match response.status() {

--- a/mullvad-rpc/src/tcp_stream.rs
+++ b/mullvad-rpc/src/tcp_stream.rs
@@ -37,7 +37,6 @@ impl TcpStreamHandle {
     }
 }
 
-
 pub struct TcpStream {
     inner: Arc<Mutex<Option<StreamInner>>>,
 }
@@ -80,7 +79,6 @@ impl Drop for TcpStream {
         }
     }
 }
-
 
 impl AsyncWrite for TcpStream {
     fn poll_write(

--- a/mullvad-setup/src/daemon_paths.rs
+++ b/mullvad-setup/src/daemon_paths.rs
@@ -35,7 +35,6 @@ pub fn get_mullvad_daemon_settings_path() -> io::Result<PathBuf> {
         .map(|settings| settings.join(mullvad_paths::PRODUCT_NAME))
 }
 
-
 /// Get local AppData path for the system service user. Requires elevated privileges to work.
 /// Useful for deducing the config path for the daemon on Windows when running as a user that
 /// isn't the system service.
@@ -216,7 +215,6 @@ fn get_running_process_id_from_name(target_name: &Path) -> io::Result<DWORD> {
     num_procs = bytes_written / (mem::size_of::<DWORD>() as u32);
     pid_buffer.resize(num_procs as usize, 0);
 
-
     for process in pid_buffer {
         let process_handle = unsafe { OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, process) };
         if process_handle.is_null() {
@@ -227,7 +225,6 @@ fn get_running_process_id_from_name(target_name: &Path) -> io::Result<DWORD> {
             );
             continue;
         }
-
 
         let mut process_name = vec![0u16; 512];
         let mut process_name_size = process_name.len() as u32;
@@ -247,7 +244,6 @@ fn get_running_process_id_from_name(target_name: &Path) -> io::Result<DWORD> {
         };
 
         process_name.resize(process_name_size as usize, 0u16);
-
 
         let process_path = PathBuf::from(OsString::from_wide(&process_name));
         let canonical_process_path = process_path.canonicalize().unwrap_or(process_path);

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -8,7 +8,6 @@ use std::{
 };
 use talpid_types::net::{openvpn, wireguard, Endpoint, TunnelParameters};
 
-
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "Invalid host/domain: {}", _0)]
@@ -17,7 +16,6 @@ pub enum Error {
     #[error(display = "Host has no IPv4 address: {}", _0)]
     HostHasNoIpv4(String),
 }
-
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 // TODO: Remove this Java conversion once `jnix` supports skipping fields in enum tuple variants.
@@ -87,7 +85,6 @@ impl fmt::Display for CustomTunnelEndpoint {
         }
     }
 }
-
 
 /// Does a DNS lookup if the host isn't an IP.
 /// Returns the first IPv4 address if one exists, otherwise the first IPv6 address.

--- a/mullvad-types/src/endpoint.rs
+++ b/mullvad-types/src/endpoint.rs
@@ -7,7 +7,6 @@ use talpid_types::net::{wireguard, Endpoint, TransportProtocol};
 
 use crate::relay_list::{OpenVpnEndpointData, WireguardEndpointData};
 
-
 /// Contains server data needed to connect to a single mullvad endpoint
 #[derive(Debug, Clone)]
 pub enum MullvadEndpoint {

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -53,7 +53,6 @@ fn haversine_dist_rad(lat: f64, lon: f64, other_lat: f64, other_lon: f64) -> f64
     haversine.sqrt().asin() * 2.0 * RAIDUS_OF_EARTH
 }
 
-
 /// The response from the am.i.mullvad.net location service.
 #[derive(Debug, Deserialize)]
 pub struct AmIMullvad {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fmt};
 use talpid_types::net::{openvpn::ProxySettings, IpVersion, TransportProtocol, TunnelType};
 
-
 pub trait Match<T> {
     fn matches(&self, other: &T) -> bool;
 }
@@ -281,7 +280,6 @@ impl fmt::Display for RelayConstraints {
     }
 }
 
-
 /// Limits the set of [`crate::relay_list::Relay`]s used by a `RelaySelector` based on
 /// location.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -542,7 +540,6 @@ impl Match<WireguardEndpointData> for WireguardConstraints {
     }
 }
 
-
 /// Specifies a specific endpoint or [`BridgeConstraints`] to use when `mullvad-daemon` selects a
 /// bridge server.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -552,7 +549,6 @@ pub enum BridgeSettings {
     Normal(BridgeConstraints),
     Custom(ProxySettings),
 }
-
 
 /// Limits the set of bridge servers to use in `mullvad-daemon`.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -14,7 +14,6 @@ use talpid_types::net::{
     wireguard, Endpoint, TransportProtocol,
 };
 
-
 /// Stores a list of relays for each country obtained from the API using
 /// `mullvad_rpc::RelayListProxy`. This can also be passed to frontends.
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -52,7 +52,6 @@ impl Serialize for SettingsVersion {
     }
 }
 
-
 /// Mullvad daemon settings.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -10,7 +10,6 @@ lazy_static::lazy_static! {
     static ref DEV_REGEX: Regex = Regex::new(r"^(\d{4})\.(\d+)(\.\d+)?(-beta(\d+))?-dev-(\w+)$").unwrap();
 }
 
-
 /// AppVersionInfo represents the current stable and the current latest release versions of the
 /// Mullvad VPN app.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -36,7 +35,6 @@ pub struct AppVersionInfo {
 }
 
 pub type AppVersion = String;
-
 
 /// Parses a version string into a type that can be used for comparisons.
 #[derive(Eq, PartialEq, Debug, Clone)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -8,4 +8,3 @@ imports_granularity = "Crate"
 
 # Heavily subjective style choices
 comment_width = 100
-blank_lines_upper_bound = 2

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -10,7 +10,6 @@ use self::{
 use crate::routing::RouteManagerHandle;
 use std::{env, fmt, net::IpAddr};
 
-
 const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/talpid-core/src/dns/linux/network_manager.rs
+++ b/talpid-core/src/dns/linux/network_manager.rs
@@ -4,13 +4,11 @@ use talpid_dbus::network_manager::{self, DeviceConfig, NetworkManager as DBus};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-
 pub struct NetworkManager {
     pub connection: DBus,
     device: Option<String>,
     settings_backup: Option<DeviceConfig>,
 }
-
 
 impl NetworkManager {
     pub fn new() -> Result<Self> {

--- a/talpid-core/src/dns/linux/systemd_resolved.rs
+++ b/talpid-core/src/dns/linux/systemd_resolved.rs
@@ -24,7 +24,6 @@ pub struct SystemdResolved {
     tunnel_index: u32,
 }
 
-
 impl SystemdResolved {
     pub fn new() -> Result<Self> {
         let dbus_interface = DbusInterface::new()?.async_handle();
@@ -65,7 +64,6 @@ impl SystemdResolved {
 
         Ok(())
     }
-
 
     pub async fn reset(&mut self) -> Result<()> {
         if let Err(error) = self

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -11,7 +11,6 @@ use winreg::{
     RegKey, RegValue,
 };
 
-
 const DNS_CACHE_POLICY_GUID: &str = "{d57d2750-f971-408e-8e55-cfddb37e60ae}";
 
 lazy_static! {
@@ -219,7 +218,6 @@ fn is_minimum_windows10() -> bool {
 ffi_error!(InitializationResult, Error::Initialization);
 ffi_error!(DeinitializationResult, Error::Deinitialization);
 ffi_error!(SettingResult, Error::Setting);
-
 
 #[allow(non_snake_case)]
 extern "stdcall" {

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -265,7 +265,6 @@ impl<'a> PolicyBatch<'a> {
         batch.add(&in_chain, nftnl::MsgType::Add);
         batch.add(&forward_chain, nftnl::MsgType::Add);
 
-
         Self::flush_table(&mut batch, &tables.mangle_v4);
         Self::flush_table(&mut batch, &tables.mangle_v6);
 

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -11,7 +11,6 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
 use talpid_types::net::Endpoint;
 
-
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]
 mod imp;
@@ -81,7 +80,6 @@ const DHCPV4_CLIENT_PORT: u16 = 68;
 const DHCPV6_SERVER_PORT: u16 = 547;
 #[cfg(all(unix, not(target_os = "android")))]
 const DHCPV6_CLIENT_PORT: u16 = 546;
-
 
 #[cfg(all(unix, not(target_os = "android")))]
 /// Returns whether an address belongs to a private subnet.

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -10,7 +10,6 @@ use std::os::windows::ffi::OsStrExt;
 use talpid_types::{net::Endpoint, tunnel::FirewallPolicyError};
 use widestring::WideCString;
 
-
 /// Errors that can happen when configuring the Windows firewall.
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]

--- a/talpid-core/src/logging/windows.rs
+++ b/talpid-core/src/logging/windows.rs
@@ -5,7 +5,6 @@ use winapi::um::{stringapiset::MultiByteToWideChar, winnls::CP_ACP};
 /// Logging callback type.
 pub type LogSink = extern "system" fn(level: log::Level, msg: *const c_char, context: *mut c_void);
 
-
 /// Logging callback implementation.
 pub extern "system" fn log_sink(level: log::Level, msg: *const c_char, context: *mut c_void) {
     if msg.is_null() {

--- a/talpid-core/src/network_interface.rs
+++ b/talpid-core/src/network_interface.rs
@@ -46,7 +46,6 @@ pub trait NetworkInterface: Sized {
     fn get_name(&self) -> &str;
 }
 
-
 trait WireguardLink: AsRawFd + IntoRawFd {}
 
 fn apply_async_flags(fd: RawFd) -> Result<(), nix::Error> {

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -83,7 +83,6 @@ pub async fn spawn_monitor(
     Ok(monitor_handle)
 }
 
-
 async fn public_ip_unreachable(handle: &RouteManagerHandle) -> Result<bool> {
     Ok(handle
         .get_destination_route(PUBLIC_INTERNET_ADDRESS_V4, true)

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -23,7 +23,6 @@ use system_configuration::{
     },
 };
 
-
 const PRIMARY_INTERFACE_KEY: &str = "State:/Network/Global/IPv4";
 
 #[derive(err_derive::Error, Debug)]
@@ -76,7 +75,6 @@ pub async fn spawn_monitor(notify_tx: UnboundedSender<bool>) -> Result<MonitorHa
             is_offline: Arc::new(AtomicBool::new(is_currently_offline)),
         };
 
-
         let result = || -> Result<SCDynamicStore, Error> {
             let dynamic_store = create_dynamic_store(context.clone())?;
             CFRunLoop::get_current().add_source(&dynamic_store.create_run_loop_source(), unsafe {
@@ -92,10 +90,8 @@ pub async fn spawn_monitor(notify_tx: UnboundedSender<bool>) -> Result<MonitorHa
                 kCFRunLoopCommonModes
             })?;
 
-
             Ok(dynamic_store)
         };
-
 
         match result() {
             Ok(_dynamic_store) => {

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -36,7 +36,6 @@ use winapi::{
 const CLASS_NAME: &[u8] = b"S\0T\0A\0T\0I\0C\0\0\0";
 const REQUEST_THREAD_SHUTDOWN: UINT = WM_USER + 1;
 
-
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "Unable to create listener thread")]
@@ -44,7 +43,6 @@ pub enum Error {
     #[error(display = "Failed to start connectivity monitor")]
     ConnectivityMonitorError(#[error(source)] winnet::DefaultRouteCallbackError),
 }
-
 
 pub struct BroadcastListener {
     thread_handle: RawHandle,

--- a/talpid-core/src/ping_monitor/mod.rs
+++ b/talpid-core/src/ping_monitor/mod.rs
@@ -2,7 +2,6 @@
 #[path = "unix.rs"]
 mod imp;
 
-
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 #[path = "icmp.rs"]
 mod imp;

--- a/talpid-core/src/ping_monitor/unix.rs
+++ b/talpid-core/src/ping_monitor/unix.rs
@@ -29,7 +29,6 @@ impl Pinger {
         })
     }
 
-
     fn try_deplete_process_list(&mut self) {
         self.processes.retain(|child| {
             match child.try_wait() {
@@ -77,7 +76,6 @@ impl Drop for Pinger {
         }
     }
 }
-
 
 fn ping_cmd(ip: Ipv4Addr, timeout_secs: u16, interface: &str) -> duct::Expression {
     let mut args = vec!["-n", "-i", "1"];

--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -476,7 +476,6 @@ impl Drop for OpenVpnProcHandle {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::OpenVpnCommand;

--- a/talpid-core/src/routing/android.rs
+++ b/talpid-core/src/routing/android.rs
@@ -11,7 +11,6 @@ pub struct Error;
 /// Stub route manager for Android
 pub struct RouteManagerImpl {}
 
-
 impl RouteManagerImpl {
     pub async fn new(_required_routes: HashSet<RequiredRoute>) -> Result<Self, Error> {
         Ok(RouteManagerImpl {})

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -38,7 +38,6 @@ use rtnetlink::{
 
 use libc::{AF_INET, AF_INET6};
 
-
 lazy_static! {
     static ref SUPPRESS_RULE_V4: RuleMessage = RuleMessage {
         header: RuleHeader {
@@ -81,7 +80,6 @@ lazy_static! {
     ];
 }
 
-
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can happen in the Linux routing integration
@@ -122,7 +120,6 @@ pub enum Error {
     #[error(display = "Shutting down route manager")]
     Shutdown,
 }
-
 
 pub struct RouteManagerImpl {
     handle: Handle,
@@ -302,7 +299,6 @@ impl RouteManagerImpl {
         Ok(link_map)
     }
 
-
     fn find_iface_idx(&self, iface_name: &str) -> Option<u32> {
         self.iface_map
             .iter()
@@ -322,7 +318,6 @@ impl RouteManagerImpl {
             }
         }
     }
-
 
     pub(crate) async fn run(
         mut self,
@@ -422,7 +417,6 @@ impl RouteManagerImpl {
             }
         };
 
-
         // By default, the prefix is unspecified.
         let mut prefix = IpNetwork::new(
             if is_ipv4 {
@@ -491,7 +485,6 @@ impl RouteManagerImpl {
         if device.is_none() && node_addr.is_none() && gateway.is_none() {
             return Err(Error::InvalidRoute);
         }
-
 
         let node = Node {
             ip: node_addr.or(gateway.into()),
@@ -823,7 +816,6 @@ impl NetworkInterface {
 mod test {
     use super::*;
     use std::collections::HashSet;
-
 
     /// Tests if dropping inside a tokio runtime panics
     #[test]

--- a/talpid-core/src/routing/macos.rs
+++ b/talpid-core/src/routing/macos.rs
@@ -15,7 +15,6 @@ use std::{
 use tokio::{io::AsyncBufReadExt, process::Command};
 use tokio_stream::wrappers::LinesStream;
 
-
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can happen in the macOS routing integration.
@@ -62,7 +61,6 @@ pub struct RouteManagerImpl {
     connectivity_change:
         Option<Box<dyn FusedStream<Item = std::io::Result<()>> + Unpin + Send + Sync>>,
 }
-
 
 impl RouteManagerImpl {
     pub async fn new(required_routes: HashSet<RequiredRoute>) -> Result<Self> {
@@ -231,7 +229,6 @@ impl RouteManagerImpl {
         cmd.status().await.map_err(Error::FailedToRemoveRoute)
     }
 
-
     async fn add_route(route: &Route) -> Result<ExitStatus> {
         let mut cmd = Command::new("route");
         cmd.arg("-q")
@@ -289,7 +286,6 @@ impl RouteManagerImpl {
     }
 }
 
-
 fn ip_vers(prefix: IpNetwork) -> &'static str {
     if prefix.is_ipv4() {
         "-inet"
@@ -297,7 +293,6 @@ fn ip_vers(prefix: IpNetwork) -> &'static str {
         "-inet6"
     }
 }
-
 
 /// Returns a stream that produces an item whenever a default route is either added or deleted from
 /// the routing table.
@@ -309,7 +304,6 @@ async fn listen_for_default_route_changes() -> Result<impl Stream<Item = std::io
         .stderr(Stdio::null())
         .stdout(Stdio::piped())
         .stdin(Stdio::null());
-
 
     let mut process = cmd.spawn().map_err(Error::FailedToMonitorRoutes)?;
     let reader = tokio::io::BufReader::new(process.stdout.take().unwrap());
@@ -350,7 +344,6 @@ async fn listen_for_default_route_changes() -> Result<impl Stream<Item = std::io
         }
         future::ready(Ok(None))
     });
-
 
     Ok(monitor)
 }

--- a/talpid-core/src/split_tunnel/linux.rs
+++ b/talpid-core/src/split_tunnel/linux.rs
@@ -87,7 +87,6 @@ impl PidManager {
         )
         .map_err(Error::InitNetClsCGroup)?;
 
-
         Ok(net_cls_dir)
     }
 

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -516,7 +516,6 @@ impl SplitTunnel {
             ),
         ));
 
-
         self._route_change_callback = None;
         let mut context = context_mutex.lock().unwrap();
         let callback = winnet::add_default_route_change_callback(

--- a/talpid-core/src/split_tunnel/windows/path_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/path_monitor.rs
@@ -51,7 +51,6 @@ const CSTR_EQUAL: i32 = 2;
 const ANYSIZE_ARRAY: usize = 1;
 const SYMLINK_FLAG_RELATIVE: u32 = 0x00000001;
 
-
 // See https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/c3a420cb-8a72-4adf-87e8-eee95379d78f.
 #[repr(C)]
 struct ReparseData {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -62,7 +62,6 @@ pub enum Error {
     WireguardTunnelMonitoringError(#[error(source)] wireguard::Error),
 }
 
-
 /// Possible events from the VPN tunnel and the child process managing it.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum TunnelEvent {
@@ -273,7 +272,6 @@ impl TunnelMonitor {
     }
 }
 
-
 /// A handle to a `TunnelMonitor`
 pub enum CloseHandle {
     #[cfg(not(target_os = "android"))]
@@ -322,7 +320,6 @@ impl InternalTunnelMonitor {
         Ok(())
     }
 }
-
 
 #[cfg(target_os = "windows")]
 fn is_ipv6_enabled_in_os() -> bool {

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -40,7 +40,6 @@ use winapi::shared::{guiddef::GUID, ifdef::NET_LUID};
 #[cfg(windows)]
 mod wintun;
 
-
 #[cfg(windows)]
 lazy_static! {
     static ref ADAPTER_ALIAS: U16CString = U16CString::from_str("Mullvad").unwrap();
@@ -54,7 +53,6 @@ const ADAPTER_GUID: GUID = GUID {
     Data3: 0x4EBB,
     Data4: [0x85, 0x36, 0x57, 0x6A, 0xB8, 0x6A, 0xFE, 0x9A],
 };
-
 
 /// Results from fallible operations on the OpenVPN tunnel.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -155,12 +153,10 @@ pub enum Error {
     ParseRemoteHost(#[error(source)] std::net::AddrParseError),
 }
 
-
 #[cfg(unix)]
 static OPENVPN_DIE_TIMEOUT: Duration = Duration::from_secs(4);
 #[cfg(windows)]
 static OPENVPN_DIE_TIMEOUT: Duration = Duration::from_secs(30);
-
 
 #[cfg(target_os = "macos")]
 const OPENVPN_PLUGIN_FILENAME: &str = "libtalpid_openvpn_plugin.dylib";
@@ -249,7 +245,6 @@ impl WintunContext for WintunContextImpl {
         self.adapter.adapter().try_disable_unused_features();
     }
 }
-
 
 impl OpenVpnMonitor<OpenVpnCommand> {
     /// Creates a new `OpenVpnMonitor` with the given listener and using the plugin at the given
@@ -645,7 +640,6 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
         Ok(temp_file)
     }
 
-
     #[cfg(unix)]
     fn set_user_pass_file_permissions(file: &fs::File) -> io::Result<()> {
         use std::os::unix::fs::PermissionsExt;
@@ -810,7 +804,6 @@ impl ProcessHandle for OpenVpnProcHandle {
         self.nice_kill(OPENVPN_DIE_TIMEOUT)
     }
 }
-
 
 mod event_server {
     use crate::tunnel::TunnelMetadata;
@@ -1109,7 +1102,6 @@ mod event_server {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/talpid-core/src/tunnel/openvpn/wintun.rs
+++ b/talpid-core/src/tunnel/openvpn/wintun.rs
@@ -75,7 +75,6 @@ enum WintunLoggerLevel {
     Err,
 }
 
-
 pub struct WintunDll {
     handle: HINSTANCE,
     func_open: WintunOpenAdapterFn,

--- a/talpid-core/src/tunnel/tun_provider/android/mod.rs
+++ b/talpid-core/src/tunnel/tun_provider/android/mod.rs
@@ -19,7 +19,6 @@ use std::{
 };
 use talpid_types::{android::AndroidContext, ErrorExt};
 
-
 /// Errors that occur while setting up VpnService tunnel.
 #[derive(Debug, err_derive::Error)]
 #[error(no_from)]

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -163,7 +163,6 @@ impl<'a> From<&'a [u8]> for ConfValue<'a> {
     }
 }
 
-
 impl<'a> ConfValue<'a> {
     fn to_bytes(&self) -> Cow<'a, [u8]> {
         match self {

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -15,7 +15,6 @@ const DELAY_ON_INITIAL_SETUP: Duration = Duration::from_millis(50);
 /// Sleep time used when checking if an established connection is still working.
 const REGULAR_LOOP_SLEEP: Duration = Duration::from_secs(1);
 
-
 /// Timeout for waiting on receiving traffic after sending outgoing traffic.  Once this timeout is
 /// hit, a ping will be sent every `SECONDS_PER_PING` until `PING_TIMEOUT` is reached, or traffic
 /// is received.
@@ -40,7 +39,6 @@ pub enum Error {
     #[error(display = "Ping monitor failed")]
     PingError(#[error(source)] crate::ping_monitor::Error),
 }
-
 
 /// Verifies if a connection to a tunnel is working.
 /// The connectivity monitor is biased to receiving traffic - it is expected that all outgoing
@@ -72,7 +70,6 @@ pub struct ConnectivityMonitor {
     pinger: Box<dyn Pinger>,
     close_receiver: mpsc::Receiver<()>,
 }
-
 
 impl ConnectivityMonitor {
     pub(super) fn new(
@@ -602,7 +599,6 @@ mod test {
             stats,
         }
     }
-
 
     #[test]
     /// Verify that `check_connectivity()` returns `false` if the tunnel is connected and traffic is

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -72,7 +72,6 @@ pub enum Error {
     SetIpAddressesError,
 }
 
-
 /// Spawns and monitors a wireguard tunnel
 pub struct WireguardMonitor {
     runtime: tokio::runtime::Handle,
@@ -479,7 +478,6 @@ impl WireguardMonitor {
             }
         })
     }
-
 
     /// On linux, there is no need
     #[cfg(target_os = "linux")]

--- a/talpid-core/src/tunnel/wireguard/stats.rs
+++ b/talpid-core/src/tunnel/wireguard/stats.rs
@@ -1,7 +1,6 @@
 #[cfg(target_os = "linux")]
 use super::wireguard_kernel::wg_message::{DeviceMessage, DeviceNla, PeerNla};
 
-
 #[derive(err_derive::Error, Debug, PartialEq)]
 pub enum Error {
     #[error(display = "Failed to parse peer pubkey from string \"_0\"")]
@@ -121,7 +120,6 @@ impl Stats {
         map
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
@@ -29,7 +29,6 @@ pub use netlink_tunnel::NetlinkTunnel;
 pub mod nm_tunnel;
 pub use nm_tunnel::NetworkManagerTunnel;
 
-
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
 pub enum Error {
@@ -95,7 +94,6 @@ pub struct Handle {
     route_abort_handle: AbortHandle,
 }
 
-
 impl Handle {
     pub async fn connect() -> Result<Self, Error> {
         let message_type = Self::get_wireguard_message_type().await?;
@@ -111,7 +109,6 @@ impl Handle {
             rtnetlink::new_connection().map_err(Error::NetlinkSocketError)?;
         let (abortable_connection, route_abort_handle) = abortable(conn);
         tokio::spawn(abortable_connection);
-
 
         Ok(Self {
             wg_handle,
@@ -200,7 +197,6 @@ impl Handle {
             }
         }
 
-
         Err(Error::NoDevice)
     }
 
@@ -208,7 +204,6 @@ impl Handle {
         let address_message = add_ip_addr_message(index, addr);
         let mut request = NetlinkMessage::from(RtnlMessage::NewAddress(address_message));
         request.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
-
 
         let mut response = self
             .route_handle
@@ -312,7 +307,6 @@ impl WireguardConnection {
         Ok(())
     }
 }
-
 
 fn consume_netlink_error<
     T,

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
@@ -4,7 +4,6 @@ use super::{
     Config, Error, Handle, Tunnel, TunnelError, MULLVAD_INTERFACE_NAME,
 };
 
-
 pub struct NetlinkTunnel {
     interface_index: u32,
     netlink_connections: Handle,
@@ -38,7 +37,6 @@ impl NetlinkTunnel {
                 }
                 return Err(err);
             }
-
 
             Ok(tunnel)
         })

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/nl_message.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/nl_message.rs
@@ -10,7 +10,6 @@ use netlink_packet_utils::{
 };
 use std::{ffi::CString, io::Write, mem};
 
-
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "Family name too long")]
@@ -36,7 +35,6 @@ impl NetlinkControlMessage {
         })
     }
 }
-
 
 impl NetlinkSerializable<NetlinkControlMessage> for NetlinkControlMessage {
     fn message_type(&self) -> u16 {

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/nm_tunnel.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/nm_tunnel.rs
@@ -11,7 +11,6 @@ use talpid_dbus::{
     },
 };
 
-
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "Error while communicating over Dbus")]
@@ -28,7 +27,6 @@ pub struct NetworkManagerTunnel {
     tokio_handle: tokio::runtime::Handle,
     interface_name: String,
 }
-
 
 impl NetworkManagerTunnel {
     pub fn new(
@@ -119,7 +117,6 @@ fn convert_config_to_dbus(config: &Config) -> DeviceConfig {
             .map(ToString::to_string)
             .collect::<Vec<_>>();
 
-
         peer_config.insert("allowed-ips".into(), Variant(Box::new(allowed_ips)));
         peer_config.insert(
             "endpoint".into(),
@@ -144,7 +141,6 @@ fn convert_config_to_dbus(config: &Config) -> DeviceConfig {
         Variant(Box::new(MULLVAD_INTERFACE_NAME.to_string())),
     );
     connection_config.insert("autoconnect".into(), Variant(Box::new(true)));
-
 
     let ipv4_addrs: Vec<_> = config
         .tunnel
@@ -176,7 +172,6 @@ fn convert_config_to_dbus(config: &Config) -> DeviceConfig {
         ipv6_config.insert("ignore-auto-dns".into(), Variant(Box::new(true)));
         ipv6_config.insert("may-fail".into(), Variant(Box::new(true)));
     }
-
 
     let mut settings = HashMap::new();
     settings.insert("ipv4".into(), ipv4_config);

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/wg_message.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/wg_message.rs
@@ -67,7 +67,6 @@ type PrivateKey = [u8; 32];
 type PublicKey = [u8; 32];
 type PresharedKey = [u8; 32];
 
-
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DeviceMessage {
     pub nlas: Vec<DeviceNla>,
@@ -98,7 +97,6 @@ impl DeviceMessage {
             DeviceNla::Flags(WGDEVICE_F_REPLACE_PEERS),
             DeviceNla::Peers(peers),
         ];
-
 
         Self {
             nlas,
@@ -495,7 +493,6 @@ impl<'a, T: AsRef<[u8]> + 'a + ?Sized> Parseable<NlaBuffer<&'a T>> for AllowedIp
     }
 }
 
-
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum AllowedIpNla {
     AddressFamily(u16),
@@ -591,7 +588,6 @@ mod test {
     use super::*;
     use nix::sys::time::TimeValLike;
     use std::net::Ipv4Addr;
-
 
     #[test]
     fn deserialize_netlink_message() {
@@ -864,7 +860,6 @@ mod test {
         }
     }
 
-
     #[test]
     fn serialize_netlink_message() {
         let expected_payload: &[u8] = &[
@@ -891,7 +886,6 @@ mod test {
 
         let mut message = sample_set_message();
         message.command = WG_CMD_SET_DEVICE;
-
 
         let mut payload_buffer = vec![0u8; message.buffer_len()];
         message.serialize(&mut payload_buffer);

--- a/talpid-core/src/tunnel/wireguard/wireguard_nt.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_nt.rs
@@ -38,7 +38,6 @@ use winapi::{
     },
 };
 
-
 lazy_static! {
     static ref WG_NT_DLL: Mutex<Option<Arc<WgNtDll>>> = Mutex::new(None);
     static ref ADAPTER_POOL: U16CString = U16CString::from_str("Mullvad").unwrap();
@@ -426,7 +425,6 @@ enum WgAdapterState {
     Up = 1,
 }
 
-
 impl WgNtTunnel {
     pub fn start_tunnel(
         config: &Config,
@@ -564,7 +562,6 @@ impl Drop for LoggerHandle {
         logging::clean_up_logging(self.context);
     }
 }
-
 
 struct WgNtAdapter {
     dll_handle: Arc<WgNtDll>,

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -28,7 +28,6 @@ use super::connecting_state::TunnelCloseEvent;
 pub(crate) type TunnelEventsReceiver =
     Fuse<mpsc::UnboundedReceiver<(TunnelEvent, oneshot::Sender<()>)>>;
 
-
 pub struct ConnectedStateBootstrap {
     pub metadata: TunnelMetadata,
     pub tunnel_events: TunnelEventsReceiver,

--- a/talpid-dbus/src/lib.rs
+++ b/talpid-dbus/src/lib.rs
@@ -10,7 +10,6 @@ lazy_static::lazy_static! {
     static ref DBUS_CONNECTION: Mutex<Option<Arc<SyncConnection>>> = Mutex::new(None);
 }
 
-
 /// Reuse or create a system DBus connection.
 pub fn get_connection() -> Result<Arc<SyncConnection>, dbus::Error> {
     let mut connection = DBUS_CONNECTION.lock().expect("DBus lock poisoned");

--- a/talpid-dbus/src/network_manager.rs
+++ b/talpid-dbus/src/network_manager.rs
@@ -108,7 +108,6 @@ pub enum Error {
     ObtainDevices,
 }
 
-
 pub type VariantRefArg = Variant<Box<dyn RefArg>>;
 pub type VariantMap = HashMap<String, VariantRefArg>;
 // settings are a{sa{sv}}
@@ -188,7 +187,6 @@ impl NetworkManager {
             .get(NM_CONNECTION_ACTIVE, "Devices")
             .map_err(Error::Dbus)?;
         let device_path = device_paths.into_iter().next().ok_or(Error::NoDevice)?;
-
 
         Ok(WireguardTunnel {
             config_path,
@@ -447,7 +445,6 @@ impl NetworkManager {
         let device_path = self.fetch_device(interface_name)?;
         self.wait_until_device_is_ready(&device_path)?;
 
-
         let device = self.as_path(&device_path);
         // Get the last applied connection
         let (mut settings, version_id): (
@@ -639,7 +636,6 @@ impl NetworkManager {
         Err(Error::DeviceNotFound)
     }
 
-
     pub fn convert_address_to_dbus(address: &IpAddr) -> VariantMap {
         let mut map: VariantMap = HashMap::new();
         map.insert(
@@ -692,7 +688,6 @@ impl WireguardTunnel {
     }
 }
 
-
 pub fn device_is_ready(device_state: u32) -> bool {
     /// Any state above `NM_DEVICE_STATE_IP_CONFIG` is considered to be an OK state to change the
     /// DNS config. For the enums, see https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMDeviceState
@@ -710,7 +705,6 @@ fn verify_etc_resolv_conf_contents() -> bool {
     let actual_resolv_conf = "/etc/resolv.conf";
     eq_file_content(&expected_resolv_conf, &actual_resolv_conf)
 }
-
 
 fn eq_file_content<P: AsRef<Path>>(a: &P, b: &P) -> bool {
     let file_a = match File::open(a).map(BufReader::new) {

--- a/talpid-dbus/src/systemd_resolved.rs
+++ b/talpid-dbus/src/systemd_resolved.rs
@@ -13,7 +13,6 @@ use std::{fs, io, net::IpAddr, path::Path, sync::Arc, time::Duration};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
 pub enum Error {
@@ -220,7 +219,6 @@ impl SystemdResolved {
             Ok(false)
         }
     }
-
 
     fn as_manager_object(&self) -> Proxy<'_, &SyncConnection> {
         Proxy::new(

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -7,7 +7,6 @@ use talpid_types::ErrorExt;
 mod processing;
 use crate::processing::EventProcessor;
 
-
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
 pub enum Error {
@@ -32,7 +31,6 @@ pub enum Error {
     #[error(display = "Unhandled event type: {:?}", _0)]
     UnhandledEvent(openvpn_plugin::EventType),
 }
-
 
 /// All the OpenVPN events this plugin will register for listening to. Edit this variable to change
 /// events.
@@ -81,7 +79,6 @@ fn parse_args(args: &[CString]) -> Result<Arguments, Error> {
 
     Ok(Arguments { ipc_socket_path })
 }
-
 
 fn openvpn_close(_handle: Mutex<Option<EventProcessor>>) {
     log::info!("Unloading plugin");

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -10,7 +10,6 @@ use tonic::{
 
 use tokio::runtime::{self, Runtime};
 
-
 mod proto {
     tonic::include_proto!("talpid_openvpn_plugin");
 }

--- a/talpid-platform-metadata/src/macos.rs
+++ b/talpid-platform-metadata/src/macos.rs
@@ -6,7 +6,6 @@ pub fn version() -> String {
     format!("macOS {}", version)
 }
 
-
 pub fn short_version() -> String {
     let version = run_sw_vers()
         .and_then(parse_short_version_output)

--- a/talpid-platform-metadata/src/windows.rs
+++ b/talpid-platform-metadata/src/windows.rs
@@ -34,7 +34,6 @@ pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
     std::iter::empty()
 }
 
-
 pub struct WindowsVersion {
     inner: RTL_OSVERSIONINFOW,
 }
@@ -46,7 +45,6 @@ impl WindowsVersion {
             .encode_wide()
             .chain(iter::once(0u16))
             .collect();
-
 
         let ntdll = unsafe { GetModuleHandleW(module_name.as_ptr()) };
         if ntdll == ptr::null_mut() {

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -10,7 +10,6 @@ pub mod tunnel;
 #[cfg(target_os = "linux")]
 pub mod cgroup;
 
-
 /// Used to generate string representations of error chains.
 pub trait ErrorExt {
     /// Creates a string representation of the entire error chain.

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -20,7 +20,6 @@ pub enum TunnelParameters {
     Wireguard(wireguard::TunnelParameters),
 }
 
-
 impl TunnelParameters {
     pub fn get_tunnel_endpoint(&self) -> TunnelEndpoint {
         match self {
@@ -144,7 +143,6 @@ impl fmt::Display for TunnelEndpoint {
     }
 }
 
-
 /// Represents a network layer IP address together with the transport layer protocol and port.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
@@ -231,7 +229,6 @@ impl fmt::Display for TransportProtocol {
         }
     }
 }
-
 
 /// Returned when `TransportProtocol::from_str` fails to convert a string into a
 /// [`TransportProtocol`] object.

--- a/talpid-types/src/net/openvpn.rs
+++ b/talpid-types/src/net/openvpn.rs
@@ -53,7 +53,6 @@ pub enum ProxySettings {
     Shadowsocks(ShadowsocksProxySettings),
 }
 
-
 impl ProxySettings {
     pub fn get_endpoint(&self) -> ProxyEndpoint {
         match self {

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -20,7 +20,6 @@ impl fmt::Display for ProxyType {
     }
 }
 
-
 /// Bridge endpoint, broadcast as part of a [`crate::net::TunnelEndpoint`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProxyEndpoint {

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -10,7 +10,6 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
-
 /// Tunnel parameters required to start a `WireguardMonitor`.
 /// See [`crate::net::TunnelParameters`].
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]
@@ -188,7 +187,6 @@ impl PublicKey {
         Ok(From::from(key))
     }
 }
-
 
 impl<'a> From<&'a x25519_dalek::StaticSecret> for PublicKey {
     fn from(private_key: &'a x25519_dalek::StaticSecret) -> PublicKey {

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -76,7 +76,6 @@ impl ErrorState {
     }
 }
 
-
 /// Reason for the tunnel state machine entering an [`ErrorState`].
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
Remove `blank_lines_upper_bound = 2` from our `rustfmt.toml`. It is an unstable option and accidentally running `cargo fmt` on stable reformat a lot of the code (removes blank lines) which is super annoying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3150)
<!-- Reviewable:end -->
