### PR TITLE
Make trust-dns a macOS exclusive dependency

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -32,7 +32,6 @@ tokio = { version = "1.8", features = [ "process", "rt-multi-thread", "fs" ] }
 tokio-stream = { version = "0.1", features =  [ "io-util" ] }
 rand = "0.7"
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "1e27324362ed123b61fa2062b1599e5f9d569796" }
-trust-dns-server = {  git = "https://github.com/mullvad/trust-dns", rev = "c782de0645335d1893a854337b965dd07790c068", features = [ "trust-dns-resolver" ] }
 socket2 = { version = "0.4.2", features = [ "all" ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
@@ -71,6 +70,7 @@ internet-checksum = "0.2"
 either = "1"
 pfctl = "0.4.4"
 system-configuration = "0.4"
+trust-dns-server = {  git = "https://github.com/mullvad/trust-dns", rev = "c782de0645335d1893a854337b965dd07790c068", features = [ "trust-dns-resolver" ] }
 tun = "0.5.1"
 subslice = "0.2"
 


### PR DESCRIPTION
The `trust-dns-server` dependency should only be a dependency for macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3192)
<!-- Reviewable:end -->
