### PR TITLE
Fix path to gradle file in versioning scripts

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -76,7 +76,7 @@ git commit -S -m "Updating version in package files" \
     mullvad-exclude/Cargo.toml \
     talpid-openvpn-plugin/Cargo.toml \
     Cargo.lock \
-    android/build.gradle \
+    android/app/build.gradle \
     dist-assets/windows/version.h
 
 echo "Tagging current git commit with release tag $PRODUCT_VERSION..."

--- a/version-metadata.sh
+++ b/version-metadata.sh
@@ -96,11 +96,11 @@ EOF
 
         echo "Setting Android versionName to $PRODUCT_VERSION and versionCode to $android_version_code"
 
-        cp android/build.gradle android/build.gradle.bak
+        cp android/app/build.gradle android/app/build.gradle.bak
         sed -i -Ee "s/versionCode [0-9]+/versionCode $android_version_code/g" \
-            android/build.gradle
+            android/app/build.gradle
         sed -i -Ee "s/versionName \"[^\"]+\"/versionName \"$PRODUCT_VERSION\"/g" \
-            android/build.gradle
+            android/app/build.gradle
     fi
 }
 
@@ -123,7 +123,7 @@ function restore_backup {
 
     if [[ "$ANDROID" == "true" ]]; then
         # Android
-        mv android/build.gradle.bak android/build.gradle
+        mv android/app/build.gradle.bak android/app/build.gradle
     fi
     set -e
 }
@@ -147,7 +147,7 @@ function delete_backup {
 
     if [[ "$ANDROID" == "true" ]]; then
         # Android
-        rm android/build.gradle.bak
+        rm android/app/build.gradle.bak
     fi
     set -e
 }


### PR DESCRIPTION
Fixes the path to the gradle file used to handle versioning. The issue
was instroduced when the project/app module were split in the following
commit: f249bc175d21c3f732541266be9004700a913487

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3211)
<!-- Reviewable:end -->
