### PR TITLE
Improve android app build in github actions

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -30,32 +30,45 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
+            - name: Calculate native lib cache hash
+              id: native-lib-cache-hash
+              shell: bash
+              run: |
+                non_android_hash="$(git grep --cached -l '' -- ':!android/' | xargs -d '\n' sha1sum | sha1sum | awk '{print $1}')"
+                echo "::set-output name=native_lib_hash::$non_android_hash"
+
+            - name: Cache native libraries
+              uses: actions/cache@v2
+              id: cache-native-libs
+              with:
+                path: |
+                  ./android/app/build/extraJni
+                  ./dist-assets/relays.json
+                  ./dist-assets/api-ip-address.txt
+                key: android-native-libs-${{ runner.os }}-x86_64-${{ steps.native-lib-cache-hash.outputs.native_lib_hash }}
+
             - name: Configure Rust
+              if: steps.cache-native-libs.outputs.cache-hit != 'true'
               uses: ATiltedTree/setup-rust@v1.0.4
               with:
                   rust-version: stable
                   targets: x86_64-linux-android
 
             - name: Configure Go
+              if: steps.cache-native-libs.outputs.cache-hit != 'true'
               uses: actions/setup-go@v2.1.3
               with:
                   go-version: 1.16
 
-            - name: Configure Android SDK
-              uses: maxim-lobanov/setup-android-tools@v1
-              with:
-                  packages: |
-                      platforms;android-30
-                      build-tools;30.0.3
-                  cache: true
-
             - name: Configure Android NDK
+              if: steps.cache-native-libs.outputs.cache-hit != 'true'
               id: install-android-ndk
               uses: nttld/setup-ndk@v1
               with:
                   ndk-version: r20b
 
             - name: Bind Cargo with NDK
+              if: steps.cache-native-libs.outputs.cache-hit != 'true'
               run: |
                 cat >> $HOME/.cargo/config << EOF
                 [target.x86_64-linux-android]
@@ -64,6 +77,7 @@ jobs:
                 EOF
 
             - name: Build native libraries
+              if: steps.cache-native-libs.outputs.cache-hit != 'true'
               env:
                 RUSTFLAGS: --deny warnings
                 NDK_TOOLCHAIN_DIR: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin
@@ -83,6 +97,14 @@ jobs:
                 cargo run --bin relay_list > dist-assets/relays.json
                 cargo run --bin address_cache > dist-assets/api-ip-address.txt
                 $NDK_TOOLCHAIN_STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+
+            - name: Configure Android SDK
+              uses: maxim-lobanov/setup-android-tools@v1
+              with:
+                  packages: |
+                      platforms;android-30
+                      build-tools;30.0.3
+                  cache: true
 
             - name: Build Android app
               uses: burrunan/gradle-cache-action@v1

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -107,6 +107,7 @@ jobs:
                 cd android
                 ./gradlew --console plain assembleDebug
                 ./gradlew testDebugUnitTest
+                ./gradlew assembleAndroidTest
 
             - name: Upload apks
               uses: actions/upload-artifact@v2
@@ -128,30 +129,9 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Declare commit sha variable
-              id: vars
-              shell: bash
-              run: |
-                echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-
-            - name: Set up Java
-              uses: actions/setup-java@v1
+            - uses: actions/download-artifact@v2
               with:
-                java-version: 1.8
-
-            - uses: gradle/wrapper-validation-action@v1
-
-            - name: Configure cache
-              uses: actions/cache@v2
-              with:
-                path: |
-                    ~/.gradle/caches
-                    ~/.gradle/wrapper
-                    ./android/build
-                    ./android/app/build
-                key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ steps.vars.outputs.sha_short }}
-                restore-keys: |
-                    gradle-${{ steps.vars.outputs.sha_short }}
+                name: apks
 
             - name: Run Android instrumented tests
               uses: reactivecircus/android-emulator-runner@v2
@@ -161,7 +141,6 @@ jobs:
                 emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-load -noaudio -no-boot-anim
                 disable-animations: true
                 profile: pixel
-                script: ./gradlew connectedCheck --stacktrace
-                working-directory: ./android
+                script: ./ci/run-android-instrumented-tests.sh $(pwd)
               env:
                 API_LEVEL: 29

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -30,12 +30,6 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Declare commit sha variable
-              id: vars
-              shell: bash
-              run: |
-                echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-
             - name: Configure Rust
               uses: ATiltedTree/setup-rust@v1.0.4
               with:
@@ -60,18 +54,6 @@ jobs:
               uses: nttld/setup-ndk@v1
               with:
                   ndk-version: r20b
-
-            - name: Configure cache
-              uses: actions/cache@v2
-              with:
-                path: |
-                    ~/.gradle/caches
-                    ~/.gradle/wrapper
-                    ./android/build
-                    ./android/app/build
-                key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ steps.vars.outputs.sha_short }}
-                restore-keys: |
-                    gradle-${{ steps.vars.outputs.sha_short }}
 
             - name: Bind Cargo with NDK
               run: |
@@ -102,12 +84,31 @@ jobs:
                 cargo run --bin address_cache > dist-assets/api-ip-address.txt
                 $NDK_TOOLCHAIN_STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
 
-            - name: Build and run unit tests
-              run: |
-                cd android
-                ./gradlew --console plain assembleDebug
-                ./gradlew testDebugUnitTest
-                ./gradlew assembleAndroidTest
+            - name: Build Android app
+              uses: burrunan/gradle-cache-action@v1
+              with:
+                job-id: jdk8
+                arguments: assembleDebug
+                gradle-version: wrapper
+                build-root-directory: android
+
+            - name: Run unit tests
+              uses: burrunan/gradle-cache-action@v1
+              with:
+                job-id: jdk8
+                arguments: testDebugUnitTest
+                gradle-version: wrapper
+                build-root-directory: android
+                execution-only-caches: true
+
+            - name: Assemble instrumented test apk
+              uses: burrunan/gradle-cache-action@v1
+              with:
+                job-id: jdk8
+                arguments: assembleAndroidTest
+                gradle-version: wrapper
+                build-root-directory: android
+                execution-only-caches: true
 
             - name: Upload apks
               uses: actions/upload-artifact@v2

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -96,6 +96,14 @@ jobs:
                 ./gradlew --console plain assembleDebug
                 ./gradlew testDebugUnitTest
 
+            - name: Upload apks
+              uses: actions/upload-artifact@v2
+              with:
+                name: apks
+                path: android/app/build/outputs/apk
+                if-no-files-found: error
+                retention-days: 1
+
     instrumented-tests:
         name: Instrumented tests
         runs-on: macos-latest

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -87,11 +87,20 @@ jobs:
                 NDK_TOOLCHAIN_DIR: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin
                 AR_x86_64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar
                 CC_x86_64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang
-                ARCHITECTURES: aarch64 x86_64
+                ARCHITECTURES: x86_64
+                TARGET: "x86_64-linux-android"
+                BUILD_TYPE: debug
               run: |
+                ABI="$ARCHITECTURES"
+                UNSTRIPPED_LIB_PATH="./target/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
+                STRIPPED_LIB_PATH="./android/app/build/extraJni/$ABI/libmullvad_jni.so"
+                NDK_TOOLCHAIN_STRIP_TOOL="$NDK_TOOLCHAIN_DIR/x86_64-linux-android-strip"
                 ./wireguard/build-wireguard-go.sh --android --no-docker
-                source env.sh x86_64-linux-android
-                cargo build --target x86_64-linux-android --verbose --package mullvad-jni
+                source env.sh $TARGET
+                cargo build --target $TARGET --verbose --package mullvad-jni
+                cargo run --bin relay_list > dist-assets/relays.json
+                cargo run --bin address_cache > dist-assets/api-ip-address.txt
+                $NDK_TOOLCHAIN_STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
                 cd android
                 ./gradlew --console plain assembleDebug
                 ./gradlew testDebugUnitTest

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -134,12 +134,36 @@ jobs:
               with:
                 name: apks
 
+            - name: AVD cache
+              uses: actions/cache@v2
+              id: avd-cache
+              with:
+                path: |
+                  ~/.android/avd/*
+                  ~/.android/adb*
+                key: emulator-api-29
+
+            - name: Create avd and generate snapshot
+              uses: reactivecircus/android-emulator-runner@v2
+              if: steps.avd-cache.outputs.cache-hit != 'true'
+              with:
+                force-avd-creation: false
+                api-level: 29
+                arch: x86_64
+                emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                disable-animations: true
+                profile: pixel
+                script: echo "Generated AVD snapshot for caching."
+              env:
+                API_LEVEL: 29
+
             - name: Run Android instrumented tests
               uses: reactivecircus/android-emulator-runner@v2
               with:
+                force-avd-creation: false
                 api-level: 29
                 arch: x86_64
-                emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-load -noaudio -no-boot-anim
+                emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                 disable-animations: true
                 profile: pixel
                 script: ./ci/run-android-instrumented-tests.sh $(pwd)

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -81,17 +81,17 @@ jobs:
                 linker = "${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang"
                 EOF
 
-            - name: Build and run unit tests
+            - name: Build native libraries
               env:
                 RUSTFLAGS: --deny warnings
                 NDK_TOOLCHAIN_DIR: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin
                 AR_x86_64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar
                 CC_x86_64_linux_android: ${{ steps.install-android-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang
-                ARCHITECTURES: x86_64
-                TARGET: "x86_64-linux-android"
+                ABI: x86_64
+                TARGET: x86_64-linux-android
                 BUILD_TYPE: debug
               run: |
-                ABI="$ARCHITECTURES"
+                ARCHITECTURES="$ABI"
                 UNSTRIPPED_LIB_PATH="./target/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
                 STRIPPED_LIB_PATH="./android/app/build/extraJni/$ABI/libmullvad_jni.so"
                 NDK_TOOLCHAIN_STRIP_TOOL="$NDK_TOOLCHAIN_DIR/x86_64-linux-android-strip"
@@ -101,6 +101,9 @@ jobs:
                 cargo run --bin relay_list > dist-assets/relays.json
                 cargo run --bin address_cache > dist-assets/api-ip-address.txt
                 $NDK_TOOLCHAIN_STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+
+            - name: Build and run unit tests
+              run: |
                 cd android
                 ./gradlew --console plain assembleDebug
                 ./gradlew testDebugUnitTest

--- a/ci/run-android-instrumented-tests.sh
+++ b/ci/run-android-instrumented-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+APK_BASE_DIR=$1
+adb install "$APK_BASE_DIR/debug/app-debug.apk"
+adb install "$APK_BASE_DIR/androidTest/debug/app-debug-androidTest.apk"
+adb shell am instrument -w net.mullvad.mullvadvpn.test/androidx.test.runner.AndroidJUnitRunner


### PR DESCRIPTION
Improve the Android app build and testing in GitHub in the following ways:
- Improve Gradle caching by using a dedicated action which is more efficient.
- Introduce caching of native libs (daemon/wireguard-go) to avoid rebuilding unless changed.
- Publish apks with a one day retention.
- Cache emulator.
- Split build of instrumented test apk from the emulator test execution.

The result is a reduced execution time which will depend on how much of the cached result can be re-used. For example, in case nothing needs to be rebuilt, the execution time has went from around 17min -> 6min.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3312)
<!-- Reviewable:end -->
