### PR TITLE
Use exponential backoff for WireGuard connectivity check timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Line wrap the file at 100 chars.                                              Th
 - Disable logging of translation errors in production. This will among other things prevent error
   messages from translating the country in the disconnected state.
 - Update Electron from 15.0.0 to 16.0.4.
+- Gradually increase the WireGuard connectivity check timeout, lowering the timeout for the first
+  few attempts.
 
 #### Android
 - Avoid running in foreground when not connected.

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -106,6 +106,7 @@ impl TunnelMonitor {
         on_event: L,
         tun_provider: &mut TunProvider,
         route_manager: &mut RouteManager,
+        retry_attempt: u32,
     ) -> Result<Self>
     where
         L: (Fn(TunnelEvent) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>)
@@ -133,6 +134,7 @@ impl TunnelMonitor {
                 on_event,
                 tun_provider,
                 route_manager,
+                retry_attempt,
             ),
         }
     }
@@ -165,6 +167,7 @@ impl TunnelMonitor {
         on_event: L,
         tun_provider: &mut TunProvider,
         route_manager: &mut RouteManager,
+        retry_attempt: u32,
     ) -> Result<Self>
     where
         L: (Fn(TunnelEvent) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>)
@@ -182,6 +185,7 @@ impl TunnelMonitor {
             on_event,
             tun_provider,
             route_manager,
+            retry_attempt,
         )?;
         Ok(TunnelMonitor {
             monitor: InternalTunnelMonitor::Wireguard(monitor),

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -168,6 +168,7 @@ impl WireguardMonitor {
         on_event: F,
         tun_provider: &mut TunProvider,
         route_manager: &mut routing::RouteManager,
+        retry_attempt: u32,
     ) -> Result<WireguardMonitor> {
         let mut tcp_proxies = vec![];
         let mut endpoint_addrs = vec![];
@@ -287,7 +288,7 @@ impl WireguardMonitor {
                 return;
             }
 
-            match connectivity_monitor.establish_connectivity() {
+            match connectivity_monitor.establish_connectivity(retry_attempt) {
                 Ok(true) => {
                     runtime.block_on((on_event)(TunnelEvent::Up(metadata)));
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -118,6 +118,7 @@ impl ConnectingState {
             on_tunnel_event,
             tun_provider,
             route_manager,
+            retry_attempt,
         )?;
         let close_handle = Some(monitor.close_handle());
         let tunnel_close_event =


### PR DESCRIPTION
Previously, the timeout for establishing a WireGuard tunnel was always 15 seconds. This is very high except for very slow connections. It is bad for two reasons: 1) If a relay is down, it takes far too much time to try another relay. 2) On the device concept branch, the device validity check occurs after a couple of failed connect attempts. This means that it takes over 30 seconds to discover that the device/WireGuard key is invalid.

This PR sets the initial timeout to 4 seconds, and multiplies it by two for each reconnect attempt, up to a maximum of 15 seconds. So if a relay is down (and the relay list does not say so), it will normally take 4 seconds to try a working one. It will also "only" take about 12 seconds to discover that the device has been revoked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3195)
<!-- Reviewable:end -->
