### PR TITLE
Make gui/changes.txt include instructions on how to fill it

### DIFF
--- a/gui/changes.txt
+++ b/gui/changes.txt
@@ -1,4 +1,5 @@
-Add multihop with WireGuard tunnels. Can be enabled under the advanced settings.
-Add malware blocking. Can be found under preferences.
-[macOS] Fix slow wakeups from sleep. The internet and VPN tunnels should now come up instantly.
-[Windows] Make WireGuardNT the default driver for WireGuard. If you use WireGuard, you can potentially see significant performance increases.
+CHANGE THIS BEFORE A RELEASE
+Each line is treated as a separate change item shown in the GUI the first time it runs after install.
+Start each line with a capital letter and end each line with a period.
+[macOS, Windows, linux] To make an entry platform specific, start the line with an angle bracket enclosed comma separated list of platforms to show the entry on.
+Only point out the major changes.

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -46,6 +46,11 @@ if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
     exit 1
 fi
 
+if [[ $DESKTOP == "true" && $(grep "CHANGE THIS BEFORE A RELEASE" gui/changes.txt) != "" ]]; then
+    echo "It looks like you did not update gui/changes.txt"
+    exit 1
+fi
+
 if [[ $(grep "^## \\[$PRODUCT_VERSION\\] - " CHANGELOG.md) == "" ]]; then
     echo "It looks like you did not add $PRODUCT_VERSION to the changelog?"
     echo "Please make sure the changelog is up to date and correct before you proceed."


### PR DESCRIPTION
Instead of having the changes from the last release in `gui/changes.txt` it can contain instructions on how to update it. This has a number of benefits:
* We don't need to keep backporting its contents from release branches into the main branch. It can stay static.
* Known contents allows us to sanity check it in `prepare_release.sh`, like I have done here.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3374)
<!-- Reviewable:end -->
