### PR TITLE
Refactor tunnel state handling

### DIFF
--- a/gui/src/shared/connect-helper.ts
+++ b/gui/src/shared/connect-helper.ts
@@ -1,0 +1,34 @@
+import { AccountToken, TunnelState } from './daemon-rpc-types';
+
+export function connectEnabled(
+  connectedToDaemon: boolean,
+  accountToken: AccountToken | undefined,
+  tunnelState: TunnelState['state'],
+) {
+  return (
+    connectedToDaemon &&
+    accountToken !== undefined &&
+    (tunnelState === 'disconnected' || tunnelState === 'disconnecting' || tunnelState === 'error')
+  );
+}
+
+export function reconnectEnabled(
+  connectedToDaemon: boolean,
+  accountToken: AccountToken | undefined,
+  tunnelState: TunnelState['state'],
+) {
+  return (
+    connectedToDaemon &&
+    accountToken !== undefined &&
+    (tunnelState === 'connected' || tunnelState === 'connecting')
+  );
+}
+
+// Disconnecting while logged out is allowed since it's possible to "connect" and end up in the
+// blocked state with the CLI.
+export function disconnectEnabled(connectedToDaemon: boolean, tunnelState: TunnelState['state']) {
+  return (
+    connectedToDaemon &&
+    (tunnelState === 'connected' || tunnelState === 'connecting' || tunnelState === 'error')
+  );
+}


### PR DESCRIPTION
This PR refactors how the next assumed tunnel state is handled (called optimistic tunnel state before this PR). Previously this was done both in the main and renderer processes. Now it's instead handled in the main process only.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3260)
<!-- Reviewable:end -->
