### PR TITLE
Fix port confusion when picking WG endpoints

### DIFF
--- a/mullvad-daemon/src/relays/mod.rs
+++ b/mullvad-daemon/src/relays/mod.rs
@@ -389,6 +389,10 @@ impl RelaySelector {
         }
 
         entry_relay_matcher.location = wireguard_constraints.entry_location.clone();
+        entry_relay_matcher.tunnel.port = entry_relay_matcher
+            .tunnel
+            .port
+            .or(Self::preferred_wireguard_port(retry_attempt));
         self.get_wireguard_multi_hop_endpoint(entry_relay_matcher, location.clone())
     }
 

--- a/mullvad-daemon/src/relays/mod.rs
+++ b/mullvad-daemon/src/relays/mod.rs
@@ -1432,4 +1432,39 @@ mod test {
         assert!(matches!(endpoint.peer.protocol, TransportProtocol::Tcp));
         assert!(endpoint.exit_peer.is_none());
     }
+
+    #[test]
+    fn test_selecting_wg_multihop_ports() {
+        let mut relay_constraints = WIREGUARD_MULTIHOP_CONSTRAINTS.clone();
+        let relay_selector = new_relay_selector();
+
+        const INVALID_UDP_PORTS: [u16; 2] = [80, 443];
+        for attempt in 0..1000 {
+            let result = relay_selector
+                .get_tunnel_endpoint(&relay_constraints, BridgeState::Off, attempt, true)
+                .expect("Failed to get WireGuard TCP multihop relay");
+            assert!(!INVALID_UDP_PORTS.contains(&result.endpoint.to_endpoint().address.port()));
+            assert_eq!(
+                result.endpoint.unwrap_wireguard().peer.protocol,
+                TransportProtocol::Udp
+            );
+        }
+
+        relay_constraints.wireguard_constraints.port = Constraint::Only(TransportPort {
+            port: Constraint::Any,
+            protocol: TransportProtocol::Tcp,
+        });
+
+        const VALID_TCP_PORTS: [u16; 3] = [80, 443, 5001];
+        for attempt in 0..1000 {
+            let result = relay_selector
+                .get_tunnel_endpoint(&relay_constraints, BridgeState::Off, attempt, true)
+                .expect("Failed to get WireGuard TCP multihop relay");
+            assert!(VALID_TCP_PORTS.contains(&result.endpoint.to_endpoint().address.port()));
+            assert_eq!(
+                result.endpoint.unwrap_wireguard().peer.protocol,
+                TransportProtocol::Tcp
+            );
+        }
+    }
 }


### PR DESCRIPTION
The relay selector was buggy in three ways - when selecting an entry endpoint for multi-hop, it would consider both TCP and UDP endpoints and when trying to construct a valid configuration, the endpoint protocol constraint wouldn't be taken into consideration and finally, the config construction would assume that only UDP endpoints have been selected if the transport protocol was not specified. Thus, when using multi-hop the relay selector could end up picking a UDP configuration with TCP ports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3314)
<!-- Reviewable:end -->
