### PR TITLE
Use correct time constant type on all architectures

### DIFF
--- a/talpid-time/src/unix.rs
+++ b/talpid-time/src/unix.rs
@@ -1,7 +1,7 @@
-use libc::{clock_gettime, clockid_t, timespec};
+use libc::{c_long, clock_gettime, clockid_t, timespec};
 use std::{mem::MaybeUninit, time::Duration};
 
-const NSEC_PER_SEC: i64 = 1000000000;
+const NSEC_PER_SEC: c_long = 1000000000;
 
 #[cfg(target_os = "macos")]
 const CLOCK_ID: clockid_t = libc::CLOCK_MONOTONIC;

--- a/talpid-time/src/unix.rs
+++ b/talpid-time/src/unix.rs
@@ -1,7 +1,7 @@
 use libc::{c_long, clock_gettime, clockid_t, timespec};
 use std::{mem::MaybeUninit, time::Duration};
 
-const NSEC_PER_SEC: c_long = 1000000000;
+const NSEC_PER_SEC: c_long = 1_000_000_000;
 
 #[cfg(target_os = "macos")]
 const CLOCK_ID: clockid_t = libc::CLOCK_MONOTONIC;


### PR DESCRIPTION
Previously, `talpid-time` refused to build for ARMv7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3499)
<!-- Reviewable:end -->
