### PR TITLE
Fix overzealous relay selector test

### DIFF
--- a/mullvad-daemon/src/relays/mod.rs
+++ b/mullvad-daemon/src/relays/mod.rs
@@ -1661,7 +1661,6 @@ mod test {
                 .get_tunnel_endpoint(&WIREGUARD_SINGLEHOP_CONSTRAINTS, BridgeState::Off, attempt)
                 .expect("Failed to select a WireGuard relay");
             assert!(result.entry_relay.is_none());
-            assert!(!TCP2UDP_PORTS.contains(&result.endpoint.to_endpoint().address.port()));
 
             let (obfs_config, _obfs_relay) = relay_selector
                 .get_obfuscator(


### PR DESCRIPTION
The relay selector test was testing if a WireGuard endpoint wasn't using
the same ports as TCP2UDP relays will be listening on. This doesn't make
much sense as a relay could very well be using those same ports, and in
some cases it was, thus making this test fail. The faulty assertion has
been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3503)
<!-- Reviewable:end -->
