### PR TITLE
Refresh tunnel status only when connecting or reasserting to pick up the next relay

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -279,10 +279,17 @@ final class TunnelManager: TunnelManagerStateDelegate {
                 self.logger.error(chainedError: error, message: "Failed to reconnect the tunnel.")
             }
 
-            // Refresh tunnel status since reasserting may not be lowered until the tunnel is fully
+            // Refresh tunnel status only when connecting or reasserting to pick up the next relay,
+            // since both states may persist for a long period of time until the tunnel is fully
             // connected.
-            self.logger.debug("Refresh tunnel status due to reconnect.")
-            self.refreshTunnelStatus()
+            switch self.tunnelState {
+            case .connecting, .reconnecting:
+                self.logger.debug("Refresh tunnel status due to reconnect.")
+                self.refreshTunnelStatus()
+
+            default:
+                break
+            }
 
             DispatchQueue.main.async {
                 completionHandler?()


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

Normally the tunnel manager receives a system notification when tunnel connection status changes from `connecting` to  `connected` or `reasserting` (aka `reconnecting`) state. In response to those notifications, tunnel manager issues IPC request to fetch the relay the tunnel process is attempting to establish connection with.

However due to introduction of tunnel monitor, the tunnel process may remain in the `connecting` or `reasserting` state until VPN connection is fully established, hence no system notifications are issued. We use a timer to poll tunnel process periodically.

However if user requests to change relay during the `connecting` or `reconnecting` phase, we won't see the new relay until the polling timer fires. Instead when in that phase we want to fetch the next relay right away. 

However when in any other phase, we shall the system notify us via the system notification.

This PR simply guards the tunnel from being forcefully refreshed in all other phases which prevents inconsistencies in tunnel state, caused by delay to when tunnel process notifies the GUI process that it switched to `reasserting` (aka `reconnecting` state)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3455)
<!-- Reviewable:end -->
