### PR TITLE
Disable account creation while entering account number

### DIFF
--- a/gui/src/renderer/components/Login.tsx
+++ b/gui/src/renderer/components/Login.tsx
@@ -201,6 +201,11 @@ export default class Login extends React.Component<IProps, IState> {
     return this.props.loginState.type !== 'logging in' && this.props.loginState.type !== 'ok';
   }
 
+  private allowCreateAccount() {
+    const { accountToken } = this.props;
+    return this.allowInteraction() && (accountToken === undefined || accountToken.length === 0);
+  }
+
   private accountTokenValid(): boolean {
     const { accountToken } = this.props;
     return accountToken !== undefined && accountToken.length >= MIN_ACCOUNT_TOKEN_LENGTH;
@@ -251,7 +256,7 @@ export default class Login extends React.Component<IProps, IState> {
               groupLength={4}
               placeholder="0000 0000 0000 0000"
               value={this.props.accountToken || ''}
-              disabled={!this.allowInteraction()}
+              disabled={!allowInteraction}
               onFocus={this.onFocus}
               onBlur={this.onBlur}
               handleChange={this.onInputChange}
@@ -298,7 +303,7 @@ export default class Login extends React.Component<IProps, IState> {
         </StyledLoginFooterPrompt>
         <AppButton.BlueButton
           onClick={this.props.createNewAccount}
-          disabled={!this.allowInteraction()}>
+          disabled={!this.allowCreateAccount()}>
           {messages.pgettext('login-view', 'Create account')}
         </AppButton.BlueButton>
       </>


### PR DESCRIPTION
This PR disables the "Create new account" button while the login field isn't empty. This is to prevent users from hitting the "Create new account" button as a submit button for the login field.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3165)
<!-- Reviewable:end -->
