### PR TITLE
Shrink connection panel header to the size of its content

### DIFF
--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -46,6 +46,11 @@ interface IProps {
   className?: string;
 }
 
+const Container = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
 const Row = styled.div({
   display: 'flex',
   marginTop: '3px',
@@ -67,6 +72,7 @@ const IpAddresses = styled.div({
 });
 
 const Header = styled.div({
+  alignSelf: 'start',
   display: 'flex',
   alignItems: 'center',
 });
@@ -77,7 +83,7 @@ export default class ConnectionPanel extends React.Component<IProps> {
     const entryPoint = this.getEntryPoint();
 
     return (
-      <div className={this.props.className}>
+      <Container className={this.props.className}>
         {this.props.hostname && (
           <Header>
             <ConnectionPanelDisclosure pointsUp={this.props.isOpen} onToggle={this.props.onToggle}>
@@ -114,7 +120,7 @@ export default class ConnectionPanel extends React.Component<IProps> {
             )}
           </React.Fragment>
         )}
-      </div>
+      </Container>
     );
   }
 


### PR DESCRIPTION
This PR shrinks the width of the connection panel header to the size of its content. Previously it was possible to click to the right of the label and chevron to open it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3393)
<!-- Reviewable:end -->
