### PR TITLE
Use release 0.4.2 of socket2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,15 +2488,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
-source = "git+https://github.com/rust-lang/socket2?rev=f7023b4c810eb7b0fedf23a1752461c41765c797#f7023b4c810eb7b0fedf23a1752461c41765c797"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
@@ -2649,7 +2640,7 @@ dependencies = [
  "resolv-conf",
  "rtnetlink",
  "shell-escape",
- "socket2 0.4.0",
+ "socket2 0.4.2",
  "subslice",
  "system-configuration",
  "talpid-dbus",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -33,7 +33,7 @@ tokio-stream = { version = "0.1", features =  [ "io-util" ] }
 rand = "0.7"
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "1e27324362ed123b61fa2062b1599e5f9d569796" }
 trust-dns-server = {  git = "https://github.com/mullvad/trust-dns", rev = "c782de0645335d1893a854337b965dd07790c068", features = [ "trust-dns-resolver" ] }
-socket2 = { git = "https://github.com/rust-lang/socket2", rev = "f7023b4c810eb7b0fedf23a1752461c41765c797", features = [ "all" ] }
+socket2 = { version = "0.4.2", features = [ "all" ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
 parity-tokio-ipc = "0.9"
@@ -64,7 +64,6 @@ mnl = { version = "0.2.0", features = ["mnl-1-0-4"] }
 which = { version = "4.0", default-features = false }
 tun = "0.5.1"
 talpid-dbus = { path = "../talpid-dbus" }
-# socket2 = { version = "0.4", features = ["all"] }
 internet-checksum = "0.2"
 
 
@@ -82,7 +81,6 @@ internet-checksum = "0.2"
 widestring = "0.5"
 winreg = { version = "0.7", features = ["transactions"] }
 winapi = { version = "0.3.6", features = ["combaseapi", "handleapi", "ifdef", "libloaderapi", "netioapi", "psapi", "stringapiset", "synchapi", "tlhelp32", "winbase", "winioctl", "winuser"] }
-# socket2 = { version = "0.4", features = ["all"] }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 memoffset = "0.6"
 


### PR DESCRIPTION
In #3138, I made `talpdi-core` depend on a git revision of `socket2`. This is no longer required, so I've upgraded it to use version `0.4.2`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3189)
<!-- Reviewable:end -->
