### PR TITLE
Add #[serde(default)] to some settings types. And clean up Android stuff from migration code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,7 +1333,6 @@ dependencies = [
  "fern",
  "futures",
  "ipnetwork",
- "jnix",
  "lazy_static",
  "libc",
  "log",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -41,7 +41,6 @@ mullvad-management-interface = { path = "../mullvad-management-interface" }
 
 [target.'cfg(target_os="android")'.dependencies]
 android_logger = "0.8"
-jnix = { version = "0.4", features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.22.2"

--- a/mullvad-daemon/src/migrations/v3.rs
+++ b/mullvad-daemon/src/migrations/v3.rs
@@ -1,6 +1,4 @@
 use super::{Error, Result};
-#[cfg(target_os = "android")]
-use jnix::IntoJava;
 use mullvad_types::settings::SettingsVersion;
 use std::net::IpAddr;
 
@@ -23,19 +21,16 @@ impl Default for DnsState {
 
 /// DNS config
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-#[cfg_attr(target_os = "android", derive(IntoJava))]
-#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
+#[serde(default)]
 pub struct DnsOptions {
-    #[cfg_attr(target_os = "android", jnix(map = "|state| state == DnsState::Custom"))]
     pub state: DnsState,
-    #[cfg_attr(target_os = "android", jnix(skip))]
     pub default_options: DefaultDnsOptions,
-    #[cfg_attr(target_os = "android", jnix(map = "|opts| opts.addresses"))]
     pub custom_options: CustomDnsOptions,
 }
 
 /// Default DNS config
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(default)]
 pub struct DefaultDnsOptions {
     pub block_ads: bool,
     pub block_trackers: bool,

--- a/mullvad-daemon/src/migrations/v4.rs
+++ b/mullvad-daemon/src/migrations/v4.rs
@@ -1,6 +1,4 @@
 use super::{Error, Result};
-#[cfg(target_os = "android")]
-use jnix::IntoJava;
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
 
 // ======================================================
@@ -13,8 +11,6 @@ const OPENVPN_TCP_PORTS: [u16; 2] = [80, 443];
 /// Representation of a transport protocol, either UDP or TCP.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(target_os = "android", derive(IntoJava))]
-#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.talpid.net"))]
 pub enum TransportProtocol {
     /// Represents the UDP transport protocol.
     Udp,

--- a/mullvad-daemon/src/migrations/v5.rs
+++ b/mullvad-daemon/src/migrations/v5.rs
@@ -1,6 +1,12 @@
 use super::{Error, Result};
 use mullvad_types::settings::SettingsVersion;
 
+// ======================================================
+// Section for vendoring types and values that
+// this settings version depend on. See `mod.rs`.
+
+// ======================================================
+
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {
         return Ok(());

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -238,6 +238,7 @@ impl Default for DnsState {
 
 /// DNS config
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(default)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct DnsOptions {
@@ -292,6 +293,7 @@ where
 
 /// Default DNS config
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(default)]
 pub struct DefaultDnsOptions {
     pub block_ads: bool,
     pub block_trackers: bool,


### PR DESCRIPTION
Fixes a bug in #3245. Since these attributes were missing a missing `block_malware` was not initialized to the default, instead the entire settings deserialization failed and everything was falling back to defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3249)
<!-- Reviewable:end -->
