### PR TITLE
Fix tile service crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ Line wrap the file at 100 chars.                                              Th
 - Remove auto-launch file, GUI settings and other files created by the app in user directories, when
   uninstalling/purging.
 
+#### Android
+- Fix tile service crash when trying to unbind.
+
 ### Security
 - Restrict which applications are allowed to communicate with the API while in a blocking state.
   This prevents malicious scripts on websites from trying to do so. On Windows, only

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.util.Log
 import android.view.animation.Animation
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +52,11 @@ fun Context.bindServiceFlow(intent: Intent, flags: Int = 0): Flow<ServiceResult>
         safeOffer(ServiceResult.NOT_CONNECTED)
 
         Dispatchers.Default.dispatch(EmptyCoroutineContext) {
-            unbindService(connectionCallback)
+            try {
+                unbindService(connectionCallback)
+            } catch (e: IllegalArgumentException) {
+                Log.e("mullvad", "Cannot unbind as no binding exists.")
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes tile service crash that occurred when the tile service tries to
unbind even though there are no binding or pending binding.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3316)
<!-- Reviewable:end -->
