### PR TITLE
Ignore entry location if multihop is off when using constraints for location

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -986,8 +986,10 @@ export default class AppRenderer {
           const city = country?.cities.find((location) => location.code === constraint.hostname[1]);
 
           let entryHostname: string | undefined;
+          const multihopConstraint = relaySettings.normal.wireguardConstraints.useMultihop;
           const entryLocationConstraint = relaySettings.normal.wireguardConstraints.entryLocation;
           if (
+            multihopConstraint &&
             entryLocationConstraint !== 'any' &&
             'hostname' in entryLocationConstraint.only &&
             entryLocationConstraint.only.hostname.length === 3


### PR DESCRIPTION
This PR fixes the bug where the gui claimed to be connecting over multihop when multihop was off. This happened if multihop had been on previously and specefic relays had been selected for entry and exit. The incorrect label was visible between the `disconnecting(reconnect)` and the `reconnecting` events. Between those events the location is calculated from the current constraints and there was a check for the multihop state missing.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3491)
<!-- Reviewable:end -->
