### PR TITLE
Improve random port distribution

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -37,6 +37,9 @@ Line wrap the file at 100 chars.                                              Th
   credits on accounts that no longer exist on our backend. Usually the case with newly created 
   accounts that went stale.
 
+### Fixed
+- Improve random port distribution. Should be less biased towards port 53.
+
 
 ## [2022.1] - 2022-02-15
 ### Added

--- a/ios/MullvadVPN/REST/ServerRelaysResponse.swift
+++ b/ios/MullvadVPN/REST/ServerRelaysResponse.swift
@@ -34,7 +34,7 @@ extension REST {
     struct ServerWireguardTunnels: Codable {
         let ipv4Gateway: IPv4Address
         let ipv6Gateway: IPv6Address
-        let portRanges: [ClosedRange<UInt16>]
+        let portRanges: [[UInt16]]
         let relays: [ServerRelay]
     }
 

--- a/ios/MullvadVPNTests/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/RelaySelectorTests.swift
@@ -60,7 +60,7 @@ private let sampleRelays = REST.ServerRelaysResponse(
     wireguard: REST.ServerWireguardTunnels(
         ipv4Gateway: .loopback,
         ipv6Gateway: .loopback,
-        portRanges: [53...53],
+        portRanges: [[53, 53]],
         relays: [
             REST.ServerRelay(
                 hostname: "es1-wireguard",


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- Improve random port distribution. Should be less biased towards port 53. See Rust code for reference: 
  https://github.com/mullvad/mullvadvpn-app/blob/66ff8978f94d4ad1c8c45872de9f540cbcbcf612/mullvad-daemon/src/relays/matcher.rs#L202-L238
- Replace `CloseRange<UInt16>` in relay model with `[[UInt16]]`. Parse and validate  port ranges manually in `RelaySelector`, skip invalid ranges but don't error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3493)
<!-- Reviewable:end -->
