### PR TITLE
Enable continue-on-error for the nightly Rust job

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -38,6 +38,7 @@ jobs:
             matrix:
                 rust: [stable, beta, nightly]
 
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository


### PR DESCRIPTION
The nightly CI fails due to https://github.com/briansmith/ring/issues/1469. Trying to wrestle Github Actions into allowing nightly to fail but still show it as a red marker in PRs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3442)
<!-- Reviewable:end -->
