### PR TITLE
Fix GUI not starting after a fresh install

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -13,6 +13,7 @@ import {
   systemPreferences,
   Tray,
 } from 'electron';
+import fs from 'fs';
 import * as path from 'path';
 import util from 'util';
 import config from '../config.json';
@@ -336,9 +337,11 @@ class ApplicationMain {
     if (process.platform === 'win32') {
       const appDataDir = process.env.LOCALAPPDATA;
       if (appDataDir) {
+        const userData = path.join(appDataDir, app.name);
         app.setPath('appData', appDataDir);
-        app.setPath('userData', path.join(appDataDir, app.name));
+        app.setPath('userData', userData);
         app.setPath('logs', path.join(appDataDir, app.name, 'logs'));
+        fs.mkdirSync(userData, { recursive: true });
       } else {
         throw new Error('Missing %LOCALAPPDATA% environment variable');
       }


### PR DESCRIPTION
Due to #3210, the GUI crashes if `%localappdata%\Mullvad VPN` does not exist, e.g. the first time you run it after installing the app. Electron tries to create a lockfile there without ensuring that the directory exists first:

```
[22500:0118/134306.582:ERROR:process_singleton_win.cc(466)] Lock file can not be created! Error code: 3
```

This PR works around the issue by simply creating the directory if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3273)
<!-- Reviewable:end -->
