### PR TITLE
Fix relay selector with bridge constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
   pressed.
 - Disable logging of translation errors in production. This will among other things prevent error
   messages from translating the country in the disconnected state.
+- Stop preferring OpenVPN when bridge mode is enabled.
 
 #### Android
 - Avoid running in foreground when not connected.

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -172,30 +172,6 @@ impl RelaySettings {
             }),
         }
     }
-
-    pub(crate) fn ensure_bridge_compatibility(&mut self) {
-        match self {
-            RelaySettings::Normal(ref mut constraints) => {
-                if constraints.tunnel_protocol == Constraint::Only(TunnelType::Wireguard) {
-                    constraints.tunnel_protocol = Constraint::Any;
-                }
-                if let Constraint::Only(TransportPort {
-                    protocol: TransportProtocol::Udp,
-                    ..
-                }) = constraints.openvpn_constraints.port
-                {
-                    constraints.openvpn_constraints.port = Constraint::Any;
-                }
-            }
-            RelaySettings::CustomTunnelEndpoint(config) => {
-                if config.endpoint().protocol == TransportProtocol::Udp {
-                    log::warn!(
-                        "Using custom tunnel endpoint with UDP, bridges will likely not work"
-                    );
-                }
-            }
-        }
-    }
 }
 
 /// Limits the set of [`crate::relay_list::Relay`]s that a `RelaySelector` may select.

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -194,9 +194,6 @@ impl Settings {
     pub fn set_bridge_state(&mut self, bridge_state: BridgeState) -> bool {
         if self.bridge_state != bridge_state {
             self.bridge_state = bridge_state;
-            if self.bridge_state == BridgeState::On {
-                self.relay_settings.ensure_bridge_compatibility();
-            }
             true
         } else {
             false


### PR DESCRIPTION
Changes:
* Stop always preferring OpenVPN when the tunnel protocol is set to `any` and bridges are enabled. It doesn't make much sense if WireGuard multihop is enabled especially.
* Enabling bridges no longer resets the tunnel protocol to `any` if it is currently set to `wireguard`. This can currently only occur in the CLI.