### PR TITLE
Upgrade clap to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,34 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+dependencies = [
+ "atty",
+ "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678db4c39c013cc68b54d372bce2efc58e30a0337c497c9032fd196802df3bc3"
+dependencies = [
+ "clap 3.0.14",
 ]
 
 [[package]]
@@ -1290,7 +1315,8 @@ version = "2021.6.0"
 dependencies = [
  "base64",
  "chrono",
- "clap",
+ "clap 3.0.14",
+ "clap_complete",
  "env_logger 0.8.4",
  "err-derive",
  "futures",
@@ -1313,7 +1339,7 @@ dependencies = [
  "android_logger",
  "cfg-if 1.0.0",
  "chrono",
- "clap",
+ "clap 3.0.14",
  "ctrlc",
  "dirs-next",
  "duct",
@@ -1414,7 +1440,7 @@ dependencies = [
 name = "mullvad-problem-report"
 version = "2021.6.0"
 dependencies = [
- "clap",
+ "clap 3.0.14",
  "dirs-next",
  "duct",
  "env_logger 0.8.4",
@@ -1463,7 +1489,7 @@ dependencies = [
 name = "mullvad-setup"
 version = "2021.6.0"
 dependencies = [
- "clap",
+ "clap 3.0.14",
  "env_logger 0.8.4",
  "err-derive",
  "lazy_static",
@@ -1750,6 +1776,15 @@ checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2500,12 +2535,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "lazy_static",
  "structopt-derive",
 ]
@@ -2731,6 +2772,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
-clap = "2.32"
+clap = { version = "3.0", features = ["cargo"] }
 err-derive = "0.3.0"
 env_logger = "0.8.2"
 futures = "0.3"
@@ -28,6 +28,9 @@ talpid-types = { path = "../talpid-types" }
 
 mullvad-management-interface = { path = "../mullvad-management-interface" }
 tokio = { version = "1.8", features =  [ "rt-multi-thread" ] }
+
+[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
+clap_complete = { version = "3.0" }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -1,5 +1,4 @@
 use crate::{new_rpc_client, Command, Error, Result};
-use clap::value_t_or_exit;
 use itertools::Itertools;
 use mullvad_management_interface::{types::Timestamp, Code};
 use mullvad_types::account::AccountToken;
@@ -13,43 +12,38 @@ impl Command for Account {
         "account"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Control and display information about your Mullvad account")
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
-                clap::SubCommand::with_name("set")
-                    .about("Change account")
-                    .arg(
-                        clap::Arg::with_name("token")
-                            .help("The Mullvad account token to configure the client with")
-                            .required(false),
-                    ),
+                clap::App::new("set").about("Change account").arg(
+                    clap::Arg::new("token")
+                        .help("The Mullvad account token to configure the client with")
+                        .required(false),
+                ),
             )
             .subcommand(
-                clap::SubCommand::with_name("get")
+                clap::App::new("get")
                     .about("Display information about the currently configured account"),
             )
             .subcommand(
-                clap::SubCommand::with_name("unset")
-                    .about("Removes the account number from the settings"),
+                clap::App::new("unset").about("Removes the account number from the settings"),
             )
             .subcommand(
-                clap::SubCommand::with_name("create")
+                clap::App::new("create")
                     .about("Creates a new account and sets it as the active one"),
             )
             .subcommand(
-                clap::SubCommand::with_name("redeem")
-                    .about("Redeems a voucher")
-                    .arg(
-                        clap::Arg::with_name("voucher")
-                            .help("The Mullvad voucher code to be submitted")
-                            .required(true),
-                    ),
+                clap::App::new("redeem").about("Redeems a voucher").arg(
+                    clap::Arg::new("voucher")
+                        .help("The Mullvad voucher code to be submitted")
+                        .required(true),
+                ),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             let mut token = match set_matches.value_of("token") {
                 Some(token) => token.to_string(),
@@ -74,7 +68,7 @@ impl Command for Account {
         } else if let Some(_matches) = matches.subcommand_matches("create") {
             self.create().await
         } else if let Some(matches) = matches.subcommand_matches("redeem") {
-            let voucher = value_t_or_exit!(matches.value_of("voucher"), String);
+            let voucher = matches.value_of_t_or_exit("voucher");
             self.redeem_voucher(voucher).await
         } else {
             unreachable!("No account command given");

--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -1,5 +1,4 @@
 use crate::{new_rpc_client, Command, Result};
-use clap::value_t_or_exit;
 
 pub struct AutoConnect;
 
@@ -9,28 +8,25 @@ impl Command for AutoConnect {
         "auto-connect"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Control the daemon auto-connect setting")
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
-                clap::SubCommand::with_name("set")
+                clap::App::new("set")
                     .about("Change auto-connect setting")
                     .arg(
-                        clap::Arg::with_name("policy")
+                        clap::Arg::new("policy")
                             .required(true)
                             .possible_values(&["on", "off"]),
                     ),
             )
-            .subcommand(
-                clap::SubCommand::with_name("get")
-                    .about("Display the current auto-connect setting"),
-            )
+            .subcommand(clap::App::new("get").about("Display the current auto-connect setting"))
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
-            let auto_connect = value_t_or_exit!(set_matches.value_of("policy"), String);
+            let auto_connect = set_matches.value_of("policy").expect("missing policy");
             self.set(auto_connect == "on").await
         } else if let Some(_matches) = matches.subcommand_matches("get") {
             self.get().await

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -1,5 +1,4 @@
 use crate::{new_rpc_client, Command, Result};
-use clap::value_t_or_exit;
 
 pub struct BlockWhenDisconnected;
 
@@ -9,28 +8,28 @@ impl Command for BlockWhenDisconnected {
         "always-require-vpn"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Control if the system service should block network access when disconnected from VPN")
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
-                clap::SubCommand::with_name("set")
+                clap::App::new("set")
                     .about("Change the always require VPN setting")
                     .arg(
-                        clap::Arg::with_name("policy")
+                        clap::Arg::new("policy")
                             .required(true)
                             .possible_values(&["on", "off"]),
                     ),
             )
             .subcommand(
-                clap::SubCommand::with_name("get")
+                clap::App::new("get")
                     .about("Display the current always require VPN setting"),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
-            let block_when_disconnected = value_t_or_exit!(set_matches.value_of("policy"), String);
+            let block_when_disconnected = set_matches.value_of("policy").expect("missing policy");
             self.set(block_when_disconnected == "on").await
         } else if let Some(_matches) = matches.subcommand_matches("get") {
             self.get().await

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -10,18 +10,18 @@ impl Command for Connect {
         "connect"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Command the client to start establishing a VPN tunnel")
             .arg(
-                clap::Arg::with_name("wait")
+                clap::Arg::new("wait")
                     .long("wait")
-                    .short("w")
+                    .short('w')
                     .help("Wait until connected before exiting"),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
 
         let receiver_option = if matches.is_present("wait") {

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -10,18 +10,18 @@ impl Command for Disconnect {
         "disconnect"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Command the client to disconnect the VPN tunnel")
             .arg(
-                clap::Arg::with_name("wait")
+                clap::Arg::new("wait")
                     .long("wait")
-                    .short("w")
+                    .short('w')
                     .help("Wait until disconnected before exiting"),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
 
         let receiver_option = if matches.is_present("wait") {

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -1,5 +1,4 @@
 use crate::{new_rpc_client, Command, Result};
-use clap::value_t_or_exit;
 
 pub struct Lan;
 
@@ -9,28 +8,25 @@ impl Command for Lan {
         "lan"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Control the allow local network sharing setting")
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
-                clap::SubCommand::with_name("set")
-                    .about("Change allow LAN setting")
-                    .arg(
-                        clap::Arg::with_name("policy")
-                            .required(true)
-                            .possible_values(&["allow", "block"]),
-                    ),
+                clap::App::new("set").about("Change allow LAN setting").arg(
+                    clap::Arg::new("policy")
+                        .required(true)
+                        .possible_values(&["allow", "block"]),
+                ),
             )
             .subcommand(
-                clap::SubCommand::with_name("get")
-                    .about("Display the current local network sharing setting"),
+                clap::App::new("get").about("Display the current local network sharing setting"),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
-            let allow_lan = value_t_or_exit!(set_matches.value_of("policy"), String);
+            let allow_lan = set_matches.value_of("policy").expect("missing policy");
             self.set(allow_lan == "allow").await
         } else if let Some(_matches) = matches.subcommand_matches("get") {
             self.get().await

--- a/mullvad-cli/src/cmds/reconnect.rs
+++ b/mullvad-cli/src/cmds/reconnect.rs
@@ -10,18 +10,18 @@ impl Command for Reconnect {
         "reconnect"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Command the client to reconnect")
             .arg(
-                clap::Arg::with_name("wait")
+                clap::Arg::new("wait")
                     .long("wait")
-                    .short("w")
+                    .short('w')
                     .help("Wait until reconnected before exiting"),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
 
         let receiver_option = if matches.is_present("wait") {

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -1,5 +1,4 @@
 use crate::{location, new_rpc_client, Command, Error, Result};
-use clap::{value_t, values_t};
 use itertools::Itertools;
 use std::{
     convert::TryFrom,
@@ -20,49 +19,49 @@ impl Command for Relay {
         "relay"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Manage relay and tunnel constraints")
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(
-                clap::SubCommand::with_name("set")
+                clap::App::new("set")
                     .about(
                         "Set relay server selection parameters. Such as location and port/protocol",
                     )
                     .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                     .subcommand(
-                        clap::SubCommand::with_name("custom")
+                        clap::App::new("custom")
                             .about("Set a custom VPN relay")
                             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
-                            .subcommand(clap::SubCommand::with_name("wireguard")
+                            .subcommand(clap::App::new("wireguard")
                                 .arg(
-                                    clap::Arg::with_name("host")
+                                    clap::Arg::new("host")
                                         .help("Hostname or IP")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("port")
+                                    clap::Arg::new("port")
                                         .help("Remote network port")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("peer-pubkey")
+                                    clap::Arg::new("peer-pubkey")
                                         .help("Base64 encoded peer public key")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("v4-gateway")
+                                    clap::Arg::new("v4-gateway")
                                         .help("IPv4 gateway address")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("addr")
+                                    clap::Arg::new("addr")
                                         .help("Local address of wireguard tunnel")
                                         .required(true)
-                                        .multiple(true),
+                                        .multiple_values(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("protocol")
+                                    clap::Arg::new("protocol")
                                         .help("Transport protocol. If TCP is selected, traffic is \
                                                sent over TCP using a udp-over-tcp proxy")
                                         .long("protocol")
@@ -70,35 +69,35 @@ impl Command for Relay {
                                         .possible_values(&["udp", "tcp"]),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("v6-gateway")
+                                    clap::Arg::new("v6-gateway")
                                         .help("IPv6 gateway address")
                                         .long("v6-gateway")
                                         .takes_value(true),
                                 )
                             )
-                            .subcommand(clap::SubCommand::with_name("openvpn")
+                            .subcommand(clap::App::new("openvpn")
                                 .arg(
-                                    clap::Arg::with_name("host")
+                                    clap::Arg::new("host")
                                         .help("Hostname or IP")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("port")
+                                    clap::Arg::new("port")
                                         .help("Remote network port")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("username")
+                                    clap::Arg::new("username")
                                         .help("Username to be used with the OpenVpn relay")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("password")
+                                    clap::Arg::new("password")
                                         .help("Password to be used with the OpenVpn relay")
                                         .required(true),
                                 )
                                 .arg(
-                                    clap::Arg::with_name("protocol")
+                                    clap::Arg::new("protocol")
                                         .help("Transport protocol")
                                         .long("protocol")
                                         .default_value("udp")
@@ -112,42 +111,42 @@ impl Command for Relay {
                                    command to show available alternatives.")
                     )
                     .subcommand(
-                        clap::SubCommand::with_name("hostname")
+                        clap::App::new("hostname")
                             .about("Set the exact relay to use via its hostname. Shortcut for \
                                 'location <country> <city> <hostname>'.")
                             .arg(
-                                clap::Arg::with_name("hostname")
+                                clap::Arg::new("hostname")
                                     .help("The hostname")
                                     .required(true),
                             ),
                     )
                     .subcommand(
-                        clap::SubCommand::with_name("provider")
+                        clap::App::new("provider")
                             .about("Set hosting provider(s) to select relays from. The 'list' \
                                    command shows the available relays and their providers.")
                             .arg(
-                                clap::Arg::with_name("provider")
+                                clap::Arg::new("provider")
                                 .help("The hosting provider(s) to use, or 'any' for no preference.")
-                                .multiple(true)
+                                .multiple_values(true)
                                 .required(true)
                             )
                     )
                     .subcommand(
-                        clap::SubCommand::with_name("tunnel")
+                        clap::App::new("tunnel")
                             .about("Set tunnel protocol-specific constraints.")
                             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
                             .subcommand(
-                                clap::SubCommand::with_name("openvpn")
+                                clap::App::new("openvpn")
                                     .about("Set OpenVPN-specific constraints")
                                     .setting(clap::AppSettings::ArgRequiredElseHelp)
                                     .arg(
-                                        clap::Arg::with_name("port")
+                                        clap::Arg::new("port")
                                             .help("Port to use. Either 'any' or a specific port")
                                             .long("port")
                                             .takes_value(true),
                                     )
                                     .arg(
-                                        clap::Arg::with_name("transport protocol")
+                                        clap::Arg::new("transport protocol")
                                             .help("Transport protocol")
                                             .long("protocol")
                                             .possible_values(&["any", "udp", "tcp"])
@@ -155,17 +154,17 @@ impl Command for Relay {
                                     )
                             )
                             .subcommand(
-                                clap::SubCommand::with_name("wireguard")
+                                clap::App::new("wireguard")
                                     .about("Set WireGuard-specific constraints")
                                     .setting(clap::AppSettings::ArgRequiredElseHelp)
                                     .arg(
-                                        clap::Arg::with_name("port")
+                                        clap::Arg::new("port")
                                             .help("Port to use. Either 'any' or a specific port")
                                             .long("port")
                                             .takes_value(true),
                                     )
                                     .arg(
-                                        clap::Arg::with_name("transport protocol")
+                                        clap::Arg::new("transport protocol")
                                             .help("Transport protocol. If TCP is selected, traffic is \
                                                    sent over TCP using a udp-over-tcp proxy")
                                             .long("protocol")
@@ -173,13 +172,13 @@ impl Command for Relay {
                                             .takes_value(true),
                                     )
                                     .arg(
-                                        clap::Arg::with_name("ip version")
+                                        clap::Arg::new("ip version")
                                             .long("ipv")
                                             .possible_values(&["any", "4", "6"])
                                             .takes_value(true),
                                     )
                                     .arg(
-                                        clap::Arg::with_name("entry location")
+                                        clap::Arg::new("entry location")
                                             .help("Entry endpoint to use. This can be 'any', 'none', or \
                                                    any location that is valid with 'set location', \
                                                    such as 'se got'.")
@@ -189,27 +188,27 @@ impl Command for Relay {
                                     )
                             )
                     )
-                    .subcommand(clap::SubCommand::with_name("tunnel-protocol")
+                    .subcommand(clap::App::new("tunnel-protocol")
                                 .about("Set tunnel protocol")
                                 .arg(
-                                    clap::Arg::with_name("tunnel protocol")
+                                    clap::Arg::new("tunnel protocol")
                                     .required(true)
                                     .index(1)
                                     .possible_values(&["any", "wireguard", "openvpn", ]),
                                     )
                                 ),
             )
-            .subcommand(clap::SubCommand::with_name("get"))
+            .subcommand(clap::App::new("get"))
             .subcommand(
-                clap::SubCommand::with_name("list").about("List available countries and cities"),
+                clap::App::new("list").about("List available countries and cities"),
             )
             .subcommand(
-                clap::SubCommand::with_name("update")
+                clap::App::new("update")
                     .about("Update the list of available countries and cities"),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(set_matches) = matches.subcommand_matches("set") {
             self.set(set_matches).await
         } else if matches.subcommand_matches("get").is_some() {
@@ -234,7 +233,7 @@ impl Relay {
         Ok(())
     }
 
-    async fn set(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set(&self, matches: &clap::ArgMatches) -> Result<()> {
         if let Some(custom_matches) = matches.subcommand_matches("custom") {
             self.set_custom(custom_matches).await
         } else if let Some(location_matches) = matches.subcommand_matches("location") {
@@ -258,11 +257,11 @@ impl Relay {
         }
     }
 
-    async fn set_custom(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set_custom(&self, matches: &clap::ArgMatches) -> Result<()> {
         let custom_endpoint = match matches.subcommand() {
-            ("openvpn", Some(openvpn_matches)) => Self::read_custom_openvpn_relay(openvpn_matches),
-            ("wireguard", Some(wg_matches)) => Self::read_custom_wireguard_relay(wg_matches),
-            (_unknown_tunnel, _) => unreachable!("No set relay command given"),
+            Some(("openvpn", openvpn_matches)) => Self::read_custom_openvpn_relay(openvpn_matches),
+            Some(("wireguard", wg_matches)) => Self::read_custom_wireguard_relay(wg_matches),
+            _ => unreachable!("No set relay command given"),
         };
 
         self.update_constraints(types::RelaySettingsUpdate {
@@ -271,12 +270,12 @@ impl Relay {
         .await
     }
 
-    fn read_custom_openvpn_relay(matches: &clap::ArgMatches<'_>) -> types::CustomRelaySettings {
-        let host = value_t!(matches.value_of("host"), String).unwrap_or_else(|e| e.exit());
-        let port = value_t!(matches.value_of("port"), u16).unwrap_or_else(|e| e.exit());
-        let username = value_t!(matches.value_of("username"), String).unwrap_or_else(|e| e.exit());
-        let password = value_t!(matches.value_of("password"), String).unwrap_or_else(|e| e.exit());
-        let protocol = value_t!(matches.value_of("protocol"), String).unwrap_or_else(|e| e.exit());
+    fn read_custom_openvpn_relay(matches: &clap::ArgMatches) -> types::CustomRelaySettings {
+        let host = matches.value_of_t_or_exit("host");
+        let port = matches.value_of_t_or_exit("port");
+        let username = matches.value_of_t_or_exit("username");
+        let password = matches.value_of_t_or_exit("password");
+        let protocol: String = matches.value_of_t_or_exit("protocol");
 
         let protocol = Self::validate_transport_protocol(&protocol);
 
@@ -296,24 +295,22 @@ impl Relay {
         }
     }
 
-    fn read_custom_wireguard_relay(matches: &clap::ArgMatches<'_>) -> types::CustomRelaySettings {
+    fn read_custom_wireguard_relay(matches: &clap::ArgMatches) -> types::CustomRelaySettings {
         use types::connection_config::wireguard_config;
 
-        let host = value_t!(matches.value_of("host"), String).unwrap_or_else(|e| e.exit());
-        let port = value_t!(matches.value_of("port"), u16).unwrap_or_else(|e| e.exit());
-        let addresses = values_t!(matches.values_of("addr"), IpAddr).unwrap_or_else(|e| e.exit());
-        let peer_key_str =
-            value_t!(matches.value_of("peer-pubkey"), String).unwrap_or_else(|e| e.exit());
-        let ipv4_gateway =
-            value_t!(matches.value_of("v4-gateway"), Ipv4Addr).unwrap_or_else(|e| e.exit());
-        let ipv6_gateway = match value_t!(matches.value_of("v6-gateway"), Ipv6Addr) {
+        let host = matches.value_of_t_or_exit("host");
+        let port = matches.value_of_t_or_exit("port");
+        let addresses: Vec<IpAddr> = matches.values_of_t_or_exit("addr");
+        let peer_key_str: String = matches.value_of_t_or_exit("peer-pubkey");
+        let ipv4_gateway: Ipv4Addr = matches.value_of_t_or_exit("v4-gateway");
+        let ipv6_gateway = match matches.value_of_t::<Ipv6Addr>("v6-gateway") {
             Ok(gateway) => Some(gateway),
             Err(e) => match e.kind {
                 clap::ErrorKind::ArgumentNotFound => None,
                 _ => e.exit(),
             },
         };
-        let protocol = value_t!(matches.value_of("protocol"), String).unwrap_or_else(|e| e.exit());
+        let protocol: String = matches.value_of_t_or_exit("protocol");
         let protocol = Self::validate_transport_protocol(&protocol);
         let mut private_key_str = String::new();
         println!("Reading private key from standard input");
@@ -380,15 +377,15 @@ impl Relay {
         match protocol {
             "udp" => types::TransportProtocol::Udp,
             "tcp" => types::TransportProtocol::Tcp,
-            _ => clap::Error::with_description(
-                "invalid transport protocol",
+            _ => clap::Error::raw(
                 clap::ErrorKind::ValueValidation,
+                "invalid transport protocol",
             )
             .exit(),
         }
     }
 
-    async fn set_hostname(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set_hostname(&self, matches: &clap::ArgMatches) -> Result<()> {
         let hostname = matches.value_of("hostname").unwrap();
         let countries = Self::get_filtered_relays().await?;
 
@@ -425,15 +422,11 @@ impl Relay {
             })
             .await
         } else {
-            clap::Error::with_description(
-                "No matching server found",
-                clap::ErrorKind::ValueValidation,
-            )
-            .exit()
+            clap::Error::raw(clap::ErrorKind::ValueValidation, "No matching server found").exit()
         }
     }
 
-    async fn set_location(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set_location(&self, matches: &clap::ArgMatches) -> Result<()> {
         let location_constraint = location::get_constraint_from_args(matches);
         let mut found = false;
 
@@ -490,10 +483,8 @@ impl Relay {
         .await
     }
 
-    async fn set_providers(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
-        let providers =
-            values_t!(matches.values_of("provider"), String).unwrap_or_else(|e| e.exit());
-
+    async fn set_providers(&self, matches: &clap::ArgMatches) -> Result<()> {
+        let providers: Vec<String> = matches.values_of_t_or_exit("provider");
         let providers = if providers.iter().next().map(String::as_str) == Some("any") {
             vec![]
         } else {
@@ -511,7 +502,7 @@ impl Relay {
         .await
     }
 
-    async fn set_openvpn_constraints(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set_openvpn_constraints(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut openvpn_constraints = {
             let mut rpc = new_rpc_client().await?;
             self.get_openvpn_constraints(&mut rpc).await?
@@ -552,7 +543,7 @@ impl Relay {
         }
     }
 
-    async fn set_wireguard_constraints(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set_wireguard_constraints(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
         let mut wireguard_constraints = self.get_wireguard_constraints(&mut rpc).await?;
 
@@ -606,7 +597,7 @@ impl Relay {
         }
     }
 
-    async fn set_tunnel_protocol(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn set_tunnel_protocol(&self, matches: &clap::ArgMatches) -> Result<()> {
         let tunnel_type = match matches.value_of("tunnel protocol").unwrap() {
             "wireguard" => Some(types::TunnelType::Wireguard),
             "openvpn" => Some(types::TunnelType::Openvpn),
@@ -775,7 +766,7 @@ fn parse_entry_location_constraint<'a, T: Iterator<Item = &'a str>>(
 }
 
 fn parse_transport_port(
-    matches: &clap::ArgMatches<'_>,
+    matches: &clap::ArgMatches,
     current_constraint: &mut Option<types::TransportPort>,
 ) -> Result<Option<types::TransportPort>> {
     let protocol = match matches.value_of("transport protocol") {

--- a/mullvad-cli/src/cmds/reset.rs
+++ b/mullvad-cli/src/cmds/reset.rs
@@ -8,11 +8,11 @@ impl Command for Reset {
         "factory-reset"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name()).about("Reset settings, caches and logs")
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name()).about("Reset settings, caches and logs")
     }
 
-    async fn run(&self, _: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, _: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
         if Self::receive_confirmation() {
             rpc.factory_reset(())

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -11,27 +11,27 @@ impl Command for Status {
         "status"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("View the state of the VPN tunnel")
             .arg(
-                clap::Arg::with_name("location")
+                clap::Arg::new("location")
                     .long("location")
-                    .short("l")
+                    .short('l')
                     .help("Prints the current location and IP. Based on GeoIP lookups"),
             )
             .subcommand(
-                clap::SubCommand::with_name("listen")
+                clap::App::new("listen")
                     .about("Listen for VPN tunnel state changes")
                     .arg(
-                        clap::Arg::with_name("verbose")
-                            .short("v")
+                        clap::Arg::new("verbose")
+                            .short('v')
                             .help("Enables verbose output"),
                     ),
             )
     }
 
-    async fn run(&self, matches: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
         let state = rpc.get_tunnel_state(()).await?.into_inner();
 

--- a/mullvad-cli/src/cmds/version.rs
+++ b/mullvad-cli/src/cmds/version.rs
@@ -8,12 +8,12 @@ impl Command for Version {
         "version"
     }
 
-    fn clap_subcommand(&self) -> clap::App<'static, 'static> {
-        clap::SubCommand::with_name(self.name())
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
             .about("Shows current version, and the currently supported versions")
     }
 
-    async fn run(&self, _: &clap::ArgMatches<'_>) -> Result<()> {
+    async fn run(&self, _: &clap::ArgMatches) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
         let current_version = rpc
             .get_current_version(())

--- a/mullvad-cli/src/location.rs
+++ b/mullvad-cli/src/location.rs
@@ -1,28 +1,24 @@
 use mullvad_management_interface::types::RelayLocation;
 
-pub fn get_subcommand() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("location")
+pub fn get_subcommand() -> clap::App<'static> {
+    clap::App::new("location")
         .arg(
-            clap::Arg::with_name("country")
+            clap::Arg::new("country")
                 .help("The two letter country code, or 'any' for no preference.")
                 .required(true)
                 .index(1)
                 .validator(country_code_validator),
         )
         .arg(
-            clap::Arg::with_name("city")
+            clap::Arg::new("city")
                 .help("The three letter city code")
                 .index(2)
                 .validator(city_code_validator),
         )
-        .arg(
-            clap::Arg::with_name("hostname")
-                .help("The hostname")
-                .index(3),
-        )
+        .arg(clap::Arg::new("hostname").help("The hostname").index(3))
 }
 
-pub fn get_constraint_from_args(matches: &clap::ArgMatches<'_>) -> RelayLocation {
+pub fn get_constraint_from_args(matches: &clap::ArgMatches) -> RelayLocation {
     let country = matches.value_of("country").unwrap();
     let city = matches.value_of("city");
     let hostname = matches.value_of("hostname");
@@ -41,9 +37,9 @@ pub fn get_constraint<T: AsRef<str>>(
 
     match (country_original, city, hostname) {
         ("any", None, None) => RelayLocation::default(),
-        ("any", ..) => clap::Error::with_description(
-            "City can't be given when selecting 'any' country",
+        ("any", ..) => clap::Error::raw(
             clap::ErrorKind::InvalidValue,
+            "City can't be given when selecting 'any' country",
         )
         .exit(),
         (_, None, None) => RelayLocation {
@@ -60,24 +56,24 @@ pub fn get_constraint<T: AsRef<str>>(
             city,
             hostname,
         },
-        (..) => clap::Error::with_description(
-            "Invalid country, city and hostname combination given",
+        (..) => clap::Error::raw(
             clap::ErrorKind::InvalidValue,
+            "Invalid country, city and hostname combination given",
         )
         .exit(),
     }
 }
 
-pub fn country_code_validator<T: AsRef<str>>(code: T) -> std::result::Result<(), String> {
-    if code.as_ref().len() == 2 || code.as_ref() == "any" {
+pub fn country_code_validator(code: &str) -> std::result::Result<(), String> {
+    if code.len() == 2 || code == "any" {
         Ok(())
     } else {
         Err(String::from("Country codes must be two letters, or 'any'."))
     }
 }
 
-pub fn city_code_validator<T: AsRef<str>>(code: T) -> std::result::Result<(), String> {
-    if code.as_ref().len() == 3 {
+pub fn city_code_validator(code: &str) -> std::result::Result<(), String> {
+    if code.len() == 3 {
         Ok(())
     } else {
         Err(String::from("City codes must be three letters"))

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 cfg-if = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-clap = "2.25"
+clap = { version = "3.0", features = ["cargo"] }
 err-derive = "0.3.0"
 either = "1"
 fern = { version = "0.6", features = ["colored"] }

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -66,42 +66,42 @@ lazy_static::lazy_static! {
         mullvad_paths::get_default_rpc_socket_path().display());
 }
 
-fn create_app() -> App<'static, 'static> {
+fn create_app() -> App<'static> {
     let mut app = App::new(crate_name!())
         .version(version::PRODUCT_VERSION)
         .author(crate_authors!(", "))
         .about(crate_description!())
         .after_help(ENV_DESC.as_str())
         .arg(
-            Arg::with_name("v")
-                .short("v")
-                .multiple(true)
+            Arg::new("v")
+                .short('v')
+                .multiple_occurrences(true)
                 .help("Sets the level of verbosity"),
         )
         .arg(
-            Arg::with_name("disable_log_to_file")
+            Arg::new("disable_log_to_file")
                 .long("disable-log-to-file")
                 .help("Disable logging to file"),
         )
         .arg(
-            Arg::with_name("disable_stdout_timestamps")
+            Arg::new("disable_stdout_timestamps")
                 .long("disable-stdout-timestamps")
                 .help("Don't log timestamps when logging to stdout, useful when running as a systemd service")
         );
 
     if cfg!(windows) {
         app = app.arg(
-            Arg::with_name("run_as_service")
+            Arg::new("run_as_service")
                 .long("run-as-service")
                 .help("Run as a system service. On Windows this option must be used when running a system service"),
         )
         .arg(
-            Arg::with_name("register_service")
+            Arg::new("register_service")
                 .long("register-service")
                 .help("Register itself as a system service"),
         )
         .arg(
-            Arg::with_name("restart_service")
+            Arg::new("restart_service")
                 .long("restart-service")
                 .help("Restarts the existing system service"),
         )

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-clap = "2.25"
+clap = { version = "3.0", features = ["cargo"] }
 dirs-next = "2.0"
 env_logger = "0.8.2"
 err-derive = "0.3.0"

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -22,62 +22,65 @@ fn run() -> Result<(), Error> {
         .author(crate_authors!())
         .about("Mullvad VPN problem report tool. Collects logs and sends them to Mullvad support.")
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
-        .global_settings(&[
-            clap::AppSettings::DisableHelpSubcommand,
-            clap::AppSettings::VersionlessSubcommands,
-        ])
+        .global_setting(clap::AppSettings::DisableHelpSubcommand)
+        .global_setting(clap::AppSettings::DisableVersionFlag)
         .subcommand(
-            clap::SubCommand::with_name("collect")
+            clap::App::new("collect")
                 .about("Collect problem report")
                 .arg(
-                    clap::Arg::with_name("output")
+                    clap::Arg::new("output")
                         .help("The destination path for saving the collected report.")
                         .long("output")
-                        .short("o")
+                        .short('o')
                         .value_name("PATH")
+                        .allow_invalid_utf8(true)
                         .takes_value(true)
                         .required(true),
                 )
                 .arg(
-                    clap::Arg::with_name("extra_logs")
+                    clap::Arg::new("extra_logs")
                         .help("Paths to additional log files to be included.")
-                        .multiple(true)
+                        .multiple_occurrences(true)
+                        .multiple_values(true)
                         .value_name("EXTRA LOGS")
+                        .allow_invalid_utf8(true)
                         .takes_value(true)
                         .required(false),
                 )
                 .arg(
-                    clap::Arg::with_name("redact")
+                    clap::Arg::new("redact")
                         .help("List of words and expressions to remove from the report")
                         .long("redact")
                         .value_name("PHRASE")
-                        .multiple(true)
+                        .multiple_occurrences(true)
+                        .multiple_values(true)
                         .takes_value(true),
                 ),
         )
         .subcommand(
-            clap::SubCommand::with_name("send")
+            clap::App::new("send")
                 .about("Send collected problem report")
                 .arg(
-                    clap::Arg::with_name("report")
+                    clap::Arg::new("report")
                         .long("report")
-                        .short("r")
+                        .short('r')
                         .help("The path to previously collected report file.")
+                        .allow_invalid_utf8(true)
                         .takes_value(true)
                         .required(true),
                 )
                 .arg(
-                    clap::Arg::with_name("email")
+                    clap::Arg::new("email")
                         .long("email")
-                        .short("e")
+                        .short('e')
                         .help("Reporter's email")
                         .takes_value(true)
                         .required(false),
                 )
                 .arg(
-                    clap::Arg::with_name("message")
+                    clap::Arg::new("message")
                         .long("message")
-                        .short("m")
+                        .short('m')
                         .help("Reporter's message")
                         .takes_value(true)
                         .required(false),
@@ -88,8 +91,8 @@ fn run() -> Result<(), Error> {
 
     if let Some(collect_matches) = matches.subcommand_matches("collect") {
         let redact_custom_strings = collect_matches
-            .values_of_lossy("redact")
-            .unwrap_or_else(Vec::new);
+            .values_of_t("redact")
+            .unwrap_or_else(|_| vec![]);
         let extra_logs = collect_matches
             .values_of_os("extra_logs")
             .map(|os_values| os_values.map(Path::new).collect())

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -12,7 +12,7 @@ name = "mullvad-setup"
 path = "src/main.rs"
 
 [dependencies]
-clap = "2.32"
+clap = { version = "3.0", features = ["cargo"] }
 env_logger = "0.8.2"
 err-derive = "0.3.0"
 lazy_static = "1.1.0"


### PR DESCRIPTION
The changes are fairly minimal. All breaking API changes and deprecated functionality are fixed. Unfortunately, clap 2.34 is still a dependency due to `udp-over-tcp`.

Closes #3305.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3353)
<!-- Reviewable:end -->
