### PR TITLE
Adjust margins in connection panel

### DIFF
--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -76,6 +76,7 @@ const Header = styled.div({
   alignSelf: 'start',
   display: 'flex',
   alignItems: 'center',
+  width: '100%',
 });
 
 export default class ConnectionPanel extends React.Component<IProps> {

--- a/gui/src/renderer/components/ConnectionPanelDisclosure.tsx
+++ b/gui/src/renderer/components/ConnectionPanelDisclosure.tsx
@@ -40,8 +40,8 @@ export default function ConnectionPanelDisclosure(props: IProps) {
       <Caption open={props.pointsUp}>{props.children}</Caption>
       <Chevron
         source={props.pointsUp ? 'icon-chevron-up' : 'icon-chevron-down'}
-        width={24}
-        height={24}
+        width={22}
+        height={22}
         tintColor={colors.white40}
       />
     </Container>

--- a/gui/src/renderer/components/Marquee.tsx
+++ b/gui/src/renderer/components/Marquee.tsx
@@ -9,6 +9,8 @@ const Container = styled.div({
 
 const Text = styled.span({}, (props: { overflow: number; alignRight: boolean }) => ({
   display: 'inline-block',
+  // Prevents Container from adding 2px below the text.
+  verticalAlign: 'middle',
   whiteSpace: 'nowrap',
   willChange: 'transform',
   transform: props.alignRight ? `translate(${-props.overflow}px)` : 'translate(0)',

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -31,7 +31,6 @@ const SwitchLocationButton = styled(AppButton.TransparentButton)({
 const Secured = styled(SecuredLabel)(normalText, {
   fontWeight: 700,
   lineHeight: '22px',
-  marginBottom: '2px',
 });
 
 const Footer = styled.div({
@@ -60,7 +59,6 @@ const Wrapper = styled.div({
 const Location = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  marginBottom: 2,
 });
 
 const LocationRow = styled.div({


### PR DESCRIPTION
This PR fixes the height of the city and country containers. For some reason they added `2px` to the bottom of the container which caused everything to be bit to far apart resulting in the connection info not fitting and pushing the buttons downward.

The simplest solution was to add `vertical-align: middle` to the content.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3511)
<!-- Reviewable:end -->
