### PR TITLE
Suppress output to stderr.log from pfctl

### DIFF
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -558,7 +558,9 @@ impl Firewall {
     }
 
     fn is_enabled(&self) -> bool {
-        let cmd = duct::cmd!("/sbin/pfctl", "-s", "info");
+        let cmd = duct::cmd!("/sbin/pfctl", "-s", "info")
+            .stderr_null()
+            .stdout_capture();
         const EXPECTED_OUTPUT: &'static [u8] = b"Status: Enabled";
         match cmd.run() {
             Ok(output) => output.stdout.as_slice().find(&EXPECTED_OUTPUT).is_some(),


### PR DESCRIPTION
As above. The log is currently filled with output from `pfctl`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3155)
<!-- Reviewable:end -->
