### PR TITLE
Deserialize ST events correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix apps not always visible in split tunneling view after browsing for an app and then removing it
   from the excluded applications.
 - Fix navigation resetting to main view when toggling the unpinned window setting.
+- Log splitting event reason correctly.
 
 ### Security
 #### Android

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -283,7 +283,6 @@ impl SplitTunnel {
                         "Stop splitting process"
                     }
                     EventId::ErrorMessage => "ErrorMessage",
-                    _ => "Unknown event ID",
                 };
 
                 match event_body {


### PR DESCRIPTION
Changes:
* Deserialize the splitting event reason correctly and add some missing some flags.
* Generally reject invalid enum variants instead of unsafely initializing them.
* Rather than blindly trusting that the event buffer returned by the driver is valid, panic if the driver returns an event buffer that is too small.
* Document more unsafe code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3508)
<!-- Reviewable:end -->
