### PR TITLE
Tray context menu improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Line wrap the file at 100 chars.                                              Th
   environment variable `http_proxy` is set. This caused the app to fail to connect to the daemon.
 - Disable built-in DNS resolver in Electron. Prevents Electron from establishing connections to
   DNS servers set in system network preferences.
+- Fix tray context menu showing or executing wrong actions, using wrong language or in other
+  ways not update properly.
 
 #### macOS
 - Resolve issues with the app blocking internet connectivity after sleep or when connecting to new

--- a/gui/src/shared/connect-helper.ts
+++ b/gui/src/shared/connect-helper.ts
@@ -8,6 +8,7 @@ export function connectEnabled(
   return (
     connectedToDaemon &&
     accountToken !== undefined &&
+    accountToken !== '' &&
     (tunnelState === 'disconnected' || tunnelState === 'disconnecting' || tunnelState === 'error')
   );
 }
@@ -20,6 +21,7 @@ export function reconnectEnabled(
   return (
     connectedToDaemon &&
     accountToken !== undefined &&
+    accountToken !== '' &&
     (tunnelState === 'connected' || tunnelState === 'connecting')
   );
 }


### PR DESCRIPTION
This PR improves the context menu by:
* Move code that creates the menu to `tray-icon-controller.ts`
* Change layout of context menu to not change text and action of items and instead just change `enabled`
* Update context menu when account, daemon connection or language changes.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3266)
<!-- Reviewable:end -->
