### PR TITLE
Begin listening to route changes before initializing the current default route

### DIFF
--- a/windows/winnet/src/winnet/routing/defaultroutemonitor.cpp
+++ b/windows/winnet/src/winnet/routing/defaultroutemonitor.cpp
@@ -29,13 +29,7 @@ DefaultRouteMonitor::DefaultRouteMonitor
 		TWO_SECOND_INTERFERENCE
 	))
 {
-	try
-	{
-		m_bestRoute = GetBestDefaultRoute(m_family);
-	}
-	catch (...)
-	{
-	}
+	std::scoped_lock<std::mutex> lock(m_evaluationLock);
 
 	auto status = NotifyRouteChange2(AF_UNSPEC, RouteChangeCallback, this, FALSE, &m_routeNotificationHandle);
 
@@ -51,6 +45,14 @@ DefaultRouteMonitor::DefaultRouteMonitor
 	{
 		CancelMibChangeNotify2(m_routeNotificationHandle);
 		THROW_WINDOWS_ERROR(status, "Register for network interface change notifications");
+	}
+
+	try
+	{
+		m_bestRoute = GetBestDefaultRoute(m_family);
+	}
+	catch (...)
+	{
 	}
 }
 


### PR DESCRIPTION
The potential for this to cause any issues is probably very small, but surely the route monitoring must start before the initial default route is obtained. Otherwise there's a chance that a route change is missed immediately after fetching the initial route.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3426)
<!-- Reviewable:end -->
