### PR TITLE
Work around `Path::strip_prefix` panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Line wrap the file at 100 chars.                                              Th
 - Allow Mullvad wireguard-nt tunnels to work simultaneously with other wg-nt tunnels.
 - Fix notifications on Windows not showing if window is unpinned and hidden.
 - Wait for IP interfaces to arrive before trying to configure them when using wireguard-nt.
+- Fix panic that occurs in the split tunnel monitor when a path consisting only of a prefix,
+  such as "C:", is excluded using the CLI.
 
 #### Linux
 - Remove auto-launch file, GUI settings and other files created by the app in user directories, when


### PR DESCRIPTION
If a path `C:` (or any other drive letter + colon) is added to the list of excluded apps using `mullvad split-tunnel app add C:`, a panic occurs in `Path::strip_prefix`. This causes the split tunnel monitor thread to stop. The PR works around the issue by rejecting every `path` for which `path.is_absolute()` is false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3320)
<!-- Reviewable:end -->
