### PR TITLE
Fix auto-connect on app removed from recent apps

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,7 +51,8 @@
         </activity>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"
                  android:permission="android.permission.BIND_VPN_SERVICE"
-                 android:process=":mullvadvpn_daemon">
+                 android:process=":mullvadvpn_daemon"
+                 android:stopWithTask="false">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
 import net.mullvad.mullvadvpn.service.notifications.AccountExpiryNotification
 import net.mullvad.mullvadvpn.ui.MainActivity
@@ -167,6 +168,15 @@ class MullvadVpnService : TalpidVpnService() {
         notificationManager.onDestroy()
         daemonInstance.onDestroy()
         super.onDestroy()
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        connectionProxy.onStateChange.latestEvent.let { tunnelState ->
+            Log.d(TAG, "Task removed (tunnelState=$tunnelState)")
+            if (tunnelState == TunnelState.Disconnected) {
+                stop()
+            }
+        }
     }
 
     private fun handleDaemonInstance(daemon: MullvadDaemon?) {


### PR DESCRIPTION
By default in Android, a service will be automatically killed if it
belongs to a task that was removed (i.e. from recent apps) without a
chance to run any cleanup logic.

In this case, the lack of cleanup would lead to a crash and auto-restart
(triggered by the system) resulting in a auto-connect. To fix this, a
graceful stop will be ran if the task is removed while the tunnel is
disconnected (service not running as foreground). However if the tunnel
is in other states than disconnected (service running as foreground),
the service should continue to run as it's bound by the system.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3277)
<!-- Reviewable:end -->
