### PR TITLE
Add canary build type for checking memory leaks

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -57,6 +57,10 @@ android {
             isMinifyEnabled = false
             signingConfig = null
         }
+
+        create("leakCanary") {
+            initWith(buildTypes.getByName("debug"))
+        }
     }
 
     sourceSets {
@@ -153,14 +157,17 @@ dependencies {
     implementation(Dependencies.Kotlin.stdlib)
     implementation(Dependencies.KotlinX.coroutinesAndroid)
 
-    /* Test dependencies */
+    // Leak canary
+    leakCanaryImplementation(Dependencies.leakCanary)
+
+    // Test dependencies
     testImplementation(Dependencies.Koin.test)
     testImplementation(Dependencies.Kotlin.test)
     testImplementation(Dependencies.KotlinX.coroutinesTest)
     testImplementation(Dependencies.MockK.core)
     testImplementation(Dependencies.junit)
 
-    /* UI test dependencies */
+    // UI test dependencies
     debugImplementation(Dependencies.AndroidX.fragmentTestning)
     androidTestImplementation(Dependencies.AndroidX.espressoContrib)
     androidTestImplementation(Dependencies.AndroidX.espressoCore)

--- a/android/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/android/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,6 +3,7 @@ object Dependencies {
     const val commonsValidator = "commons-validator:commons-validator:${Versions.commonsValidator}"
     const val jodaTime = "joda-time:joda-time:${Versions.jodaTime}"
     const val junit = "junit:junit:${Versions.junit}"
+    const val leakCanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakCanary}"
 
     object AndroidX {
         const val appcompat = "androidx.appcompat:appcompat:${Versions.AndroidX.appcompat}"

--- a/android/buildSrc/src/main/kotlin/Extensions.kt
+++ b/android/buildSrc/src/main/kotlin/Extensions.kt
@@ -1,3 +1,6 @@
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
 fun String.isNonStableVersion(): Boolean {
     val nonStableQualifiers = listOf("alpha", "beta", "rc")
 
@@ -7,3 +10,6 @@ fun String.isNonStableVersion(): Boolean {
 
     return isNonStable
 }
+
+fun DependencyHandler.`leakCanaryImplementation`(dependencyNotation: Any): Dependency? =
+    add("leakCanaryImplementation", dependencyNotation)

--- a/android/buildSrc/src/main/kotlin/Versions.kt
+++ b/android/buildSrc/src/main/kotlin/Versions.kt
@@ -6,6 +6,7 @@ object Versions {
     const val koin = "2.2.2"
     const val kotlin = "1.4.31"
     const val kotlinx = "1.5.1"
+    const val leakCanary = "2.8.1"
     const val mockk = "1.12.0"
 
     object Android {


### PR DESCRIPTION
Adds a new build type which can be used to identify memory leaks by using the Leak Canary dependency/tool.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. **SKIPPED**
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3201)
<!-- Reviewable:end -->
