### PR TITLE
Tiny simplification/code cleanup

### DIFF
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -54,14 +54,12 @@ impl FirewallT for Firewall {
     }
 
     fn reset_policy(&mut self) -> Result<()> {
-        vec![
-            self.remove_rules(),
-            self.remove_anchor(),
-            self.restore_state(),
-        ]
-        .into_iter()
-        .collect::<Result<Vec<_>>>()
-        .map(|_| ())
+        // Implemented this way to not early return on an error.
+        // We always want all three methods to run, and then return
+        // the first error it encounterd, if any.
+        self.remove_rules()
+            .and(self.remove_anchor())
+            .and(self.restore_state())
     }
 }
 


### PR DESCRIPTION
I think this does the exact same thing but in a much simpler manner. Allocating a vector of `Result<()>` on the heap and then mapping over them seems a bit complicated to just run three fallible methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3202)
<!-- Reviewable:end -->
