### PR TITLE
Update error message when there aren't any server for location/settings

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -699,6 +699,10 @@ msgid "Disconnected and unsecure"
 msgstr ""
 
 msgctxt "notifications"
+msgid "No servers in your selected location match your settings."
+msgstr ""
+
+msgctxt "notifications"
 msgid "Reconnecting"
 msgstr ""
 
@@ -765,10 +769,6 @@ msgstr ""
 #. The in-app banner and system notification which are displayed to the user when the running app becomes unsupported.
 msgctxt "notifications"
 msgid "Your privacy might be at risk with this unsupported app version. Please update now."
-msgstr ""
-
-msgctxt "notifications"
-msgid "Your selected server and tunnel protocol don't match. Please adjust your settings."
 msgstr ""
 
 #. Title label in navigation bar

--- a/gui/src/shared/notifications/error.ts
+++ b/gui/src/shared/notifications/error.ts
@@ -154,7 +154,7 @@ function getTunnelParameterMessage(err: TunnelParameterError): string {
     case 'no_matching_relay':
       return messages.pgettext(
         'notifications',
-        "Your selected server and tunnel protocol don't match. Please adjust your settings.",
+        'No servers in your selected location match your settings.',
       );
     case 'no_wireguard_key':
       return messages.pgettext(


### PR DESCRIPTION
This PR updates the error message that's shown when there are no servers for the location and settings combination. The new message is `No servers in your selected location match your settings.`

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3346)
<!-- Reviewable:end -->
