### PR TITLE
Restrict API access to some applications on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ Line wrap the file at 100 chars.                                              Th
 - Fix banner sometimes incorrectly showing (e.g. "BLOCKING INTERNET").
 - Fix issue with the user getting kicked out of certain views in settings when the app is brought to the foreground.
 
+### Security
+#### Windows
+- Restrict which applications are allowed to communicate with the API while in a blocking state.
+  This prevents malicious scripts on websites from trying to do so.
+
+
 ## [2021.6] - 2021-11-17
 ### Fixed
 - Fix the font for Russian. Issue introduced in 2021.6-beta1.

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,6 +99,13 @@ The following network traffic is allowed or blocked independent of state:
 On Linux, any situation that permits incoming or outgoing traffic also allows that traffic to be
 forwarded. All other forward traffic is rejected.
 
+#### Mullvad API
+
+The firewall allows traffic for the API regardless of tunnel state, to allow for updating keys,
+fetching account data, etc. In the [Connected] state, this is only allowed inside the tunnel.
+For the other states, it is allowed regardless. On Windows, only the Mullvad service and problem
+report tool are able to communicate with the API in any of the blocking states.
+
 ### Disconnected
 
 This is the default state that the `mullvad-daemon` starts in when the device boots, unless
@@ -184,7 +191,6 @@ disconnect/quit is explicitly requested by the user. At the same time there migh
 when the app can't establish a tunnel for the device. This includes, but is not limited to:
 * Account runs out of time
 * The computer is offline
-* the TAP adapter driver has an error or the adapter can't be found (Windows)
 * Some internal error parsing or modifying system routing table, DNS settings etc.
 
 In the above cases the app gives up trying to create a tunnel, but it can't go to the

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -560,7 +560,7 @@ impl<'a> PolicyBatch<'a> {
                 allowed_endpoint,
             } => {
                 self.add_allow_tunnel_endpoint_rules(peer_endpoint);
-                self.add_allow_endpoint_rules(allowed_endpoint);
+                self.add_allow_endpoint_rules(&allowed_endpoint.endpoint);
 
                 // Important to block DNS after allow relay rule (so the relay can operate
                 // over port 53) but before allow LAN (so DNS does not leak to the LAN)
@@ -596,7 +596,7 @@ impl<'a> PolicyBatch<'a> {
                 allow_lan,
                 allowed_endpoint,
             } => {
-                self.add_allow_endpoint_rules(allowed_endpoint);
+                self.add_allow_endpoint_rules(&allowed_endpoint.endpoint);
 
                 // Important to drop DNS before allowing LAN (to stop DNS leaking to the LAN)
                 self.add_drop_dns_rule();

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -104,7 +104,7 @@ impl Firewall {
                 allowed_endpoint,
             } => {
                 let mut rules = vec![self.get_allow_relay_rule(peer_endpoint)?];
-                rules.push(self.get_allowed_endpoint_rule(allowed_endpoint)?);
+                rules.push(self.get_allowed_endpoint_rule(allowed_endpoint.endpoint)?);
 
                 // Important to block DNS after allow relay rule (so the relay can operate
                 // over port 53) but before allow LAN (so DNS does not leak to the LAN)
@@ -150,7 +150,7 @@ impl Firewall {
                 allowed_endpoint,
             } => {
                 let mut rules = Vec::new();
-                rules.push(self.get_allowed_endpoint_rule(allowed_endpoint)?);
+                rules.push(self.get_allowed_endpoint_rule(allowed_endpoint.endpoint)?);
                 if allow_lan {
                     // Important to block DNS before allow LAN (so DNS does not leak to the LAN)
                     rules.append(&mut self.get_block_dns_rules()?);

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(windows)]
 use std::path::PathBuf;
-use talpid_types::net::Endpoint;
+use talpid_types::net::{AllowedEndpoint, Endpoint};
 
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]
@@ -107,8 +107,8 @@ pub enum FirewallPolicy {
         tunnel: Option<crate::tunnel::TunnelMetadata>,
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
-        /// Host that should be reachable by the tunnel client while connecting.
-        allowed_endpoint: Endpoint,
+        /// Host that should be reachable while connecting.
+        allowed_endpoint: AllowedEndpoint,
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]
         relay_client: PathBuf,
@@ -135,7 +135,7 @@ pub enum FirewallPolicy {
         /// Flag setting if communication with LAN networks should be possible.
         allow_lan: bool,
         /// Host that should be reachable while in the blocked state.
-        allowed_endpoint: Endpoint,
+        allowed_endpoint: AllowedEndpoint,
     },
 }
 
@@ -225,10 +225,7 @@ pub enum InitialFirewallState {
     /// Do not set any policy.
     None,
     /// Atomically enter the blocked state.
-    Blocked {
-        /// Host that should be reachable while in the blocked state.
-        allowed_endpoint: Endpoint,
-    },
+    Blocked(AllowedEndpoint),
 }
 
 impl Firewall {

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -282,6 +282,13 @@ mod winfw {
     use talpid_types::net::TransportProtocol;
 
     #[repr(C)]
+    pub struct WinFwAllowedEndpoint {
+        pub num_clients: u32,
+        pub clients: *const *const libc::wchar_t,
+        pub endpoint: WinFwEndpoint,
+    }
+
+    #[repr(C)]
     pub struct WinFwEndpoint {
         pub ip: *const libc::wchar_t,
         pub port: u16,
@@ -370,7 +377,7 @@ mod winfw {
         pub fn WinFw_InitializeBlocked(
             timeout: libc::c_uint,
             settings: &WinFwSettings,
-            allowed_endpoint: *const WinFwEndpoint,
+            allowed_endpoint: *const WinFwAllowedEndpoint,
             sink: Option<LogSink>,
             sink_context: *const u8,
         ) -> InitializationResult;
@@ -384,7 +391,7 @@ mod winfw {
             relay: &WinFwEndpoint,
             relayClient: *const libc::wchar_t,
             tunnelIfaceAlias: *const libc::wchar_t,
-            allowed_endpoint: *const WinFwEndpoint,
+            allowed_endpoint: *const WinFwAllowedEndpoint,
         ) -> WinFwPolicyStatus;
 
         #[link_name = "WinFw_ApplyPolicyConnected"]
@@ -402,7 +409,7 @@ mod winfw {
         #[link_name = "WinFw_ApplyPolicyBlocked"]
         pub fn WinFw_ApplyPolicyBlocked(
             settings: &WinFwSettings,
-            allowed_endpoint: *const WinFwEndpoint,
+            allowed_endpoint: *const WinFwAllowedEndpoint,
         ) -> WinFwPolicyStatus;
 
         #[link_name = "WinFw_Reset"]

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -21,7 +21,7 @@ public:
 	(
 		uint32_t timeout,
 		const WinFwSettings &settings,
-		const std::optional<WinFwEndpoint> &allowedEndpoint
+		const std::optional<WinFwAllowedEndpoint> &allowedEndpoint
 	);
 
 	bool applyPolicyConnecting
@@ -30,7 +30,7 @@ public:
 		const WinFwEndpoint &relay,
 		const std::wstring &relayClient,
 		const std::optional<std::wstring> &tunnelInterfaceAlias,
-		const std::optional<WinFwEndpoint> &allowedEndpoint
+		const std::optional<WinFwAllowedEndpoint> &allowedEndpoint
 	);
 
 	bool applyPolicyConnected
@@ -45,7 +45,7 @@ public:
 
 	bool applyPolicyBlocked(
 		const WinFwSettings &settings,
-		const std::optional<WinFwEndpoint> &allowedEndpoint
+		const std::optional<WinFwAllowedEndpoint> &allowedEndpoint
 	);
 
 	bool reset();
@@ -67,10 +67,10 @@ private:
 	FwContext(const FwContext &) = delete;
 	FwContext &operator=(const FwContext &) = delete;
 
-	Ruleset composePolicyBlocked(const WinFwSettings &settings, const std::optional<WinFwEndpoint> &allowedEndpoint);
+	Ruleset composePolicyBlocked(const WinFwSettings &settings, const std::optional<WinFwAllowedEndpoint> &allowedEndpoint);
 
 	bool applyBaseConfiguration();
-	bool applyBlockedBaseConfiguration(const WinFwSettings &settings, const std::optional<WinFwEndpoint> &allowedEndpoint, uint32_t &checkpoint);
+	bool applyBlockedBaseConfiguration(const WinFwSettings &settings, const std::optional<WinFwAllowedEndpoint> &allowedEndpoint, uint32_t &checkpoint);
 	bool applyCommonBaseConfiguration(SessionController &controller, wfp::FilterEngine &engine);
 
 	bool applyRuleset(const Ruleset &ruleset);

--- a/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
@@ -48,10 +48,12 @@ std::unique_ptr<ConditionProtocol> CreateProtocolCondition(WinFwProtocol protoco
 PermitEndpoint::PermitEndpoint
 (
 	const wfp::IpAddress &address,
+	const std::vector<std::wstring> &clients,
 	uint16_t port,
 	WinFwProtocol protocol
 )
 	: m_address(address)
+	, m_clients(clients)
 	, m_port(port)
 	, m_protocol(protocol)
 {
@@ -80,6 +82,10 @@ bool PermitEndpoint::apply(IObjectInstaller &objectInstaller)
 	conditionBuilder.add_condition(ConditionIp::Remote(m_address));
 	conditionBuilder.add_condition(ConditionPort::Remote(m_port));
 	conditionBuilder.add_condition(CreateProtocolCondition(m_protocol));
+
+	for (const auto client : m_clients) {
+		conditionBuilder.add_condition(std::make_unique<ConditionApplication>(client));
+	}
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }

--- a/windows/winfw/src/winfw/rules/baseline/permitendpoint.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitendpoint.h
@@ -3,6 +3,7 @@
 #include <winfw/rules/ifirewallrule.h>
 #include <winfw/winfw.h>
 #include <libwfp/ipaddress.h>
+#include <vector>
 #include <string>
 
 namespace rules::baseline
@@ -15,6 +16,7 @@ public:
 	PermitEndpoint
 	(
 		const wfp::IpAddress &address,
+		const std::vector<std::wstring> &clients,
 		uint16_t port,
 		WinFwProtocol protocol
 	);
@@ -24,6 +26,7 @@ public:
 private:
 
 	const wfp::IpAddress m_address;
+	const std::vector<std::wstring> m_clients;
 	const uint16_t m_port;
 	const WinFwProtocol m_protocol;
 };

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -118,7 +118,7 @@ WINFW_API
 WinFw_InitializeBlocked(
 	uint32_t timeout,
 	const WinFwSettings *settings,
-	const WinFwEndpoint *allowedEndpoint,
+	const WinFwAllowedEndpoint *allowedEndpoint,
 	MullvadLogSink logSink,
 	void *logSinkContext
 )
@@ -233,7 +233,7 @@ WinFw_ApplyPolicyConnecting(
 	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
 	const wchar_t *tunnelInterfaceAlias,
-	const WinFwEndpoint *allowedEndpoint
+	const WinFwAllowedEndpoint *allowedEndpoint
 )
 {
 	if (nullptr == g_fwContext)
@@ -433,7 +433,7 @@ WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyBlocked(
 	const WinFwSettings *settings,
-	const WinFwEndpoint *allowedEndpoint
+	const WinFwAllowedEndpoint *allowedEndpoint
 )
 {
 	if (nullptr == g_fwContext)

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -19,8 +19,6 @@
 // Structures
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma pack(push, 1)
-
 typedef struct tag_WinFwSettings
 {
 	// Permit outbound DHCP requests and inbound DHCP responses on all interfaces.
@@ -56,8 +54,6 @@ typedef struct tag_WinFwAllowedEndpoint
 	WinFwEndpoint endpoint;
 }
 WinFwAllowedEndpoint;
-
-#pragma pack(pop)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Functions

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -45,6 +45,18 @@ typedef struct tag_WinFwEndpoint
 }
 WinFwEndpoint;
 
+typedef struct tag_WinFwAllowedEndpoint
+{
+	uint32_t numClients;
+
+	// A list of paths that are allowed to reach the given endpoint,
+	// even when traffic would otherwise be blocked.
+	const wchar_t **clients;
+
+	WinFwEndpoint endpoint;
+}
+WinFwAllowedEndpoint;
+
 #pragma pack(pop)
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -88,7 +100,7 @@ WINFW_API
 WinFw_InitializeBlocked(
 	uint32_t timeout,
 	const WinFwSettings *settings,
-	const WinFwEndpoint *allowedEndpoint,
+	const WinFwAllowedEndpoint *allowedEndpoint,
 	MullvadLogSink logSink,
 	void *logSinkContext
 );
@@ -142,7 +154,7 @@ WinFw_ApplyPolicyConnecting(
 	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
 	const wchar_t *tunnelInterfaceAlias,
-	const WinFwEndpoint *allowedEndpoint
+	const WinFwAllowedEndpoint *allowedEndpoint
 );
 
 //
@@ -189,7 +201,7 @@ WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyBlocked(
 	const WinFwSettings *settings,
-	const WinFwEndpoint *allowedEndpoint
+	const WinFwAllowedEndpoint *allowedEndpoint
 );
 
 //


### PR DESCRIPTION
This adds `FWPM_CONDITION_ALE_APP_ID` conditions to the allowed endpoint firewall filter on Windows. With these changes, only `mullvad-daemon.exe` and `mullvad-problem-report.exe` can communicate with the API in the blocked state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3168)
<!-- Reviewable:end -->
