### PR TITLE
Remove explicitly passing handles to tokio runtimes in mullvad-rpc

### DIFF
--- a/mullvad-rpc/src/bin/address_cache.rs
+++ b/mullvad-rpc/src/bin/address_cache.rs
@@ -5,8 +5,7 @@ use talpid_types::ErrorExt;
 
 #[tokio::main]
 async fn main() {
-    let mut runtime =
-        MullvadRpcRuntime::new(tokio::runtime::Handle::current()).expect("Failed to load runtime");
+    let mut runtime = MullvadRpcRuntime::new().expect("Failed to load runtime");
 
     let api_proxy = ApiProxy::new(runtime.mullvad_rest_handle());
     let request = api_proxy.get_api_addrs().await;

--- a/mullvad-rpc/src/bin/relay_list.rs
+++ b/mullvad-rpc/src/bin/relay_list.rs
@@ -6,8 +6,7 @@ use talpid_types::ErrorExt;
 
 #[tokio::main]
 async fn main() {
-    let mut runtime =
-        MullvadRpcRuntime::new(tokio::runtime::Handle::current()).expect("Failed to load runtime");
+    let mut runtime = MullvadRpcRuntime::new().expect("Failed to load runtime");
 
     let relay_list_request = RelayListProxy::new(runtime.mullvad_rest_handle())
         .relay_list(None)


### PR DESCRIPTION
What do you think about this? I agree it's a bit implicit that some stuff has to run in an async context. But on the other hand, there is a lot of arguments to pass around for basically no reason here...

Some parts of the problem report tool was the only things that called into this code from a non async context. So I slightly refactored that to be an `async fn`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3151)
<!-- Reviewable:end -->
