### PR TITLE
Placate Rust audit CI job 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
As described [here](https://rustsec.org/advisories/RUSTSEC-2022-0013), it is possible to construct regexes that take arbitrary amounts of time to compile. This PR upgrades `regex` to 1.5.5, which fixes this. Note that it doesn't affect the app, however, as all regexes are effectively constants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3406)
<!-- Reviewable:end -->
