### PR TITLE
Enable LTO and opt-level=3 in the Rust workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,5 @@ members = [
 exclude = ["dist-assets/binaries/shadowsocks-rust"]
 
 [profile.release]
-# FIXME: This is here as a temporary hack to stop the mullvad-daemon from segfaulting
-# on Windows. Can hopefully be removed after we have replaced OpenSSL with Rustls.
-# https://github.com/mullvad/mullvadvpn-app/pull/1438
-# Other opt-levels that stops the daemon from crashing include 0 and 1. Crashes has
-# only been detected on 2.
-opt-level = "s"
+opt-level = 3
+lto = true


### PR DESCRIPTION
A long time ago we enabled LTO and `opt-level="z"` (#892). A while later we reverted that (#902 + #1459) due to segfaults somewhere around loading TLS certificates in OpenSSL. We never tracked down the real cause. We suspect it might have been something around how OpenSSL was statically compiled and/or a rustc compiler bug even. But we took the easy route of just disabling optimizations to get rid of the issue.

A long time has passed since. We don't even use/link to OpenSSL in the daemon/Rust code any longer. And the Rust compiler has seen many new releases. Even if we don't know exactly what caused the segfault we can't live in fear forever. Let's enable full optimizations and see what happens!

The result of this change is longer compile times, but smaller binaries. Hopefully it leads to more efficient code also. Not that we do much that is performance critical, but anyway.

The binary size differences that I can observe on Linux when building with `./build.sh --optimize` is:

| Binary | Size before this PR | Size after this PR |
| --- | :-: | :-: |
| mullvad | 5.3 MiB | 5.0 MiB |
| mullvad-daemon | 17 MiB | 16 MiB |
| mullvad-setup | 10 MiB | 6.5 MiB |