### PR TITLE
Don't log an error if the target state cache cannot be removed on exit

### DIFF
--- a/mullvad-daemon/src/target_state.rs
+++ b/mullvad-daemon/src/target_state.rs
@@ -95,10 +95,12 @@ impl PersistentTargetState {
             return;
         }
         let _ = fs::remove_file(&self.cache_path).await.map_err(|error| {
-            log::error!(
-                "{}",
-                error.display_chain_with_msg("Cannot delete target tunnel state cache")
-            );
+            if error.kind() != io::ErrorKind::NotFound {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Cannot delete target tunnel state cache")
+                );
+            }
         });
         // prevent the sync destructor from running
         self.locked = true;
@@ -134,10 +136,12 @@ impl Drop for PersistentTargetState {
             return;
         }
         let _ = std::fs::remove_file(&self.cache_path).map_err(|error| {
-            log::error!(
-                "{}",
-                error.display_chain_with_msg("Cannot delete target tunnel state cache")
-            );
+            if error.kind() != io::ErrorKind::NotFound {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Cannot delete target tunnel state cache")
+                );
+            }
         });
     }
 }


### PR DESCRIPTION
Minor cleanup. An error is logged if there's no target state file on exit. This is actually expected behavior if the target state hasn't been set at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3402)
<!-- Reviewable:end -->
