### PR TITLE
Increase WFP transaction lock timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Line wrap the file at 100 chars.                                              Th
 - Update wireguard-nt to 0.10.1.
 - Make wireguard-nt the default driver for WireGuard. This is used instead of wireguard-go and
   Wintun.
+- Increase firewall transaction timeout from 2 to 6 seconds.
 
 ### Fixed
 - Always kill `sslocal` if the tunnel monitor fails to start when using bridges.

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -1,6 +1,6 @@
 use crate::{logging::windows::log_sink, tunnel::TunnelMetadata};
 
-use std::{net::IpAddr, path::Path, ptr};
+use std::{net::IpAddr, path::Path, ptr, time::Duration};
 
 use self::winfw::*;
 use super::{FirewallArguments, FirewallPolicy, FirewallT, InitialFirewallState};
@@ -45,7 +45,8 @@ pub enum Error {
     SetTunMetric(#[error(source)] crate::winnet::Error),
 }
 
-const WINFW_TIMEOUT_SECONDS: u32 = 2;
+/// Timeout for WFP transactions
+const WINFW_TXN_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// The Windows implementation for the firewall and DNS.
 pub struct Firewall(());
@@ -56,12 +57,13 @@ impl FirewallT for Firewall {
     fn new(args: FirewallArguments) -> Result<Self, Self::Error> {
         let logging_context = b"WinFw\0".as_ptr();
 
+        let timeout_secs = u32::try_from(WINFW_TXN_TIMEOUT.as_secs()).unwrap();
         if let InitialFirewallState::Blocked(allowed_endpoint) = args.initial_state {
             let cfg = &WinFwSettings::new(args.allow_lan);
             let allowed_endpoint = WinFwAllowedEndpointContainer::from(allowed_endpoint);
             unsafe {
                 WinFw_InitializeBlocked(
-                    WINFW_TIMEOUT_SECONDS,
+                    timeout_secs,
                     &cfg,
                     &allowed_endpoint.as_endpoint(),
                     Some(log_sink),
@@ -71,8 +73,7 @@ impl FirewallT for Firewall {
             };
         } else {
             unsafe {
-                WinFw_Initialize(WINFW_TIMEOUT_SECONDS, Some(log_sink), logging_context)
-                    .into_result()?
+                WinFw_Initialize(timeout_secs, Some(log_sink), logging_context).into_result()?
             };
         }
 


### PR DESCRIPTION
Acquiring the lock appears to fail every now and then, perhaps more so on slow systems. It doesn't seem to be obviously caused by third-party software.

The timeout is increased somewhat here to hopefully improve things. A very long timeout would be a bad idea, because, among other reasons, firewall state changes block the tunnel state machine.

(Changing the tunnel state machine architecture at some point to allow for async transitions that could be interrupted by `mullvad disconnect`, etc., seems like a good idea, irrespective of what the timeout is here.)