### PR TITLE
Remember history and scroll positions when replacing window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix "Open Mullvad VPN" tray context menu item not working after toggling unpinned window setting.
 - Fix apps not always visible in split tunneling view after browsing for an app and then removing it
   from the excluded applications.
+- Fix navigation resetting to main view when toggling the unpinned window setting.
 
 ### Security
 #### Android

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -43,7 +43,12 @@ import {
 import { messages, relayLocations } from '../shared/gettext';
 import { SYSTEM_PREFERRED_LOCALE_KEY } from '../shared/gui-settings-state';
 import { ITranslations, MacOsScrollbarVisibility } from '../shared/ipc-schema';
-import { IChangelog, ICurrentAppVersionInfo, IHistoryObject } from '../shared/ipc-types';
+import {
+  IChangelog,
+  ICurrentAppVersionInfo,
+  IHistoryObject,
+  ScrollPositions,
+} from '../shared/ipc-types';
 import log, { ConsoleOutput, Logger } from '../shared/logging';
 import { LogLevel } from '../shared/logging-types';
 import {
@@ -253,6 +258,7 @@ class ApplicationMain {
   private changelog?: IChangelog;
 
   private navigationHistory?: IHistoryObject;
+  private scrollPositions: ScrollPositions = {};
 
   public run() {
     // Remove window animations to combat window flickering when opening window. Can be removed when
@@ -1276,6 +1282,7 @@ class ApplicationMain {
       macOsScrollbarVisibility: this.macOsScrollbarVisibility,
       changelog: this.changelog ?? [],
       navigationHistory: this.navigationHistory,
+      scrollPositions: this.scrollPositions,
     }));
 
     IpcMainEventChannel.settings.handleSetAllowLan((allowLan: boolean) =>
@@ -1491,6 +1498,9 @@ class ApplicationMain {
 
     IpcMainEventChannel.navigation.handleSetHistory((history) => {
       this.navigationHistory = history;
+    });
+    IpcMainEventChannel.navigation.handleSetScrollPositions((scrollPositions) => {
+      this.scrollPositions = scrollPositions;
     });
 
     if (windowsSplitTunneling) {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1667,7 +1667,7 @@ class ApplicationMain {
 
       const window = await this.createWindow();
 
-      this.windowController.destroy();
+      this.windowController.close();
       this.windowController = new WindowController(
         window,
         this.tray,

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -43,7 +43,7 @@ import {
 import { messages, relayLocations } from '../shared/gettext';
 import { SYSTEM_PREFERRED_LOCALE_KEY } from '../shared/gui-settings-state';
 import { ITranslations, MacOsScrollbarVisibility } from '../shared/ipc-schema';
-import { IChangelog, ICurrentAppVersionInfo } from '../shared/ipc-types';
+import { IChangelog, ICurrentAppVersionInfo, IHistoryObject } from '../shared/ipc-types';
 import log, { ConsoleOutput, Logger } from '../shared/logging';
 import { LogLevel } from '../shared/logging-types';
 import {
@@ -251,6 +251,8 @@ class ApplicationMain {
   private quitWithoutDisconnect = false;
 
   private changelog?: IChangelog;
+
+  private navigationHistory?: IHistoryObject;
 
   public run() {
     // Remove window animations to combat window flickering when opening window. Can be removed when
@@ -1273,6 +1275,7 @@ class ApplicationMain {
       windowsSplitTunnelingApplications: this.windowsSplitTunnelingApplications,
       macOsScrollbarVisibility: this.macOsScrollbarVisibility,
       changelog: this.changelog ?? [],
+      navigationHistory: this.navigationHistory,
     }));
 
     IpcMainEventChannel.settings.handleSetAllowLan((allowLan: boolean) =>
@@ -1484,6 +1487,10 @@ class ApplicationMain {
 
     IpcMainEventChannel.currentVersion.handleDisplayedChangelog(() => {
       this.guiSettings.changelogDisplayedForVersion = this.currentVersion.gui;
+    });
+
+    IpcMainEventChannel.navigation.handleSetHistory((history) => {
+      this.navigationHistory = history;
     });
 
     if (windowsSplitTunneling) {

--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -192,9 +192,11 @@ export default class WindowController {
     this.notifyUpdateWindowShape();
   }
 
-  public destroy() {
+  public close() {
     if (this.window && !this.window.isDestroyed()) {
-      this.window.destroy();
+      this.window.webContents.closeDevTools();
+      this.window.closable = true;
+      this.window.close();
     }
   }
 

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -25,7 +25,12 @@ import {
 import { messages, relayLocations } from '../shared/gettext';
 import { IGuiSettingsState, SYSTEM_PREFERRED_LOCALE_KEY } from '../shared/gui-settings-state';
 import { IRelayListPair, LaunchApplicationResult } from '../shared/ipc-schema';
-import { IChangelog, ICurrentAppVersionInfo, IHistoryObject } from '../shared/ipc-types';
+import {
+  IChangelog,
+  ICurrentAppVersionInfo,
+  IHistoryObject,
+  ScrollPositions,
+} from '../shared/ipc-types';
 import log, { ConsoleOutput } from '../shared/logging';
 import { LogLevel } from '../shared/logging-types';
 import { Scheduler } from '../shared/scheduler';
@@ -247,6 +252,8 @@ export default class AppRenderer {
     }
 
     void this.updateLocation();
+
+    this.reduxActions.userInterface.setScrollPositions(initialState.scrollPositions);
 
     if (initialState.navigationHistory) {
       this.history = History.fromSavedHistory(initialState.navigationHistory);
@@ -565,6 +572,10 @@ export default class AppRenderer {
 
   public setNavigationHistory(history: IHistoryObject) {
     IpcRendererEventChannel.navigation.setHistory(history);
+  }
+
+  public setScrollPositions(scrollPositions: ScrollPositions) {
+    IpcRendererEventChannel.navigation.setScrollPositions(scrollPositions);
   }
 
   // Make sure that the content height is correct and log if it isn't. This is mostly for debugging

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -25,7 +25,7 @@ import {
 import { messages, relayLocations } from '../shared/gettext';
 import { IGuiSettingsState, SYSTEM_PREFERRED_LOCALE_KEY } from '../shared/gui-settings-state';
 import { IRelayListPair, LaunchApplicationResult } from '../shared/ipc-schema';
-import { IChangelog, ICurrentAppVersionInfo } from '../shared/ipc-types';
+import { IChangelog, ICurrentAppVersionInfo, IHistoryObject } from '../shared/ipc-types';
 import log, { ConsoleOutput } from '../shared/logging';
 import { LogLevel } from '../shared/logging-types';
 import { Scheduler } from '../shared/scheduler';
@@ -208,7 +208,11 @@ export default class AppRenderer {
     this.setAccountExpiry(initialState.accountData?.expiry);
     this.setSettings(initialState.settings);
     this.setIsPerformingPostUpgrade(initialState.isPerformingPostUpgrade);
-    this.handleAccountChange({ deviceConfig: initialState.deviceConfig }, undefined);
+    this.handleAccountChange(
+      { deviceConfig: initialState.deviceConfig },
+      undefined,
+      initialState.navigationHistory !== undefined,
+    );
     this.hasReceivedDeviceConfig = initialState.hasReceivedDeviceConfig;
     this.setAccountHistory(initialState.accountHistory);
     this.setTunnelState(initialState.tunnelState);
@@ -244,8 +248,12 @@ export default class AppRenderer {
 
     void this.updateLocation();
 
-    const navigationBase = this.getNavigationBase();
-    this.history = new History(navigationBase);
+    if (initialState.navigationHistory) {
+      this.history = History.fromSavedHistory(initialState.navigationHistory);
+    } else {
+      const navigationBase = this.getNavigationBase();
+      this.history = new History(navigationBase);
+    }
   }
 
   public renderView() {
@@ -555,6 +563,10 @@ export default class AppRenderer {
     IpcRendererEventChannel.currentVersion.displayedChangelog();
   };
 
+  public setNavigationHistory(history: IHistoryObject) {
+    IpcRendererEventChannel.navigation.setHistory(history);
+  }
+
   // Make sure that the content height is correct and log if it isn't. This is mostly for debugging
   // purposes since there's a bug in Electron that causes the app height to be another value than
   // the one we have set.
@@ -804,7 +816,11 @@ export default class AppRenderer {
     }
   }
 
-  private handleAccountChange(newDeviceEvent: IDeviceEvent, oldAccount?: string) {
+  private handleAccountChange(
+    newDeviceEvent: IDeviceEvent,
+    oldAccount?: string,
+    preventRedirectToConnect?: boolean,
+  ) {
     const reduxAccount = this.reduxActions.account;
 
     this.deviceConfig = newDeviceEvent.deviceConfig;
@@ -828,7 +844,7 @@ export default class AppRenderer {
 
           if (this.previousLoginState === 'too many devices') {
             this.resetNavigation();
-          } else {
+          } else if (!preventRedirectToConnect) {
             this.redirectToConnect();
           }
           break;

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -256,6 +256,8 @@ export default class AppRenderer {
     this.reduxActions.userInterface.setScrollPositions(initialState.scrollPositions);
 
     if (initialState.navigationHistory) {
+      // Set last action to POP to trigger automatic scrolling to saved coordinates.
+      initialState.navigationHistory.lastAction = 'POP';
       this.history = History.fromSavedHistory(initialState.navigationHistory);
     } else {
       const navigationBase = this.getNavigationBase();

--- a/gui/src/renderer/components/AppRouter.tsx
+++ b/gui/src/renderer/components/AppRouter.tsx
@@ -12,6 +12,7 @@ import SelectLocationPage from '../containers/SelectLocationPage';
 import SettingsPage from '../containers/SettingsPage';
 import SupportPage from '../containers/SupportPage';
 import WireguardSettingsPage from '../containers/WireguardSettingsPage';
+import withAppContext, { IAppContext } from '../context';
 import { IHistoryProps, ITransitionSpecification, transitions, withHistory } from '../lib/history';
 import { RoutePath } from '../lib/routes';
 import { DeviceRevokedView } from './DeviceRevokedView';
@@ -36,12 +37,12 @@ interface IAppRoutesState {
   action?: Action;
 }
 
-class AppRouter extends React.Component<IHistoryProps, IAppRoutesState> {
+class AppRouter extends React.Component<IHistoryProps & IAppContext, IAppRoutesState> {
   private unobserveHistory?: () => void;
 
   private focusRef = React.createRef<IFocusHandle>();
 
-  constructor(props: IHistoryProps) {
+  constructor(props: IHistoryProps & IAppContext) {
     super(props);
 
     this.state = {
@@ -54,6 +55,7 @@ class AppRouter extends React.Component<IHistoryProps, IAppRoutesState> {
     // React throttles updates, so it's impossible to capture the intermediate navigation without
     // listening to the history directly.
     this.unobserveHistory = this.props.history.listen((location, action, transition) => {
+      this.props.app.setNavigationHistory(this.props.history.asObject);
       this.setState({
         currentLocation: location,
         transition,
@@ -114,6 +116,6 @@ class AppRouter extends React.Component<IHistoryProps, IAppRoutesState> {
   };
 }
 
-const AppRoutesWithRouter = withHistory(AppRouter);
+const AppRoutesWithRouter = withAppContext(withHistory(AppRouter));
 
 export default AppRoutesWithRouter;

--- a/gui/src/renderer/components/NavigationBar.tsx
+++ b/gui/src/renderer/components/NavigationBar.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useContext, useLayoutEffect, useRef } from 'react';
+import React, { useCallback, useContext, useEffect, useLayoutEffect, useRef } from 'react';
 
 import { colors } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { useAppContext } from '../context';
 import useActions from '../lib/actionsHook';
 import { useHistory } from '../lib/history';
 import { useCombinedRefs } from '../lib/utilityHooks';
@@ -114,18 +115,20 @@ export const NavigationScrollbars = React.forwardRef(function NavigationScrollba
 ) {
   const history = useHistory();
   const { onScroll } = useContext(NavigationScrollContext);
+  const { setScrollPositions } = useAppContext();
 
   const ref = useRef<CustomScrollbarsRef>();
   const combinedRefs = useCombinedRefs(forwardedRef, ref);
 
   const { addScrollPosition, removeScrollPosition } = useActions(userInterface);
-  const scrollPosition = useSelector(
-    (state) => state.userInterface.scrollPosition[history.location.pathname],
-  );
+  const scrollPositions = useSelector((state) => state.userInterface.scrollPosition);
+
+  useEffect(() => setScrollPositions(scrollPositions), [scrollPositions]);
 
   useLayoutEffect(() => {
     const path = history.location.pathname;
 
+    const scrollPosition = scrollPositions[history.location.pathname];
     if (history.action === 'POP' && scrollPosition) {
       ref.current?.scrollTo(...scrollPosition);
       removeScrollPosition(path);

--- a/gui/src/renderer/components/NavigationBar.tsx
+++ b/gui/src/renderer/components/NavigationBar.tsx
@@ -123,7 +123,19 @@ export const NavigationScrollbars = React.forwardRef(function NavigationScrollba
   const { addScrollPosition, removeScrollPosition } = useActions(userInterface);
   const scrollPositions = useSelector((state) => state.userInterface.scrollPosition);
 
-  useEffect(() => setScrollPositions(scrollPositions), [scrollPositions]);
+  useEffect(() => {
+    const path = history.location.pathname;
+    const beforeunload = () => {
+      if (ref.current) {
+        const scrollPosition = ref.current.getScrollPosition();
+        setScrollPositions({ ...scrollPositions, [path]: scrollPosition });
+      }
+    };
+
+    window.addEventListener('beforeunload', beforeunload);
+
+    return () => window.removeEventListener('beforeunload', beforeunload);
+  }, [scrollPositions]);
 
   useLayoutEffect(() => {
     const path = history.location.pathname;

--- a/gui/src/renderer/lib/history.tsx
+++ b/gui/src/renderer/lib/history.tsx
@@ -2,6 +2,7 @@ import { Action, History as OriginalHistory, Location, LocationDescriptorObject 
 import React from 'react';
 import { RouteComponentProps, useHistory as useReactRouterHistory, withRouter } from 'react-router';
 
+import { IHistoryObject } from '../../shared/ipc-types';
 import { GeneratedRoutePath, RoutePath } from './routes';
 
 export interface ITransitionSpecification {
@@ -59,6 +60,15 @@ export default class History {
 
   public constructor(location: LocationDescriptor<S>, state?: S) {
     this.entries = [this.createLocation(location, state)];
+  }
+
+  public static fromSavedHistory(savedHistory: IHistoryObject): History {
+    const history = new History(RoutePath.launch);
+    history.entries = savedHistory.entries;
+    history.index = savedHistory.index;
+    history.lastAction = savedHistory.lastAction;
+
+    return history;
   }
 
   public get location(): Location<S> {
@@ -124,6 +134,14 @@ export default class History {
   // implementation would handle any string as expected.
   public get asHistory(): OriginalHistory {
     return this as OriginalHistory;
+  }
+
+  public get asObject(): IHistoryObject {
+    return {
+      entries: this.entries,
+      index: this.index,
+      lastAction: this.lastAction,
+    };
   }
 
   public block(): never {

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -1,5 +1,5 @@
 import { MacOsScrollbarVisibility } from '../../../shared/ipc-schema';
-import { IChangelog } from '../../../shared/ipc-types';
+import { IChangelog, ScrollPositions } from '../../../shared/ipc-types';
 
 export interface IUpdateLocaleAction {
   type: 'UPDATE_LOCALE';
@@ -18,6 +18,11 @@ export interface IUpdateConnectionInfoOpenAction {
 export interface ISetWindowFocusedAction {
   type: 'SET_WINDOW_FOCUSED';
   focused: boolean;
+}
+
+export interface ISetScrollPositions {
+  type: 'SET_SCROLL_POSITIONS';
+  scrollPositions: ScrollPositions;
 }
 
 export interface IAddScrollPosition {
@@ -56,6 +61,7 @@ export type UserInterfaceAction =
   | IUpdateWindowArrowPositionAction
   | IUpdateConnectionInfoOpenAction
   | ISetWindowFocusedAction
+  | ISetScrollPositions
   | IAddScrollPosition
   | IRemoveScrollPosition
   | ISetMacOsScrollbarVisibility
@@ -87,6 +93,13 @@ function setWindowFocused(focused: boolean): ISetWindowFocusedAction {
   return {
     type: 'SET_WINDOW_FOCUSED',
     focused,
+  };
+}
+
+function setScrollPositions(scrollPositions: ScrollPositions): ISetScrollPositions {
+  return {
+    type: 'SET_SCROLL_POSITIONS',
+    scrollPositions,
   };
 }
 
@@ -140,6 +153,7 @@ export default {
   updateWindowArrowPosition,
   toggleConnectionPanel,
   setWindowFocused,
+  setScrollPositions,
   addScrollPosition,
   removeScrollPosition,
   setMacOsScrollbarVisibility,

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -42,6 +42,9 @@ export default function (
     case 'SET_WINDOW_FOCUSED':
       return { ...state, windowFocused: action.focused };
 
+    case 'SET_SCROLL_POSITIONS':
+      return { ...state, scrollPosition: action.scrollPositions };
+
     case 'ADD_SCROLL_POSITION':
       return {
         ...state,

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -32,6 +32,7 @@ import {
   ICurrentAppVersionInfo,
   IHistoryObject,
   IWindowShapeParameters,
+  ScrollPositions,
 } from './ipc-types';
 
 export interface ITranslations {
@@ -72,6 +73,7 @@ export interface IAppStateSnapshot {
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
   changelog: IChangelog;
   navigationHistory?: IHistoryObject;
+  scrollPositions: ScrollPositions;
 }
 
 // The different types of requests are:
@@ -125,6 +127,7 @@ export const ipcSchema = {
   navigation: {
     reset: notifyRenderer<void>(),
     setHistory: send<IHistoryObject>(),
+    setScrollPositions: send<ScrollPositions>(),
   },
   daemon: {
     isPerformingPostUpgrade: notifyRenderer<boolean>(),

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -27,7 +27,12 @@ interface ILogEntry {
   message: string;
 }
 import { invoke, invokeSync, notifyRenderer, send } from './ipc-helpers';
-import { IChangelog, ICurrentAppVersionInfo, IWindowShapeParameters } from './ipc-types';
+import {
+  IChangelog,
+  ICurrentAppVersionInfo,
+  IHistoryObject,
+  IWindowShapeParameters,
+} from './ipc-types';
 
 export interface ITranslations {
   locale: string;
@@ -66,6 +71,7 @@ export interface IAppStateSnapshot {
   windowsSplitTunnelingApplications?: IWindowsApplication[];
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
   changelog: IChangelog;
+  navigationHistory?: IHistoryObject;
 }
 
 // The different types of requests are:
@@ -118,6 +124,7 @@ export const ipcSchema = {
   },
   navigation: {
     reset: notifyRenderer<void>(),
+    setHistory: send<IHistoryObject>(),
   },
   daemon: {
     isPerformingPostUpgrade: notifyRenderer<boolean>(),

--- a/gui/src/shared/ipc-types.ts
+++ b/gui/src/shared/ipc-types.ts
@@ -1,3 +1,5 @@
+import { Action, Location } from 'history';
+
 export interface ICurrentAppVersionInfo {
   gui: string;
   daemon?: string;
@@ -10,3 +12,9 @@ export interface IWindowShapeParameters {
 }
 
 export type IChangelog = Array<string>;
+
+export interface IHistoryObject {
+  entries: Location<unknown>[];
+  index: number;
+  lastAction: Action;
+}

--- a/gui/src/shared/ipc-types.ts
+++ b/gui/src/shared/ipc-types.ts
@@ -18,3 +18,5 @@ export interface IHistoryObject {
   index: number;
   lastAction: Action;
 }
+
+export type ScrollPositions = Record<string, [number, number]>;


### PR DESCRIPTION
This PR adds storage of the navigation history and scroll positions in the main process for reuse when the browser window is replaced or refreshed. This is useful when toggling unpinned window and when refreshing during development.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3507)
<!-- Reviewable:end -->
