### PR TITLE
Use `Duration::MAX` where applicable

### DIFF
--- a/talpid-core/src/future_retry.rs
+++ b/talpid-core/src/future_retry.rs
@@ -81,8 +81,8 @@ impl ExponentialBackoff {
         }
     }
 
-    /// Set the maximum delay. By default, there is no maximum value set, but the practical limit
-    /// is `std::u64::MAX`.
+    /// Set the maximum delay. By default, there is no maximum value set. The limit is
+    /// `Duration::MAX`.
     pub fn max_delay(mut self, duration: Duration) -> ExponentialBackoff {
         self.max_delay = Some(duration);
         self
@@ -98,10 +98,7 @@ impl ExponentialBackoff {
             }
         }
 
-        // TODO: Use Duration::MAX when it is available
-        self.next = next
-            .checked_mul(self.factor)
-            .unwrap_or(Duration::from_secs(u64::MAX));
+        self.next = next.saturating_mul(self.factor);
 
         next
     }
@@ -161,7 +158,7 @@ mod test {
 
     #[test]
     fn test_at_maximum_value() {
-        let max = Duration::from_secs(u64::MAX);
+        let max = Duration::MAX;
         let mu = Duration::from_micros(1);
         let mut backoff = ExponentialBackoff::new(max - mu, 2);
 


### PR DESCRIPTION
`Duration::MAX` was stabilized in [Rust 1.53](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html), so let's use that instead of `Duration::from_secs(u64::MAX)` now (which was slightly incorrect as well).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3197)
<!-- Reviewable:end -->
