### PR TITLE
Fix zero weight handling (iOS)

### DIFF
--- a/ios/MullvadVPN/REST/ServerRelaysResponse.swift
+++ b/ios/MullvadVPN/REST/ServerRelaysResponse.swift
@@ -24,7 +24,7 @@ extension REST {
         let owned: Bool
         let location: String
         let provider: String
-        let weight: Int32
+        let weight: UInt64
         let ipv4AddrIn: IPv4Address
         let ipv6AddrIn: IPv6Address
         let publicKey: Data


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- Change `ServerRelay.weight` type to `UInt64`.
- Pick random relay when all relays within the list have zero weight.
- Fix roulette algorithm to skip relays with zero weight.

Similar PR for desktop: https://github.com/mullvad/mullvadvpn-app/pull/3262

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3331)
<!-- Reviewable:end -->
