### PR TITLE
Don't treat an empty account history as invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix resource leak caused by location check.
 - Fix issue where sockets didn't close after disconnecting from WireGuard servers over TCP
   by updating `udp-over-tcp` to 0.2.
+- Parse old account history formats correctly when they are empty.
 
 #### Windows
 - Fix "Open Mullvad VPN" tray context menu item not working after toggling unpinned window setting.


### PR DESCRIPTION
When updating from `2021.4` to `2022.1` and the user had never logged in, the migration stopped because the code treated an empty, valid account history as an error. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3482)
<!-- Reviewable:end -->
