### PR TITLE
Make build.sh produce single architecture pkg by default (add --universal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ Building this requires at least 1GB of memory.
 
 #### macOS
 
-By default a universal app is built on macOS. To build specifically for x86_64 or ARM64 add
-`--target x86_64-apple-darwin` or `--target aarch64-apple-darwin`.
+By default, `build.sh` produces a pkg for your current architecture only. To build a universal
+app that works on both Intel and Apple Silicon macs, build with `--universal`.
 
 ##### Apple ARM64 (aka Apple Silicon)
 

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -107,7 +107,12 @@ build_ref() {
       nvm install --latest-npm
   fi
 
-  ./build.sh || return 0
+  BUILD_ARGS=()
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    BUILD_ARGS+=(--universal)
+  fi
+  ./build.sh "${BUILD_ARGS[@]}" || return 0
+
   case "$(uname -s)" in
     MINGW*|MSYS_NT*)
       echo "Packaging all PDB files..."

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -8,7 +8,6 @@ const { version } = require('../package.json');
 const compression = process.argv.includes('--no-compression') ? 'store' : 'normal';
 const noAppleNotarization = process.argv.includes('--no-apple-notarization');
 
-const arm64 = process.argv.includes('--arm64');
 const universal = process.argv.includes('--universal');
 
 const config = {
@@ -299,8 +298,6 @@ function root(relativePath) {
 function getMacArch() {
   if (universal) {
     return 'universal';
-  } else if (arm64) {
-    return 'arm64';
   } else {
     // Not specifying an arch makes Electron builder build for the arch it's running on.
     return undefined;


### PR DESCRIPTION
In order to make it easier to use `build.sh` while developing we make it the default to build for the current architecture only. Since currently developers type `build.sh --target ..-darwin-...` every time. Add --universal flag for building universal app for both Intel and Apple Silicon. Make the build server script use the new flag, so it keeps producing universal binaries.

Maybe it's a little strange to carry around the `TARGETS` variable now when it's only ever used to list the two macOS target triples if it should be built for both.. But maybe it's worth keeping? I guess we are not sure how we will build arm64 Linux later? Or do you have another design that you prefer?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3221)
<!-- Reviewable:end -->
