### PR TITLE
Shut down REST request service when all handles have been dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix the sometimes incorrect time added text after adding time to the account.
 - Fix scrollbar no longer responsive and usable when covered by other elements.
 - Improve tunnel bypass for the API sometimes not working in the connecting state.
+- Fix resource leak caused by location check.
 
 #### Windows
 - Fix "Open Mullvad VPN" tray context menu item not working after toggling unpinned window setting.


### PR DESCRIPTION
Since the dawn of time, the REST request service has owned a copy of its own command sender. Because of this, the actor never stops waiting for commands to process. This is made apparent by the fact that sockets remain open long after location lookups are made. Notably, it also means that the lookup RPC previously leaked some memory every time it was called.

The PR fixes this by only keeping a weak reference to the sender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3407)
<!-- Reviewable:end -->
