### PR TITLE
Fix migration from Windows.old and system user app data when updating

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -174,8 +174,11 @@ mod windows {
     };
 
     const MIGRATION_DIRNAME: &str = "windows.old";
-    const MIGRATE_FILES: [(&str, bool); 2] =
-        [("settings.json", true), ("account-history.json", false)];
+    const MIGRATE_FILES: [(&str, bool); 3] = [
+        ("settings.json", true),
+        ("device.json", true),
+        ("account-history.json", false),
+    ];
 
     #[derive(err_derive::Error, Debug)]
     #[error(no_from)]

--- a/windows/nsis-plugins/src/cleanup/cleaningops.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleaningops.cpp
@@ -153,6 +153,7 @@ void MigrateCacheServiceUser()
 
 		notNamedSet->addObject(L"account-history.json");
 		notNamedSet->addObject(L"settings.json");
+		notNamedSet->addObject(L"device.json");
 
 		files.addFilter(std::move(notNamedSet));
 		files.addFilter(std::make_unique<common::fs::FilterFiles>());


### PR DESCRIPTION
This PR fixes two oversights:
* When updating or reinstalling the app, `device.json` was incorrectly moved to `C:\ProgramData\Mullvad VPN\cache`.
* After larger Windows updates, `device.json` was not moved from `C:\Windows.old\System32\config\systemprofile\AppData\Local\Mullvad VPN` to the new directory.