### PR TITLE
Remove go runtime from GUI process

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		5806768127048EE000C858CB /* KeychainMatchLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FAEDFC24533A5500CB0F5B /* KeychainMatchLimit.swift */; };
 		5806768227048F6800C858CB /* AnyOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E1337026D2BE9C00CC316B /* AnyOptional.swift */; };
 		5806768327048F7A00C858CB /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585DA8AE26B9492500B8C587 /* Promise.swift */; };
+		5807483B27DB8A980020ECBF /* WireGuardKitTypes in Frameworks */ = {isa = PBXBuildFile; productRef = 5807483A27DB8A980020ECBF /* WireGuardKitTypes */; };
 		5807E2C02432038B00F5FF30 /* String+Split.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E2BF2432038B00F5FF30 /* String+Split.swift */; };
 		5807E2C2243203D000F5FF30 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E2C1243203D000F5FF30 /* StringTests.swift */; };
 		5807E2C3243203E700F5FF30 /* String+Split.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E2BF2432038B00F5FF30 /* String+Split.swift */; };
@@ -246,7 +247,6 @@
 		58BA692E23E99EFF009DC256 /* Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA692D23E99EFF009DC256 /* Locking.swift */; };
 		58BA693123EADA6A009DC256 /* SimulatorTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */; };
 		58BA791B2578F092006FAEA0 /* WireGuardKit in Frameworks */ = {isa = PBXBuildFile; productRef = 58BA791A2578F092006FAEA0 /* WireGuardKit */; };
-		58BA7947257901A5006FAEA0 /* WireGuardKit in Frameworks */ = {isa = PBXBuildFile; productRef = 58BA7946257901A5006FAEA0 /* WireGuardKit */; };
 		58BFA5C622A7C97F00A6173D /* RelayCacheTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5C522A7C97F00A6173D /* RelayCacheTracker.swift */; };
 		58BFA5CC22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
 		58BFA5CD22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
@@ -624,8 +624,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5807483B27DB8A980020ECBF /* WireGuardKitTypes in Frameworks */,
 				585834F824D2BC1F00A8AF56 /* Logging in Frameworks */,
-				58BA7947257901A5006FAEA0 /* WireGuardKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1115,7 +1115,7 @@
 			name = MullvadVPN;
 			packageProductDependencies = (
 				585834F724D2BC1F00A8AF56 /* Logging */,
-				58BA7946257901A5006FAEA0 /* WireGuardKit */,
+				5807483A27DB8A980020ECBF /* WireGuardKitTypes */,
 			);
 			productName = MullvadVPN;
 			productReference = 58CE5E60224146200008646E /* MullvadVPN.app */;
@@ -2193,15 +2193,20 @@
 		};
 		58BA79192578F092006FAEA0 /* XCRemoteSwiftPackageReference "wireguard-apple" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://git.zx2c4.com/wireguard-apple";
+			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
-				kind = revision;
-				revision = 7dea71898d7d11495c7bb9a0b4f8215ae2efe53f;
+				branch = "mullvad-master";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5807483A27DB8A980020ECBF /* WireGuardKitTypes */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 58BA79192578F092006FAEA0 /* XCRemoteSwiftPackageReference "wireguard-apple" */;
+			productName = WireGuardKitTypes;
+		};
 		584789EB2652A1A2000E45FB /* Logging */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 585834F624D2BC1F00A8AF56 /* XCRemoteSwiftPackageReference "swift-log" */;
@@ -2223,11 +2228,6 @@
 			productName = WireGuardKit;
 		};
 		58BA791A2578F092006FAEA0 /* WireGuardKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 58BA79192578F092006FAEA0 /* XCRemoteSwiftPackageReference "wireguard-apple" */;
-			productName = WireGuardKit;
-		};
-		58BA7946257901A5006FAEA0 /* WireGuardKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 58BA79192578F092006FAEA0 /* XCRemoteSwiftPackageReference "wireguard-apple" */;
 			productName = WireGuardKit;

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,10 @@
       },
       {
         "package": "WireGuardKit",
-        "repositoryURL": "https://git.zx2c4.com/wireguard-apple",
+        "repositoryURL": "https://github.com/mullvad/wireguard-apple.git",
         "state": {
-          "branch": null,
-          "revision": "7dea71898d7d11495c7bb9a0b4f8215ae2efe53f",
+          "branch": "mullvad-master",
+          "revision": "736a4bb5baba4e2c70686f59416d50c3b06e8424",
           "version": null
         }
       }

--- a/ios/MullvadVPN/IPAddressRange+Codable.swift
+++ b/ios/MullvadVPN/IPAddressRange+Codable.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import struct WireGuardKit.IPAddressRange
+import struct WireGuardKitTypes.IPAddressRange
 
 extension IPAddressRange: Codable {
     public func encode(to encoder: Encoder) throws {

--- a/ios/MullvadVPN/PrivateKeyWithMetadata.swift
+++ b/ios/MullvadVPN/PrivateKeyWithMetadata.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import class WireGuardKit.PrivateKey
-import class WireGuardKit.PublicKey
+import class WireGuardKitTypes.PrivateKey
+import class WireGuardKitTypes.PublicKey
 
 /// A struct holding a private WireGuard key with associated metadata
 struct PrivateKeyWithMetadata: Equatable {

--- a/ios/MullvadVPN/REST/RESTClient.swift
+++ b/ios/MullvadVPN/REST/RESTClient.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 import Network
-import class WireGuardKit.PublicKey
-import struct WireGuardKit.IPAddressRange
+import class WireGuardKitTypes.PublicKey
+import struct WireGuardKitTypes.IPAddressRange
 
 extension REST {
 

--- a/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import class WireGuardKit.PublicKey
+import class WireGuardKitTypes.PublicKey
 import Logging
 
 class SetAccountOperation: AsyncOperation {

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -11,7 +11,7 @@ import Foundation
 import NetworkExtension
 import UIKit
 import Logging
-import class WireGuardKit.PublicKey
+import class WireGuardKitTypes.PublicKey
 
 /// A class that provides a convenient interface for VPN tunnels configuration, manipulation and
 /// monitoring.

--- a/ios/MullvadVPN/TunnelSettings.swift
+++ b/ios/MullvadVPN/TunnelSettings.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 import struct Network.IPv4Address
-import class WireGuardKit.PublicKey
-import struct WireGuardKit.IPAddressRange
+import class WireGuardKitTypes.PublicKey
+import struct WireGuardKitTypes.IPAddressRange
 
 /// A struct that holds a tun interface configuration.
 struct InterfaceSettings: Codable, Equatable {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Based on the recently merged PR:  https://github.com/mullvad/wireguard-apple/pull/2

- GUI app shall use `WireGuardKitTypes` when it needs to work with data structs used by `WireGuardKit`.
- Packet tunnel shall continue using `WireGuardKit` which links against `wg-go` that comes with go runtime. This is expected. `WireGuardKit` also re-exports `WireGuardKitTypes` so there is no need to import it individually in the packet tunnel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3423)
<!-- Reviewable:end -->
