### PR TITLE
Make GitHub Actions workflows trigger on all changes in pull request

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -1,7 +1,7 @@
 name: Android app CI
 on:
-    # Build whenever a file that affects Android is changed by a push
-    push:
+    # Build whenever a file that affects Android is changed in a pull request
+    pull_request:
         paths:
             - .github/workflows/android-app.yml
             - android/**

--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -1,6 +1,6 @@
 name: Android audit
 on:
-    push:
+    pull_request:
         paths:
             - .github/workflows/android-audit.yml
             - android/**

--- a/.github/workflows/android-ktlint.yml
+++ b/.github/workflows/android-ktlint.yml
@@ -1,7 +1,7 @@
 name: Android app Kotlin linter
 on:
     # Run linter whenever a Kotlin file changes
-    push:
+    pull_request:
         paths:
             - .github/workflows/android-ktlint.yml
             - android/**/*.kt

--- a/.github/workflows/android-xml-tidy.yml
+++ b/.github/workflows/android-xml-tidy.yml
@@ -1,7 +1,7 @@
 name: Android app XML formatting verifier
 on:
     # Run verifier whenever an Android XML file changes
-    push:
+    pull_request:
         paths:
             - .github/workflows/android-xml-tidy.yml
             - android/app/src/main/**/*.xml

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,6 +1,6 @@
 name: Audit Rust dependencies CI
 on:
-    push:
+    pull_request:
         paths:
             - .github/workflows/cargo-audit.yml
             - '**/*.rs'

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -1,7 +1,7 @@
 name: Mullvad VPN daemon CI
 on:
-    # Build whenever a file that affects a Rust crate is changed by a push
-    push:
+    # Build whenever a file that affects a Rust crate is changed in a pull request
+    pull_request:
         paths-ignore:
             - '**/*.md'
             - .github/workflows/android*.yml

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,7 +1,7 @@
 name: Electron frontend CI
 on:
-    # Build whenever a file that affects the frontend is changed by a push
-    push:
+    # Build whenever a file that affects the frontend is changed in a pull request
+    pull_request:
         paths:
             - .github/workflows/frontend.yml
             - gui/**

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,6 +1,6 @@
 name: iOS app CI
 on:
-    push:
+    pull_request:
         paths:
             - .github/workflows/ios.yml
             - ios/**

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,7 +1,7 @@
 name: Rust formatting check CI
 on:
-    # Check whenever a file that affects Rust formatting is changed by a push
-    push:
+    # Check whenever a file that affects Rust formatting is changed in a pull request
+    pull_request:
         paths:
             - .github/workflows/rustfmt.yml
             - rustfmt.toml

--- a/.github/workflows/translations-converter.yml
+++ b/.github/workflows/translations-converter.yml
@@ -1,7 +1,7 @@
 name: Translations converter tool CI
 on:
     # Run whenever a file that affects the translations converter tool is changed
-    push:
+    pull_request:
         paths:
             - .github/workflows/translations-converter.yml
             - android/translations-converter/**

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,7 +1,7 @@
 name: Translation check CI
 on:
-    # Check whenever a file that affects Rust formatting is changed by a push
-    push:
+    # Check whenever a file that affects Rust formatting is changed in a pull request
+    pull_request:
         paths:
             - .github/workflows/translations.yml
             - android/translations-converter/**

--- a/.github/workflows/unicode-check.yml
+++ b/.github/workflows/unicode-check.yml
@@ -1,8 +1,5 @@
 name: Bidirectional Unicode scan
-on:
-    push:
-    # Request manually from the Actions tab
-    workflow_dispatch:
+on: [pull_request, workflow_dispatch]
 jobs:
     build-linux:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes all GitHub Actions workflow triggers from `push` to `pull_request` which will trigger for when the commits change in a PR, when it's opened and when it's reopened if closed. The paths that triggers a workflow will now be compared against the full list of changed files in the pull request instead of just the latest push.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3252)
<!-- Reviewable:end -->
