### PR TITLE
Allow only root to reach the API in blocked state on Linux and macOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix issue with the user getting kicked out of certain views in settings when the app is brought to the foreground.
 
 ### Security
-#### Windows
 - Restrict which applications are allowed to communicate with the API while in a blocking state.
-  This prevents malicious scripts on websites from trying to do so.
+  This prevents malicious scripts on websites from trying to do so. On Windows, the split-tunneling
+  mechanism is used to exclude API traffic, whereas on Linux and macOS only root processes are able
+  to reach the API.
 
 
 ## [2021.6] - 2021-11-17

--- a/docs/security.md
+++ b/docs/security.md
@@ -104,7 +104,8 @@ forwarded. All other forward traffic is rejected.
 The firewall allows traffic for the API regardless of tunnel state, to allow for updating keys,
 fetching account data, etc. In the [Connected] state, this is only allowed inside the tunnel.
 For the other states, it is allowed regardless. On Windows, only the Mullvad service and problem
-report tool are able to communicate with the API in any of the blocking states.
+report tool are able to communicate with the API in any of the blocking states. On macOS and Linux
+all applications runnning as root are able to reach the API in blocking states.
 
 ### Disconnected
 

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -653,6 +653,8 @@ impl<'a> PolicyBatch<'a> {
         self.batch.add(&out_rule, nftnl::MsgType::Add);
     }
 
+    /// Adds firewall rules allow traffic to flow to the API. Allows the app to reach the API in
+    /// blocked states.
     fn add_allow_endpoint_rules(&mut self, endpoint: &Endpoint) {
         let mut in_rule = Rule::new(&self.in_chain);
         check_endpoint(&mut in_rule, End::Src, endpoint);
@@ -662,6 +664,8 @@ impl<'a> PolicyBatch<'a> {
 
         let mut out_rule = Rule::new(&self.out_chain);
         check_endpoint(&mut out_rule, End::Dst, endpoint);
+        out_rule.add_expr(&nft_expr!(meta skuid));
+        out_rule.add_expr(&nft_expr!(cmp == super::ROOT_UID));
         add_verdict(&mut out_rule, &Verdict::Accept);
 
         self.batch.add(&out_rule, nftnl::MsgType::Add);

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -17,9 +17,6 @@ type Result<T> = std::result::Result<T, Error>;
 /// replaced by allowing the anchor name to be configured from the public API of this crate.
 const ANCHOR_NAME: &'static str = "mullvad";
 
-const ROOT_UID: u32 = 0;
-
-/// The macOS firewall and DNS implementation.
 pub struct Firewall {
     pf: pfctl::PfCtl,
     pf_was_enabled: Option<bool>,
@@ -286,11 +283,13 @@ impl Firewall {
             .proto(pfctl_proto)
             .keep_state(pfctl::StatePolicy::Keep)
             .tcp_flags(Self::get_tcp_flags())
-            .user(Uid::from(ROOT_UID))
+            .user(Uid::from(super::ROOT_UID))
             .quick(true)
             .build()?)
     }
 
+    /// Produces a rule that allows traffic to flow to the API. Allows the app to reach the API in
+    /// blocked states.
     fn get_allowed_endpoint_rule(
         &self,
         allowed_endpoint: net::Endpoint,
@@ -303,6 +302,7 @@ impl Firewall {
             .to(allowed_endpoint.address)
             .proto(pfctl_proto)
             .keep_state(pfctl::StatePolicy::Keep)
+            .user(Uid::from(super::ROOT_UID))
             .quick(true)
             .build()?)
     }

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -82,6 +82,8 @@ const DHCPV4_CLIENT_PORT: u16 = 68;
 const DHCPV6_SERVER_PORT: u16 = 547;
 #[cfg(all(unix, not(target_os = "android")))]
 const DHCPV6_CLIENT_PORT: u16 = 546;
+#[cfg(all(unix, not(target_os = "android")))]
+const ROOT_UID: u32 = 0;
 
 #[cfg(all(unix, not(target_os = "android")))]
 /// Returns whether an address belongs to a private subnet.


### PR DESCRIPTION
These changes _plug the hole_ in the firewall in blocked states that allowed arbitrary processes to send traffic to the current API address. Now, only root processes can do that.