### PR TITLE
Move printing to stdout/stderr out of problem-report library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "env_logger 0.8.4",
  "err-derive",
  "lazy_static",
+ "log",
  "mullvad-paths",
  "mullvad-rpc",
  "regex",

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -13,6 +13,7 @@ dirs-next = "2.0"
 env_logger = "0.8.2"
 err-derive = "0.3.0"
 lazy_static = "1.0"
+log = "0.4"
 regex = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 tokio = { version = "1.8", features = [ "rt" ] }


### PR DESCRIPTION
I found we wrote to stdout/stderr in the *library* part of `mullvad-problem-report`. I don't think libraries should print to stdout/stderr. I guess this is a remains that was forgotten when migrating it from a binary to a library a long time ago?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3271)
<!-- Reviewable:end -->
