### PR TITLE
Take transport protocol into account for WireGuard.

### DIFF
--- a/mullvad-daemon/src/relays/matcher.rs
+++ b/mullvad-daemon/src/relays/matcher.rs
@@ -258,17 +258,20 @@ impl From<WireguardConstraints> for WireguardMatcher {
 
 impl Match<WireguardEndpointData> for WireguardMatcher {
     fn matches(&self, endpoint: &WireguardEndpointData) -> bool {
-        match self
-            .port
-            .as_ref()
-            .map(|port| port.port)
-            .unwrap_or(Constraint::Any)
-        {
+        match self.port {
             Constraint::Any => true,
-            Constraint::Only(port) => endpoint
-                .port_ranges
-                .iter()
-                .any(|range| (port >= range.0 && port <= range.1)),
+            Constraint::Only(TransportPort { port, protocol }) => {
+                if protocol != endpoint.protocol {
+                    return false;
+                }
+                match port {
+                    Constraint::Any => true,
+                    Constraint::Only(port) => endpoint
+                        .port_ranges
+                        .iter()
+                        .any(|range| (port >= range.0 && port <= range.1)),
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
When selecting relays, take WireGuard transport protocol constraint into account. In the recent refactor, the transport protocol for WireGuard was being disregarded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3310)
<!-- Reviewable:end -->
