### PR TITLE
Fix settings issues

### DIFF
--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.7"
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.8", features =  [ "fs", "rt-multi-thread", "sync", "time" ] }
+tokio = { version = "1.8", features =  ["fs", "io-util", "rt-multi-thread", "sync", "time"] }
 tokio-stream = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/mullvad-daemon/src/account_history.rs
+++ b/mullvad-daemon/src/account_history.rs
@@ -116,7 +116,6 @@ impl AccountHistory {
                 .await
                 .map_err(Error::Write)?;
         }
-        self.file.flush().await.map_err(Error::Write)?;
         self.file.get_mut().sync_all().await.map_err(Error::Write)
     }
 }

--- a/mullvad-daemon/src/migrations/account_history.rs
+++ b/mullvad-daemon/src/migrations/account_history.rs
@@ -67,7 +67,6 @@ pub async fn migrate_formats(settings_dir: &Path, settings: &mut serde_json::Val
     file.write_all(token.as_bytes())
         .await
         .map_err(Error::WriteHistoryError)?;
-    file.flush().await.map_err(Error::WriteHistoryError)?;
     file.sync_all().await.map_err(Error::WriteHistoryError)?;
 
     Ok(())

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -142,6 +142,9 @@ pub async fn migrate_all(cache_dir: &Path, settings_dir: &Path) -> Result<()> {
         .await
         .map_err(Error::WriteError)?;
     file.sync_data().await.map_err(Error::SyncError)?;
+
+    log::debug!("Migrated settings. Wrote settings to {}", path.display());
+
     Ok(())
 }
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -59,7 +59,7 @@ impl SettingsPersister {
                     "{}",
                     error.display_chain_with_msg("Failed to load settings. Using defaults.")
                 );
-                (Settings::default(), true)
+                (Self::default_settings(), true)
             }
         };
 
@@ -91,7 +91,7 @@ impl SettingsPersister {
             Err(error) => {
                 if error.kind() == io::ErrorKind::NotFound {
                     log::info!("No settings were found. Using defaults.");
-                    return Ok((Settings::default(), true));
+                    return Ok((Self::default_settings(), true));
                 } else {
                     return Err(Error::ReadError(path.display().to_string(), error));
                 }
@@ -152,7 +152,7 @@ impl SettingsPersister {
     /// Resets default settings
     #[cfg(not(target_os = "android"))]
     pub async fn reset(&mut self) -> Result<(), Error> {
-        self.settings = Settings::default();
+        self.settings = Self::default_settings();
         let path = self.path.clone();
         self.save()
             .or_else(|e| async move {
@@ -170,6 +170,16 @@ impl SettingsPersister {
 
     pub fn to_settings(&self) -> Settings {
         self.settings.clone()
+    }
+
+    /// Modifies `Settings::default()` somewhat, e.g. depending on whether a beta version
+    /// is being run or not.
+    fn default_settings() -> Settings {
+        let mut settings = Settings::default();
+        if crate::version::is_beta_version() {
+            settings.show_beta_releases = true;
+        }
+        settings
     }
 
     /// Changes account number to the one given. Also saves the new settings to disk.


### PR DESCRIPTION
This PR fixes several small issues relating to settings:
* Primarily, ensure that the settings file buffer is flushed after running migration code. This may have resulted in settings not being read correctly afterwards.
* The result of settings migrations was pointlessly written to disk even if nothing had changed.
* Don't write new settings to disk twice when running beta versions.
* Remove instances of `File::flush`. It is usually a no-op. At worst, it does the same thing as (i.e., repeats) `File::sync_all`.
* The `io-util` feature was missing for tokio in `mullvad-daemon`. Needed for `AsyncWriteExt`.