### PR TITLE
Propagate device state over service connection

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Event.kt
@@ -4,6 +4,7 @@ import android.os.Message as RawMessage
 import android.os.Messenger
 import kotlinx.parcelize.Parcelize
 import net.mullvad.mullvadvpn.model.AppVersionInfo as AppVersionInfoData
+import net.mullvad.mullvadvpn.model.DeviceState
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.KeygenEvent
 import net.mullvad.mullvadvpn.model.LoginStatus as LoginStatusData
@@ -27,6 +28,9 @@ sealed class Event : Message.EventMessage() {
 
     @Parcelize
     data class CurrentVersion(val version: String?) : Event()
+
+    @Parcelize
+    data class DeviceStateEvent(val newState: DeviceState) : Event()
 
     @Parcelize
     data class ListenerReady(val connection: Messenger, val listenerId: Int) : Event()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -42,6 +42,9 @@ sealed class Request : Message.RequestMessage() {
     data class Login(val account: String?) : Request()
 
     @Parcelize
+    object RefreshDeviceState : Request()
+
+    @Parcelize
     object Logout : Request()
 
     @Parcelize

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/DeviceState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/DeviceState.kt
@@ -1,0 +1,29 @@
+package net.mullvad.mullvadvpn.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+sealed class DeviceState : Parcelable {
+    @Parcelize
+    object InitialState : DeviceState()
+
+    @Parcelize
+    data class DeviceRegistered(val deviceConfig: DeviceConfig) : DeviceState()
+
+    @Parcelize
+    object DeviceNotRegistered : DeviceState()
+
+    fun isInitialState(): Boolean {
+        return this is InitialState
+    }
+
+    fun token(): String? {
+        return (this as? DeviceRegistered)?.deviceConfig?.token
+    }
+
+    companion object {
+        fun fromDeviceConfig(deviceConfig: DeviceConfig?): DeviceState {
+            return deviceConfig?.let { DeviceRegistered(it) } ?: DeviceNotRegistered
+        }
+    }
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -204,10 +204,8 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
     }
 
     private suspend fun doLogout() {
-        if (accountNumber != null) {
-            daemon.await().logoutAccount()
-            loginStatus = null
-        }
+        daemon.await().logoutAccount()
+        loginStatus = null
     }
 
     private fun fetchAccountHistory() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/DaemonDeviceDataSource.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/DaemonDeviceDataSource.kt
@@ -1,0 +1,47 @@
+package net.mullvad.mullvadvpn.service.endpoint
+
+import kotlinx.coroutines.flow.collect
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.Request
+import net.mullvad.mullvadvpn.model.DeviceState
+import net.mullvad.mullvadvpn.service.MullvadDaemon
+import net.mullvad.mullvadvpn.util.JobTracker
+
+class DaemonDeviceDataSource(
+    val endpoint: ServiceEndpoint
+) {
+    private val tracker = JobTracker()
+
+    init {
+        endpoint.intermittentDaemon.registerListener(this) { daemon ->
+            if (daemon != null) {
+                launchDeviceEndpointJobs(daemon)
+            } else {
+                tracker.cancelAllJobs()
+            }
+        }
+    }
+
+    private fun launchDeviceEndpointJobs(daemon: MullvadDaemon) {
+        tracker.newBackgroundJob("propagateDeviceUpdates") {
+            daemon.deviceStateUpdates.collect { newState ->
+                endpoint.sendEvent(Event.DeviceStateEvent(newState))
+            }
+        }
+
+        endpoint.dispatcher.registerHandler(Request.RefreshDeviceState::class) {
+            tracker.newBackgroundJob("refreshDeviceJob") {
+                daemon.getDevice()
+                    .let { deviceConfig ->
+                        Event.DeviceStateEvent(DeviceState.fromDeviceConfig(deviceConfig))
+                    }
+                    .also { event -> endpoint.sendEvent(event) }
+            }
+        }
+    }
+
+    fun onDestroy() {
+        tracker.cancelAllJobs()
+        endpoint.intermittentDaemon.unregisterListener(this)
+    }
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/ServiceEndpoint.kt
@@ -58,6 +58,8 @@ class ServiceEndpoint(
     val splitTunneling = SplitTunneling(SplitTunnelingPersistence(context), this)
     val voucherRedeemer = VoucherRedeemer(this)
 
+    private val deviceRepositoryBackend = DaemonDeviceDataSource(this)
+
     init {
         dispatcher.apply {
             registerHandler(Request.RegisterListener::class) { request ->
@@ -79,6 +81,7 @@ class ServiceEndpoint(
         authTokenCache.onDestroy()
         connectionProxy.onDestroy()
         customDns.onDestroy()
+        deviceRepositoryBackend.onDestroy()
         keyStatusListener.onDestroy()
         locationInfoCache.onDestroy()
         relayListListener.onDestroy()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -10,6 +10,7 @@ import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.CustomDns
+import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.KeyStatusListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.RelayListListener
@@ -48,6 +49,9 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
     lateinit var customDns: CustomDns
         private set
 
+    lateinit var deviceRepository: DeviceRepository
+        private set
+
     lateinit var keyStatusListener: KeyStatusListener
         private set
 
@@ -70,6 +74,7 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         appVersionInfoCache = serviceConnection.appVersionInfoCache
         authTokenCache = serviceConnection.authTokenCache
         connectionProxy = serviceConnection.connectionProxy
+        deviceRepository = serviceConnection.deviceRepository
         customDns = serviceConnection.customDns
         keyStatusListener = serviceConnection.keyStatusListener
         locationInfoCache = serviceConnection.locationInfoCache

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -57,9 +57,7 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyStart() {
-        accountCache.onAccountNumberChange.subscribe(this) { account ->
-            updateAccountNumber(account)
-        }
+        updateAccountNumber(deviceRepository.deviceState.value.token())
 
         accountCache.onAccountExpiryChange.subscribe(this) { expiry ->
             checkExpiry(expiry)
@@ -76,7 +74,6 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
     }
 
     override fun onSafelyStop() {
-        accountCache.onAccountNumberChange.unsubscribe(this)
         accountCache.onAccountExpiryChange.unsubscribe(this)
         jobTracker.cancelJob("pollAccountData")
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountCache.kt
@@ -9,7 +9,6 @@ import net.mullvad.talpid.util.EventNotifier
 import org.joda.time.DateTime
 
 class AccountCache(private val connection: Messenger, eventDispatcher: EventDispatcher) {
-    val onAccountNumberChange = EventNotifier<String?>(null)
     val onAccountExpiryChange = EventNotifier<DateTime?>(null)
     val onAccountHistoryChange = EventNotifier<String?>(null)
     val onLoginStatusChange = EventNotifier<LoginStatus?>(null)
@@ -25,8 +24,6 @@ class AccountCache(private val connection: Messenger, eventDispatcher: EventDisp
 
             registerHandler(Event.LoginStatus::class) { event ->
                 loginStatus = event.status
-
-                onAccountNumberChange.notifyIfChanged(loginStatus?.account)
                 onAccountExpiryChange.notifyIfChanged(loginStatus?.expiry)
             }
         }
@@ -59,7 +56,6 @@ class AccountCache(private val connection: Messenger, eventDispatcher: EventDisp
     }
 
     fun onDestroy() {
-        onAccountNumberChange.unsubscribeAll()
         onAccountExpiryChange.unsubscribeAll()
         onAccountHistoryChange.unsubscribeAll()
         onLoginStatusChange.unsubscribeAll()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/DeviceRepository.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/DeviceRepository.kt
@@ -1,0 +1,20 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted.Companion.Lazily
+import kotlinx.coroutines.flow.stateIn
+import net.mullvad.mullvadvpn.model.DeviceState
+
+class DeviceRepository(
+    private val dataSource: ServiceConnectionDeviceDataSource,
+    externalScope: CoroutineScope
+) {
+    val deviceState = dataSource.deviceStateUpdates
+        .stateIn(
+            externalScope,
+            Lazily,
+            DeviceState.InitialState
+        )
+
+    fun refreshDeviceState() = dataSource.refreshDevice()
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnection.kt
@@ -4,6 +4,7 @@ import android.os.Looper
 import android.os.Messenger
 import android.os.RemoteException
 import android.util.Log
+import kotlinx.coroutines.MainScope
 import net.mullvad.mullvadvpn.di.SERVICE_CONNECTION_SCOPE
 import net.mullvad.mullvadvpn.ipc.DispatchingHandler
 import net.mullvad.mullvadvpn.ipc.Event
@@ -35,6 +36,8 @@ class ServiceConnection(
     val accountCache = AccountCache(connection, dispatcher)
     val authTokenCache = AuthTokenCache(connection, dispatcher)
     val connectionProxy = ConnectionProxy(connection, dispatcher)
+    val deviceRepository =
+        DeviceRepository(ServiceConnectionDeviceDataSource(connection, dispatcher), MainScope())
     val keyStatusListener = KeyStatusListener(connection, dispatcher)
     val locationInfoCache = LocationInfoCache(dispatcher)
     val settingsListener = SettingsListener(connection, dispatcher)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionDeviceDataSource.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionDeviceDataSource.kt
@@ -1,0 +1,27 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
+import net.mullvad.mullvadvpn.ipc.Request
+
+class ServiceConnectionDeviceDataSource(
+    private val connection: Messenger,
+    private val dispatcher: EventDispatcher
+) {
+    val deviceStateUpdates = callbackFlow {
+        dispatcher.registerHandler(Event.DeviceStateEvent::class) { event ->
+            trySend(event.newState)
+        }
+        awaitClose {
+            // The current dispatcher doesn't support unregistration of handlers.
+        }
+    }
+
+    // Async result: Event.DeviceChanged
+    fun refreshDevice() {
+        connection.send(Request.RefreshDeviceState.message)
+    }
+}


### PR DESCRIPTION
Adds device state communication between the app and service with a
repository backed by a data source to add abstraction layers on the app
side.

Limitations:
* Expiration is not updated correctly.
* The login/creation flow has not been fully adapted to devices.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3467)
<!-- Reviewable:end -->
