### PR TITLE
Fix socket bypass on Android

### DIFF
--- a/mullvad-rpc/src/https_client_with_sni.rs
+++ b/mullvad-rpc/src/https_client_with_sni.rs
@@ -127,7 +127,7 @@ impl HttpsConnectorWithSni {
             }
         }
 
-        timeout(CONNECT_TIMEOUT, TokioTcpStream::connect(addr))
+        timeout(CONNECT_TIMEOUT, socket.connect(addr))
             .await
             .map_err(|err| io::Error::new(io::ErrorKind::TimedOut, err))?
     }


### PR DESCRIPTION
Apparently a regression due to the tokio 1 migration. The API likely isn't reachable in blocking states on master right now. The bug had not yet made it to a release, however.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3243)
<!-- Reviewable:end -->
