### PR TITLE
Rename some Github Actions jobs to make them easier to find

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -1,4 +1,4 @@
-name: Android app CI
+name: Android - Build and test
 on:
     # Build whenever a file that affects Android is changed in a pull request
     pull_request:

--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -1,4 +1,4 @@
-name: Android audit
+name: Android - Audit dependencies
 on:
     pull_request:
         paths:

--- a/.github/workflows/android-ktlint.yml
+++ b/.github/workflows/android-ktlint.yml
@@ -1,4 +1,4 @@
-name: Android app Kotlin linter
+name: Android - Kotlin linter
 on:
     # Run linter whenever a Kotlin file changes
     pull_request:

--- a/.github/workflows/android-xml-tidy.yml
+++ b/.github/workflows/android-xml-tidy.yml
@@ -1,4 +1,4 @@
-name: Android app XML formatting verifier
+name: Android - Check XML formatting
 on:
     # Run verifier whenever an Android XML file changes
     pull_request:

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,4 +1,4 @@
-name: Audit Rust dependencies CI
+name: Rust - Audit dependencies
 on:
     pull_request:
         paths:

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -1,4 +1,4 @@
-name: Mullvad VPN daemon CI
+name: Daemon+CLI - Build and test
 on:
     # Build whenever a file that affects a Rust crate is changed in a pull request
     pull_request:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,4 +1,4 @@
-name: Electron frontend CI
+name: Desktop frontend
 on:
     # Build whenever a file that affects the frontend is changed in a pull request
     pull_request:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,4 @@
-name: iOS app CI
+name: iOS app
 on:
     pull_request:
         paths:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,4 +1,4 @@
-name: Rust formatting check CI
+name: Rust - Check formatting
 on:
     # Check whenever a file that affects Rust formatting is changed in a pull request
     pull_request:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,6 +1,5 @@
-name: Translation check CI
+name: Translation check
 on:
-    # Check whenever a file that affects Rust formatting is changed in a pull request
     pull_request:
         paths:
             - .github/workflows/translations.yml


### PR DESCRIPTION
I found the list on the left hand side of https://github.com/mullvad/mullvadvpn-app/actions a bit hard to parse. With this change, all Rust-related CI jobs will start with "Rust", so hopefully they end up next to each other and are easier to spot.

I also removed "CI" at the end of all names. That felt superfluous

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3371)
<!-- Reviewable:end -->
