### PR TITLE
Propagate selected obfuscator hostname to frontends

### DIFF
--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -233,6 +233,7 @@ message GeoIpLocation {
 	string hostname = 8;
 	string bridge_hostname = 9;
 	string entry_hostname = 10;
+	string obfuscator_hostname = 11;
 }
 
 message BridgeSettings {

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -19,6 +19,7 @@ impl From<mullvad_types::location::GeoIpLocation> for GeoIpLocation {
             hostname: geoip.hostname.unwrap_or_default(),
             bridge_hostname: geoip.bridge_hostname.unwrap_or_default(),
             entry_hostname: geoip.entry_hostname.unwrap_or_default(),
+            obfuscator_hostname: geoip.obfuscator_hostname.unwrap_or_default(),
         }
     }
 }

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -154,6 +154,8 @@ pub struct GeoIpLocation {
     pub bridge_hostname: Option<String>,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub entry_hostname: Option<String>,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub obfuscator_hostname: Option<String>,
 }
 
 impl From<AmIMullvad> for GeoIpLocation {
@@ -174,6 +176,7 @@ impl From<AmIMullvad> for GeoIpLocation {
             hostname: None,
             bridge_hostname: None,
             entry_hostname: None,
+            obfuscator_hostname: None,
         }
     }
 }


### PR DESCRIPTION
The obfuscator hostname should be propagated to the frontends, which implies that it should be stored for later querying in the daemon. Since all other relays were being kept as fields in the daemon god-struct, I factored them out into a single enum containing all the individual relays that could be selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3449)
<!-- Reviewable:end -->
