### PR TITLE
Fix app list race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix "Open Mullvad VPN" tray context menu item not working after toggling unpinned window setting.
+- Fix apps not always visible in split tunneling view after browsing for an app and then removing it
+  from the excluded applications.
 
 ### Security
 #### Android

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -566,7 +566,11 @@ class ApplicationMain {
 
       if (process.env.NODE_ENV === 'development') {
         await this.installDevTools();
-        this.windowController.window.webContents.openDevTools({ mode: 'detach' });
+
+        // The devtools doesn't open on Windows if openDevTools is called without a delay here.
+        this.windowController.window.once('ready-to-show', () => {
+          this.windowController?.window?.webContents.openDevTools({ mode: 'detach' });
+        });
       }
 
       switch (process.platform) {


### PR DESCRIPTION
This PR fixes:
* That the devtools wont open on windows
* A race condition in the `List` component which prevented items from being removed. The solution implemented is to add a fallback timeout that removes it if `onTransitionEnd` isn't triggered.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3466)
<!-- Reviewable:end -->
