### PR TITLE
Position button content with css

### DIFF
--- a/gui/src/renderer/components/AppButtonStyles.tsx
+++ b/gui/src/renderer/components/AppButtonStyles.tsx
@@ -1,27 +1,41 @@
 import styled from 'styled-components';
 import { buttonText } from './common-styles';
 
-export const StyledLabelContainer = styled.div((props: { textAdjustment: number }) => ({
-  display: 'flex',
-  flex: 1,
-  paddingRight: `${props.textAdjustment > 0 ? props.textAdjustment : 0}px`,
-  paddingLeft: `${props.textAdjustment < 0 ? Math.abs(props.textAdjustment) : 0}px`,
+export const StyledLabel = styled.span(buttonText, (props: { textOffset: number }) => ({
+  paddingLeft: props.textOffset > 0 ? `${props.textOffset}px` : 0,
+  paddingRight: props.textOffset < 0 ? `${-props.textOffset}px` : 0,
+  textAlign: 'center',
+  wordBreak: 'break-word',
 }));
 
-export const StyledLabel = styled.span(buttonText, {
-  flex: 1,
-  textAlign: 'center',
-});
-
 export const StyledButtonContent = styled.div({
-  display: 'flex',
   flex: 1,
-  flexDirection: 'row',
+  display: 'grid',
+  gridTemplateColumns: '1fr auto 1fr',
   alignItems: 'center',
-  justifyContent: 'center',
   padding: '9px',
 });
 
 export const transparentButton = {
   backdropFilter: 'blur(4px)',
 };
+
+export const StyledLeft = styled.div({
+  justifySelf: 'start',
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const StyledRight = styled(StyledLeft)({
+  justifySelf: 'end',
+});
+
+export const StyledVisibleSide = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+});
+
+export const StyledHiddenSide = styled(StyledVisibleSide).attrs({ 'aria-hidden': true })({
+  height: 0,
+  visibility: 'hidden',
+});

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -268,7 +268,9 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
         onClick={this.props.onReconnect}
         aria-label={messages.gettext('Reconnect')}
         {...props}>
-        <ImageView height={22} width={22} source="icon-reload" tintColor="white" />
+        <AppButton.Label>
+          <ImageView height={22} width={22} source="icon-reload" tintColor="white" />
+        </AppButton.Label>
       </AppButton.RedTransparentButton>
     );
   };


### PR DESCRIPTION
This PR positions button content with CSS instead of JavaScript. The solution is similar to the navigation bar but a different requirement is that the text should always be centered. To accomplish this when there are icons of different width on the sides of the label, the icons are added to both sides but hidden on the one where they shouldn't be visible. This makes them take up the width and makes the widest side use up the same amount on both sides.

This made it possible to simplify the code a lot since `ref`s to the button and text aren't needed anymore.

One issue I ran into was that the `buttonRef.current?.getBoundingClientRect()` triggered a reflow which made transitions in `TransitionContainer` work. When removing the calls to `getBoundingClientRect` in `AppButton` some views lost their navigation transition. This was solved by triggering a reflow in `TransitionContainer` to make sure it's always done before setting the CSS that initiates the transition.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3229)
<!-- Reviewable:end -->
