### PR TITLE
Stable settings migrations (vendor types that a specific version depends on)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ dependencies = [
  "fern",
  "futures",
  "ipnetwork",
+ "jnix",
  "lazy_static",
  "libc",
  "log",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -41,6 +41,7 @@ mullvad-management-interface = { path = "../mullvad-management-interface" }
 
 [target.'cfg(target_os="android")'.dependencies]
 android_logger = "0.8"
+jnix = { version = "0.4", features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.22.2"

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -1,3 +1,24 @@
+//! Code for migrating between different versions of the settings.
+//! Migration only supports migrating forward, to newer formats.
+//!
+//! A settings migration module is responsible for converting
+//! from its own version to the next version. So `v3::migrate`
+//! migrates from settings version `V3` to `V4` etc.
+//!
+//! Migration modules may NOT import and use structs that may
+//! change. Because then a later change to the current code can break
+//! old migrations. The only items a settings migration module may import
+//! are anything from `std` plus the following:
+//!
+//! ```ignore
+//! use super::{Error, Result};
+//! use mullvad_types::relay_constraints::Constraint;
+//! use mullvad_types::settings::SettingsVersion;
+//! ```
+//!
+//! Any other type must be vendored into the migration module so the format
+//! it has is locked over time.
+
 use std::path::Path;
 use tokio::{
     fs,

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -8,7 +8,7 @@
 //! Migration modules may NOT import and use structs that may
 //! change. Because then a later change to the current code can break
 //! old migrations. The only items a settings migration module may import
-//! are anything from `std` plus the following:
+//! are anything from `std`, `jnix` and the following:
 //!
 //! ```ignore
 //! use super::{Error, Result};

--- a/mullvad-daemon/src/migrations/v1.rs
+++ b/mullvad-daemon/src/migrations/v1.rs
@@ -1,6 +1,21 @@
 use super::Result;
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
-use talpid_types::net::TunnelType;
+
+// ======================================================
+// Section for vendoring types and values that
+// this settings version depend on. See `mod.rs`.
+
+/// The tunnel protocol used by a [`TunnelEndpoint`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename = "tunnel_type")]
+pub enum TunnelType {
+    #[serde(rename = "openvpn")]
+    OpenVpn,
+    #[serde(rename = "wireguard")]
+    Wireguard,
+}
+
+// ======================================================
 
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {

--- a/mullvad-daemon/src/migrations/v2.rs
+++ b/mullvad-daemon/src/migrations/v2.rs
@@ -1,7 +1,15 @@
 use super::{Error, Result};
-use crate::wireguard::{MAX_ROTATION_INTERVAL, MIN_ROTATION_INTERVAL};
 use mullvad_types::settings::SettingsVersion;
 use std::time::Duration;
+
+// ======================================================
+// Section for vendoring types and values that
+// this settings version depend on. See `mod.rs`.
+
+pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_secs(1 * 24 * 60 * 60);
+pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+// ======================================================
 
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {

--- a/mullvad-daemon/src/migrations/v3.rs
+++ b/mullvad-daemon/src/migrations/v3.rs
@@ -1,4 +1,6 @@
 use super::{Error, Result};
+#[cfg(target_os = "android")]
+use jnix::IntoJava;
 use mullvad_types::settings::SettingsVersion;
 use std::net::IpAddr;
 

--- a/mullvad-daemon/src/migrations/v3.rs
+++ b/mullvad-daemon/src/migrations/v3.rs
@@ -1,7 +1,51 @@
 use super::{Error, Result};
-use mullvad_types::settings::{
-    CustomDnsOptions, DefaultDnsOptions, DnsOptions, DnsState, SettingsVersion,
-};
+use mullvad_types::settings::SettingsVersion;
+use std::net::IpAddr;
+
+// ======================================================
+// Section for vendoring types and values that
+// this settings version depend on. See `mod.rs`.
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum DnsState {
+    Default,
+    Custom,
+}
+
+impl Default for DnsState {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+/// DNS config
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[cfg_attr(target_os = "android", derive(IntoJava))]
+#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
+pub struct DnsOptions {
+    #[cfg_attr(target_os = "android", jnix(map = "|state| state == DnsState::Custom"))]
+    pub state: DnsState,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub default_options: DefaultDnsOptions,
+    #[cfg_attr(target_os = "android", jnix(map = "|opts| opts.addresses"))]
+    pub custom_options: CustomDnsOptions,
+}
+
+/// Default DNS config
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct DefaultDnsOptions {
+    pub block_ads: bool,
+    pub block_trackers: bool,
+}
+
+/// Custom DNS config
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct CustomDnsOptions {
+    pub addresses: Vec<IpAddr>,
+}
+
+// ======================================================
 
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {

--- a/mullvad-daemon/src/migrations/v4.rs
+++ b/mullvad-daemon/src/migrations/v4.rs
@@ -1,4 +1,6 @@
 use super::{Error, Result};
+#[cfg(target_os = "android")]
+use jnix::IntoJava;
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
 
 // ======================================================

--- a/mullvad-daemon/src/migrations/v4.rs
+++ b/mullvad-daemon/src/migrations/v4.rs
@@ -1,12 +1,32 @@
 use super::{Error, Result};
-use mullvad_types::{
-    relay_constraints::{Constraint, TransportPort},
-    settings::SettingsVersion,
-};
-use talpid_types::net::TransportProtocol;
+use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
+
+// ======================================================
+// Section for vendoring types and values that
+// this settings version depend on. See `mod.rs`.
 
 const WIREGUARD_TCP_PORTS: [u16; 3] = [80, 443, 5001];
 const OPENVPN_TCP_PORTS: [u16; 2] = [80, 443];
+
+/// Representation of a transport protocol, either UDP or TCP.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(target_os = "android", derive(IntoJava))]
+#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.talpid.net"))]
+pub enum TransportProtocol {
+    /// Represents the UDP transport protocol.
+    Udp,
+    /// Represents the TCP transport protocol.
+    Tcp,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct TransportPort {
+    pub protocol: TransportProtocol,
+    pub port: Constraint<u16>,
+}
+
+// ======================================================
 
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {


### PR DESCRIPTION
The current settings migration is very fragile to changes. Take for example `v3` that depends on the `DefaultDnsOptions` type. If we were today to remove the `block_trackers` setting in `master`, then this migration would break. It would still migrate settings, but the `v4` settings it would output would not have this flag properly set.

The solution I opted for was to vendor all the relevant dependencies to each settings version. It did not end up being too much.

Did I miss something here, or is this a good way to make the migration more stable and less susceptible to future changes?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3246)
<!-- Reviewable:end -->
