### PR TITLE
Better build.sh logging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -194,6 +194,8 @@ function sign_win {
     return 0
 }
 
+# Build the daemon and other Rust/C++ binaries, optionally
+# sign them, strip them of debug symbols and copy to `dist-assets/`.
 function build {
     local current_target=${1:-""}
     local for_target_string=""

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,35 @@
 
 set -eu
 
+function log {
+    local NO_COLOR="0m"
+    local msg=$1
+    local color=${2:-"$NO_COLOR"}
+    echo -e "\033[$color$msg\033[$NO_COLOR"
+}
+
+function log_header {
+    local YELLOW="33m"
+    echo ""
+    log "### $1 ###" $YELLOW
+    echo ""
+}
+
+function log_success {
+    local GREEN="32m"
+    log "$1" $GREEN
+}
+
+function log_error {
+    local RED="31m"
+    log "!! $1" $RED
+}
+
+function log_info {
+    local BOLD="1m"
+    log "$1" $BOLD
+}
+
 ################################################################################
 # Verify and configure environment.
 ################################################################################
@@ -31,12 +60,12 @@ while [[ "$#" -gt 0 ]]; do
                 TARGETS=(x86_64-apple-darwin aarch64-apple-darwin)
                 NPM_PACK_ARGS+=(--universal)
             else
-                echo "--universal only works on macOS"
+                log_error "--universal only works on macOS"
                 exit 1
             fi
             ;;
         *)
-            echo "Unknown parameter: $1"
+            log_error "Unknown parameter: $1"
             exit 1
             ;;
     esac
@@ -45,17 +74,16 @@ done
 
 if [[ "$BUILD_MODE" == "release" ]]; then
     if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
-        echo "Dirty working directory!"
-        echo "You should only build releases in clean working directories in order to make it"
-        echo "easier to reproduce the same build."
+        log_error "Dirty working directory!"
+        log_error "Will only build a signed app in a clean working directory"
         exit 1
     fi
 
     if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "MINGW"* ]]; then
-        echo "Configuring environment for signing of binaries"
+        log_info "Configuring environment for signing of binaries"
         if [[ -z ${CSC_LINK-} ]]; then
-            echo "The variable CSC_LINK is not set. It needs to point to a file containing the"
-            echo "private key used for signing of binaries."
+            log_error "The variable CSC_LINK is not set. It needs to point to a file containing the"
+            log_error "private key used for signing of binaries."
             exit 1
         fi
         if [[ -z ${CSC_KEY_PASSWORD-} ]]; then
@@ -78,7 +106,7 @@ if [[ "$BUILD_MODE" == "release" ]]; then
     fi
 else
     NPM_PACK_ARGS+=(--no-compression)
-    echo "!! Development build. Not for general distribution !!"
+    log_info "!! Development build. Not for general distribution !!"
     unset CSC_LINK CSC_KEY_PASSWORD
     export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
@@ -87,16 +115,17 @@ product_version_commit_hash=$(git rev-parse "$PRODUCT_VERSION^{commit}" || echo 
 current_head_commit_hash=$(git rev-parse "HEAD^{commit}")
 if [[ "$BUILD_MODE" == "dev" || $product_version_commit_hash != "$current_head_commit_hash" ]]; then
     PRODUCT_VERSION="$PRODUCT_VERSION-dev-${current_head_commit_hash:0:6}"
-    echo "Modifying product version to $PRODUCT_VERSION"
 
-    echo "Disabling Apple notarization (macOS only) of installer in this dev build"
+    log_info "Disabling Apple notarization (macOS only) of installer in this dev build"
     NPM_PACK_ARGS+=(--no-apple-notarization)
     CARGO_ARGS+=(--features api-override)
 else
-    echo "Removing old Rust build artifacts"
+    log_info "Removing old Rust build artifacts..."
     cargo +stable clean
     CARGO_ARGS+=(--locked)
 fi
+
+log_header "Building Mullvad VPN $PRODUCT_VERSION"
 
 if [[ ("$(uname -s)" == "Darwin") ]]; then
     BINARIES=(
@@ -127,14 +156,14 @@ fi
 
 function restore_metadata_backups {
     pushd "$SCRIPT_DIR"
-    echo "Restoring version metadata files..."
+    log_info "Restoring version metadata files..."
     ./version-metadata.sh restore-backup --desktop
     mv Cargo.lock.bak Cargo.lock || true
     popd
 }
 trap 'restore_metadata_backups' EXIT
 
-echo "Updating version in metadata files..."
+log_info "Updating version in metadata files..."
 cp Cargo.lock Cargo.lock.bak
 ./version-metadata.sh inject "$PRODUCT_VERSION" --desktop
 
@@ -172,8 +201,6 @@ function build {
         for_target_string=" for $current_target"
     fi
 
-    echo "Building Mullvad VPN $PRODUCT_VERSION$for_target_string"
-
     ################################################################################
     # Compile and link all binaries.
     ################################################################################
@@ -190,7 +217,7 @@ function build {
 
     export MULLVAD_ADD_MANIFEST="1"
 
-    echo "Building Rust code in release mode using $RUSTC_VERSION$for_target_string..."
+    log_header "Building Rust code in release mode using $RUSTC_VERSION$for_target_string"
 
     CARGO_TARGET_ARG=()
     if [[ -n $current_target ]]; then
@@ -224,10 +251,10 @@ function build {
         fi
 
         if [[ "$(uname -s)" == "MINGW"* || "$binary" == *.dylib ]]; then
-            echo "Copying $SRC => $DST"
+            log_info "Copying $SRC => $DST"
             cp "$SRC" "$DST"
         else
-            echo "Stripping $SRC => $DST"
+            log_info "Stripping $SRC => $DST"
             strip "$SRC" -o "$DST"
         fi
     done
@@ -236,7 +263,7 @@ function build {
 if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "Linux" ]]; then
     mkdir -p "dist-assets/shell-completions"
     for sh in bash zsh fish; do
-        echo "Generating shell completion script for $sh..."
+        log_info "Generating shell completion script for $sh..."
         cargo +stable run --bin mullvad "${CARGO_ARGS[@]}" --release -- shell-completions "$sh" \
             "dist-assets/shell-completions/"
     done
@@ -268,17 +295,17 @@ if [[ "$BUILD_MODE" == "release" && "$(uname -s)" == "MINGW"* ]]; then
     sign_win "${signdep[@]}"
 fi
 
+
+log_header "Installing JavaScript dependencies"
+
 pushd gui
-
-echo "Installing JavaScript dependencies..."
-
 npm ci
 
 ################################################################################
 # Package release.
 ################################################################################
 
-echo "Packing final release artifact..."
+log_header "Packing final release artifact(s)"
 
 case "$(uname -s)" in
     Linux*)     npm run pack:linux -- "${NPM_PACK_ARGS[@]}";;
@@ -291,7 +318,7 @@ popd
 SEMVER_VERSION=$(echo "$PRODUCT_VERSION" | sed -Ee 's/($|-.*)/.0\1/g')
 for semver_path in dist/*"$SEMVER_VERSION"*; do
     product_path=$(echo "$semver_path" | sed -Ee "s/$SEMVER_VERSION/$PRODUCT_VERSION/g")
-    echo "Moving $semver_path -> $product_path"
+    log_info "Moving $semver_path -> $product_path"
     mv "$semver_path" "$product_path"
 
     if [[ "$BUILD_MODE" == "release" && "$(uname -s)" == "MINGW"* && "$product_path" == *.exe ]]
@@ -301,11 +328,12 @@ for semver_path in dist/*"$SEMVER_VERSION"*; do
     fi
 done
 
-echo "**********************************"
-echo ""
-echo " The build finished successfully! "
-echo " You have built:"
-echo ""
-echo " $PRODUCT_VERSION"
-echo ""
-echo "**********************************"
+
+log_success "**********************************"
+log_success ""
+log_success " The build finished successfully! "
+log_success " You have built:"
+log_success ""
+log_success " $PRODUCT_VERSION"
+log_success ""
+log_success "**********************************"


### PR DESCRIPTION
`build.sh` outputs a lot of text. Most of it is noise. Some of it is interesting some of the time. For example, when I'm looking at build server logs I want to know which branch/version it's currently building. It's also nice to be able to see approximately where in the build process it is. Currently we have ~6 `cargo run`/`cargo build` calls after each other in this script. So seeing some random cargo output does not say much about the overall progress.

Because of this I added some helper functions to log with color. And use those to have some nicer output from the script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3226)
<!-- Reviewable:end -->
