### PR TITLE
Don't update the device when `GetDevice()` is called

### DIFF
--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -135,6 +135,9 @@ impl Account {
 
     async fn get(&self, verbose: bool) -> Result<()> {
         let mut rpc = new_rpc_client().await?;
+
+        let _ = rpc.update_device(()).await;
+
         let device = rpc
             .get_device(())
             .await

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -55,6 +55,7 @@ service ManagementService {
 
 	// Device management
 	rpc GetDevice(google.protobuf.Empty) returns (DeviceConfig) {}
+	rpc UpdateDevice(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 	rpc ListDevices(google.protobuf.StringValue) returns (DeviceList) {}
 	rpc RemoveDevice(DeviceRemoval) returns (google.protobuf.Empty) {}
 


### PR DESCRIPTION
Previously, fetching the current device from the daemon would also call the API to update all data and check if it still existed, and falling back on the last known data after a timeout. This is now done using a separate function (`UpdateDevice`), since frontends should be able to obtain the last known state immediately.