### PR TITLE
Add tray icon tooltip containing connection info.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 - Obfuscate traffic to the Mullvad API using bridges if it cannot be reached directly.
 - Add device management to desktop app. This simplifies knowing which device is which and adds the
   option to log out other devices when there are already 5 connected when logging in.
+- Add tray icon tooltip with connection info in desktop app.
 
 #### Windows
 - Detect mounting and dismounting of volumes, such as VeraCrypt volumes or USB drives,

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -99,6 +99,12 @@ msgstr ""
 msgid "Connect"
 msgstr ""
 
+msgid "Connected"
+msgstr ""
+
+msgid "Connecting"
+msgstr ""
+
 msgid "CREATING SECURE CONNECTION"
 msgstr ""
 
@@ -109,6 +115,12 @@ msgid "Disable"
 msgstr ""
 
 msgid "Disconnect"
+msgstr ""
+
+msgid "Disconnected"
+msgstr ""
+
+msgid "Disconnecting"
 msgstr ""
 
 msgid "Dismiss"
@@ -1338,7 +1350,23 @@ msgid "Your email (optional)"
 msgstr ""
 
 msgctxt "tray-icon-context-menu"
+msgid "Disconnected from system service"
+msgstr ""
+
+msgctxt "tray-icon-context-menu"
 msgid "Open %(mullvadVpn)s"
+msgstr ""
+
+msgctxt "tray-icon-tooltip"
+msgid "%(city)s, %(country)s"
+msgstr ""
+
+msgctxt "tray-icon-tooltip"
+msgid "Connected. %(location)s"
+msgstr ""
+
+msgctxt "tray-icon-tooltip"
+msgid "Connecting. %(location)s"
 msgstr ""
 
 msgctxt "tunnel-control"
@@ -1429,9 +1457,6 @@ msgid "Critical error (your attention is required)"
 msgstr ""
 
 msgid "Custom DNS server addresses %s are invalid"
-msgstr ""
-
-msgid "Disconnecting"
 msgstr ""
 
 msgid "Enable"

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -524,6 +524,7 @@ class ApplicationMain {
       await this.trayIconController.updateTheme();
 
       this.setTrayContextMenu();
+      this.trayIconController?.setTooltip(this.connectedToDaemon, this.tunnelState);
 
       if (process.platform === 'win32') {
         nativeTheme.on('updated', async () => {
@@ -753,6 +754,7 @@ class ApplicationMain {
       // update the tray icon to indicate that the computer is not secure anymore
       this.updateTrayIcon({ state: 'disconnected' }, false);
       this.setTrayContextMenu();
+      this.trayIconController?.setTooltip(this.connectedToDaemon, this.tunnelState);
 
       // notify renderer process
       if (this.windowController) {
@@ -918,6 +920,7 @@ class ApplicationMain {
     this.updateTrayIcon(newState, this.settings.blockWhenDisconnected);
 
     this.setTrayContextMenu();
+    this.trayIconController?.setTooltip(this.connectedToDaemon, this.tunnelState);
 
     this.notificationController.notifyTunnelState(
       newState,
@@ -1665,6 +1668,7 @@ class ApplicationMain {
     };
 
     this.setTrayContextMenu();
+    this.trayIconController?.setTooltip(this.connectedToDaemon, this.tunnelState);
   }
 
   private blockPermissionRequests() {

--- a/gui/src/shared/localization-contexts.ts
+++ b/gui/src/shared/localization-contexts.ts
@@ -34,4 +34,5 @@ export type LocalizationContexts =
   | 'split-tunneling-nav'
   | 'support-view'
   | 'select-language-nav'
-  | 'tray-icon-context-menu';
+  | 'tray-icon-context-menu'
+  | 'tray-icon-tooltip';


### PR DESCRIPTION
This PR adds a tooltip to the tray icon containing some connection info. Unfortunately it's not working on Ubuntu but it's working great on Windows and macOS. I haven't tested any other Linux distributions but due to the general tray icon support in Gnome I'm not surprised it isn't working.

Closes https://github.com/mullvad/mullvadvpn-app/issues/3368.

<img width="127" alt="image" src="https://user-images.githubusercontent.com/3668602/162380430-7336bd2c-c4e1-456a-90fc-0aa15cb00323.png">

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3490)
<!-- Reviewable:end -->
