### PR TITLE
Restructure WireGuard obfuscation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add toggle for split tunneling state.
 
 ### Changed
+- Update settings format to `v6`.
+- Move WireGuard TCP obfuscation settings into `mullvad obfuscation` command in CLI.
 - Decrease the size of fonts, some icons and other design elements in the desktop app. This makes it
   possible to fit more into the same area and makes text easier to read.
 - Don't block the tunnel state machine while starting the tunnel monitor. This also means that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,19 +1890,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
@@ -3130,7 +3117,7 @@ dependencies = [
  "triggered",
  "trust-dns-server",
  "tun",
- "udp-over-tcp",
+ "tunnel-obfuscation",
  "uuid",
  "which",
  "widestring 0.5.1",
@@ -3632,6 +3619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tunnel-obfuscation"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "err-derive",
+ "futures",
+ "tokio",
+ "udp-over-tcp",
+]
+
+[[package]]
 name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3646,14 +3644,14 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 [[package]]
 name = "udp-over-tcp"
 version = "0.1.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=1e27324362ed123b61fa2062b1599e5f9d569796#1e27324362ed123b61fa2062b1599e5f9d569796"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=27b9519b63244736b6f3c7c4af60976c88dc6b95#27b9519b63244736b6f3c7c4af60976c88dc6b95"
 dependencies = [
  "env_logger 0.8.4",
  "err-context",
  "futures",
  "lazy_static",
  "log",
- "nix 0.20.2",
+ "nix 0.23.1",
  "structopt",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "talpid-dbus",
     "talpid-platform-metadata",
     "mullvad-management-interface",
+    "tunnel-obfuscation",
 ]
 exclude = ["dist-assets/binaries/shadowsocks-rust"]
 

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -1206,7 +1206,7 @@ function convertFromWireguardConstraints(
     entryLocation: 'any',
   };
 
-  const port = constraints.getPort()?.getPort();
+  const port = constraints.getPort();
   if (port) {
     result.port = { only: port };
   }
@@ -1332,10 +1332,7 @@ function convertToWireguardConstraints(
 
     const port = liftConstraint(constraint.port);
     if (port) {
-      const portConstraints = new grpcTypes.TransportPort();
-      portConstraints.setPort(port);
-      portConstraints.setProtocol(grpcTypes.TransportProtocol.UDP);
-      wireguardConstraints.setPort(portConstraints);
+      wireguardConstraints.setPort(port);
     }
 
     const ipVersion = liftConstraint(constraint.ipVersion);

--- a/mullvad-api/src/relay_list.rs
+++ b/mullvad-api/src/relay_list.rs
@@ -4,7 +4,7 @@ use crate::rest;
 
 use hyper::{header, Method, StatusCode};
 use mullvad_types::{location, relay_list};
-use talpid_types::net::{wireguard, TransportProtocol};
+use talpid_types::net::wireguard;
 
 use std::{
     collections::BTreeMap,
@@ -182,7 +182,6 @@ impl ServerRelayList {
                 ipv4_gateway,
                 ipv6_gateway,
                 public_key,
-                protocol: TransportProtocol::Udp,
             };
 
         for mut wireguard_relay in relays {
@@ -315,6 +314,7 @@ fn relay(relay: Relay, location: location::Location) -> relay_list::Relay {
         weight: relay.weight,
         tunnels: Default::default(),
         bridges: Default::default(),
+        obfuscators: Default::default(),
         location: Some(location),
     }
 }

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -28,6 +28,9 @@ pub use self::dns::Dns;
 mod lan;
 pub use self::lan::Lan;
 
+mod obfuscation;
+pub use self::obfuscation::Obfuscation;
+
 mod reconnect;
 pub use self::reconnect::Reconnect;
 
@@ -64,6 +67,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         Box::new(Dns),
         Box::new(Reconnect),
         Box::new(Lan),
+        Box::new(Obfuscation),
         Box::new(Relay),
         Box::new(Reset),
         #[cfg(any(target_os = "linux", windows))]

--- a/mullvad-cli/src/cmds/obfuscation.rs
+++ b/mullvad-cli/src/cmds/obfuscation.rs
@@ -1,0 +1,134 @@
+use crate::{new_rpc_client, Command, Result};
+
+use mullvad_management_interface::{types as grpc_types, ManagementServiceClient};
+
+use mullvad_types::relay_constraints::{ObfuscationSettings, SelectedObfuscation};
+
+use std::convert::TryFrom;
+
+pub struct Obfuscation;
+
+#[mullvad_management_interface::async_trait]
+impl Command for Obfuscation {
+    fn name(&self) -> &'static str {
+        "obfuscation"
+    }
+
+    fn clap_subcommand(&self) -> clap::App<'static> {
+        clap::App::new(self.name())
+            .about("Manage use of obfuscators")
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+            .subcommand(create_obfuscation_set_subcommand())
+            .subcommand(create_obfuscation_get_subcommand())
+    }
+
+    async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("set", set_matches)) => Self::handle_set(set_matches).await,
+            Some(("get", get_matches)) => Self::handle_get(get_matches).await,
+            _ => unreachable!("unhandled command"),
+        }
+    }
+}
+
+impl Obfuscation {
+    async fn handle_set(matches: &clap::ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("mode", mode_matches)) => {
+                let obfuscator_type = mode_matches.value_of("mode").unwrap();
+                let mut rpc = new_rpc_client().await?;
+                let mut settings = Self::get_obfuscation_settings(&mut rpc).await?;
+                settings.selected_obfuscation = match obfuscator_type {
+                    "auto" => SelectedObfuscation::Auto,
+                    "off" => SelectedObfuscation::Off,
+                    "udp2tcp" => SelectedObfuscation::Udp2Tcp,
+                    _ => unreachable!("Unhandled obfuscator mode"),
+                };
+                Self::set_obfuscation_settings(&mut rpc, &settings).await?;
+            }
+            Some(("udp2tcp-settings", settings_matches)) => {
+                let port: String = settings_matches.value_of_t_or_exit("port");
+                let mut rpc = new_rpc_client().await?;
+                let mut settings = Self::get_obfuscation_settings(&mut rpc).await?;
+                settings.udp2tcp.port = if port == "any" {
+                    mullvad_types::relay_constraints::Constraint::Any
+                } else {
+                    mullvad_types::relay_constraints::Constraint::Only(
+                        port.parse::<u16>().expect("Invalid port number"),
+                    )
+                };
+                Self::set_obfuscation_settings(&mut rpc, &settings).await?;
+            }
+            _ => unreachable!("unhandled command"),
+        }
+        Ok(())
+    }
+
+    async fn handle_get(matches: &clap::ArgMatches) -> Result<()> {
+        let mut rpc = new_rpc_client().await?;
+        let settings = Self::get_obfuscation_settings(&mut rpc).await?;
+        match matches.subcommand() {
+            Some(("udp2tcp-settings", _)) => println!("Udp2Tcp: {}", settings.udp2tcp),
+            _ => println!("Current settings: {}", settings),
+        }
+        Ok(())
+    }
+
+    async fn get_obfuscation_settings(
+        rpc: &mut ManagementServiceClient,
+    ) -> Result<ObfuscationSettings> {
+        let settings = rpc.get_settings(()).await?.into_inner();
+
+        let obfuscation_settings = ObfuscationSettings::try_from(
+            settings
+                .obfuscation_settings
+                .expect("No obfuscation settings"),
+        )
+        .expect("failed to parse obfuscation settings");
+        Ok(obfuscation_settings)
+    }
+
+    async fn set_obfuscation_settings(
+        rpc: &mut ManagementServiceClient,
+        settings: &ObfuscationSettings,
+    ) -> Result<()> {
+        let grpc_settings: grpc_types::ObfuscationSettings = settings.into();
+        let _ = rpc.set_obfuscation_settings(grpc_settings).await?;
+        Ok(())
+    }
+}
+
+fn create_obfuscation_set_subcommand() -> clap::App<'static> {
+    clap::App::new("set")
+        .about("Set obfuscation settings")
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(
+            clap::App::new("mode").about("Set obfuscation mode").arg(
+                clap::Arg::new("mode")
+                    .help("Specifies what kind of obfuscation should be used, if any")
+                    .required(true)
+                    .index(1)
+                    .possible_values(&["auto", "off", "udp2tcp"]),
+            ),
+        )
+        .subcommand(
+            clap::App::new("udp2tcp-settings")
+                .about("Specifies the config for the udp2tcp obfuscator")
+                .setting(clap::AppSettings::ArgRequiredElseHelp)
+                .arg(
+                    clap::Arg::new("port")
+                        .help("TCP port of remote endpoint. Either 'any' or a specific port")
+                        .long("port")
+                        .takes_value(true),
+                ),
+        )
+}
+
+fn create_obfuscation_get_subcommand() -> clap::App<'static> {
+    clap::App::new("get")
+        .about("Get obfuscation settings")
+        .subcommand(
+            clap::App::new("udp2tcp-settings")
+                .about("Specifies the config for the udp2tcp obfuscator"),
+        )
+}

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -61,14 +61,6 @@ impl Command for Relay {
                                         .multiple_values(true),
                                 )
                                 .arg(
-                                    clap::Arg::new("protocol")
-                                        .help("Transport protocol. If TCP is selected, traffic is \
-                                               sent over TCP using a udp-over-tcp proxy")
-                                        .long("protocol")
-                                        .default_value("udp")
-                                        .possible_values(&["udp", "tcp"]),
-                                )
-                                .arg(
                                     clap::Arg::new("v6-gateway")
                                         .help("IPv6 gateway address")
                                         .long("v6-gateway")
@@ -161,14 +153,6 @@ impl Command for Relay {
                                         clap::Arg::new("port")
                                             .help("Port to use. Either 'any' or a specific port")
                                             .long("port")
-                                            .takes_value(true),
-                                    )
-                                    .arg(
-                                        clap::Arg::new("transport protocol")
-                                            .help("Transport protocol. If TCP is selected, traffic is \
-                                                   sent over TCP using a udp-over-tcp proxy")
-                                            .long("protocol")
-                                            .possible_values(&["any", "udp", "tcp"])
                                             .takes_value(true),
                                     )
                                     .arg(
@@ -310,8 +294,6 @@ impl Relay {
                 _ => e.exit(),
             },
         };
-        let protocol: String = matches.value_of_t_or_exit("protocol");
-        let protocol = Self::validate_transport_protocol(&protocol);
         let mut private_key_str = String::new();
         println!("Reading private key from standard input");
         let _ = io::stdin().lock().read_line(&mut private_key_str);
@@ -341,7 +323,6 @@ impl Relay {
                                 .collect(),
                             endpoint: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
                                 .to_string(),
-                            protocol: protocol as i32,
                         }),
                         ipv4_gateway: ipv4_gateway.to_string(),
                         ipv6_gateway: ipv6_gateway
@@ -547,8 +528,12 @@ impl Relay {
         let mut rpc = new_rpc_client().await?;
         let mut wireguard_constraints = self.get_wireguard_constraints(&mut rpc).await?;
 
-        wireguard_constraints.port =
-            parse_transport_port(matches, &mut wireguard_constraints.port)?;
+        if let Some(port) = matches.value_of("port") {
+            wireguard_constraints.port = match parse_port_constraint(port)? {
+                Constraint::Any => 0,
+                Constraint::Only(specific_port) => u32::from(specific_port),
+            }
+        }
 
         if let Some(ipv) = matches.value_of("ip version") {
             wireguard_constraints.ip_version =

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -5,7 +5,8 @@ use mullvad_management_interface::types::{
     },
     tunnel_state,
     tunnel_state::State::*,
-    ErrorState, ProxyType, TransportProtocol, TunnelEndpoint, TunnelState, TunnelType,
+    ErrorState, ObfuscationType, ProxyType, TransportProtocol, TunnelEndpoint, TunnelState,
+    TunnelType,
 };
 use mullvad_types::auth_failed::AuthFailed;
 use std::fmt::Write;
@@ -78,6 +79,24 @@ fn format_endpoint(endpoint: &TunnelEndpoint) -> String {
                     entry_endpoint.address,
                     format_protocol(
                         TransportProtocol::from_i32(entry_endpoint.protocol)
+                            .expect("invalid transport protocol")
+                    )
+                )
+                .unwrap();
+            }
+            if let Some(ref obfuscation) = endpoint.obfuscation {
+                write!(
+                    &mut out,
+                    " via {} {}:{} over {}",
+                    match ObfuscationType::from_i32(obfuscation.obfuscation_type)
+                        .expect("invalid obfuscation type")
+                    {
+                        ObfuscationType::Udp2tcp => "Udp2Tcp",
+                    },
+                    obfuscation.address,
+                    obfuscation.port,
+                    format_protocol(
+                        TransportProtocol::from_i32(obfuscation.protocol)
                             .expect("invalid transport protocol")
                     )
                 )

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -41,8 +41,8 @@ use mullvad_types::{
     endpoint::MullvadEndpoint,
     location::{Coordinates, GeoIpLocation},
     relay_constraints::{
-        BridgeSettings, BridgeState, Constraint, InternalBridgeConstraints, RelaySettings,
-        RelaySettingsUpdate,
+        BridgeSettings, BridgeState, Constraint, InternalBridgeConstraints, ObfuscationSettings,
+        RelaySettings, RelaySettingsUpdate, SelectedObfuscation,
     },
     relay_list::{Relay, RelayList},
     settings::{DnsOptions, DnsState, Settings},
@@ -154,6 +154,9 @@ pub enum Error {
 
     #[error(display = "No bridge available")]
     NoBridgeAvailable,
+
+    #[error(display = "Failed to select a compatible obfuscator")]
+    NoObfuscator,
 
     #[error(display = "No matching entry relay was found")]
     NoEntryRelayAvailable,
@@ -318,6 +321,8 @@ pub enum DaemonCommand {
     /// Notify the split tunnel monitor that a volume was mounted or dismounted
     #[cfg(target_os = "windows")]
     CheckVolumes(ResponseTx<(), Error>),
+    /// Register settings for WireGuard obfuscator
+    SetObfuscationSettings(ResponseTx<(), settings::Error>, ObfuscationSettings),
     /// Makes the daemon exit the main loop and quit.
     Shutdown,
     /// Saves the target tunnel state and enters a blocking state. The state is restored
@@ -1043,6 +1048,7 @@ where
                         let result = self
                             .create_tunnel_parameters(
                                 &exit_relay,
+                                &entry_relay,
                                 endpoint,
                                 device.token,
                                 retry_attempt,
@@ -1084,6 +1090,7 @@ where
     async fn create_tunnel_parameters(
         &mut self,
         relay: &Relay,
+        entry_relay: &Option<Relay>,
         endpoint: MullvadEndpoint,
         account_token: String,
         retry_attempt: u32,
@@ -1169,6 +1176,29 @@ where
                         wg_data.addresses.ipv6_address.ip().into(),
                     ],
                 };
+
+                let obfuscation = match self.settings.obfuscation_settings.selected_obfuscation {
+                    SelectedObfuscation::Off | SelectedObfuscation::Auto
+                        if !self
+                            .relay_selector
+                            .should_use_auto_obfuscator(retry_attempt) =>
+                    {
+                        None
+                    }
+                    _ => {
+                        let obfuscator = self
+                            .relay_selector
+                            .get_obfuscator(
+                                &self.settings.obfuscation_settings,
+                                entry_relay.as_ref().unwrap_or(relay),
+                                &endpoint,
+                                retry_attempt,
+                            )
+                            .ok_or(Error::NoObfuscator)?;
+                        Some(obfuscator)
+                    }
+                };
+
                 Ok(wireguard::TunnelParameters {
                     connection: wireguard::ConnectionConfig {
                         tunnel,
@@ -1179,6 +1209,7 @@ where
                     },
                     options: tunnel_options.wireguard.options,
                     generic_options: tunnel_options.generic,
+                    obfuscation,
                 }
                 .into())
             }
@@ -1280,6 +1311,9 @@ where
             UseWireGuardNt(tx, state) => self.on_use_wireguard_nt(tx, state).await,
             #[cfg(target_os = "windows")]
             CheckVolumes(tx) => self.on_check_volumes(tx).await,
+            SetObfuscationSettings(tx, settings) => {
+                self.on_set_obfuscation_settings(tx, settings).await
+            }
             Shutdown => self.trigger_shutdown_event(),
             PrepareRestart => self.on_prepare_restart(),
             #[cfg(target_os = "android")]
@@ -2211,6 +2245,30 @@ where
                     e.display_chain_with_msg("Failed to set new bridge settings")
                 );
                 Self::oneshot_send(tx, Err(e), "set_bridge_settings");
+            }
+        }
+    }
+
+    async fn on_set_obfuscation_settings(
+        &mut self,
+        tx: ResponseTx<(), settings::Error>,
+        new_settings: ObfuscationSettings,
+    ) {
+        match self.settings.set_obfuscation_settings(new_settings).await {
+            Ok(settings_changed) => {
+                if settings_changed {
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
+                    self.reconnect_tunnel();
+                }
+                Self::oneshot_send(tx, Ok(()), "set_obfuscation_settings");
+            }
+            Err(err) => {
+                log::error!(
+                    "{}",
+                    err.display_chain_with_msg("Failed to set obfuscation settings")
+                );
+                Self::oneshot_send(tx, Err(err), "set_obfuscation_settings");
             }
         }
     }

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -43,7 +43,6 @@ mod v1;
 mod v2;
 mod v3;
 mod v4;
-// Not yet done. Add to this instead of creating v6 for now.
 mod v5;
 
 const SETTINGS_FILE: &str = "settings.json";

--- a/mullvad-daemon/src/migrations/v5.rs
+++ b/mullvad-daemon/src/migrations/v5.rs
@@ -1,11 +1,50 @@
 use super::{Error, Result};
-use mullvad_types::settings::SettingsVersion;
+use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
 
 // ======================================================
 // Section for vendoring types and values that
 // this settings version depend on. See `mod.rs`.
 
 pub type AccountToken = String;
+
+/// Representation of a transport protocol, either UDP or TCP.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportProtocol {
+    /// Represents the UDP transport protocol.
+    Udp,
+    /// Represents the TCP transport protocol.
+    Tcp,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct TransportPort {
+    pub protocol: TransportProtocol,
+    pub port: Constraint<u16>,
+}
+
+/// Contains obfuscation settings
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ObfuscationSettings {
+    pub selected_obfuscation: SelectedObfuscation,
+    pub udp2tcp: Udp2TcpObfuscationSettings,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Udp2TcpObfuscationSettings {
+    pub port: Constraint<u16>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectedObfuscation {
+    Auto,
+    Off,
+    Udp2Tcp,
+}
 
 // ======================================================
 
@@ -14,13 +53,6 @@ pub(crate) struct MigrationData {
     pub wg_data: Option<serde_json::Value>,
 }
 
-/// This is an open ended migration. There is no v6 yet!
-/// The migrations performed by this function are still backwards compatible.
-/// The JSON coming out of this migration can be read by any v5 compatible daemon.
-///
-/// When further migrations are needed, add them here and if they are not backwards
-/// compatible then create v6 and "close" this migration for further modification.
-///
 /// # Changes to the format
 ///
 /// The ability to disable WireGuard multihop while preserving the entry location was added.
@@ -32,61 +64,105 @@ pub(crate) struct MigrationData {
 /// is null in order to make it default back to the default location.
 ///
 /// This also removes the account token and WireGuard key from the settings.
+///
+/// Additionally, the WireGuard protocol constraint, if set to be using TCP, is migrated into
+/// having an active Udp2Tcp obfuscator. The protocol constraint is then removed from WireGuard
+/// settings since all WireGuard traffic is UDP.
 pub(crate) async fn migrate(settings: &mut serde_json::Value) -> Result<Option<MigrationData>> {
     if !version_matches(settings) {
         return Ok(None);
     }
-    let wireguard_constraints = || -> Option<&serde_json::Value> {
-        settings
-            .get("relay_settings")?
-            .get("normal")?
-            .get("wireguard_constraints")
-    }();
-    if let Some(constraints) = wireguard_constraints {
-        if let Some(location) = constraints.get("entry_location") {
-            if constraints.get("use_multihop").is_none() {
+    if let Some(wireguard_constraints) = get_wireguard_constraints(settings) {
+        if let Some(location) = wireguard_constraints.get("entry_location") {
+            if wireguard_constraints.get("use_multihop").is_none() {
                 if location.is_null() {
                     // "Null" is no longer valid. It is not an option.
-                    settings["relay_settings"]["normal"]["wireguard_constraints"]
+                    wireguard_constraints
                         .as_object_mut()
                         .ok_or(Error::NoMatchingVersion)?
                         .remove("entry_location");
                 } else {
-                    settings["relay_settings"]["normal"]["wireguard_constraints"]["use_multihop"] =
-                        serde_json::json!(true);
+                    wireguard_constraints["use_multihop"] = serde_json::json!(true);
+                }
+            }
+        }
+        // The field `pub port: Constraint<TransportPort>` is now `pub port: Constraint<u16>`.
+        // Data is migrated as follows:
+        // If the existing field has `protocol == Tcp` configured, then we need to create a
+        // corresponding setting to enable the Udp2Tcp obfuscator. In this case, the port
+        // constraint is moved as well. Otherwise the existing port constraint is moved into
+        // the new field.
+        //
+        if let Some(port) = wireguard_constraints.get("port") {
+            let port_constraint: Constraint<TransportPort> =
+                serde_json::from_value(port.clone()).map_err(Error::ParseError)?;
+            if let Some(transport_port) = port_constraint.option() {
+                let (port, obfuscation_settings) = match transport_port.protocol {
+                    TransportProtocol::Udp => (serde_json::json!(transport_port.port), None),
+                    TransportProtocol::Tcp => (
+                        serde_json::json!(Constraint::<u16>::Any),
+                        Some(serde_json::json!(create_migrated_obfuscation_settings(
+                            transport_port.port
+                        ))),
+                    ),
+                };
+                wireguard_constraints["port"] = port;
+                if let Some(obfuscation_settings) = obfuscation_settings {
+                    settings["obfuscation_settings"] = obfuscation_settings;
                 }
             }
         }
     }
 
-    if let Some(token) = settings.get("account_token").filter(|t| !t.is_null()) {
+    let migration_data = if let Some(token) = settings.get("account_token").filter(|t| !t.is_null())
+    {
         let token: AccountToken =
             serde_json::from_value(token.clone()).map_err(Error::ParseError)?;
         let migration_data =
             if let Some(wg_data) = settings.get("wireguard").filter(|wg| !wg.is_null()) {
-                Ok(Some(MigrationData {
+                Some(MigrationData {
                     token,
                     wg_data: Some(wg_data.clone()),
-                }))
+                })
             } else {
-                Ok(Some(MigrationData {
+                Some(MigrationData {
                     token,
                     wg_data: None,
-                }))
+                })
             };
 
         let settings_map = settings.as_object_mut().ok_or(Error::NoMatchingVersion)?;
         settings_map.remove("account_token");
         settings_map.remove("wireguard");
 
-        return migration_data;
+        migration_data
+    } else {
+        None
+    };
+
+    settings["settings_version"] = serde_json::json!(SettingsVersion::V6);
+
+    Ok(migration_data)
+}
+
+fn get_wireguard_constraints(settings: &mut serde_json::Value) -> Option<&mut serde_json::Value> {
+    if let Some(relay_settings) = settings.get_mut("relay_settings") {
+        if let Some(normal) = relay_settings.get_mut("normal") {
+            return normal.get_mut("wireguard_constraints");
+        }
     }
+    None
+}
 
-    // Note: Not incrementing the version number yet, since this migration is still open
-    // for future modification.
-    // settings["settings_version"] = serde_json::json!(SettingsVersion::V6);
-
-    Ok(None)
+// Create an ObfuscationSettings struct that replaces the `protocol == TCP` setting
+// that was previously used on the wireguard constraints.
+// If a port is specified, this is the remote port to be used for Udp2Tcp.
+//
+fn create_migrated_obfuscation_settings(port: Constraint<u16>) -> ObfuscationSettings {
+    ObfuscationSettings {
+        selected_obfuscation: SelectedObfuscation::Udp2Tcp,
+        udp2tcp: Udp2TcpObfuscationSettings { port },
+    }
 }
 
 fn version_matches(settings: &mut serde_json::Value) -> bool {
@@ -101,7 +177,7 @@ mod test {
     use super::{migrate, version_matches};
     use serde_json;
 
-    pub const V5_SETTINGS_V1: &str = r#"
+    pub const V5_SETTINGS: &str = r#"
 {
   "account_token": "1234",
   "relay_settings": {
@@ -113,7 +189,12 @@ mod test {
       },
       "tunnel_protocol": "any",
       "wireguard_constraints": {
-        "port": "any",
+        "port": {
+            "only": {
+              "protocol": "tcp",
+              "port": "any"
+            }
+        },
         "ip_version": "any",
         "entry_location": "any"
       },
@@ -170,7 +251,7 @@ mod test {
 }
 "#;
 
-    pub const V5_SETTINGS_V2: &str = r#"
+    pub const V6_SETTINGS: &str = r#"
 {
   "relay_settings": {
     "normal": {
@@ -203,6 +284,12 @@ mod test {
       "location": "any"
     }
   },
+  "obfuscation_settings": {
+    "selected_obfuscation": "udp2_tcp",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
   "bridge_state": "auto",
   "allow_lan": true,
   "block_when_disconnected": false,
@@ -235,17 +322,17 @@ mod test {
       }
     }
   },
-  "settings_version": 5
+  "settings_version": 6
 }
 "#;
 
     #[tokio::test]
-    async fn test_v5_v1_migration() {
-        let mut old_settings = serde_json::from_str(V5_SETTINGS_V1).unwrap();
+    async fn test_v5_to_v6_migration() {
+        let mut old_settings = serde_json::from_str(V5_SETTINGS).unwrap();
 
         assert!(version_matches(&mut old_settings));
         migrate(&mut old_settings).await.unwrap();
-        let new_settings: serde_json::Value = serde_json::from_str(V5_SETTINGS_V2).unwrap();
+        let new_settings: serde_json::Value = serde_json::from_str(V6_SETTINGS).unwrap();
 
         assert_eq!(&old_settings, &new_settings);
     }

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "android"))]
 use futures::TryFutureExt;
 use mullvad_types::{
-    relay_constraints::{BridgeSettings, BridgeState, RelaySettingsUpdate},
+    relay_constraints::{BridgeSettings, BridgeState, ObfuscationSettings, RelaySettingsUpdate},
     settings::{DnsOptions, Settings},
     wireguard::RotationInterval,
 };
@@ -318,6 +318,18 @@ impl SettingsPersister {
         } else {
             false
         }
+    }
+
+    pub async fn set_obfuscation_settings(
+        &mut self,
+        obfuscation_settings: ObfuscationSettings,
+    ) -> Result<bool, Error> {
+        let should_save = Self::update_field(
+            &mut self.settings.obfuscation_settings,
+            obfuscation_settings,
+        );
+
+        self.update(should_save).await
     }
 
     async fn update(&mut self, should_save: bool) -> Result<bool, Error> {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -30,6 +30,7 @@ service ManagementService {
 	rpc GetCurrentLocation(google.protobuf.Empty) returns (GeoIpLocation) {}
 	rpc SetBridgeSettings(BridgeSettings) returns (google.protobuf.Empty) {}
 	rpc SetBridgeState(BridgeState) returns (google.protobuf.Empty) {}
+	rpc SetObfuscationSettings(ObfuscationSettings) returns (google.protobuf.Empty) {}
 
 	// Settings
 	rpc GetSettings(google.protobuf.Empty) returns (Settings) {}
@@ -190,7 +191,19 @@ message TunnelEndpoint {
 	TransportProtocol protocol = 2;
 	TunnelType tunnel_type = 3;
 	ProxyEndpoint proxy = 4;
-	Endpoint entry_endpoint = 5;
+	ObfuscationEndpoint obfuscation = 5;
+	Endpoint entry_endpoint = 6;
+}
+
+enum ObfuscationType {
+	UDP2TCP = 0;
+}
+
+message ObfuscationEndpoint {
+	string address = 1;
+	uint32 port = 2;
+	TransportProtocol protocol = 3;
+	ObfuscationType obfuscation_type = 4;
 }
 
 enum ProxyType {
@@ -269,6 +282,20 @@ message BridgeState {
 	State state = 1;
 }
 
+message Udp2TcpObfuscationSettings {
+  uint32 port = 1;
+}
+
+message ObfuscationSettings {
+  enum SelectedObfuscation {
+    AUTO = 0;
+    OFF = 1;
+	UDP2TCP = 2;
+  }
+  SelectedObfuscation selected_obfuscation = 1;
+  Udp2TcpObfuscationSettings udp2tcp = 2;
+}
+
 message Settings {
 	RelaySettings relay_settings = 1;
 	BridgeSettings bridge_settings = 2;
@@ -279,6 +306,7 @@ message Settings {
 	TunnelOptions tunnel_options = 7;
 	bool show_beta_releases = 8;
 	SplitTunnelSettings split_tunnel = 9;
+	ObfuscationSettings obfuscation_settings = 10;
 }
 
 message SplitTunnelSettings {
@@ -341,7 +369,7 @@ message IpVersionConstraint {
 }
 
 message WireguardConstraints {
-	TransportPort port = 1;
+	uint32 port = 1;
 	IpVersionConstraint ip_version = 2;
 	bool use_multihop = 3;
 	RelayLocation entry_location = 4;
@@ -368,7 +396,6 @@ message ConnectionConfig {
 			bytes public_key = 1;
 			repeated string allowed_ips = 2;
 			string endpoint = 3;
-			TransportProtocol protocol = 4;
 		}
 
 		TunnelConfig tunnel = 1;

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -60,6 +60,7 @@ impl CustomTunnelEndpoint {
                 connection,
                 options: tunnel_options.wireguard.options.clone(),
                 generic_options: tunnel_options.generic.clone(),
+                obfuscation: None,
             }
             .into(),
         };

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -1,7 +1,8 @@
 use crate::{
     relay_constraints::{
         BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
-        RelayConstraints, RelaySettings, RelaySettingsUpdate,
+        ObfuscationSettings, RelayConstraints, RelaySettings, RelaySettingsUpdate,
+        SelectedObfuscation,
     },
     wireguard,
 };
@@ -65,6 +66,8 @@ pub struct Settings {
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub bridge_settings: BridgeSettings,
     #[cfg_attr(target_os = "android", jnix(skip))]
+    pub obfuscation_settings: ObfuscationSettings,
+    #[cfg_attr(target_os = "android", jnix(skip))]
     bridge_state: BridgeState,
     /// If the daemon should allow communication with private (LAN) networks.
     pub allow_lan: bool,
@@ -104,6 +107,10 @@ impl Default for Settings {
                 ..Default::default()
             }),
             bridge_settings: BridgeSettings::Normal(BridgeConstraints::default()),
+            obfuscation_settings: ObfuscationSettings {
+                selected_obfuscation: SelectedObfuscation::Off,
+                ..Default::default()
+            },
             bridge_state: BridgeState::Auto,
             allow_lan: false,
             block_when_disconnected: false,

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -18,7 +18,7 @@ use talpid_types::net::{self, openvpn, GenericTunnelOptions};
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V5;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V6;
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -27,6 +27,7 @@ pub enum SettingsVersion {
     V3 = 3,
     V4 = 4,
     V5 = 5,
+    V6 = 6,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -39,6 +40,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V3 as u32 => Ok(SettingsVersion::V3),
             v if v == SettingsVersion::V4 as u32 => Ok(SettingsVersion::V4),
             v if v == SettingsVersion::V5 as u32 => Ok(SettingsVersion::V5),
+            v if v == SettingsVersion::V6 as u32 => Ok(SettingsVersion::V6),
             v => Err(serde::de::Error::custom(format!(
                 "{} is not a valid SettingsVersion",
                 v

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -31,7 +31,7 @@ chrono = "0.4.19"
 tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 rand = "0.7"
-udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "1e27324362ed123b61fa2062b1599e5f9d569796" }
+tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 socket2 = { version = "0.4.2", features = ["all"] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::CString,
     net::{Ipv4Addr, Ipv6Addr},
 };
-use talpid_types::net::{wireguard, GenericTunnelOptions};
+use talpid_types::net::{obfuscation::ObfuscatorConfig, wireguard, GenericTunnelOptions};
 
 /// Config required to set up a single WireGuard tunnel
 pub struct Config {
@@ -26,6 +26,8 @@ pub struct Config {
     /// Temporary switch for wireguard-nt
     #[cfg(target_os = "windows")]
     pub use_wireguard_nt: bool,
+    /// Obfuscator config to be used for reaching the relay.
+    pub obfuscator_config: Option<ObfuscatorConfig>,
 }
 
 const DEFAULT_MTU: u16 = 1380;
@@ -60,6 +62,7 @@ impl Config {
             &params.connection,
             &params.options,
             &params.generic_options,
+            params.obfuscation.clone(),
         )
     }
 
@@ -70,6 +73,7 @@ impl Config {
         connection_config: &wireguard::ConnectionConfig,
         wg_options: &wireguard::TunnelOptions,
         generic_options: &GenericTunnelOptions,
+        obfuscator_config: Option<ObfuscatorConfig>,
     ) -> Result<Config, Error> {
         if peers.is_empty() {
             return Err(Error::NoPeersSuppliedError);
@@ -114,6 +118,7 @@ impl Config {
             enable_ipv6: generic_options.enable_ipv6,
             #[cfg(target_os = "windows")]
             use_wireguard_nt: wg_options.use_wireguard_nt,
+            obfuscator_config,
         })
     }
 

--- a/talpid-core/src/tunnel/wireguard/wireguard_nt.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_nt.rs
@@ -982,7 +982,7 @@ impl Tunnel for WgNtTunnel {
 mod tests {
     use super::*;
     use lazy_static::lazy_static;
-    use talpid_types::net::{wireguard, TransportProtocol};
+    use talpid_types::net::wireguard;
 
     #[derive(Debug, Eq, PartialEq, Clone, Copy)]
     #[repr(C)]
@@ -1006,12 +1006,12 @@ mod tests {
                     public_key: WG_PUBLIC_KEY.clone(),
                     allowed_ips: vec!["1.3.3.0/24".parse().unwrap()],
                     endpoint: "1.2.3.4:1234".parse().unwrap(),
-                    protocol: TransportProtocol::Udp,
                 }],
                 ipv4_gateway: "0.0.0.0".parse().unwrap(),
                 ipv6_gateway: None,
                 mtu: 0,
                 use_wireguard_nt: true,
+                obfuscator_config: None,
             }
         };
         static ref WG_STRUCT_CONFIG: Interface = Interface {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -479,7 +479,7 @@ fn should_retry(error: &tunnel::Error, retry_attempt: u32) -> bool {
     use tunnel::wireguard::{Error, TunnelError};
 
     match error {
-        tunnel::Error::WireguardTunnelMonitoringError(Error::Udp2TcpError(_)) => true,
+        tunnel::Error::WireguardTunnelMonitoringError(Error::CreateObfuscatorError(_)) => true,
 
         #[cfg(not(windows))]
         tunnel::Error::WireguardTunnelMonitoringError(Error::TunnelError(

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "android")]
 use jnix::IntoJava;
+use obfuscation::ObfuscatorConfig;
 use serde::{Deserialize, Serialize};
 #[cfg(windows)]
 use std::path::PathBuf;
@@ -9,6 +10,7 @@ use std::{
     str::FromStr,
 };
 
+pub mod obfuscation;
 pub mod openvpn;
 pub mod proxy;
 pub mod wireguard;
@@ -29,6 +31,7 @@ impl TunnelParameters {
                 tunnel_type: TunnelType::OpenVpn,
                 endpoint: params.config.endpoint,
                 proxy: params.proxy.as_ref().map(|proxy| proxy.get_endpoint()),
+                obfuscation: None,
                 entry_endpoint: None,
             },
             TunnelParameters::Wireguard(params) => TunnelEndpoint {
@@ -38,6 +41,10 @@ impl TunnelParameters {
                     .get_exit_endpoint()
                     .unwrap_or(params.connection.get_endpoint()),
                 proxy: None,
+                obfuscation: params
+                    .obfuscation
+                    .as_ref()
+                    .map(|obfs| ObfuscationEndpoint::from(obfs)),
                 entry_endpoint: params
                     .connection
                     .get_exit_endpoint()
@@ -54,7 +61,20 @@ impl TunnelParameters {
                 .as_ref()
                 .map(|proxy| proxy.get_endpoint().endpoint)
                 .unwrap_or(params.config.endpoint),
-            TunnelParameters::Wireguard(params) => params.connection.get_endpoint(),
+            TunnelParameters::Wireguard(params) => params
+                .obfuscation
+                .as_ref()
+                .map(|obfuscator| Self::get_obfuscator_endpoint(obfuscator))
+                .unwrap_or(params.connection.get_endpoint()),
+        }
+    }
+
+    fn get_obfuscator_endpoint(obfuscator: &ObfuscatorConfig) -> Endpoint {
+        match obfuscator {
+            ObfuscatorConfig::Udp2Tcp { endpoint } => Endpoint {
+                address: *endpoint,
+                protocol: TransportProtocol::Tcp,
+            },
         }
     }
 
@@ -119,6 +139,8 @@ pub struct TunnelEndpoint {
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub proxy: Option<proxy::ProxyEndpoint>,
     #[cfg_attr(target_os = "android", jnix(skip))]
+    pub obfuscation: Option<ObfuscationEndpoint>,
+    #[cfg_attr(target_os = "android", jnix(skip))]
     pub entry_endpoint: Option<Endpoint>,
 }
 
@@ -139,8 +161,60 @@ impl fmt::Display for TunnelEndpoint {
                 if let Some(ref entry_endpoint) = self.entry_endpoint {
                     write!(f, " via {}", entry_endpoint)?;
                 }
+                if let Some(ref obfuscation) = self.obfuscation {
+                    write!(f, " via {}", obfuscation)?;
+                }
             }
         }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename = "obfuscation_type")]
+pub enum ObfuscationType {
+    #[serde(rename = "udp2tcp")]
+    Udp2Tcp,
+}
+
+impl fmt::Display for ObfuscationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let obfuscation = match self {
+            ObfuscationType::Udp2Tcp => "Udp2Tcp",
+        };
+        write!(f, "{}", obfuscation)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename = "obfuscation_endpoint")]
+pub struct ObfuscationEndpoint {
+    pub endpoint: Endpoint,
+    pub obfuscation_type: ObfuscationType,
+}
+
+impl From<&ObfuscatorConfig> for ObfuscationEndpoint {
+    fn from(config: &ObfuscatorConfig) -> ObfuscationEndpoint {
+        let (endpoint, obfuscation_type) = match config {
+            ObfuscatorConfig::Udp2Tcp { endpoint } => (
+                Endpoint {
+                    address: *endpoint,
+                    protocol: TransportProtocol::Tcp,
+                },
+                ObfuscationType::Udp2Tcp,
+            ),
+        };
+
+        ObfuscationEndpoint {
+            endpoint,
+            obfuscation_type,
+        }
+    }
+}
+
+impl fmt::Display for ObfuscationEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{} {}", self.obfuscation_type, self.endpoint)?;
         Ok(())
     }
 }

--- a/talpid-types/src/net/obfuscation.rs
+++ b/talpid-types/src/net/obfuscation.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+
+#[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]
+pub enum ObfuscatorConfig {
+    Udp2Tcp { endpoint: SocketAddr },
+}

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -17,6 +17,7 @@ pub struct TunnelParameters {
     pub connection: ConnectionConfig,
     pub options: TunnelOptions,
     pub generic_options: GenericTunnelOptions,
+    pub obfuscation: Option<super::obfuscation::ObfuscatorConfig>,
 }
 
 /// Connection-specific configuration in [`TunnelParameters`].
@@ -34,14 +35,14 @@ impl ConnectionConfig {
     pub fn get_endpoint(&self) -> Endpoint {
         Endpoint {
             address: self.peer.endpoint,
-            protocol: self.peer.protocol,
+            protocol: TransportProtocol::Udp,
         }
     }
 
     pub fn get_exit_endpoint(&self) -> Option<Endpoint> {
         self.exit_peer.as_ref().map(|peer| Endpoint {
             address: peer.endpoint,
-            protocol: peer.protocol,
+            protocol: TransportProtocol::Udp,
         })
     }
 }
@@ -54,14 +55,6 @@ pub struct PeerConfig {
     pub allowed_ips: Vec<IpNetwork>,
     /// IP address of the WireGuard server.
     pub endpoint: SocketAddr,
-    /// Transport protocol. WireGuard only supports UDP directly.
-    /// If this is set to TCP, then traffic is proxied using [udp_over_tcp](https://github.com/mullvad/udp-over-tcp).
-    #[serde(default = "default_peer_transport")]
-    pub protocol: TransportProtocol,
-}
-
-fn default_peer_transport() -> TransportProtocol {
-    TransportProtocol::Udp
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tunnel-obfuscation"
+version = "0.1.0"
+authors = ["Mullvad VPN"]
+description = "Provides different types of obfuscation layers for WireGuard"
+license = "GPL-3.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+err-derive = "0.3.0"
+futures = "0.3.5"
+tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "net", "io-util"] }
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "27b9519b63244736b6f3c7c4af60976c88dc6b95" }

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use std::net::SocketAddr;
+
+mod udp2tcp;
+pub use udp2tcp::Udp2TcpSettings;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(err_derive::Error, Debug)]
+#[error(no_from)]
+pub enum Error {
+    #[error(display = "Failed to create Udp2Tcp obfuscator")]
+    CreateUdp2TcpObfuscator(#[error(source)] udp2tcp::Error),
+
+    #[error(display = "Failed to run Udp2Tcp obfuscator")]
+    RunUdp2TcpObfuscator(#[error(source)] udp2tcp::Error),
+}
+
+#[async_trait]
+pub trait Obfuscator: Send {
+    fn endpoint(&self) -> SocketAddr;
+    async fn run(self: Box<Self>) -> Result<()>;
+}
+
+pub enum Settings {
+    Udp2Tcp(Udp2TcpSettings),
+}
+
+pub async fn create_obfuscator(settings: &Settings) -> Result<Box<dyn Obfuscator>> {
+    match settings {
+        Settings::Udp2Tcp(s) => udp2tcp::create_obfuscator(s)
+            .await
+            .map_err(Error::CreateUdp2TcpObfuscator),
+    }
+}

--- a/tunnel-obfuscation/src/main.rs
+++ b/tunnel-obfuscation/src/main.rs
@@ -1,0 +1,36 @@
+use std::{env::args, net::SocketAddr};
+use tunnel_obfuscation::{create_obfuscator, Obfuscator, Settings, Udp2TcpSettings};
+
+#[tokio::main]
+async fn main() {
+    if args().len() != 2 {
+        println!("Missing arguments");
+    }
+
+    let obfuscator = instantiate_requested(&args().last().unwrap()).await;
+
+    println!("endpoint() returns {:?}", obfuscator.endpoint());
+
+    if let Err(err) = obfuscator.run().await {
+        println!("obfuscator.run() failed: {:?}", err);
+    }
+}
+
+async fn instantiate_requested(obfuscator_type: &String) -> Box<dyn Obfuscator> {
+    match obfuscator_type.as_str() {
+        "udp2tcp" => {
+            let settings = Udp2TcpSettings {
+                peer: SocketAddr::new("127.0.0.1".parse().unwrap(), 3030),
+                #[cfg(target_os = "linux")]
+                fwmark: Some(1337),
+            };
+
+            create_obfuscator(&Settings::Udp2Tcp(settings))
+                .await
+                .expect("Creating obfuscator failed")
+        }
+        _ => {
+            unimplemented!()
+        }
+    }
+}

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -1,0 +1,88 @@
+use crate::Obfuscator;
+use async_trait::async_trait;
+use std::net::SocketAddr;
+use udp_over_tcp::{
+    udp2tcp::{ConnectError, ForwardError, Udp2Tcp as Udp2TcpImpl},
+    TcpOptions,
+};
+
+pub struct Udp2TcpSettings {
+    pub peer: SocketAddr,
+    #[cfg(target_os = "linux")]
+    pub fwmark: Option<u32>,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(err_derive::Error, Debug)]
+#[error(no_from)]
+pub enum Error {
+    /// Failed to create obfuscator
+    #[error(display = "Failed to create obfuscator")]
+    CreateObfuscator(#[error(source)] ConnectError),
+
+    /// Failed to determine UDP socket details
+    #[error(display = "Failed to determine UDP socket details")]
+    GetUdpSocketDetails(#[error(source)] std::io::Error),
+
+    /// Failed to run obfuscator
+    #[error(display = "Failed to run obfuscator")]
+    RunObfuscator(#[error(source)] ForwardError),
+}
+
+struct Udp2Tcp {
+    local_addr: SocketAddr,
+    instance: Udp2TcpImpl,
+}
+
+impl Udp2Tcp {
+    pub async fn new(settings: &Udp2TcpSettings) -> Result<Self> {
+        let listen_addr = if settings.peer.is_ipv4() {
+            SocketAddr::new("127.0.0.1".parse().unwrap(), 0)
+        } else {
+            SocketAddr::new("::1".parse().unwrap(), 0)
+        };
+
+        let instance = Udp2TcpImpl::new(
+            listen_addr,
+            settings.peer,
+            #[cfg(target_os = "linux")]
+            TcpOptions {
+                recv_buffer_size: None,
+                send_buffer_size: None,
+                fwmark: settings.fwmark,
+            },
+            #[cfg(not(target_os = "linux"))]
+            TcpOptions::default(),
+        )
+        .await
+        .map_err(Error::CreateObfuscator)?;
+        let local_addr = instance
+            .local_udp_addr()
+            .map_err(Error::GetUdpSocketDetails)?;
+
+        Ok(Self {
+            local_addr,
+            instance,
+        })
+    }
+}
+
+#[async_trait]
+impl Obfuscator for Udp2Tcp {
+    fn endpoint(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    async fn run(self: Box<Self>) -> crate::Result<()> {
+        self.instance
+            .run()
+            .await
+            .map_err(Error::RunObfuscator)
+            .map_err(crate::Error::RunUdp2TcpObfuscator)
+    }
+}
+
+pub async fn create_obfuscator(settings: &Udp2TcpSettings) -> Result<Box<dyn Obfuscator>> {
+    Ok(Box::new(Udp2Tcp::new(settings).await?))
+}


### PR DESCRIPTION
This PR aims to create a more abstract model for WireGuard obfuscation. It introduces and employs the `tunnel-obfuscation` crate in the hope that additional obfuscation methods can be more easily plugged in.

At this time, the current support has not been extended beyond supporting the udp-over-tcp wrapper (Udp2Tcp). However, the CLI commands that manage related settings have been improved. The daemon as well as clients will now use separate obfuscation settings instead of expressing obfuscation as a protocol settings.

Additionally, an auto mode has been implemented that will enable obfuscation usage after several failed connection attempts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3431)
<!-- Reviewable:end -->
