### PR TITLE
Improve escape shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 - Don't block the tunnel state machine while starting the tunnel monitor. This also means that
   the machine will not transition directly from the `disconnected` to the `disconnecting` state
   if an error occurs.
+- Change behavior of escape key in the desktop app. It now navigates backwards one step instead of
+  to the main view. To navigate back to the main view Shift+Escape can be used.
 
 ### Fixed
 - Fix the sometimes incorrect time added text after adding time to the account.

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -17,10 +17,11 @@ import AccountTokenLabel from './AccountTokenLabel';
 import * as AppButton from './AppButton';
 import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import { Layout } from './Layout';
-import { BackBarItem, NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
+import { NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 
 import { AccountToken } from '../../shared/daemon-rpc-types';
+import { BackAction } from './KeyboardNavigation';
 
 interface IProps {
   accountToken?: AccountToken;
@@ -40,75 +41,78 @@ export default class Account extends React.Component<IProps> {
 
   public render() {
     return (
-      <Layout>
-        <StyledContainer>
-          <NavigationBar>
-            <NavigationItems>
-              <BackBarItem action={this.props.onClose} />
-              <TitleBarItem>
-                {
-                  // TRANSLATORS: Title label in navigation bar
-                  messages.pgettext('account-view', 'Account')
-                }
-              </TitleBarItem>
-            </NavigationItems>
-          </NavigationBar>
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <StyledContainer>
+            <NavigationBar>
+              <NavigationItems>
+                <TitleBarItem>
+                  {
+                    // TRANSLATORS: Title label in navigation bar
+                    messages.pgettext('account-view', 'Account')
+                  }
+                </TitleBarItem>
+              </NavigationItems>
+            </NavigationBar>
 
-          <AccountContainer>
-            <SettingsHeader>
-              <HeaderTitle>{messages.pgettext('account-view', 'Account')}</HeaderTitle>
-            </SettingsHeader>
+            <AccountContainer>
+              <SettingsHeader>
+                <HeaderTitle>{messages.pgettext('account-view', 'Account')}</HeaderTitle>
+              </SettingsHeader>
 
-            <AccountRows>
-              <AccountRow>
-                <AccountRowLabel>
-                  {messages.pgettext('account-view', 'Account number')}
-                </AccountRowLabel>
-                <AccountRowValue
-                  as={AccountTokenLabel}
-                  accountToken={this.props.accountToken || ''}
-                />
-              </AccountRow>
+              <AccountRows>
+                <AccountRow>
+                  <AccountRowLabel>
+                    {messages.pgettext('account-view', 'Account number')}
+                  </AccountRowLabel>
+                  <AccountRowValue
+                    as={AccountTokenLabel}
+                    accountToken={this.props.accountToken || ''}
+                  />
+                </AccountRow>
 
-              <AccountRow>
-                <AccountRowLabel>{messages.pgettext('account-view', 'Paid until')}</AccountRowLabel>
-                <FormattedAccountExpiry
-                  expiry={this.props.accountExpiry}
-                  locale={this.props.expiryLocale}
-                />
-              </AccountRow>
-            </AccountRows>
+                <AccountRow>
+                  <AccountRowLabel>
+                    {messages.pgettext('account-view', 'Paid until')}
+                  </AccountRowLabel>
+                  <FormattedAccountExpiry
+                    expiry={this.props.accountExpiry}
+                    locale={this.props.expiryLocale}
+                  />
+                </AccountRow>
+              </AccountRows>
 
-            <AccountFooter>
-              <AppButton.BlockingButton
-                disabled={this.props.isOffline}
-                onClick={this.props.onBuyMore}>
-                <AriaDescriptionGroup>
-                  <AriaDescribed>
-                    <StyledBuyCreditButton>
-                      <AppButton.Label>{messages.gettext('Buy more credit')}</AppButton.Label>
-                      <AriaDescription>
-                        <AppButton.Icon
-                          source="icon-extLink"
-                          height={16}
-                          width={16}
-                          aria-label={messages.pgettext('accessibility', 'Opens externally')}
-                        />
-                      </AriaDescription>
-                    </StyledBuyCreditButton>
-                  </AriaDescribed>
-                </AriaDescriptionGroup>
-              </AppButton.BlockingButton>
+              <AccountFooter>
+                <AppButton.BlockingButton
+                  disabled={this.props.isOffline}
+                  onClick={this.props.onBuyMore}>
+                  <AriaDescriptionGroup>
+                    <AriaDescribed>
+                      <StyledBuyCreditButton>
+                        <AppButton.Label>{messages.gettext('Buy more credit')}</AppButton.Label>
+                        <AriaDescription>
+                          <AppButton.Icon
+                            source="icon-extLink"
+                            height={16}
+                            width={16}
+                            aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                          />
+                        </AriaDescription>
+                      </StyledBuyCreditButton>
+                    </AriaDescribed>
+                  </AriaDescriptionGroup>
+                </AppButton.BlockingButton>
 
-              <StyledRedeemVoucherButton />
+                <StyledRedeemVoucherButton />
 
-              <AppButton.RedButton onClick={this.props.onLogout}>
-                {messages.pgettext('account-view', 'Log out')}
-              </AppButton.RedButton>
-            </AccountFooter>
-          </AccountContainer>
-        </StyledContainer>
-      </Layout>
+                <AppButton.RedButton onClick={this.props.onLogout}>
+                  {messages.pgettext('account-view', 'Log out')}
+                </AppButton.RedButton>
+              </AccountFooter>
+            </AccountContainer>
+          </StyledContainer>
+        </Layout>
+      </BackAction>
     );
   }
 }

--- a/gui/src/renderer/components/AdvancedSettings.tsx
+++ b/gui/src/renderer/components/AdvancedSettings.tsx
@@ -16,16 +16,11 @@ import * as Cell from './cell';
 import CustomDnsSettings from './CustomDnsSettings';
 import { Layout, SettingsContainer } from './Layout';
 import { ModalAlert, ModalAlertType, ModalMessage } from './Modal';
-import {
-  BackBarItem,
-  NavigationBar,
-  NavigationContainer,
-  NavigationItems,
-  TitleBarItem,
-} from './NavigationBar';
+import { NavigationBar, NavigationContainer, NavigationItems, TitleBarItem } from './NavigationBar';
 import { ISelectorItem } from './cell/Selector';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 import Switch from './Switch';
+import { BackAction } from './KeyboardNavigation';
 
 type OptionalTunnelProtocol = TunnelProtocol | undefined;
 
@@ -58,137 +53,143 @@ export default class AdvancedSettings extends React.Component<IProps, IState> {
     const hasWireguardKey = this.props.wireguardKeyState.type === 'key-set';
 
     return (
-      <Layout>
-        <SettingsContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('advanced-settings-nav', 'Advanced')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <SettingsContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('advanced-settings-nav', 'Advanced')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <StyledNavigationScrollbars>
-              <SettingsHeader>
-                <HeaderTitle>{messages.pgettext('advanced-settings-view', 'Advanced')}</HeaderTitle>
-              </SettingsHeader>
+              <StyledNavigationScrollbars>
+                <SettingsHeader>
+                  <HeaderTitle>
+                    {messages.pgettext('advanced-settings-view', 'Advanced')}
+                  </HeaderTitle>
+                </SettingsHeader>
 
-              <AriaInputGroup>
-                <Cell.Container>
-                  <AriaLabel>
-                    <Cell.InputLabel>
-                      {messages.pgettext('advanced-settings-view', 'Enable IPv6')}
-                    </Cell.InputLabel>
-                  </AriaLabel>
-                  <AriaInput>
-                    <Cell.Switch isOn={this.props.enableIpv6} onChange={this.props.setEnableIpv6} />
-                  </AriaInput>
-                </Cell.Container>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {messages.pgettext(
-                        'advanced-settings-view',
-                        'Enable IPv6 communication through the tunnel.',
-                      )}
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('advanced-settings-view', 'Enable IPv6')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        isOn={this.props.enableIpv6}
+                        onChange={this.props.setEnableIpv6}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'advanced-settings-view',
+                          'Enable IPv6 communication through the tunnel.',
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
 
-              <AriaInputGroup>
-                <Cell.Container>
-                  <AriaLabel>
-                    <Cell.InputLabel>
-                      {messages.pgettext('advanced-settings-view', 'Always require VPN')}
-                    </Cell.InputLabel>
-                  </AriaLabel>
-                  <AriaInput>
-                    <Cell.Switch
-                      ref={this.blockWhenDisconnectedRef}
-                      isOn={this.props.blockWhenDisconnected}
-                      onChange={this.setBlockWhenDisconnected}
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('advanced-settings-view', 'Always require VPN')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        ref={this.blockWhenDisconnectedRef}
+                        isOn={this.props.blockWhenDisconnected}
+                        onChange={this.setBlockWhenDisconnected}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {messages.pgettext(
+                          'advanced-settings-view',
+                          'If you disconnect or quit the app, this setting will block your internet.',
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                {(window.env.platform === 'linux' || window.env.platform === 'win32') && (
+                  <Cell.CellButtonGroup>
+                    <Cell.CellButton onClick={this.props.onViewSplitTunneling}>
+                      <Cell.Label>
+                        {messages.pgettext('advanced-settings-view', 'Split tunneling')}
+                      </Cell.Label>
+                      <Cell.Icon height={12} width={7} source="icon-chevron" />
+                    </Cell.CellButton>
+                  </Cell.CellButtonGroup>
+                )}
+
+                <AriaInputGroup>
+                  <StyledTunnelProtocolContainer>
+                    <StyledSelectorForFooter
+                      title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
+                      values={this.tunnelProtocolItems(hasWireguardKey)}
+                      value={this.props.tunnelProtocol}
+                      onSelect={this.onSelectTunnelProtocol}
                     />
-                  </AriaInput>
-                </Cell.Container>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {messages.pgettext(
-                        'advanced-settings-view',
-                        'If you disconnect or quit the app, this setting will block your internet.',
-                      )}
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
+                    {!hasWireguardKey && (
+                      <StyledNoWireguardKeyErrorContainer>
+                        <AriaDescription>
+                          <StyledNoWireguardKeyError>
+                            {messages.pgettext(
+                              'advanced-settings-view',
+                              'To enable WireGuard, generate a key under the "WireGuard key" setting below.',
+                            )}
+                          </StyledNoWireguardKeyError>
+                        </AriaDescription>
+                      </StyledNoWireguardKeyErrorContainer>
+                    )}
+                  </StyledTunnelProtocolContainer>
+                </AriaInputGroup>
 
-              {(window.env.platform === 'linux' || window.env.platform === 'win32') && (
                 <Cell.CellButtonGroup>
-                  <Cell.CellButton onClick={this.props.onViewSplitTunneling}>
+                  <Cell.CellButton
+                    onClick={this.props.onViewWireguardSettings}
+                    disabled={this.props.tunnelProtocol === 'openvpn'}>
                     <Cell.Label>
-                      {messages.pgettext('advanced-settings-view', 'Split tunneling')}
+                      {messages.pgettext('advanced-settings-view', 'WireGuard settings')}
+                    </Cell.Label>
+                    <Cell.Icon height={12} width={7} source="icon-chevron" />
+                  </Cell.CellButton>
+
+                  <Cell.CellButton
+                    onClick={this.props.onViewOpenVpnSettings}
+                    disabled={this.props.tunnelProtocol === 'wireguard'}>
+                    <Cell.Label>
+                      {messages.pgettext('advanced-settings-view', 'OpenVPN settings')}
                     </Cell.Label>
                     <Cell.Icon height={12} width={7} source="icon-chevron" />
                   </Cell.CellButton>
                 </Cell.CellButtonGroup>
-              )}
 
-              <AriaInputGroup>
-                <StyledTunnelProtocolContainer>
-                  <StyledSelectorForFooter
-                    title={messages.pgettext('advanced-settings-view', 'Tunnel protocol')}
-                    values={this.tunnelProtocolItems(hasWireguardKey)}
-                    value={this.props.tunnelProtocol}
-                    onSelect={this.onSelectTunnelProtocol}
-                  />
-                  {!hasWireguardKey && (
-                    <StyledNoWireguardKeyErrorContainer>
-                      <AriaDescription>
-                        <StyledNoWireguardKeyError>
-                          {messages.pgettext(
-                            'advanced-settings-view',
-                            'To enable WireGuard, generate a key under the "WireGuard key" setting below.',
-                          )}
-                        </StyledNoWireguardKeyError>
-                      </AriaDescription>
-                    </StyledNoWireguardKeyErrorContainer>
-                  )}
-                </StyledTunnelProtocolContainer>
-              </AriaInputGroup>
+                <CustomDnsSettings />
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </SettingsContainer>
 
-              <Cell.CellButtonGroup>
-                <Cell.CellButton
-                  onClick={this.props.onViewWireguardSettings}
-                  disabled={this.props.tunnelProtocol === 'openvpn'}>
-                  <Cell.Label>
-                    {messages.pgettext('advanced-settings-view', 'WireGuard settings')}
-                  </Cell.Label>
-                  <Cell.Icon height={12} width={7} source="icon-chevron" />
-                </Cell.CellButton>
-
-                <Cell.CellButton
-                  onClick={this.props.onViewOpenVpnSettings}
-                  disabled={this.props.tunnelProtocol === 'wireguard'}>
-                  <Cell.Label>
-                    {messages.pgettext('advanced-settings-view', 'OpenVPN settings')}
-                  </Cell.Label>
-                  <Cell.Icon height={12} width={7} source="icon-chevron" />
-                </Cell.CellButton>
-              </Cell.CellButtonGroup>
-
-              <CustomDnsSettings />
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </SettingsContainer>
-
-        {this.renderConfirmBlockWhenDisconnectedAlert()}
-      </Layout>
+          {this.renderConfirmBlockWhenDisconnectedAlert()}
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/FilterByProvider.tsx
+++ b/gui/src/renderer/components/FilterByProvider.tsx
@@ -8,9 +8,9 @@ import { useSelector } from '../redux/store';
 import * as AppButton from './AppButton';
 import { normalText } from './common-styles';
 import ImageView from './ImageView';
+import { BackAction } from './KeyboardNavigation';
 import { Container, Layout } from './Layout';
 import {
-  BackBarItem,
   NavigationBar,
   NavigationContainer,
   NavigationItems,
@@ -106,39 +106,47 @@ export default function FilterByProvider() {
   }, [providers, history, updateRelaySettings, selectionStatus]);
 
   return (
-    <Layout>
-      <StyledContainer>
-        <NavigationContainer>
-          <NavigationBar alwaysDisplayBarTitle={true}>
-            <NavigationItems>
-              <BackBarItem action={history.pop} />
-              <TitleBarItem>
-                {
-                  // TRANSLATORS: Title label in navigation bar
-                  messages.pgettext('filter-by-provider-nav', 'Filter by provider')
-                }
-              </TitleBarItem>
-            </NavigationItems>
-          </NavigationBar>
-          <StyledNavigationScrollbars>
-            <ProviderRow
-              provider={messages.pgettext('filter-by-provider-view', 'All providers')}
-              bold
-              checked={selectionStatus === Selection.all}
-              onCheck={toggleAll}
-            />
-            {Object.entries(providers).map(([provider, checked]) => (
-              <ProviderRow key={provider} provider={provider} checked={checked} onCheck={onCheck} />
-            ))}
-          </StyledNavigationScrollbars>
-          <StyledFooter>
-            <AppButton.GreenButton disabled={selectionStatus === Selection.none} onClick={onApply}>
-              {messages.gettext('Apply')}
-            </AppButton.GreenButton>
-          </StyledFooter>
-        </NavigationContainer>
-      </StyledContainer>
-    </Layout>
+    <BackAction action={history.pop}>
+      <Layout>
+        <StyledContainer>
+          <NavigationContainer>
+            <NavigationBar alwaysDisplayBarTitle={true}>
+              <NavigationItems>
+                <TitleBarItem>
+                  {
+                    // TRANSLATORS: Title label in navigation bar
+                    messages.pgettext('filter-by-provider-nav', 'Filter by provider')
+                  }
+                </TitleBarItem>
+              </NavigationItems>
+            </NavigationBar>
+            <StyledNavigationScrollbars>
+              <ProviderRow
+                provider={messages.pgettext('filter-by-provider-view', 'All providers')}
+                bold
+                checked={selectionStatus === Selection.all}
+                onCheck={toggleAll}
+              />
+              {Object.entries(providers).map(([provider, checked]) => (
+                <ProviderRow
+                  key={provider}
+                  provider={provider}
+                  checked={checked}
+                  onCheck={onCheck}
+                />
+              ))}
+            </StyledNavigationScrollbars>
+            <StyledFooter>
+              <AppButton.GreenButton
+                disabled={selectionStatus === Selection.none}
+                onClick={onApply}>
+                {messages.gettext('Apply')}
+              </AppButton.GreenButton>
+            </StyledFooter>
+          </NavigationContainer>
+        </StyledContainer>
+      </Layout>
+    </BackAction>
   );
 }
 

--- a/gui/src/renderer/components/KeyboardNavigation.tsx
+++ b/gui/src/renderer/components/KeyboardNavigation.tsx
@@ -1,20 +1,26 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useHistory } from '../lib/history';
 
 interface IKeyboardNavigationProps {
   children: React.ReactElement;
 }
 
+// Listens for and handles keyboard shortcuts
 export default function KeyboardNavigation(props: IKeyboardNavigationProps) {
   const history = useHistory();
+  const [backAction, setBackAction] = useState<IBackActionConfiguration>();
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        history.dismiss(true);
+        if (event.shiftKey) {
+          history.dismiss(true);
+        } else {
+          backAction?.action();
+        }
       }
     },
-    [history.reset],
+    [history.dismiss, backAction],
   );
 
   useEffect(() => {
@@ -22,5 +28,97 @@ export default function KeyboardNavigation(props: IKeyboardNavigationProps) {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [handleKeyDown]);
 
-  return props.children;
+  return <BackActionTracker registerBackAction={setBackAction}>{props.children}</BackActionTracker>;
+}
+
+type BackActionIcon = 'back' | 'close';
+type BackActionFn = () => void;
+
+interface IBackActionConfiguration {
+  icon: BackActionIcon;
+  action: BackActionFn;
+}
+
+interface IBackActionContext {
+  parentBackAction?: IBackActionConfiguration;
+  registerBackAction: (backAction: IBackActionConfiguration) => void;
+  removeBackAction: (backAction: IBackActionConfiguration) => void;
+}
+
+export const BackActionContext = React.createContext<IBackActionContext>({
+  registerBackAction(_backAction) {
+    throw new Error('Missing BackActionContext');
+  },
+  removeBackAction(_backAction) {
+    throw new Error('Missing BackActionContext');
+  },
+});
+
+interface IBackActionProps {
+  disabled?: boolean;
+  icon?: BackActionIcon;
+  action: BackActionFn;
+  children: React.ReactNode;
+}
+
+// Component for registering back actions, e.g. navigate back or close modal. These are called
+// either by pressing the back button in the navigation bar or by pressing escape.
+export function BackAction(props: IBackActionProps) {
+  const backActionContext = useContext(BackActionContext);
+  const [childrenBackAction, setChildrenBackAction] = useState<IBackActionConfiguration>();
+
+  const parentBackAction = useMemo<IBackActionConfiguration>(
+    () => ({ icon: props.icon ?? 'back', action: props.action }),
+    [props.icon, props.action],
+  );
+  const backActionConfiguration = childrenBackAction ?? parentBackAction;
+
+  // Every time the action or the disabled property changes the action needs to be reregistered.
+  useEffect((): (() => void) | void => {
+    if (!props.disabled && backActionConfiguration) {
+      backActionContext.registerBackAction(backActionConfiguration);
+      return () => backActionContext.removeBackAction(backActionConfiguration);
+    }
+  }, [props.disabled, backActionConfiguration]);
+
+  // Every back action keeps track of the back actions in its subtree. This makes it possible to
+  // always use the action furthest down in the tree.
+  return (
+    <BackActionTracker
+      registerBackAction={setChildrenBackAction}
+      parentBackAction={parentBackAction}>
+      {props.children}
+    </BackActionTracker>
+  );
+}
+
+interface IBackActionTracker {
+  parentBackAction?: IBackActionConfiguration;
+  registerBackAction: (backAction: IBackActionConfiguration | undefined) => void;
+  children: React.ReactNode;
+}
+
+// This component keeps track of all registered back actions in it's subtree and reports one of them
+// to it's parent.
+function BackActionTracker(props: IBackActionTracker) {
+  const [backActions, setBackActions] = useState<Array<IBackActionConfiguration>>([]);
+
+  const registerBackAction = useCallback((backAction: IBackActionConfiguration) => {
+    setBackActions((backActions) => [...backActions, backAction]);
+  }, []);
+  const removeBackAction = useCallback((backAction: IBackActionConfiguration) => {
+    setBackActions((backActions) => backActions.filter((action) => action !== backAction));
+  }, []);
+  const backActionContext = useMemo(
+    () => ({ parentBackAction: props.parentBackAction, registerBackAction, removeBackAction }),
+    [backActions],
+  );
+
+  useEffect(() => props.registerBackAction(backActions.at(0)), [backActions]);
+
+  return (
+    <BackActionContext.Provider value={backActionContext}>
+      {props.children}
+    </BackActionContext.Provider>
+  );
 }

--- a/gui/src/renderer/components/NavigationBar.tsx
+++ b/gui/src/renderer/components/NavigationBar.tsx
@@ -7,17 +7,15 @@ import { useCombinedRefs } from '../lib/utilityHooks';
 import { useSelector } from '../redux/store';
 import userInterface from '../redux/userinterface/actions';
 import CustomScrollbars, { CustomScrollbarsRef, IScrollEvent } from './CustomScrollbars';
+import { BackActionContext } from './KeyboardNavigation';
 import {
   StyledBackBarItemButton,
   StyledBackBarItemIcon,
-  StyledCloseBarItemButton,
-  StyledCloseBarItemIcon,
   StyledNavigationBar,
+  StyledNavigationItems,
   StyledNavigationBarSeparator,
   StyledTitleBarItemLabel,
 } from './NavigationBarStyles';
-
-export { StyledNavigationItems as NavigationItems } from './NavigationBarStyles';
 
 interface INavigationContainerProps {
   children?: React.ReactNode;
@@ -179,6 +177,20 @@ export const NavigationBar = function NavigationBarT(props: INavigationBarProps)
   );
 };
 
+interface INavigationItemsProps {
+  children: React.ReactNode;
+}
+
+export function NavigationItems(props: INavigationItemsProps) {
+  const { parentBackAction } = useContext(BackActionContext);
+  return (
+    <StyledNavigationItems>
+      {parentBackAction && <BackBarItem />}
+      {props.children}
+    </StyledNavigationItems>
+  );
+}
+
 interface ITitleBarItemProps {
   children?: React.ReactText;
 }
@@ -188,32 +200,15 @@ export const TitleBarItem = React.memo(function TitleBarItemT(props: ITitleBarIt
   return <StyledTitleBarItemLabel visible={visible}>{props.children}</StyledTitleBarItemLabel>;
 });
 
-interface ICloseBarItemProps {
-  action: () => void;
-}
+export function BackBarItem() {
+  const { parentBackAction } = useContext(BackActionContext);
+  const iconSource = parentBackAction?.icon === 'back' ? 'icon-back' : 'icon-close-down';
+  const ariaLabel =
+    parentBackAction?.icon === 'back' ? messages.gettext('Back') : messages.gettext('Close');
 
-export function CloseBarItem(props: ICloseBarItemProps) {
   return (
-    <StyledCloseBarItemButton aria-label={messages.gettext('Close')} onClick={props.action}>
-      <StyledCloseBarItemIcon
-        height={24}
-        width={24}
-        source={'icon-close-down'}
-        tintColor={colors.white40}
-        tintHoverColor={colors.white60}
-      />
-    </StyledCloseBarItemButton>
-  );
-}
-
-interface IBackBarItemProps {
-  action: () => void;
-}
-
-export function BackBarItem(props: IBackBarItemProps) {
-  return (
-    <StyledBackBarItemButton onClick={props.action}>
-      <StyledBackBarItemIcon source="icon-back" tintColor={colors.white40} />
+    <StyledBackBarItemButton aria-label={ariaLabel} onClick={parentBackAction?.action}>
+      <StyledBackBarItemIcon source={iconSource} tintColor={colors.white40} width={24} />
     </StyledBackBarItemButton>
   );
 }

--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -37,19 +37,6 @@ export const StyledTitleBarItemLabel = styled.h1(normalText, (props: { visible?:
   transition: 'opacity 250ms ease-in-out',
 }));
 
-export const StyledCloseBarItemButton = styled.button({
-  justifySelf: 'start',
-  borderWidth: 0,
-  padding: 0,
-  margin: 0,
-  cursor: 'default',
-  backgroundColor: 'transparent',
-});
-
-export const StyledCloseBarItemIcon = styled(ImageView)({
-  flex: 0,
-});
-
 export const StyledBackBarItemButton = styled.button({
   justifySelf: 'start',
   borderWidth: 0,

--- a/gui/src/renderer/components/OpenVPNSettings.tsx
+++ b/gui/src/renderer/components/OpenVPNSettings.tsx
@@ -9,7 +9,6 @@ import * as Cell from './cell';
 import { Layout, SettingsContainer } from './Layout';
 import { ModalAlert, ModalAlertType } from './Modal';
 import {
-  BackBarItem,
   NavigationBar,
   NavigationContainer,
   NavigationItems,
@@ -19,6 +18,7 @@ import {
 import Selector, { ISelectorItem } from './cell/Selector';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 import { formatMarkdown } from '../markdown-formatter';
+import { BackAction } from './KeyboardNavigation';
 
 const MIN_MSSFIX_VALUE = 1000;
 const MAX_MSSFIX_VALUE = 1450;
@@ -86,146 +86,147 @@ export default class OpenVpnSettings extends React.Component<IProps, IState> {
 
   public render() {
     return (
-      <Layout>
-        <SettingsContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('openvpn-settings-nav', 'OpenVPN settings')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
-
-            <StyledNavigationScrollbars>
-              <SettingsHeader>
-                <HeaderTitle>
-                  {messages.pgettext('openvpn-settings-view', 'OpenVPN settings')}
-                </HeaderTitle>
-              </SettingsHeader>
-
-              <StyledSelectorContainer>
-                <AriaInputGroup>
-                  <Selector
-                    title={messages.pgettext('openvpn-settings-view', 'Transport protocol')}
-                    values={this.protocolItems(this.props.bridgeState !== 'on')}
-                    value={this.props.openvpn.protocol}
-                    onSelect={this.onSelectOpenvpnProtocol}
-                    hasFooter={this.props.bridgeState === 'on'}
-                  />
-                  {this.props.bridgeState === 'on' && (
-                    <Cell.Footer>
-                      <AriaDescription>
-                        <Cell.FooterText>
-                          {formatMarkdown(
-                            // TRANSLATORS: This is used to instruct users how to make UDP mode
-                            // TRANSLATORS: available.
-                            messages.pgettext(
-                              'openvpn-settings-view',
-                              'To activate UDP, change **Bridge mode** to **Automatic** or **Off**.',
-                            ),
-                          )}
-                        </Cell.FooterText>
-                      </AriaDescription>
-                    </Cell.Footer>
-                  )}
-                </AriaInputGroup>
-              </StyledSelectorContainer>
-
-              <StyledSelectorContainer>
-                <AriaInputGroup>
-                  {this.props.openvpn.protocol ? (
-                    <Selector
-                      title={sprintf(
-                        // TRANSLATORS: The title for the port selector section.
-                        // TRANSLATORS: Available placeholders:
-                        // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
-                        messages.pgettext('openvpn-settings-view', '%(portType)s port'),
-                        {
-                          portType: this.props.openvpn.protocol.toUpperCase(),
-                        },
-                      )}
-                      values={this.portItems[this.props.openvpn.protocol]}
-                      value={this.props.openvpn.port}
-                      onSelect={this.onSelectOpenVpnPort}
-                    />
-                  ) : undefined}
-                </AriaInputGroup>
-              </StyledSelectorContainer>
-
-              <AriaInputGroup>
-                <StyledSelectorContainer>
-                  <Selector
-                    title={
-                      // TRANSLATORS: The title for the shadowsocks bridge selector section.
-                      messages.pgettext('openvpn-settings-view', 'Bridge mode')
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <SettingsContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('openvpn-settings-nav', 'OpenVPN settings')
                     }
-                    values={this.bridgeStateItems(
-                      this.props.bridgeModeAvailablity === BridgeModeAvailability.available,
-                    )}
-                    value={this.props.bridgeState}
-                    onSelect={this.onSelectBridgeState}
-                    hasFooter
-                  />
-                </StyledSelectorContainer>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>{this.bridgeModeFooterText()}</Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-              <AriaInputGroup>
-                <Cell.Container>
-                  <AriaLabel>
-                    <Cell.InputLabel>
-                      {messages.pgettext('openvpn-settings-view', 'Mssfix')}
-                    </Cell.InputLabel>
-                  </AriaLabel>
-                  <AriaInput>
-                    <Cell.AutoSizingTextInput
-                      value={this.props.mssfix ? this.props.mssfix.toString() : ''}
-                      inputMode={'numeric'}
-                      maxLength={4}
-                      placeholder={messages.gettext('Default')}
-                      onSubmitValue={this.onMssfixSubmit}
-                      validateValue={OpenVpnSettings.mssfixIsValid}
-                      submitOnBlur={true}
-                      modifyValue={OpenVpnSettings.removeNonNumericCharacters}
+              <StyledNavigationScrollbars>
+                <SettingsHeader>
+                  <HeaderTitle>
+                    {messages.pgettext('openvpn-settings-view', 'OpenVPN settings')}
+                  </HeaderTitle>
+                </SettingsHeader>
+
+                <StyledSelectorContainer>
+                  <AriaInputGroup>
+                    <Selector
+                      title={messages.pgettext('openvpn-settings-view', 'Transport protocol')}
+                      values={this.protocolItems(this.props.bridgeState !== 'on')}
+                      value={this.props.openvpn.protocol}
+                      onSelect={this.onSelectOpenvpnProtocol}
+                      hasFooter={this.props.bridgeState === 'on'}
                     />
-                  </AriaInput>
-                </Cell.Container>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {sprintf(
-                        // TRANSLATORS: The hint displayed below the Mssfix input field.
-                        // TRANSLATORS: Available placeholders:
-                        // TRANSLATORS: %(max)d - the maximum possible mssfix value
-                        // TRANSLATORS: %(min)d - the minimum possible mssfix value
-                        messages.pgettext(
-                          'openvpn-settings-view',
-                          'Set OpenVPN MSS value. Valid range: %(min)d - %(max)d.',
-                        ),
-                        {
-                          min: MIN_MSSFIX_VALUE,
-                          max: MAX_MSSFIX_VALUE,
-                        },
-                      )}
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </SettingsContainer>
+                    {this.props.bridgeState === 'on' && (
+                      <Cell.Footer>
+                        <AriaDescription>
+                          <Cell.FooterText>
+                            {formatMarkdown(
+                              // TRANSLATORS: This is used to instruct users how to make UDP mode
+                              // TRANSLATORS: available.
+                              messages.pgettext(
+                                'openvpn-settings-view',
+                                'To activate UDP, change **Bridge mode** to **Automatic** or **Off**.',
+                              ),
+                            )}
+                          </Cell.FooterText>
+                        </AriaDescription>
+                      </Cell.Footer>
+                    )}
+                  </AriaInputGroup>
+                </StyledSelectorContainer>
 
-        {this.renderBridgeStateConfirmation()}
-      </Layout>
+                <StyledSelectorContainer>
+                  <AriaInputGroup>
+                    {this.props.openvpn.protocol ? (
+                      <Selector
+                        title={sprintf(
+                          // TRANSLATORS: The title for the port selector section.
+                          // TRANSLATORS: Available placeholders:
+                          // TRANSLATORS: %(portType)s - a selected protocol (either TCP or UDP)
+                          messages.pgettext('openvpn-settings-view', '%(portType)s port'),
+                          {
+                            portType: this.props.openvpn.protocol.toUpperCase(),
+                          },
+                        )}
+                        values={this.portItems[this.props.openvpn.protocol]}
+                        value={this.props.openvpn.port}
+                        onSelect={this.onSelectOpenVpnPort}
+                      />
+                    ) : undefined}
+                  </AriaInputGroup>
+                </StyledSelectorContainer>
+
+                <AriaInputGroup>
+                  <StyledSelectorContainer>
+                    <Selector
+                      title={
+                        // TRANSLATORS: The title for the shadowsocks bridge selector section.
+                        messages.pgettext('openvpn-settings-view', 'Bridge mode')
+                      }
+                      values={this.bridgeStateItems(
+                        this.props.bridgeModeAvailablity === BridgeModeAvailability.available,
+                      )}
+                      value={this.props.bridgeState}
+                      onSelect={this.onSelectBridgeState}
+                      hasFooter
+                    />
+                  </StyledSelectorContainer>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>{this.bridgeModeFooterText()}</Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('openvpn-settings-view', 'Mssfix')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.AutoSizingTextInput
+                        value={this.props.mssfix ? this.props.mssfix.toString() : ''}
+                        inputMode={'numeric'}
+                        maxLength={4}
+                        placeholder={messages.gettext('Default')}
+                        onSubmitValue={this.onMssfixSubmit}
+                        validateValue={OpenVpnSettings.mssfixIsValid}
+                        submitOnBlur={true}
+                        modifyValue={OpenVpnSettings.removeNonNumericCharacters}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {sprintf(
+                          // TRANSLATORS: The hint displayed below the Mssfix input field.
+                          // TRANSLATORS: Available placeholders:
+                          // TRANSLATORS: %(max)d - the maximum possible mssfix value
+                          // TRANSLATORS: %(min)d - the minimum possible mssfix value
+                          messages.pgettext(
+                            'openvpn-settings-view',
+                            'Set OpenVPN MSS value. Valid range: %(min)d - %(max)d.',
+                          ),
+                          {
+                            min: MIN_MSSFIX_VALUE,
+                            max: MAX_MSSFIX_VALUE,
+                          },
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </SettingsContainer>
+
+          {this.renderBridgeStateConfirmation()}
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/Preferences.tsx
+++ b/gui/src/renderer/components/Preferences.tsx
@@ -8,10 +8,10 @@ import * as AppButton from './AppButton';
 import { AriaDescription, AriaInput, AriaInputGroup, AriaLabel } from './AriaGroup';
 import * as Cell from './cell';
 import ImageView from './ImageView';
+import { BackAction } from './KeyboardNavigation';
 import { Layout } from './Layout';
 import { ModalAlert, ModalAlertType } from './Modal';
 import {
-  BackBarItem,
   NavigationBar,
   NavigationContainer,
   NavigationItems,
@@ -53,223 +53,63 @@ export default class Preferences extends React.Component<IProps, IState> {
 
   public render() {
     return (
-      <Layout>
-        <StyledContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('preferences-nav', 'Preferences')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <StyledContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('preferences-nav', 'Preferences')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <NavigationScrollbars>
-              <SettingsHeader>
-                <HeaderTitle>{messages.pgettext('preferences-view', 'Preferences')}</HeaderTitle>
-              </SettingsHeader>
+              <NavigationScrollbars>
+                <SettingsHeader>
+                  <HeaderTitle>{messages.pgettext('preferences-view', 'Preferences')}</HeaderTitle>
+                </SettingsHeader>
 
-              <StyledContent>
-                <Cell.CellButton onClick={this.showKillSwitchInfo}>
-                  <Cell.InputLabel>
-                    {messages.pgettext('preferences-view', 'Kill switch')}
-                  </Cell.InputLabel>
-                  <ImageView source="icon-info" width={18} tintColor={colors.white} />
-                </Cell.CellButton>
-                <StyledSeparator height={20} />
+                <StyledContent>
+                  <Cell.CellButton onClick={this.showKillSwitchInfo}>
+                    <Cell.InputLabel>
+                      {messages.pgettext('preferences-view', 'Kill switch')}
+                    </Cell.InputLabel>
+                    <ImageView source="icon-info" width={18} tintColor={colors.white} />
+                  </Cell.CellButton>
+                  <StyledSeparator height={20} />
 
-                <AriaInputGroup>
-                  <Cell.Container>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Launch app on start-up')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch isOn={this.props.autoStart} onChange={this.props.setAutoStart} />
-                    </AriaInput>
-                  </Cell.Container>
-                </AriaInputGroup>
-                <StyledSeparator />
-
-                <AriaInputGroup>
-                  <Cell.Container>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Auto-connect')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch
-                        isOn={this.props.autoConnect}
-                        onChange={this.props.setAutoConnect}
-                      />
-                    </AriaInput>
-                  </Cell.Container>
-                  <Cell.Footer>
-                    <AriaDescription>
-                      <Cell.FooterText>
-                        {messages.pgettext(
-                          'preferences-view',
-                          'Automatically connect to a server when the app launches.',
-                        )}
-                      </Cell.FooterText>
-                    </AriaDescription>
-                  </Cell.Footer>
-                </AriaInputGroup>
-
-                <AriaInputGroup>
-                  <Cell.Container disabled={this.props.dns.state === 'custom'}>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Block ads')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch
-                        isOn={
-                          this.props.dns.state === 'default' &&
-                          this.props.dns.defaultOptions.blockAds
-                        }
-                        onChange={this.setBlockAds}
-                      />
-                    </AriaInput>
-                  </Cell.Container>
-                </AriaInputGroup>
-                <StyledSeparator />
-                <AriaInputGroup>
-                  <Cell.Container disabled={this.props.dns.state === 'custom'}>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Block trackers')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch
-                        isOn={
-                          this.props.dns.state === 'default' &&
-                          this.props.dns.defaultOptions.blockTrackers
-                        }
-                        onChange={this.setBlockTrackers}
-                      />
-                    </AriaInput>
-                  </Cell.Container>
-                </AriaInputGroup>
-                <StyledSeparator />
-                <AriaInputGroup>
-                  <Cell.Container disabled={this.props.dns.state === 'custom'}>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Block malware')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch
-                        isOn={
-                          this.props.dns.state === 'default' &&
-                          this.props.dns.defaultOptions.blockMalware
-                        }
-                        onChange={this.setBlockMalware}
-                      />
-                    </AriaInput>
-                  </Cell.Container>
-                  {this.props.dns.state === 'custom' && <CustomDnsEnabledFooter />}
-                </AriaInputGroup>
-
-                {this.props.dns.state !== 'custom' && <StyledSeparator height={20} />}
-
-                <AriaInputGroup>
-                  <Cell.Container>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Local network sharing')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
-                    </AriaInput>
-                  </Cell.Container>
-                  <Cell.Footer>
-                    <AriaDescription>
-                      <Cell.FooterText>
-                        {messages.pgettext(
-                          'preferences-view',
-                          'Allows access to other devices on the same network for sharing, printing etc.',
-                        )}
-                      </Cell.FooterText>
-                    </AriaDescription>
-                  </Cell.Footer>
-                </AriaInputGroup>
-
-                <AriaInputGroup>
-                  <Cell.Container>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Notifications')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch
-                        isOn={this.props.enableSystemNotifications}
-                        onChange={this.props.setEnableSystemNotifications}
-                      />
-                    </AriaInput>
-                  </Cell.Container>
-                  <Cell.Footer>
-                    <AriaDescription>
-                      <Cell.FooterText>
-                        {messages.pgettext(
-                          'preferences-view',
-                          'Enable or disable system notifications. The critical notifications will always be displayed.',
-                        )}
-                      </Cell.FooterText>
-                    </AriaDescription>
-                  </Cell.Footer>
-                </AriaInputGroup>
-
-                <AriaInputGroup>
-                  <Cell.Container>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Monochromatic tray icon')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch
-                        isOn={this.props.monochromaticIcon}
-                        onChange={this.props.setMonochromaticIcon}
-                      />
-                    </AriaInput>
-                  </Cell.Container>
-                  <Cell.Footer>
-                    <AriaDescription>
-                      <Cell.FooterText>
-                        {messages.pgettext(
-                          'preferences-view',
-                          'Use a monochromatic tray icon instead of a colored one.',
-                        )}
-                      </Cell.FooterText>
-                    </AriaDescription>
-                  </Cell.Footer>
-                </AriaInputGroup>
-
-                {(window.env.platform === 'win32' ||
-                  (window.env.platform === 'darwin' && window.env.development)) && (
                   <AriaInputGroup>
                     <Cell.Container>
                       <AriaLabel>
                         <Cell.InputLabel>
-                          {messages.pgettext('preferences-view', 'Unpin app from taskbar')}
+                          {messages.pgettext('preferences-view', 'Launch app on start-up')}
                         </Cell.InputLabel>
                       </AriaLabel>
                       <AriaInput>
                         <Cell.Switch
-                          isOn={this.props.unpinnedWindow}
-                          onChange={this.props.setUnpinnedWindow}
+                          isOn={this.props.autoStart}
+                          onChange={this.props.setAutoStart}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                  </AriaInputGroup>
+                  <StyledSeparator />
+
+                  <AriaInputGroup>
+                    <Cell.Container>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Auto-connect')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={this.props.autoConnect}
+                          onChange={this.props.setAutoConnect}
                         />
                       </AriaInput>
                     </Cell.Container>
@@ -278,27 +118,161 @@ export default class Preferences extends React.Component<IProps, IState> {
                         <Cell.FooterText>
                           {messages.pgettext(
                             'preferences-view',
-                            'Enable to move the app around as a free-standing window.',
+                            'Automatically connect to a server when the app launches.',
                           )}
                         </Cell.FooterText>
                       </AriaDescription>
                     </Cell.Footer>
                   </AriaInputGroup>
-                )}
 
-                {this.props.unpinnedWindow && (
-                  <React.Fragment>
+                  <AriaInputGroup>
+                    <Cell.Container disabled={this.props.dns.state === 'custom'}>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Block ads')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={
+                            this.props.dns.state === 'default' &&
+                            this.props.dns.defaultOptions.blockAds
+                          }
+                          onChange={this.setBlockAds}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                  </AriaInputGroup>
+                  <StyledSeparator />
+                  <AriaInputGroup>
+                    <Cell.Container disabled={this.props.dns.state === 'custom'}>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Block trackers')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={
+                            this.props.dns.state === 'default' &&
+                            this.props.dns.defaultOptions.blockTrackers
+                          }
+                          onChange={this.setBlockTrackers}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                  </AriaInputGroup>
+                  <StyledSeparator />
+                  <AriaInputGroup>
+                    <Cell.Container disabled={this.props.dns.state === 'custom'}>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Block malware')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={
+                            this.props.dns.state === 'default' &&
+                            this.props.dns.defaultOptions.blockMalware
+                          }
+                          onChange={this.setBlockMalware}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                    {this.props.dns.state === 'custom' && <CustomDnsEnabledFooter />}
+                  </AriaInputGroup>
+
+                  {this.props.dns.state !== 'custom' && <StyledSeparator height={20} />}
+
+                  <AriaInputGroup>
+                    <Cell.Container>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Local network sharing')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch isOn={this.props.allowLan} onChange={this.props.setAllowLan} />
+                      </AriaInput>
+                    </Cell.Container>
+                    <Cell.Footer>
+                      <AriaDescription>
+                        <Cell.FooterText>
+                          {messages.pgettext(
+                            'preferences-view',
+                            'Allows access to other devices on the same network for sharing, printing etc.',
+                          )}
+                        </Cell.FooterText>
+                      </AriaDescription>
+                    </Cell.Footer>
+                  </AriaInputGroup>
+
+                  <AriaInputGroup>
+                    <Cell.Container>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Notifications')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={this.props.enableSystemNotifications}
+                          onChange={this.props.setEnableSystemNotifications}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                    <Cell.Footer>
+                      <AriaDescription>
+                        <Cell.FooterText>
+                          {messages.pgettext(
+                            'preferences-view',
+                            'Enable or disable system notifications. The critical notifications will always be displayed.',
+                          )}
+                        </Cell.FooterText>
+                      </AriaDescription>
+                    </Cell.Footer>
+                  </AriaInputGroup>
+
+                  <AriaInputGroup>
+                    <Cell.Container>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Monochromatic tray icon')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={this.props.monochromaticIcon}
+                          onChange={this.props.setMonochromaticIcon}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                    <Cell.Footer>
+                      <AriaDescription>
+                        <Cell.FooterText>
+                          {messages.pgettext(
+                            'preferences-view',
+                            'Use a monochromatic tray icon instead of a colored one.',
+                          )}
+                        </Cell.FooterText>
+                      </AriaDescription>
+                    </Cell.Footer>
+                  </AriaInputGroup>
+
+                  {(window.env.platform === 'win32' ||
+                    (window.env.platform === 'darwin' && window.env.development)) && (
                     <AriaInputGroup>
                       <Cell.Container>
                         <AriaLabel>
                           <Cell.InputLabel>
-                            {messages.pgettext('preferences-view', 'Start minimized')}
+                            {messages.pgettext('preferences-view', 'Unpin app from taskbar')}
                           </Cell.InputLabel>
                         </AriaLabel>
                         <AriaInput>
                           <Cell.Switch
-                            isOn={this.props.startMinimized}
-                            onChange={this.props.setStartMinimized}
+                            isOn={this.props.unpinnedWindow}
+                            onChange={this.props.setUnpinnedWindow}
                           />
                         </AriaInput>
                       </Cell.Container>
@@ -307,65 +281,95 @@ export default class Preferences extends React.Component<IProps, IState> {
                           <Cell.FooterText>
                             {messages.pgettext(
                               'preferences-view',
-                              'Show only the tray icon when the app starts.',
+                              'Enable to move the app around as a free-standing window.',
                             )}
                           </Cell.FooterText>
                         </AriaDescription>
                       </Cell.Footer>
                     </AriaInputGroup>
-                  </React.Fragment>
-                )}
+                  )}
 
-                <AriaInputGroup>
-                  <Cell.Container disabled={this.props.isBeta}>
-                    <AriaLabel>
-                      <Cell.InputLabel>
-                        {messages.pgettext('preferences-view', 'Beta program')}
-                      </Cell.InputLabel>
-                    </AriaLabel>
-                    <AriaInput>
-                      <Cell.Switch
-                        isOn={this.props.showBetaReleases}
-                        onChange={this.props.setShowBetaReleases}
-                      />
-                    </AriaInput>
-                  </Cell.Container>
-                  <Cell.Footer>
-                    <AriaDescription>
-                      <Cell.FooterText>
-                        {this.props.isBeta
-                          ? messages.pgettext(
-                              'preferences-view',
-                              'This option is unavailable while using a beta version.',
-                            )
-                          : messages.pgettext(
-                              'preferences-view',
-                              'Enable to get notified when new beta versions of the app are released.',
-                            )}
-                      </Cell.FooterText>
-                    </AriaDescription>
-                  </Cell.Footer>
-                </AriaInputGroup>
-              </StyledContent>
-            </NavigationScrollbars>
-          </NavigationContainer>
-        </StyledContainer>
+                  {this.props.unpinnedWindow && (
+                    <React.Fragment>
+                      <AriaInputGroup>
+                        <Cell.Container>
+                          <AriaLabel>
+                            <Cell.InputLabel>
+                              {messages.pgettext('preferences-view', 'Start minimized')}
+                            </Cell.InputLabel>
+                          </AriaLabel>
+                          <AriaInput>
+                            <Cell.Switch
+                              isOn={this.props.startMinimized}
+                              onChange={this.props.setStartMinimized}
+                            />
+                          </AriaInput>
+                        </Cell.Container>
+                        <Cell.Footer>
+                          <AriaDescription>
+                            <Cell.FooterText>
+                              {messages.pgettext(
+                                'preferences-view',
+                                'Show only the tray icon when the app starts.',
+                              )}
+                            </Cell.FooterText>
+                          </AriaDescription>
+                        </Cell.Footer>
+                      </AriaInputGroup>
+                    </React.Fragment>
+                  )}
 
-        <ModalAlert
-          isOpen={this.state.showKillSwitchInfo}
-          message={messages.pgettext(
-            'preferences-view',
-            'The app has a built in kill switch that is enabled by default and cannot be disabled. This is to prevent your traffic from leaking outside of the VPN tunnel if your network suddenly stops working or if the tunnel fails for any reason. Mullvad automatically protects your data until your connection is reestablished.',
-          )}
-          type={ModalAlertType.info}
-          buttons={[
-            <AppButton.BlueButton key="back" onClick={this.hideKillSwitchInfo}>
-              {messages.gettext('Got it!')}
-            </AppButton.BlueButton>,
-          ]}
-          close={this.hideKillSwitchInfo}
-        />
-      </Layout>
+                  <AriaInputGroup>
+                    <Cell.Container disabled={this.props.isBeta}>
+                      <AriaLabel>
+                        <Cell.InputLabel>
+                          {messages.pgettext('preferences-view', 'Beta program')}
+                        </Cell.InputLabel>
+                      </AriaLabel>
+                      <AriaInput>
+                        <Cell.Switch
+                          isOn={this.props.showBetaReleases}
+                          onChange={this.props.setShowBetaReleases}
+                        />
+                      </AriaInput>
+                    </Cell.Container>
+                    <Cell.Footer>
+                      <AriaDescription>
+                        <Cell.FooterText>
+                          {this.props.isBeta
+                            ? messages.pgettext(
+                                'preferences-view',
+                                'This option is unavailable while using a beta version.',
+                              )
+                            : messages.pgettext(
+                                'preferences-view',
+                                'Enable to get notified when new beta versions of the app are released.',
+                              )}
+                        </Cell.FooterText>
+                      </AriaDescription>
+                    </Cell.Footer>
+                  </AriaInputGroup>
+                </StyledContent>
+              </NavigationScrollbars>
+            </NavigationContainer>
+          </StyledContainer>
+
+          <ModalAlert
+            isOpen={this.state.showKillSwitchInfo}
+            message={messages.pgettext(
+              'preferences-view',
+              'The app has a built in kill switch that is enabled by default and cannot be disabled. This is to prevent your traffic from leaking outside of the VPN tunnel if your network suddenly stops working or if the tunnel fails for any reason. Mullvad automatically protects your data until your connection is reestablished.',
+            )}
+            type={ModalAlertType.info}
+            buttons={[
+              <AppButton.BlueButton key="back" onClick={this.hideKillSwitchInfo}>
+                {messages.gettext('Got it!')}
+              </AppButton.BlueButton>,
+            ]}
+            close={this.hideKillSwitchInfo}
+          />
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/SelectLanguage.tsx
+++ b/gui/src/renderer/components/SelectLanguage.tsx
@@ -6,7 +6,6 @@ import { AriaInputGroup } from './AriaGroup';
 import { CustomScrollbarsRef } from './CustomScrollbars';
 import { Container, Layout } from './Layout';
 import {
-  BackBarItem,
   NavigationBar,
   NavigationContainer,
   NavigationItems,
@@ -15,6 +14,7 @@ import {
 } from './NavigationBar';
 import Selector, { ISelectorItem } from './cell/Selector';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
+import { BackAction } from './KeyboardNavigation';
 
 interface IProps {
   preferredLocale: string;
@@ -59,40 +59,41 @@ export default class SelectLanguage extends React.Component<IProps, IState> {
 
   public render() {
     return (
-      <Layout>
-        <StyledContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('select-language-nav', 'Select language')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <StyledContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('select-language-nav', 'Select language')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <StyledNavigationScrollbars ref={this.scrollView}>
-              <SettingsHeader>
-                <HeaderTitle>
-                  {messages.pgettext('select-language-nav', 'Select language')}
-                </HeaderTitle>
-              </SettingsHeader>
-              <AriaInputGroup>
-                <StyledSelector
-                  title=""
-                  values={this.state.source}
-                  value={this.props.preferredLocale}
-                  onSelect={this.props.setPreferredLocale}
-                  selectedCellRef={this.selectedCellRef}
-                />
-              </AriaInputGroup>
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </StyledContainer>
-      </Layout>
+              <StyledNavigationScrollbars ref={this.scrollView}>
+                <SettingsHeader>
+                  <HeaderTitle>
+                    {messages.pgettext('select-language-nav', 'Select language')}
+                  </HeaderTitle>
+                </SettingsHeader>
+                <AriaInputGroup>
+                  <StyledSelector
+                    title=""
+                    values={this.state.source}
+                    value={this.props.preferredLocale}
+                    onSelect={this.props.setPreferredLocale}
+                    selectedCellRef={this.selectedCellRef}
+                  />
+                </AriaInputGroup>
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </StyledContainer>
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/SelectLocation.tsx
+++ b/gui/src/renderer/components/SelectLocation.tsx
@@ -15,7 +15,6 @@ import LocationList, {
   LocationSelectionType,
 } from './LocationList';
 import {
-  CloseBarItem,
   NavigationBar,
   NavigationContainer,
   NavigationItems,
@@ -38,6 +37,7 @@ import {
   StyledSettingsHeader,
 } from './SelectLocationStyles';
 import { HeaderSubTitle, HeaderTitle } from './SettingsHeader';
+import { BackAction } from './KeyboardNavigation';
 
 interface IProps {
   locale: string;
@@ -132,101 +132,102 @@ export default class SelectLocation extends React.Component<IProps, IState> {
 
   public render() {
     return (
-      <Layout onClick={this.onClickAnywhere}>
-        <StyledContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <CloseBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('select-location-nav', 'Select location')
-                  }
-                </TitleBarItem>
+      <BackAction icon="close" action={this.props.onClose}>
+        <Layout onClick={this.onClickAnywhere}>
+          <StyledContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('select-location-nav', 'Select location')
+                    }
+                  </TitleBarItem>
 
-                <StyledFilterContainer ref={this.filterButtonRef}>
-                  <StyledFilterIconButton
-                    onClick={this.toggleFilterMenu}
-                    aria-label={messages.gettext('Filter')}>
-                    <ImageView
-                      source="icon-filter-round"
-                      tintColor={colors.white40}
-                      tintHoverColor={colors.white60}
-                      height={24}
-                      width={24}
-                    />
-                  </StyledFilterIconButton>
-                  {this.state.showFilterMenu && (
-                    <StyledFilterMenu>
-                      <StyledFilterByProviderButton onClick={this.props.onViewFilterByProvider}>
-                        {messages.pgettext('select-location-view', 'Filter by provider')}
-                      </StyledFilterByProviderButton>
-                    </StyledFilterMenu>
-                  )}
-                </StyledFilterContainer>
-              </NavigationItems>
-            </NavigationBar>
-            <NavigationScrollbars ref={this.scrollView}>
-              <SpacePreAllocationView ref={this.spacePreAllocationViewRef}>
-                <StyledNavigationBarAttachment top={-this.state.headingHeight}>
-                  <StyledSettingsHeader ref={this.headerRef}>
-                    <HeaderTitle>
-                      {
-                        // TRANSLATORS: Heading in select location view
-                        messages.pgettext('select-location-view', 'Select location')
-                      }
-                    </HeaderTitle>
-                    {this.renderHeaderSubtitle()}
-                  </StyledSettingsHeader>
+                  <StyledFilterContainer ref={this.filterButtonRef}>
+                    <StyledFilterIconButton
+                      onClick={this.toggleFilterMenu}
+                      aria-label={messages.gettext('Filter')}>
+                      <ImageView
+                        source="icon-filter-round"
+                        tintColor={colors.white40}
+                        tintHoverColor={colors.white60}
+                        height={24}
+                        width={24}
+                      />
+                    </StyledFilterIconButton>
+                    {this.state.showFilterMenu && (
+                      <StyledFilterMenu>
+                        <StyledFilterByProviderButton onClick={this.props.onViewFilterByProvider}>
+                          {messages.pgettext('select-location-view', 'Filter by provider')}
+                        </StyledFilterByProviderButton>
+                      </StyledFilterMenu>
+                    )}
+                  </StyledFilterContainer>
+                </NavigationItems>
+              </NavigationBar>
+              <NavigationScrollbars ref={this.scrollView}>
+                <SpacePreAllocationView ref={this.spacePreAllocationViewRef}>
+                  <StyledNavigationBarAttachment top={-this.state.headingHeight}>
+                    <StyledSettingsHeader ref={this.headerRef}>
+                      <HeaderTitle>
+                        {
+                          // TRANSLATORS: Heading in select location view
+                          messages.pgettext('select-location-view', 'Select location')
+                        }
+                      </HeaderTitle>
+                      {this.renderHeaderSubtitle()}
+                    </StyledSettingsHeader>
 
-                  {this.props.providers.length > 0 && (
-                    <StyledProviderCountRow>
-                      {messages.pgettext('select-location-view', 'Filtered:')}
-                      <StyledProvidersCount>
-                        {sprintf(
-                          messages.pgettext(
-                            'select-location-view',
-                            'Providers: %(numberOfProviders)d',
-                          ),
-                          {
-                            numberOfProviders: this.props.providers.length,
-                          },
-                        )}
-                        <StyledClearProvidersButton
-                          aria-label={messages.gettext('Clear')}
-                          onClick={this.props.onClearProviders}>
-                          <ImageView
-                            height={16}
-                            width={16}
-                            source="icon-close"
-                            tintColor={colors.white60}
-                            tintHoverColor={colors.white80}
-                          />
-                        </StyledClearProvidersButton>
-                      </StyledProvidersCount>
-                    </StyledProviderCountRow>
-                  )}
-                  {this.props.allowEntrySelection && (
-                    <StyledScopeBar
-                      defaultSelectedIndex={this.state.locationScope}
-                      onChange={this.onChangeLocationScope}>
-                      <ScopeBarItem>
-                        {messages.pgettext('select-location-view', 'Entry')}
-                      </ScopeBarItem>
-                      <ScopeBarItem>
-                        {messages.pgettext('select-location-view', 'Exit')}
-                      </ScopeBarItem>
-                    </StyledScopeBar>
-                  )}
-                </StyledNavigationBarAttachment>
+                    {this.props.providers.length > 0 && (
+                      <StyledProviderCountRow>
+                        {messages.pgettext('select-location-view', 'Filtered:')}
+                        <StyledProvidersCount>
+                          {sprintf(
+                            messages.pgettext(
+                              'select-location-view',
+                              'Providers: %(numberOfProviders)d',
+                            ),
+                            {
+                              numberOfProviders: this.props.providers.length,
+                            },
+                          )}
+                          <StyledClearProvidersButton
+                            aria-label={messages.gettext('Clear')}
+                            onClick={this.props.onClearProviders}>
+                            <ImageView
+                              height={16}
+                              width={16}
+                              source="icon-close"
+                              tintColor={colors.white60}
+                              tintHoverColor={colors.white80}
+                            />
+                          </StyledClearProvidersButton>
+                        </StyledProvidersCount>
+                      </StyledProviderCountRow>
+                    )}
+                    {this.props.allowEntrySelection && (
+                      <StyledScopeBar
+                        defaultSelectedIndex={this.state.locationScope}
+                        onChange={this.onChangeLocationScope}>
+                        <ScopeBarItem>
+                          {messages.pgettext('select-location-view', 'Entry')}
+                        </ScopeBarItem>
+                        <ScopeBarItem>
+                          {messages.pgettext('select-location-view', 'Exit')}
+                        </ScopeBarItem>
+                      </StyledScopeBar>
+                    )}
+                  </StyledNavigationBarAttachment>
 
-                <StyledContent>{this.renderLocationList()}</StyledContent>
-              </SpacePreAllocationView>
-            </NavigationScrollbars>
-          </NavigationContainer>
-        </StyledContainer>
-      </Layout>
+                  <StyledContent>{this.renderLocationList()}</StyledContent>
+                </SpacePreAllocationView>
+              </NavigationScrollbars>
+            </NavigationContainer>
+          </StyledContainer>
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -6,13 +6,7 @@ import History from '../lib/history';
 import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import * as Cell from './cell';
 import { Layout } from './Layout';
-import {
-  CloseBarItem,
-  NavigationBar,
-  NavigationContainer,
-  NavigationItems,
-  TitleBarItem,
-} from './NavigationBar';
+import { NavigationBar, NavigationContainer, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 import {
   StyledCellIcon,
@@ -26,6 +20,7 @@ import {
 } from './SettingsStyles';
 
 import { LoginState } from '../redux/account/reducers';
+import { BackAction } from './KeyboardNavigation';
 
 export interface IProps {
   preferredLocaleDisplayName: string;
@@ -60,41 +55,42 @@ export default class Settings extends React.Component<IProps> {
     const showLargeTitle = this.props.loginState.type !== 'ok';
 
     return (
-      <Layout>
-        <StyledContainer>
-          <NavigationContainer>
-            <NavigationBar alwaysDisplayBarTitle={!showLargeTitle}>
-              <NavigationItems>
-                <CloseBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('navigation-bar', 'Settings')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <BackAction icon="close" action={this.props.onClose}>
+        <Layout>
+          <StyledContainer>
+            <NavigationContainer>
+              <NavigationBar alwaysDisplayBarTitle={!showLargeTitle}>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('navigation-bar', 'Settings')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <StyledNavigationScrollbars fillContainer>
-              <StyledContent>
-                {showLargeTitle && (
-                  <SettingsHeader>
-                    <HeaderTitle>{messages.pgettext('navigation-bar', 'Settings')}</HeaderTitle>
-                  </SettingsHeader>
-                )}
+              <StyledNavigationScrollbars fillContainer>
+                <StyledContent>
+                  {showLargeTitle && (
+                    <SettingsHeader>
+                      <HeaderTitle>{messages.pgettext('navigation-bar', 'Settings')}</HeaderTitle>
+                    </SettingsHeader>
+                  )}
 
-                <StyledSettingsContent>
-                  {this.renderTopButtons()}
-                  {this.renderMiddleButtons()}
-                  {this.renderBottomButtons()}
-                </StyledSettingsContent>
-              </StyledContent>
+                  <StyledSettingsContent>
+                    {this.renderTopButtons()}
+                    {this.renderMiddleButtons()}
+                    {this.renderBottomButtons()}
+                  </StyledSettingsContent>
+                </StyledContent>
 
-              {this.renderQuitButton()}
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </StyledContainer>
-      </Layout>
+                {this.renderQuitButton()}
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </StyledContainer>
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/SplitTunnelingSettings.tsx
+++ b/gui/src/renderer/components/SplitTunnelingSettings.tsx
@@ -16,13 +16,7 @@ import ImageView from './ImageView';
 import { Layout } from './Layout';
 import List from './List';
 import { ModalAlert, ModalAlertType } from './Modal';
-import {
-  BackBarItem,
-  NavigationBar,
-  NavigationContainer,
-  NavigationItems,
-  TitleBarItem,
-} from './NavigationBar';
+import { NavigationBar, NavigationContainer, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderSubTitle, HeaderTitle } from './SettingsHeader';
 import {
   StyledPageCover,
@@ -48,6 +42,7 @@ import {
   StyledListContainer,
 } from './SplitTunnelingSettingsStyles';
 import { formatMarkdown } from '../markdown-formatter';
+import { BackAction } from './KeyboardNavigation';
 
 export default function SplitTunneling() {
   const { pop } = useHistory();
@@ -59,32 +54,33 @@ export default function SplitTunneling() {
   return (
     <>
       <StyledPageCover show={browsing} />
-      <Layout>
-        <StyledContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={pop} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('split-tunneling-nav', 'Split tunneling')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <BackAction action={pop}>
+        <Layout>
+          <StyledContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('split-tunneling-nav', 'Split tunneling')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <StyledNavigationScrollbars ref={scrollbarsRef}>
-              <StyledContent>
-                <PlatformSpecificSplitTunnelingSettings
-                  setBrowsing={setBrowsing}
-                  scrollToTop={scrollToTop}
-                />
-              </StyledContent>
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </StyledContainer>
-      </Layout>
+              <StyledNavigationScrollbars ref={scrollbarsRef}>
+                <StyledContent>
+                  <PlatformSpecificSplitTunnelingSettings
+                    setBrowsing={setBrowsing}
+                    scrollToTop={scrollToTop}
+                  />
+                </StyledContent>
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </StyledContainer>
+        </Layout>
+      </BackAction>
     </>
   );
 }

--- a/gui/src/renderer/components/Support.tsx
+++ b/gui/src/renderer/components/Support.tsx
@@ -6,7 +6,7 @@ import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGrou
 import ImageView from './ImageView';
 import { Layout } from './Layout';
 import { ModalAlert, ModalAlertType } from './Modal';
-import { BackBarItem, NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
+import { NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderSubTitle, HeaderTitle } from './SettingsHeader';
 import {
   StyledBlueButton,
@@ -28,6 +28,7 @@ import {
 
 import { AccountToken } from '../../shared/daemon-rpc-types';
 import { ISupportReportForm } from '../redux/support/actions';
+import { BackAction } from './KeyboardNavigation';
 
 enum SendState {
   initial,
@@ -150,28 +151,29 @@ export default class Support extends React.Component<ISupportProps, ISupportStat
     const content = this.renderContent();
 
     return (
-      <Layout>
-        <StyledContainer>
-          <NavigationBar>
-            <NavigationItems>
-              <BackBarItem action={this.props.onClose} />
-              <TitleBarItem>
-                {
-                  // TRANSLATORS: Title label in navigation bar
-                  messages.pgettext('support-view', 'Report a problem')
-                }
-              </TitleBarItem>
-            </NavigationItems>
-          </NavigationBar>
-          <StyledContentContainer>
-            {header}
-            {content}
-          </StyledContentContainer>
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <StyledContainer>
+            <NavigationBar>
+              <NavigationItems>
+                <TitleBarItem>
+                  {
+                    // TRANSLATORS: Title label in navigation bar
+                    messages.pgettext('support-view', 'Report a problem')
+                  }
+                </TitleBarItem>
+              </NavigationItems>
+            </NavigationBar>
+            <StyledContentContainer>
+              {header}
+              {content}
+            </StyledContentContainer>
 
-          {this.renderNoEmailDialog()}
-          {this.renderOutdateVersionWarningDialog()}
-        </StyledContainer>
-      </Layout>
+            {this.renderNoEmailDialog()}
+            {this.renderOutdateVersionWarningDialog()}
+          </StyledContainer>
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/WireguardKeys.tsx
+++ b/gui/src/renderer/components/WireguardKeys.tsx
@@ -9,14 +9,9 @@ import * as AppButton from './AppButton';
 import { AriaDescribed, AriaDescription, AriaDescriptionGroup } from './AriaGroup';
 import ClipboardLabel from './ClipboardLabel';
 import ImageView from './ImageView';
+import { BackAction } from './KeyboardNavigation';
 import { Layout } from './Layout';
-import {
-  BackBarItem,
-  NavigationBar,
-  NavigationContainer,
-  NavigationItems,
-  TitleBarItem,
-} from './NavigationBar';
+import { NavigationBar, NavigationContainer, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 import {
   StyledButtonRow,
@@ -95,85 +90,86 @@ export default class WireguardKeys extends React.Component<IProps, IState> {
 
   public render() {
     return (
-      <Layout>
-        <StyledContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('wireguard-keys-nav', 'WireGuard key')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <StyledContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('wireguard-keys-nav', 'WireGuard key')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <StyledNavigationScrollbars fillContainer>
-              <StyledContent>
-                <SettingsHeader>
-                  <HeaderTitle>
-                    {messages.pgettext('wireguard-keys-nav', 'WireGuard key')}
-                  </HeaderTitle>
-                </SettingsHeader>
+              <StyledNavigationScrollbars fillContainer>
+                <StyledContent>
+                  <SettingsHeader>
+                    <HeaderTitle>
+                      {messages.pgettext('wireguard-keys-nav', 'WireGuard key')}
+                    </HeaderTitle>
+                  </SettingsHeader>
 
-                <StyledRow>
-                  <StyledRowLabel>
-                    <span>{messages.pgettext('wireguard-key-view', 'Public key')}</span>
-                    <StyledRowLabelSpacer />
-                    <span>{this.keyValidityLabel()}</span>
-                  </StyledRowLabel>
+                  <StyledRow>
+                    <StyledRowLabel>
+                      <span>{messages.pgettext('wireguard-key-view', 'Public key')}</span>
+                      <StyledRowLabelSpacer />
+                      <span>{this.keyValidityLabel()}</span>
+                    </StyledRowLabel>
 
-                  <StyledRowValue>{this.getKeyText()}</StyledRowValue>
-                </StyledRow>
-                <StyledRow>
-                  <StyledRowLabel>
-                    {messages.pgettext('wireguard-key-view', 'Key generated')}
-                  </StyledRowLabel>
-                  <StyledRowValue>{this.state.ageOfKeyString}</StyledRowValue>
-                </StyledRow>
+                    <StyledRowValue>{this.getKeyText()}</StyledRowValue>
+                  </StyledRow>
+                  <StyledRow>
+                    <StyledRowLabel>
+                      {messages.pgettext('wireguard-key-view', 'Key generated')}
+                    </StyledRowLabel>
+                    <StyledRowValue>{this.state.ageOfKeyString}</StyledRowValue>
+                  </StyledRow>
 
-                <StyledMessages>{this.getStatusMessage()}</StyledMessages>
+                  <StyledMessages>{this.getStatusMessage()}</StyledMessages>
 
-                <StyledButtonRow>{this.getGenerateButton()}</StyledButtonRow>
-                <StyledButtonRow>
-                  <AppButton.BlueButton
-                    disabled={this.isVerifyButtonDisabled()}
-                    onClick={this.handleVerifyKeyPress}>
-                    <AppButton.Label>
-                      {messages.pgettext('wireguard-key-view', 'Verify key')}
-                    </AppButton.Label>
-                  </AppButton.BlueButton>
-                </StyledButtonRow>
-                <StyledLastButtonRow>
-                  <AppButton.BlockingButton
-                    disabled={this.props.isOffline}
-                    onClick={this.props.onVisitWebsiteKey}>
-                    <AriaDescriptionGroup>
-                      <AriaDescribed>
-                        <AppButton.BlueButton>
-                          <AppButton.Label>
-                            {messages.pgettext('wireguard-key-view', 'Manage keys')}
-                          </AppButton.Label>
-                          <AriaDescription>
-                            <AppButton.Icon
-                              source="icon-extLink"
-                              height={16}
-                              width={16}
-                              aria-label={messages.pgettext('accessibility', 'Opens externally')}
-                            />
-                          </AriaDescription>
-                        </AppButton.BlueButton>
-                      </AriaDescribed>
-                    </AriaDescriptionGroup>
-                  </AppButton.BlockingButton>
-                </StyledLastButtonRow>
-              </StyledContent>
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </StyledContainer>
-      </Layout>
+                  <StyledButtonRow>{this.getGenerateButton()}</StyledButtonRow>
+                  <StyledButtonRow>
+                    <AppButton.BlueButton
+                      disabled={this.isVerifyButtonDisabled()}
+                      onClick={this.handleVerifyKeyPress}>
+                      <AppButton.Label>
+                        {messages.pgettext('wireguard-key-view', 'Verify key')}
+                      </AppButton.Label>
+                    </AppButton.BlueButton>
+                  </StyledButtonRow>
+                  <StyledLastButtonRow>
+                    <AppButton.BlockingButton
+                      disabled={this.props.isOffline}
+                      onClick={this.props.onVisitWebsiteKey}>
+                      <AriaDescriptionGroup>
+                        <AriaDescribed>
+                          <AppButton.BlueButton>
+                            <AppButton.Label>
+                              {messages.pgettext('wireguard-key-view', 'Manage keys')}
+                            </AppButton.Label>
+                            <AriaDescription>
+                              <AppButton.Icon
+                                source="icon-extLink"
+                                height={16}
+                                width={16}
+                                aria-label={messages.pgettext('accessibility', 'Opens externally')}
+                              />
+                            </AriaDescription>
+                          </AppButton.BlueButton>
+                        </AriaDescribed>
+                      </AriaDescriptionGroup>
+                    </AppButton.BlockingButton>
+                  </StyledLastButtonRow>
+                </StyledContent>
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </StyledContainer>
+        </Layout>
+      </BackAction>
     );
   }
 

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -9,7 +9,6 @@ import * as Cell from './cell';
 import { Layout, SettingsContainer } from './Layout';
 import { ModalAlert, ModalAlertType } from './Modal';
 import {
-  BackBarItem,
   NavigationBar,
   NavigationContainer,
   NavigationItems,
@@ -19,6 +18,7 @@ import {
 import Selector, { ISelectorItem } from './cell/Selector';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 import Switch from './Switch';
+import { BackAction } from './KeyboardNavigation';
 
 const MIN_WIREGUARD_MTU_VALUE = 1280;
 const MAX_WIREGUARD_MTU_VALUE = 1420;
@@ -97,167 +97,168 @@ export default class WireguardSettings extends React.Component<IProps, IState> {
 
   public render() {
     return (
-      <Layout>
-        <SettingsContainer>
-          <NavigationContainer>
-            <NavigationBar>
-              <NavigationItems>
-                <BackBarItem action={this.props.onClose} />
-                <TitleBarItem>
-                  {
-                    // TRANSLATORS: Title label in navigation bar
-                    messages.pgettext('wireguard-settings-nav', 'WireGuard settings')
-                  }
-                </TitleBarItem>
-              </NavigationItems>
-            </NavigationBar>
+      <BackAction action={this.props.onClose}>
+        <Layout>
+          <SettingsContainer>
+            <NavigationContainer>
+              <NavigationBar>
+                <NavigationItems>
+                  <TitleBarItem>
+                    {
+                      // TRANSLATORS: Title label in navigation bar
+                      messages.pgettext('wireguard-settings-nav', 'WireGuard settings')
+                    }
+                  </TitleBarItem>
+                </NavigationItems>
+              </NavigationBar>
 
-            <StyledNavigationScrollbars>
-              <SettingsHeader>
-                <HeaderTitle>
-                  {messages.pgettext('wireguard-settings-view', 'WireGuard settings')}
-                </HeaderTitle>
-              </SettingsHeader>
+              <StyledNavigationScrollbars>
+                <SettingsHeader>
+                  <HeaderTitle>
+                    {messages.pgettext('wireguard-settings-view', 'WireGuard settings')}
+                  </HeaderTitle>
+                </SettingsHeader>
 
-              <AriaInputGroup>
-                <StyledSelectorContainer>
-                  <StyledSelectorForFooter
-                    // TRANSLATORS: The title for the WireGuard port selector.
-                    title={messages.pgettext('wireguard-settings-view', 'Port')}
-                    values={this.wireguardPortItems}
-                    value={this.props.wireguard.port}
-                    onSelect={this.props.setWireguardPort}
-                  />
-                </StyledSelectorContainer>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {
-                        // TRANSLATORS: The hint displayed below the WireGuard port selector.
-                        messages.pgettext(
-                          'wireguard-settings-view',
-                          'The automatic setting will randomly choose from a wide range of ports.',
-                        )
-                      }
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
-
-              <AriaInputGroup>
-                <Cell.Container>
-                  <AriaLabel>
-                    <Cell.InputLabel>
-                      {
-                        // TRANSLATORS: The label next to the multihop settings toggle.
-                        messages.pgettext('advanced-settings-view', 'Enable multihop')
-                      }
-                    </Cell.InputLabel>
-                  </AriaLabel>
-                  <AriaInput>
-                    <Cell.Switch
-                      ref={this.multihopRef}
-                      isOn={this.props.wireguardMultihop}
-                      onChange={this.setWireguardMultihop}
+                <AriaInputGroup>
+                  <StyledSelectorContainer>
+                    <StyledSelectorForFooter
+                      // TRANSLATORS: The title for the WireGuard port selector.
+                      title={messages.pgettext('wireguard-settings-view', 'Port')}
+                      values={this.wireguardPortItems}
+                      value={this.props.wireguard.port}
+                      onSelect={this.props.setWireguardPort}
                     />
-                  </AriaInput>
-                </Cell.Container>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {
-                        // TRANSLATORS: Description for multihop settings toggle.
-                        messages.pgettext(
-                          'advanced-settings-view',
-                          'Increases anonymity by routing your traffic into one WireGuard server and out another, making it harder to trace.',
-                        )
-                      }
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
-
-              <AriaInputGroup>
-                <StyledSelectorContainer>
-                  <StyledSelectorForFooter
-                    // TRANSLATORS: The title for the WireGuard IP version selector.
-                    title={messages.pgettext('wireguard-settings-view', 'IP version')}
-                    values={this.wireguardIpVersionItems}
-                    value={this.props.wireguard.ipVersion}
-                    onSelect={this.props.setWireguardIpVersion}
-                  />
-                </StyledSelectorContainer>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {
-                        // TRANSLATORS: The hint displayed below the WireGuard IP version selector.
-                        messages.pgettext(
-                          'wireguard-settings-view',
-                          'This allows access to WireGuard for devices that only support IPv6.',
-                        )
-                      }
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
-
-              <Cell.CellButtonGroup>
-                <Cell.CellButton onClick={this.props.onViewWireguardKeys}>
-                  <Cell.Label>
-                    {messages.pgettext('wireguard-settings-view', 'WireGuard key')}
-                  </Cell.Label>
-                  <Cell.Icon height={12} width={7} source="icon-chevron" />
-                </Cell.CellButton>
-              </Cell.CellButtonGroup>
-
-              <AriaInputGroup>
-                <Cell.Container>
-                  <AriaLabel>
-                    <Cell.InputLabel>
-                      {messages.pgettext('wireguard-settings-view', 'MTU')}
-                    </Cell.InputLabel>
-                  </AriaLabel>
-                  <AriaInput>
-                    <Cell.AutoSizingTextInput
-                      value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
-                      inputMode={'numeric'}
-                      maxLength={4}
-                      placeholder={messages.gettext('Default')}
-                      onSubmitValue={this.onWireguardMtuSubmit}
-                      validateValue={WireguardSettings.wireguarMtuIsValid}
-                      submitOnBlur={true}
-                      modifyValue={WireguardSettings.removeNonNumericCharacters}
-                    />
-                  </AriaInput>
-                </Cell.Container>
-                <Cell.Footer>
-                  <AriaDescription>
-                    <Cell.FooterText>
-                      {sprintf(
-                        // TRANSLATORS: The hint displayed below the WireGuard MTU input field.
-                        // TRANSLATORS: Available placeholders:
-                        // TRANSLATORS: %(max)d - the maximum possible wireguard mtu value
-                        // TRANSLATORS: %(min)d - the minimum possible wireguard mtu value
-                        messages.pgettext(
-                          'wireguard-settings-view',
-                          'Set WireGuard MTU value. Valid range: %(min)d - %(max)d.',
-                        ),
+                  </StyledSelectorContainer>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
                         {
-                          min: MIN_WIREGUARD_MTU_VALUE,
-                          max: MAX_WIREGUARD_MTU_VALUE,
-                        },
-                      )}
-                    </Cell.FooterText>
-                  </AriaDescription>
-                </Cell.Footer>
-              </AriaInputGroup>
-            </StyledNavigationScrollbars>
-          </NavigationContainer>
-        </SettingsContainer>
+                          // TRANSLATORS: The hint displayed below the WireGuard port selector.
+                          messages.pgettext(
+                            'wireguard-settings-view',
+                            'The automatic setting will randomly choose from a wide range of ports.',
+                          )
+                        }
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
 
-        {this.renderMultihopConfirmation()}
-      </Layout>
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {
+                          // TRANSLATORS: The label next to the multihop settings toggle.
+                          messages.pgettext('advanced-settings-view', 'Enable multihop')
+                        }
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.Switch
+                        ref={this.multihopRef}
+                        isOn={this.props.wireguardMultihop}
+                        onChange={this.setWireguardMultihop}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {
+                          // TRANSLATORS: Description for multihop settings toggle.
+                          messages.pgettext(
+                            'advanced-settings-view',
+                            'Increases anonymity by routing your traffic into one WireGuard server and out another, making it harder to trace.',
+                          )
+                        }
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <AriaInputGroup>
+                  <StyledSelectorContainer>
+                    <StyledSelectorForFooter
+                      // TRANSLATORS: The title for the WireGuard IP version selector.
+                      title={messages.pgettext('wireguard-settings-view', 'IP version')}
+                      values={this.wireguardIpVersionItems}
+                      value={this.props.wireguard.ipVersion}
+                      onSelect={this.props.setWireguardIpVersion}
+                    />
+                  </StyledSelectorContainer>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {
+                          // TRANSLATORS: The hint displayed below the WireGuard IP version selector.
+                          messages.pgettext(
+                            'wireguard-settings-view',
+                            'This allows access to WireGuard for devices that only support IPv6.',
+                          )
+                        }
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+
+                <Cell.CellButtonGroup>
+                  <Cell.CellButton onClick={this.props.onViewWireguardKeys}>
+                    <Cell.Label>
+                      {messages.pgettext('wireguard-settings-view', 'WireGuard key')}
+                    </Cell.Label>
+                    <Cell.Icon height={12} width={7} source="icon-chevron" />
+                  </Cell.CellButton>
+                </Cell.CellButtonGroup>
+
+                <AriaInputGroup>
+                  <Cell.Container>
+                    <AriaLabel>
+                      <Cell.InputLabel>
+                        {messages.pgettext('wireguard-settings-view', 'MTU')}
+                      </Cell.InputLabel>
+                    </AriaLabel>
+                    <AriaInput>
+                      <Cell.AutoSizingTextInput
+                        value={this.props.wireguardMtu ? this.props.wireguardMtu.toString() : ''}
+                        inputMode={'numeric'}
+                        maxLength={4}
+                        placeholder={messages.gettext('Default')}
+                        onSubmitValue={this.onWireguardMtuSubmit}
+                        validateValue={WireguardSettings.wireguarMtuIsValid}
+                        submitOnBlur={true}
+                        modifyValue={WireguardSettings.removeNonNumericCharacters}
+                      />
+                    </AriaInput>
+                  </Cell.Container>
+                  <Cell.Footer>
+                    <AriaDescription>
+                      <Cell.FooterText>
+                        {sprintf(
+                          // TRANSLATORS: The hint displayed below the WireGuard MTU input field.
+                          // TRANSLATORS: Available placeholders:
+                          // TRANSLATORS: %(max)d - the maximum possible wireguard mtu value
+                          // TRANSLATORS: %(min)d - the minimum possible wireguard mtu value
+                          messages.pgettext(
+                            'wireguard-settings-view',
+                            'Set WireGuard MTU value. Valid range: %(min)d - %(max)d.',
+                          ),
+                          {
+                            min: MIN_WIREGUARD_MTU_VALUE,
+                            max: MAX_WIREGUARD_MTU_VALUE,
+                          },
+                        )}
+                      </Cell.FooterText>
+                    </AriaDescription>
+                  </Cell.Footer>
+                </AriaInputGroup>
+              </StyledNavigationScrollbars>
+            </NavigationContainer>
+          </SettingsContainer>
+
+          {this.renderMultihopConfirmation()}
+        </Layout>
+      </BackAction>
     );
   }
 


### PR DESCRIPTION
This PR changes the behavior of the escape hot key. It now navigates one step back instead of all the way to the main view. For navigating back to the main view Shift+Escape is used. To enable this I had to change how the back actions are registered.

Back actions are now registered using a `<BackAction ...>` component and both the escape listener and the back/close button uses the action registered in `BackAction`.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3382)
<!-- Reviewable:end -->
