### PR TITLE
Never bypass the tunnel for the geoIP service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Line wrap the file at 100 chars.                                              Th
 - Enable "Always require VPN" by default if the settings cannot be parsed. This reduces the number
   of errors that lead to the daemon unexpectedly starting into non-blocking mode.
 
+#### Android
+- Prevent location request responses from being received outside the tunnel when in the connected
+  state.
+
 
 ## [2022.1-beta1] - 2022-02-14
 ### Added


### PR DESCRIPTION
`VpnService.protect()` is currently called for all sockets, including when requesting the current location. Unlike other API requests, these requests are not aborted when entering the connected state. This PR fixes the issue by never bypassing the tunnel in the first place.