### PR TITLE
Use transform translate for positioning Marquee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix the sometimes incorrect time added text after adding time to the account.
 - Fix scrollbar no longer responsive and usable when covered by other elements.
 - Fix settings file being truncated before being read.
+- Improve performance for automatically scrolling text in desktop app.
 
 
 ## [2022.1-beta1] - 2022-02-14

--- a/gui/src/renderer/components/Marquee.tsx
+++ b/gui/src/renderer/components/Marquee.tsx
@@ -3,19 +3,25 @@ import styled from 'styled-components';
 import { Scheduler } from '../../shared/scheduler';
 
 const Container = styled.div({
+  position: 'relative',
   overflow: 'hidden',
 });
 
-const Text = styled.span(
-  {
-    position: 'relative',
-    whiteSpace: 'nowrap',
-  },
-  (props: { overflow: number; alignRight: boolean }) => ({
-    left: props.alignRight ? -props.overflow + 'px' : '0',
-    transition: `left linear ${props.overflow * 80}ms`,
-  }),
-);
+// Having an element take up the same amount of space as Text is required since Text is position
+// absolute and therefore doesn't take up any space.
+const Filler = styled.span({
+  whiteSpace: 'nowrap',
+  visibility: 'hidden',
+});
+
+// Using transform for positioning since that makes the transition GPU accelerated. Absolute
+// positioning is required for transform translate function to work.
+const Text = styled.span({}, (props: { overflow: number; alignRight: boolean }) => ({
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+  transform: props.alignRight ? `translate(${-props.overflow}px)` : 'translate(0)',
+  transition: `transform linear ${props.overflow * 80}ms`,
+}));
 
 interface IMarqueeProps {
   className?: string;
@@ -71,6 +77,7 @@ export default class Marquee extends React.Component<IMarqueeProps, IMarqueeStat
           onTransitionEnd={this.scheduleToggleAlignRight}>
           {this.props.children}
         </Text>
+        <Filler className={this.props.className}>{this.props.children}</Filler>
       </Container>
     );
   }


### PR DESCRIPTION
This PR changes the positioning in `Marquee` to use `transform: translate()` instead of `left:` to make it GPU accelerated. This required the text to be `position: absolute` which in turn required another element to take up the space of the text since the visible text no longer uses any space.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
