### PR TITLE
Add entry location to connecting state before connecting event

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -933,10 +933,21 @@ export default class AppRenderer {
           const country = relayLocations.find(({ code }) => constraint.hostname[0] === code);
           const city = country?.cities.find((location) => location.code === constraint.hostname[1]);
 
+          let entryHostname: string | undefined;
+          const entryLocationConstraint = relaySettings.normal.wireguardConstraints.entryLocation;
+          if (
+            entryLocationConstraint !== 'any' &&
+            'hostname' in entryLocationConstraint.only &&
+            entryLocationConstraint.only.hostname.length === 3
+          ) {
+            entryHostname = entryLocationConstraint.only.hostname[2];
+          }
+
           return {
             country: country?.name,
             city: city?.name,
             hostname: constraint.hostname[2],
+            entryHostname,
             ...coordinates,
           };
         }


### PR DESCRIPTION
This PR adds the text `via <entry location>` to the connection panel after pressing connect before the app receives the `connecting` state from the daemon. The issue was that when the location was derived from the location constraints, the entry location wasn't used.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3317)
<!-- Reviewable:end -->
