### PR TITLE
Fix android tv startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix issue with the user getting kicked out of certain views in settings when the app is brought to the foreground.
 - Fix "Secure my connection" action not always visible in tunnel state notification.
 - Fix tunnel state notification sometimes re-appearing after being dismissed.
+- Fix app sometimes crashing during startup on Android TVs.
 
 ### Security
 - Restrict which applications are allowed to communicate with the API while in a blocking state.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,25 +28,15 @@
                   android:label="@string/app_name"
                   android:launchMode="singleTask"
                   android:configChanges="orientation|screenSize|screenLayout"
-                  android:screenOrientation="sensorPortrait"
+                  android:screenOrientation="locked"
                   android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
-            </intent-filter>
-        </activity>
-        <activity android:name="net.mullvad.mullvadvpn.ui.activities.TVActivity"
-                  android:label="@string/app_name"
-                  android:launchMode="singleTask"
-                  android:configChanges="orientation|screenSize|screenLayout"
-                  android:screenOrientation="sensor"
-                  android:windowSoftInputMode="adjustPan">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
         <service android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -1,19 +1,14 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
-import android.app.UiModeManager
 import android.content.Context
-import android.content.Context.UI_MODE_SERVICE
 import android.content.Intent
-import android.content.res.Configuration.UI_MODE_TYPE_TELEVISION
 import android.net.VpnService
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.ui.MainActivity
-import net.mullvad.mullvadvpn.ui.activities.TVActivity
 import net.mullvad.mullvadvpn.util.Intermittent
 
 class VpnPermission(private val context: Context, private val endpoint: ServiceEndpoint) {
-    private val activityClass = discoverActivityClass()
     private val isGranted = Intermittent<Boolean>()
 
     var waitingForResponse = false
@@ -32,7 +27,7 @@ class VpnPermission(private val context: Context, private val endpoint: ServiceE
         if (intent == null) {
             isGranted.update(true)
         } else {
-            val activityIntent = Intent(context, activityClass).apply {
+            val activityIntent = Intent(context, MainActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
@@ -45,15 +40,5 @@ class VpnPermission(private val context: Context, private val endpoint: ServiceE
         }
 
         return isGranted.await()
-    }
-
-    private fun discoverActivityClass(): Class<out MainActivity> {
-        val uiModeManager = context.getSystemService(UI_MODE_SERVICE) as UiModeManager
-
-        return if (uiModeManager.currentModeType == UI_MODE_TYPE_TELEVISION) {
-            TVActivity::class.java
-        } else {
-            MainActivity::class.java
-        }
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -64,8 +64,10 @@ open class MainActivity : FragmentActivity() {
     var backButtonHandler: (() -> Boolean)? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        if (deviceIsTv) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE)
+        requestedOrientation = if (deviceIsTv) {
+            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        } else {
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
 
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/activities/TVActivity.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/activities/TVActivity.kt
@@ -1,5 +1,0 @@
-package net.mullvad.mullvadvpn.ui.activities
-
-import net.mullvad.mullvadvpn.ui.MainActivity
-
-class TVActivity : MainActivity()


### PR DESCRIPTION
The main activity and tv activity are both designed to be running as
singleTask and the app would crash if both were started. This would not
be common, but possible, on a phone or tablet, however this can
potentially occur frequently on Android TV (perhaps depending on OEM),
as both categories  LAUNCHER and LEANBACK_LAUNCHER are used. E.g.the tv
launcher would use LEANBACK_LAUNCHER whereas the settings app would use
LAUNCHER.
    
As the tv activity isn't used for any customization atm, this was fixed
by simply removing the tv activity and adding the LEANBACK_LAUNCHER
category to the main activity.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3296)
<!-- Reviewable:end -->
