### PR TITLE
Remove unused account creation url in Android

### DIFF
--- a/android/app/src/main/res/values/strings_non_translatable.xml
+++ b/android/app/src/main/res/values/strings_non_translatable.xml
@@ -9,8 +9,6 @@
             translatable="false">https://mullvad.net/account</string>
     <string name="wg_key_url"
             translatable="false">https://mullvad.net/account/ports</string>
-    <string name="create_account_url"
-            translatable="false">https://mullvad.net/account/create</string>
     <string name="download_url"
             translatable="false">https://mullvad.net/download</string>
     <string name="faqs_and_guides_url"


### PR DESCRIPTION
The URL is a left-over after implementing in-app account creation via the daemon.

Git checklist:

~~* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.~~
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3441)
<!-- Reviewable:end -->
