### PR TITLE
Fix tunnel state notification behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Line wrap the file at 100 chars.                                              Th
   * The System Settings way of killing apps ("Force Stop").
 - Change Quick Settings tile label to reflect the action of clicking the tile. Also add a subtitle
   on supported Android versions (Q and above) to reflect the state.
+- Hide the tunnel state notification from the lock screen.
 
 #### Windows
 - Update wireguard-nt to 0.10.1.
@@ -93,6 +94,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix Quick Settings tile showing wrong state in certain scenarios.
 - Fix banner sometimes incorrectly showing (e.g. "BLOCKING INTERNET").
 - Fix issue with the user getting kicked out of certain views in settings when the app is brought to the foreground.
+- Fix "Secure my connection" action not always visible in tunnel state notification.
+- Fix tunnel state notification sometimes re-appearing after being dismissed.
 
 ### Security
 - Restrict which applications are allowed to communicate with the API while in a blocking state.

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -86,8 +86,6 @@ class ForegroundNotificationManager(
     }
 
     fun onDestroy() {
-        accountNumberEvents = null
-
         connectionProxy.onStateChange.unsubscribe(this)
         service.unregisterReceiver(deviceLockListener)
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -128,6 +128,10 @@ class ForegroundNotificationManager(
         }
     }
 
+    fun cancelNotification() {
+        tunnelStateNotification.visible = false
+    }
+
     private fun updateNotificationAction() {
         tunnelStateNotification.showAction = loggedIn && deviceIsUnlocked
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -1,11 +1,6 @@
 package net.mullvad.mullvadvpn.service
 
-import android.app.KeyguardManager
 import android.app.Service
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -19,8 +14,7 @@ import net.mullvad.talpid.util.autoSubscribable
 
 class ForegroundNotificationManager(
     val service: MullvadVpnService,
-    val connectionProxy: ConnectionProxy,
-    val keyguardManager: KeyguardManager
+    val connectionProxy: ConnectionProxy
 ) {
     private sealed class UpdaterMessage {
         class UpdateNotification : UpdaterMessage()
@@ -31,20 +25,6 @@ class ForegroundNotificationManager(
     private val updater = runUpdater()
 
     private val tunnelStateNotification = TunnelStateNotification(service)
-
-    private val deviceLockListener = object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            val action = intent.action
-
-            if (action == Intent.ACTION_USER_PRESENT || action == Intent.ACTION_SCREEN_OFF) {
-                deviceIsUnlocked = !keyguardManager.isDeviceLocked
-            }
-        }
-    }
-
-    private var deviceIsUnlocked by observable(!keyguardManager.isDeviceLocked) { _, _, _ ->
-        updater.sendBlocking(UpdaterMessage.UpdateAction())
-    }
 
     private var loggedIn by observable(false) { _, _, _ ->
         updater.sendBlocking(UpdaterMessage.UpdateAction())
@@ -72,23 +52,11 @@ class ForegroundNotificationManager(
             updater.sendBlocking(UpdaterMessage.NewTunnelState(newState))
         }
 
-        service.apply {
-            registerReceiver(
-                deviceLockListener,
-                IntentFilter().apply {
-                    addAction(Intent.ACTION_USER_PRESENT)
-                    addAction(Intent.ACTION_SCREEN_OFF)
-                }
-            )
-        }
-
         updater.sendBlocking(UpdaterMessage.UpdateNotification())
     }
 
     fun onDestroy() {
         connectionProxy.onStateChange.unsubscribe(this)
-        service.unregisterReceiver(deviceLockListener)
-
         updater.close()
     }
 
@@ -133,6 +101,6 @@ class ForegroundNotificationManager(
     }
 
     private fun updateNotificationAction() {
-        tunnelStateNotification.showAction = loggedIn && deviceIsUnlocked
+        tunnelStateNotification.showAction = loggedIn
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -174,6 +174,7 @@ class MullvadVpnService : TalpidVpnService() {
         connectionProxy.onStateChange.latestEvent.let { tunnelState ->
             Log.d(TAG, "Task removed (tunnelState=$tunnelState)")
             if (tunnelState == TunnelState.Disconnected) {
+                notificationManager.cancelNotification()
                 stop()
             }
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -83,7 +83,7 @@ class MullvadVpnService : TalpidVpnService() {
         }
 
         notificationManager =
-            ForegroundNotificationManager(this, connectionProxy, keyguardManager).apply {
+            ForegroundNotificationManager(this, connectionProxy).apply {
                 accountNumberEvents = endpoint.settingsListener.accountNumberNotifier
             }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -40,7 +40,8 @@ class AccountExpiryNotification(
         NotificationCompat.VISIBILITY_PRIVATE,
         R.string.account_time_notification_channel_name,
         R.string.account_time_notification_channel_description,
-        NotificationManager.IMPORTANCE_HIGH
+        NotificationManager.IMPORTANCE_HIGH,
+        true
     )
 
     var loginStatus by observable<LoginStatus?>(null) { _, oldValue, newValue ->

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.core.app.NotificationCompat
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.R
@@ -36,6 +37,7 @@ class AccountExpiryNotification(
     private val channel = NotificationChannel(
         context,
         "mullvad_account_time",
+        NotificationCompat.VISIBILITY_PRIVATE,
         R.string.account_time_notification_channel_name,
         R.string.account_time_notification_channel_description,
         NotificationManager.IMPORTANCE_HIGH

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -14,7 +14,8 @@ class NotificationChannel(
     val visibility: Int,
     name: Int,
     description: Int,
-    importance: Int
+    importance: Int,
+    isVibrationEnabled: Boolean
 ) {
     private val badgeColor by lazy {
         context.getColor(R.color.colorPrimary)
@@ -30,6 +31,7 @@ class NotificationChannel(
             .setName(channelName)
             .setDescription(channelDescription)
             .setShowBadge(true)
+            .setVibrationEnabled(isVibrationEnabled)
             .build()
 
         notificationManager.createNotificationChannel(channel)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -1,8 +1,6 @@
 package net.mullvad.mullvadvpn.service.notifications
 
 import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.NotificationChannelCompat
@@ -13,6 +11,7 @@ import net.mullvad.mullvadvpn.R
 class NotificationChannel(
     val context: Context,
     val id: String,
+    val visibility: Int,
     name: Int,
     description: Int,
     importance: Int
@@ -72,6 +71,7 @@ class NotificationChannel(
             .setColor(badgeColor)
             .setContentTitle(title)
             .setContentIntent(pendingIntent)
+            .setVisibility(visibility)
 
         for (action in actions) {
             builder.addAction(action)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -5,31 +5,33 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import net.mullvad.mullvadvpn.R
 
 class NotificationChannel(
     val context: Context,
     val id: String,
-    val name: Int,
-    val description: Int,
-    val importance: Int
+    name: Int,
+    description: Int,
+    importance: Int
 ) {
     private val badgeColor by lazy {
         context.getColor(R.color.colorPrimary)
     }
 
-    val notificationManager =
-        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    val notificationManager = NotificationManagerCompat.from(context)
 
     init {
         val channelName = context.getString(name)
         val channelDescription = context.getString(description)
 
-        val channel = NotificationChannel(id, channelName, importance).apply {
-            description = channelDescription
-            setShowBadge(true)
-        }
+        val channel = NotificationChannelCompat.Builder(id, importance)
+            .setName(channelName)
+            .setDescription(channelDescription)
+            .setShowBadge(true)
+            .build()
 
         notificationManager.createNotificationChannel(channel)
     }
@@ -59,7 +61,7 @@ class NotificationChannel(
         return buildNotification(pendingIntent, context.getString(title), actions, deleteIntent)
     }
 
-    fun buildNotification(
+    private fun buildNotification(
         pendingIntent: PendingIntent,
         title: String,
         actions: List<NotificationCompat.Action>,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -23,7 +23,8 @@ class TunnelStateNotification(val context: Context) {
         NotificationCompat.VISIBILITY_SECRET,
         R.string.foreground_notification_channel_name,
         R.string.foreground_notification_channel_description,
-        NotificationManager.IMPORTANCE_MIN
+        NotificationManager.IMPORTANCE_MIN,
+        false
     )
 
     private val notificationText: Int

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -20,6 +20,7 @@ class TunnelStateNotification(val context: Context) {
     private val channel = NotificationChannel(
         context,
         "vpn_tunnel_status",
+        NotificationCompat.VISIBILITY_SECRET,
         R.string.foreground_notification_channel_name,
         R.string.foreground_notification_channel_description,
         NotificationManager.IMPORTANCE_MIN


### PR DESCRIPTION
This PR aims to improve the general tunnel state notification behavior as there were plenty of cases where dismissed notifications ("Unsecured") would appear again, such as:
- When locking device. 
- If the notification is dismissed quick after disconnecting and putting the app to the background. The new notificaiton would not have any action buttons in this case.

These issues are fixed by:
- Hiding the the notificaiton from the lock screen.
- Avoiding updating the notification (to hide action buttons).

This PR also makes sure to clean-up the notification if the app task is removed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3288)
<!-- Reviewable:end -->
