### PR TITLE
Fix bug with `PidManager::add_list`

### DIFF
--- a/talpid-core/src/proxy/shadowsocks.rs
+++ b/talpid-core/src/proxy/shadowsocks.rs
@@ -186,17 +186,14 @@ impl ShadowsocksProxyMonitor {
                     error.display_chain_with_msg("Failed to initialize PidManager"),
                 )
             })?;
-            let i32_pids = subproc
-                .pids()
-                .iter()
-                .map(|pid| *pid as i32)
-                .collect::<Vec<_>>();
-            excluded_pids.add_list(&i32_pids).map_err(|error| {
-                Error::new(
-                    ErrorKind::Other,
-                    error.display_chain_with_msg("Failed to exclude Shadowsocks process"),
-                )
-            })?;
+            for pid in subproc.pids() {
+                excluded_pids.add(pid as i32).map_err(|error| {
+                    Error::new(
+                        ErrorKind::Other,
+                        error.display_chain_with_msg("Failed to exclude Shadowsocks process"),
+                    )
+                })?;
+            }
         }
 
         match Self::get_bound_port(File::open(&logfile)?, &subproc) {

--- a/talpid-core/src/split_tunnel/linux.rs
+++ b/talpid-core/src/split_tunnel/linux.rs
@@ -1,6 +1,6 @@
 use std::{
     env, fs,
-    io::{self, BufRead, BufReader, BufWriter, Write},
+    io::{self, BufRead, BufReader, Write},
     path::PathBuf,
 };
 use talpid_types::cgroup::{find_net_cls_mount, SPLIT_TUNNEL_CGROUP_NAME};
@@ -108,18 +108,14 @@ impl PidManager {
             .join(SPLIT_TUNNEL_CGROUP_NAME)
             .join("cgroup.procs");
 
-        let file = fs::OpenOptions::new()
+        let mut file = fs::OpenOptions::new()
             .write(true)
             .create(true)
             .open(exclusions_path)
             .map_err(Error::AddCGroupPid)?;
 
-        let mut writer = BufWriter::new(file);
-
-        writer
-            .write_all(pid.to_string().as_bytes())
-            .map_err(Error::AddCGroupPid)?;
-        Ok(())
+        file.write_all(pid.to_string().as_bytes())
+            .map_err(Error::AddCGroupPid)
     }
 
     /// Remove a PID from processes to exclude from the tunnel.

--- a/talpid-core/src/split_tunnel/linux.rs
+++ b/talpid-core/src/split_tunnel/linux.rs
@@ -103,11 +103,6 @@ impl PidManager {
 
     /// Add a PID to exclude from the tunnel.
     pub fn add(&self, pid: i32) -> Result<(), Error> {
-        self.add_list(&[pid])
-    }
-
-    /// Add PIDs to exclude from the tunnel.
-    pub fn add_list<T: Into<i32> + ToString>(&self, pids: &[T]) -> Result<(), Error> {
         let exclusions_path = self
             .net_cls_path
             .join(SPLIT_TUNNEL_CGROUP_NAME)
@@ -121,12 +116,9 @@ impl PidManager {
 
         let mut writer = BufWriter::new(file);
 
-        for pid in pids {
-            writer
-                .write_all(pid.to_string().as_bytes())
-                .map_err(Error::AddCGroupPid)?;
-        }
-
+        writer
+            .write_all(pid.to_string().as_bytes())
+            .map_err(Error::AddCGroupPid)?;
         Ok(())
     }
 


### PR DESCRIPTION
This first caught my attention when seeing the code `T: Into<i32> + ToString`. `T` was never used as integers. It was only converted to string. So this felt like a strange way to try to encourage the user to send `i32`s instead of just taking an `&[i32]` directly. I first converted to that and tried it. But it did not work. I then realized that the code did not put any separators between the PIDs it wrote. So essentially trying to add PIDs `&[1, 2, 3]` resulted in `"123"` being written to the file.

I guess this bug was never found because we never called this method with more than one PID.

Some more possible improvements I see here that is out of scope for this PR is:
* Convert the OpenVPN Shadowsocks proxying into using our bundled Shadowsocks library, not `sslocal` as a subprocess. I have created a backlog item for it.
* Move CGroup management to a separate crate. I really don't think we should define constants such as `SPLIT_TUNNEL_CGROUP_NAME` and functions such as `find_net_cls_mount` in `talpid-types`. This crate has become too much of a kitchen sink.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3439)
<!-- Reviewable:end -->
