### PR TITLE
WireGuard multihop UI improvements

### DIFF
--- a/gui/src/renderer/components/LocationList.tsx
+++ b/gui/src/renderer/components/LocationList.tsx
@@ -430,10 +430,10 @@ export class RelayLocations extends React.PureComponent<
                   ),
               };
             })
-            .sort((a, b) => a.name.localeCompare(b.name, this.props.locale)),
+            .sort((a, b) => a.label.localeCompare(b.label, this.props.locale)),
         };
       })
-      .sort((a, b) => a.name.localeCompare(b.name, this.props.locale));
+      .sort((a, b) => a.label.localeCompare(b.label, this.props.locale));
   }
 
   private formatRowName(

--- a/gui/src/renderer/containers/SelectLocationPage.tsx
+++ b/gui/src/renderer/containers/SelectLocationPage.tsx
@@ -30,12 +30,12 @@ const mapStateToProps = (state: IReduxState, props: IHistoryProps & IAppContext)
   if (tunnelProtocol === 'openvpn' && 'normal' in state.settings.bridgeSettings) {
     selectedBridgeLocation = state.settings.bridgeSettings.normal.location;
   } else if ('normal' in relaySettings) {
+    multihopEnabled = relaySettings.normal.wireguard.useMultihop;
+
     const entryLocation = relaySettings.normal.wireguard.entryLocation;
-    if (entryLocation !== 'any') {
+    if (multihopEnabled && entryLocation !== 'any') {
       selectedEntryLocation = entryLocation;
     }
-
-    multihopEnabled = relaySettings.normal.wireguard.useMultihop;
   }
 
   const allowEntrySelection =


### PR DESCRIPTION
This PR fixes two UI bugs related to WireGuard multihop:
* Previous entry location was marked as entry location in exit selection after switching multihop off,
* Sorting of countries and cities in languages other than English.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3230)
<!-- Reviewable:end -->
