### PR TITLE
Add split tunneling remove button

### DIFF
--- a/gui/src/main/gui-settings.ts
+++ b/gui/src/main/gui-settings.ts
@@ -90,6 +90,15 @@ export default class GuiSettings {
     });
   }
 
+  public deleteBrowsedForSplitTunnelingApplications(path: string) {
+    this.changeStateAndNotify({
+      ...this.stateValue,
+      browsedForSplitTunnelingApplications: this.browsedForSplitTunnelingApplications.filter(
+        (application) => application !== path,
+      ),
+    });
+  }
+
   get browsedForSplitTunnelingApplications(): Array<string> {
     return this.stateValue.browsedForSplitTunnelingApplications;
   }

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -16,7 +16,7 @@ import userInterfaceActions from './redux/userinterface/actions';
 import versionActions from './redux/version/actions';
 
 import { IChangelog, ICurrentAppVersionInfo } from '../shared/ipc-types';
-import { IApplication, ILinuxSplitTunnelingApplication } from '../shared/application-types';
+import { IWindowsApplication, ILinuxSplitTunnelingApplication } from '../shared/application-types';
 import { IGuiSettingsState, SYSTEM_PREFERRED_LOCALE_KEY } from '../shared/gui-settings-state';
 import { messages, relayLocations } from '../shared/gettext';
 import log, { ConsoleOutput } from '../shared/logging';
@@ -171,7 +171,7 @@ export default class AppRenderer {
       this.storeAutoStart(autoStart);
     });
 
-    IpcRendererEventChannel.windowsSplitTunneling.listen((applications: IApplication[]) => {
+    IpcRendererEventChannel.windowsSplitTunneling.listen((applications: IWindowsApplication[]) => {
       this.reduxActions.settings.setSplitTunnelingApplications(applications);
     });
 
@@ -471,12 +471,18 @@ export default class AppRenderer {
     return IpcRendererEventChannel.windowsSplitTunneling.setState(enabled);
   };
 
-  public addSplitTunnelingApplication(application: IApplication | string): Promise<void> {
+  public addSplitTunnelingApplication(application: IWindowsApplication | string): Promise<void> {
     return IpcRendererEventChannel.windowsSplitTunneling.addApplication(application);
   }
 
-  public removeSplitTunnelingApplication(application: IApplication | string) {
+  public removeSplitTunnelingApplication(application: IWindowsApplication) {
     void IpcRendererEventChannel.windowsSplitTunneling.removeApplication(application);
+  }
+
+  public forgetManuallyAddedSplitTunnelingApplication(application: IWindowsApplication) {
+    return IpcRendererEventChannel.windowsSplitTunneling.forgetManuallyAddedApplication(
+      application,
+    );
   }
 
   public collectProblemReport(toRedact?: string): Promise<string> {

--- a/gui/src/renderer/components/List.tsx
+++ b/gui/src/renderer/components/List.tsx
@@ -69,7 +69,7 @@ export default function List<T>(props: ListProps<T>) {
   useEffect(
     () => () => {
       // Cancel all schedulers on unmount
-      Object.values(removeFallbackSchedulers).forEach((scheduler) => scheduler.cancel());
+      Object.values(removeFallbackSchedulers.current).forEach((scheduler) => scheduler.cancel());
     },
     [],
   );

--- a/gui/src/renderer/components/SplitTunnelingSettingsStyles.tsx
+++ b/gui/src/renderer/components/SplitTunnelingSettingsStyles.tsx
@@ -49,7 +49,7 @@ export const StyledIcon = styled(Cell.UntintedIcon)(disabledApplication, {
 });
 
 export const StyledActionIcon = styled(ImageView)({
-  marginLeft: '6px',
+  marginLeft: '8px',
 });
 
 export const StyledCellWarningIcon = styled(Cell.Icon)({

--- a/gui/src/renderer/redux/settings/actions.ts
+++ b/gui/src/renderer/redux/settings/actions.ts
@@ -1,6 +1,6 @@
 import { BridgeState, IDnsOptions } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
-import { IApplication } from '../../../shared/application-types';
+import { IWindowsApplication } from '../../../shared/application-types';
 import { BridgeSettingsRedux, IRelayLocationRedux, RelaySettingsRedux } from './reducers';
 
 export interface IUpdateGuiSettingsAction {
@@ -80,7 +80,7 @@ export interface IUpdateSplitTunnelingStateAction {
 
 export interface ISetSplitTunnelingApplicationsAction {
   type: 'SET_SPLIT_TUNNELING_APPLICATIONS';
-  applications: IApplication[];
+  applications: IWindowsApplication[];
 }
 
 export type SettingsAction =
@@ -211,7 +211,7 @@ function updateSplitTunnelingState(enabled: boolean): IUpdateSplitTunnelingState
 }
 
 function setSplitTunnelingApplications(
-  applications: IApplication[],
+  applications: IWindowsApplication[],
 ): ISetSplitTunnelingApplicationsAction {
   return {
     type: 'SET_SPLIT_TUNNELING_APPLICATIONS',

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -1,4 +1,4 @@
-import { IApplication } from '../../../shared/application-types';
+import { IWindowsApplication } from '../../../shared/application-types';
 import {
   BridgeState,
   LiftedConstraint,
@@ -91,7 +91,7 @@ export interface ISettingsReduxState {
   };
   dns: IDnsOptions;
   splitTunneling: boolean;
-  splitTunnelingApplications: IApplication[];
+  splitTunnelingApplications: IWindowsApplication[];
 }
 
 const initialState: ISettingsReduxState = {

--- a/gui/src/shared/application-types.ts
+++ b/gui/src/shared/application-types.ts
@@ -6,6 +6,10 @@ export interface IApplication {
   icon?: string;
 }
 
+export interface IWindowsApplication extends IApplication {
+  deletable: boolean;
+}
+
 export interface ILinuxApplication extends IApplication {
   exec: string;
   type: string;

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -1,5 +1,5 @@
 import { GetTextTranslations } from 'gettext-parser';
-import { IApplication, ILinuxSplitTunnelingApplication } from './application-types';
+import { IWindowsApplication, ILinuxSplitTunnelingApplication } from './application-types';
 import {
   AccountToken,
   BridgeSettings,
@@ -60,7 +60,7 @@ export interface IAppStateSnapshot {
   upgradeVersion: IAppVersionInfo;
   guiSettings: IGuiSettingsState;
   translations: ITranslations;
-  windowsSplitTunnelingApplications?: IApplication[];
+  windowsSplitTunnelingApplications?: IWindowsApplication[];
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
   changelog: IChangelog;
 }
@@ -201,10 +201,11 @@ export const ipcSchema = {
     launchApplication: invoke<ILinuxSplitTunnelingApplication | string, LaunchApplicationResult>(),
   },
   windowsSplitTunneling: {
-    '': notifyRenderer<IApplication[]>(),
+    '': notifyRenderer<IWindowsApplication[]>(),
     setState: invoke<boolean, void>(),
-    getApplications: invoke<boolean, { fromCache: boolean; applications: IApplication[] }>(),
-    addApplication: invoke<IApplication | string, void>(),
-    removeApplication: invoke<IApplication | string, void>(),
+    getApplications: invoke<boolean, { fromCache: boolean; applications: IWindowsApplication[] }>(),
+    addApplication: invoke<IWindowsApplication | string, void>(),
+    removeApplication: invoke<IWindowsApplication, void>(),
+    forgetManuallyAddedApplication: invoke<IWindowsApplication, void>(),
   },
 };


### PR DESCRIPTION
This PR adds a button to remove manually added applications in the split tunneling view on Windows. I also did a small fix for accessing the ref in the `List` clean up code.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3468)
<!-- Reviewable:end -->
