### PR TITLE
Fix device revoked message

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -514,6 +514,10 @@ msgctxt "device-management"
 msgid "Go to login"
 msgstr ""
 
+msgctxt "device-management"
+msgid "Going to login will unblock the Internet on this device."
+msgstr ""
+
 #. Confirmation button when logging out
 msgctxt "device-management"
 msgid "Log out anyway"
@@ -551,7 +555,7 @@ msgid "You can now continue logging in on this device."
 msgstr ""
 
 msgctxt "device-management"
-msgid "You have removed this device from your list of active devices. To connect with this device again, log in."
+msgid "You have removed this device. To connect again, you will need to log back in."
 msgstr ""
 
 msgctxt "device-management"

--- a/gui/src/renderer/components/DeviceRevokedView.tsx
+++ b/gui/src/renderer/components/DeviceRevokedView.tsx
@@ -78,8 +78,15 @@ export function DeviceRevokedView() {
             <StyledMessage>
               {messages.pgettext(
                 'device-management',
-                'You have removed this device from your list of active devices. To connect with this device again, log in.',
+                'You have removed this device. To connect again, you will need to log back in.',
               )}
+            </StyledMessage>
+            <StyledMessage>
+              {tunnelState.state !== 'disconnected' &&
+                messages.pgettext(
+                  'device-management',
+                  'Going to login will unblock the Internet on this device.',
+                )}
             </StyledMessage>
           </StyledBody>
 


### PR DESCRIPTION
The device revoked view was missing parts of the text that is supposed to display. This PR adds the missing parts.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3447)
<!-- Reviewable:end -->
