### PR TITLE
Remove allowed endpoint from Android tun provider

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -211,7 +211,7 @@ impl ConnectedState {
                 }
             }
             Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
-                let _ = shared_values.set_allowed_endpoint(endpoint);
+                shared_values.allowed_endpoint = endpoint;
                 if let Err(_) = tx.send(()) {
                     log::error!("The AllowEndpoint receiver was dropped");
                 }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -328,7 +328,8 @@ impl ConnectingState {
                 }
             }
             Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
-                if shared_values.set_allowed_endpoint(endpoint) {
+                if shared_values.allowed_endpoint != endpoint {
+                    shared_values.allowed_endpoint = endpoint;
                     if let Err(error) = Self::set_firewall_policy(
                         shared_values,
                         &self.tunnel_parameters,

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -150,7 +150,8 @@ impl TunnelState for DisconnectedState {
                 SameState(self.into())
             }
             Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
-                if shared_values.set_allowed_endpoint(endpoint) {
+                if shared_values.allowed_endpoint != endpoint {
+                    shared_values.allowed_endpoint = endpoint;
                     Self::set_firewall_policy(shared_values, true);
                 }
                 if let Err(_) = tx.send(()) {

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -28,7 +28,7 @@ impl DisconnectingState {
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
-                    let _ = shared_values.set_allowed_endpoint(endpoint);
+                    shared_values.allowed_endpoint = endpoint;
                     if let Err(_) = tx.send(()) {
                         log::error!("The AllowEndpoint receiver was dropped");
                     }
@@ -66,7 +66,7 @@ impl DisconnectingState {
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
-                    let _ = shared_values.set_allowed_endpoint(endpoint);
+                    shared_values.allowed_endpoint = endpoint;
                     if let Err(_) = tx.send(()) {
                         log::error!("The AllowEndpoint receiver was dropped");
                     }
@@ -109,7 +109,7 @@ impl DisconnectingState {
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
-                    let _ = shared_values.set_allowed_endpoint(endpoint);
+                    shared_values.allowed_endpoint = endpoint;
                     if let Err(_) = tx.send(()) {
                         log::error!("The AllowEndpoint receiver was dropped");
                     }

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -149,7 +149,8 @@ impl TunnelState for ErrorState {
                 }
             }
             Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
-                if shared_values.set_allowed_endpoint(endpoint) {
+                if shared_values.allowed_endpoint != endpoint {
+                    shared_values.allowed_endpoint = endpoint;
                     let _ = Self::set_firewall_policy(shared_values);
 
                     #[cfg(target_os = "android")]

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -122,8 +122,6 @@ pub async fn spawn(
         #[cfg(target_os = "android")]
         initial_settings.allow_lan,
         #[cfg(target_os = "android")]
-        initial_settings.allowed_endpoint.endpoint.address.ip(),
-        #[cfg(target_os = "android")]
         initial_settings.dns_servers.clone(),
     );
 
@@ -429,22 +427,6 @@ impl SharedTunnelStateValues {
         }
 
         Ok(())
-    }
-
-    pub fn set_allowed_endpoint(&mut self, endpoint: AllowedEndpoint) -> bool {
-        if self.allowed_endpoint != endpoint {
-            #[cfg(target_os = "android")]
-            self.tun_provider
-                .lock()
-                .unwrap()
-                .set_allowed_endpoint(endpoint.endpoint.address.ip());
-
-            self.allowed_endpoint = endpoint;
-
-            true
-        } else {
-            false
-        }
     }
 
     pub fn set_dns_servers(


### PR DESCRIPTION
Seems to be a holdover from the old hacky implementation. Since `VpnService.protect()` is called for all Mullvad API sockets, it should be unnecessary to modify the routes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3358)
<!-- Reviewable:end -->
