### PR TITLE
Format Kotlin according to official code style

### DIFF
--- a/.github/workflows/android-ktlint.yml
+++ b/.github/workflows/android-ktlint.yml
@@ -17,7 +17,7 @@ jobs:
             # Install Ktlint
             - uses: nbadal/action-ktlint-setup@v1
               with:
-                  ktlint_version: 0.40.0
+                  ktlint_version: 0.45.1
 
             # Check formatting
             - run: |

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
@@ -17,7 +17,7 @@ import org.koin.dsl.onClose
 val appModule = module {
 
     single<PackageManager> { androidContext().packageManager }
-    single<String> (named(SELF_PACKAGE_NAME)) { androidContext().packageName }
+    single<String>(named(SELF_PACKAGE_NAME)) { androidContext().packageName }
 
     scope(named(APPS_SCOPE)) {
         viewModel { SplitTunnelingViewModel(get(), get(), Dispatchers.Default) }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/HandlerFlow.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/HandlerFlow.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.onCompletion
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/DnsOptions.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/DnsOptions.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.model
 
 import android.os.Parcelable
 import java.net.InetAddress
-import java.util.ArrayList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/KeygenEvent.kt
@@ -10,7 +10,7 @@ sealed class KeygenEvent : Parcelable {
         val verified: Boolean?,
         val replacementFailure: KeygenFailure?
     ) : KeygenEvent() {
-        constructor(publicKey: PublicKey) : this (publicKey, null, null)
+        constructor(publicKey: PublicKey) : this(publicKey, null, null)
     }
 
     @Parcelize

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/ListItemData.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/ListItemData.kt
@@ -3,7 +3,6 @@ package net.mullvad.mullvadvpn.model
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.annotation.StringRes
-import java.lang.IllegalArgumentException
 
 data class ListItemData
 private constructor(
@@ -23,11 +22,14 @@ private constructor(
 
     class Builder(private val identifier: String) {
         var text: String? = null
+
         @StringRes
         var textRes: Int? = null
+
         @DrawableRes
         var iconRes: Int? = null
         var isSelected: Boolean = false
+
         @ItemType
         var type: Int = 0
         var widget: WidgetState? = null

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayList.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.model
 
 import android.os.Parcelable
-import java.util.ArrayList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCity.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.model
 
 import android.os.Parcelable
-import java.util.ArrayList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayListCountry.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.model
 
 import android.os.Parcelable
-import java.util.ArrayList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayTunnels.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RelayTunnels.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.model
 
 import android.os.Parcelable
-import java.util.ArrayList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VoucherRedeemer.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VoucherRedeemer.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
 import net.mullvad.mullvadvpn.ipc.Event
 import net.mullvad.mullvadvpn.ipc.Request
-import net.mullvad.mullvadvpn.model.VoucherSubmissionResult
 
 class VoucherRedeemer(private val endpoint: ServiceEndpoint) {
     private val daemon

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -59,13 +59,10 @@ class TunnelStateNotification(val context: Context) {
     var showAction by observable(false) { _, _, _ -> update() }
 
     var tunnelState by observable<TunnelState>(TunnelState.Disconnected) { _, _, newState ->
-        reconnecting =
-            (
-            newState is TunnelState.Disconnecting &&
-                newState.actionAfterDisconnect == ActionAfterDisconnect.Reconnect
-            ) ||
-            (newState is TunnelState.Connecting && reconnecting)
-
+        val isReconnecting = newState is TunnelState.Connecting && reconnecting
+        val shouldBeginReconnecting = (newState as? TunnelState.Disconnecting)
+            ?.actionAfterDisconnect == ActionAfterDisconnect.Reconnect
+        reconnecting = isReconnecting || shouldBeginReconnecting
         update()
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemsAdapter.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ListItemsAdapter.kt
@@ -28,19 +28,19 @@ class ListItemsAdapter : RecyclerView.Adapter<ListItemsAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, @ListItemData.ItemType viewType: Int):
         ListItemsAdapter.ViewHolder {
-            return ViewHolder(
-                when (viewType) {
-                    ListItemData.DIVIDER -> DividerGroupListItemView(parent.context)
-                    ListItemData.PROGRESS -> ProgressListItemView(parent.context)
-                    ListItemData.PLAIN -> PlainListItemView(parent.context)
-                    ListItemData.ACTION -> ActionListItemView(parent.context)
-                    ListItemData.APPLICATION -> ApplicationListItemView(parent.context)
-                    ListItemData.DOUBLE_ACTION -> TwoActionListItemView(parent.context)
-                    else ->
-                        throw IllegalArgumentException("View type '$viewType' is not supported")
-                }
-            )
-        }
+        return ViewHolder(
+            when (viewType) {
+                ListItemData.DIVIDER -> DividerGroupListItemView(parent.context)
+                ListItemData.PROGRESS -> ProgressListItemView(parent.context)
+                ListItemData.PLAIN -> PlainListItemView(parent.context)
+                ListItemData.ACTION -> ActionListItemView(parent.context)
+                ListItemData.APPLICATION -> ApplicationListItemView(parent.context)
+                ListItemData.DOUBLE_ACTION -> TwoActionListItemView(parent.context)
+                else ->
+                    throw IllegalArgumentException("View type '$viewType' is not supported")
+            }
+        )
+    }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         (holder.itemView as ListItemView).update(getItem(position))

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -41,9 +41,11 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
             tunnelState = this@OutOfTimeFragment.tunnelState
         }
 
-        view.findViewById<TextView>(R.id.account_credit_has_expired).text =
-            parentActivity.getString(R.string.account_credit_has_expired) + " " +
+        view.findViewById<TextView>(R.id.account_credit_has_expired).text = buildString {
+            append(parentActivity.getString(R.string.account_credit_has_expired))
+            append(" ")
             parentActivity.getString(R.string.add_time_to_account)
+        }
 
         disconnectButton = view.findViewById<Button>(R.id.disconnect).apply {
             setOnClickAction("disconnect", jobTracker) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -84,7 +84,8 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     onSafelyStop()
                     onSafelyStart()
                 }
-                else -> {}
+                else -> {
+                }
             }
         }
     }
@@ -100,7 +101,8 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     state = State.LostConnection
                     leaveFragment()
                 }
-                else -> {}
+                else -> {
+                }
             }
         }
     }
@@ -131,7 +133,8 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     state = State.Active
                     onSafelyStart()
                 }
-                else -> {}
+                else -> {
+                }
             }
         }
     }
@@ -142,7 +145,8 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                 State.Initialized, State.Stopped, State.Active -> {
                     onSafelySaveInstanceState(instanceState)
                 }
-                else -> {}
+                else -> {
+                }
             }
         }
     }
@@ -154,7 +158,8 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     onSafelyStop()
                     state = State.Stopped
                 }
-                else -> {}
+                else -> {
+                }
             }
         }
 
@@ -165,7 +170,8 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         synchronized(this) {
             when (state) {
                 State.Initialized, State.Stopped, State.Active -> onSafelyDestroyView()
-                else -> {}
+                else -> {
+                }
             }
         }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -84,8 +84,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     onSafelyStop()
                     onSafelyStart()
                 }
-                else -> {
-                }
+                else -> Unit
             }
         }
     }
@@ -101,8 +100,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     state = State.LostConnection
                     leaveFragment()
                 }
-                else -> {
-                }
+                else -> Unit
             }
         }
     }
@@ -133,8 +131,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     state = State.Active
                     onSafelyStart()
                 }
-                else -> {
-                }
+                else -> Unit
             }
         }
     }
@@ -145,8 +142,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                 State.Initialized, State.Stopped, State.Active -> {
                     onSafelySaveInstanceState(instanceState)
                 }
-                else -> {
-                }
+                else -> Unit
             }
         }
     }
@@ -158,8 +154,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
                     onSafelyStop()
                     state = State.Stopped
                 }
-                else -> {
-                }
+                else -> Unit
             }
         }
 
@@ -170,8 +165,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         synchronized(this) {
             when (state) {
                 State.Initialized, State.Stopped, State.Active -> onSafelyDestroyView()
-                else -> {
-                }
+                else -> Unit
             }
         }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -38,9 +38,11 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
             setOnClickListener { copyAccountTokenToClipboard() }
         }
 
-        view.findViewById<TextView>(R.id.pay_to_start_using).text =
-            parentActivity.getString(R.string.pay_to_start_using) + " " +
-            parentActivity.getString(R.string.add_time_to_account)
+        view.findViewById<TextView>(R.id.pay_to_start_using).text = buildString {
+            append(parentActivity.getString(R.string.pay_to_start_using))
+            append(" ")
+            append(parentActivity.getString(R.string.add_time_to_account))
+        }
 
         sitePaymentButton = view.findViewById<SitePaymentButton>(R.id.site_payment).apply {
             newAccount = true

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/CustomDnsAdapter.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/customdns/CustomDnsAdapter.kt
@@ -30,8 +30,9 @@ class CustomDnsAdapter(
 
     private var editingPosition: Int? = null
 
-    private var activeCustomDnsServers by observable<List<InetAddress>>(emptyList()) {
-        _, _, servers ->
+    private var activeCustomDnsServers by observable<List<InetAddress>>(
+        emptyList()
+    ) { _, _, servers ->
         if (servers != cachedCustomDnsServers) {
             cachedCustomDnsServers = servers.toMutableList()
             notifyDataSetChanged()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/listitemview/ActionListItemView.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/listitemview/ActionListItemView.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.ui.listitemview
 import android.content.Context
 import android.content.res.Resources
 import android.util.AttributeSet
+import android.view.View.OnClickListener
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/listitemview/ListItemView.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/listitemview/ListItemView.kt
@@ -17,6 +17,7 @@ abstract class ListItemView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs, defStyleAttr, defStyleRes) {
     @get:LayoutRes
     protected abstract val layoutRes: Int
+
     @get:DimenRes
     protected abstract val heightRes: Int?
     protected lateinit var itemData: ListItemData

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -19,19 +19,27 @@ class SettingsListener(private val connection: Messenger, eventDispatcher: Event
 
     var account: String?
         get() = accountNumberNotifier.latestEvent
-        set(value) { connection.send(Request.SetAccount(value).message) }
+        set(value) {
+            connection.send(Request.SetAccount(value).message)
+        }
 
     var allowLan: Boolean
         get() = settingsNotifier.latestEvent?.allowLan ?: false
-        set(value) { connection.send(Request.SetAllowLan(value).message) }
+        set(value) {
+            connection.send(Request.SetAllowLan(value).message)
+        }
 
     var autoConnect: Boolean
         get() = settingsNotifier.latestEvent?.autoConnect ?: false
-        set(value) { connection.send(Request.SetAutoConnect(value).message) }
+        set(value) {
+            connection.send(Request.SetAutoConnect(value).message)
+        }
 
     var wireguardMtu: Int?
         get() = settingsNotifier.latestEvent?.tunnelOptions?.wireguard?.options?.mtu
-        set(value) { connection.send(Request.SetWireGuardMtu(value).message) }
+        set(value) {
+            connection.send(Request.SetWireGuardMtu(value).message)
+        }
 
     init {
         eventDispatcher.registerHandler(Event.SettingsUpdate::class, ::handleNewEvent)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
@@ -59,13 +59,6 @@ class AccountCell : NavigateCell {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     init {
         cell.addView(remainingTimeLabel, cell.childCount - 1)
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
@@ -52,19 +52,19 @@ class AccountCell : NavigateCell {
         }
     }
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         cell.addView(remainingTimeLabel, cell.childCount - 1)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountCell.kt
@@ -62,8 +62,4 @@ class AccountCell : NavigateCell {
     init {
         cell.addView(remainingTimeLabel, cell.childCount - 1)
     }
-
-    private fun getRemainingText(pluralId: Int, quantity: Int): String {
-        return resources.getQuantityString(pluralId, quantity, quantity)
-    }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -91,13 +91,6 @@ class AccountInput : LinearLayout {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     init {
         orientation = HORIZONTAL
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -84,20 +84,19 @@ class AccountInput : LinearLayout {
 
     var onLogin: ((String) -> Unit)? = null
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {
-    }
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         orientation = HORIZONTAL

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -137,13 +137,6 @@ class AccountLogin : RelativeLayout {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     init {
         border.elevation = elevation + 0.1f
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLogin.kt
@@ -120,26 +120,29 @@ class AccountLogin : RelativeLayout {
 
     var onLogin: ((String) -> Unit)?
         get() = input.onLogin
-        set(value) { input.onLogin = value }
+        set(value) {
+            input.onLogin = value
+        }
 
     var onClearHistory: (() -> Unit)?
         get() = historyAdapter.onRemoveEntry
-        set(value) { historyAdapter.onRemoveEntry = value }
+        set(value) {
+            historyAdapter.onRemoveEntry = value
+        }
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {
-    }
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         border.elevation = elevation + 0.1f

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLoginBorder.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountLoginBorder.kt
@@ -72,20 +72,19 @@ class AccountLoginBorder : RelativeLayout {
             }
         }
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {
-    }
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     private fun setBorder(drawables: StateDrawables) {
         topLeftCorner.setImageDrawable(drawables.corner)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
@@ -59,7 +59,7 @@ class AppVersionCell : UrlCell {
         attributes: AttributeSet? = null,
         defaultStyleAttribute: Int = 0,
         defaultStyleResource: Int = 0
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         cell.addView(warningIcon, 0)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/BackButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/BackButton.kt
@@ -27,8 +27,8 @@ class BackButton : LinearLayout {
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute) {
-            loadAttributes(attributes)
-        }
+        loadAttributes(attributes)
+    }
 
     constructor(
         context: Context,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Button.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/Button.kt
@@ -73,7 +73,9 @@ open class Button : FrameLayout {
 
     var label: CharSequence
         get() = button.text
-        set(value) { button.text = value }
+        set(value) {
+            button.text = value
+        }
 
     var showSpinner = false
 
@@ -85,8 +87,8 @@ open class Button : FrameLayout {
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute) {
-            loadAttributes(attributes)
-        }
+        loadAttributes(attributes)
+    }
 
     constructor(
         context: Context,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
@@ -153,19 +153,19 @@ class CellSwitch : LinearLayout {
 
     private val gestureDetector = GestureDetector(context, gestureListener)
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         setBackground(resources.getDrawable(R.drawable.cell_switch_background, null))

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CellSwitch.kt
@@ -160,13 +160,6 @@ class CellSwitch : LinearLayout {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     init {
         setBackground(resources.getDrawable(R.drawable.cell_switch_background, null))
         addView(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CopyableInformationView.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CopyableInformationView.kt
@@ -24,8 +24,8 @@ class CopyableInformationView : InformationView {
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute) {
-            loadAttributes(attributes)
-        }
+        loadAttributes(attributes)
+    }
 
     constructor(
         context: Context,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/CustomRecyclerView.kt
@@ -13,13 +13,12 @@ class CustomRecyclerView : RecyclerView, ListenableScrollableView {
 
     override var onScrollListener: ((Int, Int, Int, Int) -> Unit)? = null
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {
-        }
+        super(context, attributes, defaultStyleAttribute)
 
     init {
         itemAnimator = customItemAnimator.apply {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/InformationView.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/InformationView.kt
@@ -68,8 +68,8 @@ open class InformationView : LinearLayout {
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute) {
-            loadAttributes(attributes)
-        }
+        loadAttributes(attributes)
+    }
 
     constructor(
         context: Context,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ListenableScrollView.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ListenableScrollView.kt
@@ -13,21 +13,19 @@ class ListenableScrollView : ScrollView, ListenableScrollableView {
 
     override var onScrollListener: ((Int, Int, Int, Int) -> Unit)? = null
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {
-        }
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {
-    }
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     override fun onScrollChanged(left: Int, top: Int, oldLeft: Int, oldTop: Int) {
         super.onScrollChanged(left, top, oldLeft, oldTop)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ListenableScrollView.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ListenableScrollView.kt
@@ -20,13 +20,6 @@ class ListenableScrollView : ScrollView, ListenableScrollableView {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     override fun onScrollChanged(left: Int, top: Int, oldLeft: Int, oldTop: Int) {
         super.onScrollChanged(left, top, oldLeft, oldTop)
         onScrollListener?.invoke(left, top, oldLeft, oldTop)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NavigateCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NavigateCell.kt
@@ -28,13 +28,6 @@ open class NavigateCell : Cell {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     init {
         cell.addView(chevron)
         onClickListener = { openSubFragment() }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NavigateCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NavigateCell.kt
@@ -21,19 +21,19 @@ open class NavigateCell : Cell {
 
     var targetFragment: KClass<out Fragment>? = null
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         cell.addView(chevron)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
@@ -78,18 +78,18 @@ class NotificationBanner : FrameLayout {
         }
     }
 
-    constructor(context: Context) : super(context) {}
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         setBackgroundResource(R.color.darkBlue)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NotificationBanner.kt
@@ -84,13 +84,6 @@ class NotificationBanner : FrameLayout {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     init {
         setBackgroundResource(R.color.darkBlue)
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/RedeemVoucherButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/RedeemVoucherButton.kt
@@ -14,13 +14,6 @@ class RedeemVoucherButton : Button {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     fun prepare(
         fragmentManager: FragmentManager?,
         jobTracker: JobTracker,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/RedeemVoucherButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/RedeemVoucherButton.kt
@@ -7,19 +7,19 @@ import net.mullvad.mullvadvpn.ui.RedeemVoucherDialogFragment
 import net.mullvad.mullvadvpn.util.JobTracker
 
 class RedeemVoucherButton : Button {
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     fun prepare(
         fragmentManager: FragmentManager?,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SitePaymentButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SitePaymentButton.kt
@@ -6,19 +6,19 @@ import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.R
 
 class SitePaymentButton : UrlButton {
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     var newAccount by observable(false) { _, _, isNewAccount ->
         if (isNewAccount) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SitePaymentButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SitePaymentButton.kt
@@ -13,13 +13,6 @@ class SitePaymentButton : UrlButton {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     var newAccount by observable(false) { _, _, isNewAccount ->
         if (isNewAccount) {
             label = context.getString(R.string.buy_credit)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SwitchLocationButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SwitchLocationButton.kt
@@ -51,19 +51,19 @@ class SwitchLocationButton : FrameLayout {
         }
     }
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     private fun showLabel() {
         updateButton(buttonWithLabel, true)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SwitchLocationButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/SwitchLocationButton.kt
@@ -58,13 +58,6 @@ class SwitchLocationButton : FrameLayout {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     private fun showLabel() {
         updateButton(buttonWithLabel, true)
         updateButton(buttonWithLocation, false)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ToggleCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ToggleCell.kt
@@ -10,25 +10,29 @@ class ToggleCell : Cell {
 
     var state
         get() = toggle.state
-        set(value) { toggle.state = value }
+        set(value) {
+            toggle.state = value
+        }
 
     var listener
         get() = toggle.listener
-        set(value) { toggle.listener = value }
+        set(value) {
+            toggle.listener = value
+        }
 
-    constructor(context: Context) : super(context) {}
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context, attributes: AttributeSet) : super(context, attributes) {}
+    constructor(context: Context, attributes: AttributeSet) : super(context, attributes)
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
-        super(context, attributes, defaultStyleAttribute) {}
+        super(context, attributes, defaultStyleAttribute)
 
     constructor(
         context: Context,
         attributes: AttributeSet,
         defaultStyleAttribute: Int,
         defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource) {}
+    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
 
     init {
         onClickListener = { toggle() }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ToggleCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/ToggleCell.kt
@@ -27,13 +27,6 @@ class ToggleCell : Cell {
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute)
 
-    constructor(
-        context: Context,
-        attributes: AttributeSet,
-        defaultStyleAttribute: Int,
-        defaultStyleResource: Int
-    ) : super(context, attributes, defaultStyleAttribute, defaultStyleResource)
-
     init {
         onClickListener = { toggle() }
         cell.addView(toggle)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlButton.kt
@@ -27,8 +27,8 @@ open class UrlButton : Button {
 
     constructor(context: Context, attributes: AttributeSet, defaultStyleAttribute: Int) :
         super(context, attributes, defaultStyleAttribute) {
-            loadAttributes(attributes)
-        }
+        loadAttributes(attributes)
+    }
 
     constructor(
         context: Context,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/AdapterWithHeader.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/AdapterWithHeader.kt
@@ -3,16 +3,15 @@ package net.mullvad.mullvadvpn.util
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView.Adapter
-import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
+import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import kotlin.properties.Delegates.observable
 
 class AdapterWithHeader<H : ViewHolder>(
-    val adapter: Adapter<H>,
+    val adapter: RecyclerView.Adapter<H>,
     val headerLayoutId: Int
-) : Adapter<HeaderOrHolder<H>>() {
-    private val observer = object : AdapterDataObserver() {
+) : RecyclerView.Adapter<HeaderOrHolder<H>>() {
+    private val observer = object : RecyclerView.AdapterDataObserver() {
         override fun onChanged() {
             notifyDataSetChanged()
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/FlowUtils.kt
@@ -23,7 +23,10 @@ fun <T> SendChannel<T>.safeOffer(element: T): Boolean {
 fun Animation.transitionFinished(): Flow<Unit> = callbackFlow<Unit> {
     val transitionAnimationListener = object : Animation.AnimationListener {
         override fun onAnimationStart(animation: Animation?) {}
-        override fun onAnimationEnd(animation: Animation?) { safeOffer(Unit) }
+        override fun onAnimationEnd(animation: Animation?) {
+            safeOffer(Unit)
+        }
+
         override fun onAnimationRepeat(animation: Animation?) {}
     }
     setAnimationListener(transitionAnimationListener)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/Intermittent.kt
@@ -75,7 +75,6 @@ class Intermittent<T> {
     }
 
     // Helper method that provides a simple way to change the wrapped value.
-    // 
     // The method returns a property delegate that will spawn a coroutine to update the wrapped
     // value every time the property is written to.
     fun source() = observable<T?>(null) { _, _, newValue ->

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SplitTunnelingViewModel.kt
@@ -26,6 +26,7 @@ class SplitTunnelingViewModel(
     dispatcher: CoroutineDispatcher
 ) : ViewModel() {
     private val listItemsSink = MutableSharedFlow<List<ListItemData>>(replay = 1)
+
     // read-only public view
     val listItems: SharedFlow<List<ListItemData>> = listItemsSink.asSharedFlow()
 

--- a/android/app/src/main/kotlin/net/mullvad/talpid/tun_provider/TunConfig.kt
+++ b/android/app/src/main/kotlin/net/mullvad/talpid/tun_provider/TunConfig.kt
@@ -1,7 +1,6 @@
 package net.mullvad.talpid.tun_provider
 
 import java.net.InetAddress
-import java.util.ArrayList
 
 data class TunConfig(
     val addresses: ArrayList<InetAddress>,

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,16 +1,4 @@
-## For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-#
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx1024m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-#
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-#Mon Jan 04 14:44:17 CET 2021
 android.enableJetifier=true
 android.useAndroidX=true
+kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"


### PR DESCRIPTION
Android Studio and ktlint seem to agree on most styling except for
imports. Some settings can be changed in Android Studio, however it
seems to be hard to get lexicographical order (which ktlin wants).
Therefore ktlint should be ran after any formatting has been applied by
Android Studio (otherwise the CI workflow will complain).

Git checklist:

~~* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.~~ (only formatting)
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3456)
<!-- Reviewable:end -->
