### PR TITLE
Always use logging macros prefixed with log::

### DIFF
--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::{crate_authors, crate_description, crate_name, App, Arg};
-use log;
 
 use crate::version;
 

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -2,7 +2,6 @@ use fern::{
     colors::{Color, ColoredLevelConfig},
     Output,
 };
-use log;
 use std::{fmt, io, path::PathBuf};
 use talpid_core::logging::rotate_log;
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -1,6 +1,5 @@
 #![deny(rust_2018_idioms)]
 
-use log::{debug, error, info, trace, warn};
 use mullvad_daemon::{
     logging,
     management_interface::{ManagementInterfaceEventBroadcaster, ManagementInterfaceServer},
@@ -26,7 +25,7 @@ fn main() {
         std::process::exit(1)
     });
 
-    trace!("Using configuration: {:?}", config);
+    log::trace!("Using configuration: {:?}", config);
 
     let runtime = new_runtime_builder().build().unwrap_or_else(|error| {
         eprintln!("{}", error.display_chain());
@@ -36,11 +35,11 @@ fn main() {
     let exit_code = match runtime.block_on(run_platform(config, log_dir)) {
         Ok(_) => 0,
         Err(error) => {
-            error!("{}", error);
+            log::error!("{}", error);
             1
         }
     };
-    debug!("Process exiting with code {}", exit_code);
+    log::debug!("Process exiting with code {}", exit_code);
     std::process::exit(exit_code);
 }
 
@@ -58,7 +57,7 @@ fn init_logging(config: &cli::Config) -> Result<Option<PathBuf>, String> {
     exception_logging::enable();
     version::log_version();
     if let Some(ref log_dir) = log_dir {
-        info!("Logging to {}", log_dir.display());
+        log::info!("Logging to {}", log_dir.display());
     }
     Ok(log_dir)
 }
@@ -114,7 +113,7 @@ async fn run_standalone(log_dir: Option<PathBuf>) -> Result<(), String> {
     }
 
     if !running_as_admin() {
-        warn!("Running daemon as a non-administrator user, clients might refuse to connect");
+        log::warn!("Running daemon as a non-administrator user, clients might refuse to connect");
     }
 
     let daemon = create_daemon(log_dir).await?;
@@ -125,7 +124,7 @@ async fn run_standalone(log_dir: Option<PathBuf>) -> Result<(), String> {
 
     daemon.run().await.map_err(|e| e.display_chain())?;
 
-    info!("Mullvad daemon is quitting");
+    log::info!("Mullvad daemon is quitting");
     thread::sleep(Duration::from_millis(500));
     Ok(())
 }
@@ -163,7 +162,7 @@ async fn spawn_management_interface(
         error.display_chain_with_msg("Unable to start management interface server")
     })?;
 
-    info!("Management interface listening on {}", socket_path);
+    log::info!("Management interface listening on {}", socket_path);
 
     Ok(event_broadcaster)
 }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 #[cfg(target_os = "android")]
 use jnix::{jni::objects::JObject, FromJava, IntoJava, JnixEnv};
-use log::{debug, info};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::net::IpAddr;
 #[cfg(target_os = "windows")]
@@ -133,16 +132,16 @@ impl Settings {
     /// The boolean in the Result indicates if the account token changed or not
     pub fn set_account_token(&mut self, mut account_token: Option<String>) -> bool {
         if account_token.as_ref().map(String::len) == Some(0) {
-            debug!("Setting empty account token is treated as unsetting it");
+            log::debug!("Setting empty account token is treated as unsetting it");
             account_token = None;
         }
         if account_token != self.account_token {
             if account_token.is_none() {
-                info!("Unsetting account token");
+                log::info!("Unsetting account token");
             } else if self.account_token.is_none() {
-                info!("Setting account token");
+                log::info!("Setting account token");
             } else {
-                info!("Changing account token")
+                log::info!("Changing account token")
             }
             self.account_token = account_token;
             true
@@ -175,9 +174,10 @@ impl Settings {
             if !update_supports_bridge && BridgeState::On == self.bridge_state {
                 self.bridge_state = BridgeState::Auto;
             }
-            debug!(
+            log::debug!(
                 "Changing relay settings:\n\tfrom: {}\n\tto: {}",
-                self.relay_settings, new_settings
+                self.relay_settings,
+                new_settings
             );
 
             self.relay_settings = new_settings;

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 
 use lazy_static::lazy_static;
-use log::{error, trace, warn};
 use std::{env, io, net::IpAddr, path::Path};
 use talpid_types::ErrorExt;
 use widestring::WideCString;
@@ -84,8 +83,8 @@ impl super::DnsMonitorT for DnsMonitor {
             .map(|ip_cstr| ip_cstr.as_ptr())
             .collect::<Vec<_>>();
 
-        trace!("ipv4 ips - {:?} - {}", ipv4, ipv4.len());
-        trace!("ipv6 ips - {:?} - {}", ipv6, ipv6.len());
+        log::trace!("ipv4 ips - {:?} - {}", ipv4, ipv4.len());
+        log::trace!("ipv6 ips - {:?} - {}", ipv6, ipv6.len());
 
         let luid = luid_from_alias(interface).map_err(Error::InterfaceLuidError)?;
 
@@ -102,8 +101,8 @@ impl super::DnsMonitorT for DnsMonitor {
 
         if *GLOBAL_DNS_CACHE_POLICY && is_minimum_windows10() {
             if let Err(error) = set_dns_cache_policy(servers) {
-                error!("{}", error.display_chain());
-                warn!("DNS resolution may be slowed down");
+                log::error!("{}", error.display_chain());
+                log::warn!("DNS resolution may be slowed down");
             }
         }
 
@@ -127,7 +126,7 @@ impl Drop for DnsMonitor {
     fn drop(&mut self) {
         if *GLOBAL_DNS_CACHE_POLICY && is_minimum_windows10() {
             if let Err(error) = reset_dns_cache_policy() {
-                warn!(
+                log::warn!(
                     "{}",
                     error.display_chain_with_msg("Failed to reset DNS cache policy")
                 );
@@ -135,9 +134,9 @@ impl Drop for DnsMonitor {
         }
 
         if unsafe { WinDns_Deinitialize().into_result().is_ok() } {
-            trace!("Successfully deinitialized WinDns");
+            log::trace!("Successfully deinitialized WinDns");
         } else {
-            error!("Failed to deinitialize WinDns");
+            log::error!("Failed to deinitialize WinDns");
         }
     }
 }
@@ -213,7 +212,7 @@ fn is_minimum_windows10() -> bool {
     match talpid_platform_metadata::WindowsVersion::new() {
         Ok(version_info) => version_info.major_version() >= 10,
         Err(error) => {
-            error!(
+            log::error!(
                 "{}",
                 error.display_chain_with_msg("OS version check failed")
             );

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -5,7 +5,6 @@ use std::{net::IpAddr, path::Path, ptr};
 use self::winfw::*;
 use super::{FirewallArguments, FirewallPolicy, FirewallT, InitialFirewallState};
 use crate::winnet;
-use log::{debug, error, trace};
 use talpid_types::{
     net::{AllowedEndpoint, Endpoint},
     tunnel::FirewallPolicyError,
@@ -77,7 +76,7 @@ impl FirewallT for Firewall {
             };
         }
 
-        trace!("Successfully initialized windows firewall module");
+        log::trace!("Successfully initialized windows firewall module");
         Ok(Firewall(()))
     }
 
@@ -136,9 +135,9 @@ impl Drop for Firewall {
                 .into_result()
                 .is_ok()
         } {
-            trace!("Successfully deinitialized windows firewall module");
+            log::trace!("Successfully deinitialized windows firewall module");
         } else {
-            error!("Failed to deinitialize windows firewall module");
+            log::error!("Failed to deinitialize windows firewall module");
         };
     }
 }
@@ -152,7 +151,7 @@ impl Firewall {
         allowed_endpoint: &WinFwAllowedEndpoint<'_>,
         relay_client: &Path,
     ) -> Result<(), Error> {
-        trace!("Applying 'connecting' firewall policy");
+        log::trace!("Applying 'connecting' firewall policy");
         let ip_str = widestring_ip(endpoint.address.ip());
         let winfw_relay = WinFwEndpoint {
             ip: ip_str.as_ptr(),
@@ -192,7 +191,7 @@ impl Firewall {
         dns_servers: &[IpAddr],
         relay_client: &Path,
     ) -> Result<(), Error> {
-        trace!("Applying 'connected' firewall policy");
+        log::trace!("Applying 'connected' firewall policy");
         let ip_str = widestring_ip(endpoint.address.ip());
         let v4_gateway = widestring_ip(tunnel_metadata.ipv4_gateway.into());
         let v6_gateway = tunnel_metadata
@@ -212,9 +211,9 @@ impl Firewall {
             .map_err(Error::SetTunMetric)?;
 
         if metrics_set {
-            debug!("Network interface metrics were changed");
+            log::debug!("Network interface metrics were changed");
         } else {
-            debug!("Network interface metrics were not changed");
+            log::debug!("Network interface metrics were not changed");
         }
 
         let v6_gateway_ptr = match &v6_gateway {
@@ -249,7 +248,7 @@ impl Firewall {
         winfw_settings: &WinFwSettings,
         allowed_endpoint: &WinFwAllowedEndpoint<'_>,
     ) -> Result<(), Error> {
-        trace!("Applying 'blocked' firewall policy");
+        log::trace!("Applying 'blocked' firewall policy");
         unsafe {
             WinFw_ApplyPolicyBlocked(winfw_settings, allowed_endpoint)
                 .into_result()


### PR DESCRIPTION
I'm thinking about adding a section to the coding guidelines on trying to avoid importing stand alone functions and macros as much as possible. At least where prefixing with the module adds valuable information to the reader. Logging was a prime example of this. So I thought I'd take this change through review before proposing any coding guidelines changes. `log::` is very short. It makes very few lines of code expand into more lines than they already were. And it adds a lot of context to the reader IMO. Only `error!(...)` could very well be some kind of sibling to `try!(...)`. `log::error!` is very clear.

Also, we are already using `log::$macro` in a lot of places in the code. Even in the same file we mix using it qualified and unqualified, so this is also in order to make it more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3242)
<!-- Reviewable:end -->
