### PR TITLE
Remove unused dependencies found by cargo-udeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "err-derive",
- "filetime",
  "futures",
  "http",
  "hyper",
@@ -1478,7 +1477,6 @@ dependencies = [
  "serde",
  "serde_json",
  "talpid-types",
- "tempfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -1519,7 +1517,6 @@ dependencies = [
  "log",
  "regex",
  "serde",
- "serde_json",
  "talpid-types",
 ]
 

--- a/mullvad-rpc/Cargo.toml
+++ b/mullvad-rpc/Cargo.toml
@@ -33,9 +33,5 @@ lazy_static = "1.1.0"
 mullvad-types = { path = "../mullvad-types" }
 talpid-types = { path = "../talpid-types" }
 
-[dev-dependencies]
-filetime = "0.2"
-tempfile = "3.0"
-
 [target.'cfg(target_os="macos")'.dependencies]
 tokio-stream = { version = "0.1", features = ["io-util"] }

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -15,7 +15,6 @@ lazy_static = "1.1.0"
 log = "0.4"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 talpid-types = { path = "../talpid-types" }
 


### PR DESCRIPTION
I ran `cargo udeps` and found we had three unused dependencies. They are still in our dependency tree, so we don't get rid of them. But at least our crates should not specify dependencies we don't use.

I'm considering adding a CI job for `cargo udeps`, but not sure it's worth it given that one must compile it from source, which will take time in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3183)
<!-- Reviewable:end -->
