### PR TITLE
Use ICMP on macos

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -11,11 +11,13 @@ publish = false
 bitflags = "1.2"
 async-trait = "0.1"
 atty = "0.2"
+byteorder = "1"
 cfg-if = "1.0"
 duct = "0.13"
 err-derive = "0.3.1"
 futures = "0.3.15"
 hex = "0.4"
+internet-checksum = "0.2"
 ipnetwork = "0.16"
 lazy_static = "1.0"
 libc = "0.2"
@@ -57,13 +59,11 @@ netlink-packet-utils = "0.4"
 netlink-packet-route = "0.8"
 netlink-proto = "0.7"
 netlink-sys = "0.7"
-byteorder = "1"
 nftnl = { version = "0.6.2", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2.2", features = ["mnl-1-0-4"] }
 which = { version = "4.0", default-features = false }
 tun = "0.5.1"
 talpid-dbus = { path = "../talpid-dbus" }
-internet-checksum = "0.2"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -75,8 +75,6 @@ subslice = "0.2"
 
 
 [target.'cfg(windows)'.dependencies]
-byteorder = "1"
-internet-checksum = "0.2"
 widestring = "0.5"
 winreg = { version = "0.7", features = ["transactions"] }
 winapi = { version = "0.3.6", features = ["combaseapi", "handleapi", "ifdef", "libloaderapi", "netioapi", "psapi", "stringapiset", "synchapi", "tlhelp32", "winbase", "winioctl", "winuser", "dbt"] }

--- a/talpid-core/src/ping_monitor/icmp.rs
+++ b/talpid-core/src/ping_monitor/icmp.rs
@@ -30,6 +30,16 @@ pub enum Error {
     #[error(display = "Failed to write to socket")]
     WriteError(#[error(source)] io::Error),
 
+    /// Failed to get device index
+    #[cfg(target_os = "macos")]
+    #[error(display = "Failed to obtain device index")]
+    DeviceIdxError(nix::errno::Errno),
+
+    /// Failed to bind socket to device by index
+    #[cfg(target_os = "macos")]
+    #[error(display = "Failed to bind socket to device by index")]
+    BindSocketByDeviceError(io::Error),
+
     /// ICMP buffer too small
     #[error(display = "ICMP message buffer too small")]
     BufferTooSmall,
@@ -49,7 +59,10 @@ pub struct Pinger {
 }
 
 impl Pinger {
-    pub fn new(addr: Ipv4Addr, #[cfg(target_os = "linux")] interface_name: String) -> Result<Self> {
+    pub fn new(
+        addr: Ipv4Addr,
+        #[cfg(not(target_os = "windows"))] interface_name: String,
+    ) -> Result<Self> {
         let addr = SocketAddr::new(addr.into(), 0);
         let sock = Socket::new(Domain::IPV4, Type::RAW, Some(Protocol::ICMPV4))
             .map_err(Error::OpenError)?;
@@ -59,12 +72,27 @@ impl Pinger {
         sock.bind_device(Some(interface_name.as_bytes()))
             .map_err(Error::SocketOptError)?;
 
+        #[cfg(target_os = "macos")]
+        Self::set_device_index(&sock, &interface_name)?;
+
         Ok(Self {
             sock,
             addr,
             id: rand::random(),
             seq: 0,
         })
+    }
+
+    #[cfg(target_os = "macos")]
+    fn set_device_index(socket: &Socket, interface_name: &str) -> Result<()> {
+        let index = nix::net::if_::if_nametoindex(interface_name).map_err(Error::DeviceIdxError)?;
+        // Asserting that `index` is non-zero since otherwise `if_nametoindex` wouuld have return
+        // an error
+        socket
+            .bind_device_by_index(std::num::NonZeroU32::new(index))
+            .map_err(Error::BindSocketByDeviceError)?;
+
+        Ok(())
     }
 
     fn send_ping_request(&mut self, message: &[u8], destination: SocketAddr) -> Result<()> {

--- a/talpid-core/src/ping_monitor/mod.rs
+++ b/talpid-core/src/ping_monitor/mod.rs
@@ -1,8 +1,8 @@
-#[cfg(any(target_os = "android", target_os = "macos"))]
+#[cfg(any(target_os = "android"))]
 #[path = "unix.rs"]
 mod imp;
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 #[path = "icmp.rs"]
 mod imp;
 

--- a/talpid-core/src/ping_monitor/mod.rs
+++ b/talpid-core/src/ping_monitor/mod.rs
@@ -19,11 +19,11 @@ pub trait Pinger: Send {
 /// Create a new pinger
 pub fn new_pinger(
     addr: std::net::Ipv4Addr,
-    #[cfg(not(target_os = "windows"))] interface_name: String,
+    #[cfg(any(target_os = "linux", target_os = "macos"))] interface_name: String,
 ) -> Result<Box<dyn Pinger>, Error> {
     Ok(Box::new(imp::Pinger::new(
         addr,
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         interface_name,
     )?))
 }

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -81,13 +81,13 @@ pub struct ConnectivityMonitor {
 impl ConnectivityMonitor {
     pub(super) fn new(
         addr: Ipv4Addr,
-        #[cfg(not(target_os = "windows"))] interface: String,
+        #[cfg(any(target_os = "macos", target_os = "linux"))] interface: String,
         tunnel_handle: Weak<Mutex<Option<Box<dyn Tunnel>>>>,
         close_receiver: mpsc::Receiver<()>,
     ) -> Result<Self, Error> {
         let pinger = new_pinger(
             addr,
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             interface,
         )
         .map_err(Error::PingError)?;

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -229,7 +229,7 @@ impl WireguardMonitor {
         let gateway = config.ipv4_gateway;
         let mut connectivity_monitor = connectivity_check::ConnectivityMonitor::new(
             gateway,
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             iface_name.clone(),
             Arc::downgrade(&monitor.tunnel),
             pinger_rx,


### PR DESCRIPTION
These changes make the daemon use ICMP sockets instead of calling out to `ping` on macOS. I've verified that ICMP traffic is being sent to the relay.  