### PR TITLE
Fix some `cargo doc` warnings

### DIFF
--- a/mullvad-rpc/src/address_cache.rs
+++ b/mullvad-rpc/src/address_cache.rs
@@ -76,7 +76,7 @@ impl AddressCache {
     }
 
     /// Returns the current address without registering it as "tried"
-    /// in [`has_tried_current_address`].
+    /// in [Self::has_tried_current_address].
     pub fn peek_address(&self) -> SocketAddr {
         let inner = self.inner.lock().unwrap();
         Self::get_address_inner(&inner)

--- a/mullvad-rpc/src/relay_list.rs
+++ b/mullvad-rpc/src/relay_list.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-/// Fetches relay list from https://api.mullvad.net/v1/relays
+/// Fetches relay list from <https://api.mullvad.net/v1/relays>
 #[derive(Clone)]
 pub struct RelayListProxy {
     handle: rest::MullvadRestHandle,

--- a/talpid-core/src/routing/unix.rs
+++ b/talpid-core/src/routing/unix.rs
@@ -86,7 +86,7 @@ impl RouteManagerHandle {
             .map_err(Error::PlatformError)
     }
 
-    /// Remove any routing rules created by [`create_routing_rules`].
+    /// Remove any routing rules created by [Self::create_routing_rules].
     #[cfg(target_os = "linux")]
     pub async fn clear_routing_rules(&self) -> Result<(), Error> {
         let (response_tx, response_rx) = oneshot::channel();
@@ -242,7 +242,7 @@ impl RouteManager {
         self.handle()?.create_routing_rules(enable_ipv6).await
     }
 
-    /// Remove any routing rules created by [`create_routing_rules`].
+    /// Remove any routing rules created by [Self::create_routing_rules].
     #[cfg(target_os = "linux")]
     pub async fn clear_routing_rules(&mut self) -> Result<(), Error> {
         self.handle()?.clear_routing_rules().await

--- a/talpid-dbus/src/network_manager.rs
+++ b/talpid-dbus/src/network_manager.rs
@@ -345,7 +345,7 @@ impl NetworkManager {
     /// previous state. Returns true only if the connectivity check was enabled and is now
     /// disabled. Disabling the connectivity check should be done before a firewall is applied
     /// due to the fact that blocking DNS requests can make it hang:
-    /// https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/404
+    /// <https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/404>
     pub fn disable_connectivity_check(&self) -> Option<bool> {
         let nm_manager = self.nm_manager();
         match nm_manager.get(NM_MANAGER, CONNECTIVITY_CHECK_KEY) {

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -15,7 +15,7 @@ pub trait ErrorExt {
     /// Creates a string representation of the entire error chain.
     fn display_chain(&self) -> String;
 
-    /// Like [`display_chain`] but with an extra message at the start of the chain
+    /// Like [Self::display_chain] but with an extra message at the start of the chain
     fn display_chain_with_msg(&self, msg: &str) -> String;
 }
 

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -55,7 +55,7 @@ pub struct PeerConfig {
     /// IP address of the WireGuard server.
     pub endpoint: SocketAddr,
     /// Transport protocol. WireGuard only supports UDP directly.
-    /// If this is set to TCP, then traffic is proxied using [`udp_to_tcp::Udp2Tcp`].
+    /// If this is set to TCP, then traffic is proxied using [udp_over_tcp](https://github.com/mullvad/udp-over-tcp).
     #[serde(default = "default_peer_transport")]
     pub protocol: TransportProtocol,
 }


### PR DESCRIPTION
Some links were incorrect. This fixes the warnings, at least on Windows and Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3182)
<!-- Reviewable:end -->
