### PR TITLE
Add API address cache

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -4,6 +4,7 @@
 
 ## Generated assets
 Assets/relays.json
+Assets/api-ip-address.json
 
 ## Build generated
 build/

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Increase hit area of settings (cog) button.
 - Update launch screen.
+- Never use DNS to talk to Mullvad API. Instead use the list of IP addresses bundled with the app 
+  and update it periodically.
 
 
 ## [2021.4] - 2021-11-30

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -32,6 +32,13 @@
 		5807E2C02432038B00F5FF30 /* String+Split.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E2BF2432038B00F5FF30 /* String+Split.swift */; };
 		5807E2C2243203D000F5FF30 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E2C1243203D000F5FF30 /* StringTests.swift */; };
 		5807E2C3243203E700F5FF30 /* String+Split.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E2BF2432038B00F5FF30 /* String+Split.swift */; };
+		58095C4B2760B4F200890776 /* AddressCacheStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58095C4A2760B4F200890776 /* AddressCacheStoreError.swift */; };
+		58095C4F2760BA9100890776 /* AddressCacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58095C4E2760BA9100890776 /* AddressCacheStore.swift */; };
+		58095C512760BBB500890776 /* AddressCacheTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58095C502760BBB400890776 /* AddressCacheTracker.swift */; };
+		58095C532760EEC700890776 /* RESTNetworkOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58095C522760EEC700890776 /* RESTNetworkOperation.swift */; };
+		58095C552760F02500890776 /* UpdateAddressCacheOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58095C542760F02500890776 /* UpdateAddressCacheOperation.swift */; };
+		58095C572760F47900890776 /* api-ip-address.json in Resources */ = {isa = PBXBuildFile; fileRef = 58095C562760F47900890776 /* api-ip-address.json */; };
+		58095C592762155700890776 /* RESTRetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58095C582762155700890776 /* RESTRetryStrategy.swift */; };
 		580EE20624B3222200F9D8A1 /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580EE20524B3222200F9D8A1 /* ExclusivityController.swift */; };
 		580EE22424B3243100F9D8A1 /* AsyncBlockOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580EE22324B3243100F9D8A1 /* AsyncBlockOperation.swift */; };
 		5811DE50239014550011EB53 /* NEVPNStatus+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5811DE4F239014550011EB53 /* NEVPNStatus+Debug.swift */; };
@@ -187,6 +194,7 @@
 		58871D2325D535D2002297FA /* IPAddressRange+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5850366725A47AC700A43E93 /* IPAddressRange+Codable.swift */; };
 		5888AD83227B11080051EB06 /* SelectLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5888AD82227B11080051EB06 /* SelectLocationCell.swift */; };
 		5888AD87227B17950051EB06 /* SelectLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5888AD86227B17950051EB06 /* SelectLocationViewController.swift */; };
+		588CD8BB275A0A0B00CF902E /* RESTRequestAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588CD8BA275A0A0B00CF902E /* RESTRequestAdapter.swift */; };
 		588D2FE3248AC27F00E313F7 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E973DD24850EB600096F90 /* AsyncOperation.swift */; };
 		588DD76B26FCB49E006F6233 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588DD76A26FCB49E006F6233 /* Cancellable.swift */; };
 		588DD76C26FCB49E006F6233 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588DD76A26FCB49E006F6233 /* Cancellable.swift */; };
@@ -308,6 +316,7 @@
 		58FD5BF024238EB300112C88 /* SKProduct+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */; };
 		58FD5BF22424F7D700112C88 /* UserInterfaceInteractionRestriction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BF12424F7D700112C88 /* UserInterfaceInteractionRestriction.swift */; };
 		58FD5BF42428C67600112C88 /* InAppPurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */; };
+		58FEAFB92750DA2F003C1625 /* AddressCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FEAFB82750DA2F003C1625 /* AddressCache.swift */; };
 		58FEEB46260A028D00A621A8 /* GeoJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FEEB45260A028D00A621A8 /* GeoJSON.swift */; };
 		58FEEB58260B662E00A621A8 /* AutomaticKeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FEEB57260B662E00A621A8 /* AutomaticKeyboardResponder.swift */; };
 /* End PBXBuildFile section */
@@ -360,6 +369,13 @@
 /* Begin PBXFileReference section */
 		5807E2BF2432038B00F5FF30 /* String+Split.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Split.swift"; sourceTree = "<group>"; };
 		5807E2C1243203D000F5FF30 /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
+		58095C4A2760B4F200890776 /* AddressCacheStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressCacheStoreError.swift; sourceTree = "<group>"; };
+		58095C4E2760BA9100890776 /* AddressCacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressCacheStore.swift; sourceTree = "<group>"; };
+		58095C502760BBB400890776 /* AddressCacheTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressCacheTracker.swift; sourceTree = "<group>"; };
+		58095C522760EEC700890776 /* RESTNetworkOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTNetworkOperation.swift; sourceTree = "<group>"; };
+		58095C542760F02500890776 /* UpdateAddressCacheOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAddressCacheOperation.swift; sourceTree = "<group>"; };
+		58095C562760F47900890776 /* api-ip-address.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "api-ip-address.json"; sourceTree = "<group>"; };
+		58095C582762155700890776 /* RESTRetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRetryStrategy.swift; sourceTree = "<group>"; };
 		580EE20524B3222200F9D8A1 /* ExclusivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusivityController.swift; sourceTree = "<group>"; };
 		580EE22324B3243100F9D8A1 /* AsyncBlockOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncBlockOperation.swift; sourceTree = "<group>"; };
 		5811DE4F239014550011EB53 /* NEVPNStatus+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NEVPNStatus+Debug.swift"; sourceTree = "<group>"; };
@@ -465,6 +481,7 @@
 		587EB6732714520600123C75 /* PreferencesDataSourceDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesDataSourceDelegate.swift; sourceTree = "<group>"; };
 		5888AD82227B11080051EB06 /* SelectLocationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationCell.swift; sourceTree = "<group>"; };
 		5888AD86227B17950051EB06 /* SelectLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationViewController.swift; sourceTree = "<group>"; };
+		588CD8BA275A0A0B00CF902E /* RESTRequestAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequestAdapter.swift; sourceTree = "<group>"; };
 		588DD76A26FCB49E006F6233 /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NEProviderStopReason+Debug.swift"; sourceTree = "<group>"; };
 		58907D9424D17B4E00CFC3F5 /* DisconnectSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectSplitButton.swift; sourceTree = "<group>"; };
@@ -572,6 +589,7 @@
 		58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Formatting.swift"; sourceTree = "<group>"; };
 		58FD5BF12424F7D700112C88 /* UserInterfaceInteractionRestriction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInterfaceInteractionRestriction.swift; sourceTree = "<group>"; };
 		58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseButton.swift; sourceTree = "<group>"; };
+		58FEAFB82750DA2F003C1625 /* AddressCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressCache.swift; sourceTree = "<group>"; };
 		58FEEB45260A028D00A621A8 /* GeoJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeoJSON.swift; sourceTree = "<group>"; };
 		58FEEB57260B662E00A621A8 /* AutomaticKeyboardResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticKeyboardResponder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -619,6 +637,18 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		58095C49275FA24800890776 /* AddressCache */ = {
+			isa = PBXGroup;
+			children = (
+				58FEAFB82750DA2F003C1625 /* AddressCache.swift */,
+				58095C4E2760BA9100890776 /* AddressCacheStore.swift */,
+				58095C4A2760B4F200890776 /* AddressCacheStoreError.swift */,
+				58095C502760BBB400890776 /* AddressCacheTracker.swift */,
+				58095C542760F02500890776 /* UpdateAddressCacheOperation.swift */,
+			);
+			path = AddressCache;
 			sourceTree = "<group>";
 		};
 		580EE1FF24B3218800F9D8A1 /* Operations */ = {
@@ -726,6 +756,9 @@
 				58CB0EDF24B86751001EF0D8 /* RESTClient.swift */,
 				585DA88926B027A300B8C587 /* RESTCoding.swift */,
 				585DA88626B0277200B8C587 /* RESTError.swift */,
+				58095C522760EEC700890776 /* RESTNetworkOperation.swift */,
+				588CD8BA275A0A0B00CF902E /* RESTRequestAdapter.swift */,
+				58095C582762155700890776 /* RESTRetryStrategy.swift */,
 				585DA88326B0270700B8C587 /* ServerRelaysResponse.swift */,
 				584789DF26529D72000E45FB /* SSLPinningURLSessionDelegate.swift */,
 			);
@@ -814,6 +847,7 @@
 				58CCA01D2242787B004F3011 /* AccountTextField.swift */,
 				582AE30F2440A6CA00E6733A /* AccountTokenInput.swift */,
 				58CCA01722426713004F3011 /* AccountViewController.swift */,
+				58095C49275FA24800890776 /* AddressCache */,
 				58B9EB122488ED2100095626 /* AlertPresenter.swift */,
 				584D26BE270C550B004EA533 /* AnyIPAddress.swift */,
 				5868585424054096000B8131 /* AppButton.swift */,
@@ -978,6 +1012,7 @@
 		58F3C0A824A50C0E003E76BE /* Assets */ = {
 			isa = PBXGroup;
 			children = (
+				58095C562760F47900890776 /* api-ip-address.json */,
 				584789B7264D4A2A000E45FB /* le_root_cert.cer */,
 				58F3C0A524A50155003E76BE /* relays.json */,
 			);
@@ -1191,6 +1226,7 @@
 				58F5590F2697002100F630D0 /* ConnectionPanel.strings in Resources */,
 				58F558FA2696EB1C00F630D0 /* TunnelManager.strings in Resources */,
 				58F558E02695BD3E00F630D0 /* Login.strings in Resources */,
+				58095C572760F47900890776 /* api-ip-address.json in Resources */,
 				58CE5E6B224146210008646E /* Assets.xcassets in Resources */,
 				58F558E92695D20F00F630D0 /* SelectLocation.strings in Resources */,
 				5883A09E266A5AF7003EFFCB /* Localizable.strings in Resources */,
@@ -1299,6 +1335,7 @@
 				5820675B26E6576800655B05 /* RelayCache.swift in Sources */,
 				5846226526E0D9630035F7C2 /* ProductsRequestOperation.swift in Sources */,
 				587EB672271451E300123C75 /* PreferencesViewModel.swift in Sources */,
+				58095C512760BBB500890776 /* AddressCacheTracker.swift in Sources */,
 				584D26C6270C8741004EA533 /* SettingsDNSTextCell.swift in Sources */,
 				585DA87D26B0254000B8C587 /* RelayCacheIO.swift in Sources */,
 				58BA693123EADA6A009DC256 /* SimulatorTunnelProvider.swift in Sources */,
@@ -1309,6 +1346,7 @@
 				58E6771F24ADFE7800AA26E7 /* SettingsNavigationController.swift in Sources */,
 				5806767427048E7400C858CB /* Promise+Optional.swift in Sources */,
 				58A1AA8C23F5584C009F7EA6 /* ConnectionPanelView.swift in Sources */,
+				588CD8BB275A0A0B00CF902E /* RESTRequestAdapter.swift in Sources */,
 				582BB1B52295780F0055B6EF /* AccountExpiry.swift in Sources */,
 				582BB1B3229574F40055B6EF /* SettingsAccountCell.swift in Sources */,
 				585DA88426B0270700B8C587 /* ServerRelaysResponse.swift in Sources */,
@@ -1339,6 +1377,7 @@
 				5856D13727450A8A00DFD627 /* UIImage+TintColor.swift in Sources */,
 				58CB0EE024B86751001EF0D8 /* RESTClient.swift in Sources */,
 				5846226A26E0E6FA0035F7C2 /* ReceiptRefreshOperation.swift in Sources */,
+				58095C532760EEC700890776 /* RESTNetworkOperation.swift in Sources */,
 				58293FB125124117005D0BB5 /* CustomTextField.swift in Sources */,
 				582AE3102440A6CA00E6733A /* AccountTokenInput.swift in Sources */,
 				5806767827048E7E00C858CB /* Promise+Result.swift in Sources */,
@@ -1356,17 +1395,20 @@
 				58A99ED3240014A0006599E9 /* ConsentViewController.swift in Sources */,
 				58FAEE0124533A9C00CB0F5B /* KeychainClass.swift in Sources */,
 				58CCA0162242560B004F3011 /* UIColor+Palette.swift in Sources */,
+				58095C4F2760BA9100890776 /* AddressCacheStore.swift in Sources */,
 				58AEEF6B2344A46200C9BBD5 /* TunnelSettingsManager.swift in Sources */,
 				587CBFE322807F530028DED3 /* UIColor+Helpers.swift in Sources */,
 				5806767927048E8800C858CB /* Keychain.swift in Sources */,
 				5846227526E22A350035F7C2 /* AnyAppStorePaymentObserver.swift in Sources */,
 				585CA70F25F8C44600B47C62 /* UIMetrics.swift in Sources */,
+				58095C592762155700890776 /* RESTRetryStrategy.swift in Sources */,
 				5840250422B11AB700E4CFEC /* MullvadEndpoint.swift in Sources */,
 				58CC40EF24A601900019D96E /* ObserverList.swift in Sources */,
 				58CCA01822426713004F3011 /* AccountViewController.swift in Sources */,
 				5820674E26E6510200655B05 /* REST.swift in Sources */,
 				5871FBA0254C26C00051A0A4 /* NSRegularExpression+IPAddress.swift in Sources */,
 				58F7CA882692E34000FC59FD /* WireguardKeysContentView.swift in Sources */,
+				58095C4B2760B4F200890776 /* AddressCacheStoreError.swift in Sources */,
 				5868585524054096000B8131 /* AppButton.swift in Sources */,
 				58781CC922AE7CA8009B9D8E /* RelayConstraints.swift in Sources */,
 				584E96BC240FD4DA00D3334F /* Location.swift in Sources */,
@@ -1376,6 +1418,7 @@
 				585B4B8726D9098900555C4C /* TunnelErrorNotificationProvider.swift in Sources */,
 				5846226726E0DF960035F7C2 /* Promise+OperationQueue.swift in Sources */,
 				5850368C25A49E2200A43E93 /* PrivateKeyWithMetadata.swift in Sources */,
+				58FEAFB92750DA2F003C1625 /* AddressCache.swift in Sources */,
 				58B67B482602079E008EF58E /* RelaySelector.swift in Sources */,
 				58DF28A52417CB4B00E836B0 /* AppStorePaymentManager.swift in Sources */,
 				583DA21425FA4B5C00318683 /* LocationDataSource.swift in Sources */,
@@ -1406,6 +1449,7 @@
 				58B93A1326C3F13600A55733 /* TunnelState.swift in Sources */,
 				58FEEB46260A028D00A621A8 /* GeoJSON.swift in Sources */,
 				5815039724D6ECAE00C9C50E /* CustomFormatLogHandler.swift in Sources */,
+				58095C552760F02500890776 /* UpdateAddressCacheOperation.swift in Sources */,
 				5820675E26E6839900655B05 /* PresentAlertOperation.swift in Sources */,
 				5815039D24D6ECE600C9C50E /* TextFileOutputStream.swift in Sources */,
 				58CE5E64224146200008646E /* AppDelegate.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
+++ b/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "exec &gt; $PROJECT_DIR/prebuild.log 2&gt;&amp;1&#10;&#10;$PROJECT_DIR/update-relays.sh&#10;">
+               scriptText = "exec &gt; $PROJECT_DIR/prebuild.log 2&gt;&amp;1&#10;&#10;$PROJECT_DIR/prebuild.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/MullvadVPN/Account.swift
+++ b/ios/MullvadVPN/Account.swift
@@ -110,6 +110,7 @@ class Account {
 
     func loginWithNewAccount() -> Result<REST.AccountResponse, Account.Error>.Promise {
         return REST.Client.shared.createAccount()
+            .execute()
             .mapError { error in
                 return Error.createAccount(error)
             }
@@ -131,6 +132,7 @@ class Account {
     /// application preferences.
     func login(with accountToken: String) -> Result<REST.AccountResponse, Account.Error>.Promise {
         return REST.Client.shared.getAccountExpiry(token: accountToken)
+            .execute(retryStrategy: .default)
             .mapError { error in
                 return Account.Error.verifyAccount(error)
             }
@@ -183,6 +185,7 @@ class Account {
         Promise<String?>.deferred { self.token }
             .mapThen(defaultValue: nil) { token in
                 return REST.Client.shared.getAccountExpiry(token: token)
+                    .execute(retryStrategy: .default)
                     .onFailure { error in
                         self.logger.error(chainedError: error, message: "Failed to update account expiry")
                     }

--- a/ios/MullvadVPN/AddressCache/AddressCache.swift
+++ b/ios/MullvadVPN/AddressCache/AddressCache.swift
@@ -1,0 +1,11 @@
+//
+//  AddressCache.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 26/11/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+enum AddressCache {}

--- a/ios/MullvadVPN/AddressCache/AddressCacheStore.swift
+++ b/ios/MullvadVPN/AddressCache/AddressCacheStore.swift
@@ -1,0 +1,272 @@
+//
+//  AddressCacheStore.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 08/12/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import Logging
+
+extension AddressCache {
+
+    struct CachedAddresses: Codable {
+        /// Date when the cached addresses were last updated.
+        var updatedAt: Date
+
+        /// API endpoints.
+        var endpoints: [AnyIPEndpoint]
+    }
+
+    enum CacheSource: CustomStringConvertible {
+        /// Cache file originates from disk location.
+        case disk
+
+        /// Cache file originates from application bundle.
+        case bundle
+
+        var description: String {
+            switch self {
+            case .disk:
+                return "disk"
+            case .bundle:
+                return "bundle"
+            }
+        }
+    }
+
+    struct ReadResult {
+        var cachedAddresses: CachedAddresses
+        var source: CacheSource
+    }
+
+    class Store {
+
+        static let shared: Store = {
+            let cacheFilename = "api-ip-address.json"
+            let cacheDirectoryURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let cacheFileURL = cacheDirectoryURL.appendingPathComponent(cacheFilename, isDirectory: false)
+            let prebundledCacheFileURL = Bundle.main.url(forResource: cacheFilename, withExtension: nil)!
+
+            return Store(
+                cacheFileURL: cacheFileURL,
+                prebundledCacheFileURL: prebundledCacheFileURL
+            )
+        }()
+
+        static var defaultCachedAddresses: CachedAddresses {
+            return CachedAddresses(
+                updatedAt: Date(timeIntervalSince1970: 0),
+                endpoints: [
+                    ApplicationConfiguration.defaultAPIEndpoint
+                ]
+            )
+        }
+
+        /// Logger.
+        private let logger = Logger(label: "AddressCache.Store")
+
+        /// Memory cache.
+        private var cachedAddresses: CachedAddresses
+
+        /// Cache file location.
+        private let cacheFileURL: URL
+
+        /// The location of pre-bundled address cache file.
+        private let prebundledCacheFileURL: URL
+
+        /// Queue used for synchronizing access to instance members.
+        private let stateQueue = DispatchQueue(label: "AddressCacheStoreQueue")
+
+        /// Designated initializer
+        init(cacheFileURL: URL, prebundledCacheFileURL: URL) {
+            self.cacheFileURL = cacheFileURL
+            self.prebundledCacheFileURL = prebundledCacheFileURL
+            self.cachedAddresses = Self.defaultCachedAddresses
+
+            switch readFromCacheLocationWithFallback() {
+            case .success(let readResult):
+                if readResult.cachedAddresses.endpoints.isEmpty {
+                    logger.debug("Read empty cache from \(readResult.source). Fallback to default API endpoint.")
+
+                    cachedAddresses = Self.defaultCachedAddresses
+
+                    logger.debug("Initialized cache with default API endpoint.")
+                } else {
+                    switch readResult.source {
+                    case .disk:
+                        cachedAddresses = readResult.cachedAddresses
+
+                    case .bundle:
+                        var addresses = readResult.cachedAddresses
+                        addresses.endpoints.shuffle()
+                        cachedAddresses = addresses
+
+                        logger.debug("Persist address list read from bundle.")
+
+                        if case .failure(let error) = self.writeToDisk() {
+                            logger.error(chainedError: error, message: "Failed to persist address cache after reading it from bundle.")
+                        }
+                    }
+
+                    logger.debug("Initialized cache from \(readResult.source) with \(cachedAddresses.endpoints.count) endpoint(s).")
+                }
+
+            case .failure(let error):
+                logger.error(chainedError: error, message: "Failed to read address cache. Fallback to default API endpoint.")
+
+                cachedAddresses = Self.defaultCachedAddresses
+
+                logger.debug("Initialized cache with default API endpoint.")
+            }
+        }
+
+        func getCurrentEndpoint(_ completionHandler: @escaping (AnyIPEndpoint) -> Void) {
+            stateQueue.async {
+                let currentEndpoint = self.cachedAddresses.endpoints.first!
+
+                completionHandler(currentEndpoint)
+            }
+        }
+
+        func selectNextEndpoint(_ failedEndpoint: AnyIPEndpoint, completionHandler: @escaping (AnyIPEndpoint) -> Void) {
+            stateQueue.async {
+                var currentEndpoint = self.cachedAddresses.endpoints.first!
+
+                if failedEndpoint == currentEndpoint {
+                    self.cachedAddresses.endpoints.removeFirst()
+                    self.cachedAddresses.endpoints.append(failedEndpoint)
+
+                    currentEndpoint = self.cachedAddresses.endpoints.first!
+
+                    self.logger.debug("Failed to communicate using \(failedEndpoint). Next endpoint: \(currentEndpoint)")
+
+                    if case .failure(let error) = self.writeToDisk() {
+                        self.logger.error(chainedError: error, message: "Failed to write address cache after selecting next endpoint.")
+                    }
+                }
+
+                completionHandler(currentEndpoint)
+            }
+        }
+
+        func setEndpoints(_ endpoints: [AnyIPEndpoint], completionHandler: @escaping (AddressCache.StoreError?) -> Void) {
+            stateQueue.async {
+                guard !endpoints.isEmpty else {
+                    completionHandler(.emptyAddressList)
+                    return
+                }
+
+                if Set(self.cachedAddresses.endpoints) == Set(endpoints) {
+                    self.cachedAddresses.updatedAt = Date()
+                } else {
+                    // Shuffle new endpoints
+                    var newEndpoints = endpoints.shuffled()
+
+                    // Move current endpoint to the top of the list
+                    let currentEndpoint = self.cachedAddresses.endpoints.first!
+                    if let index = newEndpoints.firstIndex(of: currentEndpoint) {
+                        newEndpoints.remove(at: index)
+                        newEndpoints.insert(currentEndpoint, at: 0)
+                    }
+                    
+                    self.cachedAddresses = CachedAddresses(
+                        updatedAt: Date(),
+                        endpoints: newEndpoints
+                    )
+                }
+
+                let writeResult = self.writeToDisk()
+
+                completionHandler(writeResult.error)
+            }
+        }
+
+        func getLastUpdateDate(_ completionHandler: @escaping (Date) -> Void) {
+            stateQueue.async {
+                completionHandler(self.cachedAddresses.updatedAt)
+            }
+        }
+
+        func getLastUpdateDateAndWait() -> Date {
+            return stateQueue.sync {
+                return self.cachedAddresses.updatedAt
+            }
+        }
+
+        private func readFromCacheLocationWithFallback() -> Result<ReadResult, AddressCache.StoreError> {
+            return readFromCacheLocation()
+                .map { addresses in
+                    return ReadResult(
+                        cachedAddresses: addresses,
+                        source: .disk
+                    )
+                }
+                .flatMapError { error in
+                    logger.error(chainedError: error, message: "Failed to read address cache from disk. Fallback to pre-bundled cache.")
+
+                    return readFromBundle().map { cachedAddresses in
+                        return ReadResult(
+                            cachedAddresses: cachedAddresses,
+                            source: .bundle
+                        )
+                    }
+                }
+        }
+
+        private func readFromCacheLocation() -> Result<CachedAddresses, AddressCache.StoreError> {
+            return Result { try Data(contentsOf: cacheFileURL) }
+                .mapError { error in
+                    return .readCache(error)
+                }
+                .flatMap { data in
+                    return Result { try JSONDecoder().decode(CachedAddresses.self, from: data) }
+                        .mapError { error in
+                            return .decodeCache(error)
+                        }
+                }
+        }
+
+        private func writeToDisk() -> Result<(), AddressCache.StoreError> {
+            let cacheDirectoryURL = cacheFileURL.deletingLastPathComponent()
+
+            try? FileManager.default.createDirectory(
+                at: cacheDirectoryURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+
+            return Result { try JSONEncoder().encode(cachedAddresses) }
+                .mapError { error in
+                    return .encodeCache(error)
+                }
+                .flatMap { data in
+                    return Result { try data.write(to: cacheFileURL, options: .atomic) }
+                        .mapError { error in
+                            return .writeCache(error)
+                        }
+                }
+        }
+
+        private func readFromBundle() -> Result<CachedAddresses, AddressCache.StoreError> {
+            return Result { try Data(contentsOf: prebundledCacheFileURL) }
+                .mapError { error in
+                    return .readCacheFromBundle(error)
+                }
+                .flatMap { data in
+                    return Result { try JSONDecoder().decode([AnyIPEndpoint].self, from: data) }
+                        .mapError { error in
+                            return .decodeCacheFromBundle(error)
+                        }
+                        .map { endpoints in
+                            return CachedAddresses(
+                                updatedAt: Date(timeIntervalSince1970: 0),
+                                endpoints: endpoints
+                            )
+                        }
+                }
+        }
+
+    }
+}

--- a/ios/MullvadVPN/AddressCache/AddressCacheStoreError.swift
+++ b/ios/MullvadVPN/AddressCache/AddressCacheStoreError.swift
@@ -1,0 +1,53 @@
+//
+//  AddressCacheStoreError.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 08/12/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension AddressCache {
+    enum StoreError: ChainedError {
+        /// Failure to read address cache.
+        case readCache(Swift.Error)
+
+        /// Failure to read address cache from application bundle.
+        case readCacheFromBundle(Swift.Error)
+
+        /// Failure to write address cache.
+        case writeCache(Swift.Error)
+
+        /// Failure to decode address cache.
+        case decodeCache(Swift.Error)
+
+        /// Failure to encode address cache.
+        case encodeCache(Swift.Error)
+
+        /// Failure to decode address cache from application bundle.
+        case decodeCacheFromBundle(Swift.Error)
+
+        /// Failure to update endpoints with empty address list.
+        case emptyAddressList
+
+        var errorDescription: String? {
+            switch self {
+            case .readCache(_):
+                return "Cannot read address cache"
+            case .readCacheFromBundle(_):
+                return "Cannot read address cache from application bundle"
+            case .writeCache(_):
+                return "Cannot write address cache"
+            case .decodeCache(_):
+                return "Cannot decode address cache"
+            case .encodeCache(_):
+                return "Cannot encode address cache"
+            case .decodeCacheFromBundle(_):
+                return "Cannot decode address cache from application bundle"
+            case .emptyAddressList:
+                return "Cannot update endpoints with empty address list"
+            }
+        }
+    }
+}

--- a/ios/MullvadVPN/AddressCache/AddressCacheTracker.swift
+++ b/ios/MullvadVPN/AddressCache/AddressCacheTracker.swift
@@ -1,0 +1,226 @@
+//
+//  AddressCacheTracker.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 08/12/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+import BackgroundTasks
+import Logging
+
+extension AddressCache {
+    class Tracker {
+        /// Update interval (in seconds).
+        private static let updateInterval: TimeInterval = 60 * 60 * 24
+
+        /// Retry interval (in seconds).
+        private static let retryInterval: TimeInterval = 60 * 15
+
+        /// Logger.
+        private let logger = Logger(label: "AddressCache.Tracker")
+
+        /// REST client
+        private let restClient: REST.Client
+
+        /// Store.
+        private let store: AddressCache.Store
+
+        /// A flag that indicates whether periodic updates are running
+        private var isPeriodicUpdatesEnabled = false
+
+        /// The date of last failed attempt.
+        private var lastFailureAttemptDate: Date?
+
+        /// Timer used for scheduling periodic updates.
+        private var timer: DispatchSourceTimer?
+
+        /// Operation queue.
+        private let operationQueue: OperationQueue = {
+            let operationQueue = OperationQueue()
+            operationQueue.maxConcurrentOperationCount = 1
+            return operationQueue
+        }()
+
+        /// Queue used for synchronizing access to instance members.
+        private let stateQueue = DispatchQueue(label: "AddressCache.Tracker.stateQueue")
+
+        /// Designated initializer
+        init(restClient: REST.Client, store: AddressCache.Store) {
+            self.restClient = restClient
+            self.store = store
+        }
+
+        func startPeriodicUpdates() {
+            stateQueue.async {
+                guard !self.isPeriodicUpdatesEnabled else {
+                    return
+                }
+
+                self.logger.debug("Start periodic address cache updates")
+
+                self.isPeriodicUpdatesEnabled = true
+
+                let scheduleDate = self.nextScheduleDate()
+
+                self.logger.debug("Schedule address cache update on \(scheduleDate.logFormatDate())")
+
+                self.scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
+            }
+        }
+
+        func stopPeriodicUpdates() {
+            stateQueue.async {
+                guard self.isPeriodicUpdatesEnabled else { return }
+
+                self.logger.debug("Stop periodic address cache updates")
+
+                self.isPeriodicUpdatesEnabled = false
+
+                self.timer?.cancel()
+                self.timer = nil
+            }
+        }
+
+        func updateEndpoints(completionHandler: ((_ result: CacheUpdateResult) -> Void)? = nil) -> AnyCancellable {
+            let operation = UpdateAddressCacheOperation(
+                queue: stateQueue,
+                restClient: restClient,
+                store: store,
+                updateInterval: Self.updateInterval,
+                completionHandler: { [weak self] result in
+                    self?.handleCacheUpdateResult(result)
+
+                    completionHandler?(result)
+                }
+            )
+
+            let backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "AddressCache.Tracker.updateEndpoints") {
+                operation.cancel()
+            }
+
+            operation.completionBlock = {
+                UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)
+            }
+
+            operationQueue.addOperation(operation)
+
+            return AnyCancellable {
+                operation.cancel()
+            }
+        }
+
+        private func scheduleEndpointsUpdate(startTime: DispatchWallTime) {
+            let newTimer = DispatchSource.makeTimerSource()
+            newTimer.setEventHandler { [weak self] in
+                self?.handleTimer()
+            }
+
+            newTimer.schedule(wallDeadline: startTime)
+            newTimer.activate()
+
+            timer?.cancel()
+            timer = newTimer
+        }
+
+        private func handleTimer() {
+            _ = updateEndpoints { result in
+                guard self.isPeriodicUpdatesEnabled else { return }
+
+                let scheduleDate = self.nextScheduleDate()
+
+                self.logger.debug("Schedule next address cache update on \(scheduleDate.logFormatDate())")
+
+                self.scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
+            }
+        }
+
+        private func nextScheduleDate() -> Date {
+            if let lastFailureAttemptDate = lastFailureAttemptDate {
+                return Date(timeInterval: Self.retryInterval, since: lastFailureAttemptDate)
+            } else {
+                let updatedAt = store.getLastUpdateDateAndWait()
+
+                return Date(timeInterval: Self.updateInterval, since: updatedAt)
+            }
+        }
+
+        private func handleCacheUpdateResult(_ result: AddressCache.CacheUpdateResult) {
+            switch result {
+            case .success:
+                logger.debug("Finished updating address cache")
+                lastFailureAttemptDate = nil
+
+            case .failure(let error):
+                logger.error(chainedError: AnyChainedError(error), message: "Failed to update address cache")
+                lastFailureAttemptDate = Date()
+
+            case .throttled:
+                logger.debug("Address cache update was throttled")
+                lastFailureAttemptDate = nil
+
+            case .cancelled:
+                logger.debug("Address cache update was cancelled")
+                lastFailureAttemptDate = Date()
+            }
+        }
+
+    }
+}
+
+// MARK: - Background tasks
+
+@available(iOS 13.0, *)
+extension AddressCache.Tracker {
+
+    /// Register background task with scheduler.
+    func registerBackgroundTask() {
+        let taskIdentifier = ApplicationConfiguration.addressCacheUpdateTaskIdentifier
+
+        let isRegistered = BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) { task in
+            self.handleBackgroundTask(task as! BGProcessingTask)
+        }
+
+        if isRegistered {
+            logger.debug("Registered address cache update task")
+        } else {
+            logger.error("Failed to register address cache update task")
+        }
+    }
+
+    /// Create and submit task request to scheduler.
+    func scheduleBackgroundTask() throws {
+        let beginDate = nextScheduleDate()
+
+        logger.debug("Schedule address cache update task on \(beginDate.logFormatDate())")
+
+        let taskIdentifier = ApplicationConfiguration.addressCacheUpdateTaskIdentifier
+
+        let request = BGProcessingTaskRequest(identifier: taskIdentifier)
+        request.earliestBeginDate = beginDate
+        request.requiresNetworkConnectivity = true
+
+        return try BGTaskScheduler.shared.submit(request)
+    }
+
+    /// Background task handler.
+    private func handleBackgroundTask(_ task: BGProcessingTask) {
+        logger.debug("Start address cache update task")
+
+        let cancellable = updateEndpoints { result in
+            do {
+                // Schedule next background task
+                try self.scheduleBackgroundTask()
+            } catch {
+                self.logger.error(chainedError: AnyChainedError(error), message: "Failed to schedule next address cache update task")
+            }
+
+            task.setTaskCompleted(success: result.isTaskCompleted)
+        }
+
+        task.expirationHandler = {
+            cancellable.cancel()
+        }
+    }
+}

--- a/ios/MullvadVPN/AddressCache/UpdateAddressCacheOperation.swift
+++ b/ios/MullvadVPN/AddressCache/UpdateAddressCacheOperation.swift
@@ -1,0 +1,113 @@
+//
+//  UpdateAddressCacheOperation.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 08/12/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension AddressCache {
+
+    enum CacheUpdateResult {
+        /// Operation was cancelled.
+        case cancelled
+
+        /// Address cache update was throttled as it was requested too early.
+        case throttled(_ lastUpdateDate: Date)
+
+        /// Failure to update address cache.
+        case failure(Error)
+
+        /// Address cache is successfully updated.
+        case success
+
+        var isTaskCompleted: Bool {
+            switch self {
+            case .cancelled, .failure:
+                return false
+            case .success, .throttled:
+                return true
+            }
+        }
+    }
+
+    class UpdateAddressCacheOperation: AsyncOperation {
+        typealias CompletionHandler = (_ result: CacheUpdateResult) -> Void
+
+        private let queue: DispatchQueue
+        private let restClient: REST.Client
+        private let store: AddressCache.Store
+        private let updateInterval: TimeInterval
+
+        private var completionHandler: CompletionHandler?
+        private var restCancellationHandle: Cancellable?
+
+        init(queue: DispatchQueue, restClient: REST.Client, store: AddressCache.Store, updateInterval: TimeInterval, completionHandler: CompletionHandler?) {
+            self.queue = queue
+            self.restClient = restClient
+            self.store = store
+            self.updateInterval = updateInterval
+            self.completionHandler = completionHandler
+        }
+
+        override func cancel() {
+            queue.async {
+                super.cancel()
+                self.restCancellationHandle?.cancel()
+            }
+        }
+
+        override func main() {
+            queue.async {
+                self.startUpdate()
+            }
+        }
+
+        private func startUpdate() {
+            guard !isCancelled else {
+                finish(with: .cancelled)
+                return
+            }
+
+            let lastUpdate = store.getLastUpdateDateAndWait()
+            let nextUpdate = Date(timeInterval: updateInterval, since: lastUpdate)
+
+            guard nextUpdate <= Date() else {
+                finish(with: .throttled(lastUpdate))
+                return
+            }
+
+            restCancellationHandle = restClient.getAddressList()
+                .execute(retryStrategy: .default) { restResult in
+                    self.queue.async {
+                        switch restResult {
+                        case .success(let newEndpoints):
+                            self.store.setEndpoints(newEndpoints) { error in
+                                self.queue.async {
+                                    if let error = error {
+                                        self.finish(with: .failure(error))
+                                    } else {
+                                        self.finish(with: .success)
+                                    }
+                                }
+                            }
+
+                        case .failure(let error):
+                            if case URLError.cancelled = error {
+                                self.finish(with: .cancelled)
+                            } else {
+                                self.finish(with: .failure(error))
+                            }
+                        }
+                    }
+                }
+        }
+
+        private func finish(with result: CacheUpdateResult) {
+            completionHandler?(result)
+            completionHandler = nil
+        }
+    }
+}

--- a/ios/MullvadVPN/AppStorePaymentManager/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager/AppStorePaymentManager.swift
@@ -162,6 +162,7 @@ class AppStorePaymentManager: NSObject, SKPaymentTransactionObserver {
             }
             .mapThen { receiptData in
                 return REST.Client.shared.createApplePayment(token: accountToken, receiptString: receiptData)
+                    .execute()
                     .mapError { error in
                         self.logger.error(chainedError: error, message: "Failed to upload the AppStore receipt")
 

--- a/ios/MullvadVPN/ApplicationConfiguration.swift
+++ b/ios/MullvadVPN/ApplicationConfiguration.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
+import struct Network.IPv4Address
 
 enum ApplicationConfiguration {}
 
 extension ApplicationConfiguration {
-
     /// The application group identifier used for sharing application preferences between processes
     static let securityGroupIdentifier = "group.net.mullvad.MullvadVPN"
 
@@ -38,6 +38,9 @@ extension ApplicationConfiguration {
         return [mainApplicationLogFileURL, packetTunnelLogFileURL].compactMap { $0 }
     }
 
+    /// Default API endpoint
+    static let defaultAPIEndpoint = AnyIPEndpoint(string: "193.138.218.78:443")!
+
     /// Background fetch minimum interval
     static let minimumBackgroundFetchInterval: TimeInterval = 3600
 
@@ -46,4 +49,7 @@ extension ApplicationConfiguration {
 
     /// Key rotation background task identifier
     static let privateKeyRotationTaskIdentifier = "net.mullvad.MullvadVPN.PrivateKeyRotation"
+
+    /// API address background task identifier
+    static let addressCacheUpdateTaskIdentifier = "net.mullvad.MullvadVPN.AddressCacheUpdate"
 }

--- a/ios/MullvadVPN/IPEndpoint.swift
+++ b/ios/MullvadVPN/IPEndpoint.swift
@@ -7,36 +7,184 @@
 //
 
 import Foundation
-import Network
+import struct Network.IPv4Address
+import struct Network.IPv6Address
+import protocol Network.IPAddress
 
-/// An abstract struct describing IP address based endpoint
-struct IPEndpont<T>: Hashable where T: IPAddress & Hashable {
-    let ip: T
+struct IPv4Endpoint: Hashable, Equatable, Codable, CustomStringConvertible {
+    let ip: IPv4Address
     let port: UInt16
-}
 
-extension IPEndpont: Codable where T: Codable {}
+    init(ip: IPv4Address, port: UInt16) {
+        self.ip = ip
+        self.port = port
+    }
 
-extension IPEndpont: Equatable {
-    static func == (lhs: IPEndpont<T>, rhs: IPEndpont<T>) -> Bool {
-        lhs.ip.rawValue == rhs.ip.rawValue && lhs.port == rhs.port
+    init?<S>(string: S) where S: StringProtocol {
+        let components = string.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+
+        if components.count == 2, let parsedIP = IPv4Address(String(components[0])), let parsedPort = UInt16(components[1]) {
+            ip = parsedIP
+            port = parsedPort
+        } else {
+            return nil
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+
+        if let parsedAddress = IPv4Endpoint(string: string) {
+            self = parsedAddress
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot parse the IPv4 endpoint")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        try container.encode("\(self)")
+    }
+
+    var description: String {
+        return "\(ip):\(port)"
+    }
+
+    static func == (lhs: IPv4Endpoint, rhs: IPv4Endpoint) -> Bool {
+        return lhs.ip.rawValue == rhs.ip.rawValue && lhs.port == rhs.port
     }
 }
 
-extension IPEndpont: CustomStringConvertible {
-    var description: String {
-        if ip is IPv4Address {
-            return "\(ip):\(port)"
-        } else if ip is IPv6Address {
-            return "[\(ip)]:\(port)"
+struct IPv6Endpoint: Hashable, Equatable, Codable, CustomStringConvertible {
+    let ip: IPv6Address
+    let port: UInt16
+
+    init(ip: IPv6Address, port: UInt16) {
+        self.ip = ip
+        self.port = port
+    }
+
+    init?<S>(string: S) where S: StringProtocol {
+        guard let lastColon = string.lastIndex(of: ":"), lastColon != string.endIndex else {
+            return nil
+        }
+
+        let portIndex = string.index(after: lastColon)
+        let addressString = string[..<lastColon]
+        let portString = string[portIndex...]
+
+        guard addressString.first == "[" && addressString.last == "]" else {
+            return nil
+        }
+
+        let ipv6AddressString = String(addressString.dropFirst().dropLast())
+
+        if let parsedIP = IPv6Address(ipv6AddressString), let parsedPort = UInt16(portString) {
+            ip = parsedIP
+            port = parsedPort
         } else {
-            fatalError()
+            return nil
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+
+        if let parsedAddress = IPv6Endpoint(string: string) {
+            self = parsedAddress
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot parse the IPv6 endpoint")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        try container.encode("\(self)")
+    }
+
+    var description: String {
+        return "[\(ip)]:\(port)"
+    }
+
+    static func == (lhs: IPv6Endpoint, rhs: IPv6Endpoint) -> Bool {
+        return lhs.ip.rawValue == rhs.ip.rawValue && lhs.port == rhs.port
+    }
+}
+
+enum AnyIPEndpoint: Hashable, Equatable, Codable, CustomStringConvertible {
+    case ipv4(IPv4Endpoint)
+    case ipv6(IPv6Endpoint)
+
+    var ip: IPAddress {
+        switch self {
+        case .ipv4(let ipv4Endpoint):
+            return ipv4Endpoint.ip
+        case .ipv6(let ipv6Endpoint):
+            return ipv6Endpoint.ip
+        }
+    }
+
+    var port: UInt16 {
+        switch self {
+        case .ipv4(let ipv4Endpoint):
+            return ipv4Endpoint.port
+        case .ipv6(let ipv6Endpoint):
+            return ipv6Endpoint.port
+        }
+    }
+
+    init?<S>(string: S) where S: StringProtocol {
+        if let ipv4Endpoint = IPv4Endpoint(string: string) {
+            self = .ipv4(ipv4Endpoint)
+        } else if let ipv6Endpoint = IPv6Endpoint(string: string) {
+            self = .ipv6(ipv6Endpoint)
+        } else {
+            return nil
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+
+        if let ipv4Endpoint = IPv4Endpoint(string: string) {
+            self = .ipv4(ipv4Endpoint)
+        } else if let ipv6Endpoint = IPv6Endpoint(string: string) {
+            self = .ipv6(ipv6Endpoint)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot parse the endpoint")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        try container.encode("\(self)")
+    }
+
+    var description: String {
+        switch self {
+        case .ipv4(let ipv4Endpoint):
+            return "\(ipv4Endpoint)"
+        case .ipv6(let ipv6Endpoint):
+            return "\(ipv6Endpoint)"
+        }
+    }
+
+    static func == (lhs: AnyIPEndpoint, rhs: AnyIPEndpoint) -> Bool {
+        switch (lhs, rhs) {
+        case (.ipv4(let lhsEndpoint), .ipv4(let rhsEndpoint)):
+            return lhsEndpoint == rhsEndpoint
+
+        case (.ipv6(let lhsEndpoint), .ipv6(let rhsEndpoint)):
+            return lhsEndpoint == rhsEndpoint
+
+        default:
+            return false
         }
     }
 }
-
-/// An alias for IPv4 endpoint
-typealias IPv4Endpoint = IPEndpont<IPv4Address>
-
-/// An alias for IPv6 endpoint
-typealias IPv6Endpoint = IPEndpont<IPv6Address>

--- a/ios/MullvadVPN/Info.plist
+++ b/ios/MullvadVPN/Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>net.mullvad.MullvadVPN.AppRefresh</string>
 		<string>net.mullvad.MullvadVPN.PrivateKeyRotation</string>
+		<string>net.mullvad.MullvadVPN.AddressCacheUpdate</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/ios/MullvadVPN/Operations/ExclusivityController.swift
+++ b/ios/MullvadVPN/Operations/ExclusivityController.swift
@@ -15,8 +15,6 @@ class ExclusivityController: NSObject {
 
     static let shared = ExclusivityController()
 
-    private override init() {}
-
     func addOperation(_ operation: Operation, categories: [String]) {
         lock.withCriticalBlock {
             categories.forEach { category in

--- a/ios/MullvadVPN/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/ProblemReportViewController.swift
@@ -598,6 +598,7 @@ class ProblemReportViewController: UIViewController, UITextFieldDelegate, Condit
         willSendProblemReport()
 
         REST.Client.shared.sendProblemReport(request)
+            .execute(retryStrategy: .default)
             .receive(on: .main)
             .observe { completion in
                 self.didSendProblemReport(viewModel: viewModel, result: completion.unwrappedValue!)

--- a/ios/MullvadVPN/Promise/Cancellable.swift
+++ b/ios/MullvadVPN/Promise/Cancellable.swift
@@ -11,3 +11,19 @@ import Foundation
 protocol Cancellable {
     func cancel()
 }
+
+class AnyCancellable: Cancellable {
+    private var closure: (() -> Void)?
+    private let lock = NSLock()
+
+    init(_ block: @escaping () -> Void) {
+        self.closure = block
+    }
+
+    func cancel() {
+        lock.withCriticalBlock {
+            self.closure?()
+            self.closure = nil
+        }
+    }
+}

--- a/ios/MullvadVPN/REST/HTTP.swift
+++ b/ios/MullvadVPN/REST/HTTP.swift
@@ -51,6 +51,7 @@ struct HTTPStatus: RawRepresentable, Equatable {
 
 /// HTTP headers
 enum HTTPHeader {
+    static let host = "Host"
     static let authorization = "Authorization"
     static let contentType = "Content-Type"
     static let etag = "ETag"

--- a/ios/MullvadVPN/REST/RESTNetworkOperation.swift
+++ b/ios/MullvadVPN/REST/RESTNetworkOperation.swift
@@ -1,0 +1,202 @@
+//
+//  NetworkOperation.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 08/12/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import Logging
+
+extension REST {
+
+    enum RetryAction {
+        /// Retry request using next endpoint.
+        case useNextEndpoint
+
+        /// Retry request using current endpoint.
+        case useCurrentEndpoint
+
+        /// Fail immediately.
+        case failImmediately
+    }
+
+    class NetworkOperation<Success>: AsyncOperation {
+        typealias CompletionHandler = (Result<Success, REST.Error>) -> Void
+        typealias Generator = (AnyIPEndpoint, @escaping CompletionHandler) -> Result<URLSessionTask, REST.Error>
+
+        private let networkTaskGenerator: Generator
+        private let addressCacheStore: AddressCache.Store
+        private var completionHandler: CompletionHandler?
+        private var sessionTask: URLSessionTask?
+
+        private let retryStrategy: RetryStrategy
+        private var retryTimer: DispatchSourceTimer?
+        private var retryCount = 0
+
+        private let logger = Logger(label: "REST.NetworkOperation")
+        private let loggerMetadata: Logger.Metadata = ["requestID": .string(UUID().uuidString)]
+
+        init(networkTaskGenerator: @escaping Generator, addressCacheStore: AddressCache.Store, retryStrategy: RetryStrategy, completionHandler: @escaping CompletionHandler) {
+            self.networkTaskGenerator = networkTaskGenerator
+            self.addressCacheStore = addressCacheStore
+            self.retryStrategy = retryStrategy
+            self.completionHandler = completionHandler
+        }
+
+        override func cancel() {
+            DispatchQueue.main.async {
+                super.cancel()
+
+                // Cancel pending retry
+                self.retryTimer?.cancel()
+
+                // Cancel active network task
+                self.sessionTask?.cancel()
+            }
+        }
+
+        override func main() {
+            DispatchQueue.main.async {
+                // Finish immediately if operation was cancelled before execution
+                guard !self.isCancelled else {
+                    self.finish(with: .failure(Self.cancellationError))
+                    return
+                }
+
+                // Get current endpoint
+                self.addressCacheStore.getCurrentEndpoint { endpoint in
+                    DispatchQueue.main.async {
+                        self.sendRequest(endpoint: endpoint) { [weak self] result in
+                            self?.finish(with: result)
+                        }
+                    }
+                }
+            }
+        }
+
+        private func sendRequest(endpoint: AnyIPEndpoint, completionHandler: @escaping CompletionHandler) {
+            // Handle operation cancellation
+            guard !isCancelled else {
+                completionHandler(.failure(Self.cancellationError))
+                return
+            }
+
+            // Create network task and execute it
+            let taskResult = networkTaskGenerator(endpoint) { [weak self] result in
+                DispatchQueue.main.async {
+                    self?.handleResponse(endpoint: endpoint, result: result, completionHandler: completionHandler)
+                }
+            }
+
+            switch taskResult {
+            case .success(let dataTask):
+                logger.debug("Executing request using \(endpoint)", metadata: loggerMetadata)
+
+                sessionTask = dataTask
+                dataTask.resume()
+
+            case .failure(let error):
+                logger.error(chainedError: error, message: "Failed to create data task", metadata: loggerMetadata)
+
+                completionHandler(.failure(error))
+            }
+        }
+
+        private func handleResponse(endpoint: AnyIPEndpoint, result: Result<Success, REST.Error>, completionHandler: @escaping CompletionHandler) {
+            guard case .failure(let error) = result else {
+                completionHandler(result)
+                return
+            }
+
+            logger.debug("Failed to perform request to \(endpoint)", metadata: self.loggerMetadata)
+
+            switch Self.evaluateError(error) {
+            case .useNextEndpoint:
+                // Pick next endpoint in the event of network error
+                addressCacheStore.selectNextEndpoint(endpoint) { nextEndpoint in
+                    DispatchQueue.main.async {
+                        self.retryRequest(endpoint: nextEndpoint, previousResult: result, completionHandler: completionHandler)
+                    }
+                }
+
+            case .useCurrentEndpoint:
+                // Retry request using the same endpoint otherwise
+                retryRequest(endpoint: endpoint, previousResult: result, completionHandler: completionHandler)
+
+            case .failImmediately:
+                // Fail immediately in case of other errors, like server errors
+                completionHandler(result)
+            }
+        }
+
+        private func retryRequest(endpoint: AnyIPEndpoint, previousResult: Result<Success, REST.Error>, completionHandler: @escaping CompletionHandler) {
+            // Handle operation cancellation
+            guard !isCancelled else {
+                completionHandler(.failure(Self.cancellationError))
+                return
+            }
+
+            // Increment retry count
+            retryCount += 1
+
+            // Check if retry count is not exceeded.
+            guard retryCount < retryStrategy.maxRetryCount else {
+                logger.debug("Ran out of retry attempts (\(retryStrategy.maxRetryCount))", metadata: loggerMetadata)
+
+                completionHandler(previousResult)
+                return
+            }
+
+            // Retry immediatly if retry delay is set to .never
+            guard retryStrategy.retryDelay != .never else {
+                sendRequest(endpoint: endpoint, completionHandler: completionHandler)
+                return
+            }
+
+            // Create timer to delay retry
+            retryTimer = DispatchSource.makeTimerSource(queue: .main)
+
+            retryTimer?.setEventHandler { [weak self] in
+                self?.sendRequest(endpoint: endpoint, completionHandler: completionHandler)
+            }
+
+            retryTimer?.setCancelHandler {
+                completionHandler(.failure(Self.cancellationError))
+            }
+
+            retryTimer?.schedule(wallDeadline: .now() + retryStrategy.retryDelay)
+            retryTimer?.activate()
+        }
+
+        private func finish(with result: Result<Success, REST.Error>) {
+            completionHandler?(result)
+            completionHandler = nil
+
+            finish()
+        }
+
+        private static func evaluateError(_ error: REST.Error) -> RetryAction {
+            guard case .network(let networkError) = error else {
+                return .failImmediately
+            }
+
+            switch networkError.code {
+            case .cancelled:
+                return .failImmediately
+
+            case .notConnectedToInternet, .internationalRoamingOff, .callIsActive:
+                return .useCurrentEndpoint
+
+            default:
+                return .useNextEndpoint
+            }
+        }
+
+        private static var cancellationError: REST.Error {
+            return .network(URLError(.cancelled))
+        }
+    }
+
+}

--- a/ios/MullvadVPN/REST/RESTRequestAdapter.swift
+++ b/ios/MullvadVPN/REST/RESTRequestAdapter.swift
@@ -1,0 +1,41 @@
+//
+//  RESTRequestAdapter.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 03/12/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension REST {
+
+    struct RequestAdapter<Success> {
+        typealias CompletionHandler = (Result<Success, REST.Error>) -> Void
+
+        private let block: (RetryStrategy, @escaping CompletionHandler) -> AnyCancellable
+
+        init(block: @escaping (RetryStrategy, @escaping CompletionHandler) -> AnyCancellable) {
+            self.block = block
+        }
+
+        func execute(retryStrategy: RetryStrategy = RetryStrategy.noRetry, completionHandler: @escaping CompletionHandler) -> AnyCancellable {
+            return self.block(retryStrategy, completionHandler)
+        }
+
+        func execute(retryStrategy: RetryStrategy = RetryStrategy.noRetry) -> Result<Success, REST.Error>.Promise {
+            return Promise { resolver in
+                let cancellable = self.execute(retryStrategy: retryStrategy) { result in
+                    resolver.resolve(value: result)
+                }
+
+                resolver.setCancelHandler {
+                    cancellable.cancel()
+                }
+            }
+        }
+    }
+
+
+
+}

--- a/ios/MullvadVPN/REST/RESTRetryStrategy.swift
+++ b/ios/MullvadVPN/REST/RESTRetryStrategy.swift
@@ -1,0 +1,22 @@
+//
+//  RESTRetryStrategy.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 09/12/2021.
+//  Copyright © 2021 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension REST {
+    struct RetryStrategy {
+        var maxRetryCount: Int
+        var retryDelay: DispatchTimeInterval
+
+        /// Strategy configured to never retry
+        static var noRetry = RetryStrategy(maxRetryCount: 0, retryDelay: .never)
+
+        /// Startegy configured with 3 retry attempts with 2 seconds delay between
+        static var `default` = RetryStrategy(maxRetryCount: 3, retryDelay: .seconds(2))
+    }
+}

--- a/ios/MullvadVPN/REST/SSLPinningURLSessionDelegate.swift
+++ b/ios/MullvadVPN/REST/SSLPinningURLSessionDelegate.swift
@@ -22,21 +22,14 @@ class SSLPinningURLSessionDelegate: NSObject, URLSessionDelegate {
     // MARK: - URLSessionDelegate
 
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let evaluation: (disposition: URLSession.AuthChallengeDisposition, credential: URLCredential?)
-
-        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
-            if let serverTrust = challenge.protectionSpace.serverTrust, self.verifyServerTrust(serverTrust) {
-                evaluation = (.useCredential, URLCredential(trust: serverTrust))
-            } else {
-                evaluation = (.cancelAuthenticationChallenge, nil)
-            }
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+           let serverTrust = challenge.protectionSpace.serverTrust,
+           verifyServerTrust(serverTrust) {
+            completionHandler(.useCredential, URLCredential(trust: serverTrust))
         } else {
-            evaluation = (.rejectProtectionSpace, nil)
+            completionHandler(.rejectProtectionSpace, nil)
         }
-
-        completionHandler(evaluation.disposition, evaluation.credential)
     }
-
 
     // MARK: - Private
 

--- a/ios/MullvadVPN/Result+UIBackgroundFetchResult.swift
+++ b/ios/MullvadVPN/Result+UIBackgroundFetchResult.swift
@@ -23,6 +23,21 @@ extension Result where Success == TunnelManager.KeyRotationResult {
     }
 }
 
+extension AddressCache.CacheUpdateResult {
+    var backgroundFetchResult: UIBackgroundFetchResult {
+        switch self {
+        case .failure:
+            return .failed
+        case .throttled:
+            return .noData
+        case .success:
+            return .newData
+        case .cancelled:
+            return .noData
+        }
+    }
+}
+
 extension Result where Success == RelayCache.FetchResult {
     var backgroundFetchResult: UIBackgroundFetchResult {
         switch self.asConcreteType() {
@@ -49,6 +64,12 @@ extension UIBackgroundFetchResult: CustomStringConvertible {
             return "failed"
         @unknown default:
             return "unknown (rawValue: \(self.rawValue)"
+        }
+    }
+
+    func combine(with others: [UIBackgroundFetchResult]) -> UIBackgroundFetchResult {
+        return others.reduce(self) { partialResult, other in
+            return partialResult.combine(with: other)
         }
     }
 

--- a/ios/MullvadVPN/WireguardKeysViewController.swift
+++ b/ios/MullvadVPN/WireguardKeysViewController.swift
@@ -213,6 +213,7 @@ class WireguardKeysViewController: UIViewController, TunnelObserver {
         self.updateViewState(.verifyingKey)
 
         REST.Client.shared.getWireguardKey(token: tunnelInfo.token, publicKey: tunnelInfo.tunnelSettings.interface.publicKey)
+            .execute(retryStrategy: .default)
             .map { _ in
                 return true
             }

--- a/ios/prebuild.sh
+++ b/ios/prebuild.sh
@@ -32,6 +32,6 @@ if [ ! -f "$RELAYS_FILE" ]; then
 fi
 
 if [ ! -f "$API_IP_ADDRESS_LIST_FILE" ]; then
-  echo "Download API address list file"
+  echo "Download API address list"
   curl https://api.mullvad.net/app/v1/api-addrs -s -o "$API_IP_ADDRESS_LIST_FILE"
 fi

--- a/ios/update-relays.sh
+++ b/ios/update-relays.sh
@@ -5,7 +5,10 @@ if [ -z "$PROJECT_DIR" ]; then
   exit 1
 fi
 
-RELAYS_FILE="$PROJECT_DIR/Assets/relays.json"
+ASSETS_DIR_PATH="$PROJECT_DIR/Assets"
+
+RELAYS_FILE="$ASSETS_DIR_PATH/relays.json"
+API_IP_ADDRESS_LIST_FILE="$ASSETS_DIR_PATH/api-ip-address.json"
 
 if [ $CONFIGURATION == "Release" ]; then
   echo "Remove relays file"
@@ -14,9 +17,21 @@ if [ $CONFIGURATION == "Release" ]; then
   else
     echo "Relays file does not exist"
   fi
+
+  echo "Remove API address list file"
+  if [ -f "$API_IP_ADDRESS_LIST_FILE" ]; then
+    rm "$API_IP_ADDRESS_LIST_FILE"
+  else
+    echo "API IP address list file does not exist"
+  fi
 fi
 
 if [ ! -f "$RELAYS_FILE" ]; then
   echo "Download relays file"
   curl https://api.mullvad.net/app/v1/relays -s -o "$RELAYS_FILE"
+fi
+
+if [ ! -f "$API_IP_ADDRESS_LIST_FILE" ]; then
+  echo "Download API address list file"
+  curl https://api.mullvad.net/app/v1/api-addrs -s -o "$API_IP_ADDRESS_LIST_FILE"
 fi


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR adds support for API address cache that is used to perform REST requests to Mullvad API. The address cache is updated periodically using background task and timer based solution.

Detailed changeset:

1. Rename `update-relays.sh` to `prebuild.sh`. Update script to download API address list to `Assets/api-ip-address.json`, which is later on bundled with the app.
2. SSL pinning: return `.rejectProtectionSpace` if found that SSL certificate chain is invalid. This makes the network layer return the proper error back to caller, i.e: `The certificate for this server is invalid. You might be connecting to a server that is pretending to be "<ENDPOINT_IP>" which could put your confidential information at risk.`. When returning `.cancelAuthentication`, the network layer simply cancels the request which makes it impossible to tell what really happened.
3. Add `AddressCache.Store` that's responsible for persisting API address cache on disk, loading cache shipped with the app and provides means for picking and shuffling API endpoints.
4. Add `AddressCache.Tracker` that's responsible for updating API address cache periodically.
5. Add `REST.NetworkOperation` that performs network requests using given retry strategy and address cache.
6. Add `REST.RequestAdapter` that provides a simple interface to work with REST API using either closure block or Promises.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3196)
<!-- Reviewable:end -->
