### PR TITLE
Fix REST request factory timeouts

### DIFF
--- a/mullvad-rpc/src/rest.rs
+++ b/mullvad-rpc/src/rest.rs
@@ -415,12 +415,13 @@ impl RequestFactory {
             HeaderValue::from_static("application/json"),
         );
 
-        Ok(RestRequest::from(request))
+        Ok(self.set_request_timeout(RestRequest::from(request)))
     }
 
     pub fn delete(&self, path: &str) -> Result<RestRequest> {
         self.hyper_request(path, Method::DELETE)
             .map(RestRequest::from)
+            .map(|req| self.set_request_timeout(req))
     }
 
     fn hyper_request(&self, path: &str, method: Method) -> Result<Request> {


### PR DESCRIPTION
The request factory does not always correctly set timeouts correctly. This PR fixes this. The issue is fairly harmless as the default timeout is 10 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3401)
<!-- Reviewable:end -->
