### PR TITLE
Fix error when changing relays while in airplane mode

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -28,6 +28,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix crash occurring after completing in-app purchase.
+- Fix error when changing relays while in airplane mode.
 
 ### Changed
 - Increase hit area of settings (cog) button.

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -2206,7 +2206,7 @@
 			repositoryURL = "https://git.zx2c4.com/wireguard-apple";
 			requirement = {
 				kind = revision;
-				revision = c1f509d65bba1c00c6b6ef93826f658ff36a0761;
+				revision = 7dea71898d7d11495c7bb9a0b4f8215ae2efe53f;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://git.zx2c4.com/wireguard-apple",
         "state": {
           "branch": null,
-          "revision": "c1f509d65bba1c00c6b6ef93826f658ff36a0761",
+          "revision": "7dea71898d7d11495c7bb9a0b4f8215ae2efe53f",
           "version": null
         }
       }

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -200,7 +200,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     }
                     .onFailure { error in
                         self.tunnelConnectionInfo = oldTunnelConnectionInfo
-                        self.providerLogger.error(chainedError: error, message: "Failed to update WireGuard configuration")
+                        self.providerLogger.error(chainedError: error)
                     }
             }
     }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This switches the WireGuardKit to [commit](https://git.zx2c4.com/wireguard-apple/commit/?h=am/ignore-set-network-settings-error-when-offline) that handles the error to change network settings on iOS 15.1 or newer while in airplane mode.

The primary difference is that the error is logged but ignored and then network settings are set anyway when the network connectivity comes back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3315)
<!-- Reviewable:end -->
