### PR TITLE
Handle empty relay location field (`any` location) in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Always kill `sslocal` if the tunnel monitor fails to start when using bridges.
+- Show relay location constraint correctly in the CLI when it is set to `any`.
 
 #### Windows
 - Fix app size after changing display scale.

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -773,14 +773,10 @@ impl TryFrom<RelaySettings> for mullvad_types::relay_constraints::RelaySettings 
             }
 
             relay_settings::Endpoint::Normal(settings) => {
-                let location =
-                    Constraint::<mullvad_types::relay_constraints::LocationConstraint>::from(
-                        settings
-                            .location
-                            .ok_or(FromProtobufTypeError::InvalidArgument(
-                                "missing relay location",
-                            ))?,
-                    );
+                let location = settings
+                    .location
+                    .map(Constraint::<mullvad_types::relay_constraints::LocationConstraint>::from)
+                    .unwrap_or(Constraint::Any);
                 let providers = try_providers_constraint_from_proto(&settings.providers)?;
                 let tunnel_protocol = settings
                     .tunnel_type


### PR DESCRIPTION
The conversion back from the `RelayLocation` gRPC message considers an absent `location` to be invalid. This is used for the `any` location. Confusingly, a `RelayLocation` with all fields empty can also refer to the `any` location. We need to handle both, because the CLI currently panics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3166)
<!-- Reviewable:end -->
