### PR TITLE
Add will-change CSS property for transition properties

### DIFF
--- a/gui/src/renderer/components/Accordion.tsx
+++ b/gui/src/renderer/components/Accordion.tsx
@@ -18,6 +18,7 @@ const Container = styled.div((props: { height: string; animationDuration: number
   display: 'flex',
   height: props.height,
   overflow: 'hidden',
+  willChange: 'height',
   transition: `height ${props.animationDuration}ms ease-in-out`,
 }));
 

--- a/gui/src/renderer/components/CustomScrollbars.tsx
+++ b/gui/src/renderer/components/CustomScrollbars.tsx
@@ -35,6 +35,7 @@ const StyledTrack = styled.div({}, (props: { canScroll: boolean; show: boolean }
   bottom: 0,
   width: '16px',
   backgroundColor: props.show ? 'rgba(0, 0, 0, 0.2)' : 'rgba(0, 0, 0, 0)',
+  willChange: 'width, background-color',
   transition: 'width 0.1s ease-in-out, background-color 0.25s ease-in-out',
   zIndex: 99,
   pointerEvents: props.canScroll ? 'auto' : 'none',
@@ -52,6 +53,7 @@ const StyledThumb = styled.div(
     right: 0,
     borderRadius: props.wide ? '6px' : '4px',
     width: props.wide ? '12px' : '8px',
+    willChange: 'width, border-radius, height, opacity, background-color',
     transition:
       'width 0.25s ease-in-out, border-radius 0.25s ease-in-out, height 0.25s ease-in-out, opacity 0.25s ease-in-out, background-color 0.1s ease-in-out',
     opacity: props.show ? 1 : 0,

--- a/gui/src/renderer/components/LoginStyles.tsx
+++ b/gui/src/renderer/components/LoginStyles.tsx
@@ -84,6 +84,7 @@ export const StyledFooter = styled.div({}, (props: { show: boolean }) => ({
   flexDirection: 'column',
   padding: '18px 22px 22px',
   backgroundColor: colors.darkBlue,
+  willChange: 'transform',
   transition: 'transform 250ms ease-in-out',
 }));
 
@@ -134,6 +135,7 @@ export const StyledInputButton = styled.button((props: { visible: boolean }) => 
   alignItems: 'center',
   justifyContent: 'center',
   opacity: props.visible ? 1 : 0,
+  willChange: 'opacity',
   transition: 'opacity 250ms ease-in-out',
   backgroundColor: colors.green,
 }));

--- a/gui/src/renderer/components/Marquee.tsx
+++ b/gui/src/renderer/components/Marquee.tsx
@@ -12,7 +12,7 @@ const Text = styled.span({}, (props: { overflow: number; alignRight: boolean }) 
   // Prevents Container from adding 2px below the text.
   verticalAlign: 'middle',
   whiteSpace: 'nowrap',
-  willChange: 'transform',
+  willChange: props.overflow > 0 ? 'transform' : 'auto',
   transform: props.alignRight ? `translate(${-props.overflow}px)` : 'translate(0)',
   transition: `transform linear ${props.overflow * 80}ms`,
 }));

--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -33,9 +33,13 @@ const ModalBackground = styled.div({}, (props: { visible: boolean }) => ({
   left: 0,
   right: 0,
   bottom: 0,
-  transition: 'all 150ms ease-out',
   pointerEvents: props.visible ? 'auto' : 'none',
   zIndex: 2,
+
+  willChange: 'background-color, backdrop-filter',
+  transitionProperty: 'background-color, backdrop-filter',
+  transitionDuration: '150ms',
+  transitionTimingFunction: 'ease-out',
 }));
 
 export const StyledModalContainer = styled.div({
@@ -126,7 +130,11 @@ const StyledModalAlert = styled.div({}, (props: { visible: boolean; closing: boo
     opacity: props.visible && !props.closing ? 1 : 0,
     transform,
     boxShadow: ' 0px 15px 35px 5px rgba(0,0,0,0.5)',
-    transition: 'all 150ms ease-out',
+
+    willChange: 'transform, opacity',
+    transitionProperty: 'transform, opacity',
+    transitionDuration: '150ms',
+    transitionTimingFunction: 'ease-out',
   };
 });
 

--- a/gui/src/renderer/components/NavigationBarStyles.tsx
+++ b/gui/src/renderer/components/NavigationBarStyles.tsx
@@ -35,6 +35,7 @@ export const StyledTitleBarItemLabel = styled.h1(normalText, (props: { visible?:
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   opacity: props.visible ? 1 : 0,
+  willChange: 'opacity',
   transition: 'opacity 250ms ease-in-out',
 }));
 

--- a/gui/src/renderer/components/NotificationBanner.tsx
+++ b/gui/src/renderer/components/NotificationBanner.tsx
@@ -119,6 +119,7 @@ const Collapsible = styled.div({}, (props: ICollapsibleProps) => {
     backgroundColor: 'rgba(25, 38, 56, 0.95)',
     overflow: 'hidden',
     // Using auto as the initial value prevents transition if a notification is visible on mount.
+    willChange: 'height',
     height: props.contentHeight === undefined ? 'auto' : `${props.contentHeight}px`,
     transition: `height ${duration}ms ease-in-out`,
   };

--- a/gui/src/renderer/components/SvgMap.tsx
+++ b/gui/src/renderer/components/SvgMap.tsx
@@ -31,6 +31,7 @@ const mapStyle = {
   backgroundColor: '#192e45',
 };
 const zoomableGroupStyle: React.CSSProperties = {
+  willChange: 'transform',
   transition: `transform ${MOVE_SPEED}ms ease-out`,
   // Workaround to prevent map blurryness in Electron 13+
   zoom: '100.01%',
@@ -40,6 +41,7 @@ function getMarkerImageStyle(zoom: number) {
   return {
     width: '60px',
     transform: `translate(${-30 / zoom}px, ${-30 / zoom}px) scale(${1 / zoom})`,
+    willChange: 'transform',
     transition: `transform ${MOVE_SPEED}ms ease-out`,
   };
 }

--- a/gui/src/renderer/components/Switch.tsx
+++ b/gui/src/renderer/components/Switch.tsx
@@ -35,12 +35,17 @@ const Knob = styled.div({}, (props: { isOn: boolean; disabled: boolean }) => {
     position: 'absolute',
     height: '22px',
     borderRadius: '11px',
-    transition: 'all 200ms linear',
     width: '22px',
     backgroundColor,
+    left: '2px',
     // When enabled the button should be placed all the way to the right (100%) minus padding (2px)
     // minus it's own width (22px).
-    left: props.isOn ? 'calc(100% - 2px - 22px)' : '2px',
+    transform: props.isOn ? 'translateX(18px)' : 'translateX(0)',
+
+    willChange: 'background-color, transform',
+    transitionProperty: 'background-color, transform',
+    transitionDuration: '200ms',
+    transitionTimingFunction: 'linear',
   };
 });
 

--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -60,6 +60,7 @@ export const StyledTransitionContent = styled.div({}, (props: { transition?: IIt
     bottom: 0,
     zIndex: props.transition?.inFront ? 1 : 0,
     transform: `translate(${x}, ${y})`,
+    willChange: 'transform',
     transition: `transform ${duration}ms ease-in-out`,
   };
 });


### PR DESCRIPTION
This PR aims to optimize transitions by adding the `will-change` CSS property and better define `transition-property` instead of using `all` for some transitions.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3384)
<!-- Reviewable:end -->
