### PR TITLE
Forward device arrival and removal window messages that are only received by users (not services)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Line wrap the file at 100 chars.                                              Th
 - Add malware blocking to the desktop app. Implemented via DNS on the relays.
 - Add changes dialog which will include the most notable changes in each new version.
 
+#### Windows
+- Detect mounting and dismounting of volumes, such as VeraCrypt volumes or USB drives,
+  and exclude paths from the tunnel correctly when these occur. This sometimes only works
+  when the GUI frontend is running.
+
 ### Changed
 - Keep unspecified constraints unchanged in the CLI when providing specific tunnel constraints
   instead of setting them to default values.

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -501,6 +501,10 @@ export class DaemonRpc {
     await this.callBool(this.client.setSplitTunnelState, enabled);
   }
 
+  public async checkVolumes(): Promise<void> {
+    await this.callEmpty(this.client.checkVolumes);
+  }
+
   private subscriptionId(): number {
     const current = this.nextSubscriptionId;
     this.nextSubscriptionId += 1;

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1857,6 +1857,20 @@ class ApplicationMain {
           // https://github.com/electron/electron/blob/main/docs/faq.md#the-font-looks-blurry-what-is-this-and-what-can-i-do
           backgroundColor: '#fff',
         });
+        const WM_DEVICECHANGE = 0x0219;
+        const DBT_DEVICEARRIVAL = 0x8000;
+        const DBT_DEVICEREMOVECOMPLETE = 0x8004;
+        appWindow.hookWindowMessage(WM_DEVICECHANGE, (wParam) => {
+          const wParamL = wParam.readBigInt64LE(0);
+          if (wParamL != DBT_DEVICEARRIVAL && wParamL != DBT_DEVICEREMOVECOMPLETE) {
+            return;
+          }
+          this.daemonRpc
+            .checkVolumes()
+            .catch((error) =>
+              log.error(`Unable to notify daemon of device event: ${error.message}`),
+            );
+        });
 
         appWindow.removeMenu();
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -708,6 +708,22 @@ impl ManagementService for ManagementServiceImpl {
     async fn set_use_wireguard_nt(&self, _: Request<bool>) -> ServiceResult<()> {
         Ok(Response::new(()))
     }
+
+    #[cfg(windows)]
+    async fn check_volumes(&self, _: Request<()>) -> ServiceResult<()> {
+        log::debug!("check_volumes");
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::CheckVolumes(tx))?;
+        self.wait_for_result(rx)
+            .await?
+            .map_err(map_daemon_error)
+            .map(Response::new)
+    }
+
+    #[cfg(not(windows))]
+    async fn check_volumes(&self, _: Request<()>) -> ServiceResult<()> {
+        Ok(Response::new(()))
+    }
 }
 
 impl ManagementServiceImpl {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -71,6 +71,9 @@ service ManagementService {
 	rpc SetSplitTunnelState(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
 
 	rpc SetUseWireguardNt(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
+
+	// Notify the split tunnel monitor that a volume was mounted or dismounted (Windows).
+	rpc CheckVolumes(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }
 
 message RelaySettingsUpdate {

--- a/talpid-core/src/split_tunnel/windows/volume_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/volume_monitor.rs
@@ -2,11 +2,14 @@
 //! tunnel config if any of the excluded paths are affected by them.
 use super::path_monitor::PathMonitorHandle;
 use crate::windows::window::{create_hidden_window, WindowCloseHandle};
+use futures::{channel::mpsc, StreamExt};
 use std::{
     ffi::OsString,
+    io,
     path::{self, Path},
-    sync::{mpsc as sync_mpsc, Arc, Mutex},
+    sync::{mpsc as sync_mpsc, Arc, Mutex, MutexGuard},
 };
+use talpid_types::ErrorExt;
 use winapi::{
     shared::minwindef::TRUE,
     um::{
@@ -14,83 +17,188 @@ use winapi::{
             DBTF_NET, DBT_DEVICEARRIVAL, DBT_DEVICEREMOVECOMPLETE, DBT_DEVTYP_VOLUME,
             DEV_BROADCAST_HDR, DEV_BROADCAST_VOLUME, WM_DEVICECHANGE,
         },
+        fileapi::GetLogicalDrives,
         winuser::DefWindowProcW,
     },
 };
 
 pub(super) struct VolumeMonitor(());
 
+pub(super) struct VolumeMonitorHandle {
+    window_handle: WindowCloseHandle,
+    internal_monitor_task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for VolumeMonitorHandle {
+    fn drop(&mut self) {
+        self.window_handle.close();
+        self.internal_monitor_task.abort();
+    }
+}
+
 impl VolumeMonitor {
     pub fn spawn(
         path_monitor: PathMonitorHandle,
         update_tx: sync_mpsc::Sender<()>,
         paths: Arc<Mutex<Vec<OsString>>>,
-    ) -> WindowCloseHandle {
-        create_hidden_window(move |window, message, w_param, l_param| {
-            if message != WM_DEVICECHANGE
-                || (w_param != DBT_DEVICEARRIVAL && w_param != DBT_DEVICEREMOVECOMPLETE)
-            {
-                return unsafe { DefWindowProcW(window, message, w_param, l_param) };
-            }
+        volume_update_rx: mpsc::UnboundedReceiver<()>,
+    ) -> VolumeMonitorHandle {
+        // A bitmask containing all (known) mounted drives.
+        let known_state = Arc::new(Mutex::new(0u32));
 
+        // Lock before registering event handler
+        let mut known_state_guard = known_state.lock().unwrap();
+
+        let internal_monitor_task = tokio::spawn(frontend_monitor(
+            known_state.clone(),
+            path_monitor.clone(),
+            update_tx.clone(),
+            paths.clone(),
+            volume_update_rx,
+        ));
+
+        let window_handle =
+            start_internal_monitor(known_state.clone(), path_monitor, update_tx, paths);
+
+        *known_state_guard = get_logical_drives().unwrap_or_else(|error| {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to initialize state of mounted volumes")
+            );
+            0
+        });
+
+        VolumeMonitorHandle {
+            window_handle,
+            internal_monitor_task,
+        }
+    }
+}
+
+/// Monitors update requests from frontends. This checks if the known state of mounted volumes
+/// has change, and, if so, reapplies the ST config.
+async fn frontend_monitor(
+    known_state: Arc<Mutex<u32>>,
+    path_monitor: PathMonitorHandle,
+    update_tx: sync_mpsc::Sender<()>,
+    paths: Arc<Mutex<Vec<OsString>>>,
+    mut volume_update_rx: mpsc::UnboundedReceiver<()>,
+) {
+    while let Some(()) = volume_update_rx.next().await {
+        let mut known_state_guard = known_state.lock().unwrap();
+        let new_state = get_logical_drives().unwrap_or_else(|error| {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to obtain new state of mounted volumes")
+            );
+            *known_state_guard
+        });
+
+        // Was there a change?
+        let state_diff = *known_state_guard ^ new_state;
+        if state_diff != 0 {
+            *known_state_guard = new_state;
             let paths_guard = paths.lock().unwrap();
-            let mut label_found = false;
-
-            let volumes = unsafe { parse_broadcast(&*(l_param as *const _)) };
-            for volume in volumes {
-                for path in &*paths_guard {
-                    let path = (path as &dyn AsRef<Path>).as_ref();
-                    if let Some(path::Component::Prefix(prefix)) = path.components().next() {
-                        match prefix.kind() {
-                            path::Prefix::VerbatimDisk(disk) | path::Prefix::Disk(disk) => {
-                                if disk == volume {
-                                    label_found = true;
-                                    break;
-                                }
-                            }
-                            _ => (),
-                        }
-                    }
-                }
-                if label_found {
-                    break;
-                }
-            }
-
-            if label_found {
+            if matches_volume(state_diff, &paths_guard) {
                 // Reapply config
                 let _ = update_tx.send(());
                 let _ = path_monitor.refresh();
             }
-
-            // Always grant the request
-            TRUE as isize
-        })
+        }
     }
 }
 
-/// Return volume labels (ASCII-encoded) affected by the device arrival or removal message, if any.
-unsafe fn parse_broadcast(broadcast: &DEV_BROADCAST_HDR) -> Vec<u8> {
-    let mut labels = vec![];
+/// Monitors window events received by session 0.
+fn start_internal_monitor(
+    known_state: Arc<Mutex<u32>>,
+    path_monitor: PathMonitorHandle,
+    update_tx: sync_mpsc::Sender<()>,
+    paths: Arc<Mutex<Vec<OsString>>>,
+) -> WindowCloseHandle {
+    create_hidden_window(move |window, message, w_param, l_param| {
+        if !is_device_arrival_or_removal(message, w_param) {
+            return unsafe { DefWindowProcW(window, message, w_param, l_param) };
+        }
+        let paths_guard = paths.lock().unwrap();
+        let mut known_state_guard = known_state.lock().unwrap();
 
+        let volumes = unsafe { parse_device_volume_broadcast(&*(l_param as *const _)) };
+
+        let prev_state = *known_state_guard;
+        let is_arrival = w_param == DBT_DEVICEARRIVAL;
+        if is_arrival {
+            *known_state_guard |= volumes;
+        } else {
+            *known_state_guard &= !volumes;
+        }
+
+        // Compare against known state to ignore duplicate notifications
+        // from frontends
+        let state_diff = *known_state_guard ^ prev_state;
+        if state_diff != 0 {
+            if matches_volume(volumes, &paths_guard) {
+                // Reapply config
+                let _ = update_tx.send(());
+                let _ = path_monitor.refresh();
+            }
+        }
+
+        // Always grant the request
+        TRUE as isize
+    })
+}
+
+/// Return a bitmask representing all currently available disk drives.
+/// Each bit refers to a volume letter. The bit 0 refers to 'A', bit 1
+/// refers to 'B', bit 2 to 'C', etc.
+fn get_logical_drives() -> io::Result<u32> {
+    let result = unsafe { GetLogicalDrives() };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(result)
+}
+
+/// Return whether any of the paths in `paths_guard` reside on any volume in `volumes` (a mask).
+fn matches_volume(volumes: u32, paths_guard: &MutexGuard<'_, Vec<OsString>>) -> bool {
+    for path in &**paths_guard {
+        let path = (path as &dyn AsRef<Path>).as_ref();
+        if let Some(path::Component::Prefix(prefix)) = path.components().next() {
+            match prefix.kind() {
+                path::Prefix::VerbatimDisk(disk) | path::Prefix::Disk(disk) => {
+                    if disk < 'A' as u8 || disk > 'Z' as u8 {
+                        log::warn!("Ignoring invalid volume \"{}\"", disk as char);
+                        continue;
+                    }
+                    let disk = disk - 'A' as u8;
+                    if volumes & (1 << disk) != 0 {
+                        return true;
+                    }
+                }
+                _ => (),
+            }
+        }
+    }
+    false
+}
+
+fn is_device_arrival_or_removal(message: u32, w_param: usize) -> bool {
+    message == WM_DEVICECHANGE
+        && (w_param == DBT_DEVICEARRIVAL || w_param == DBT_DEVICEREMOVECOMPLETE)
+}
+
+/// Return volumes affected by the device arrival or removal message as a mask.
+/// This has the same format as `get_logical_drives()`.
+unsafe fn parse_device_volume_broadcast(broadcast: &DEV_BROADCAST_HDR) -> u32 {
     if broadcast.dbch_devicetype != DBT_DEVTYP_VOLUME {
-        return labels;
+        return 0;
     }
 
     let volume_broadcast = &*(broadcast as *const _ as *const DEV_BROADCAST_VOLUME);
     if volume_broadcast.dbcv_flags & DBTF_NET != 0 {
         // Ignore net event
-        return labels;
+        return 0;
     }
 
-    // 26 = 1 + 'Z' - 'A'
-    let num_drives = 1 + 'Z' as u8 - 'A' as u8;
-    for i in 0..num_drives {
-        let is_affected = ((volume_broadcast.dbcv_unitmask >> i) & 1) != 0;
-        if is_affected {
-            labels.push('A' as u8 + i);
-        }
-    }
-
-    labels
+    volume_broadcast.dbcv_unitmask
 }


### PR DESCRIPTION
This makes it possible to detect, for example, VeraCrypt volumes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3322)
<!-- Reviewable:end -->
