### PR TITLE
Fix notifications on Windows when unpinned window is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix daemon not starting if all excluded app paths reside on non-existent/unmounted volumes.
 - Remove tray icon of current running app version when upgrading.
 - Allow Mullvad wireguard-nt tunnels to work simultaneously with other wg-nt tunnels.
+- Fix notifications on Windows not showing if window is unpinned and hidden.
 
 #### Android
 - Fix Quick Settings tile showing wrong state in certain scenarios.

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -179,7 +179,7 @@ export default class WindowController {
   }
 
   public isVisible(): boolean {
-    return this.window?.isVisible() ?? false;
+    return this.window !== undefined && this.window.isVisible() && !this.window.isMinimized();
   }
 
   public updatePosition() {


### PR DESCRIPTION
This PR fixes a bug which prevented notifications from showing on Windows if the window was unpinned and hidden (not closed). The problem was the `window.isVisible()` returns `true` when the Window is minimized. To solve this `&& !window.isMinimized()` has been added.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3225)
<!-- Reviewable:end -->
