### PR TITLE
Show launch view before receiving device config

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -513,6 +513,10 @@ export class DaemonRpc {
     }
   }
 
+  public async updateDevice(): Promise<void> {
+    await this.callEmpty(this.client.updateDevice);
+  }
+
   public async listDevices(accountToken: AccountToken): Promise<Array<IDevice>> {
     const response = await this.callString<grpcTypes.DeviceList>(
       this.client.listDevices,

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -198,6 +198,7 @@ class ApplicationMain {
     },
   };
   private deviceConfig?: IDeviceConfig;
+  private hasReceivedDeviceConfig = false;
   private guiSettings = new GuiSettings();
   private tunnelStateExpectation?: Expectation;
 
@@ -647,6 +648,9 @@ class ApplicationMain {
     // fetch device
     try {
       this.setDeviceConfig({ deviceConfig: await this.daemonRpc.getDevice() });
+      void this.daemonRpc
+        .updateDevice()
+        .catch((error: Error) => log.warn(`Failed to update device info: ${error.message}`));
     } catch (e) {
       const error = e as Error;
       log.error(`Failed to fetch device: ${error.message}`);
@@ -1118,6 +1122,7 @@ class ApplicationMain {
   private setDeviceConfig(deviceEvent: IDeviceEvent) {
     const oldDeviceConfig = this.deviceConfig;
     this.deviceConfig = deviceEvent.deviceConfig;
+    this.hasReceivedDeviceConfig = true;
 
     // make sure to invalidate the account data cache when account tokens change
     this.updateAccountDataOnAccountChange(
@@ -1214,6 +1219,7 @@ class ApplicationMain {
       tunnelState: this.tunnelState,
       settings: this.settings,
       deviceConfig: this.deviceConfig,
+      hasReceivedDeviceConfig: this.hasReceivedDeviceConfig,
       relayListPair: {
         relays: this.processRelaysForPresentation(this.relays, this.settings.relaySettings),
         bridges: this.processBridgesForPresentation(this.relays, this.settings.bridgeState),

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -99,6 +99,7 @@ export default class AppRenderer {
   private tunnelState!: TunnelState;
   private settings!: ISettings;
   private deviceConfig?: IDeviceConfig;
+  private hasReceivedDeviceConfig = false;
   private guiSettings!: IGuiSettingsState;
   private loginState: LoginState = 'none';
   private previousLoginState: LoginState = 'none';
@@ -130,6 +131,7 @@ export default class AppRenderer {
 
     IpcRendererEventChannel.account.listenDevice((deviceEvent) => {
       const oldDeviceConfig = this.deviceConfig;
+      this.hasReceivedDeviceConfig = true;
       this.handleAccountChange(deviceEvent, oldDeviceConfig?.accountToken);
     });
 
@@ -205,6 +207,7 @@ export default class AppRenderer {
     this.setAccountExpiry(initialState.accountData?.expiry);
     this.setSettings(initialState.settings);
     this.handleAccountChange({ deviceConfig: initialState.deviceConfig }, undefined);
+    this.hasReceivedDeviceConfig = initialState.hasReceivedDeviceConfig;
     this.setAccountHistory(initialState.accountHistory);
     this.setTunnelState(initialState.tunnelState);
     this.updateBlockedState(initialState.tunnelState, initialState.settings.blockWhenDisconnected);
@@ -696,7 +699,7 @@ export default class AppRenderer {
   }
 
   private getNavigationBase(): RoutePath {
-    if (this.connectedToDaemon) {
+    if (this.connectedToDaemon && this.hasReceivedDeviceConfig) {
       const loginState = this.reduxStore.getState().account.status;
       const deviceRevoked = loginState.type === 'none' && loginState.deviceRevoked;
 

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -55,6 +55,7 @@ export interface IAppStateSnapshot {
   tunnelState: TunnelState;
   settings: ISettings;
   deviceConfig?: IDeviceConfig;
+  hasReceivedDeviceConfig: boolean;
   relayListPair: IRelayListPair;
   currentVersion: ICurrentAppVersionInfo;
   upgradeVersion: IAppVersionInfo;


### PR DESCRIPTION
This PR makes the app wait until device info has been received before leaving the `launch` view. It also adds the `updateDevice` call since that was previously done automatically in `getDevice`, but now is a separate call.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3472)
<!-- Reviewable:end -->
