### PR TITLE
Send entry WireGuard relay hostname to frontends

### DIFF
--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -242,7 +242,7 @@ impl RelaySelector {
         bridge_state: BridgeState,
         retry_attempt: u32,
         wg_key_exists: bool,
-    ) -> Result<(Relay, MullvadEndpoint), Error> {
+    ) -> Result<(Relay, Option<Relay>, MullvadEndpoint), Error> {
         let mut exit_relay_constraints = relay_constraints.clone();
         let wg_entry_is_subset = if let Some(entry_location) =
             exit_relay_constraints.wireguard_constraints.entry_location
@@ -307,7 +307,7 @@ impl RelaySelector {
                     "Selected entry relay {} at {}",
                     entry_relay.hostname, addr_in
                 );
-                return Ok((exit_relay, entry_endpoint));
+                return Ok((exit_relay, Some(entry_relay), entry_endpoint));
             } else if relay_constraints
                 .wireguard_constraints
                 .entry_location
@@ -317,7 +317,7 @@ impl RelaySelector {
             }
         }
 
-        Ok((exit_relay, endpoint))
+        Ok((exit_relay, None, endpoint))
     }
 
     fn get_tunnel_exit_endpoint(
@@ -1431,7 +1431,7 @@ mod test {
             Some(Constraint::Only(location_specific.clone()));
 
         // The exit must not equal the entry
-        let (exit_relay, _exit_endpoint) = relay_selector
+        let (exit_relay, _entry_relay, _exit_endpoint) = relay_selector
             .get_tunnel_endpoint(&relay_constraints, BridgeState::Off, 0, true)
             .map_err(|error| error.to_string())?;
 
@@ -1442,7 +1442,7 @@ mod test {
             Some(Constraint::Only(location_general));
 
         // The entry must not equal the exit
-        let (exit_relay, exit_endpoint) = relay_selector
+        let (exit_relay, _entry_relay, exit_endpoint) = relay_selector
             .get_tunnel_endpoint(&relay_constraints, BridgeState::Off, 0, true)
             .map_err(|error| error.to_string())?;
 

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -211,6 +211,7 @@ message GeoIpLocation {
 	bool mullvad_exit_ip = 7;
 	string hostname = 8;
 	string bridge_hostname = 9;
+	string entry_hostname = 10;
 }
 
 message BridgeSettings {

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -18,6 +18,7 @@ impl From<mullvad_types::location::GeoIpLocation> for GeoIpLocation {
             mullvad_exit_ip: geoip.mullvad_exit_ip,
             hostname: geoip.hostname.unwrap_or_default(),
             bridge_hostname: geoip.bridge_hostname.unwrap_or_default(),
+            entry_hostname: geoip.entry_hostname.unwrap_or_default(),
         }
     }
 }

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -82,6 +82,8 @@ pub struct GeoIpLocation {
     pub hostname: Option<String>,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub bridge_hostname: Option<String>,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub entry_hostname: Option<String>,
 }
 
 impl From<AmIMullvad> for GeoIpLocation {
@@ -101,6 +103,7 @@ impl From<AmIMullvad> for GeoIpLocation {
             mullvad_exit_ip: location.mullvad_exit_ip,
             hostname: None,
             bridge_hostname: None,
+            entry_hostname: None,
         }
     }
 }


### PR DESCRIPTION
The GUI needs to be able to show which entry relay it's connecting to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3171)
<!-- Reviewable:end -->
