### PR TITLE
Drop software rendering in spinner

### DIFF
--- a/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
+++ b/ios/MullvadVPN/SpinnerActivityIndicatorView.swift
@@ -12,7 +12,6 @@ private let kRotationAnimationKey = "rotation"
 private let kAnimationDuration = 0.6
 
 class SpinnerActivityIndicatorView: UIView {
-
     enum Style {
         case small, medium, large
 
@@ -26,73 +25,39 @@ class SpinnerActivityIndicatorView: UIView {
                 return .init(width: 60, height: 60)
             }
         }
-
-        var thickness: CGFloat {
-            switch self {
-            case .small, .medium:
-                return 2
-            case .large:
-                return 8
-            }
-        }
     }
 
-    /// Thickness of the front and back circles
-    var thickness: CGFloat = 6 {
-        didSet {
-            setLayersThickness()
-        }
-    }
-
-    /// The back circle color
-    var backCircleColor = UIColor.white.withAlphaComponent(0.2) {
-        didSet {
-            setBackCircleLayerColor()
-        }
-    }
-
-    /// The front circle color
-    var frontCircleColor: UIColor? {
-        didSet {
-            setFrontCircleLayerColor()
-        }
-    }
+    private let imageView = UIImageView(image: UIImage(named: "IconSpinner"))
 
     private(set) var isAnimating = false
     private(set) var style = Style.large
 
-    fileprivate let frontCircle = CAShapeLayer()
-    fileprivate let backCircle = CAShapeLayer()
-    fileprivate var startTime = CFTimeInterval(0)
-    fileprivate var stopTime = CFTimeInterval(0)
+    private var startTime = CFTimeInterval(0)
+    private var stopTime = CFTimeInterval(0)
 
     override var intrinsicContentSize: CGSize {
         return style.intrinsicSize
     }
 
-    convenience init(style: Style) {
-        self.init(frame: .init(origin: .zero, size: style.intrinsicSize))
+    init(style: Style) {
         self.style = style
-        self.thickness = style.thickness
-        commonInit()
-    }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        commonInit()
+        super.init(frame: CGRect(origin: .zero, size: style.intrinsicSize))
+
+        addSubview(imageView)
+        isHidden = true
+        backgroundColor = UIColor.clear
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(restartAnimationIfNeeded),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        unregisterFromAppStateNotifications()
-    }
-
-    override func layoutSublayers(of layer: CALayer) {
-        super.layoutSublayers(of: layer)
-        setupBezierPaths()
     }
 
     override func didMoveToWindow() {
@@ -103,10 +68,10 @@ class SpinnerActivityIndicatorView: UIView {
         }
     }
 
-    override func tintColorDidChange() {
-        super.tintColorDidChange()
+    override func layoutSubviews() {
+        super.layoutSubviews()
 
-        setFrontCircleLayerColor()
+        imageView.frame = CGRect(origin: .zero, size: style.intrinsicSize)
     }
 
     func startAnimating() {
@@ -123,39 +88,6 @@ class SpinnerActivityIndicatorView: UIView {
 
         isHidden = true
         removeAnimation()
-    }
-
-    // MARK: - Private
-
-    private func commonInit() {
-        registerForAppStateNotifications()
-
-        isHidden = true
-        backgroundColor = UIColor.clear
-
-        backCircle.fillColor = UIColor.clear.cgColor
-        frontCircle.fillColor = UIColor.clear.cgColor
-        frontCircle.lineCap = .round
-
-        setBackCircleLayerColor()
-        setFrontCircleLayerColor()
-        setLayersThickness()
-
-        layer.addSublayer(backCircle)
-        layer.addSublayer(frontCircle)
-    }
-
-    private func setLayersThickness() {
-        backCircle.lineWidth = thickness
-        frontCircle.lineWidth = thickness
-    }
-
-    private func setBackCircleLayerColor() {
-        backCircle.strokeColor = backCircleColor.cgColor
-    }
-
-    private func setFrontCircleLayerColor() {
-        frontCircle.strokeColor = frontCircleColor?.cgColor ?? tintColor.cgColor
     }
 
     private func addAnimation() {
@@ -184,14 +116,6 @@ class SpinnerActivityIndicatorView: UIView {
         }
     }
 
-    private func registerForAppStateNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(restartAnimationIfNeeded), name: UIApplication.willEnterForegroundNotification, object: nil)
-    }
-
-    private func unregisterFromAppStateNotifications() {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     private func animation() -> CABasicAnimation {
         let animation = CABasicAnimation(keyPath: "transform.rotation")
         animation.toValue = NSNumber(value: Double.pi * 2)
@@ -201,15 +125,4 @@ class SpinnerActivityIndicatorView: UIView {
 
         return animation
     }
-
-    private func setupBezierPaths() {
-        let center = CGPoint(x: bounds.size.width * 0.5, y: bounds.size.height * 0.5)
-        let radius = bounds.size.width * 0.5 - thickness
-        let closedRingPath = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
-        let openRingPath = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 1.5, clockwise: true)
-
-        backCircle.path = closedRingPath.cgPath
-        frontCircle.path = openRingPath.cgPath
-    }
-
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Previously we used software rendering for spinner using `CAShapeLayer`s. I figured there is no need for that since PDF vectors seem to be resampled and scaled with no issues when using `UIImageView`. So in this PR instead of mimicking the look of our spinner, the new code uses a PDF asset instead. The rest remains the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3454)
<!-- Reviewable:end -->
