### PR TITLE
Improve switch confirmation

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -25,6 +25,7 @@ import {
 } from './NavigationBar';
 import { ISelectorItem } from './cell/Selector';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
+import Switch from './Switch';
 
 type OptionalTunnelProtocol = TunnelProtocol | undefined;
 
@@ -50,6 +51,8 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
   public state = {
     showConfirmBlockWhenDisconnectedAlert: false,
   };
+
+  private blockWhenDisconnectedRef = React.createRef<Switch>();
 
   public render() {
     const hasWireguardKey = this.props.wireguardKeyState.type === 'key-set';
@@ -118,6 +121,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
                     </AriaLabel>
                     <AriaInput>
                       <Cell.Switch
+                        ref={this.blockWhenDisconnectedRef}
                         isOn={this.props.blockWhenDisconnected}
                         onChange={this.setBlockWhenDisconnected}
                       />
@@ -257,7 +261,6 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
 
   private setBlockWhenDisconnected = (newValue: boolean) => {
     if (newValue) {
-      this.props.setBlockWhenDisconnected(true);
       this.setState({ showConfirmBlockWhenDisconnectedAlert: true });
     } else {
       this.props.setBlockWhenDisconnected(false);
@@ -265,13 +268,13 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
   };
 
   private hideConfirmBlockWhenDisconnectedAlert = () => {
-    this.props.setBlockWhenDisconnected(false);
     this.setState({ showConfirmBlockWhenDisconnectedAlert: false });
+    this.blockWhenDisconnectedRef.current?.setOn(this.props.blockWhenDisconnected);
   };
 
   private confirmEnableBlockWhenDisconnected = () => {
-    this.props.setBlockWhenDisconnected(true);
     this.setState({ showConfirmBlockWhenDisconnectedAlert: false });
+    this.props.setBlockWhenDisconnected(true);
   };
 
   private onSelectTunnelProtocol = (protocol?: TunnelProtocol) => {

--- a/gui/src/renderer/components/CustomDnsSettings.tsx
+++ b/gui/src/renderer/components/CustomDnsSettings.tsx
@@ -194,7 +194,7 @@ export default function CustomDnsSettings() {
           </AriaLabel>
           <AriaInput>
             <Cell.Switch
-              ref={switchRef}
+              innerRef={switchRef}
               isOn={dns.state === 'custom' || inputVisible}
               onChange={setCustomDnsEnabled}
             />

--- a/gui/src/renderer/components/Switch.tsx
+++ b/gui/src/renderer/components/Switch.tsx
@@ -11,7 +11,7 @@ interface IProps {
   onChange?: (isOn: boolean) => void;
   className?: string;
   disabled?: boolean;
-  forwardedRef?: React.Ref<HTMLDivElement>;
+  innerRef?: React.Ref<HTMLDivElement>;
 }
 
 interface IState {
@@ -103,9 +103,13 @@ export default class Switch extends React.PureComponent<IProps, IState> {
     );
   }
 
+  public setOn(isOn: boolean) {
+    this.setState({ isOn });
+  }
+
   private refCallback = (element: HTMLDivElement | null) => {
     assignToRef(element, this.containerRef);
-    assignToRef(element, this.props.forwardedRef);
+    assignToRef(element, this.props.innerRef);
   };
 
   private onTransitionEnd = (event: React.TransitionEvent) => {

--- a/gui/src/renderer/components/cell/Input.tsx
+++ b/gui/src/renderer/components/cell/Input.tsx
@@ -8,10 +8,10 @@ import ImageView from '../ImageView';
 
 export const Switch = React.forwardRef(function SwitchT(
   props: StandaloneSwitch['props'],
-  ref: React.Ref<HTMLDivElement>,
+  ref: React.Ref<StandaloneSwitch>,
 ) {
   const disabled = useContext(CellDisabledContext);
-  return <StandaloneSwitch forwardedRef={ref} disabled={disabled} {...props} />;
+  return <StandaloneSwitch ref={ref} disabled={disabled} {...props} />;
 });
 
 export const InputFrame = styled.div({


### PR DESCRIPTION
This PR changes the behavior of the block when disconnected-switch which previously showed a confirmation dialog after the setting had changed and now it shows it before changing it instead. This moves part of the logic to the `Switch` component and makes it reusable.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3170)
<!-- Reviewable:end -->
