### PR TITLE
Fix notification update when vpn service killed

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -86,8 +86,6 @@ class ForegroundNotificationManager(
     }
 
     fun onDestroy() {
-        accountNumberEvents = null
-
         connectionProxy.onStateChange.unsubscribe(this)
         service.unregisterReceiver(deviceLockListener)
 


### PR DESCRIPTION
Fixes an annoying behavior where the vpn state notification is created
or updated just before the vpn service is killed. For example, if the
tunnel is disconnected and the user swipes away the "Unsecured"
notification, a new "Unsecured" notification (without the possibility to
connect) would appear after a delay (~1-3min).

This fix ensures that the notification isn't updated when the service is
killed.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3282)
<!-- Reviewable:end -->
