### PR TITLE
Make mssfix and mtu input white when focused

### DIFF
--- a/gui/src/renderer/components/AdvancedSettingsStyles.tsx
+++ b/gui/src/renderer/components/AdvancedSettingsStyles.tsx
@@ -4,10 +4,6 @@ import * as Cell from './cell';
 import { NavigationScrollbars } from './NavigationBar';
 import Selector from './cell/Selector';
 
-export const StyledInputFrame = styled(Cell.InputFrame)({
-  flex: 0,
-});
-
 export const StyledSelectorContainer = styled.div({
   flex: 0,
 });

--- a/gui/src/renderer/components/OpenVPNSettings.tsx
+++ b/gui/src/renderer/components/OpenVPNSettings.tsx
@@ -47,10 +47,6 @@ export const StyledSelectorContainer = styled.div({
   flex: 0,
 });
 
-export const StyledInputFrame = styled(Cell.InputFrame)({
-  flex: 0,
-});
-
 interface IProps {
   bridgeModeAvailablity: BridgeModeAvailability;
   openvpn: {
@@ -195,20 +191,18 @@ export default class OpenVpnSettings extends React.Component<IProps, IState> {
                       {messages.pgettext('openvpn-settings-view', 'Mssfix')}
                     </Cell.InputLabel>
                   </AriaLabel>
-                  <StyledInputFrame>
-                    <AriaInput>
-                      <Cell.AutoSizingTextInput
-                        value={this.props.mssfix ? this.props.mssfix.toString() : ''}
-                        inputMode={'numeric'}
-                        maxLength={4}
-                        placeholder={messages.gettext('Default')}
-                        onSubmitValue={this.onMssfixSubmit}
-                        validateValue={OpenVpnSettings.mssfixIsValid}
-                        submitOnBlur={true}
-                        modifyValue={OpenVpnSettings.removeNonNumericCharacters}
-                      />
-                    </AriaInput>
-                  </StyledInputFrame>
+                  <AriaInput>
+                    <Cell.AutoSizingTextInput
+                      value={this.props.mssfix ? this.props.mssfix.toString() : ''}
+                      inputMode={'numeric'}
+                      maxLength={4}
+                      placeholder={messages.gettext('Default')}
+                      onSubmitValue={this.onMssfixSubmit}
+                      validateValue={OpenVpnSettings.mssfixIsValid}
+                      submitOnBlur={true}
+                      modifyValue={OpenVpnSettings.removeNonNumericCharacters}
+                    />
+                  </AriaInput>
                 </Cell.Container>
                 <Cell.Footer>
                   <AriaDescription>

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -43,10 +43,6 @@ export const StyledSelectorForFooter = (styled(Selector)({
   marginBottom: 0,
 }) as unknown) as new <T>() => Selector<T>;
 
-export const StyledInputFrame = styled(Cell.InputFrame)({
-  flex: 0,
-});
-
 interface IProps {
   wireguard: { port?: number; ipVersion?: IpVersion };
   wireguardMtu?: number;
@@ -227,20 +223,18 @@ export default class WireguardSettings extends React.Component<IProps, IState> {
                       {messages.pgettext('wireguard-settings-view', 'MTU')}
                     </Cell.InputLabel>
                   </AriaLabel>
-                  <StyledInputFrame>
-                    <AriaInput>
-                      <Cell.AutoSizingTextInput
-                        value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
-                        inputMode={'numeric'}
-                        maxLength={4}
-                        placeholder={messages.gettext('Default')}
-                        onSubmitValue={this.onWireguardMtuSubmit}
-                        validateValue={WireguardSettings.wireguarMtuIsValid}
-                        submitOnBlur={true}
-                        modifyValue={WireguardSettings.removeNonNumericCharacters}
-                      />
-                    </AriaInput>
-                  </StyledInputFrame>
+                  <AriaInput>
+                    <Cell.AutoSizingTextInput
+                      value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
+                      inputMode={'numeric'}
+                      maxLength={4}
+                      placeholder={messages.gettext('Default')}
+                      onSubmitValue={this.onWireguardMtuSubmit}
+                      validateValue={WireguardSettings.wireguarMtuIsValid}
+                      submitOnBlur={true}
+                      modifyValue={WireguardSettings.removeNonNumericCharacters}
+                    />
+                  </AriaInput>
                 </Cell.Container>
                 <Cell.Footer>
                   <AriaDescription>


### PR DESCRIPTION
This PR improves the small text input used for OpenVPN Mssfix and WireGuard MTU by:
* Changing the background to white while focued. This improves contrast between the background and the red text when the value is invalid, as well as makes it more consistent with other inputs in the app.
* Discard invalid values on blur.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3342)
<!-- Reviewable:end -->
