### PR TITLE
Fix android resume navigates back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix Quick Settings tile showing wrong state in certain scenarios.
 - Fix banner sometimes incorrectly showing (e.g. "BLOCKING INTERNET").
+- Fix issue with the user getting kicked out of certain views in settings when the app is brought to the foreground.
 
 ## [2021.6] - 2021-11-17
 ### Fixed

--- a/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -28,8 +28,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         Initialized,
         Active,
         Stopped,
-        LostConnection,
-        WaitingForReconnection,
+        LostConnection
     }
 
     private var state = State.Uninitialized
@@ -81,7 +80,6 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         synchronized(this) {
             when (state) {
                 State.Uninitialized -> state = State.Initialized
-                State.WaitingForReconnection -> state = State.Stopped
                 State.Active -> {
                     onSafelyStop()
                     onSafelyStart()
@@ -102,7 +100,6 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     state = State.LostConnection
                     leaveFragment()
                 }
-                State.Stopped -> state = State.WaitingForReconnection
                 else -> {}
             }
         }
@@ -118,7 +115,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                 State.Initialized, State.Active, State.Stopped -> {
                     onSafelyCreateView(inflater, container, savedInstanceState)
                 }
-                State.Uninitialized, State.LostConnection, State.WaitingForReconnection -> {
+                State.Uninitialized, State.LostConnection -> {
                     inflater.inflate(R.layout.missing_service, container, false)
                 }
             }
@@ -133,10 +130,6 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                 State.Initialized, State.Stopped -> {
                     state = State.Active
                     onSafelyStart()
-                }
-                State.WaitingForReconnection -> {
-                    state = State.LostConnection
-                    leaveFragment()
                 }
                 else -> {}
             }


### PR DESCRIPTION
Fixes the issue with the user getting kicked out of certain views in settings when the app is brought to the foreground.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3167)
<!-- Reviewable:end -->
