### PR TITLE
Make `mullvad relay set hostname` not case sensitive to the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Line wrap the file at 100 chars.                                              Th
 - Gradually increase the WireGuard connectivity check timeout, lowering the timeout for the first
   few attempts.
 - Stop preferring OpenVPN when bridge mode is enabled.
+- CLI command for setting a specific server by hostname is no longer case sensitive.
+  Example: `mullvad relay set hostname SE9-WIREGUARD` should now work.
 
 #### Android
 - Avoid running in foreground when not connected.


### PR DESCRIPTION
This has been done previously for `mullvad relay set location`, but the hostname seems to have been ignored/forgotten.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3267)
<!-- Reviewable:end -->
