### PR TITLE
Remove upstart config file

### DIFF
--- a/dist-assets/linux/mullvad-daemon.conf
+++ b/dist-assets/linux/mullvad-daemon.conf
@@ -1,6 +1,0 @@
-# Upstart job configuration file for the Mullvad VPN daemon
-
-start on local-filesystems and net-device-up IFACE!=lo
-respawn
-chdir /opt/Mullvad\ VPN/resources
-exec /opt/Mullvad\ VPN/resources/mullvad-daemon -v


### PR DESCRIPTION
We've had an upstart configuration file since forever, yet in the current master, I don't think this file is used by anything or referenced anywhere. As such, I think we can safely remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3321)
<!-- Reviewable:end -->
