### PR TITLE
Clarify cli obfuscation and bridges

### DIFF
--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -21,7 +21,8 @@ impl Command for Bridge {
             .about(
                 "Manage use of bridges, socks proxies and Shadowsocks for OpenVPN. \
                 Can make OpenVPN tunnels use Shadowsocks via one of the Mullvad bridge servers. \
-                Can also make OpenVPN connect through any custom SOCKS5 proxy",
+                Can also make OpenVPN connect through any custom SOCKS5 proxy. \
+                These settings also affect how the app reaches the API over Shadowsocks.",
             )
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(create_bridge_set_subcommand())

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -18,7 +18,11 @@ impl Command for Bridge {
 
     fn clap_subcommand(&self) -> clap::App<'static> {
         clap::App::new(self.name())
-            .about("Manage use of bridges")
+            .about(
+                "Manage use of bridges, socks proxies and Shadowsocks for OpenVPN. \
+                Can make OpenVPN tunnels use Shadowsocks via one of the Mullvad bridge servers. \
+                Can also make OpenVPN connect through any custom SOCKS5 proxy",
+            )
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(create_bridge_set_subcommand())
             .subcommand(clap::App::new("get").about("Get current bridge settings and state"))

--- a/mullvad-cli/src/cmds/obfuscation.rs
+++ b/mullvad-cli/src/cmds/obfuscation.rs
@@ -29,7 +29,7 @@ impl Command for Obfuscation {
     async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         match matches.subcommand() {
             Some(("set", set_matches)) => Self::handle_set(set_matches).await,
-            Some(("get", get_matches)) => Self::handle_get(get_matches).await,
+            Some(("get", _get_matches)) => Self::handle_get().await,
             _ => unreachable!("unhandled command"),
         }
     }
@@ -50,7 +50,7 @@ impl Obfuscation {
                 };
                 Self::set_obfuscation_settings(&mut rpc, &settings).await?;
             }
-            Some(("udp2tcp-settings", settings_matches)) => {
+            Some(("udp2tcp", settings_matches)) => {
                 let port: String = settings_matches.value_of_t_or_exit("port");
                 let mut rpc = new_rpc_client().await?;
                 let mut settings = Self::get_obfuscation_settings(&mut rpc).await?;
@@ -68,13 +68,14 @@ impl Obfuscation {
         Ok(())
     }
 
-    async fn handle_get(matches: &clap::ArgMatches) -> Result<()> {
+    async fn handle_get() -> Result<()> {
         let mut rpc = new_rpc_client().await?;
-        let settings = Self::get_obfuscation_settings(&mut rpc).await?;
-        match matches.subcommand() {
-            Some(("udp2tcp-settings", _)) => println!("Udp2Tcp: {}", settings.udp2tcp),
-            _ => println!("Current settings: {}", settings),
-        }
+        let obfuscation_settings = Self::get_obfuscation_settings(&mut rpc).await?;
+        println!(
+            "Obfuscation mode: {}",
+            obfuscation_settings.selected_obfuscation
+        );
+        println!("udp2tcp settings: {}", obfuscation_settings.udp2tcp);
         Ok(())
     }
 
@@ -119,7 +120,7 @@ fn create_obfuscation_set_subcommand() -> clap::App<'static> {
             ),
         )
         .subcommand(
-            clap::App::new("udp2tcp-settings")
+            clap::App::new("udp2tcp")
                 .about("Specifies the config for the udp2tcp obfuscator")
                 .setting(clap::AppSettings::ArgRequiredElseHelp)
                 .arg(
@@ -132,10 +133,5 @@ fn create_obfuscation_set_subcommand() -> clap::App<'static> {
 }
 
 fn create_obfuscation_get_subcommand() -> clap::App<'static> {
-    clap::App::new("get")
-        .about("Get obfuscation settings")
-        .subcommand(
-            clap::App::new("udp2tcp-settings")
-                .about("Specifies the config for the udp2tcp obfuscator"),
-        )
+    clap::App::new("get").about("Get current obfuscation settings")
 }

--- a/mullvad-cli/src/cmds/obfuscation.rs
+++ b/mullvad-cli/src/cmds/obfuscation.rs
@@ -16,7 +16,11 @@ impl Command for Obfuscation {
 
     fn clap_subcommand(&self) -> clap::App<'static> {
         clap::App::new(self.name())
-            .about("Manage use of obfuscators")
+            .about(
+                "Manage use of obfuscation protocols for WireGuard. \
+                Can make WireGuard traffic look like something else on the network. \
+                Helps circumvent censorship and to establish a tunnel when on restricted networks",
+            )
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(create_obfuscation_set_subcommand())
             .subcommand(create_obfuscation_get_subcommand())
@@ -105,7 +109,10 @@ fn create_obfuscation_set_subcommand() -> clap::App<'static> {
         .subcommand(
             clap::App::new("mode").about("Set obfuscation mode").arg(
                 clap::Arg::new("mode")
-                    .help("Specifies what kind of obfuscation should be used, if any")
+                    .help(
+                        "Specifies if obfuscation should be used with WireGuard connections. \
+                        And if so, what obfuscation protocol it should use.",
+                    )
                     .required(true)
                     .index(1)
                     .possible_values(&["auto", "off", "udp2tcp"]),

--- a/mullvad-cli/src/cmds/split_tunnel/linux.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/linux.rs
@@ -12,7 +12,7 @@ impl Command for SplitTunnel {
         clap::App::new(self.name())
             .about(
                 "Manage split tunneling. To launch applications outside \
-                    the tunnel, use the program 'mullvad-exclude'.",
+                    the tunnel, use the program 'mullvad-exclude' instead of this command.",
             )
             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(create_pid_subcommand())

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -480,15 +480,11 @@ impl Default for SelectedObfuscation {
 
 impl fmt::Display for SelectedObfuscation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                SelectedObfuscation::Auto => "auto",
-                SelectedObfuscation::Off => "off",
-                SelectedObfuscation::Udp2Tcp => "udp2tcp",
-            }
-        )
+        match self {
+            SelectedObfuscation::Auto => "auto".fmt(f),
+            SelectedObfuscation::Off => "off".fmt(f),
+            SelectedObfuscation::Udp2Tcp => "udp2tcp".fmt(f),
+        }
     }
 }
 
@@ -500,15 +496,10 @@ pub struct Udp2TcpObfuscationSettings {
 
 impl fmt::Display for Udp2TcpObfuscationSettings {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "port: {}",
-            match self.port {
-                Constraint::Any => "any".to_string(),
-                Constraint::Only(port) => port.to_string(),
-            }
-        )?;
-        Ok(())
+        match self.port {
+            Constraint::Any => write!(f, "any port"),
+            Constraint::Only(port) => write!(f, "port {}", port),
+        }
     }
 }
 
@@ -519,18 +510,6 @@ impl fmt::Display for Udp2TcpObfuscationSettings {
 pub struct ObfuscationSettings {
     pub selected_obfuscation: SelectedObfuscation,
     pub udp2tcp: Udp2TcpObfuscationSettings,
-}
-
-impl fmt::Display for ObfuscationSettings {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "selected obfuscation: ")?;
-        match self.selected_obfuscation {
-            SelectedObfuscation::Auto => write!(f, "auto")?,
-            SelectedObfuscation::Off => write!(f, "off")?,
-            SelectedObfuscation::Udp2Tcp => write!(f, "Udp2Tcp ({})", self.udp2tcp)?,
-        };
-        Ok(())
-    }
 }
 
 /// Limits the set of bridge servers to use in `mullvad-daemon`.


### PR DESCRIPTION
I found the following a bit confusing and uninformative:

```
$ mullvad --help
...
    bridge                Manage use of bridges
    obfuscation           Manage use of obfuscators
```

It is not clear what they are or what they are used for. I'm not a huge fan of the subcommand layoun we currently have. But until we fix that we can at least improve the help text. The bridge subcommand is specific to OpenVPN, so I think we should mention that. Sadly the bridge subcommand also configures a bunch of other stuff that is unrelated to bridges:
* Custom SOCKS5 proxies to use with OpenVPN
* Custom Shadowsocks endpoints to use with OpenVPN

The obfuscation subcommand is only about WireGuard even though using OpenVPN over Shadowsocks is equally much obfuscation. I'm not changing the subcommand name or location here, but giving it a more descriptive help text at least.

I removed the `mullvad obfuscation get udp2tcp-settings` subcommand. I did not see the need to have it be so specific. Instead it now prints all obfuscation settings on `mullvad obfuscation get`. What do you think? I felt like the CLI was needlessly clunky to use.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header. (Not relevant since the CLI changes have not yet been in any release)
* [X] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3502)
<!-- Reviewable:end -->
