### PR TITLE
Enable "Always require VPN" by default if settings cannot be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix settings file being truncated before being read.
 - Improve performance for automatically scrolling text in desktop app.
 
+### Security
+- Enable "Always require VPN" by default if the settings cannot be parsed. This reduces the number
+  of errors that lead to the daemon unexpectedly starting into non-blocking mode.
+
 
 ## [2022.1-beta1] - 2022-02-14
 ### Added

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -584,11 +584,7 @@ where
                 error.display_chain_with_msg("Failed to migrate settings or cache")
             );
         }
-        let mut settings = SettingsPersister::load(&settings_dir).await;
-
-        if version::is_beta_version() {
-            let _ = settings.set_show_beta_releases(true).await;
-        }
+        let settings = SettingsPersister::load(&settings_dir).await;
 
         let target_state = if settings.get_account_token().is_none() {
             PersistentTargetState::force(&cache_dir, TargetState::Unsecured).await

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -74,6 +74,9 @@ impl SettingsPersister {
             should_save |=
                 Self::update_field(&mut settings.tunnel_options.generic.enable_ipv6, true);
         }
+        if crate::version::is_beta_version() {
+            should_save |= Self::update_field(&mut settings.show_beta_releases, true);
+        }
 
         let mut persister = SettingsPersister { settings, path };
 

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -59,7 +59,13 @@ impl SettingsPersister {
                     "{}",
                     error.display_chain_with_msg("Failed to load settings. Using defaults.")
                 );
-                (Self::default_settings(), true)
+                let mut settings = Self::default_settings();
+
+                // Protect the user by blocking the internet by default. Previous settings may
+                // not have caused the daemon to enter the non-blocking disconnected state.
+                settings.block_when_disconnected = true;
+
+                (settings, true)
             }
         };
 


### PR DESCRIPTION
This prevents the app from entering the (non-blocking) disconnected state unexpectedly. For example, if "always require VPN" or auto-connect was previously enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3373)
<!-- Reviewable:end -->
