### PR TITLE
Improve translation logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Line wrap the file at 100 chars.                                              Th
   instead of setting them to default values.
 - Obscure account number in account view and add button for copying instead of copying when text is
   pressed.
+- Disable logging of translation errors in production. This will among other things prevent error
+  messages from translating the country in the disconnected state.
 
 #### Android
 - Avoid running in foreground when not connected.

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -590,7 +590,7 @@ export class DaemonRpc {
   private connectivityChangeCallback(timeoutErr?: Error) {
     const channel = this.client.getChannel();
     const currentState = channel?.getConnectivityState(true);
-    log.debug(`GRPC Channel connectivity state changed to ${currentState}`);
+    log.verbose(`GRPC Channel connectivity state changed to ${currentState}`);
     if (channel) {
       if (timeoutErr) {
         this.setChannelCallback(currentState);

--- a/gui/src/main/gui-settings.ts
+++ b/gui/src/main/gui-settings.ts
@@ -106,7 +106,7 @@ export default class GuiSettings {
       const error = e as Error & { code?: string };
       // Read settings if the file exists, otherwise write the default settings to it.
       if (error.code === 'ENOENT') {
-        log.debug('Creating gui-settings file and writing the default settings to it');
+        log.verbose('Creating gui-settings file and writing the default settings to it');
         this.store();
       } else {
         log.error(`Failed to read GUI settings file: ${error}`);

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -354,8 +354,8 @@ class ApplicationMain {
         backupLogFile(mainLogPath);
         backupLogFile(rendererLogPath);
 
-        log.addOutput(new FileOutput(LogLevel.debug, mainLogPath));
-        this.rendererLog.addOutput(new FileOutput(LogLevel.debug, rendererLogPath));
+        log.addOutput(new FileOutput(LogLevel.verbose, mainLogPath));
+        this.rendererLog.addOutput(new FileOutput(LogLevel.verbose, rendererLogPath));
       } catch (e) {
         const error = e as Error;
         console.error('Failed to initialize logging:', error);

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -270,7 +270,7 @@ class ApplicationMain {
 
     this.initLogging();
 
-    log.debug(`Chromium sandbox is ${SANDBOX_DISABLED ? 'disabled' : 'enabled'}`);
+    log.verbose(`Chromium sandbox is ${SANDBOX_DISABLED ? 'disabled' : 'enabled'}`);
     if (!SANDBOX_DISABLED) {
       app.enableSandbox();
     }
@@ -1351,7 +1351,7 @@ class ApplicationMain {
             );
             reject(error.message);
           } else {
-            log.debug(`Problem report was written to ${reportPath}`);
+            log.verbose(`Problem report was written to ${reportPath}`);
             resolve(id);
           }
         });

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -584,7 +584,7 @@ export default class AppRenderer {
 
     const contentHeight = window.innerHeight;
     if (contentHeight !== expectedContentHeight) {
-      log.debug(
+      log.verbose(
         resize ? 'Resize:' : 'Initial:',
         `Wrong content height: ${contentHeight}, expected ${expectedContentHeight}`,
       );
@@ -722,7 +722,7 @@ export default class AppRenderer {
   private setTunnelState(tunnelState: TunnelState) {
     const actions = this.reduxActions;
 
-    log.debug(`Tunnel state: ${tunnelState.state}`);
+    log.verbose(`Tunnel state: ${tunnelState.state}`);
 
     this.tunnelState = tunnelState;
     // The main process doesn't notify the tunnel state while waiting for a new one (unless it times

--- a/gui/src/renderer/containers/ConnectPage.tsx
+++ b/gui/src/renderer/containers/ConnectPage.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { sprintf } from 'sprintf-js';
-import { messages } from '../../shared/gettext';
+import { messages, relayLocations } from '../../shared/gettext';
 import log from '../../shared/logging';
 import Connect from '../components/Connect';
 import withAppContext, { IAppContext } from '../context';
@@ -9,32 +9,29 @@ import { RoutePath } from '../lib/routes';
 import { IRelayLocationRedux, RelaySettingsRedux } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 
-function getRelayName(
-  relaySettings: RelaySettingsRedux,
-  relayLocations: IRelayLocationRedux[],
-): string {
+function getRelayName(relaySettings: RelaySettingsRedux, locations: IRelayLocationRedux[]): string {
   if ('normal' in relaySettings) {
     const location = relaySettings.normal.location;
 
     if (location === 'any') {
       return 'Automatic';
     } else if ('country' in location) {
-      const country = relayLocations.find(({ code }) => code === location.country);
+      const country = locations.find(({ code }) => code === location.country);
       if (country) {
-        return country.name;
+        return relayLocations.gettext(country.name);
       }
     } else if ('city' in location) {
       const [countryCode, cityCode] = location.city;
-      const country = relayLocations.find(({ code }) => code === countryCode);
+      const country = locations.find(({ code }) => code === countryCode);
       if (country) {
         const city = country.cities.find(({ code }) => code === cityCode);
         if (city) {
-          return city.name;
+          return relayLocations.gettext(city.name);
         }
       }
     } else if ('hostname' in location) {
       const [countryCode, cityCode, hostname] = location.hostname;
-      const country = relayLocations.find(({ code }) => code === countryCode);
+      const country = locations.find(({ code }) => code === countryCode);
       if (country) {
         const city = country.cities.find(({ code }) => code === cityCode);
         if (city) {
@@ -46,7 +43,7 @@ function getRelayName(
             // TRANSLATORS: %(hostname)s - a hostname
             messages.pgettext('connect-container', '%(city)s (%(hostname)s)'),
             {
-              city: city.name,
+              city: relayLocations.gettext(city.name),
               hostname,
             },
           );

--- a/gui/src/shared/gettext.ts
+++ b/gui/src/shared/gettext.ts
@@ -6,7 +6,7 @@ const SOURCE_LANGUAGE = 'en';
 
 function setErrorHandler(catalogue: Gettext) {
   catalogue.on('error', (error) => {
-    log.warn(`Gettext error: ${error}`);
+    log.debug(`Gettext error: ${error}`);
   });
 }
 

--- a/gui/src/shared/gettext.ts
+++ b/gui/src/shared/gettext.ts
@@ -6,7 +6,7 @@ const SOURCE_LANGUAGE = 'en';
 
 function setErrorHandler(catalogue: Gettext) {
   catalogue.on('error', (error) => {
-    log.debug(`Gettext error: ${error}`);
+    log.debug(`Gettext error: ${error.message}`);
   });
 }
 

--- a/gui/src/shared/logging.ts
+++ b/gui/src/shared/logging.ts
@@ -84,7 +84,7 @@ export class ConsoleOutput implements ILogOutput {
         console.log(message);
         break;
       case LogLevel.debug:
-        console.debug(message);
+        console.log(message);
         break;
     }
   }


### PR DESCRIPTION
This PR improves logging of missing translations by
* Disables logging of translation errors when not running in development. This among other things prevent logging the error when translating the country in the disconnected state.
* Use `log.info` instead of `log.warn` to prevent showing the stack trace.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3179)
<!-- Reviewable:end -->
