### PR TITLE
Cleanup build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,7 +130,7 @@ elif [[ ("$(uname -s)" == "MINGW"*) ]]; then
     )
 fi
 
-function restore_metadata_backups() {
+function restore_metadata_backups {
     pushd "$SCRIPT_DIR"
     echo "Restoring version metadata files..."
     ./version-metadata.sh restore-backup --desktop
@@ -143,7 +143,7 @@ echo "Updating version in metadata files..."
 cp Cargo.lock Cargo.lock.bak
 ./version-metadata.sh inject "$PRODUCT_VERSION" --desktop
 
-function sign_win() {
+function sign_win {
     local NUM_RETRIES=3
 
     for binary in "$@"; do
@@ -170,7 +170,7 @@ function sign_win() {
     return 0
 }
 
-function build() {
+function build {
     local current_target=${1:-""}
     local for_target_string=""
     if [[ -n $current_target ]]; then
@@ -238,7 +238,7 @@ function build() {
     done
 }
 
-function buildTargets() {
+function buildTargets {
     if [[ -n ${TARGET:-""} ]]; then
         for t in ${TARGET[*]}; do
             source env.sh "$t"

--- a/build.sh
+++ b/build.sh
@@ -238,18 +238,6 @@ function build {
     done
 }
 
-function buildTargets {
-    if [[ -n ${TARGET:-""} ]]; then
-        for t in ${TARGET[*]}; do
-            source env.sh "$t"
-            build "$t"
-        done
-    else
-        source env.sh ""
-        build
-    fi
-}
-
 if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "Linux" ]]; then
     mkdir -p "dist-assets/shell-completions"
     for sh in bash zsh fish; do
@@ -262,7 +250,16 @@ fi
 ./update-relays.sh
 ./update-api-address.sh
 
-buildTargets
+# Compile for all defined targets, or the current architecture if unspecified.
+if [[ -n ${TARGET:-""} ]]; then
+    for t in ${TARGET[*]}; do
+        source env.sh "$t"
+        build "$t"
+    done
+else
+    source env.sh ""
+    build
+fi
 
 if [[ "$BUILD_MODE" == "release" && "$(uname -s)" == "MINGW"* ]]; then
     signdep=(


### PR DESCRIPTION
Tiny cleanup before larger refactoring of this script. Just adhering better to function style as defined in https://github.com/mullvad/coding-guidelines/

I also removed the function `buildTargets` because:
* It was only called once (no code reuse from being a function)
* It was depending on global state (`TARGET`) so sliighlty confusing
* I did not see any clear advantages of it being a function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3219)
<!-- Reviewable:end -->
