### PR TITLE
Switch to using the cache function in actions/setup-node

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -37,6 +37,7 @@ jobs:
               run: npm ci
 
             - name: Check formatting
+              if: matrix.os == 'ubuntu-latest'
               working-directory: gui
               run: npm run lint
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,18 +23,18 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v2.1.5
+              uses: actions/setup-node@v3
               with:
                   node-version: '16.9.1'
+                  cache: 'npm'
+                  cache-dependency-path: gui/package-lock.json
 
             - name: Update NPM
               run: npm i -g npm
 
-            - name: Install and cache dependencies
-              uses: bahmutov/npm-install@v1
-              with:
-                  working-directory: gui
-                  install-command: npm ci
+            - name: Install dependencies
+              working-directory: gui
+              run: npm ci
 
             - name: Check formatting
               working-directory: gui

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -16,19 +16,19 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Install Node.js
-              uses: actions/setup-node@v2
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v3
               with:
-                node-version: '14'
+                  node-version: '16.9.1'
+                  cache: 'npm'
+                  cache-dependency-path: gui/package-lock.json
 
             - name: Update NPM
               run: npm i -g npm
 
-            - name: Install and cache JS dependencies
-              uses: bahmutov/npm-install@v1
-              with:
-                  working-directory: gui
-                  install-command: npm ci
+            - name: Install JS dependencies
+              working-directory: gui
+              run: npm ci
 
             - name: Install nightly Rust
               uses: ATiltedTree/setup-rust@v1.0.4

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -12292,6 +12292,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
@@ -23861,6 +23874,16 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {


### PR DESCRIPTION
This PR:
* Contains an updated `package-lock.json` for the latest version of NPM
* Prevents the frontend job linter step from running on Windows, since it's already running on Linux
* Switches to using the npm cache in `actions/setup-node@v3` instead of a separate third party action.

According to my observations the action improvements save more than a minute each run.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3480)
<!-- Reviewable:end -->
