### PR TITLE
Explicitly set feature resolver version for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "android/translations-converter",
     "mullvad-daemon",


### PR DESCRIPTION
The feature resolution currently used enables platform-specific features for all targets. This is [no longer true](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) for version 2 of the resolver. The old behavior can be problematic when dependencies or features depend on the build target.

Specifying 2021 as the Rust edition in the root package causes the resolver to be 2 by default. Unfortunately, the edition cannot be set in the `[workspace]` section. So this PR explicitly sets `resolver = "2"` in the `[workspace]` section instead (as is suggested [here](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3332)
<!-- Reviewable:end -->
