### PR TITLE
Suppress false positive Android CVE

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -30,6 +30,7 @@ allprojects {
 
     configure<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension> {
         failBuildOnCVSS = 0F // All severity levels
+        suppressionFile = "${rootProject.projectDir}/config/dependency-check-suppression.xml"
     }
 }
 

--- a/android/config/dependency-check-suppression.xml
+++ b/android/config/dependency-check-suppression.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        This CVE only affect Multiplatform Gradle Projects, which this project is not.
+        ]]></notes>
+        <cve>CVE-2022-24329</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
The CVE (CVE-2022-24329) only affects "Multiplatform Gradle Projects" according to the CVE description, which this project is not, and therefore it's considered a false positive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3405)
<!-- Reviewable:end -->
