### PR TITLE
Add result operation

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		58F559102697002100F630D0 /* HeaderBar.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F559092697002100F630D0 /* HeaderBar.strings */; };
 		58F61F4F2692F21C00DCFC2B /* WireguardKeys.strings in Resources */ = {isa = PBXBuildFile; fileRef = 58F61F4D2692F21C00DCFC2B /* WireguardKeys.strings */; };
 		58F7CA882692E34000FC59FD /* WireguardKeysContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F7CA872692E34000FC59FD /* WireguardKeysContentView.swift */; };
+		58F7D26527EB50A300E4D821 /* ResultOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F7D26427EB50A300E4D821 /* ResultOperation.swift */; };
 		58F840B22464491D0044E708 /* ChainedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840B12464491D0044E708 /* ChainedError.swift */; };
 		58F840B32464491D0044E708 /* ChainedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F840B12464491D0044E708 /* ChainedError.swift */; };
 		58F8AC0E25D3F8CE002BE0ED /* ProblemReportReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F8AC0D25D3F8CE002BE0ED /* ProblemReportReviewViewController.swift */; };
@@ -548,6 +549,7 @@
 		58F5590A2697002100F630D0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/HeaderBar.strings; sourceTree = "<group>"; };
 		58F61F4E2692F21C00DCFC2B /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/WireguardKeys.strings; sourceTree = "<group>"; };
 		58F7CA872692E34000FC59FD /* WireguardKeysContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireguardKeysContentView.swift; sourceTree = "<group>"; };
+		58F7D26427EB50A300E4D821 /* ResultOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultOperation.swift; sourceTree = "<group>"; };
 		58F840B12464491D0044E708 /* ChainedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainedError.swift; sourceTree = "<group>"; };
 		58F8AC0D25D3F8CE002BE0ED /* ProblemReportReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemReportReviewViewController.swift; sourceTree = "<group>"; };
 		58FAEDEB245059F000CB0F5B /* KeychainAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAttributes.swift; sourceTree = "<group>"; };
@@ -632,9 +634,10 @@
 				580EE22324B3243100F9D8A1 /* AsyncBlockOperation.swift */,
 				58E973DD24850EB600096F90 /* AsyncOperation.swift */,
 				580EE20524B3222200F9D8A1 /* ExclusivityController.swift */,
+				5840BE34279EDB16002836BA /* OperationCompletion.swift */,
 				5820675D26E6839900655B05 /* PresentAlertOperation.swift */,
 				5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */,
-				5840BE34279EDB16002836BA /* OperationCompletion.swift */,
+				58F7D26427EB50A300E4D821 /* ResultOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -1290,6 +1293,7 @@
 				585DA87D26B0254000B8C587 /* RelayCacheIO.swift in Sources */,
 				582AD44027BE616E002A6BFC /* CodingErrors+ChainedError.swift in Sources */,
 				58F2E148276A307400A79513 /* MapConnectionStatusOperation.swift in Sources */,
+				58F7D26527EB50A300E4D821 /* ResultOperation.swift in Sources */,
 				58BA693123EADA6A009DC256 /* SimulatorTunnelProvider.swift in Sources */,
 				58F1311327E09B00007AC5BC /* Cancellable.swift in Sources */,
 				587C575326D2615F005EF767 /* PacketTunnelOptions.swift in Sources */,

--- a/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
@@ -24,6 +24,14 @@ class AsyncBlockOperation: AsyncOperation {
         executionBlock = nil
     }
 
+    override func finish() {
+        stateLock.lock()
+        cancellationBlocks.removeAll()
+        stateLock.unlock()
+
+        super.finish()
+    }
+
     override func cancel() {
         super.cancel()
 
@@ -39,7 +47,6 @@ class AsyncBlockOperation: AsyncOperation {
 
     func addCancellationBlock(_ block: @escaping () -> Void) {
         stateLock.lock()
-
         if isCancelled {
             stateLock.unlock()
             block()
@@ -47,11 +54,5 @@ class AsyncBlockOperation: AsyncOperation {
             cancellationBlocks.append(block)
             stateLock.unlock()
         }
-    }
-
-    override func operationDidFinish() {
-        stateLock.lock()
-        cancellationBlocks.removeAll()
-        stateLock.unlock()
     }
 }

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -71,7 +71,7 @@ class AsyncOperation: Operation {
         super.cancel()
     }
 
-    final func finish() {
+    func finish() {
         stateLock.lock()
 
         if _isExecuting {

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -45,9 +45,14 @@ class AsyncOperation: Operation {
 
     final override func start() {
         stateLock.lock()
-        setExecuting(true)
-        stateLock.unlock()
-        main()
+        if _isCancelled {
+            stateLock.unlock()
+            finish()
+        } else {
+            setExecuting(true)
+            stateLock.unlock()
+            main()
+        }
     }
 
     override func main() {

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -84,15 +84,9 @@ class AsyncOperation: Operation {
             didChangeValue(for: \.isFinished)
 
             stateLock.unlock()
-
-            operationDidFinish()
         } else {
             stateLock.unlock()
         }
-    }
-
-    func operationDidFinish() {
-        // Override in subclasses
     }
 
     private func setExecuting(_ value: Bool) {

--- a/ios/MullvadVPN/Operations/ResultOperation.swift
+++ b/ios/MullvadVPN/Operations/ResultOperation.swift
@@ -1,0 +1,77 @@
+//
+//  ResultOperation.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 23/03/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+/// Base class for operations producing result.
+class ResultOperation<Success, Failure: Error>: AsyncOperation {
+    typealias Completion = OperationCompletion<Success, Failure>
+    typealias CompletionHandler = (Completion) -> Void
+
+    private let stateLock = NSLock()
+    private var completionValue: Completion?
+    private let completionQueue: DispatchQueue?
+    private var completionHandler: CompletionHandler?
+
+    var completion: Completion? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return completionValue
+    }
+
+    init(completionQueue: DispatchQueue?, completionHandler: CompletionHandler?) {
+        self.completionQueue = completionQueue
+        self.completionHandler = completionHandler
+
+        super.init()
+    }
+
+    override func finish() {
+        // Propagate cancellation if finish() is called directly from start().
+        if isCancelled {
+            finish(completion: .cancelled)
+        } else {
+            preconditionFailure("Use finish(completion:) to finish operation.")
+        }
+    }
+
+    func finish(completion: Completion) {
+        stateLock.lock()
+
+        // Bail if operation is already finishing.
+        guard completionValue == nil else {
+            stateLock.unlock()
+            return
+        }
+
+        // Store completion value.
+        completionValue = completion
+
+        // Copy completion handler.
+        let completionHandler: CompletionHandler? = self.completionHandler
+
+        // Unset completion handler.
+        self.completionHandler = nil
+
+        stateLock.unlock()
+
+        let block = {
+            // Call completion handler.
+            completionHandler?(completion)
+
+            // Finish operation.
+            super.finish()
+        }
+
+        if let completionQueue = completionQueue {
+            completionQueue.async(execute: block)
+        } else {
+            block()
+        }
+    }
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add `ResultOperation` base class that guarantees to emit `OperationCompletion<Success, Failure>` upon completion, but before operation is finished. This should get rid of a lot of boilerplate code in operation subclasses that often maintain its own completion handler. 
    
    Note that calling completion handler before finishing the operation subclass opens a window of opportunity for the handler to perform some routine as a part of the task, which we leverage in few places. In contrast the standard `completionBlock`, that can be assigned on operations,  executes after operation is finished.
    
2. Operations should automatically finish if cancelled before starting. This should further align our `AsyncOperation` with how standard `Operation` works, i.e:
  
    ```swift
    import Foundation

    class MyOperation: Operation {
        override func main() {
            print("Never prints.")
        }
    }

    let op = MyOperation()
    op.cancel()

    let q = OperationQueue()
    q.addOperation(op)
    q.waitUntilAllOperationsAreFinished()
    ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3470)
<!-- Reviewable:end -->
