### PR TITLE
Remove `iputils-ping` from .deb dependencies

### DIFF
--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -138,6 +138,7 @@ const config = {
 
   deb: {
     fpm: [
+      '--no-depends',
       '--version',
       getDebVersion(),
       '--before-install',
@@ -159,7 +160,6 @@ const config = {
     ],
     afterInstall: distAssets('linux/after-install.sh'),
     afterRemove: distAssets('linux/after-remove.sh'),
-    depends: ['iputils-ping'],
   },
 
   rpm: {


### PR DESCRIPTION
electron-builder uses [`fpm`](https://github.com/jordansissel/fpm) to generate Debian packages. In the build configuration, `iputils-ping` is currently a dependency, but this is unnecessary now since the daemon uses ICMP directly rather than a `ping` executable.

Removing `iputils-ping` causes the default dependencies to be used instead: `["gconf2", "gconf-service", "libnotify4", "libappindicator1", "libxtst6", "libnss3"]`. This is easily fixed using the argument `--no-depends`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3193)
<!-- Reviewable:end -->
