### PR TITLE
Move electron resolver changelog item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,13 +72,12 @@ Line wrap the file at 100 chars.                                              Th
 - Show relay location constraint correctly in the CLI when it is set to `any`.
 - Prevent gRPC from trying to run the app-daemon IPC communication through a HTTP proxy when the
   environment variable `http_proxy` is set. This caused the app to fail to connect to the daemon.
-
-#### macOS
 - Disable built-in DNS resolver in Electron. Prevents Electron from establishing connections to
   DNS servers set in system network preferences.
+
+#### macOS
 - Resolve issues with the app blocking internet connectivity after sleep or when connecting to new
   wireless networks.
-
 
 #### Windows
 - Fix app size after changing display scale.


### PR DESCRIPTION
The changes that disabled the built-in DNS resolver in Electron was added under the macOS category in the changelog, but there's nothing specific to macOS in the code or documentation. I haven't tested it on other platforms but it should affect those as well.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3275)
<!-- Reviewable:end -->
