### PR TITLE
Improve tunnel bypass while in the connecting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix the sometimes incorrect time added text after adding time to the account.
 - Fix scrollbar no longer responsive and usable when covered by other elements.
+- Improve tunnel bypass for the API sometimes not working in the connecting state.
 
 ### Security
 #### Android


### PR DESCRIPTION
The bypass feature for the API previously did not work very well in the connecting state. This is because the default/1-prefix-routes were added before connectivity had been established, so requests were sent inside a possibly non-functional tunnel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3385)
<!-- Reviewable:end -->
