### PR TITLE
Add extra slack to test_establish_timeout

### DIFF
--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -801,22 +801,13 @@ mod test {
                     .unwrap();
             }
         });
-        let err = DELAY_ON_INITIAL_SETUP + Duration::from_millis(100);
-        assert!(!result_rx
-            .recv_timeout(Duration::from_millis(500) + err)
-            .unwrap()
-            .unwrap());
-        assert!(!result_rx
-            .recv_timeout(Duration::from_secs(1) + err)
-            .unwrap()
-            .unwrap());
-        assert!(!result_rx
-            .recv_timeout(Duration::from_secs(2) + err)
-            .unwrap()
-            .unwrap());
-        assert!(!result_rx
-            .recv_timeout(Duration::from_secs(2) + err)
-            .unwrap()
-            .unwrap());
+        let err = DELAY_ON_INITIAL_SETUP + Duration::from_millis(350);
+        let assert_rx = |recv_timeout: Duration| {
+            assert!(!result_rx.recv_timeout(recv_timeout + err).unwrap().unwrap());
+        };
+        assert_rx(Duration::from_millis(500));
+        assert_rx(Duration::from_secs(1));
+        assert_rx(Duration::from_secs(2));
+        assert_rx(Duration::from_secs(2));
     }
 }


### PR DESCRIPTION
`test_establish_timeout` has a great history of failing in CI for no
good reason. Whilst the _correct_ way of solving this issue would be to
mock the clock, I've added extra slack to the test to make it fail less
often.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3361)
<!-- Reviewable:end -->
