### PR TITLE
Clarify Android tile text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Line wrap the file at 100 chars.                                              Th
   * Swiping to remove from the Recents/Overview screen.
   * Android Background Execution Limits.
   * The System Settings way of killing apps ("Force Stop").
+- Change Quick Settings tile label to reflect the action of clicking the tile. Also add a subtitle 
+  on supported Android versions (Q and above) to reflect the state.
 
 #### Windows
 - Update wireguard-nt to 0.10.1.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -66,7 +66,7 @@
             </intent-filter>
         </service>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadTileService"
-                 android:label="@string/app_name"
+                 android:label="@string/toggle_vpn"
                  android:icon="@drawable/small_logo_black"
                  android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
                  android:process=":mullvadvpn_tile">

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.service
 
 import android.content.Intent
 import android.graphics.drawable.Icon
+import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import kotlin.properties.Delegates.observable
@@ -94,9 +95,17 @@ class MullvadTileService : TileService() {
             if (secured) {
                 state = Tile.STATE_ACTIVE
                 icon = securedIcon
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    subtitle = resources.getText(R.string.secured)
+                }
             } else {
                 state = Tile.STATE_INACTIVE
                 icon = unsecuredIcon
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    subtitle = resources.getText(R.string.unsecured)
+                }
             }
 
             updateTile()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -172,4 +172,5 @@
     <string name="all_applications">All applications</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>
     <string name="show_system_apps">Show system apps</string>
+    <string name="toggle_vpn">Toggle VPN</string>
 </resources>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1408,6 +1408,9 @@ msgstr ""
 msgid "This device is offline, no tunnels can be established"
 msgstr ""
 
+msgid "Toggle VPN"
+msgstr ""
+
 msgid "Too many WireGuard keys registered to account"
 msgstr ""
 


### PR DESCRIPTION
Change Android tile title/label to "Toggle VPN" to better inform the
user about the tile action. Also set the subtitle (on Android Q and
above) to match the state shown in the notification.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3208)
<!-- Reviewable:end -->
