### PR TITLE
Fix url buttons broken on app resume

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -119,6 +119,8 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         oldAccountExpiry?.let { expiry ->
             accountCache.invalidateAccountExpiry(expiry)
         }
+
+        sitePaymentButton.updateAuthTokenCache(authTokenCache)
     }
 
     override fun onSafelyStop() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -80,6 +80,8 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
                 delay(POLL_INTERVAL)
             }
         }
+
+        sitePaymentButton.updateAuthTokenCache(authTokenCache)
     }
 
     override fun onSafelyStop() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -21,6 +21,7 @@ val POLL_INTERVAL: Long = 15 /* s */ * 1000 /* ms */
 
 class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     private lateinit var accountLabel: TextView
+    private lateinit var sitePaymentButton: SitePaymentButton
 
     override fun onSafelyCreateView(
         inflater: LayoutInflater,
@@ -41,7 +42,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             parentActivity.getString(R.string.pay_to_start_using) + " " +
             parentActivity.getString(R.string.add_time_to_account)
 
-        view.findViewById<SitePaymentButton>(R.id.site_payment).apply {
+        sitePaymentButton = view.findViewById<SitePaymentButton>(R.id.site_payment).apply {
             newAccount = true
             prepare(authTokenCache, jobTracker)
         }
@@ -68,6 +69,8 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
                 delay(POLL_INTERVAL)
             }
         }
+
+        sitePaymentButton.updateAuthTokenCache(authTokenCache)
     }
 
     override fun onSafelyStop() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WireguardKeyFragment.kt
@@ -168,6 +168,8 @@ class WireguardKeyFragment : ServiceDependentFragment(OnNoService.GoToLaunchScre
             }
         }
 
+        manageKeysButton.updateAuthTokenCache(authTokenCache)
+
         actionState = ActionState.Idle(false)
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
@@ -67,6 +67,12 @@ open class UrlButton : Button {
         }
     }
 
+    fun updateAuthTokenCache(authTokenCache: AuthTokenCache) {
+        synchronized(this) {
+            this.authTokenCache = authTokenCache
+        }
+    }
+
     override fun setEnabled(enabled: Boolean) {
         synchronized(this) {
             shouldEnable = enabled


### PR DESCRIPTION
Fixes an issue with url buttons keeping an old reference to service
dependent instances, even after the service connection is no longer
available.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3234)
<!-- Reviewable:end -->
