### PR TITLE
Fix Android build asset inclusion

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -87,10 +87,8 @@ android {
         // Opt-in option for Koin annotation of KoinComponent.
     }
 
-    applicationVariants.forEach { variant ->
-        variant.mergeAssetsProvider.configure{
-            dependsOn(task("copyExtraAssets"))
-        }
+    tasks.withType<com.android.build.gradle.tasks.MergeSourceSetFolders> {
+        dependsOn(getTasksByName("copyExtraAssets", true))
     }
 
     testOptions {


### PR DESCRIPTION
Fixes an asset inclusion issue introduced during the groovy->kotlin migration

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3241)
<!-- Reviewable:end -->
