### PR TITLE
Don't update the firewall policy twice when setting a new allowed endpoint

### DIFF
--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -99,13 +99,10 @@ impl ApiEndpointUpdaterHandle {
                     get_allowed_endpoint(address.clone()),
                     result_tx,
                 ));
-                if result_rx.await.is_ok() {
-                    log::debug!("API endpoint: {}", address);
-                    true
-                } else {
-                    log::error!("Failed to update allowed endpoint");
-                    false
-                }
+                // Wait for the firewall policy to be updated.
+                let _ = result_rx.await;
+                log::debug!("API endpoint: {}", address);
+                true
             }
         }
     }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -212,9 +212,7 @@ impl ConnectedState {
             }
             Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
                 shared_values.allowed_endpoint = endpoint;
-                if let Err(_) = tx.send(()) {
-                    log::error!("The AllowEndpoint receiver was dropped");
-                }
+                let _ = tx.send(());
                 SameState(self.into())
             }
             Some(TunnelCommand::Dns(servers)) => match shared_values.set_dns_servers(servers) {

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -154,9 +154,7 @@ impl TunnelState for DisconnectedState {
                     shared_values.allowed_endpoint = endpoint;
                     Self::set_firewall_policy(shared_values, true);
                 }
-                if let Err(_) = tx.send(()) {
-                    log::error!("The AllowEndpoint receiver was dropped");
-                }
+                let _ = tx.send(());
                 SameState(self.into())
             }
             Some(TunnelCommand::Dns(servers)) => {

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -29,9 +29,7 @@ impl DisconnectingState {
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
                     shared_values.allowed_endpoint = endpoint;
-                    if let Err(_) = tx.send(()) {
-                        log::error!("The AllowEndpoint receiver was dropped");
-                    }
+                    let _ = tx.send(());
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::Dns(servers)) => {
@@ -67,9 +65,7 @@ impl DisconnectingState {
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
                     shared_values.allowed_endpoint = endpoint;
-                    if let Err(_) = tx.send(()) {
-                        log::error!("The AllowEndpoint receiver was dropped");
-                    }
+                    let _ = tx.send(());
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::Dns(servers)) => {
@@ -110,9 +106,7 @@ impl DisconnectingState {
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
                     shared_values.allowed_endpoint = endpoint;
-                    if let Err(_) = tx.send(()) {
-                        log::error!("The AllowEndpoint receiver was dropped");
-                    }
+                    let _ = tx.send(());
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::Dns(servers)) => {

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -155,15 +155,14 @@ impl TunnelState for ErrorState {
 
                     #[cfg(target_os = "android")]
                     if !Self::create_blocking_tun(shared_values) {
+                        let _ = tx.send(());
                         return NewState(Self::enter(
                             shared_values,
                             ErrorStateCause::SetFirewallPolicyError(FirewallPolicyError::Generic),
                         ));
                     }
                 }
-                if let Err(_) = tx.send(()) {
-                    log::error!("The AllowEndpoint receiver was dropped");
-                }
+                let _ = tx.send(());
                 SameState(self.into())
             }
             Some(TunnelCommand::Dns(servers)) => {

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -162,8 +162,9 @@ pub async fn spawn(
 pub enum TunnelCommand {
     /// Enable or disable LAN access in the firewall.
     AllowLan(bool),
-    /// Endpoint that should never be blocked.
-    /// If an error occurs, the sender is dropped.
+    /// Endpoint that should never be blocked. `()` is sent to the
+    /// channel after attempting to set the firewall policy, regardless
+    /// of whether it succeeded.
     AllowEndpoint(AllowedEndpoint, oneshot::Sender<()>),
     /// Set DNS servers to use.
     Dns(Option<Vec<IpAddr>>),


### PR DESCRIPTION
This PR fixes two bugs:
* `TunnelCommand::AllowEndpoint` updated the firewall policy twice in the connecting state, for no good reason.
* The `allowed_endpoint` field was updated regardless of whether setting the firewall policy succeeded. It now keeps using the old endpoint in case it fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3458)
<!-- Reviewable:end -->
