### PR TITLE
Improve blocking state presentation

### DIFF
--- a/gui/src/renderer/components/SecuredLabel.tsx
+++ b/gui/src/renderer/components/SecuredLabel.tsx
@@ -16,7 +16,7 @@ const securedDisplayStyleColorMap = {
   [SecuredDisplayStyle.securing]: colors.white,
   [SecuredDisplayStyle.unsecuring]: colors.white,
   [SecuredDisplayStyle.secured]: colors.green,
-  [SecuredDisplayStyle.blocked]: colors.green,
+  [SecuredDisplayStyle.blocked]: colors.white,
   [SecuredDisplayStyle.unsecured]: colors.red,
   [SecuredDisplayStyle.failedToSecure]: colors.red,
 };


### PR DESCRIPTION
This PR:
* Removes the map marker in the blocking state
* Changes the connection status label color to white in the blocking state

The purpose of these changes is to prevent the blocking state from looking like everything is working perfectly.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3506)
<!-- Reviewable:end -->
