### PR TITLE
Cache Windows libraries in GitHub workflow

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -90,6 +90,20 @@ jobs:
             - name: Checkout submodules
               run: git submodule update --init --depth=1
 
+            - name: Calculate Windows libraries cache hash
+              id: windows-modules-hash
+              shell: bash
+              run: |
+                hash="$(git grep --cached -l '' -- './windows/' | xargs sha1sum | sha1sum | cut -d" " -f1)"
+                echo "::set-output name=hash::$hash"
+
+            - name: Cache Windows libraries
+              uses: actions/cache@v2
+              id: cache-windows-modules
+              with:
+                path: ./windows/**/bin/
+                key: windows-modules-${{ steps.windows-modules-hash.outputs.hash }}
+
             - name: Install Rust
               uses: ATiltedTree/setup-rust@v1.0.4
               with:
@@ -104,6 +118,11 @@ jobs:
               uses: microsoft/setup-msbuild@v1.0.2
               with:
                   vs-version: 16
+
+            - name: Build Windows modules
+              if: steps.cache-windows-modules.outputs.cache-hit != 'true'
+              shell: bash
+              run: ./build-windows-modules.sh
 
             - name: Build and test crates
               shell: bash

--- a/ci/check-rust.sh
+++ b/ci/check-rust.sh
@@ -7,13 +7,6 @@ export RUSTFLAGS="--deny warnings"
 # Build WireGuard Go
 ./wireguard/build-wireguard-go.sh
 
-# Build Windows modules
-case "$(uname -s)" in
-  MINGW*|MSYS_NT*)
-    time ./build-windows-modules.sh
-    ;;
-esac
-
 # Build Rust crates
 source env.sh
 time cargo build --locked --verbose


### PR DESCRIPTION
It takes about 5 minutes to build the Windows libraries alone, and they are modified relatively rarely. This PR updates the workflow to only rebuild them if changes have been made to any files in `windows/`.