### PR TITLE
Refactor android login to use view model

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -179,6 +179,7 @@ dependencies {
     testImplementation(Dependencies.KotlinX.coroutinesTest)
     testImplementation(Dependencies.MockK.core)
     testImplementation(Dependencies.junit)
+    testImplementation(Dependencies.turbine)
 
     // UI test dependencies
     debugImplementation(Dependencies.AndroidX.fragmentTestning)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/DeviceState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/DeviceState.kt
@@ -17,6 +17,10 @@ sealed class DeviceState : Parcelable {
         return this is InitialState
     }
 
+    fun deviceName(): String? {
+        return (this as? DeviceRegistered)?.deviceConfig?.device?.name
+    }
+
     fun token(): String? {
         return (this as? DeviceRegistered)?.deviceConfig?.token
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/AccountCache.kt
@@ -206,6 +206,7 @@ class AccountCache(private val endpoint: ServiceEndpoint) {
     private suspend fun doLogout() {
         daemon.await().logoutAccount()
         loginStatus = null
+        fetchAccountHistory()
     }
 
     private fun fetchAccountHistory() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -15,6 +15,7 @@ import net.mullvad.mullvadvpn.ui.widget.CopyableInformationView
 import net.mullvad.mullvadvpn.ui.widget.InformationView
 import net.mullvad.mullvadvpn.ui.widget.RedeemVoucherButton
 import net.mullvad.mullvadvpn.ui.widget.SitePaymentButton
+import net.mullvad.mullvadvpn.util.capitalizeFirstCharOfEachWord
 import net.mullvad.talpid.tunnel.ErrorStateCause
 import org.joda.time.DateTime
 
@@ -52,6 +53,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
     private lateinit var accountExpiryView: InformationView
     private lateinit var accountNumberView: CopyableInformationView
+    private lateinit var deviceNameView: InformationView
     private lateinit var sitePaymentButton: SitePaymentButton
     private lateinit var redeemVoucherButton: RedeemVoucherButton
     private lateinit var titleController: CollapsibleTitleController
@@ -88,7 +90,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
 
         accountExpiryView = view.findViewById(R.id.account_expiry)
-
+        deviceNameView = view.findViewById(R.id.device_name)
         titleController = CollapsibleTitleController(view)
 
         return view
@@ -102,6 +104,16 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
                 }
                 .collect {
                     accountNumberView.information = it.token()
+                }
+        }
+
+        jobTracker.newUiJob("updateDeviceName") {
+            deviceRepository.deviceState
+                .onEach { state ->
+                    if (state.isInitialState()) deviceRepository.refreshDeviceState()
+                }
+                .collect { state ->
+                    deviceNameView.information = state.deviceName()?.capitalizeFirstCharOfEachWord()
                 }
         }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LaunchFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.onEach
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.DeviceState
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
@@ -39,7 +39,9 @@ class LaunchFragment : ServiceAwareFragment() {
     private fun advanceToNextScreen(deviceRepository: DeviceRepository) {
         jobTracker.newUiJob("advanceToNextScreen") {
             deviceRepository.deviceState
-                .onSubscription { deviceRepository.refreshDeviceState() }
+                .onEach { state ->
+                    if (state.isInitialState()) deviceRepository.refreshDeviceState()
+                }
                 .first { state -> state.isInitialState().not() }
                 .let { deviceState ->
                     when (deviceState) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/DeviceRepository.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/DeviceRepository.kt
@@ -1,7 +1,7 @@
 package net.mullvad.mullvadvpn.ui.serviceconnection
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted.Companion.Lazily
+import kotlinx.coroutines.flow.SharingStarted.Companion.Eagerly
 import kotlinx.coroutines.flow.stateIn
 import net.mullvad.mullvadvpn.model.DeviceState
 
@@ -12,7 +12,7 @@ class DeviceRepository(
     val deviceState = dataSource.deviceStateUpdates
         .stateIn(
             externalScope,
-            Lazily,
+            Eagerly,
             DeviceState.InitialState
         )
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/StringExtensions.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/StringExtensions.kt
@@ -1,0 +1,9 @@
+package net.mullvad.mullvadvpn.util
+
+fun String.capitalizeFirstCharOfEachWord(): String {
+    return split(" ")
+        .joinToString(" ") { word ->
+            word.replaceFirstChar { firstChar -> firstChar.uppercase() }
+        }
+        .trimEnd()
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModel.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.viewmodel
 
 import android.app.Application
+import androidx.annotation.RestrictTo
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -55,9 +56,9 @@ class LoginViewModel(
         accountCache?.login(accountToken)
     }
 
-    override fun onCleared() {
-        accountCache?.onAccountHistoryChange?.unsubscribe(this)
-        accountCache?.onLoginStatusChange?.unsubscribe(this)
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    public override fun onCleared() {
+        accountCache?.unsubscribe()
     }
 
     private fun AccountCache.subscribe() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModel.kt
@@ -1,0 +1,101 @@
+package net.mullvad.mullvadvpn.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import net.mullvad.mullvadvpn.model.LoginResult
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+
+class LoginViewModel(
+    application: Application
+) : AndroidViewModel(application) {
+    private val _uiState = MutableStateFlow<LoginUiState>(LoginUiState.Default)
+    private val _accountHistory = MutableStateFlow<String?>(null)
+    val uiState: StateFlow<LoginUiState> = _uiState
+    val accountHistory: StateFlow<String?> = _accountHistory
+
+    private var accountCache: AccountCache? = null
+
+    sealed class LoginUiState {
+        object Default : LoginUiState()
+        object Loading : LoginUiState()
+        data class Success(
+            val isOutOfTime: Boolean
+        ) : LoginUiState()
+
+        object CreatingAccount : LoginUiState()
+        object AccountCreated : LoginUiState()
+        object UnableToCreateAccountError : LoginUiState()
+        object InvalidAccountError : LoginUiState()
+        object TooManyDevicesError : LoginUiState()
+        data class OtherError(val errorMessage: String) : LoginUiState()
+    }
+
+    // Ensures the view model has an up-to-date instance of account cache. This is an intermediate
+    // solution due to limitations in the current app architecture.
+    fun updateAccountCacheInstance(newAccountCache: AccountCache?) {
+        accountCache?.unsubscribe()
+        accountCache = newAccountCache?.apply { subscribe() }
+    }
+
+    fun clearAccountHistory() {
+        accountCache?.clearAccountHistory()
+    }
+
+    fun createAccount() {
+        _uiState.value = LoginUiState.CreatingAccount
+        accountCache?.createNewAccount()
+    }
+
+    fun login(accountToken: String) {
+        _uiState.value = LoginUiState.Loading
+        accountCache?.login(accountToken)
+    }
+
+    override fun onCleared() {
+        accountCache?.onAccountHistoryChange?.unsubscribe(this)
+        accountCache?.onLoginStatusChange?.unsubscribe(this)
+    }
+
+    private fun AccountCache.subscribe() {
+        onAccountHistoryChange.subscribe(this) { history ->
+            _accountHistory.value = history
+        }
+
+        onLoginStatusChange.subscribe(this, startWithLatestEvent = false) { status ->
+            _uiState.value = when {
+                status == null -> {
+                    LoginUiState.Default
+                }
+                status.isNewAccount -> {
+                    LoginUiState.AccountCreated
+                }
+                else -> {
+                    when (status.loginResult) {
+                        LoginResult.Ok -> LoginUiState.Success(false)
+                        LoginResult.InvalidAccount -> LoginUiState.InvalidAccountError
+                        LoginResult.MaxDevicesReached -> LoginUiState.TooManyDevicesError
+                        else -> LoginUiState.OtherError(
+                            errorMessage = status.loginResult?.toString() ?: ""
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun AccountCache.unsubscribe() {
+        onAccountHistoryChange.unsubscribe(this)
+        onLoginStatusChange.unsubscribe(this)
+    }
+
+    class Factory(val application: Application) :
+        ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return LoginViewModel(application) as T
+        }
+    }
+}

--- a/android/app/src/main/res/layout/account.xml
+++ b/android/app/src/main/res/layout/account.xml
@@ -42,6 +42,13 @@
                           android:lines="1"
                           android:text="@string/settings_account"
                           style="@style/SettingsExpandedHeader" />
+                <net.mullvad.mullvadvpn.ui.widget.InformationView android:id="@+id/device_name"
+                                                                  android:layout_width="match_parent"
+                                                                  android:layout_height="wrap_content"
+                                                                  android:paddingHorizontal="@dimen/side_margin"
+                                                                  android:paddingVertical="@dimen/half_vertical_space"
+                                                                  mullvad:description="@string/device_name"
+                                                                  mullvad:whenMissing="hide" />
                 <net.mullvad.mullvadvpn.ui.widget.CopyableInformationView android:id="@+id/account_number"
                                                                           android:layout_width="match_parent"
                                                                           android:layout_height="wrap_content"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="report_a_problem">Report a problem</string>
     <string name="faqs_and_guides">FAQs &amp; Guides</string>
     <string name="account_number">Account number</string>
+    <string name="device_name">Device name</string>
     <string name="mullvad_account_number">Mullvad account number</string>
     <string name="copied_mullvad_account_number">Copied Mullvad account number to
     clipboard</string>

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
@@ -1,0 +1,221 @@
+package net.mullvad.mullvadvpn.viewmodel
+
+import app.cash.turbine.FlowTurbine
+import app.cash.turbine.test
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.invoke
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.test.runBlockingTest
+import net.mullvad.mullvadvpn.model.LoginResult
+import net.mullvad.mullvadvpn.model.LoginStatus
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.talpid.util.EventNotifier
+import org.junit.Before
+import org.junit.Test
+
+class LoginViewModelTest {
+
+    @MockK
+    private lateinit var mockedAccountCache: AccountCache
+
+    @MockK
+    private lateinit var mockedLoginStatusNotifier: EventNotifier<LoginStatus?>
+
+    @MockK
+    private lateinit var mockedAccountHistoryNotifier: EventNotifier<String?>
+
+    private lateinit var loginViewModel: LoginViewModel
+    private val capturedLoginStatusNotifierCallback = slot<(LoginStatus?) -> Unit>()
+    private val capturedAccountHistoryNotifierCallback = slot<(String?) -> Unit>()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        every {
+            mockedLoginStatusNotifier.subscribe(
+                any(),
+                any(),
+                capture(capturedLoginStatusNotifierCallback)
+            )
+        } just Runs
+
+        every {
+            mockedAccountHistoryNotifier.subscribe(
+                any(),
+                capture(capturedAccountHistoryNotifierCallback)
+            )
+        } just Runs
+
+        every { mockedAccountCache.onLoginStatusChange } returns mockedLoginStatusNotifier
+        every { mockedAccountCache.onAccountHistoryChange } returns mockedAccountHistoryNotifier
+
+        loginViewModel = LoginViewModel(mockk())
+    }
+
+    @Test
+    fun testDefaultState() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.uiState.test {
+            assertEquals(LoginViewModel.LoginUiState.Default, awaitItem())
+        }
+    }
+
+    @Test
+    fun testClearingViewModel() {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.onCleared()
+        verify {
+            mockedLoginStatusNotifier.unsubscribe(any())
+            mockedAccountHistoryNotifier.unsubscribe(any())
+        }
+    }
+
+    @Test
+    fun testCreateAccount() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.uiState.test {
+            skipDefaultItem()
+            loginViewModel.createAccount()
+            assertEquals(LoginViewModel.LoginUiState.CreatingAccount, awaitItem())
+            capturedLoginStatusNotifierCallback.captured.invoke(DummyLoginStatus.ACCOUNT_CREATED)
+            assertEquals(LoginViewModel.LoginUiState.AccountCreated, awaitItem())
+        }
+    }
+
+    @Test
+    fun testLoginWithValidAccount() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.uiState.test {
+            skipDefaultItem()
+            loginViewModel.login("")
+            assertEquals(LoginViewModel.LoginUiState.Loading, awaitItem())
+            capturedLoginStatusNotifierCallback.captured.invoke(DummyLoginStatus.SUCCESSFUL_LOGIN)
+            assertEquals(LoginViewModel.LoginUiState.Success(isOutOfTime = false), awaitItem())
+        }
+    }
+
+    @Test
+    fun testLoginWithInvalidAccount() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.uiState.test {
+            skipDefaultItem()
+            loginViewModel.login("")
+            assertEquals(LoginViewModel.LoginUiState.Loading, awaitItem())
+            capturedLoginStatusNotifierCallback.captured.invoke(
+                DummyLoginStatus.INVALID_ACCOUNT_ERROR
+            )
+            assertEquals(LoginViewModel.LoginUiState.InvalidAccountError, awaitItem())
+        }
+    }
+
+    @Test
+    fun testLoginWithTooManyDevicesError() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.uiState.test {
+            skipDefaultItem()
+            loginViewModel.login("")
+            assertEquals(LoginViewModel.LoginUiState.Loading, awaitItem())
+            capturedLoginStatusNotifierCallback.captured.invoke(DummyLoginStatus.MAX_DEVICES_ERROR)
+            assertEquals(LoginViewModel.LoginUiState.TooManyDevicesError, awaitItem())
+        }
+    }
+
+    @Test
+    fun testLoginWithRpcError() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.uiState.test {
+            skipDefaultItem()
+            loginViewModel.login("")
+            assertEquals(LoginViewModel.LoginUiState.Loading, awaitItem())
+            capturedLoginStatusNotifierCallback.captured.invoke(DummyLoginStatus.RPC_ERROR)
+            assertEquals(LoginViewModel.LoginUiState.OtherError("RpcError"), awaitItem())
+        }
+    }
+
+    @Test
+    fun testLoginWithUnknownError() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.uiState.test {
+            skipDefaultItem()
+            loginViewModel.login("")
+            assertEquals(LoginViewModel.LoginUiState.Loading, awaitItem())
+            capturedLoginStatusNotifierCallback.captured.invoke(DummyLoginStatus.OTHER_ERROR)
+            assertEquals(LoginViewModel.LoginUiState.OtherError("OtherError"), awaitItem())
+        }
+    }
+
+    @Test
+    fun testAccountHistory() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.accountHistory.test { skipDefaultItem() }
+        capturedAccountHistoryNotifierCallback.invoke(DUMMY_ACCOUNT_TOKEN)
+        loginViewModel.accountHistory.test { assertEquals(DUMMY_ACCOUNT_TOKEN, awaitItem()) }
+    }
+
+    @Test
+    fun testClearingAccountHistory() = runBlockingTest {
+        loginViewModel.updateAccountCacheInstance(mockedAccountCache)
+        loginViewModel.clearAccountHistory()
+        verify { mockedAccountCache.clearAccountHistory() }
+    }
+
+    private suspend fun <T> FlowTurbine<T>.skipDefaultItem() where T : Any? {
+        awaitItem()
+    }
+
+    companion object {
+        private const val DUMMY_ACCOUNT_TOKEN = "DUMMY"
+
+        private object DummyLoginStatus {
+            val ACCOUNT_CREATED = LoginStatus(
+                DUMMY_ACCOUNT_TOKEN,
+                mockk(),
+                isNewAccount = true,
+                mockk()
+            )
+
+            val SUCCESSFUL_LOGIN = LoginStatus(
+                DUMMY_ACCOUNT_TOKEN,
+                mockk(),
+                isNewAccount = false,
+                LoginResult.Ok
+            )
+
+            val INVALID_ACCOUNT_ERROR = LoginStatus(
+                DUMMY_ACCOUNT_TOKEN,
+                mockk(),
+                isNewAccount = false,
+                LoginResult.InvalidAccount
+            )
+
+            val MAX_DEVICES_ERROR = LoginStatus(
+                DUMMY_ACCOUNT_TOKEN,
+                mockk(),
+                isNewAccount = false,
+                LoginResult.MaxDevicesReached
+            )
+
+            val RPC_ERROR = LoginStatus(
+                DUMMY_ACCOUNT_TOKEN,
+                mockk(),
+                isNewAccount = false,
+                LoginResult.RpcError
+            )
+
+            val OTHER_ERROR = LoginStatus(
+                DUMMY_ACCOUNT_TOKEN,
+                mockk(),
+                isNewAccount = false,
+                LoginResult.OtherError
+            )
+        }
+    }
+}

--- a/android/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/android/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,6 +4,7 @@ object Dependencies {
     const val jodaTime = "joda-time:joda-time:${Versions.jodaTime}"
     const val junit = "junit:junit:${Versions.junit}"
     const val leakCanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakCanary}"
+    const val turbine = "app.cash.turbine:turbine:${Versions.turbine}"
 
     object AndroidX {
         const val appcompat = "androidx.appcompat:appcompat:${Versions.AndroidX.appcompat}"

--- a/android/buildSrc/src/main/kotlin/Versions.kt
+++ b/android/buildSrc/src/main/kotlin/Versions.kt
@@ -8,6 +8,7 @@ object Versions {
     const val kotlinx = "1.5.2"
     const val leakCanary = "2.8.1"
     const val mockk = "1.12.3"
+    const val turbine = "0.7.0"
 
     object Android {
         const val compileSdkVersion = 31


### PR DESCRIPTION
Refactor Android login to use a view model rather than keeping all logic in the fragment. Also fixes a few minor related account/device issues.

Git checklist:

~* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.~
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3505)
<!-- Reviewable:end -->
