### PR TITLE
Add links to our website and Tor onion service to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Mullvad VPN desktop and mobile app
 
-Welcome to the Mullvad VPN client app. This repository contains all the source code for the
+Welcome to the Mullvad VPN client app source code repository.
+This is the VPN client software for the Mullvad VPN service.
+For more information about the service, please visit our website,
+[mullvad.net](https://mullvad.net) (Also accessible via Tor on our
+[onion service](http://o54hon2e2vj6c7m3aqqu6uyece65by3vgoxxhlqlsvkmacw6a7m7kiad.onion/)).
+
+This repository contains all the source code for the
 desktop and mobile versions of the app. For desktop this includes the system service/daemon
 ([`mullvad-daemon`](mullvad-daemon/)), a graphical user interface ([GUI](gui/)) and a
 command line interface ([CLI](mullvad-cli/)). The Android app uses the same backing


### PR DESCRIPTION
Both to increase discoverability and to help people go around censorship we want to add links to our Tor onion service to places where people can find it even if our website is blocked. Our Github app repository seems like a prime place for that. One of the reasons we upload the app build artifacts to Github is to help people download the app even if they are in a place where mullvad.net is blocked. This is another step in that direction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3500)
<!-- Reviewable:end -->
