### PR TITLE
Improve background fetch cancellation

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -214,7 +214,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 return
             }
 
-            TunnelManager.shared.rotatePrivateKey { rotationResult, error in
+            _ = TunnelManager.shared.rotatePrivateKey { rotationResult, error in
                 if let error = error {
                     self.logger?.error(chainedError: error, message: "Failed to rotate the key")
 

--- a/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
@@ -48,4 +48,10 @@ class AsyncBlockOperation: AsyncOperation {
             stateLock.unlock()
         }
     }
+
+    override func operationDidFinish() {
+        stateLock.lock()
+        cancellationBlocks.removeAll()
+        stateLock.unlock()
+    }
 }

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -58,17 +58,27 @@ class AsyncOperation: Operation {
     }
 
     final func finish() {
-        stateLock.withCriticalBlock {
-            if _isExecuting {
-               setExecuting(false)
-            }
+        stateLock.lock()
 
-            if !_isFinished {
-                willChangeValue(for: \.isFinished)
-                _isFinished = true
-                didChangeValue(for: \.isFinished)
-            }
+        if _isExecuting {
+           setExecuting(false)
         }
+
+        if !_isFinished {
+            willChangeValue(for: \.isFinished)
+            _isFinished = true
+            didChangeValue(for: \.isFinished)
+
+            stateLock.unlock()
+
+            operationDidFinish()
+        } else {
+            stateLock.unlock()
+        }
+    }
+
+    func operationDidFinish() {
+        // Override in subclasses
     }
 
     private func setExecuting(_ value: Bool) {

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -10,7 +10,6 @@ import Foundation
 
 /// A base implementation of an asynchronous operation
 class AsyncOperation: Operation {
-
     /// A state lock used for manipulating the operation state flags in a thread safe fashion.
     private let stateLock = NSRecursiveLock()
 
@@ -85,5 +84,13 @@ class AsyncOperation: Operation {
         willChangeValue(for: \.isExecuting)
         _isExecuting = value
         didChangeValue(for: \.isExecuting)
+    }
+}
+
+extension Operation {
+    func addDependencies(_ dependencies: [Operation]) {
+        for dependency in dependencies {
+            addDependency(dependency)
+        }
     }
 }

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -124,7 +124,7 @@ class TunnelManager: TunnelManagerStateDelegate
         timer.setEventHandler { [weak self] in
             guard let self = self else { return }
 
-            self.rotatePrivateKey { rotationResult, error in
+            _ = self.rotatePrivateKey { rotationResult, error in
                 self.stateQueue.async {
                     if let scheduleDate = self.handlePrivateKeyRotationCompletion(result: rotationResult, error: error) {
                         guard self.isRunningPeriodicPrivateKeyRotation else { return }

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -352,7 +352,7 @@ class TunnelManager: TunnelManagerStateDelegate
         operationQueue.addOperation(operation)
     }
 
-    func rotatePrivateKey(completionHandler: @escaping (KeyRotationResult?, TunnelManager.Error?) -> Void) {
+    func rotatePrivateKey(completionHandler: @escaping (KeyRotationResult?, TunnelManager.Error?) -> Void) -> Cancellable {
         let operation = ReplaceKeyOperation.operationForKeyRotation(
             queue: stateQueue,
             state: state,
@@ -399,6 +399,10 @@ class TunnelManager: TunnelManagerStateDelegate
         exclusivityController.addOperation(operation, categories: [OperationCategory.changeTunnelSettings])
 
         operationQueue.addOperation(operation)
+
+        return AnyCancellable {
+            operation.cancel()
+        }
     }
 
     func setRelayConstraints(_ newConstraints: RelayConstraints, completionHandler: @escaping (TunnelManager.Error?) -> Void) {
@@ -666,7 +670,7 @@ extension TunnelManager {
     private func handleBackgroundTask(_ task: BGProcessingTask) {
         logger.debug("Start private key rotation task")
 
-        rotatePrivateKey { rotationResult, error in
+        let request = rotatePrivateKey { rotationResult, error in
             if let scheduleDate = self.handlePrivateKeyRotationCompletion(result: rotationResult, error: error) {
                 // Schedule next background task
                 switch self.submitBackgroundTask(at: scheduleDate) {
@@ -683,7 +687,7 @@ extension TunnelManager {
         }
 
         task.expirationHandler = {
-            // TODO: handle cancellation?
+            request.cancel()
         }
     }
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add a method to assign cancellation handler for `AsyncBlockOperation`. (See `AsyncBlockOperation.addCancellationHandler`)
2. Add `operationDidFinish` hook in `AsyncOperation` to be able to do perform cleanup once operation is finished. Used in `AsyncBlockOperation` to release cancellation handlers and break any potential retain cycles, where the operation and block retain each other, therefore neither can be released from memory as they hold each other.
3. Add `Operation` extension to add multiple dependencies at once (see `Operation.addDependencies`)
4. Improve cancellation in background fetch.
5. Return `Cancellable` object from `TunnelManager.rotatePrivateKey`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3329)
<!-- Reviewable:end -->
