### PR TITLE
Fix changelog title styles

### DIFF
--- a/gui/src/renderer/components/Changelog.tsx
+++ b/gui/src/renderer/components/Changelog.tsx
@@ -1,14 +1,12 @@
 import styled from 'styled-components';
-import { colors } from '../../config.json';
 import { messages } from '../../shared/gettext';
 import { useAppContext } from '../context';
 import { useSelector } from '../redux/store';
 import * as AppButton from './AppButton';
-import { bigText, smallText } from './common-styles';
+import { hugeText, smallText } from './common-styles';
 import { ModalAlert, ModalMessage } from './Modal';
 
-const StyledTitle = styled.h1(bigText, {
-  fontColor: colors.white,
+const StyledTitle = styled.h1(hugeText, {
   textAlign: 'center',
   margin: '7px 0 4px',
 });


### PR DESCRIPTION
This PR fixes the title in the changelog dialog. This wasn't updated in https://github.com/mullvad/mullvadvpn-app/pull/3344 to have the right size and color.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3369)
<!-- Reviewable:end -->
