### PR TITLE
Add fallback quit handler

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -310,6 +310,7 @@ class ApplicationMain {
     app.on('ready', this.onReady);
     app.on('window-all-closed', () => app.quit());
     app.on('before-quit', this.onBeforeQuit);
+    app.on('quit', this.onQuit);
   }
 
   private addSecondInstanceEventHandler() {
@@ -379,6 +380,14 @@ class ApplicationMain {
   private onActivate = () => {
     if (this.windowController) {
       this.windowController.show();
+    }
+  };
+
+  // This is a last try to disconnect and quit gracefully if the app quits without having received
+  // the before-quit event.
+  private onQuit = async () => {
+    if (this.quitStage !== AppQuitStage.ready) {
+      await this.prepareToQuit();
     }
   };
 


### PR DESCRIPTION
This PR adds a fallback quit handler. When logging out on Ubuntu the `quit` event is sometimes received without the preceding `before-quit` event. On most logouts the `quit` event isn't received and this won't do anything but sometimes it manages to disconnect.

Improves the issue described in https://github.com/mullvad/mullvadvpn-app/issues/3286 but is far from a solution unfortunately.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3496)
<!-- Reviewable:end -->
