### PR TITLE
Log api availability and improve interval usage

### DIFF
--- a/mullvad-daemon/src/wireguard.rs
+++ b/mullvad-daemon/src/wireguard.rs
@@ -354,6 +354,7 @@ impl KeyManager {
 
     async fn wait_for_key_expiry(key: &PublicKey, rotation_interval_secs: u64) {
         let mut interval = tokio::time::interval(KEY_CHECK_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
             if (Utc::now().signed_duration_since(key.created)).num_seconds() as u64

--- a/mullvad-rpc/src/availability.rs
+++ b/mullvad-rpc/src/availability.rs
@@ -66,6 +66,7 @@ pub struct ApiAvailabilityHandle {
 
 impl ApiAvailabilityHandle {
     pub fn suspend(&self) {
+        log::debug!("Suspending API requests");
         let mut state = self.state.lock().unwrap();
         if !state.suspended {
             state.suspended = true;
@@ -74,6 +75,7 @@ impl ApiAvailabilityHandle {
     }
 
     pub fn unsuspend(&self) {
+        log::debug!("Unsuspending API requests");
         let mut state = self.state.lock().unwrap();
         if state.suspended {
             state.suspended = false;
@@ -82,6 +84,7 @@ impl ApiAvailabilityHandle {
     }
 
     pub fn pause_background(&self) {
+        log::debug!("Pausing background API requests");
         let mut state = self.state.lock().unwrap();
         if !state.pause_background {
             state.pause_background = true;
@@ -90,6 +93,7 @@ impl ApiAvailabilityHandle {
     }
 
     pub fn resume_background(&self) {
+        log::debug!("Resuming background API requests");
         let mut state = self.state.lock().unwrap();
         if state.pause_background {
             state.pause_background = false;
@@ -98,6 +102,11 @@ impl ApiAvailabilityHandle {
     }
 
     pub fn set_offline(&self, offline: bool) {
+        if offline {
+            log::debug!("Pausing API requests due to being offline");
+        } else {
+            log::debug!("Resuming API requests due to coming online");
+        }
         let mut state = self.state.lock().unwrap();
         if state.offline != offline {
             state.offline = offline;

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -91,3 +91,4 @@ tonic-build = { version = "0.5", default-features = false, features = ["transpor
 tempfile = "3.0"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
+tokio = { version = "1", features = [ "test-util" ] }

--- a/talpid-core/src/future_retry.rs
+++ b/talpid-core/src/future_retry.rs
@@ -205,4 +205,27 @@ mod test {
         let jittered_duration = apply_jitter(unjittered_duration, jitter);
         assert!(jittered_duration <= unjittered_duration);
     }
+
+    #[tokio::test]
+    async fn test_exponential_backoff_delay() {
+        let retry_interval_initial = Duration::from_secs(4);
+        let retry_interval_factor = 5;
+        let retry_interval_max = Duration::from_secs(24 * 60 * 60);
+        tokio::time::pause();
+
+        let _ = retry_future_n(
+            || async { 0 },
+            |_| true,
+            ExponentialBackoff::new(retry_interval_initial, retry_interval_factor)
+                .max_delay(retry_interval_max),
+            5,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_timer_advancement() {
+        tokio::time::pause();
+        sleep(Duration::from_secs(60 * 60)).await
+    }
 }


### PR DESCRIPTION
This branch brings 3 small changes:
- change the missed tick behavior in intervals to skip the missed ticks
- log every API availability change
- add some timer tests to our retry logic to ensure they do not panic with the interval values we're using

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3363)
<!-- Reviewable:end -->
