### PR TITLE
Reapply split tunnel config if drives arrive or are removed

### DIFF
--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -1,40 +1,20 @@
-use crate::winnet;
+use crate::{
+    windows::window::{create_hidden_window, WindowCloseHandle},
+    winnet,
+};
 use futures::channel::mpsc::UnboundedSender;
 use parking_lot::Mutex;
 use std::{
     ffi::c_void,
     io,
-    mem::zeroed,
-    os::windows::io::{IntoRawHandle, RawHandle},
-    ptr,
     sync::{Arc, Weak},
     thread,
     time::Duration,
 };
 use talpid_types::ErrorExt;
-use winapi::{
-    shared::{
-        basetsd::LONG_PTR,
-        minwindef::{DWORD, LPARAM, LRESULT, UINT, WPARAM},
-        windef::HWND,
-    },
-    um::{
-        handleapi::CloseHandle,
-        libloaderapi::GetModuleHandleW,
-        processthreadsapi::GetThreadId,
-        synchapi::WaitForSingleObject,
-        winbase::INFINITE,
-        winuser::{
-            CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
-            GetWindowLongPtrW, PostQuitMessage, PostThreadMessageW, SetWindowLongPtrW,
-            GWLP_USERDATA, GWLP_WNDPROC, PBT_APMRESUMEAUTOMATIC, PBT_APMSUSPEND, WM_DESTROY,
-            WM_POWERBROADCAST, WM_USER,
-        },
-    },
+use winapi::um::winuser::{
+    DefWindowProcW, PBT_APMRESUMEAUTOMATIC, PBT_APMSUSPEND, WM_POWERBROADCAST,
 };
-
-const CLASS_NAME: &[u8] = b"S\0T\0A\0T\0I\0C\0\0\0";
-const REQUEST_THREAD_SHUTDOWN: UINT = WM_USER + 1;
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
@@ -45,8 +25,7 @@ pub enum Error {
 }
 
 pub struct BroadcastListener {
-    thread_handle: RawHandle,
-    thread_id: DWORD,
+    window: WindowCloseHandle,
     system_state: Arc<Mutex<SystemState>>,
     _callback_handle: winnet::WinNetCallbackHandle,
     _notify_tx: Arc<UnboundedSender<bool>>,
@@ -67,7 +46,7 @@ impl BroadcastListener {
 
         let power_broadcast_state_ref = system_state.clone();
 
-        let power_broadcast_callback = move |message: UINT, wparam: WPARAM, _lparam: LPARAM| {
+        let power_broadcast_callback = move |window, message, wparam, lparam| {
             let state = power_broadcast_state_ref.clone();
             if message == WM_POWERBROADCAST {
                 if wparam == PBT_APMSUSPEND {
@@ -83,22 +62,16 @@ impl BroadcastListener {
                     });
                 }
             }
+            unsafe { DefWindowProcW(window, message, wparam, lparam) }
         };
 
-        let join_handle = thread::Builder::new()
-            .spawn(move || unsafe {
-                Self::message_pump(power_broadcast_callback);
-            })
-            .map_err(Error::ThreadCreationError)?;
-
-        let real_handle = join_handle.into_raw_handle();
+        let window = create_hidden_window(power_broadcast_callback);
 
         let callback_handle =
             unsafe { Self::setup_network_connectivity_listener(system_state.clone())? };
 
         Ok(BroadcastListener {
-            thread_handle: real_handle,
-            thread_id: unsafe { GetThreadId(real_handle) },
+            window,
             system_state,
             _callback_handle: callback_handle,
             _notify_tx: notify_tx,
@@ -129,88 +102,6 @@ impl BroadcastListener {
         log::info!("Initial connectivity: {}", is_offline_str(!is_online));
 
         (v4_connectivity, v6_connectivity)
-    }
-
-    unsafe fn message_pump<F>(client_callback: F)
-    where
-        F: Fn(UINT, WPARAM, LPARAM),
-    {
-        let dummy_window = CreateWindowExW(
-            0,
-            CLASS_NAME.as_ptr() as *const u16,
-            ptr::null_mut(),
-            0,
-            0,
-            0,
-            0,
-            0,
-            ptr::null_mut(),
-            ptr::null_mut(),
-            GetModuleHandleW(ptr::null_mut()),
-            ptr::null_mut(),
-        );
-
-        // Move callback information to the heap.
-        // This enables us to reach the callback through a "thin pointer".
-        let boxed_callback = Box::new(client_callback);
-
-        // Detach callback from Box.
-        let raw_callback = Box::into_raw(boxed_callback) as *mut c_void;
-
-        SetWindowLongPtrW(dummy_window, GWLP_USERDATA, raw_callback as LONG_PTR);
-        SetWindowLongPtrW(
-            dummy_window,
-            GWLP_WNDPROC,
-            Self::window_procedure::<F> as LONG_PTR,
-        );
-
-        let mut msg = zeroed();
-
-        loop {
-            let status = GetMessageW(&mut msg, 0 as HWND, 0, 0);
-
-            if status < 0 {
-                continue;
-            }
-            if status == 0 {
-                break;
-            }
-
-            if msg.hwnd.is_null() {
-                if msg.message == REQUEST_THREAD_SHUTDOWN {
-                    DestroyWindow(dummy_window);
-                }
-            } else {
-                DispatchMessageW(&mut msg);
-            }
-        }
-
-        // Reattach callback to Box for proper clean-up.
-        let _ = Box::from_raw(raw_callback as *mut F);
-    }
-
-    unsafe extern "system" fn window_procedure<F>(
-        window: HWND,
-        message: UINT,
-        wparam: WPARAM,
-        lparam: LPARAM,
-    ) -> LRESULT
-    where
-        F: Fn(UINT, WPARAM, LPARAM),
-    {
-        let raw_callback = GetWindowLongPtrW(window, GWLP_USERDATA);
-
-        if raw_callback != 0 {
-            let typed_callback = &mut *(raw_callback as *mut F);
-            typed_callback(message, wparam, lparam);
-        }
-
-        if message == WM_DESTROY {
-            PostQuitMessage(0);
-            return 0;
-        }
-
-        DefWindowProcW(window, message, wparam, lparam)
     }
 
     /// The caller must make sure the `system_state` reference is valid
@@ -252,11 +143,7 @@ impl BroadcastListener {
 
 impl Drop for BroadcastListener {
     fn drop(&mut self) {
-        unsafe {
-            PostThreadMessageW(self.thread_id, REQUEST_THREAD_SHUTDOWN, 0, 0);
-            WaitForSingleObject(self.thread_handle, INFINITE);
-            CloseHandle(self.thread_handle);
-        }
+        self.window.close();
     }
 }
 

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -316,10 +316,9 @@ impl DeviceHandle {
         for app in apps.as_ref() {
             match get_device_path(app.as_ref()) {
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                    log::warn!(
+                    log::debug!(
                         "{}\nPath: {}",
-                        error
-                            .display_chain_with_msg("Skipping path with non-existent drive letter"),
+                        error.display_chain_with_msg("Ignoring path on unmounted volume"),
                         app.as_ref().to_string_lossy()
                     );
                 }

--- a/talpid-core/src/split_tunnel/windows/volume_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/volume_monitor.rs
@@ -1,0 +1,93 @@
+//! Used to monitor volume mounts and dismounts, and reapply the split
+//! tunnel config if any of the excluded paths are affected by them.
+use crate::windows::window::{create_hidden_window, WindowCloseHandle};
+use std::{
+    ffi::OsString,
+    path::{self, Path},
+    sync::{mpsc as sync_mpsc, Arc, Mutex},
+};
+use winapi::{
+    shared::minwindef::TRUE,
+    um::{
+        dbt::{
+            DBTF_NET, DBT_DEVICEARRIVAL, DBT_DEVICEREMOVECOMPLETE, DBT_DEVTYP_VOLUME,
+            DEV_BROADCAST_HDR, DEV_BROADCAST_VOLUME, WM_DEVICECHANGE,
+        },
+        winuser::DefWindowProcW,
+    },
+};
+
+pub(super) struct VolumeMonitor(());
+
+impl VolumeMonitor {
+    pub fn spawn(
+        update_tx: sync_mpsc::Sender<()>,
+        paths: Arc<Mutex<Vec<OsString>>>,
+    ) -> WindowCloseHandle {
+        create_hidden_window(move |window, message, w_param, l_param| {
+            if message != WM_DEVICECHANGE
+                || (w_param != DBT_DEVICEARRIVAL && w_param != DBT_DEVICEREMOVECOMPLETE)
+            {
+                return unsafe { DefWindowProcW(window, message, w_param, l_param) };
+            }
+
+            let paths_guard = paths.lock().unwrap();
+            let mut label_found = false;
+
+            let volumes = unsafe { parse_broadcast(&*(l_param as *const _)) };
+            for volume in volumes {
+                for path in &*paths_guard {
+                    let path = (path as &dyn AsRef<Path>).as_ref();
+                    if let Some(path::Component::Prefix(prefix)) = path.components().next() {
+                        match prefix.kind() {
+                            path::Prefix::VerbatimDisk(disk) | path::Prefix::Disk(disk) => {
+                                if disk == volume {
+                                    label_found = true;
+                                    break;
+                                }
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+                if label_found {
+                    break;
+                }
+            }
+
+            if label_found {
+                // Reapply config
+                let _ = update_tx.send(());
+            }
+
+            // Always grant the request
+            TRUE as isize
+        })
+    }
+}
+
+/// Return volume labels (ASCII-encoded) affected by the device arrival or removal message, if any.
+unsafe fn parse_broadcast(broadcast: &DEV_BROADCAST_HDR) -> Vec<u8> {
+    let mut labels = vec![];
+
+    if broadcast.dbch_devicetype != DBT_DEVTYP_VOLUME {
+        return labels;
+    }
+
+    let volume_broadcast = &*(broadcast as *const _ as *const DEV_BROADCAST_VOLUME);
+    if volume_broadcast.dbcv_flags & DBTF_NET != 0 {
+        // Ignore net event
+        return labels;
+    }
+
+    // 26 = 1 + 'Z' - 'A'
+    let num_drives = 1 + 'Z' as u8 - 'A' as u8;
+    for i in 0..num_drives {
+        let is_affected = ((volume_broadcast.dbcv_unitmask >> i) & 1) != 0;
+        if is_affected {
+            labels.push('A' as u8 + i);
+        }
+    }
+
+    labels
+}

--- a/talpid-core/src/split_tunnel/windows/volume_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/volume_monitor.rs
@@ -1,5 +1,6 @@
 //! Used to monitor volume mounts and dismounts, and reapply the split
 //! tunnel config if any of the excluded paths are affected by them.
+use super::path_monitor::PathMonitorHandle;
 use crate::windows::window::{create_hidden_window, WindowCloseHandle};
 use std::{
     ffi::OsString,
@@ -21,6 +22,7 @@ pub(super) struct VolumeMonitor(());
 
 impl VolumeMonitor {
     pub fn spawn(
+        path_monitor: PathMonitorHandle,
         update_tx: sync_mpsc::Sender<()>,
         paths: Arc<Mutex<Vec<OsString>>>,
     ) -> WindowCloseHandle {
@@ -58,6 +60,7 @@ impl VolumeMonitor {
             if label_found {
                 // Reapply config
                 let _ = update_tx.send(());
+                let _ = path_monitor.refresh();
             }
 
             // Always grant the request

--- a/talpid-core/src/windows/mod.rs
+++ b/talpid-core/src/windows/mod.rs
@@ -31,6 +31,8 @@ use winapi::shared::{
     ws2ipdef::{SOCKADDR_IN6_LH as sockaddr_in6, SOCKADDR_INET},
 };
 
+pub mod window;
+
 /// Result type for this module.
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/talpid-core/src/windows/window.rs
+++ b/talpid-core/src/windows/window.rs
@@ -1,0 +1,128 @@
+//! Utilities for windows.
+
+use std::{os::windows::io::AsRawHandle, ptr, thread};
+use winapi::{
+    shared::{
+        basetsd::LONG_PTR,
+        minwindef::{LPARAM, LRESULT, UINT, WPARAM},
+        windef::HWND,
+    },
+    um::{
+        libloaderapi::GetModuleHandleW,
+        processthreadsapi::GetThreadId,
+        winuser::{
+            CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
+            GetWindowLongPtrW, PostQuitMessage, PostThreadMessageW, SetWindowLongPtrW,
+            TranslateMessage, GWLP_USERDATA, GWLP_WNDPROC, WM_DESTROY, WM_USER,
+        },
+    },
+};
+
+const CLASS_NAME: &[u8] = b"S\0T\0A\0T\0I\0C\0\0\0";
+const REQUEST_THREAD_SHUTDOWN: UINT = WM_USER + 1;
+
+/// Handle for closing an associated window.
+/// The window is not destroyed when this is dropped.
+pub struct WindowCloseHandle {
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl WindowCloseHandle {
+    /// Close the window and wait for the thread.
+    pub fn close(&mut self) {
+        if let Some(thread) = self.thread.take() {
+            let thread_id = unsafe { GetThreadId(thread.as_raw_handle()) };
+            unsafe { PostThreadMessageW(thread_id, REQUEST_THREAD_SHUTDOWN, 0, 0) };
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Creates a dummy window whose messages are handled by `wnd_proc`.
+pub fn create_hidden_window<F: (Fn(HWND, UINT, WPARAM, LPARAM) -> LRESULT) + Send + 'static>(
+    wnd_proc: F,
+) -> WindowCloseHandle {
+    let join_handle = thread::spawn(move || {
+        let dummy_window = unsafe {
+            CreateWindowExW(
+                0,
+                CLASS_NAME.as_ptr() as *const u16,
+                ptr::null_mut(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                GetModuleHandleW(ptr::null_mut()),
+                ptr::null_mut(),
+            )
+        };
+
+        // Move callback information to the heap.
+        // This enables us to reach the callback through a "thin pointer".
+        let raw_callback = Box::into_raw(Box::new(wnd_proc));
+
+        unsafe {
+            SetWindowLongPtrW(dummy_window, GWLP_USERDATA, raw_callback as LONG_PTR);
+            SetWindowLongPtrW(
+                dummy_window,
+                GWLP_WNDPROC,
+                window_procedure::<F> as LONG_PTR,
+            );
+        }
+
+        let mut msg = unsafe { std::mem::zeroed() };
+
+        loop {
+            let status = unsafe { GetMessageW(&mut msg, ptr::null_mut(), 0, 0) };
+
+            if status < 0 {
+                continue;
+            }
+            if status == 0 {
+                break;
+            }
+
+            if msg.hwnd.is_null() {
+                if msg.message == REQUEST_THREAD_SHUTDOWN {
+                    unsafe { DestroyWindow(dummy_window) };
+                }
+            } else {
+                unsafe {
+                    TranslateMessage(&mut msg);
+                    DispatchMessageW(&mut msg);
+                }
+            }
+        }
+
+        // Free callback.
+        let _ = unsafe { Box::from_raw(raw_callback) };
+    });
+
+    WindowCloseHandle {
+        thread: Some(join_handle),
+    }
+}
+
+unsafe extern "system" fn window_procedure<F>(
+    window: HWND,
+    message: UINT,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT
+where
+    F: Fn(HWND, UINT, WPARAM, LPARAM) -> LRESULT,
+{
+    if message == WM_DESTROY {
+        PostQuitMessage(0);
+        return 0;
+    }
+    let raw_callback = GetWindowLongPtrW(window, GWLP_USERDATA);
+    if raw_callback != 0 {
+        let typed_callback = &mut *(raw_callback as *mut F);
+        return typed_callback(window, message, wparam, lparam);
+    }
+    DefWindowProcW(window, message, wparam, lparam)
+}


### PR DESCRIPTION
Excluded paths are now re-resolved to device paths when volumes are mounted, if necessary. Previously, paths that included a non-existent disk prefix were not excluded from the tunnel even if a volume was later assigned that letter prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3303)
<!-- Reviewable:end -->
