### PR TITLE
Improve information in ConnectionPanel when connected over custom bridge

### DIFF
--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -150,6 +150,11 @@ export default class ConnectionPanel extends React.Component<IProps> {
           entry: this.props.entryHostname,
         },
       );
+    } else if (this.props.bridgeInfo?.ip) {
+      return sprintf(messages.pgettext('connection-info', '%(relay)s via %(entry)s'), {
+        relay: this.props.hostname,
+        entry: this.props.bridgeInfo.ip,
+      });
     } else {
       return this.props.hostname || '';
     }

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -73,7 +73,7 @@ export type ProxyType = 'shadowsocks' | 'custom';
 export function proxyTypeToString(proxy: ProxyType): string {
   switch (proxy) {
     case 'shadowsocks':
-      return 'Shadowsocks';
+      return 'Shadowsocks bridge';
     case 'custom':
       return 'custom bridge';
     default:


### PR DESCRIPTION
This PR adds information to the connection panel when connected over a custom bridge. The hostname line will now say `<exit server> via <bridge ip>` and the protocol line will say `OpenVPN via Shadowsocks bridge` if using Shadowsocks.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3348)
<!-- Reviewable:end -->
