### PR TITLE
Disable background throttling while resetting navigation while in background

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -177,7 +177,9 @@ export default class AppRenderer {
       this.reduxActions.userInterface.setMacOsScrollbarVisibility(visibility);
     });
 
-    IpcRendererEventChannel.navigation.listenReset(() => this.history.dismiss(true));
+    IpcRendererEventChannel.navigation.listenReset(() =>
+      this.history.dismiss(true, transitions.none),
+    );
 
     // Request the initial state from the main process
     const initialState = IpcRendererEventChannel.state.get();

--- a/gui/src/renderer/lib/history.tsx
+++ b/gui/src/renderer/lib/history.tsx
@@ -88,9 +88,9 @@ export default class History {
     this.notify(transitions.show);
   };
 
-  public dismiss = (all?: boolean) => {
+  public dismiss = (all?: boolean, transition = transitions.dismiss) => {
     if (this.popImpl(all ? this.index : 1)) {
-      this.notify(transitions.dismiss);
+      this.notify(transition);
     }
   };
 


### PR DESCRIPTION
This PR disabled background throttling of the renderer process during the `navigation.notifyReset` call is made. This is to allow the UI to update and perform the navigation while the window isn't visible. Without this the previous view will be visible for a split second when opening the window after resetting.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3223)
<!-- Reviewable:end -->
