### PR TITLE
Update the default password and cipher for the custom bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Line wrap the file at 100 chars.                                              Th
 - Stop preferring OpenVPN when bridge mode is enabled.
 - CLI command for setting a specific server by hostname is no longer case sensitive.
   Example: `mullvad relay set hostname SE9-WIREGUARD` should now work.
+- Update the default Shadowsocks password to `mullvad` and cipher to `aes-256-gcm` in the CLI
+  when using it to configure a *custom Shadowsocks bridge*. The Mullvad bridges recently changed
+  these parameters on port 443 (which is the default port).
 
 #### Windows
 - Update wireguard-nt to 0.10.1.

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -155,13 +155,13 @@ fn create_set_custom_settings_subcommand() -> clap::App<'static, 'static> {
                 .arg(
                     clap::Arg::with_name("password")
                         .help("Specifies the password on the remote Shadowsocks server")
-                        .default_value("23#dfsbbb")
+                        .default_value("mullvad")
                         .index(3),
                 )
                 .arg(
                     clap::Arg::with_name("cipher")
                         .help("Specifies the cipher to use")
-                        .default_value("chacha20")
+                        .default_value("aes-256-gcm")
                         .possible_values(SHADOWSOCKS_CIPHERS)
                         .index(4),
                 ),


### PR DESCRIPTION
We recently changed the cipher from chacha20 -> aes-256-gcm
and the password from 23#dfsbbb to mullvad
on port 443 on all our shadowsocks bridges

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3328)
<!-- Reviewable:end -->
