### PR TITLE
Add blocking message on login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Show warning message when blocking internet while logged out, and make it possible to unblock the
+  connection from the login view.
+
 #### Windows
 - Detect mounting and dismounting of volumes, such as VeraCrypt volumes or USB drives,
   and exclude paths from the tunnel correctly when these occur. This sometimes only works

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -78,6 +78,9 @@ msgstr ""
 msgid "BLOCKED CONNECTION"
 msgstr ""
 
+msgid "Blocking internet"
+msgstr ""
+
 msgid "Buy credit"
 msgstr ""
 
@@ -100,6 +103,9 @@ msgid "CREATING SECURE CONNECTION"
 msgstr ""
 
 msgid "Default"
+msgstr ""
+
+msgid "Disable"
 msgstr ""
 
 msgid "Disconnect"
@@ -171,6 +177,9 @@ msgid "This setting increases latency. Use only if needed."
 msgstr ""
 
 msgid "UDP"
+msgstr ""
+
+msgid "Unblock"
 msgstr ""
 
 msgid "UNSECURED CONNECTION"
@@ -565,6 +574,14 @@ msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr ""
 
+#. This is a warning message shown when the app is blocking the users
+#. internet connection while logged out.
+#. Available placeholder:
+#. %(alwaysRequireVpnSettingsName)s - The translation of "Always require VPN"
+msgctxt "login-view"
+msgid "**%(alwaysRequireVpnSettingsName)s** is enabled. Disable it to unblock your connection."
+msgstr ""
+
 msgctxt "login-view"
 msgid "Account created"
 msgstr ""
@@ -611,6 +628,12 @@ msgstr ""
 
 msgctxt "login-view"
 msgid "Login failed"
+msgstr ""
+
+#. This is a warning message shown when the app is blocking the users
+#. internet connection while logged out.
+msgctxt "login-view"
+msgid "Our kill switch is currently blocking your connection."
 msgstr ""
 
 msgctxt "login-view"
@@ -1372,9 +1395,6 @@ msgid "All applications"
 msgstr ""
 
 msgid "Blocking all connections"
-msgstr ""
-
-msgid "Blocking internet"
 msgstr ""
 
 msgid "Copied Mullvad account number to clipboard"

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -381,11 +381,11 @@ export default class AppRenderer {
     actions.settings.updateBridgeState(bridgeState);
   }
 
-  public async setBlockWhenDisconnected(blockWhenDisconnected: boolean) {
+  public setBlockWhenDisconnected = async (blockWhenDisconnected: boolean) => {
     const actions = this.reduxActions;
     await IpcRendererEventChannel.settings.setBlockWhenDisconnected(blockWhenDisconnected);
     actions.settings.updateBlockWhenDisconnected(blockWhenDisconnected);
-  }
+  };
 
   public async setOpenVpnMssfix(mssfix?: number) {
     const actions = this.reduxActions;

--- a/gui/src/renderer/components/LoginStyles.tsx
+++ b/gui/src/renderer/components/LoginStyles.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { colors } from '../../config.json';
 import ImageView from './ImageView';
 import * as Cell from './cell';
-import { hugeText, largeText, tinyText } from './common-styles';
+import { hugeText, largeText, smallText, tinyText } from './common-styles';
 import FormattableTextInput from './FormattableTextInput';
 
 export const StyledAccountDropdownContainer = styled.ul({
@@ -67,12 +67,19 @@ export const StyledAccountDropdownItemButtonLabel = styled(Cell.Label)(largeText
   },
 });
 
+export const StyledTopInfo = styled.div({
+  display: 'flex',
+  justifyContent: 'center',
+  flex: 1,
+});
+
 export const StyledFooter = styled.div({}, (props: { show: boolean }) => ({
-  position: 'absolute',
+  position: 'relative',
   width: '100%',
   bottom: 0,
   transform: `translateY(${props.show ? 0 : 100}%)`,
   display: 'flex',
+  flex: '0',
   flexDirection: 'column',
   padding: '18px 22px 22px',
   backgroundColor: colors.darkBlue,
@@ -81,6 +88,7 @@ export const StyledFooter = styled.div({}, (props: { show: boolean }) => ({
 
 export const StyledStatusIcon = styled.div({
   display: 'flex',
+  alignSelf: 'end',
   flex: 0,
   marginBottom: '30px',
   justifyContent: 'center',
@@ -90,11 +98,10 @@ export const StyledStatusIcon = styled.div({
 
 export const StyledLoginForm = styled.div({
   display: 'flex',
-  flex: 1,
+  flex: '0 1 225px',
   flexDirection: 'column',
   overflow: 'visible',
   padding: '0 22px',
-  margin: '83px 0 0',
 });
 
 interface IStyledAccountInputGroupProps {
@@ -163,4 +170,26 @@ export const StyledInput = styled(FormattableTextInput)(largeText, {
   '::placeholder': {
     color: colors.blue40,
   },
+});
+
+export const StyledBlockMessageContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  alignSelf: 'start',
+  backgroundColor: colors.darkBlue,
+  borderRadius: '8px',
+  margin: '5px 16px 10px',
+  padding: '16px',
+});
+
+export const StyledBlockTitle = styled.div(smallText, {
+  color: colors.white,
+  marginBottom: '5px',
+  fontWeight: 700,
+});
+
+export const StyledBlockMessage = styled.div(tinyText, {
+  color: colors.white,
+  marginBottom: '10px',
 });

--- a/gui/src/renderer/containers/LoginPage.tsx
+++ b/gui/src/renderer/containers/LoginPage.tsx
@@ -6,11 +6,17 @@ import accountActions from '../redux/account/actions';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 
 const mapStateToProps = (state: IReduxState) => {
+  const tunnelState = state.connection.status;
+  const blockWhenDisconnected = state.settings.blockWhenDisconnected;
   const { accountToken, accountHistory, status } = state.account;
+
+  const showBlockMessage = tunnelState.state === 'error' || blockWhenDisconnected;
+
   return {
     accountToken,
     accountHistory,
     loginState: status,
+    showBlockMessage,
   };
 };
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: IAppContext) => {


### PR DESCRIPTION
This PR adds warning messages for when the app is logged out and Always require vpn is on or if the app is in the blocked state.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3378)
<!-- Reviewable:end -->
