### PR TITLE
Respect `--no-compression` when building rpm-package

### DIFF
--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -5,7 +5,7 @@ const parseSemver = require('semver/functions/parse');
 const { notarize } = require('electron-notarize');
 const { version } = require('../package.json');
 
-const compression = process.argv.includes('--no-compression') ? 'store' : 'normal';
+const noCompression = process.argv.includes('--no-compression');
 const noAppleNotarization = process.argv.includes('--no-apple-notarization');
 
 const universal = process.argv.includes('--universal');
@@ -15,7 +15,7 @@ const config = {
   copyright: 'Mullvad VPN AB',
   productName: 'Mullvad VPN',
   asar: true,
-  compression: compression,
+  compression: noCompression ? 'store' : 'normal',
   extraResources: [
     { from: distAssets('ca.crt'), to: '.' },
     { from: distAssets('relays.json'), to: '.' },
@@ -269,6 +269,10 @@ function notarizeMac(notarizePath) {
 }
 
 function packLinux() {
+  if (noCompression) {
+    config.rpm.fpm.unshift('--rpm-compression', 'none');
+  }
+
   return builder.build({
     targets: builder.Platform.LINUX.createTarget(),
     config: {


### PR DESCRIPTION
`compression: 'store'` apparently doesn't affect the `rpm` package, it will still be compressed which takes a lot of time. To avoid this if `--no-compression` is supplied, the fpm argument `--rpm-compression none` is added. This shaves more than 3 minutes of the build time on my computer.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3237)
<!-- Reviewable:end -->
