### PR TITLE
Don't abort the uninstallation if removing the device fails on macOS

### DIFF
--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -22,8 +22,8 @@ sudo dscl . -delete /groups/mullvad-exclusion || echo "Failed to remove 'mullvad
 
 
 echo "Resetting firewall"
-sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup reset-firewall
-sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup remove-device
+sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup reset-firewall || echo "Failed to reset firewall"
+sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup remove-device || echo "Failed to remove device from account"
 
 echo "Removing zsh shell completion symlink ..."
 sudo rm -f /usr/local/share/zsh/site-functions/_mullvad


### PR DESCRIPTION
This might happen because the API is not reachable, or simply because the device no longer exists. Regardless of the reason, it should not prevent the app from being uninstalled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3465)
<!-- Reviewable:end -->
