### PR TITLE
Prevent bundling grpc-tools and @types/* dependencies in builds

### DIFF
--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -41,8 +41,10 @@ const config = {
     'build/src/renderer/index.html',
     'build/src/renderer/bundle.js',
     'build/src/renderer/preloadBundle.js',
-    'node_modules/',
     '!**/*.tsbuildinfo',
+    'node_modules/',
+    '!node_modules/grpc-tools',
+    '!node_modules/@types',
   ],
 
   mac: {
@@ -114,7 +116,10 @@ const config = {
       { from: distAssets('binaries/x86_64-pc-windows-msvc/sslocal.exe'), to: '.' },
       { from: root('build/lib/x86_64-pc-windows-msvc/libwg.dll'), to: '.' },
       { from: distAssets('binaries/x86_64-pc-windows-msvc/wintun/wintun.dll'), to: '.' },
-      { from: distAssets('binaries/x86_64-pc-windows-msvc/wireguard-nt/mullvad-wireguard.dll'), to: '.' },
+      {
+        from: distAssets('binaries/x86_64-pc-windows-msvc/wireguard-nt/mullvad-wireguard.dll'),
+        to: '.',
+      },
     ],
   },
 


### PR DESCRIPTION
This PR prevents grpc-tools and @types/* depdendencies from being bundled in builds of the app. Those dependencies are only used for building the app and are not needed.

This PR also contains a formatting change which was applied by prettier.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3213)
<!-- Reviewable:end -->
