### PR TITLE
Fix scrollbar responsive through modal overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix tray context menu showing or executing wrong actions, using wrong language or in other
   ways not update properly.
 - Fix the sometimes incorrect time added text after adding time to the account.
+- Fix scrollbar no longer responsive and usable when covered by other elements.
 
 #### macOS
 - Resolve issues with the app blocking internet connectivity after sleep or when connecting to new


### PR DESCRIPTION
This PR improves the event handling of the scrollbar implementation. Previously it reacted to all mouse events that intersected with the scrollbar/-track and didn't respect if it was covered by something else. Now the events `mouseenter`, `mouseleave` and `mousedown` is listened for on the track/bar instead of document.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3345)
<!-- Reviewable:end -->
