### PR TITLE
Propagate new WindowController to TrayIconController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix scrollbar no longer responsive and usable when covered by other elements.
 - Improve tunnel bypass for the API sometimes not working in the connecting state.
 
+#### Windows
+- Fix "Open Mullvad VPN" tray context menu item not working after toggling unpinned window setting.
+
 ### Security
 #### Android
 - Prevent location request responses from being received outside the tunnel when in the connected

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -594,6 +594,7 @@ class ApplicationMain {
 
       this.installWindowCloseHandler(this.windowController);
       this.installTrayClickHandlers();
+      this.trayIconController?.setWindowController(this.windowController);
 
       const filePath = path.resolve(path.join(__dirname, '../renderer/index.html'));
       try {

--- a/gui/src/main/tray-icon-controller.ts
+++ b/gui/src/main/tray-icon-controller.ts
@@ -45,6 +45,10 @@ export default class TrayIconController {
     }
   }
 
+  public setWindowController(windowController: WindowController) {
+    this.windowController = windowController;
+  }
+
   get iconType(): TrayIconType {
     return this.iconTypeValue;
   }


### PR DESCRIPTION
This PR propagates the new `WindowController` to `TrayIconController`. Not having the latest `WindowController` prevented the `Open Mullvad VPN` context menu item from working after switching between pinned/unpinned on Windows.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
