### PR TITLE
Fix failure to set MTU on wireguard-nt interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove tray icon of current running app version when upgrading.
 - Allow Mullvad wireguard-nt tunnels to work simultaneously with other wg-nt tunnels.
 - Fix notifications on Windows not showing if window is unpinned and hidden.
+- Wait for IP interfaces to arrive before trying to configure them when using wireguard-nt.
 
 #### Android
 - Fix Quick Settings tile showing wrong state in certain scenarios.

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -589,11 +589,6 @@ mod test {
             "mock-tunnel".to_string()
         }
 
-        #[cfg(windows)]
-        fn get_interface_luid(&self) -> u64 {
-            0
-        }
-
         fn stop(self: Box<Self>) -> Result<(), TunnelError> {
             Ok(())
         }

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -42,7 +42,7 @@ impl<E: Error> ErrorExt for E {
 }
 
 #[derive(Debug)]
-pub struct BoxedError(Box<dyn Error>);
+pub struct BoxedError(Box<dyn Error + 'static + Send>);
 
 impl fmt::Display for BoxedError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -57,7 +57,7 @@ impl Error for BoxedError {
 }
 
 impl BoxedError {
-    pub fn new(error: impl Error + 'static) -> Self {
+    pub fn new(error: impl Error + 'static + Send) -> Self {
         BoxedError(Box::new(error))
     }
 }

--- a/wireguard/libwg/libwg_windows.go
+++ b/wireguard/libwg/libwg_windows.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 //export wgTurnOn
-func wgTurnOn(cIfaceName *C.char, mtu int, waitOnIpv6 bool, cSettings *C.char, cIfaceNameOut **C.char, cLuidOut *uint64, logSink LogSink, logContext LogContext) int32 {
+func wgTurnOn(cIfaceName *C.char, mtu int, cSettings *C.char, cIfaceNameOut **C.char, cLuidOut *uint64, logSink LogSink, logContext LogContext) int32 {
 	logger := logging.NewLogger(logSink, logContext)
 	if cIfaceNameOut != nil {
 		*cIfaceNameOut = nil


### PR DESCRIPTION
Previously, there was a race, as the code did not make sure that any IP interfaces had been added before setting any IP interface properties. The PR fixes this by waiting for `MibAddInstance` notifications first, if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3240)
<!-- Reviewable:end -->
