### PR TITLE
REST: handle success response codes defensively

### DIFF
--- a/ios/MullvadVPN/REST/HTTP.swift
+++ b/ios/MullvadVPN/REST/HTTP.swift
@@ -20,32 +20,11 @@ struct HTTPMethod: RawRepresentable {
     }
 }
 
-// HTTP status codes
-struct HTTPStatus: RawRepresentable, Equatable {
-    static let ok = HTTPStatus(rawValue: 200)
-    static let created = HTTPStatus(rawValue: 201)
-    static let noContent = HTTPStatus(rawValue: 204)
-    static let notModified = HTTPStatus(rawValue: 304)
+enum HTTPStatus {
+    static let notModified = 304
 
-    let rawValue: Int
-    init(rawValue value: Int) {
-        rawValue = value
-    }
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-
-    static func == (lhs: Self, rhs: Int) -> Bool {
-        return lhs.rawValue == rhs
-    }
-
-    static func == (lhs: Int, rhs: Self) -> Bool {
-        return lhs == rhs.rawValue
-    }
-
-    static func ~= (lhs: Self, rhs: Int) -> Bool {
-        return lhs.rawValue == rhs
+    static func isSuccess(_ code: Int) -> Bool {
+        return (200..<300).contains(code)
     }
 }
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR changes the way REST API client handles HTTP status codes, by basically treating all `2xx` response codes as successful to improve resilience towards any potential changes in the API status codes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3214)
<!-- Reviewable:end -->
