### PR TITLE
Prevent login input from being emptied on failed attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
   to the main view. To navigate back to the main view Shift+Escape can be used.
 - Update Electron from 16.0.4 to 18.0.3.
 - Randomize bridge selection with a bias in favor of close bridges.
+- Make login field keep previous value when submitting an incorrect account number in desktop app.
 
 ### Fixed
 - Fix the sometimes incorrect time added text after adding time to the account.

--- a/gui/src/renderer/redux/account/reducers.ts
+++ b/gui/src/renderer/redux/account/reducers.ts
@@ -48,7 +48,6 @@ export default function (
       return {
         ...state,
         status: { type: 'failed', method: 'existing_account', error: action.error },
-        accountToken: undefined,
       };
     case 'TOO_MANY_DEVICES':
       return {


### PR DESCRIPTION
This PR prevents the login from being emptied when submitting an incorrect account number. This is the same behavior as on Android and iOS.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3504)
<!-- Reviewable:end -->
