### PR TITLE
Add WireGuard multihop setting and selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add information about the always on kill switch in the desktop app.
+- Add WireGuard multihop setting and entry location selection to desktop app.
 
 #### macOS
 - Add an opt-in feature to leak macOS network check traffic in blocked states to resolve issues with

--- a/gui/locales/da/messages.po
+++ b/gui/locales/da/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Bemærk: aktivering af dette medfører, at der altid kræves en Mullvad VPN-forbindelse for at oprette forbindelse til internettet."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Aktivér alligevel"
 
@@ -437,10 +436,10 @@ msgstr "Du er klar!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s via %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s via %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Vælg sprog"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Indgang"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Udgang"
 

--- a/gui/locales/de/messages.po
+++ b/gui/locales/de/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Achtung: Wenn Sie diese Einstellung aktivieren, wird immer eine Mullvad VPN-Verbindung erfordert, um das Internet zu erreichen."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Trotzdem aktivieren"
 
@@ -437,10 +436,10 @@ msgstr "Sie sind startklar!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s über %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s über %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Sprache auswählen"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Eingang"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Ausgang"
 

--- a/gui/locales/es/messages.po
+++ b/gui/locales/es/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Atención: Si activa esta opción, se exigirá siempre el uso de una conexión de Mullvad VPN para conectarse a Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Habilitar de todos modos"
 
@@ -437,10 +436,10 @@ msgstr "¡Ya está!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s a través de %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s a través de %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Seleccionar idioma"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Entrada"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Salida"
 

--- a/gui/locales/fi/messages.po
+++ b/gui/locales/fi/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Huomio: jos tämä otetaan käyttöön, verkkoon yhdistäminen vaatii aina Mullvad VPN -yhteyden."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Ota silti käyttöön"
 
@@ -437,10 +436,10 @@ msgstr "Olet valmis!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s, yhteys: %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s, yhteys: %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Valitse kieli"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Tulo"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Lähtö"
 

--- a/gui/locales/fr/messages.po
+++ b/gui/locales/fr/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Attention : si vous activez cette option, les connexions à Internet nécessiteront toujours une connexion Mullvad VPN."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Activer quand même"
 
@@ -437,10 +436,10 @@ msgstr "Tout est prêt !"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s via %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s via %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Sélectionner la langue"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Entrée"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Sortie"
 

--- a/gui/locales/it/messages.po
+++ b/gui/locales/it/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Attenzione: abilitando questa opzione, si richiederà sempre una connessione Mullvad VPN per navigare in Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Abilita comunque"
 
@@ -437,10 +436,10 @@ msgstr "È tutto pronto!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s tramite %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s tramite %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Seleziona lingua"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Ingresso"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Uscita"
 

--- a/gui/locales/ja/messages.po
+++ b/gui/locales/ja/messages.po
@@ -258,7 +258,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "注意：この設定を有効化すると、インターネットにアクセスするために常にMullvad VPNへの接続が必要になります。"
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "それでも有効化する"
 
@@ -434,10 +433,10 @@ msgstr "準備完了！"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(bridge)s経由で%(relay)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(entry)s経由で%(relay)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -921,11 +920,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "言語を選択"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "入口"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "出口"
 

--- a/gui/locales/ko/messages.po
+++ b/gui/locales/ko/messages.po
@@ -250,7 +250,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "주의: 이 기능을 사용하려면 인터넷 연결을 위해 항상 Mullvad VPN 연결이 필요합니다."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "그래도 사용"
 
@@ -426,10 +425,10 @@ msgstr "준비가 완료되었습니다!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(bridge)s을(를) 통한 %(relay)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(entry)s을(를) 통한 %(relay)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -913,11 +912,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "언어 선택"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "시작"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "종료"
 

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -105,6 +105,9 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
+msgid "Enable anyway"
+msgstr ""
+
 msgid "FAILED TO SECURE CONNECTION"
 msgstr ""
 
@@ -157,6 +160,10 @@ msgid "System default"
 msgstr ""
 
 msgid "TCP"
+msgstr ""
+
+#. Warning text in a dialog that is displayed after a setting is toggled.
+msgid "This setting increases latency. Use only if needed."
 msgstr ""
 
 msgid "UDP"
@@ -267,15 +274,16 @@ msgid "Attention: enabling this will always require a Mullvad VPN connection in 
 msgstr ""
 
 msgctxt "advanced-settings-view"
-msgid "Enable anyway"
-msgstr ""
-
-msgctxt "advanced-settings-view"
 msgid "Enable IPv6"
 msgstr ""
 
 msgctxt "advanced-settings-view"
 msgid "Enable IPv6 communication through the tunnel."
+msgstr ""
+
+#. The label next to the multihop settings toggle.
+msgctxt "advanced-settings-view"
+msgid "Enable multihop"
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -288,6 +296,11 @@ msgstr ""
 
 msgctxt "advanced-settings-view"
 msgid "If you disconnect or quit the app, this setting will block your internet."
+msgstr ""
+
+#. Description for multihop settings toggle.
+msgctxt "advanced-settings-view"
+msgid "Increases anonymity by routing your traffic into one WireGuard server and out another, making it harder to trace."
 msgstr ""
 
 msgctxt "advanced-settings-view"
@@ -442,9 +455,9 @@ msgstr ""
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
+msgid "%(relay)s via %(entry)s"
 msgstr ""
 
 #. The tunnel type line displayed below the hostname line on the main screen
@@ -775,6 +788,12 @@ msgctxt "openvpn-settings-view"
 msgid "Bridge mode"
 msgstr ""
 
+#. This is used as a description for the bridge mode
+#. setting.
+msgctxt "openvpn-settings-view"
+msgid "Helps circumvent censorship, by routing your traffic through a bridge server before reaching an OpenVPN server. Obfuscation is added to make fingerprinting harder."
+msgstr ""
+
 msgctxt "openvpn-settings-view"
 msgid "Mssfix"
 msgstr ""
@@ -789,6 +808,12 @@ msgstr ""
 #. %(min)d - the minimum possible mssfix value
 msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
+msgstr ""
+
+#. This is used to instruct users how to make the bridge
+#. mode setting available.
+msgctxt "openvpn-settings-view"
+msgid "To activate Bridge mode, go back and change **Tunnel protocol** to **OpenVPN**."
 msgstr ""
 
 msgctxt "openvpn-settings-view"
@@ -945,21 +970,30 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr ""
 
-msgctxt "select-location-nav"
-msgid "Entry"
-msgstr ""
-
-msgctxt "select-location-nav"
-msgid "Exit"
-msgstr ""
-
 #. Title label in navigation bar
 msgctxt "select-location-nav"
 msgid "Select location"
 msgstr ""
 
+#. This is used for appending information about a location.
+#. E.g. "Gothenburg (Entry)" if Gothenburg has been selected as the entrypoint.
+#. Available placeholders:
+#. %(location)s - Translated location name
+#. %(info)s - Information about the location
+msgctxt "select-location-view"
+msgid "%(location)s (%(info)s)"
+msgstr ""
+
 msgctxt "select-location-view"
 msgid "Closest to exit server"
+msgstr ""
+
+msgctxt "select-location-view"
+msgid "Entry"
+msgstr ""
+
+msgctxt "select-location-view"
+msgid "Exit"
 msgstr ""
 
 msgctxt "select-location-view"
@@ -981,6 +1015,10 @@ msgstr ""
 
 msgctxt "select-location-view"
 msgid "While connected, your traffic will be routed through two secure locations, the entry point (a bridge server) and the exit point (a VPN server)."
+msgstr ""
+
+msgctxt "select-location-view"
+msgid "While connected, your traffic will be routed through two secure locations, the entry point and the exit point (needs to be two different VPN servers)."
 msgstr ""
 
 #. Navigation button to the 'Account' view

--- a/gui/locales/my/messages.po
+++ b/gui/locales/my/messages.po
@@ -250,7 +250,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "သတိပြုရန်- ၎င်းကို ဖွင့်ခြင်းဖြင့် အင်တာနက် သုံးရန်အတွက် Mullvad VPN ချိတ်ဆက်မှုကို အမြဲ လိုအပ်ပါမည်။"
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "မည်သို့ပင်ဖြစ်စေ ဖွင့်ရန်"
 
@@ -426,10 +425,10 @@ msgstr "အားလုံး သတ်မှတ်ပြီးပါပြီ�
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(bridge)s မှတစ်ဆင့် %(relay)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(entry)s မှတစ်ဆင့် %(relay)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -913,11 +912,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "ဘာသာစကား ရွေးရန်"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "အဝင်"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "အထွက်"
 

--- a/gui/locales/nb/messages.po
+++ b/gui/locales/nb/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Advarsel: Hvis du aktiverer dette, må du alltid ha en Mullvad VPN-tilkobling for å være tilkoblet internett."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Aktiver uansett"
 
@@ -437,10 +436,10 @@ msgstr "Du er klar!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s via %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s via %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Velg språk"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Inngang"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Utgang"
 

--- a/gui/locales/nl/messages.po
+++ b/gui/locales/nl/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Opgelet: dit inschakelen vereist altijd een Mullvad VPN-verbinding om het internet te bereiken."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Toch inschakelen"
 
@@ -437,10 +436,10 @@ msgstr "U bent er helmaal klaar voor!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s via %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s via %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Taal selecteren"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Ingang"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Uitgang"
 

--- a/gui/locales/pl/messages.po
+++ b/gui/locales/pl/messages.po
@@ -283,7 +283,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Uwaga: wskutek włączenia tej opcji w celu uzyskania dostępu do Internetu zawsze wymagane będzie połączenie przez Mullvad VPN."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Mimo to włącz"
 
@@ -459,10 +458,10 @@ msgstr "Wszystko gotowe!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s przez %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s przez %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -946,11 +945,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Wybierz język"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Wejście"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Wyjście"
 

--- a/gui/locales/pt/messages.po
+++ b/gui/locales/pt/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Atenção: ativar esta opção exige sempre uma ligação através de Mullvad VPN para aceder à Internet."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Ativar mesmo assim"
 
@@ -437,10 +436,10 @@ msgstr "Está pronto!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s via %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s via %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Selecionar idioma"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Entrada"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Saída"
 

--- a/gui/locales/ru/messages.po
+++ b/gui/locales/ru/messages.po
@@ -283,7 +283,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Внимание: при активации этого параметра для выхода в Интернет необходимо будет обязательно подключиться через Mullvad VPN."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Всё равно активировать"
 
@@ -459,10 +458,10 @@ msgstr "Готово!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s через %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s через %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -946,11 +945,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Выбрать язык"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Вход"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Выход"
 

--- a/gui/locales/sv/messages.po
+++ b/gui/locales/sv/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Obs! Om du aktiverar detta kommer det alltid att krävas en Mullvad VPN-anslutning för att nå internet."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Aktivera ändå"
 
@@ -437,10 +436,10 @@ msgstr "Du är klar!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s via %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s via %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Välj språk"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Ingång"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Utgång"
 

--- a/gui/locales/th/messages.po
+++ b/gui/locales/th/messages.po
@@ -250,7 +250,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "โปรดทราบ: การเปิดใช้งานสิ่งนี้จะทำให้คุณจำเป็นต้องเชื่อมต่อ Mullvad VPN ไว้ตลอดเวลา เพื่อที่จะเข้าถึงอินเทอร์เน็ต"
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "เปิดใช้งานต่อไป"
 
@@ -426,10 +425,10 @@ msgstr "คุณพร้อมแล้ว!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s ผ่าน %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s ผ่าน %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -913,11 +912,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "เลือกภาษา"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "เข้า"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "ออก"
 

--- a/gui/locales/tr/messages.po
+++ b/gui/locales/tr/messages.po
@@ -261,7 +261,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "Dikkat: bu seçeneğin etkinleştirilmesi, internete erişim için her zaman bir Mullvad VPN bağlantısı gerektirir."
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "Yine de etkinleştir"
 
@@ -437,10 +436,10 @@ msgstr "Hazırsınız!"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(bridge)s aracılığıyla %(relay)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(entry)s aracılığıyla %(relay)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -924,11 +923,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "Dili seçin"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "Giriş"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "Çıkış"
 

--- a/gui/locales/zh-CN/messages.po
+++ b/gui/locales/zh-CN/messages.po
@@ -250,7 +250,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "注意：启用此选项后，将始终需要 Mullvad VPN 才能连接到网络。"
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "仍然启用"
 
@@ -426,10 +425,10 @@ msgstr "您已设置完毕！"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s，经由 %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s，经由 %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -913,11 +912,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "选择语言"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "入口"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "出口"
 

--- a/gui/locales/zh-TW/messages.po
+++ b/gui/locales/zh-TW/messages.po
@@ -250,7 +250,6 @@ msgctxt "advanced-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr "注意：啟用此功能，皆需 Mullvad VPN 連線才能上網。"
 
-msgctxt "advanced-settings-view"
 msgid "Enable anyway"
 msgstr "仍然啟用"
 
@@ -426,10 +425,10 @@ msgstr "您已設定完畢！"
 #. The hostname line displayed below the country on the main screen
 #. Available placeholders:
 #. %(relay)s - the relay hostname
-#. %(bridge)s - the bridge hostname
+#. %(entry)s - the entry relay hostname
 msgctxt "connection-info"
-msgid "%(relay)s via %(bridge)s"
-msgstr "%(relay)s 透過 %(bridge)s"
+msgid "%(relay)s via %(entry)s"
+msgstr "%(relay)s 透過 %(entry)s"
 
 #. The tunnel type line displayed below the hostname line on the main screen
 #. Available placeholders:
@@ -913,11 +912,11 @@ msgctxt "select-language-nav"
 msgid "Select language"
 msgstr "選擇語言"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Entry"
 msgstr "入口"
 
-msgctxt "select-location-nav"
+msgctxt "select-location-view"
 msgid "Exit"
 msgstr "出口"
 

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -907,11 +907,7 @@ class ApplicationMain {
   ) {
     this.relays = newRelayList;
 
-    const filteredRelays = this.processRelaysForPresentation(
-      newRelayList,
-      relaySettings,
-      bridgeState,
-    );
+    const filteredRelays = this.processRelaysForPresentation(newRelayList, relaySettings);
     const filteredBridges = this.processBridgesForPresentation(newRelayList, bridgeState);
 
     if (this.windowController) {
@@ -925,7 +921,6 @@ class ApplicationMain {
   private processRelaysForPresentation(
     relayList: IRelayList,
     relaySettings: RelaySettings,
-    bridgeState: BridgeState,
   ): IRelayList {
     const tunnelProtocol =
       'normal' in relaySettings ? liftConstraint(relaySettings.normal.tunnelProtocol) : undefined;
@@ -945,14 +940,16 @@ class ApplicationMain {
                   case 'wireguard':
                     return relay.tunnels.wireguard.length > 0;
 
-                  case 'any':
-                    // TODO: Drop win32 check when Wireguard becomes default on Windows
-                    if (process.platform === 'win32' || bridgeState === 'on') {
-                      return relay.tunnels.openvpn.length > 0;
+                  case 'any': {
+                    const useMultihop =
+                      'normal' in relaySettings &&
+                      relaySettings.normal.wireguardConstraints.useMultihop;
+                    if (useMultihop) {
+                      return relay.tunnels.wireguard.length > 0;
                     } else {
                       return relay.tunnels.openvpn.length > 0 || relay.tunnels.wireguard.length > 0;
                     }
-
+                  }
                   default:
                     return false;
                 }
@@ -1153,11 +1150,7 @@ class ApplicationMain {
       tunnelState: this.tunnelState,
       settings: this.settings,
       relayListPair: {
-        relays: this.processRelaysForPresentation(
-          this.relays,
-          this.settings.relaySettings,
-          this.settings.bridgeState,
-        ),
+        relays: this.processRelaysForPresentation(this.relays, this.settings.relaySettings),
         bridges: this.processBridgesForPresentation(this.relays, this.settings.bridgeState),
       },
       currentVersion: this.currentVersion,

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -158,6 +158,8 @@ class ApplicationMain {
         wireguardConstraints: {
           port: 'any',
           ipVersion: 'any',
+          useMultihop: false,
+          entryLocation: 'any',
         },
       },
     },

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -624,6 +624,8 @@ export default class AppRenderer {
           wireguard: {
             port: liftConstraint(wireguardConstraints.port),
             ipVersion: liftConstraint(wireguardConstraints.ipVersion),
+            useMultihop: wireguardConstraints.useMultihop,
+            entryLocation: liftConstraint(wireguardConstraints.entryLocation),
           },
           tunnelProtocol: liftConstraint(tunnelProtocol),
         },

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -236,7 +236,7 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
         type={ModalAlertType.caution}
         buttons={[
           <AppButton.RedButton key="confirm" onClick={this.confirmEnableBlockWhenDisconnected}>
-            {messages.pgettext('advanced-settings-view', 'Enable anyway')}
+            {messages.gettext('Enable anyway')}
           </AppButton.RedButton>,
           <AppButton.BlueButton key="back" onClick={this.hideConfirmBlockWhenDisconnectedAlert}>
             {messages.gettext('Back')}

--- a/gui/src/renderer/components/BridgeLocations.tsx
+++ b/gui/src/renderer/components/BridgeLocations.tsx
@@ -17,6 +17,7 @@ export enum SpecialBridgeLocationType {
 
 interface IBridgeLocationsProps {
   source: IRelayLocationRedux[];
+  locale: string;
   defaultExpandedLocations?: RelayLocation[];
   selectedValue?: LiftedConstraint<RelayLocation>;
   selectedElementRef?: React.Ref<React.ReactInstance>;
@@ -53,6 +54,7 @@ const BridgeLocations = React.forwardRef(function BridgeLocationsT(
       </SpecialLocations>
       <RelayLocations
         source={props.source}
+        locale={props.locale}
         onWillExpand={props.onWillExpand}
         onTransitionEnd={props.onTransitionEnd}
       />

--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import { default as ConnectionPanelDisclosure } from '../components/ConnectionPanelDisclosure';
+import Marquee from './Marquee';
 
 export interface IEndpoint {
   ip: string;
@@ -82,7 +83,7 @@ export default class ConnectionPanel extends React.Component<IProps> {
         {this.props.hostname && (
           <Header>
             <ConnectionPanelDisclosure pointsUp={this.props.isOpen} onToggle={this.props.onToggle}>
-              {this.hostnameLine()}
+              <Marquee>{this.hostnameLine()}</Marquee>
             </ConnectionPanelDisclosure>
           </Header>
         )}

--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -35,6 +35,7 @@ interface IProps {
   isOpen: boolean;
   hostname?: string;
   bridgeHostname?: string;
+  entryHostname?: string;
   inAddress?: IInAddress;
   entryLocationInAddress?: IInAddress;
   bridgeInfo?: IBridgeData;
@@ -132,15 +133,20 @@ export default class ConnectionPanel extends React.Component<IProps> {
 
   private hostnameLine() {
     if (this.props.hostname && this.props.bridgeHostname) {
+      return sprintf(messages.pgettext('connection-info', '%(relay)s via %(entry)s'), {
+        relay: this.props.hostname,
+        entry: this.props.bridgeHostname,
+      });
+    } else if (this.props.hostname && this.props.entryHostname) {
       return sprintf(
         // TRANSLATORS: The hostname line displayed below the country on the main screen
         // TRANSLATORS: Available placeholders:
         // TRANSLATORS: %(relay)s - the relay hostname
-        // TRANSLATORS: %(bridge)s - the bridge hostname
-        messages.pgettext('connection-info', '%(relay)s via %(bridge)s'),
+        // TRANSLATORS: %(entry)s - the entry relay hostname
+        messages.pgettext('connection-info', '%(relay)s via %(entry)s'),
         {
           relay: this.props.hostname,
-          bridge: this.props.bridgeHostname,
+          entry: this.props.entryHostname,
         },
       );
     } else {

--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -36,6 +36,7 @@ interface IProps {
   hostname?: string;
   bridgeHostname?: string;
   inAddress?: IInAddress;
+  entryLocationInAddress?: IInAddress;
   bridgeInfo?: IBridgeData;
   outAddress?: IOutAddress;
   onToggle: () => void;
@@ -72,8 +73,8 @@ const Header = styled.div({
 
 export default class ConnectionPanel extends React.Component<IProps> {
   public render() {
-    const { inAddress, outAddress, bridgeInfo } = this.props;
-    const entryPoint = bridgeInfo && inAddress ? bridgeInfo : inAddress;
+    const { outAddress } = this.props;
+    const entryPoint = this.getEntryPoint();
 
     return (
       <div className={this.props.className}>
@@ -115,6 +116,18 @@ export default class ConnectionPanel extends React.Component<IProps> {
         )}
       </div>
     );
+  }
+
+  private getEntryPoint() {
+    const { inAddress, entryLocationInAddress, bridgeInfo } = this.props;
+
+    if (entryLocationInAddress && inAddress) {
+      return entryLocationInAddress;
+    } else if (bridgeInfo && inAddress) {
+      return bridgeInfo;
+    } else {
+      return inAddress;
+    }
   }
 
   private hostnameLine() {

--- a/gui/src/renderer/components/ConnectionPanelDisclosure.tsx
+++ b/gui/src/renderer/components/ConnectionPanelDisclosure.tsx
@@ -6,13 +6,15 @@ import ImageView from './ImageView';
 const Container = styled.div({
   display: 'flex',
   alignItems: 'center',
+  width: '100%',
 });
 
-const Caption = styled.span((props: { open: boolean }) => ({
+const Caption = styled.span({}, (props: { open: boolean }) => ({
   fontFamily: 'Open Sans',
   fontSize: '15px',
   fontWeight: 600,
   lineHeight: '20px',
+  minWidth: '0px',
   color: props.open ? colors.white : colors.white40,
   [Container + ':hover &']: {
     color: colors.white,
@@ -28,7 +30,7 @@ const Chevron = styled(ImageView)({
 interface IProps {
   pointsUp: boolean;
   onToggle?: () => void;
-  children: React.ReactText;
+  children: React.ReactNode;
   className?: string;
 }
 

--- a/gui/src/renderer/components/LocationList.tsx
+++ b/gui/src/renderer/components/LocationList.tsx
@@ -421,10 +421,18 @@ export class RelayLocations extends React.PureComponent<IRelayLocationsProps> {
     }
 
     return info !== undefined
-      ? sprintf(messages.pgettext('select-location-view', '%(location)s (%(info)s)'), {
-          location: translatedName,
-          info,
-        })
+      ? sprintf(
+          // TRANSLATORS: This is used for appending information about a location.
+          // TRANSLATORS: E.g. "Gothenburg (Entry)" if Gothenburg has been selected as the entrypoint.
+          // TRANSLATORS: Available placeholders:
+          // TRANSLATORS: %(location)s - Translated location name
+          // TRANSLATORS: %(info)s - Information about the location
+          messages.pgettext('select-location-view', '%(location)s (%(info)s)'),
+          {
+            location: translatedName,
+            info,
+          },
+        )
       : translatedName;
   }
 

--- a/gui/src/renderer/components/LocationList.tsx
+++ b/gui/src/renderer/components/LocationList.tsx
@@ -281,17 +281,55 @@ interface IRelayLocationsProps {
   onTransitionEnd?: () => void;
 }
 
+interface Relay extends IRelayLocationRelayRedux {
+  label: string;
+  disabled: boolean;
+}
+
+interface City extends Omit<IRelayLocationCityRedux, 'relays'> {
+  label: string;
+  active: boolean;
+  disabled: boolean;
+  relays: Array<Relay>;
+}
+
+interface Country extends Omit<IRelayLocationRedux, 'cities'> {
+  label: string;
+  active: boolean;
+  disabled: boolean;
+  cities: Array<City>;
+}
+
+type CountryList = Array<Country>;
+
+interface IRelayLocationsState {
+  countries: CountryList;
+}
+
 interface ICommonCellProps {
   location: RelayLocation;
   selected: boolean;
   ref?: React.Ref<HTMLDivElement>;
 }
 
-export class RelayLocations extends React.PureComponent<IRelayLocationsProps> {
+export class RelayLocations extends React.PureComponent<
+  IRelayLocationsProps,
+  IRelayLocationsState
+> {
+  public state = {
+    countries: this.prepareRelaysForPresentation(this.props.source),
+  };
+
+  public componentDidUpdate(prevProps: IRelayLocationsProps) {
+    if (this.props.source !== prevProps.source) {
+      this.setState({ countries: this.prepareRelaysForPresentation(this.props.source) });
+    }
+  }
+
   public render() {
     return (
       <>
-        {this.prepareRelaysForPresentation(this.props.source).map((relayCountry) => {
+        {this.state.countries.map((relayCountry) => {
           const countryLocation: RelayLocation = { country: relayCountry.code };
 
           return (
@@ -349,7 +387,7 @@ export class RelayLocations extends React.PureComponent<IRelayLocationsProps> {
     );
   }
 
-  private prepareRelaysForPresentation(relayList: IRelayLocationRedux[]) {
+  private prepareRelaysForPresentation(relayList: IRelayLocationRedux[]): CountryList {
     return relayList
       .map((country) => {
         const countryDisabled = this.isCountryDisabled(country, country.code);

--- a/gui/src/renderer/components/LocationRow.tsx
+++ b/gui/src/renderer/components/LocationRow.tsx
@@ -67,6 +67,7 @@ const Label = styled(Cell.Label)({
 interface IProps {
   name: string;
   active: boolean;
+  disabled: boolean;
   location: RelayLocation;
   selected: boolean;
   expanded?: boolean;
@@ -105,13 +106,13 @@ function LocationRow(props: IProps, ref: React.Ref<HTMLDivElement>) {
       <Container
         ref={ref}
         selected={props.selected}
-        disabled={!props.active}
+        disabled={props.disabled}
         location={props.location}>
         <Button
           ref={buttonRef}
           onClick={handleClick}
           location={props.location}
-          disabled={!props.active}>
+          disabled={props.disabled}>
           <RelayStatusIndicator active={props.active} selected={props.selected} />
           <Label>{props.name}</Label>
         </Button>
@@ -149,6 +150,7 @@ function compareProps(oldProps: IProps, nextProps: IProps): boolean {
     React.Children.count(oldProps.children) === React.Children.count(nextProps.children) &&
     oldProps.name === nextProps.name &&
     oldProps.active === nextProps.active &&
+    oldProps.disabled === nextProps.disabled &&
     oldProps.selected === nextProps.selected &&
     oldProps.expanded === nextProps.expanded &&
     oldProps.onSelect === nextProps.onSelect &&

--- a/gui/src/renderer/components/Locations.tsx
+++ b/gui/src/renderer/components/Locations.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { RelayLocation } from '../../shared/daemon-rpc-types';
 import { IRelayLocationRedux } from '../redux/settings/reducers';
 import LocationList, {
+  DisabledReason,
   LocationSelection,
   LocationSelectionType,
   RelayLocations,
@@ -9,8 +10,10 @@ import LocationList, {
 
 interface ILocationsProps {
   source: IRelayLocationRedux[];
+  locale: string;
   defaultExpandedLocations?: RelayLocation[];
   selectedValue?: RelayLocation;
+  disabledLocation?: { location: RelayLocation; reason: DisabledReason };
   selectedElementRef?: React.Ref<React.ReactInstance>;
   onSelect?: (value: LocationSelection<never>) => void;
   onWillExpand?: (locationRect: DOMRect, expandedContentHeight: number) => void;
@@ -31,6 +34,8 @@ function Locations(props: ILocationsProps, ref: React.Ref<LocationList<never>>) 
       onSelect={props.onSelect}>
       <RelayLocations
         source={props.source}
+        locale={props.locale}
+        disabledLocation={props.disabledLocation}
         onWillExpand={props.onWillExpand}
         onTransitionEnd={props.onTransitionEnd}
       />

--- a/gui/src/renderer/components/Locations.tsx
+++ b/gui/src/renderer/components/Locations.tsx
@@ -7,7 +7,7 @@ import LocationList, {
   RelayLocations,
 } from './LocationList';
 
-interface IExitLocationsProps {
+interface ILocationsProps {
   source: IRelayLocationRedux[];
   defaultExpandedLocations?: RelayLocation[];
   selectedValue?: RelayLocation;
@@ -17,10 +17,7 @@ interface IExitLocationsProps {
   onTransitionEnd?: () => void;
 }
 
-const ExitLocations = React.forwardRef(function ExitLocationsT(
-  props: IExitLocationsProps,
-  ref: React.Ref<LocationList<never>>,
-) {
+function Locations(props: ILocationsProps, ref: React.Ref<LocationList<never>>) {
   const selectedValue: LocationSelection<never> | undefined = props.selectedValue
     ? { type: LocationSelectionType.relay, value: props.selectedValue }
     : undefined;
@@ -39,6 +36,7 @@ const ExitLocations = React.forwardRef(function ExitLocationsT(
       />
     </LocationList>
   );
-});
+}
 
-export default ExitLocations;
+export const ExitLocations = React.forwardRef(Locations);
+export const EntryLocations = React.forwardRef(Locations);

--- a/gui/src/renderer/components/OpenVPNSettings.tsx
+++ b/gui/src/renderer/components/OpenVPNSettings.tsx
@@ -183,10 +183,9 @@ export default class OpenVpnSettings extends React.Component<IProps, IState> {
                               'openvpn-settings-view',
                               'Helps circumvent censorship, by routing your traffic through a bridge server before reaching an OpenVPN server. Obfuscation is added to make fingerprinting harder.',
                             )
-                          : // This line is here to prevent prettier from moving up the next line.
-                            // TRANSLATORS: This is used to instruct users how to make the bridge
-                            // TRANSLATORS: mode setting available.
-                            formatMarkdown(
+                          : formatMarkdown(
+                              // TRANSLATORS: This is used to instruct users how to make the bridge
+                              // TRANSLATORS: mode setting available.
                               messages.pgettext(
                                 'openvpn-settings-view',
                                 'To activate Bridge mode, go back and change **Tunnel protocol** to **OpenVPN**.',

--- a/gui/src/renderer/components/SelectLocation.tsx
+++ b/gui/src/renderer/components/SelectLocation.tsx
@@ -212,10 +212,10 @@ export default class SelectLocation extends React.Component<IProps, IState> {
                       defaultSelectedIndex={this.state.locationScope}
                       onChange={this.onChangeLocationScope}>
                       <ScopeBarItem>
-                        {messages.pgettext('select-location-nav', 'Entry')}
+                        {messages.pgettext('select-location-view', 'Entry')}
                       </ScopeBarItem>
                       <ScopeBarItem>
-                        {messages.pgettext('select-location-nav', 'Exit')}
+                        {messages.pgettext('select-location-view', 'Exit')}
                       </ScopeBarItem>
                     </StyledScopeBar>
                   )}

--- a/gui/src/renderer/components/SelectLocation.tsx
+++ b/gui/src/renderer/components/SelectLocation.tsx
@@ -9,7 +9,11 @@ import { CustomScrollbarsRef } from './CustomScrollbars';
 import { EntryLocations, ExitLocations } from './Locations';
 import ImageView from './ImageView';
 import { Layout } from './Layout';
-import LocationList, { LocationSelection, LocationSelectionType } from './LocationList';
+import LocationList, {
+  DisabledReason,
+  LocationSelection,
+  LocationSelectionType,
+} from './LocationList';
 import {
   CloseBarItem,
   NavigationBar,
@@ -36,6 +40,7 @@ import {
 import { HeaderSubTitle, HeaderTitle } from './SettingsHeader';
 
 interface IProps {
+  locale: string;
   selectedExitLocation?: RelayLocation;
   selectedEntryLocation?: RelayLocation;
   selectedBridgeLocation?: LiftedConstraint<RelayLocation>;
@@ -283,26 +288,42 @@ export default class SelectLocation extends React.Component<IProps, IState> {
 
   private renderLocationList() {
     if (this.state.locationScope === LocationScope.exit) {
+      const disabledLocation = this.props.selectedEntryLocation
+        ? {
+            location: this.props.selectedEntryLocation,
+            reason: DisabledReason.entry,
+          }
+        : undefined;
       return (
         <ExitLocations
           ref={this.exitLocationList}
           source={this.props.relayLocations}
+          locale={this.props.locale}
           defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
           selectedValue={this.props.selectedExitLocation}
           selectedElementRef={this.selectedExitLocationRef}
+          disabledLocation={disabledLocation}
           onSelect={this.onSelectExitLocation}
           onWillExpand={this.onWillExpand}
           onTransitionEnd={this.resetHeight}
         />
       );
     } else if (this.props.tunnelProtocol === 'any' || this.props.tunnelProtocol === 'wireguard') {
+      const disabledLocation = this.props.selectedExitLocation
+        ? {
+            location: this.props.selectedExitLocation,
+            reason: DisabledReason.exit,
+          }
+        : undefined;
       return (
         <EntryLocations
           ref={this.entryLocationList}
           source={this.props.relayLocations}
+          locale={this.props.locale}
           defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
           selectedValue={this.props.selectedEntryLocation}
           selectedElementRef={this.selectedEntryLocationRef}
+          disabledLocation={disabledLocation}
           onSelect={this.onSelectEntryLocation}
           onWillExpand={this.onWillExpand}
           onTransitionEnd={this.resetHeight}
@@ -313,6 +334,7 @@ export default class SelectLocation extends React.Component<IProps, IState> {
         <BridgeLocations
           ref={this.bridgeLocationList}
           source={this.props.bridgeLocations}
+          locale={this.props.locale}
           defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
           selectedValue={this.props.selectedBridgeLocation}
           selectedElementRef={this.selectedBridgeLocationRef}

--- a/gui/src/renderer/components/SelectLocation.tsx
+++ b/gui/src/renderer/components/SelectLocation.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { sprintf } from 'sprintf-js';
 import { colors } from '../../config.json';
-import { LiftedConstraint, RelayLocation } from '../../shared/daemon-rpc-types';
+import { LiftedConstraint, RelayLocation, TunnelProtocol } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import { IRelayLocationRedux } from '../redux/settings/reducers';
-import { LocationScope } from '../redux/userinterface/reducers';
 import BridgeLocations, { SpecialBridgeLocationType } from './BridgeLocations';
 import { CustomScrollbarsRef } from './CustomScrollbars';
-import ExitLocations from './ExitLocations';
+import { EntryLocations, ExitLocations } from './Locations';
 import ImageView from './ImageView';
 import { Layout } from './Layout';
 import LocationList, { LocationSelection, LocationSelectionType } from './LocationList';
@@ -37,25 +36,32 @@ import {
 import { HeaderSubTitle, HeaderTitle } from './SettingsHeader';
 
 interface IProps {
-  locationScope: LocationScope;
   selectedExitLocation?: RelayLocation;
+  selectedEntryLocation?: RelayLocation;
   selectedBridgeLocation?: LiftedConstraint<RelayLocation>;
   relayLocations: IRelayLocationRedux[];
   bridgeLocations: IRelayLocationRedux[];
-  allowBridgeSelection: boolean;
+  allowEntrySelection: boolean;
+  tunnelProtocol: LiftedConstraint<TunnelProtocol>;
   providers: string[];
   onClose: () => void;
   onViewFilterByProvider: () => void;
-  onChangeLocationScope: (location: LocationScope) => void;
   onSelectExitLocation: (location: RelayLocation) => void;
+  onSelectEntryLocation: (location: RelayLocation) => void;
   onSelectBridgeLocation: (location: RelayLocation) => void;
   onSelectClosestToExit: () => void;
   onClearProviders: () => void;
 }
 
+enum LocationScope {
+  entry = 0,
+  exit,
+}
+
 interface IState {
   showFilterMenu: boolean;
   headingHeight: number;
+  locationScope: LocationScope;
 }
 
 interface ISelectLocationSnapshot {
@@ -64,17 +70,19 @@ interface ISelectLocationSnapshot {
 }
 
 export default class SelectLocation extends React.Component<IProps, IState> {
-  public state = { showFilterMenu: false, headingHeight: 0 };
+  public state = { showFilterMenu: false, headingHeight: 0, locationScope: LocationScope.exit };
 
   private scrollView = React.createRef<CustomScrollbarsRef>();
   private spacePreAllocationViewRef = React.createRef<SpacePreAllocationView>();
   private selectedExitLocationRef = React.createRef<React.ReactInstance>();
+  private selectedEntryLocationRef = React.createRef<React.ReactInstance>();
   private selectedBridgeLocationRef = React.createRef<React.ReactInstance>();
 
   private exitLocationList = React.createRef<LocationList<never>>();
+  private entryLocationList = React.createRef<LocationList<never>>();
   private bridgeLocationList = React.createRef<LocationList<SpecialBridgeLocationType>>();
 
-  private snapshotByScope: { [index: number]: ISelectLocationSnapshot } = {};
+  private snapshotByScope: Partial<Record<LocationScope, ISelectLocationSnapshot>> = {};
 
   private filterButtonRef = React.createRef<HTMLDivElement>();
   private headerRef = React.createRef<HTMLHeadingElement>();
@@ -87,25 +95,25 @@ export default class SelectLocation extends React.Component<IProps, IState> {
   }
 
   public componentDidUpdate(
-    prevProps: IProps,
-    _prevState: unknown,
+    _prevProps: IProps,
+    prevState: IState,
     snapshot?: ISelectLocationSnapshot,
   ) {
-    if (this.props.locationScope !== prevProps.locationScope) {
-      this.restoreScrollPosition(this.props.locationScope);
+    if (this.state.locationScope !== prevState.locationScope) {
+      this.restoreScrollPosition(this.state.locationScope);
 
       if (snapshot) {
-        this.snapshotByScope[prevProps.locationScope] = snapshot;
+        this.snapshotByScope[prevState.locationScope] = snapshot;
       }
     }
   }
 
-  public getSnapshotBeforeUpdate(prevProps: IProps): ISelectLocationSnapshot | undefined {
+  public getSnapshotBeforeUpdate(
+    prevProps: IProps,
+    prevState: IState,
+  ): ISelectLocationSnapshot | undefined {
     const scrollView = this.scrollView.current;
-    const locationList =
-      prevProps.locationScope === LocationScope.relay
-        ? this.exitLocationList.current
-        : this.bridgeLocationList.current;
+    const locationList = this.getLocationListRef(prevProps, prevState);
 
     if (scrollView && locationList) {
       return {
@@ -164,13 +172,7 @@ export default class SelectLocation extends React.Component<IProps, IState> {
                         messages.pgettext('select-location-view', 'Select location')
                       }
                     </HeaderTitle>
-                    <HeaderSubTitle>
-                      {this.props.allowBridgeSelection &&
-                        messages.pgettext(
-                          'select-location-view',
-                          'While connected, your traffic will be routed through two secure locations, the entry point (a bridge server) and the exit point (a VPN server).',
-                        )}
-                    </HeaderSubTitle>
+                    {this.renderHeaderSubtitle()}
                   </StyledSettingsHeader>
 
                   {this.props.providers.length > 0 && (
@@ -200,10 +202,10 @@ export default class SelectLocation extends React.Component<IProps, IState> {
                       </StyledProvidersCount>
                     </StyledProviderCountRow>
                   )}
-                  {this.props.allowBridgeSelection && (
+                  {this.props.allowEntrySelection && (
                     <StyledScopeBar
-                      defaultSelectedIndex={this.props.locationScope}
-                      onChange={this.props.onChangeLocationScope}>
+                      defaultSelectedIndex={this.state.locationScope}
+                      onChange={this.onChangeLocationScope}>
                       <ScopeBarItem>
                         {messages.pgettext('select-location-nav', 'Entry')}
                       </ScopeBarItem>
@@ -214,31 +216,7 @@ export default class SelectLocation extends React.Component<IProps, IState> {
                   )}
                 </StyledNavigationBarAttachment>
 
-                <StyledContent>
-                  {this.props.locationScope === LocationScope.relay ? (
-                    <ExitLocations
-                      ref={this.exitLocationList}
-                      source={this.props.relayLocations}
-                      defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
-                      selectedValue={this.props.selectedExitLocation}
-                      selectedElementRef={this.selectedExitLocationRef}
-                      onSelect={this.onSelectExitLocation}
-                      onWillExpand={this.onWillExpand}
-                      onTransitionEnd={this.resetHeight}
-                    />
-                  ) : (
-                    <BridgeLocations
-                      ref={this.bridgeLocationList}
-                      source={this.props.bridgeLocations}
-                      defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
-                      selectedValue={this.props.selectedBridgeLocation}
-                      selectedElementRef={this.selectedBridgeLocationRef}
-                      onSelect={this.onSelectBridgeLocation}
-                      onWillExpand={this.onWillExpand}
-                      onTransitionEnd={this.resetHeight}
-                    />
-                  )}
-                </StyledContent>
+                <StyledContent>{this.renderLocationList()}</StyledContent>
               </SpacePreAllocationView>
             </NavigationScrollbars>
           </NavigationContainer>
@@ -257,12 +235,101 @@ export default class SelectLocation extends React.Component<IProps, IState> {
     }
   }
 
+  private getLocationListRef(prevProps: IProps, prevState: IState) {
+    if (prevState.locationScope === LocationScope.exit) {
+      return this.exitLocationList.current;
+    } else if (prevProps.tunnelProtocol === 'wireguard') {
+      return this.entryLocationList.current;
+    } else {
+      return this.bridgeLocationList.current;
+    }
+  }
+
+  private getSelectedLocationRef() {
+    if (this.state.locationScope === LocationScope.exit) {
+      return this.selectedExitLocationRef.current;
+    } else if (this.props.tunnelProtocol === 'wireguard') {
+      return this.selectedEntryLocationRef.current;
+    } else {
+      return this.selectedBridgeLocationRef.current;
+    }
+  }
+
+  private renderHeaderSubtitle() {
+    if (this.props.allowEntrySelection) {
+      if (this.props.tunnelProtocol === 'openvpn') {
+        return (
+          <HeaderSubTitle>
+            {messages.pgettext(
+              'select-location-view',
+              'While connected, your traffic will be routed through two secure locations, the entry point (a bridge server) and the exit point (a VPN server).',
+            )}
+          </HeaderSubTitle>
+        );
+      } else {
+        return (
+          <HeaderSubTitle>
+            {messages.pgettext(
+              'select-location-view',
+              'While connected, your traffic will be routed through two secure locations, the entry point and the exit point (needs to be two different VPN servers).',
+            )}
+          </HeaderSubTitle>
+        );
+      }
+    } else {
+      return null;
+    }
+  }
+
+  private renderLocationList() {
+    if (this.state.locationScope === LocationScope.exit) {
+      return (
+        <ExitLocations
+          ref={this.exitLocationList}
+          source={this.props.relayLocations}
+          defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
+          selectedValue={this.props.selectedExitLocation}
+          selectedElementRef={this.selectedExitLocationRef}
+          onSelect={this.onSelectExitLocation}
+          onWillExpand={this.onWillExpand}
+          onTransitionEnd={this.resetHeight}
+        />
+      );
+    } else if (this.props.tunnelProtocol === 'any' || this.props.tunnelProtocol === 'wireguard') {
+      return (
+        <EntryLocations
+          ref={this.entryLocationList}
+          source={this.props.relayLocations}
+          defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
+          selectedValue={this.props.selectedEntryLocation}
+          selectedElementRef={this.selectedEntryLocationRef}
+          onSelect={this.onSelectEntryLocation}
+          onWillExpand={this.onWillExpand}
+          onTransitionEnd={this.resetHeight}
+        />
+      );
+    } else {
+      return (
+        <BridgeLocations
+          ref={this.bridgeLocationList}
+          source={this.props.bridgeLocations}
+          defaultExpandedLocations={this.getExpandedLocationsFromSnapshot()}
+          selectedValue={this.props.selectedBridgeLocation}
+          selectedElementRef={this.selectedBridgeLocationRef}
+          onSelect={this.onSelectBridgeLocation}
+          onWillExpand={this.onWillExpand}
+          onTransitionEnd={this.resetHeight}
+        />
+      );
+    }
+  }
+
   private resetHeight = () => {
     this.spacePreAllocationViewRef.current?.reset();
   };
 
   private getExpandedLocationsFromSnapshot(): RelayLocation[] | undefined {
-    const snapshot = this.snapshotByScope[this.props.locationScope];
+    const snapshot = this.snapshotByScope[this.state.locationScope];
     if (snapshot) {
       return snapshot.expandedLocations;
     } else {
@@ -278,10 +345,7 @@ export default class SelectLocation extends React.Component<IProps, IState> {
   }
 
   private scrollToSelectedCell() {
-    const ref =
-      this.props.locationScope === LocationScope.relay
-        ? this.selectedExitLocationRef.current
-        : this.selectedBridgeLocationRef.current;
+    const ref = this.getSelectedLocationRef();
     const scrollView = this.scrollView.current;
 
     if (scrollView) {
@@ -295,10 +359,18 @@ export default class SelectLocation extends React.Component<IProps, IState> {
     }
   }
 
+  private onChangeLocationScope = (locationScope: LocationScope) => {
+    this.setState({ locationScope });
+  };
+
   private onSelectExitLocation = (location: LocationSelection<never>) => {
     if (location.type === LocationSelectionType.relay) {
       this.props.onSelectExitLocation(location.value);
     }
+  };
+
+  private onSelectEntryLocation = (location: LocationSelection<never>) => {
+    this.props.onSelectEntryLocation(location.value);
   };
 
   private onSelectBridgeLocation = (location: LocationSelection<SpecialBridgeLocationType>) => {

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -3,9 +3,11 @@ import { sprintf } from 'sprintf-js';
 import styled from 'styled-components';
 import { IpVersion } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
+import * as AppButton from './AppButton';
 import { AriaDescription, AriaInput, AriaInputGroup, AriaLabel } from './AriaGroup';
 import * as Cell from './cell';
 import { Layout, SettingsContainer } from './Layout';
+import { ModalAlert, ModalAlertType, ModalContainer } from './Modal';
 import {
   BackBarItem,
   NavigationBar,
@@ -16,6 +18,7 @@ import {
 } from './NavigationBar';
 import Selector, { ISelectorItem } from './cell/Selector';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
+import Switch from './Switch';
 
 const MIN_WIREGUARD_MTU_VALUE = 1280;
 const MAX_WIREGUARD_MTU_VALUE = 1420;
@@ -47,13 +50,24 @@ export const StyledInputFrame = styled(Cell.InputFrame)({
 interface IProps {
   wireguard: { port?: number; ipVersion?: IpVersion };
   wireguardMtu?: number;
+  wireguardMultihop: boolean;
   setWireguardMtu: (value: number | undefined) => void;
-  setWireguardRelayPortAndIpVersion: (port?: number, ipVersion?: IpVersion) => void;
+  setWireguardMultihop: (value: boolean) => void;
+  setWireguardPort: (port?: number) => void;
+  setWireguardIpVersion: (ipVersion?: IpVersion) => void;
   onViewWireguardKeys: () => void;
   onClose: () => void;
 }
 
-export default class WireguardSettings extends React.Component<IProps> {
+interface IState {
+  showMultihopConfirmationDialog: boolean;
+}
+
+export default class WireguardSettings extends React.Component<IProps, IState> {
+  public state = { showMultihopConfirmationDialog: false };
+
+  private multihopRef = React.createRef<Switch>();
+
   private wireguardPortItems: Array<ISelectorItem<OptionalPort>>;
   private wireguardIpVersionItems: Array<ISelectorItem<OptionalIpVersion>>;
 
@@ -87,149 +101,172 @@ export default class WireguardSettings extends React.Component<IProps> {
 
   public render() {
     return (
-      <Layout>
-        <SettingsContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={this.props.onClose}>
-                  {
-                    // TRANSLATORS: Back button in navigation bar
-                    messages.pgettext('navigation-bar', 'Advanced')
-                  }
-                </BackBarItem>
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('wireguard-settings-nav', 'WireGuard settings')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <ModalContainer>
+        <Layout>
+          <SettingsContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <BackBarItem action={this.props.onClose}>
+                    {
+                      // TRANSLATORS: Back button in navigation bar
+                      messages.pgettext('navigation-bar', 'Advanced')
+                    }
+                  </BackBarItem>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('wireguard-settings-nav', 'WireGuard settings')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <StyledNavigationScrollbars>
-              <SettingsHeader>
-                <HeaderTitle>
-                  {messages.pgettext('wireguard-settings-view', 'WireGuard settings')}
-                </HeaderTitle>
-              </SettingsHeader>
+              <StyledNavigationScrollbars>
+                <SettingsHeader>
+                  <HeaderTitle>
+                    {messages.pgettext('wireguard-settings-view', 'WireGuard settings')}
+                  </HeaderTitle>
+                </SettingsHeader>
 
-              <AriaInputGroup>
-                <StyledSelectorContainer>
-                  <StyledSelectorForFooter
-                    // TRANSLATORS: The title for the WireGuard port selector.
-                    title={messages.pgettext('wireguard-settings-view', 'Port')}
-                    values={this.wireguardPortItems}
-                    value={this.props.wireguard.port}
-                    onSelect={this.onSelectWireguardPort}
-                  />
-                </StyledSelectorContainer>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {
-                        // TRANSLATORS: The hint displayed below the WireGuard port selector.
-                        messages.pgettext(
-                          'wireguard-settings-view',
-                          'The automatic setting will randomly choose from a wide range of ports.',
-                        )
-                      }
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
+                <AriaInputGroup>
+                  <StyledSelectorContainer>
+                    <StyledSelectorForFooter
+                      // TRANSLATORS: The title for the WireGuard port selector.
+                      title={messages.pgettext('wireguard-settings-view', 'Port')}
+                      values={this.wireguardPortItems}
+                      value={this.props.wireguard.port}
+                      onSelect={this.props.setWireguardPort}
+                    />
+                  </StyledSelectorContainer>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {
+                          // TRANSLATORS: The hint displayed below the WireGuard port selector.
+                          messages.pgettext(
+                            'wireguard-settings-view',
+                            'The automatic setting will randomly choose from a wide range of ports.',
+                          )
+                        }
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
 
-              <AriaInputGroup>
-                <StyledSelectorContainer>
-                  <StyledSelectorForFooter
-                    // TRANSLATORS: The title for the WireGuard IP version selector.
-                    title={messages.pgettext('wireguard-settings-view', 'IP version')}
-                    values={this.wireguardIpVersionItems}
-                    value={this.props.wireguard.ipVersion}
-                    onSelect={this.onSelectWireguardIpVersion}
-                  />
-                </StyledSelectorContainer>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {
-                        // TRANSLATORS: The hint displayed below the WireGuard IP version selector.
-                        messages.pgettext(
-                          'wireguard-settings-view',
-                          'This allows access to WireGuard for devices that only support IPv6.',
-                        )
-                      }
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
-
-              <Cell.CellButtonGroup>
-                <Cell.CellButton onClick={this.props.onViewWireguardKeys}>
-                  <Cell.Label>
-                    {messages.pgettext('wireguard-settings-view', 'WireGuard key')}
-                  </Cell.Label>
-                  <Cell.Icon height={12} width={7} source="icon-chevron" />
-                </Cell.CellButton>
-              </Cell.CellButtonGroup>
-
-              <AriaInputGroup>
-                <Cell.Container>
-                  <AriaLabel>
-                    <Cell.InputLabel>
-                      {messages.pgettext('wireguard-settings-view', 'MTU')}
-                    </Cell.InputLabel>
-                  </AriaLabel>
-                  <StyledInputFrame>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('advanced-settings-view', 'Enable multihop')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
                     <AriaInput>
-                      <Cell.AutoSizingTextInput
-                        value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
-                        inputMode={'numeric'}
-                        maxLength={4}
-                        placeholder={messages.gettext('Default')}
-                        onSubmitValue={this.onWireguardMtuSubmit}
-                        validateValue={WireguardSettings.wireguarMtuIsValid}
-                        submitOnBlur={true}
-                        modifyValue={WireguardSettings.removeNonNumericCharacters}
+                      <Cell.Switch
+                        ref={this.multihopRef}
+                        isOn={this.props.wireguardMultihop}
+                        onChange={this.setWireguardMultihop}
                       />
                     </AriaInput>
-                  </StyledInputFrame>
-                </Cell.Container>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {sprintf(
-                        // TRANSLATORS: The hint displayed below the WireGuard MTU input field.
-                        // TRANSLATORS: Available placeholders:
-                        // TRANSLATORS: %(max)d - the maximum possible wireguard mtu value
-                        // TRANSLATORS: %(min)d - the minimum possible wireguard mtu value
-                        messages.pgettext(
-                          'wireguard-settings-view',
-                          'Set WireGuard MTU value. Valid range: %(min)d - %(max)d.',
-                        ),
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'advanced-settings-view',
+                          'Increases anonymity by routing your traffic into one WireGuard server and out another, making it harder to trace.',
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <StyledSelectorContainer>
+                    <StyledSelectorForFooter
+                      // TRANSLATORS: The title for the WireGuard IP version selector.
+                      title={messages.pgettext('wireguard-settings-view', 'IP version')}
+                      values={this.wireguardIpVersionItems}
+                      value={this.props.wireguard.ipVersion}
+                      onSelect={this.props.setWireguardIpVersion}
+                    />
+                  </StyledSelectorContainer>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
                         {
-                          min: MIN_WIREGUARD_MTU_VALUE,
-                          max: MAX_WIREGUARD_MTU_VALUE,
-                        },
-                      )}
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </SettingsContainer>
-      </Layout>
+                          // TRANSLATORS: The hint displayed below the WireGuard IP version selector.
+                          messages.pgettext(
+                            'wireguard-settings-view',
+                            'This allows access to WireGuard for devices that only support IPv6.',
+                          )
+                        }
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <Cell.CellButtonGroup>
+                  <Cell.CellButton onClick={this.props.onViewWireguardKeys}>
+                    <Cell.Label>
+                      {messages.pgettext('wireguard-settings-view', 'WireGuard key')}
+                    </Cell.Label>
+                    <Cell.Icon height={12} width={7} source="icon-chevron" />
+                  </Cell.CellButton>
+                </Cell.CellButtonGroup>
+
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('wireguard-settings-view', 'MTU')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <StyledInputFrame>
+                      <AriaInput>
+                        <Cell.AutoSizingTextInput
+                          value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
+                          inputMode={'numeric'}
+                          maxLength={4}
+                          placeholder={messages.gettext('Default')}
+                          onSubmitValue={this.onWireguardMtuSubmit}
+                          validateValue={WireguardSettings.wireguarMtuIsValid}
+                          submitOnBlur={true}
+                          modifyValue={WireguardSettings.removeNonNumericCharacters}
+                        />
+                      </AriaInput>
+                    </StyledInputFrame>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {sprintf(
+                          // TRANSLATORS: The hint displayed below the WireGuard MTU input field.
+                          // TRANSLATORS: Available placeholders:
+                          // TRANSLATORS: %(max)d - the maximum possible wireguard mtu value
+                          // TRANSLATORS: %(min)d - the minimum possible wireguard mtu value
+                          messages.pgettext(
+                            'wireguard-settings-view',
+                            'Set WireGuard MTU value. Valid range: %(min)d - %(max)d.',
+                          ),
+                          {
+                            min: MIN_WIREGUARD_MTU_VALUE,
+                            max: MAX_WIREGUARD_MTU_VALUE,
+                          },
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </SettingsContainer>
+        </Layout>
+
+        {this.state.showMultihopConfirmationDialog && this.renderMultihopConfirmation()}
+      </ModalContainer>
     );
   }
-
-  private onSelectWireguardPort = (port?: number) => {
-    this.props.setWireguardRelayPortAndIpVersion(port, this.props.wireguard.ipVersion);
-  };
-
-  private onSelectWireguardIpVersion = (ipVersion?: IpVersion) => {
-    this.props.setWireguardRelayPortAndIpVersion(this.props.wireguard.port, ipVersion);
-  };
 
   private static removeNonNumericCharacters(value: string) {
     return value.replace(/[^0-9]/g, '');
@@ -249,4 +286,39 @@ export default class WireguardSettings extends React.Component<IProps> {
       (parsedMtu >= MIN_WIREGUARD_MTU_VALUE && parsedMtu <= MAX_WIREGUARD_MTU_VALUE)
     );
   }
+
+  private renderMultihopConfirmation = () => {
+    return (
+      <ModalAlert
+        type={ModalAlertType.info}
+        message={messages.gettext('This setting increases latency. Use only if needed.')}
+        buttons={[
+          <AppButton.RedButton key="confirm" onClick={this.confirmWireguardMultihop}>
+            {messages.gettext('Enable anyway')}
+          </AppButton.RedButton>,
+          <AppButton.BlueButton key="back" onClick={this.hideWireguardMultihopConfirmationDialog}>
+            {messages.gettext('Back')}
+          </AppButton.BlueButton>,
+        ]}
+        close={this.hideWireguardMultihopConfirmationDialog}></ModalAlert>
+    );
+  };
+
+  private setWireguardMultihop = (newValue: boolean) => {
+    if (newValue) {
+      this.setState({ showMultihopConfirmationDialog: true });
+    } else {
+      this.props.setWireguardMultihop(false);
+    }
+  };
+
+  private hideWireguardMultihopConfirmationDialog = () => {
+    this.setState({ showMultihopConfirmationDialog: false });
+    this.multihopRef.current?.setOn(this.props.wireguardMultihop);
+  };
+
+  private confirmWireguardMultihop = () => {
+    this.setState({ showMultihopConfirmationDialog: false });
+    this.props.setWireguardMultihop(true);
+  };
 }

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -158,7 +158,10 @@ export default class WireguardSettings extends React.Component<IProps, IState> {
                   <Cell.Container>
                     <AriaLabel>
                       <Cell.InputLabel>
-                        {messages.pgettext('advanced-settings-view', 'Enable multihop')}
+                        {
+                          // TRANSLATORS: The label next to the multihop settings toggle.
+                          messages.pgettext('advanced-settings-view', 'Enable multihop')
+                        }
                       </Cell.InputLabel>
                     </AriaLabel>
                     <AriaInput>
@@ -172,10 +175,13 @@ export default class WireguardSettings extends React.Component<IProps, IState> {
                   <Cell.Footer>
                     <AriaDescription>
                       <Cell.FooterText>
-                        {messages.pgettext(
-                          'advanced-settings-view',
-                          'Increases anonymity by routing your traffic into one WireGuard server and out another, making it harder to trace.',
-                        )}
+                        {
+                          // TRANSLATORS: Description for multihop settings toggle.
+                          messages.pgettext(
+                            'advanced-settings-view',
+                            'Increases anonymity by routing your traffic into one WireGuard server and out another, making it harder to trace.',
+                          )
+                        }
                       </Cell.FooterText>
                     </AriaDescription>
                   </Cell.Footer>
@@ -291,7 +297,10 @@ export default class WireguardSettings extends React.Component<IProps, IState> {
     return (
       <ModalAlert
         type={ModalAlertType.info}
-        message={messages.gettext('This setting increases latency. Use only if needed.')}
+        message={
+          // TRANSLATORS: Warning text in a dialog that is displayed after a setting is toggled.
+          messages.gettext('This setting increases latency. Use only if needed.')
+        }
         buttons={[
           <AppButton.RedButton key="confirm" onClick={this.confirmWireguardMultihop}>
             {messages.gettext('Enable anyway')}

--- a/gui/src/renderer/containers/ConnectionPanelContainer.tsx
+++ b/gui/src/renderer/containers/ConnectionPanelContainer.tsx
@@ -76,6 +76,7 @@ const mapStateToProps = (state: IReduxState) => {
     isOpen: state.userInterface.connectionPanelVisible,
     hostname: state.connection.hostname,
     bridgeHostname: state.connection.bridgeHostname,
+    entryHostname: state.connection.entryHostname,
     inAddress,
     entryLocationInAddress,
     bridgeInfo,

--- a/gui/src/renderer/containers/ConnectionPanelContainer.tsx
+++ b/gui/src/renderer/containers/ConnectionPanelContainer.tsx
@@ -19,6 +19,22 @@ function tunnelEndpointToRelayInAddress(tunnelEndpoint: ITunnelEndpoint): IInAdd
   };
 }
 
+function tunnelEndpointToEntryLocationInAddress(
+  tunnelEndpoint: ITunnelEndpoint,
+): IInAddress | undefined {
+  if (!tunnelEndpoint.entryEndpoint) {
+    return undefined;
+  }
+
+  const socketAddr = parseSocketAddress(tunnelEndpoint.entryEndpoint.address);
+  return {
+    ip: socketAddr.host,
+    port: socketAddr.port,
+    protocol: tunnelEndpoint.entryEndpoint.transportProtocol,
+    tunnelType: tunnelEndpoint.tunnelType,
+  };
+}
+
 function tunnelEndpointToBridgeData(endpoint: ITunnelEndpoint): IBridgeData | undefined {
   if (!endpoint.proxy) {
     return undefined;
@@ -46,6 +62,11 @@ const mapStateToProps = (state: IReduxState) => {
       ? tunnelEndpointToRelayInAddress(status.details.endpoint)
       : undefined;
 
+  const entryLocationInAddress: IInAddress | undefined =
+    (status.state === 'connecting' || status.state === 'connected') && status.details
+      ? tunnelEndpointToEntryLocationInAddress(status.details.endpoint)
+      : undefined;
+
   const bridgeInfo: IBridgeData | undefined =
     (status.state === 'connecting' || status.state === 'connected') && status.details
       ? tunnelEndpointToBridgeData(status.details.endpoint)
@@ -56,6 +77,7 @@ const mapStateToProps = (state: IReduxState) => {
     hostname: state.connection.hostname,
     bridgeHostname: state.connection.bridgeHostname,
     inAddress,
+    entryLocationInAddress,
     bridgeInfo,
     outAddress,
   };

--- a/gui/src/renderer/containers/OpenVPNSettingsPage.tsx
+++ b/gui/src/renderer/containers/OpenVPNSettingsPage.tsx
@@ -13,10 +13,24 @@ const mapStateToProps = (state: IReduxState) => {
   const protocolAndPort = mapRelaySettingsToProtocolAndPort(state.settings.relaySettings);
 
   return {
+    tunnelProtocolIsOpenVpn: mapRelaySettingsToProtocol(state.settings.relaySettings) === 'openvpn',
     mssfix: state.settings.openVpn.mssfix,
     bridgeState: state.settings.bridgeState,
     ...protocolAndPort,
   };
+};
+
+const mapRelaySettingsToProtocol = (relaySettings: RelaySettingsRedux) => {
+  if ('normal' in relaySettings) {
+    const { tunnelProtocol } = relaySettings.normal;
+    return tunnelProtocol === 'any' ? undefined : tunnelProtocol;
+    // since the GUI doesn't display custom settings, just display the default ones.
+    // If the user sets any settings, then those will be applied.
+  } else if ('customTunnelEndpoint' in relaySettings) {
+    return undefined;
+  } else {
+    throw new Error('Unknown type of relay settings.');
+  }
 };
 
 const mapRelaySettingsToProtocolAndPort = (relaySettings: RelaySettingsRedux) => {

--- a/gui/src/renderer/containers/SelectLocationPage.tsx
+++ b/gui/src/renderer/containers/SelectLocationPage.tsx
@@ -1,21 +1,21 @@
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import BridgeSettingsBuilder from '../../shared/bridge-settings-builder';
 import { LiftedConstraint, RelayLocation } from '../../shared/daemon-rpc-types';
 import log from '../../shared/logging';
 import RelaySettingsBuilder from '../../shared/relay-settings-builder';
 import SelectLocation from '../components/SelectLocation';
 import withAppContext, { IAppContext } from '../context';
+import { createWireguardRelayUpdater } from '../lib/constraint-updater';
 import { IHistoryProps, withHistory } from '../lib/history';
 import { RoutePath } from '../lib/routes';
 import { IRelayLocationRedux } from '../redux/settings/reducers';
 import { IReduxState, ReduxDispatch } from '../redux/store';
-import userInterfaceActions from '../redux/userinterface/actions';
-import { LocationScope } from '../redux/userinterface/reducers';
 
-const mapStateToProps = (state: IReduxState) => {
+const mapStateToProps = (state: IReduxState, props: IHistoryProps & IAppContext) => {
   let selectedExitLocation: RelayLocation | undefined;
+  let selectedEntryLocation: RelayLocation | undefined;
   let selectedBridgeLocation: LiftedConstraint<RelayLocation> | undefined;
+  let multihopEnabled = false;
 
   if ('normal' in state.settings.relaySettings) {
     const exitLocation = state.settings.relaySettings.normal.location;
@@ -24,37 +24,57 @@ const mapStateToProps = (state: IReduxState) => {
     }
   }
 
-  if ('normal' in state.settings.bridgeSettings) {
+  const relaySettings = state.settings.relaySettings;
+  const tunnelProtocol = 'normal' in relaySettings ? relaySettings.normal.tunnelProtocol : 'any';
+
+  if (tunnelProtocol === 'openvpn' && 'normal' in state.settings.bridgeSettings) {
     selectedBridgeLocation = state.settings.bridgeSettings.normal.location;
+  } else if ('normal' in relaySettings) {
+    const entryLocation = relaySettings.normal.wireguard.entryLocation;
+    if (entryLocation !== 'any') {
+      selectedEntryLocation = entryLocation;
+    }
+
+    multihopEnabled = relaySettings.normal.wireguard.useMultihop;
   }
 
-  const allowBridgeSelection = state.settings.bridgeState === 'on';
-  const locationScope = allowBridgeSelection
-    ? state.userInterface.locationScope
-    : LocationScope.relay;
+  const allowEntrySelection =
+    (tunnelProtocol === 'openvpn' && state.settings.bridgeState === 'on') ||
+    ((tunnelProtocol === 'any' || tunnelProtocol === 'wireguard') && multihopEnabled);
 
-  const relaySettings = state.settings.relaySettings;
   const providers = 'normal' in relaySettings ? relaySettings.normal.providers : [];
 
   return {
     selectedExitLocation,
+    selectedEntryLocation,
     selectedBridgeLocation,
     relayLocations: filterLocationsByProvider(state.settings.relayLocations, providers),
     bridgeLocations: filterLocationsByProvider(state.settings.bridgeLocations, providers),
-    locationScope,
-    allowBridgeSelection,
+    allowEntrySelection,
+    tunnelProtocol,
     providers,
+
+    onSelectEntryLocation: async (entryLocation: RelayLocation) => {
+      // dismiss the view first
+      props.history.dismiss();
+
+      const relayUpdate = createWireguardRelayUpdater(state.settings.relaySettings)
+        .tunnel.wireguard((wireguard) => wireguard.entryLocation.exact(entryLocation))
+        .build();
+
+      try {
+        await props.app.updateRelaySettings(relayUpdate);
+      } catch (e) {
+        const error = e as Error;
+        log.error('Failed to select the entry location', error.message);
+      }
+    },
   };
 };
-const mapDispatchToProps = (dispatch: ReduxDispatch, props: IHistoryProps & IAppContext) => {
-  const userInterface = bindActionCreators(userInterfaceActions, dispatch);
-
+const mapDispatchToProps = (_dispatch: ReduxDispatch, props: IHistoryProps & IAppContext) => {
   return {
     onClose: () => props.history.dismiss(),
     onViewFilterByProvider: () => props.history.push(RoutePath.filterByProvider),
-    onChangeLocationScope: (scope: LocationScope) => {
-      userInterface.setLocationScope(scope);
-    },
     onSelectExitLocation: async (relayLocation: RelayLocation) => {
       // dismiss the view first
       props.history.dismiss();

--- a/gui/src/renderer/containers/SelectLocationPage.tsx
+++ b/gui/src/renderer/containers/SelectLocationPage.tsx
@@ -45,6 +45,7 @@ const mapStateToProps = (state: IReduxState, props: IHistoryProps & IAppContext)
   const providers = 'normal' in relaySettings ? relaySettings.normal.providers : [];
 
   return {
+    locale: state.userInterface.locale,
     selectedExitLocation,
     selectedEntryLocation,
     selectedBridgeLocation,

--- a/gui/src/renderer/lib/constraint-updater.ts
+++ b/gui/src/renderer/lib/constraint-updater.ts
@@ -1,0 +1,36 @@
+import { RelaySettingsRedux } from '../redux/settings/reducers';
+import RelaySettingsBuilder from '../../shared/relay-settings-builder';
+
+export function createWireguardRelayUpdater(
+  relaySettings: RelaySettingsRedux,
+): ReturnType<typeof RelaySettingsBuilder['normal']> {
+  if ('normal' in relaySettings) {
+    const constraints = relaySettings.normal.wireguard;
+
+    const relayUpdate = RelaySettingsBuilder.normal().tunnel.wireguard((wireguard) => {
+      if (constraints.port === 'any') {
+        wireguard.port.any();
+      } else {
+        wireguard.port.exact(constraints.port);
+      }
+
+      if (constraints.ipVersion === 'any') {
+        wireguard.ipVersion.any();
+      } else {
+        wireguard.ipVersion.exact(constraints.ipVersion);
+      }
+
+      wireguard.useMultihop(constraints.useMultihop);
+
+      if (constraints.entryLocation === 'any') {
+        wireguard.entryLocation.any();
+      } else if (constraints.entryLocation !== undefined) {
+        wireguard.entryLocation.exact(constraints.entryLocation);
+      }
+    });
+
+    return relayUpdate;
+  } else {
+    return RelaySettingsBuilder.normal();
+  }
+}

--- a/gui/src/renderer/redux/connection/reducers.ts
+++ b/gui/src/renderer/redux/connection/reducers.ts
@@ -8,6 +8,7 @@ export interface IConnectionReduxState {
   ipv6?: Ip;
   hostname?: string;
   bridgeHostname?: string;
+  entryHostname?: string;
   latitude?: number;
   longitude?: number;
   country?: string;
@@ -21,6 +22,7 @@ const initialState: IConnectionReduxState = {
   ipv6: undefined,
   hostname: undefined,
   bridgeHostname: undefined,
+  entryHostname: undefined,
   latitude: undefined,
   longitude: undefined,
   country: undefined,
@@ -43,6 +45,7 @@ export default function (
         longitude: action.newLocation.longitude,
         hostname: action.newLocation.hostname,
         bridgeHostname: action.newLocation.bridgeHostname,
+        entryHostname: action.newLocation.entryHostname,
       };
 
     case 'UPDATE_BLOCK_STATE':

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -27,6 +27,8 @@ export type RelaySettingsRedux =
         wireguard: {
           port: LiftedConstraint<number>;
           ipVersion: LiftedConstraint<IpVersion>;
+          useMultihop: boolean;
+          entryLocation: LiftedConstraint<RelayLocation>;
         };
       };
     }
@@ -161,7 +163,7 @@ const initialState: ISettingsReduxState = {
       location: 'any',
       tunnelProtocol: 'any',
       providers: [],
-      wireguard: { port: 'any', ipVersion: 'any' },
+      wireguard: { port: 'any', ipVersion: 'any', useMultihop: false, entryLocation: 'any' },
       openvpn: {
         port: 'any',
         protocol: 'any',

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -64,14 +64,12 @@ export interface IRelayLocationCityRedux {
   code: string;
   latitude: number;
   longitude: number;
-  hasActiveRelays: boolean;
   relays: IRelayLocationRelayRedux[];
 }
 
 export interface IRelayLocationRedux {
   name: string;
   code: string;
-  hasActiveRelays: boolean;
   cities: IRelayLocationCityRedux[];
 }
 

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -1,5 +1,4 @@
 import { MacOsScrollbarVisibility } from '../../../shared/ipc-schema';
-import { LocationScope } from './reducers';
 
 export interface IUpdateLocaleAction {
   type: 'UPDATE_LOCALE';
@@ -13,11 +12,6 @@ export interface IUpdateWindowArrowPositionAction {
 
 export interface IUpdateConnectionInfoOpenAction {
   type: 'TOGGLE_CONNECTION_PANEL';
-}
-
-export interface ISetLocationScopeAction {
-  type: 'SET_LOCATION_SCOPE';
-  scope: LocationScope;
 }
 
 export interface ISetWindowFocusedAction {
@@ -50,7 +44,6 @@ export type UserInterfaceAction =
   | IUpdateLocaleAction
   | IUpdateWindowArrowPositionAction
   | IUpdateConnectionInfoOpenAction
-  | ISetLocationScopeAction
   | ISetWindowFocusedAction
   | IAddScrollPosition
   | IRemoveScrollPosition
@@ -74,13 +67,6 @@ function updateWindowArrowPosition(arrowPosition: number): IUpdateWindowArrowPos
 function toggleConnectionPanel(): IUpdateConnectionInfoOpenAction {
   return {
     type: 'TOGGLE_CONNECTION_PANEL',
-  };
-}
-
-function setLocationScope(scope: LocationScope): ISetLocationScopeAction {
-  return {
-    type: 'SET_LOCATION_SCOPE',
-    scope,
   };
 }
 
@@ -126,7 +112,6 @@ export default {
   updateLocale,
   updateWindowArrowPosition,
   toggleConnectionPanel,
-  setLocationScope,
   setWindowFocused,
   addScrollPosition,
   removeScrollPosition,

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -1,16 +1,10 @@
 import { MacOsScrollbarVisibility } from '../../../shared/ipc-schema';
 import { ReduxAction } from '../store';
 
-export enum LocationScope {
-  bridge = 0,
-  relay,
-}
-
 export interface IUserInterfaceReduxState {
   locale: string;
   arrowPosition?: number;
   connectionPanelVisible: boolean;
-  locationScope: LocationScope;
   windowFocused: boolean;
   scrollPosition: Record<string, [number, number]>;
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
@@ -20,7 +14,6 @@ export interface IUserInterfaceReduxState {
 const initialState: IUserInterfaceReduxState = {
   locale: 'en',
   connectionPanelVisible: false,
-  locationScope: LocationScope.relay,
   windowFocused: false,
   scrollPosition: {},
   macOsScrollbarVisibility: undefined,
@@ -40,9 +33,6 @@ export default function (
 
     case 'TOGGLE_CONNECTION_PANEL':
       return { ...state, connectionPanelVisible: !state.connectionPanelVisible };
-
-    case 'SET_LOCATION_SCOPE':
-      return { ...state, locationScope: action.scope };
 
     case 'SET_WINDOW_FOCUSED':
       return { ...state, windowFocused: action.focused };

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -14,6 +14,7 @@ export interface ILocation {
   mullvadExitIp: boolean;
   hostname?: string;
   bridgeHostname?: string;
+  entryHostname?: string;
   provider?: string;
 }
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -88,6 +88,12 @@ export interface ITunnelEndpoint {
   protocol: RelayProtocol;
   tunnelType: TunnelType;
   proxy?: IProxyEndpoint;
+  entryEndpoint?: IEndpoint;
+}
+
+export interface IEndpoint {
+  address: string;
+  transportProtocol: RelayProtocol;
 }
 
 export interface IProxyEndpoint {
@@ -133,6 +139,8 @@ export interface IOpenVpnConstraints {
 export interface IWireguardConstraints {
   port: Constraint<number>;
   ipVersion: Constraint<IpVersion>;
+  useMultihop: boolean;
+  entryLocation: Constraint<RelayLocation>;
 }
 
 export type TunnelProtocol = 'wireguard' | 'openvpn';

--- a/gui/src/shared/relay-settings-builder.ts
+++ b/gui/src/shared/relay-settings-builder.ts
@@ -3,6 +3,7 @@ import {
   IOpenVpnConstraints,
   IpVersion,
   IWireguardConstraints,
+  RelayLocation,
   RelayProtocol,
   RelaySettingsNormalUpdate,
   RelaySettingsUpdate,
@@ -23,6 +24,8 @@ interface IOpenVPNConfigurator {
 interface IWireguardConfigurator {
   port: IExactOrAny<number, IWireguardConfigurator>;
   ipVersion: IExactOrAny<IpVersion, IWireguardConfigurator>;
+  useMultihop: (value: boolean) => IWireguardConfigurator;
+  entryLocation: IExactOrAny<RelayLocation, IWireguardConfigurator>;
 }
 
 interface ITunnelProtocolConfigurator {
@@ -134,6 +137,22 @@ class NormalRelaySettingsBuilder {
             };
             return {
               exact: (value: IpVersion) => apply({ only: value }),
+              any: () => apply('any'),
+            };
+          },
+          get useMultihop() {
+            return (useMultihop: boolean) => {
+              updateWireguard({ useMultihop });
+              return this;
+            };
+          },
+          get entryLocation() {
+            const apply = (entryLocation: Constraint<RelayLocation> | undefined) => {
+              updateWireguard({ entryLocation });
+              return this;
+            };
+            return {
+              exact: (entryLocation: RelayLocation) => apply({ only: entryLocation }),
               any: () => apply('any'),
             };
           },

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -627,9 +627,7 @@ impl RelaySettingsUpdate {
                 endpoint.endpoint().protocol == TransportProtocol::Tcp
             }
             RelaySettingsUpdate::Normal(update) => {
-                if let Some(Constraint::Only(TunnelType::Wireguard)) = &update.tunnel_protocol {
-                    false
-                } else if let Some(constraints) = &update.openvpn_constraints {
+                if let Some(constraints) = &update.openvpn_constraints {
                     if let Constraint::Only(TransportPort {
                         protocol: TransportProtocol::Udp,
                         ..


### PR DESCRIPTION
This PR adds a setting under `WireGuard settings` for WireGuard multihop and makes it possible to select the entry location in the location selector.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3215)
<!-- Reviewable:end -->
