### PR TITLE
Make the initial allowed endpoint argument non-optional

### DIFF
--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -4,7 +4,7 @@ use mullvad_rpc::MullvadRpcRuntime;
 use mullvad_types::version::ParsedAppVersion;
 use std::{path::PathBuf, process, time::Duration};
 use talpid_core::{
-    firewall::{self, Firewall, FirewallArguments},
+    firewall::{self, Firewall, FirewallArguments, InitialFirewallState},
     future_retry::{constant_interval, retry_future_n},
 };
 use talpid_types::ErrorExt;
@@ -158,9 +158,8 @@ async fn reset_firewall() -> Result<(), Error> {
     }
 
     let mut firewall = Firewall::new(FirewallArguments {
-        initialize_blocked: false,
+        initial_state: InitialFirewallState::None,
         allow_lan: true,
-        allowed_endpoint: None,
     })
     .map_err(Error::FirewallError)?;
 

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -214,12 +214,21 @@ pub struct Firewall {
 
 /// Arguments required when first initializing the firewall.
 pub struct FirewallArguments {
-    /// Determines whether the firewall should atomically enter the blocked state during init.
-    pub initialize_blocked: bool,
+    /// Initial firewall state to enter during init.
+    pub initial_state: InitialFirewallState,
     /// This argument is required for the blocked state to configure the firewall correctly.
     pub allow_lan: bool,
-    /// This argument is required for the blocked state to configure the firewall correctly.
-    pub allowed_endpoint: Option<Endpoint>,
+}
+
+/// State to enter during firewall init.
+pub enum InitialFirewallState {
+    /// Do not set any policy.
+    None,
+    /// Atomically enter the blocked state.
+    Blocked {
+        /// Host that should be reachable while in the blocked state.
+        allowed_endpoint: Endpoint,
+    },
 }
 
 impl Firewall {


### PR DESCRIPTION
Previously, `FirewallArguments` included an optional `allowed_endpoint` field as well as a boolean `initialize_blocked`. In reality, `allowed_endpoint` will never be `None` if `initialize_blocked` is `true`, and it will only ever be `None` if `initialize_blocked` is `false`. Moreover, setting the firewall policy to `connecting` or `blocked` after init involves a non-optional `allowed_endpoint` argument. So this PR gets rid of the "invalid" combinations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3164)
<!-- Reviewable:end -->
