### PR TITLE
Fix invalid path in Android release build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,7 +7,7 @@ def repoRootPath = rootProject.projectDir.absoluteFile.parentFile.absolutePath
 def extraAssetsDirectory = "$project.buildDir/extraAssets"
 def extraJniDirectory = "$project.buildDir/extraJni"
 
-def keystorePropertiesFile = file('keystore.properties')
+def keystorePropertiesFile = file("$rootProject.projectDir/keystore.properties")
 def keystoreProperties = new Properties()
 
 if (keystorePropertiesFile.exists()) {


### PR DESCRIPTION
Fixes the invalid path to 'keystore.properties' introduced in the
previous split of the android/root project and app module.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3233)
<!-- Reviewable:end -->
