### PR TITLE
Extract Android dependencies to constants

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,13 +1,12 @@
-
 import java.io.FileInputStream
 import java.util.Properties
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("com.android.application")
-    id("com.github.triplet.play")
-    id("kotlin-android")
-    id("kotlin-parcelize")
+    id(Dependencies.Plugin.androidApplicationId)
+    id(Dependencies.Plugin.playPublisherId)
+    id(Dependencies.Plugin.kotlinAndroidId)
+    id(Dependencies.Plugin.kotlinParcelizeId)
 }
 
 val repoRootPath = rootProject.projectDir.absoluteFile.parentFile.absolutePath
@@ -22,13 +21,13 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion(30)
-    buildToolsVersion("30.0.3")
+    compileSdkVersion(Versions.Android.compileSdkVersion)
+    buildToolsVersion(Versions.Android.buildToolsVersion)
 
     defaultConfig {
         applicationId = "net.mullvad.mullvadvpn"
-        minSdkVersion(26)
-        targetSdkVersion(30)
+        minSdkVersion(Versions.Android.minSdkVersion)
+        targetSdkVersion(Versions.Android.targetSdkVersion)
         versionCode = 21010099
         versionName = "2021.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -82,7 +81,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = Versions.jvmTarget
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
         // Opt-in option for Koin annotation of KoinComponent.
     }
@@ -134,45 +133,39 @@ play {
 }
 
 dependencies {
-    val espressoVersion: String by rootProject.extra
-    val fragmentVersion: String by rootProject.extra
-    val koinVersion: String by rootProject.extra
-    val kotlinVersion: String by rootProject.extra
-    val mockkVersion: String by rootProject.extra
-
-    implementation("androidx.appcompat:appcompat:1.3.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.0")
-    implementation("androidx.coordinatorlayout:coordinatorlayout:1.1.0")
-    implementation("androidx.core:core-ktx:1.6.0")
-    implementation("androidx.fragment:fragment-ktx:$fragmentVersion")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
-    implementation("androidx.recyclerview:recyclerview:1.2.1")
-    implementation("com.google.android.material:material:1.4.0")
-    implementation("commons-validator:commons-validator:1.7")
-    implementation("io.insert-koin:koin-core:$koinVersion")
-    implementation("io.insert-koin:koin-core-ext:$koinVersion")
-    implementation("io.insert-koin:koin-androidx-fragment:$koinVersion")
-    implementation("io.insert-koin:koin-androidx-scope:$koinVersion")
-    implementation("io.insert-koin:koin-androidx-viewmodel:$koinVersion")
-    implementation("joda-time:joda-time:2.10.2")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1")
+    implementation(Dependencies.androidMaterial)
+    implementation(Dependencies.commonsValidator)
+    implementation(Dependencies.AndroidX.appcompat)
+    implementation(Dependencies.AndroidX.constraintlayout)
+    implementation(Dependencies.AndroidX.coordinatorlayout)
+    implementation(Dependencies.AndroidX.coreKtx)
+    implementation(Dependencies.AndroidX.fragmentKtx)
+    implementation(Dependencies.AndroidX.lifecycleRuntimeKtx)
+    implementation(Dependencies.AndroidX.lifecycleViewmodelKtx)
+    implementation(Dependencies.AndroidX.recyclerview)
+    implementation(Dependencies.jodaTime)
+    implementation(Dependencies.Koin.core)
+    implementation(Dependencies.Koin.coreExt)
+    implementation(Dependencies.Koin.androidXFragment)
+    implementation(Dependencies.Koin.androidXScope)
+    implementation(Dependencies.Koin.androidXViewmodel)
+    implementation(Dependencies.Kotlin.reflect)
+    implementation(Dependencies.Kotlin.stdlib)
+    implementation(Dependencies.KotlinX.coroutinesAndroid)
 
     /* Test dependencies */
-    testImplementation("io.insert-koin:koin-test:$koinVersion")
-    testImplementation("io.mockk:mockk:$mockkVersion")
-    testImplementation("junit:junit:4.13")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1")
+    testImplementation(Dependencies.Koin.test)
+    testImplementation(Dependencies.Kotlin.test)
+    testImplementation(Dependencies.KotlinX.coroutinesTest)
+    testImplementation(Dependencies.MockK.core)
+    testImplementation(Dependencies.junit)
 
     /* UI test dependencies */
-    debugImplementation("androidx.fragment:fragment-testing:$fragmentVersion")
-    androidTestImplementation("androidx.test.espresso:espresso-core:$espressoVersion")
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:$espressoVersion")
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("io.mockk:mockk-android:$mockkVersion")
-    androidTestImplementation("io.insert-koin:koin-test:$koinVersion")
-    androidTestImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+    debugImplementation(Dependencies.AndroidX.fragmentTestning)
+    androidTestImplementation(Dependencies.AndroidX.espressoContrib)
+    androidTestImplementation(Dependencies.AndroidX.espressoCore)
+    androidTestImplementation(Dependencies.AndroidX.junit)
+    androidTestImplementation(Dependencies.Koin.test)
+    androidTestImplementation(Dependencies.Kotlin.test)
+    androidTestImplementation(Dependencies.MockK.android)
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,30 +1,24 @@
 plugins {
-    id("org.owasp.dependencycheck") version "6.5.0.1" apply false
+    id(Dependencies.Plugin.dependencyCheckId) version Versions.Plugin.dependencyCheck apply false
 }
 
 buildscript {
-    val espressoVersion by extra { "3.3.0" }
-    val fragmentVersion by extra { "1.3.2" }
-    val koinVersion by extra { "2.2.2" }
-    val kotlinVersion by extra { "1.4.31" }
-    val mockkVersion by extra { "1.12.0" }
-
     repositories {
         google()
         mavenCentral()
-        maven("https://plugins.gradle.org/m2/")
+        maven(Repositories.GradlePlugins)
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.3")
-        classpath("com.github.triplet.gradle:play-publisher:2.7.5")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-        classpath("org.owasp:dependency-check-gradle:6.5.0.1")
+        classpath(Dependencies.Plugin.android)
+        classpath(Dependencies.Plugin.playPublisher)
+        classpath(Dependencies.Plugin.kotlin)
+        classpath(Dependencies.Plugin.dependencyCheck)
     }
 }
 
 allprojects {
-    apply(plugin = "org.owasp.dependencycheck")
+    apply(plugin = Dependencies.Plugin.dependencyCheckId)
 
     repositories {
         google()

--- a/android/buildSrc/build.gradle.kts
+++ b/android/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    maven("https://plugins.gradle.org/m2/")
+}

--- a/android/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/android/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,0 +1,70 @@
+object Dependencies {
+    const val androidMaterial = "com.google.android.material:material:${Versions.Android.material}"
+    const val commonsValidator = "commons-validator:commons-validator:${Versions.commonsValidator}"
+    const val jodaTime = "joda-time:joda-time:${Versions.jodaTime}"
+    const val junit = "junit:junit:${Versions.junit}"
+
+    object AndroidX {
+        const val appcompat = "androidx.appcompat:appcompat:${Versions.AndroidX.appcompat}"
+        const val constraintlayout =
+            "androidx.constraintlayout:constraintlayout:${Versions.AndroidX.constraintlayout}"
+        const val coordinatorlayout =
+            "androidx.coordinatorlayout:coordinatorlayout:${Versions.AndroidX.coordinatorlayout}"
+        const val coreKtx = "androidx.core:core-ktx:${Versions.AndroidX.coreKtx}"
+        const val fragmentKtx = "androidx.fragment:fragment-ktx:${Versions.AndroidX.fragment}"
+        const val fragmentTestning =
+            "androidx.fragment:fragment-testing:${Versions.AndroidX.fragment}"
+        const val lifecycleRuntimeKtx =
+            "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.AndroidX.lifecycle}"
+        const val lifecycleViewmodelKtx =
+            "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.AndroidX.lifecycle}"
+        const val recyclerview =
+            "androidx.recyclerview:recyclerview:${Versions.AndroidX.recyclerview}"
+        const val junit = "androidx.test.ext:junit:${Versions.AndroidX.junit}"
+        const val espressoCore =
+            "androidx.test.espresso:espresso-core:${Versions.AndroidX.espresso}"
+        const val espressoContrib =
+            "androidx.test.espresso:espresso-contrib:${Versions.AndroidX.espresso}"
+    }
+
+    object Koin {
+        const val core = "io.insert-koin:koin-core:${Versions.koin}"
+        const val coreExt = "io.insert-koin:koin-core-ext:${Versions.koin}"
+        const val androidXFragment = "io.insert-koin:koin-androidx-fragment:${Versions.koin}"
+        const val androidXScope = "io.insert-koin:koin-androidx-scope:${Versions.koin}"
+        const val androidXViewmodel = "io.insert-koin:koin-androidx-viewmodel:${Versions.koin}"
+        const val test = "io.insert-koin:koin-test:${Versions.koin}"
+    }
+
+    object Kotlin {
+        const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
+        const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlin}"
+        const val test = "org.jetbrains.kotlin:kotlin-test:${Versions.kotlin}"
+    }
+
+    object KotlinX {
+        const val coroutinesAndroid =
+            "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.kotlinx}"
+        const val coroutinesTest =
+            "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinx}"
+    }
+
+    object MockK {
+        const val core = "io.mockk:mockk:${Versions.mockk}"
+        const val android = "io.mockk:mockk-android:${Versions.mockk}"
+    }
+
+    object Plugin {
+        const val android = "com.android.tools.build:gradle:${Versions.Plugin.android}"
+        const val androidApplicationId = "com.android.application"
+        const val playPublisher =
+            "com.github.triplet.gradle:play-publisher:${Versions.Plugin.playPublisher}"
+        const val playPublisherId = "com.github.triplet.play"
+        const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Plugin.kotlin}"
+        const val kotlinAndroidId = "kotlin-android"
+        const val kotlinParcelizeId = "kotlin-parcelize"
+        const val dependencyCheck =
+            "org.owasp:dependency-check-gradle:${Versions.Plugin.dependencyCheck}"
+        const val dependencyCheckId = "org.owasp.dependencycheck"
+    }
+}

--- a/android/buildSrc/src/main/kotlin/Repositories.kt
+++ b/android/buildSrc/src/main/kotlin/Repositories.kt
@@ -1,0 +1,3 @@
+object Repositories {
+    const val GradlePlugins = "https://plugins.gradle.org/m2/"
+}

--- a/android/buildSrc/src/main/kotlin/Versions.kt
+++ b/android/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,37 @@
+object Versions {
+    const val commonsValidator = "1.7"
+    const val jodaTime = "2.10.2"
+    const val junit = "4.13"
+    const val jvmTarget = "1.8"
+    const val koin = "2.2.2"
+    const val kotlin = "1.4.31"
+    const val kotlinx = "1.5.1"
+    const val mockk = "1.12.0"
+
+    object Android {
+        const val buildToolsVersion = "30.0.3"
+        const val compileSdkVersion = 30
+        const val material = "1.4.0"
+        const val minSdkVersion = 26
+        const val targetSdkVersion = 30
+    }
+
+    object AndroidX {
+        const val appcompat = "1.3.1"
+        const val coreKtx = "1.6.0"
+        const val constraintlayout = "2.1.0"
+        const val coordinatorlayout = "1.1.0"
+        const val espresso = "3.3.0"
+        const val lifecycle = "2.3.1"
+        const val fragment = "1.3.2"
+        const val recyclerview = "1.2.1"
+        const val junit = "1.1.3"
+    }
+
+    object Plugin {
+        const val android = "4.1.3"
+        const val playPublisher = "2.7.5"
+        const val kotlin = "1.4.31"
+        const val dependencyCheck = "6.5.0.1"
+    }
+}


### PR DESCRIPTION
Extracts Android dependency names/versions/repos to Kotlin constants in
source code. The purpose of this change is to minimize duplication,
unify versions and prepare the project to be split into multiple
sub-projects/modules.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3238)
<!-- Reviewable:end -->
