### PR TITLE
Disable built-in DNS resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Line wrap the file at 100 chars.                                              Th
 - Always kill `sslocal` if the tunnel monitor fails to start when using bridges.
 - Show relay location constraint correctly in the CLI when it is set to `any`.
 
+#### macOS
+- Disable built-in DNS resolver in Electron. Prevents Electron from establishing connections to
+  DNS servers set in system network preferences.
+
 #### Windows
 - Fix app size after changing display scale.
 - Fix daemon not starting if all excluded app paths reside on non-existent/unmounted volumes.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -463,6 +463,13 @@ class ApplicationMain {
   }
 
   private onReady = async () => {
+    // Disable built-in DNS resolver.
+    app.configureHostResolver({
+      enableBuiltInResolver: false,
+      secureDnsMode: 'off',
+      secureDnsServers: [],
+    });
+
     // There's no option that prevents Electron from fetching spellcheck dictionaries from
     // Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from
     // fetching.  https://github.com/electron/electron/issues/22995


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR disables the built-in DNS resolver in Electron, which was introduced with the update to Electron 15 around `2021.6`. Although GUI process does not issue any network requests, nonetheless, Electron established connections to DNS servers specified in network preferences on macOS. 

Based on documentation, built-in DNS resolver is only enabled on macOS, hence the changelog states that the fix is for Mac only, however the patch itself disables built-in DNS resolver regardless the environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3209)
<!-- Reviewable:end -->
