### PR TITLE
Correct the logic which guards obfuscator selection

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1178,7 +1178,8 @@ where
                 };
 
                 let obfuscation = match self.settings.obfuscation_settings.selected_obfuscation {
-                    SelectedObfuscation::Off | SelectedObfuscation::Auto
+                    SelectedObfuscation::Off => None,
+                    SelectedObfuscation::Auto
                         if !self
                             .relay_selector
                             .should_use_auto_obfuscator(retry_attempt) =>


### PR DESCRIPTION
Honor the `Off` setting and don't treat it as `Auto`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3446)
<!-- Reviewable:end -->
