### PR TITLE
Bump `udp-over-tcp` to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix scrollbar no longer responsive and usable when covered by other elements.
 - Improve tunnel bypass for the API sometimes not working in the connecting state.
 - Fix resource leak caused by location check.
+- Fix issue where sockets didn't close after disconnecting from WireGuard servers over TCP
+  by updating `udp-over-tcp` to 0.2.
 
 #### Windows
 - Fix "Open Mullvad VPN" tray context menu item not working after toggling unpinned window setting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,10 +3643,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "udp-over-tcp"
-version = "0.1.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=27b9519b63244736b6f3c7c4af60976c88dc6b95#27b9519b63244736b6f3c7c4af60976c88dc6b95"
+version = "0.2.0"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=572827e69debc80d281ae1e184050feeee458792#572827e69debc80d281ae1e184050feeee458792"
 dependencies = [
- "env_logger 0.8.4",
  "err-context",
  "futures",
  "lazy_static",

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -12,4 +12,4 @@ async-trait = "0.1"
 err-derive = "0.3.0"
 futures = "0.3.5"
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "net", "io-util"] }
-udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "27b9519b63244736b6f3c7c4af60976c88dc6b95" }
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "572827e69debc80d281ae1e184050feeee458792" }

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -46,14 +46,11 @@ impl Udp2Tcp {
         let instance = Udp2TcpImpl::new(
             listen_addr,
             settings.peer,
-            #[cfg(target_os = "linux")]
             TcpOptions {
-                recv_buffer_size: None,
-                send_buffer_size: None,
+                #[cfg(target_os = "linux")]
                 fwmark: settings.fwmark,
+                ..TcpOptions::default()
             },
-            #[cfg(not(target_os = "linux"))]
-            TcpOptions::default(),
         )
         .await
         .map_err(Error::CreateObfuscator)?;


### PR DESCRIPTION
This fixes the issue where `Udp2Tcp::run` doesn't destroy sockets when dropped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3440)
<!-- Reviewable:end -->
