### PR TITLE
Just slight fix for the documentation `///` -> `//!` and similar

### DIFF
--- a/mullvad-rpc/src/bin/address_cache.rs
+++ b/mullvad-rpc/src/bin/address_cache.rs
@@ -1,4 +1,8 @@
-/// Generate a first list of IP addresses for Mullvad VPN to use to talk to the API.
+//! Fetches and prints a list of IP addresses and ports where the Mullvad API
+//! can be reached.
+//! Used by the installer artifact packer to bundle the latest available list
+//! of API IPs.
+
 use mullvad_rpc::{rest::Error as RestError, ApiProxy, MullvadRpcRuntime};
 use std::process;
 use talpid_types::ErrorExt;

--- a/mullvad-rpc/src/bin/relay_list.rs
+++ b/mullvad-rpc/src/bin/relay_list.rs
@@ -1,5 +1,7 @@
-/// Intended to be used to pre-load a relay list when creating an installer for the Mullvad VPN
-/// app.
+//! Fetches and prints the full relay list in JSON.
+//! Used by the installer artifact packer to bundle the latest available
+//! relay list at the time of creating the installer.
+
 use mullvad_rpc::{rest::Error as RestError, MullvadRpcRuntime, RelayListProxy};
 use std::process;
 use talpid_types::ErrorExt;

--- a/mullvad-rpc/src/relay_list.rs
+++ b/mullvad-rpc/src/relay_list.rs
@@ -1,4 +1,5 @@
-/// A module dedicated to retrieving the relay list from the master API.
+//! A module dedicated to retrieving the relay list from the Mullvad API.
+
 use crate::rest;
 
 use hyper::{header, Method, StatusCode};


### PR DESCRIPTION
We invalidly used `///` in a bunch of places. That's for documenting individual items, not the entire module.

I also sliightly improved the documentation in a few places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3272)
<!-- Reviewable:end -->
