### PR TITLE
Move macOS binaries to target dir and ensure all binaries are available when packaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -290,7 +290,14 @@ function build {
         mkdir -p "$destination_dir"
     else
         local cargo_output_dir="$CARGO_TARGET_DIR/$RUST_BUILD_MODE"
-        local destination_dir="dist-assets"
+
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            # Always use the same location for binaries on macOS
+            local destination_dir="dist-assets/$ENV_TARGET"
+            mkdir -p "$destination_dir"
+        else
+            local destination_dir="dist-assets"
+        fi
     fi
 
     for binary in ${BINARIES[*]}; do


### PR DESCRIPTION
This PR:
* changes the location of binaries in `dist-assets` when building on macOS to make sure they're located in the same place for both universal and non-universal builds,
* checks if all "extraResources" exist after packaging in `distribution.js`. The reason for doing it in `afterPack` instead of `beforePack` is that `beforePack` is run before `beforeBuild` which sets the target-triple environment variable. And it can't be done in `beforeBuild` since it doesn't have access to the list of files.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
