### PR TITLE
Unblock the API when connecting to a relay.

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2495,6 +2495,7 @@ where
     }
 
     fn connect_tunnel(&mut self) {
+        self.rpc_runtime.availability_handle().resume_background();
         self.send_tunnel_command(TunnelCommand::Connect);
     }
 

--- a/mullvad-daemon/src/relays/mod.rs
+++ b/mullvad-daemon/src/relays/mod.rs
@@ -252,7 +252,14 @@ impl RelaySelector {
     /// Download the newest relay list.
     pub async fn update(&self) {
         if let Some(mut updater) = self.updater.clone() {
-            let _ = updater.update_relay_list().await;
+            if let Err(err) = updater.update_relay_list().await {
+                log::error!(
+                    "{}",
+                    err.display_chain_with_msg(
+                        "Unable to send update command to relay list updater"
+                    )
+                );
+            }
         }
     }
 


### PR DESCRIPTION
To improve the reliability of relay list update, version checks and other interval based interactions with the API that can be blocked via API availability, the daemon will now consider the API available if/when it connects to a relay. 

I've also added a logging call to log when update commands can't be sent to the relay updater actor. 