### PR TITLE
Remove Switch drag function and onChange delay

### DIFF
--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -269,7 +269,6 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
 
   private hideConfirmBlockWhenDisconnectedAlert = () => {
     this.setState({ showConfirmBlockWhenDisconnectedAlert: false });
-    this.blockWhenDisconnectedRef.current?.setOn(this.props.blockWhenDisconnected);
   };
 
   private confirmEnableBlockWhenDisconnected = () => {

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -323,7 +323,6 @@ export default class WireguardSettings extends React.Component<IProps, IState> {
 
   private hideWireguardMultihopConfirmationDialog = () => {
     this.setState({ showMultihopConfirmationDialog: false });
-    this.multihopRef.current?.setOn(this.props.wireguardMultihop);
   };
 
   private confirmWireguardMultihop = () => {


### PR DESCRIPTION
This PR:
* Removes the delay before calling `onChange` in the `Switch` component. This previously caused some animation lag for settings that required daemon communication. This was solved by not using `transform` for positioning. I don't know why that happened but it's now working as it should.
* Removes the dragging functionality of the `Switch` component. This functionality added a lot of complexity and was prone to race conditions. 

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3231)
<!-- Reviewable:end -->
