### PR TITLE
Refactor widestring code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
  "talpid-core",
  "talpid-types",
  "tokio",
- "widestring",
+ "widestring 0.5.1",
  "winapi 0.3.9",
  "winres",
 ]
@@ -2512,7 +2512,7 @@ dependencies = [
  "udp-over-tcp",
  "uuid",
  "which",
- "widestring",
+ "widestring 0.5.1",
  "winapi 0.3.9",
  "winreg",
  "zeroize",
@@ -3089,6 +3089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,7 +3145,7 @@ checksum = "0c643e10139d127d30d6d753398c8a6f0a43532e8370f6c9d29ebbff29b984ab"
 dependencies = [
  "bitflags",
  "err-derive",
- "widestring",
+ "widestring 0.4.3",
  "winapi 0.3.9",
 ]
 

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -30,7 +30,7 @@ talpid-types = { path = "../talpid-types" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = [ "securitybaseapi", "impl-default", "impl-debug", "handleapi", "psapi" ]}
-widestring = "0.4"
+widestring = "0.5"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -77,7 +77,7 @@ subslice = "0.2"
 [target.'cfg(windows)'.dependencies]
 byteorder = "1"
 internet-checksum = "0.2"
-widestring = "0.4"
+widestring = "0.5"
 winreg = { version = "0.7", features = ["transactions"] }
 winapi = { version = "0.3.6", features = ["combaseapi", "handleapi", "ifdef", "libloaderapi", "netioapi", "psapi", "stringapiset", "synchapi", "tlhelp32", "winbase", "winioctl", "winuser"] }
 socket2 = { version = "0.4", features = ["all"] }

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -120,7 +120,7 @@ impl super::DnsMonitorT for DnsMonitor {
 }
 
 fn ip_to_widestring(ip: &IpAddr) -> WideCString {
-    WideCString::new(ip.to_string().encode_utf16().collect::<Vec<_>>()).unwrap()
+    WideCString::from_str_truncate(ip.to_string())
 }
 
 impl Drop for DnsMonitor {

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -1,12 +1,11 @@
 use crate::{logging::windows::log_sink, tunnel::TunnelMetadata};
 
-use std::{ffi::OsString, iter, net::IpAddr, path::Path, ptr};
+use std::{net::IpAddr, path::Path, ptr};
 
 use self::winfw::*;
 use super::{FirewallArguments, FirewallPolicy, FirewallT};
 use crate::winnet;
 use log::{debug, error, trace};
-use std::os::windows::ffi::OsStrExt;
 use talpid_types::{net::Endpoint, tunnel::FirewallPolicyError};
 use widestring::WideCString;
 
@@ -163,8 +162,7 @@ impl Firewall {
             protocol: WinFwProt::from(endpoint.protocol),
         };
 
-        let mut relay_client: Vec<u16> = relay_client.as_os_str().encode_wide().collect();
-        relay_client.push(0u16);
+        let relay_client = WideCString::from_os_str_truncate(relay_client);
 
         let allowed_endpoint_ip = widestring_ip(allowed_endpoint.address.ip());
         let winfw_allowed_endpoint = Some(WinFwEndpoint {
@@ -173,9 +171,9 @@ impl Firewall {
             protocol: WinFwProt::from(allowed_endpoint.protocol),
         });
 
-        let interface_wstr = tunnel_metadata.as_ref().map(|metadata| {
-            WideCString::new(metadata.interface.encode_utf16().collect::<Vec<_>>()).unwrap()
-        });
+        let interface_wstr = tunnel_metadata
+            .as_ref()
+            .map(|metadata| WideCString::from_str_truncate(&metadata.interface));
         let interface_wstr_ptr = if let Some(ref wstr) = interface_wstr {
             wstr.as_ptr()
         } else {
@@ -210,8 +208,7 @@ impl Firewall {
             .ipv6_gateway
             .map(|v6_ip| widestring_ip(v6_ip.into()));
 
-        let tunnel_alias =
-            WideCString::new(tunnel_metadata.interface.encode_utf16().collect::<Vec<_>>()).unwrap();
+        let tunnel_alias = WideCString::from_str_truncate(&tunnel_metadata.interface);
 
         // ip_str, gateway_str and tunnel_alias have to outlive winfw_relay
         let winfw_relay = WinFwEndpoint {
@@ -234,19 +231,10 @@ impl Firewall {
             None => ptr::null(),
         };
 
-        let mut relay_client: Vec<u16> = relay_client.as_os_str().encode_wide().collect();
-        relay_client.push(0u16);
+        let relay_client = WideCString::from_os_str_truncate(relay_client);
 
-        let dns_servers: Vec<Vec<u16>> = dns_servers
-            .iter()
-            .map(|ip| {
-                OsString::from(ip.to_string())
-                    .as_os_str()
-                    .encode_wide()
-                    .chain(iter::once(0u16))
-                    .collect()
-            })
-            .collect();
+        let dns_servers: Vec<WideCString> =
+            dns_servers.iter().cloned().map(widestring_ip).collect();
         let dns_servers: Vec<*const u16> = dns_servers.iter().map(|ip| ip.as_ptr()).collect();
 
         unsafe {
@@ -301,8 +289,7 @@ impl<T> NullablePointer<T> for Option<T> {
 }
 
 fn widestring_ip(ip: IpAddr) -> WideCString {
-    let buf = ip.to_string().encode_utf16().collect::<Vec<_>>();
-    WideCString::new(buf).unwrap()
+    WideCString::from_str_truncate(ip.to_string())
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
Changes:
* Update to `widestring` 0.5, which includes some `from_*_truncate` constructors that let us avoid some `unwrap`s.
* Use `WideCString` instead of `encode_wide` in modules where `widestring` was already being relied upon, since it accomplishes the same thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3163)
<!-- Reviewable:end -->
