### PR TITLE
Disable gRPC http proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Always kill `sslocal` if the tunnel monitor fails to start when using bridges.
 - Show relay location constraint correctly in the CLI when it is set to `any`.
+- Prevent gRPC from trying to run the app-daemon IPC communication through a HTTP proxy when the
+  environment variable `http_proxy` is set. This caused the app to fail to connect to the daemon.
 
 #### macOS
 - Disable built-in DNS resolver in Electron. Prevents Electron from establishing connections to

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -584,6 +584,9 @@ export class DaemonRpc {
       'grpc.initial_reconnect_backoff_ms': 3000,
       'grpc.keepalive_time_ms': Math.pow(2, 30),
       'grpc.keepalive_timeout_ms': Math.pow(2, 30),
+      // Prevents grpc-js from parsing the `http_proxy` environment variable and trying to use it
+      // even for IPC sockets.
+      'grpc.enable_http_proxy': 0,
     };
     /* eslint-enable @typescript-eslint/naming-convention */
   }


### PR DESCRIPTION
This prevents gRPC-js from using the environment variable `http_proxy` which is used for all connections. If that variable was set our app wasn't able to connect to the daemon.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3259)
<!-- Reviewable:end -->
