### PR TITLE
Remove user config files on purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix notifications on Windows not showing if window is unpinned and hidden.
 - Wait for IP interfaces to arrive before trying to configure them when using wireguard-nt.
 
+#### Linux
+- Remove auto-launch file, GUI settings and other files created by the app in user directories, when
+  uninstalling/purging.
+
 ### Security
 - Restrict which applications are allowed to communicate with the API while in a blocking state.
   This prevents malicious scripts on websites from trying to do so. On Windows, only

--- a/dist-assets/linux/after-remove.sh
+++ b/dist-assets/linux/after-remove.sh
@@ -11,6 +11,29 @@ function remove_logs_and_cache {
 function remove_config {
   rm -r --interactive=never /etc/mullvad-vpn || \
     echo "Failed to remove mullvad-vpn config"
+
+  # Remove app settings and auto-launcher for all users. This doesn't respect XDG_CONFIG_HOME due
+  # to the complexity required.
+  if [[ -f "/etc/passwd" ]] && command -v cut > /dev/null; then
+      local home_dirs
+      home_dirs=$(cut -d: -f6 /etc/passwd)
+      for home_dir in $home_dirs; do
+          local mullvad_dir="$home_dir/.config/Mullvad VPN"
+          if [[ -d "$mullvad_dir" ]]; then
+              echo "Removing mullvad-vpn app settings from $mullvad_dir"
+              rm -r --interactive=never "$mullvad_dir" || \
+                  echo "Failed to remove mullvad-vpn app settings"
+          fi
+
+          local autostart_path="$home_dir/.config/autostart/mullvad-vpn.desktop"
+          # mullvad-vpn.desktop can be both a file or a symlink.
+          if [[ -f "$autostart_path" || -L "$autostart_path" ]]; then
+              echo "Removing mullvad-vpn app autostart file $autostart_path"
+              rm --interactive=never "$autostart_path" || \
+                  echo "Failed to remove mullvad-vpn autostart file"
+          fi
+      done
+  fi
 }
 
 # checking what kind of an action is taking place


### PR DESCRIPTION
This PR makes `after-remove.sh`, which is run when uninstalling on Linux, remove user configuration directories and files created by the app.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3302)
<!-- Reviewable:end -->
