### PR TITLE
Add requirements for OpenVPN UDP and bridge mode

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -802,10 +802,22 @@ msgctxt "openvpn-settings-view"
 msgid "Set OpenVPN MSS value. Valid range: %(min)d - %(max)d."
 msgstr ""
 
-#. This is used to instruct users how to make the bridge
-#. mode setting available.
+#. This is used to instruct users how to make the bridge mode setting
+#. available.
+msgctxt "openvpn-settings-view"
+msgid "To activate Bridge mode, change **Transport protocol** to **Automatic** or **TCP**."
+msgstr ""
+
+#. This is used to instruct users how to make the bridge mode setting
+#. available.
 msgctxt "openvpn-settings-view"
 msgid "To activate Bridge mode, go back and change **Tunnel protocol** to **OpenVPN**."
+msgstr ""
+
+#. This is used to instruct users how to make UDP mode
+#. available.
+msgctxt "openvpn-settings-view"
+msgid "To activate UDP, change **Bridge mode** to **Automatic** or **Off**."
 msgstr ""
 
 msgctxt "openvpn-settings-view"

--- a/gui/src/renderer/components/cell/Selector.tsx
+++ b/gui/src/renderer/components/cell/Selector.tsx
@@ -17,11 +17,12 @@ interface ISelectorProps<T> {
   onSelect: (value: T) => void;
   selectedCellRef?: React.Ref<HTMLButtonElement>;
   className?: string;
+  hasFooter?: boolean;
 }
 
-const Section = styled(Cell.Section)({
-  marginBottom: 20,
-});
+const Section = styled(Cell.Section)((props: { hasFooter: boolean }) => ({
+  marginBottom: props.hasFooter ? 0 : '20px',
+}));
 
 export default class Selector<T> extends React.Component<ISelectorProps<T>> {
   public render() {
@@ -49,7 +50,10 @@ export default class Selector<T> extends React.Component<ISelectorProps<T>> {
 
     return (
       <AriaInput>
-        <Section role="listbox" className={this.props.className}>
+        <Section
+          role="listbox"
+          className={this.props.className}
+          hasFooter={this.props.hasFooter ?? false}>
           {title}
           {items}
         </Section>

--- a/gui/src/renderer/containers/OpenVPNSettingsPage.tsx
+++ b/gui/src/renderer/containers/OpenVPNSettingsPage.tsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { BridgeState, RelayProtocol } from '../../shared/daemon-rpc-types';
 import log from '../../shared/logging';
 import RelaySettingsBuilder from '../../shared/relay-settings-builder';
-import OpenVPNSettings from '../components/OpenVPNSettings';
+import OpenVPNSettings, { BridgeModeAvailability } from '../components/OpenVPNSettings';
 
 import withAppContext, { IAppContext } from '../context';
 import { IHistoryProps, withHistory } from '../lib/history';
@@ -12,8 +12,15 @@ import { IReduxState, ReduxDispatch } from '../redux/store';
 const mapStateToProps = (state: IReduxState) => {
   const protocolAndPort = mapRelaySettingsToProtocolAndPort(state.settings.relaySettings);
 
+  let bridgeModeAvailablity = BridgeModeAvailability.available;
+  if (mapRelaySettingsToProtocol(state.settings.relaySettings) !== 'openvpn') {
+    bridgeModeAvailablity = BridgeModeAvailability.blockedDueToTunnelProtocol;
+  } else if (protocolAndPort.openvpn.protocol === 'udp') {
+    bridgeModeAvailablity = BridgeModeAvailability.blockedDueToTransportProtocol;
+  }
+
   return {
-    tunnelProtocolIsOpenVpn: mapRelaySettingsToProtocol(state.settings.relaySettings) === 'openvpn',
+    bridgeModeAvailablity,
     mssfix: state.settings.openVpn.mssfix,
     bridgeState: state.settings.bridgeState,
     ...protocolAndPort,


### PR DESCRIPTION
This PR:
* Changes the bridge mode selector to not allow setting `on` if `UDP` is selected as transport protocol,
* Changes the tranport protocol selector to not allow `UDP` if bridge-mode is `on`.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3276)
<!-- Reviewable:end -->
