### PR TITLE
Return completion from key rotation

### DIFF
--- a/ios/MullvadVPN/AddressCache/AddressCacheTracker.swift
+++ b/ios/MullvadVPN/AddressCache/AddressCacheTracker.swift
@@ -149,19 +149,19 @@ extension AddressCache {
             case .success(let updateResult):
                 switch updateResult {
                 case .finished:
-                    logger.debug("Finished updating address cache")
+                    logger.debug("Finished updating address cache.")
                 case .throttled:
-                    logger.debug("Address cache update was throttled")
+                    logger.debug("Address cache update was throttled.")
                 }
 
                 lastFailureAttemptDate = nil
 
             case .failure(let error):
-                logger.error(chainedError: AnyChainedError(error), message: "Failed to update address cache")
+                logger.error(chainedError: AnyChainedError(error), message: "Failed to update address cache.")
                 lastFailureAttemptDate = Date()
 
             case .cancelled:
-                logger.debug("Address cache update was cancelled")
+                logger.debug("Address cache update was cancelled.")
                 lastFailureAttemptDate = Date()
             }
         }
@@ -208,7 +208,7 @@ extension AddressCache.Tracker {
     private func handleBackgroundTask(_ task: BGProcessingTask) {
         logger.debug("Start address cache update task")
 
-        let cancellable = updateEndpoints { result in
+        let cancellable = updateEndpoints { completion in
             do {
                 // Schedule next background task
                 try self.scheduleBackgroundTask()
@@ -216,7 +216,7 @@ extension AddressCache.Tracker {
                 self.logger.error(chainedError: AnyChainedError(error), message: "Failed to schedule next address cache update task")
             }
 
-            task.setTaskCompleted(success: result.isTaskCompleted)
+            task.setTaskCompleted(success: completion.isSuccess)
         }
 
         task.expirationHandler = {

--- a/ios/MullvadVPN/AddressCache/UpdateAddressCacheOperation.swift
+++ b/ios/MullvadVPN/AddressCache/UpdateAddressCacheOperation.swift
@@ -95,14 +95,3 @@ extension AddressCache {
         }
     }
 }
-
-extension OperationCompletion where Success == AddressCache.CacheUpdateResult {
-    var isTaskCompleted: Bool {
-        switch self {
-        case .success:
-            return true
-        case .cancelled, .failure:
-            return false
-        }
-    }
-}

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -181,8 +181,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let operationQueue = OperationQueue()
 
         let updateAddressCacheOperation = AsyncBlockOperation { operation in
-            let handle = self.addressCacheTracker.updateEndpoints { result in
-                addressCacheFetchResult = result.backgroundFetchResult
+            let handle = self.addressCacheTracker.updateEndpoints { completion in
+                addressCacheFetchResult = completion.backgroundFetchResult
                 operation.finish()
             }
 
@@ -195,15 +195,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let handle = RelayCache.Tracker.shared.updateRelays { completion in
                 switch completion {
                 case .success(let result):
-                    self.logger?.debug("Finished updating relays: \(result)")
+                    self.logger?.debug("Finished updating relays: \(result).")
                 case .failure(let error):
-                    self.logger?.error(chainedError: error, message: "Failed to update relays")
+                    self.logger?.error(chainedError: error, message: "Failed to update relays.")
                 case .cancelled:
                     break
                 }
 
-                relaysFetchResult = completion.result?.backgroundFetchResult
-
+                relaysFetchResult = completion.backgroundFetchResult
                 operation.finish()
             }
 

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -213,23 +213,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         let rotatePrivateKeyOperation = AsyncBlockOperation { operation in
-            let handle = TunnelManager.shared.rotatePrivateKey { rotationResult, error in
-                if let error = error {
-                    self.logger?.error(chainedError: error, message: "Failed to rotate the key")
-
-                    rotatePrivateKeyFetchResult = .failed
-                } else if let rotationResult = rotationResult {
-                    self.logger?.debug("Finished rotating the key: \(rotationResult)")
-
-                    switch rotationResult {
-                    case .throttled:
-                        rotatePrivateKeyFetchResult = .noData
-
-                    case .finished:
-                        rotatePrivateKeyFetchResult = .newData
-                    }
+            let handle = TunnelManager.shared.rotatePrivateKey { completion in
+                switch completion {
+                case .success(let rotationResult):
+                    self.logger?.debug("Finished rotating the key: \(rotationResult).")
+                case .failure(let error):
+                    self.logger?.error(chainedError: error, message: "Failed to rotate the key.")
+                case .cancelled:
+                    break
                 }
 
+                rotatePrivateKeyFetchResult = completion.backgroundFetchResult
                 operation.finish()
             }
 

--- a/ios/MullvadVPN/AppStorePaymentManager/AppStorePaymentManager.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager/AppStorePaymentManager.swift
@@ -175,9 +175,13 @@ class AppStorePaymentManager: NSObject, SKPaymentTransactionObserver {
     }
 
     private func sendAppStoreReceipt(accountToken: String, forceRefresh: Bool, completionHandler: @escaping (OperationCompletion<REST.CreateApplePaymentResponse, Error>) -> Void) -> Cancellable {
-        let operation = SendAppStoreReceiptOperation(restClient: REST.Client.shared, accountToken: accountToken, forceRefresh: forceRefresh, receiptProperties: nil) { completion in
-            completionHandler(completion)
-        }
+        let operation = SendAppStoreReceiptOperation(
+            restClient: REST.Client.shared,
+            accountToken: accountToken,
+            forceRefresh: forceRefresh,
+            receiptProperties: nil,
+            completionHandler: completionHandler
+        )
 
         let backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "Send AppStore receipt") {
             operation.cancel()

--- a/ios/MullvadVPN/Operations/OperationCompletion.swift
+++ b/ios/MullvadVPN/Operations/OperationCompletion.swift
@@ -13,6 +13,14 @@ enum OperationCompletion<Success, Failure: Error> {
     case success(Success)
     case failure(Failure)
 
+    var isSuccess: Bool {
+        if case .success = self {
+            return true
+        } else {
+            return false
+        }
+    }
+
     var error: Failure? {
         if case .failure(let error) = self {
             return error

--- a/ios/MullvadVPN/Operations/ResultOperation.swift
+++ b/ios/MullvadVPN/Operations/ResultOperation.swift
@@ -31,6 +31,7 @@ class ResultOperation<Success, Failure: Error>: AsyncOperation {
         super.init()
     }
 
+    @available(*, unavailable)
     override func finish() {
         // Propagate cancellation if finish() is called directly from start().
         if isCancelled {

--- a/ios/MullvadVPN/RelayCache/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCache/RelayCacheTracker.swift
@@ -267,23 +267,18 @@ extension RelayCache.Tracker {
         logger.debug("Start app refresh task.")
 
         let cancellable = self.updateRelays { completion in
-            let isTaskCompleted: Bool
-
             switch completion {
             case .success(let fetchResult):
                 self.logger.debug("Finished updating relays in app refresh task: \(fetchResult).")
-                isTaskCompleted = true
 
             case .failure(let error):
                 self.logger.error(chainedError: error, message: "Failed to update relays in app refresh task.")
-                isTaskCompleted = false
 
             case .cancelled:
                 self.logger.debug("App refresh task was cancelled.")
-                isTaskCompleted = false
             }
 
-            task.setTaskCompleted(success: isTaskCompleted)
+            task.setTaskCompleted(success: completion.isSuccess)
         }
 
         task.expirationHandler = {

--- a/ios/MullvadVPN/Result+UIBackgroundFetchResult.swift
+++ b/ios/MullvadVPN/Result+UIBackgroundFetchResult.swift
@@ -21,15 +21,26 @@ extension OperationCompletion where Success == AddressCache.CacheUpdateResult {
     }
 }
 
-extension Result where Success == RelayCache.FetchResult {
+extension OperationCompletion where Success == TunnelManager.KeyRotationResult {
+    var backgroundFetchResult: UIBackgroundFetchResult {
+        switch self {
+        case .success(.finished):
+            return .newData
+        case .success(.throttled), .cancelled:
+            return .noData
+        case .failure:
+            return .failed
+        }
+    }
+}
+
+extension OperationCompletion where Success == RelayCache.FetchResult {
     var backgroundFetchResult: UIBackgroundFetchResult {
         switch self {
         case .success(.newContent):
             return .newData
-
-        case .success(.throttled), .success(.sameContent):
+        case .success(.throttled), .success(.sameContent), .cancelled:
             return .noData
-
         case .failure:
             return .failed
         }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Return `OperationCompletion` from `TunnelManager.rotatePrivateKey()` instead of a pair of `KeyRotationResult?, TunnelManager.Error?`. This eliminates the need for both optional types, and for `KeyRotationResult` to contain the `cancelled` and `failed` cases, since `OperationCompletion` offers both of them.
2. Add `OperationCompletion.isSuccess: Bool` property which can be used to tell the system when background tasks complete. Drop `isTaskCompleted` extension.
3. Adapt iOS < 13 extension for producing `UIBackgroundFetchResult` from `OperationCompletion`.
4. Mark `ResultOperation.finish()` as unavailable to force subclasses to call `finish(completion:)` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3484)
<!-- Reviewable:end -->
