### PR TITLE
Unset launch on startup on Windows during uninstall

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -1185,6 +1185,8 @@
 		${If} $Silent != 1
 			MessageBox MB_ICONQUESTION|MB_YESNO "Would you like to remove settings files as well?" IDNO customRemoveFiles_after_remove_settings
 			${RemoveSettings}
+
+			DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "net.mullvad.vpn"
 		${EndIf}
 		customRemoveFiles_after_remove_settings:
 	${Else}


### PR DESCRIPTION
This PR updates the Windows uninstaller to remove the auto-start registry entry. It only does it for the user who runs the uninstaller.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3350)
<!-- Reviewable:end -->
