### PR TITLE
Fix time added display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Line wrap the file at 100 chars.                                              Th
   DNS servers set in system network preferences.
 - Fix tray context menu showing or executing wrong actions, using wrong language or in other
   ways not update properly.
+- Fix the sometimes incorrect time added text after adding time to the account.
 
 #### macOS
 - Resolve issues with the app blocking internet connectivity after sleep or when connecting to new

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-msgid "%(duration)s was added to your account."
+msgid "%(duration)s was added, account paid until %(expiry)s."
 msgstr ""
 
 msgid "1 day"
@@ -54,6 +54,9 @@ msgid "a year ago"
 msgid_plural "%d years ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Account paid until %(expiry)s."
+msgstr ""
 
 msgid "an hour ago"
 msgid_plural "%d hours ago"

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -230,13 +230,7 @@ class ApplicationMain {
       return this.daemonRpc.getAccountData(accountToken);
     },
     (accountData) => {
-      this.accountData = accountData && {
-        ...accountData,
-        previousExpiry:
-          accountData.expiry !== this.accountData?.expiry
-            ? this.accountData?.expiry
-            : this.accountData?.previousExpiry,
-      };
+      this.accountData = accountData;
 
       if (this.windowController) {
         IpcMainEventChannel.account.notify(this.windowController.webContents, this.accountData);

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -120,7 +120,7 @@ export default class AppRenderer {
     });
 
     IpcRendererEventChannel.account.listen((newAccountData?: IAccountData) => {
-      this.setAccountExpiry(newAccountData?.expiry, newAccountData?.previousExpiry);
+      this.setAccountExpiry(newAccountData?.expiry);
     });
 
     IpcRendererEventChannel.accountHistory.listen((newAccountHistory?: AccountToken) => {
@@ -199,10 +199,7 @@ export default class AppRenderer {
       initialState.translations.relayLocations,
     );
 
-    this.setAccountExpiry(
-      initialState.accountData?.expiry,
-      initialState.accountData?.previousExpiry,
-    );
+    this.setAccountExpiry(initialState.accountData?.expiry);
     this.setSettings(initialState.settings);
     this.handleAccountChange(undefined, initialState.settings.accountToken);
     this.setAccountHistory(initialState.accountHistory);
@@ -834,8 +831,8 @@ export default class AppRenderer {
     this.reduxActions.settings.updateGuiSettings(guiSettings);
   }
 
-  private setAccountExpiry(expiry?: string, previousExpiry?: string) {
-    this.reduxActions.account.updateAccountExpiry(expiry, previousExpiry);
+  private setAccountExpiry(expiry?: string) {
+    this.reduxActions.account.updateAccountExpiry(expiry);
   }
 
   private storeAutoStart(autoStart: boolean) {

--- a/gui/src/renderer/lib/history.tsx
+++ b/gui/src/renderer/lib/history.tsx
@@ -1,7 +1,7 @@
 import { Location, Action, LocationDescriptorObject, History as OriginalHistory } from 'history';
 import React from 'react';
 import { RouteComponentProps, useHistory as useReactRouterHistory, withRouter } from 'react-router';
-import { RoutePath } from './routes';
+import { GeneratedRoutePath, RoutePath } from './routes';
 
 export interface ITransitionSpecification {
   name: string;
@@ -38,7 +38,7 @@ export const transitions: ITransitionMap = {
   },
 };
 
-type LocationDescriptor<S> = RoutePath | LocationDescriptorObject<S>;
+type LocationDescriptor<S> = RoutePath | GeneratedRoutePath | LocationDescriptorObject<S>;
 
 type LocationListener<S = unknown> = (
   location: Location<S>,
@@ -168,7 +168,11 @@ export default class History {
   }
 
   private createLocation(location: LocationDescriptor<S>, state?: S): Location<S> {
-    if (typeof location === 'object') {
+    if (typeof location === 'string') {
+      return this.createLocationFromString(location, state);
+    } else if ('routePath' in location) {
+      return this.createLocationFromString(location.routePath, state);
+    } else {
       return {
         pathname: location.pathname ?? this.location.pathname,
         search: location.search ?? '',
@@ -176,15 +180,17 @@ export default class History {
         state: location.state,
         key: location.key ?? this.getRandomKey(),
       };
-    } else {
-      return {
-        pathname: location,
-        search: '',
-        hash: '',
-        state,
-        key: this.getRandomKey(),
-      };
     }
+  }
+
+  private createLocationFromString(path: string, state?: S): Location<S> {
+    return {
+      pathname: path,
+      search: '',
+      hash: '',
+      state,
+      key: this.getRandomKey(),
+    };
   }
 
   private getRandomKey() {

--- a/gui/src/renderer/lib/routes.ts
+++ b/gui/src/renderer/lib/routes.ts
@@ -1,9 +1,13 @@
+import { generatePath } from 'react-router';
+
+export type GeneratedRoutePath = { routePath: string };
+
 export enum RoutePath {
   launch = '/',
   login = '/login',
   main = '/main',
   redeemVoucher = '/main/voucher/redeem',
-  voucherSuccess = '/main/voucher/success',
+  voucherSuccess = '/main/voucher/success/:newExpiry/:secondsAdded',
   timeAdded = '/main/time-added',
   setupFinished = '/main/setup-finished',
   settings = '/settings',
@@ -18,4 +22,11 @@ export enum RoutePath {
   support = '/settings/support',
   selectLocation = '/select-location',
   filterByProvider = '/select-location/filter-by-provider',
+}
+
+export function generateRoutePath(
+  routePath: RoutePath,
+  parameters: Parameters<typeof generatePath>[1],
+): GeneratedRoutePath {
+  return { routePath: generatePath(routePath, parameters) };
 }

--- a/gui/src/renderer/redux/account/actions.ts
+++ b/gui/src/renderer/redux/account/actions.ts
@@ -50,7 +50,6 @@ interface IUpdateAccountHistoryAction {
 interface IUpdateAccountExpiryAction {
   type: 'UPDATE_ACCOUNT_EXPIRY';
   expiry?: string;
-  previousExpiry?: string;
 }
 
 export type AccountAction =
@@ -133,11 +132,10 @@ function updateAccountHistory(accountHistory?: AccountToken): IUpdateAccountHist
   };
 }
 
-function updateAccountExpiry(expiry?: string, previousExpiry?: string): IUpdateAccountExpiryAction {
+function updateAccountExpiry(expiry?: string): IUpdateAccountExpiryAction {
   return {
     type: 'UPDATE_ACCOUNT_EXPIRY',
     expiry,
-    previousExpiry,
   };
 }
 

--- a/gui/src/renderer/redux/account/reducers.ts
+++ b/gui/src/renderer/redux/account/reducers.ts
@@ -10,7 +10,6 @@ export interface IAccountReduxState {
   accountToken?: AccountToken;
   accountHistory?: AccountToken;
   expiry?: string; // ISO8601
-  previousExpiry?: string; // ISO8601
   status: LoginState;
 }
 
@@ -18,7 +17,6 @@ const initialState: IAccountReduxState = {
   accountToken: undefined,
   accountHistory: undefined,
   expiry: undefined,
-  previousExpiry: undefined,
   status: { type: 'none' },
 };
 
@@ -50,7 +48,6 @@ export default function (
         status: { type: 'none' },
         accountToken: undefined,
         expiry: undefined,
-        previousExpiry: undefined,
       };
     case 'RESET_LOGIN_ERROR':
       return {
@@ -73,7 +70,6 @@ export default function (
         status: { type: 'ok', method: 'new_account' },
         accountToken: action.token,
         expiry: action.expiry,
-        previousExpiry: undefined,
       };
     case 'UPDATE_ACCOUNT_TOKEN':
       return {
@@ -89,7 +85,6 @@ export default function (
       return {
         ...state,
         expiry: action.expiry,
-        previousExpiry: action.previousExpiry,
       };
   }
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -1,6 +1,5 @@
 export interface IAccountData {
   expiry: string;
-  previousExpiry?: string;
 }
 export type AccountToken = string;
 export type Ip = string;


### PR DESCRIPTION
This PR removes the calculation of added time since it wasn't correct, and since it's not possible to do it correctly in all cases. When adding time we now show either `%(duration)s was added, account paid until %(expiry)s.` if it's a voucher payment, otherwise `Account paid until %(expiry)s.` is displayed.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3339)
<!-- Reviewable:end -->
