### PR TITLE
Add WG entry hop "state" setting

### DIFF
--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -571,6 +571,7 @@ impl Relay {
         }
         if let Some(entry) = matches.values_of("entry location") {
             wireguard_constraints.entry_location = parse_entry_location_constraint(entry);
+            wireguard_constraints.use_multihop = wireguard_constraints.entry_location.is_some();
         }
 
         self.update_constraints(types::RelaySettingsUpdate {

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -9,6 +9,7 @@ mod v1;
 mod v2;
 mod v3;
 mod v4;
+mod v5;
 
 const SETTINGS_FILE: &str = "settings.json";
 
@@ -71,6 +72,7 @@ pub async fn migrate_all(cache_dir: &Path, settings_dir: &Path) -> Result<()> {
     v2::migrate(&mut settings)?;
     v3::migrate(&mut settings)?;
     v4::migrate(&mut settings)?;
+    v5::migrate(&mut settings)?;
 
     account_history::migrate_location(cache_dir, settings_dir).await;
     account_history::migrate_formats(settings_dir, &mut settings).await?;

--- a/mullvad-daemon/src/migrations/v5.rs
+++ b/mullvad-daemon/src/migrations/v5.rs
@@ -1,0 +1,199 @@
+use super::{Error, Result};
+use mullvad_types::settings::SettingsVersion;
+
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    let wireguard_constraints = || -> Option<&serde_json::Value> {
+        settings
+            .get("relay_settings")?
+            .get("normal")?
+            .get("wireguard_constraints")
+    }();
+    if let Some(constraints) = wireguard_constraints {
+        if let Some(location) = constraints.get("entry_location") {
+            if constraints.get("use_multihop").is_none() {
+                if location.is_null() {
+                    // "Null" is no longer valid. It is not an option.
+                    settings["relay_settings"]["normal"]["wireguard_constraints"]
+                        .as_object_mut()
+                        .ok_or(Error::NoMatchingVersion)?
+                        .remove("entry_location");
+                } else {
+                    settings["relay_settings"]["normal"]["wireguard_constraints"]["use_multihop"] =
+                        serde_json::json!(true);
+                }
+            }
+        }
+    }
+
+    // Note: Not incrementing the version number
+
+    Ok(())
+}
+
+fn version_matches(settings: &mut serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V5 as u64)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{migrate, version_matches};
+    use serde_json;
+
+    pub const V5_SETTINGS_V1: &str = r#"
+{
+  "account_token": "1234",
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "country": "se"
+        }
+      },
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "entry_location": "any"
+      },
+      "openvpn_constraints": {
+        "port": {
+          "only": {
+            "protocol": "udp",
+            "port": {
+              "only": 1195
+            }
+          }
+        }
+      }
+    }
+  },
+  "bridge_settings": {
+    "normal": {
+      "location": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "rotation_interval": {
+          "secs": 86400,
+          "nanos": 0
+      }
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false
+      },
+      "custom_options": {
+        "addresses": [
+          "1.1.1.1",
+          "1.2.3.4"
+        ]
+      }
+    }
+  },
+  "settings_version": 5
+}
+"#;
+
+    pub const V5_SETTINGS_V2: &str = r#"
+{
+  "account_token": "1234",
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "country": "se"
+        }
+      },
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": true,
+        "entry_location": "any"
+      },
+      "openvpn_constraints": {
+        "port": {
+          "only": {
+            "protocol": "udp",
+            "port": {
+              "only": 1195
+            }
+          }
+        }
+      }
+    }
+  },
+  "bridge_settings": {
+    "normal": {
+      "location": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "rotation_interval": {
+          "secs": 86400,
+          "nanos": 0
+      }
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false
+      },
+      "custom_options": {
+        "addresses": [
+          "1.1.1.1",
+          "1.2.3.4"
+        ]
+      }
+    }
+  },
+  "settings_version": 5
+}
+"#;
+
+    #[test]
+    fn test_v5_v1_migration() {
+        let mut old_settings = serde_json::from_str(V5_SETTINGS_V1).unwrap();
+
+        assert!(version_matches(&mut old_settings));
+
+        migrate(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = serde_json::from_str(V5_SETTINGS_V2).unwrap();
+
+        assert_eq!(&old_settings, &new_settings);
+    }
+}

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -58,7 +58,8 @@ const WIREGUARD_EXIT_CONSTRAINTS: WireguardConstraints = WireguardConstraints {
         port: Constraint::Only(DEFAULT_WIREGUARD_PORT),
     }),
     ip_version: Constraint::Only(IpVersion::V4),
-    entry_location: None,
+    use_multihop: false,
+    entry_location: Constraint::Any,
 };
 const WIREGUARD_TCP_PORTS: [(u16, u16); 3] = [(80, 80), (443, 443), (5001, 5001)];
 
@@ -244,12 +245,13 @@ impl RelaySelector {
         wg_key_exists: bool,
     ) -> Result<(Relay, Option<Relay>, MullvadEndpoint), Error> {
         let mut exit_relay_constraints = relay_constraints.clone();
-        let wg_entry_is_subset = if let Some(entry_location) =
-            exit_relay_constraints.wireguard_constraints.entry_location
-        {
+        let wg_entry_is_subset = if exit_relay_constraints.wireguard_constraints.use_multihop {
+            let use_multihop = exit_relay_constraints.wireguard_constraints.use_multihop;
+            let entry_location = exit_relay_constraints.wireguard_constraints.entry_location;
             let is_subset = entry_location.is_subset(&exit_relay_constraints.location);
             exit_relay_constraints.wireguard_constraints = WireguardConstraints {
-                entry_location: Some(entry_location),
+                use_multihop,
+                entry_location,
                 ..WIREGUARD_EXIT_CONSTRAINTS
             };
             is_subset
@@ -257,16 +259,12 @@ impl RelaySelector {
             false
         };
 
-        let entry_endpoint = if wg_entry_is_subset
-            && relay_constraints
-                .wireguard_constraints
-                .entry_location
-                .is_some()
-        {
-            self.select_entry_endpoint(None, &relay_constraints, retry_attempt)
-        } else {
-            None
-        };
+        let entry_endpoint =
+            if wg_entry_is_subset && relay_constraints.wireguard_constraints.use_multihop {
+                self.select_entry_endpoint(None, &relay_constraints, retry_attempt)
+            } else {
+                None
+            };
 
         let (exit_relay, mut endpoint) = self.get_tunnel_exit_endpoint(
             &exit_relay_constraints,
@@ -283,12 +281,7 @@ impl RelaySelector {
         )?;
 
         let mut entry_endpoint = entry_endpoint.or_else(|| {
-            if !wg_entry_is_subset
-                && relay_constraints
-                    .wireguard_constraints
-                    .entry_location
-                    .is_some()
-            {
+            if !wg_entry_is_subset && relay_constraints.wireguard_constraints.use_multihop {
                 if let MullvadEndpoint::Wireguard { peer, .. } = &endpoint {
                     self.select_entry_endpoint(Some(peer), &relay_constraints, retry_attempt)
                 } else {
@@ -308,11 +301,7 @@ impl RelaySelector {
                     entry_relay.hostname, addr_in
                 );
                 return Ok((exit_relay, Some(entry_relay), entry_endpoint));
-            } else if relay_constraints
-                .wireguard_constraints
-                .entry_location
-                .is_some()
-            {
+            } else if relay_constraints.wireguard_constraints.use_multihop {
                 return Err(Error::NoRelay);
             }
         }
@@ -450,10 +439,13 @@ impl RelaySelector {
         relay_constraints: &RelayConstraints,
         retry_attempt: u32,
     ) -> Option<(Relay, MullvadEndpoint)> {
+        if !relay_constraints.wireguard_constraints.use_multihop {
+            return None;
+        }
         let entry_location = relay_constraints
             .wireguard_constraints
             .entry_location
-            .clone()?;
+            .clone();
         let entry_constraints = RelayConstraints {
             location: entry_location,
             tunnel_protocol: Constraint::Only(TunnelType::Wireguard),
@@ -1393,14 +1385,15 @@ mod test {
             ..RelayConstraints::default()
         };
 
-        relay_constraints.wireguard_constraints.entry_location = Some(Constraint::Only(location1));
+        relay_constraints.wireguard_constraints.use_multihop = true;
+        relay_constraints.wireguard_constraints.entry_location = Constraint::Only(location1);
 
         // The same host cannot be used for entry and exit
         assert!(relay_selector
             .get_tunnel_endpoint(&relay_constraints, BridgeState::Off, 0, true)
             .is_err());
 
-        relay_constraints.wireguard_constraints.entry_location = Some(Constraint::Only(location2));
+        relay_constraints.wireguard_constraints.entry_location = Constraint::Only(location2);
 
         // If the entry and exit differ, this should succeed
         assert!(relay_selector
@@ -1427,8 +1420,9 @@ mod test {
             ..RelayConstraints::default()
         };
 
+        relay_constraints.wireguard_constraints.use_multihop = true;
         relay_constraints.wireguard_constraints.entry_location =
-            Some(Constraint::Only(location_specific.clone()));
+            Constraint::Only(location_specific.clone());
 
         // The exit must not equal the entry
         let (exit_relay, _entry_relay, _exit_endpoint) = relay_selector
@@ -1439,7 +1433,7 @@ mod test {
 
         relay_constraints.location = Constraint::Only(location_specific);
         relay_constraints.wireguard_constraints.entry_location =
-            Some(Constraint::Only(location_general));
+            Constraint::Only(location_general);
 
         // The entry must not equal the exit
         let (exit_relay, _entry_relay, exit_endpoint) = relay_selector

--- a/mullvad-daemon/src/relays.rs
+++ b/mullvad-daemon/src/relays.rs
@@ -1432,8 +1432,7 @@ mod test {
         assert_ne!(exit_relay.hostname, specific_hostname);
 
         relay_constraints.location = Constraint::Only(location_specific);
-        relay_constraints.wireguard_constraints.entry_location =
-            Constraint::Only(location_general);
+        relay_constraints.wireguard_constraints.entry_location = Constraint::Only(location_general);
 
         // The entry must not equal the exit
         let (exit_relay, _entry_relay, exit_endpoint) = relay_selector

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -336,7 +336,8 @@ message IpVersionConstraint {
 message WireguardConstraints {
 	TransportPort port = 1;
 	IpVersionConstraint ip_version = 2;
-	RelayLocation entry_location = 3;
+	bool use_multihop = 3;
+	RelayLocation entry_location = 4;
 }
 
 message CustomRelaySettings {

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -505,9 +505,11 @@ impl From<mullvad_types::relay_constraints::RelaySettings> for RelaySettings {
                             .option()
                             .map(IpVersion::from)
                             .map(IpVersionConstraint::from),
+                        use_multihop: constraints.wireguard_constraints.use_multihop,
                         entry_location: constraints
                             .wireguard_constraints
                             .entry_location
+                            .option()
                             .map(RelayLocation::from),
                     }),
 
@@ -715,10 +717,12 @@ impl TryFrom<&WireguardConstraints> for mullvad_types::relay_constraints::Wiregu
         Ok(mullvad_constraints::WireguardConstraints {
             port: Constraint::from(wireguard_transport_port),
             ip_version: Constraint::from(ip_version),
+            use_multihop: constraints.use_multihop,
             entry_location: constraints
                 .entry_location
                 .clone()
-                .map(Constraint::<mullvad_types::relay_constraints::LocationConstraint>::from),
+                .map(Constraint::<mullvad_types::relay_constraints::LocationConstraint>::from)
+                .unwrap_or(Constraint::Any),
         })
     }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -494,7 +494,8 @@ impl Match<OpenVpnEndpointData> for OpenVpnConstraints {
 pub struct WireguardConstraints {
     pub port: Constraint<TransportPort>,
     pub ip_version: Constraint<IpVersion>,
-    pub entry_location: Option<Constraint<LocationConstraint>>,
+    pub use_multihop: bool,
+    pub entry_location: Constraint<LocationConstraint>,
 }
 
 impl fmt::Display for WireguardConstraints {
@@ -514,8 +515,11 @@ impl fmt::Display for WireguardConstraints {
             Constraint::Any => write!(f, "IPv4 or IPv6")?,
             Constraint::Only(protocol) => write!(f, "{}", protocol)?,
         }
-        if let Some(Constraint::Only(ref entry)) = self.entry_location {
-            write!(f, " (via {})", entry)
+        if self.use_multihop {
+            match &self.entry_location {
+                Constraint::Any => write!(f, " (via any location)"),
+                Constraint::Only(location) => write!(f, " (via {})", location),
+            }
         } else {
             Ok(())
         }


### PR DESCRIPTION
Previously, the entry location was an `Option`. This meant that it could not be turned off without losing the location, and the gRPC message worked differently than it did for relays, etc. This PR adds a separate "state" and makes the entry location non-optional.

The CLI currently behaves exactly as before. The state setting is not exposed at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3177)
<!-- Reviewable:end -->
