### PR TITLE
Vertically fix location rows

### DIFF
--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -63,6 +63,10 @@ const Location = styled.div({
   marginBottom: 2,
 });
 
+const LocationRow = styled.div({
+  height: '36px',
+});
+
 const StyledMarquee = styled(Marquee)(hugeText, {
   lineHeight: '36px',
   overflow: 'hidden',
@@ -163,7 +167,10 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
           <Wrapper>
             <Body>
               <Secured displayStyle={SecuredDisplayStyle.unsecuring} />
-              <Location>{this.renderCountry()}</Location>
+              <Location>
+                <LocationRow />
+                {this.renderCountry()}
+              </Location>
             </Body>
             <Footer>
               {this.selectLocationButton()}
@@ -180,7 +187,10 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
           <Wrapper>
             <Body>
               <Secured displayStyle={displayStyle} />
-              <Location>{this.renderCountry()}</Location>
+              <Location>
+                <LocationRow />
+                {this.renderCountry()}
+              </Location>
             </Body>
             <Footer>
               {this.selectLocationButton()}
@@ -197,13 +207,21 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
 
   private renderCity() {
     const city = this.props.city === undefined ? '' : relayLocations.gettext(this.props.city);
-    return <StyledMarquee>{city}</StyledMarquee>;
+    return (
+      <LocationRow>
+        <StyledMarquee>{city}</StyledMarquee>
+      </LocationRow>
+    );
   }
 
   private renderCountry() {
     const country =
       this.props.country === undefined ? '' : relayLocations.gettext(this.props.country);
-    return <StyledMarquee>{country}</StyledMarquee>;
+    return (
+      <LocationRow>
+        <StyledMarquee>{country}</StyledMarquee>
+      </LocationRow>
+    );
   }
 
   private switchLocationButton() {

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -103,8 +103,8 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
             <Body>
               <Secured displayStyle={SecuredDisplayStyle.securing} />
               <Location>
-                {this.renderCity()}
                 {this.renderCountry()}
+                {this.renderCity()}
               </Location>
               <ConnectionPanelContainer />
             </Body>
@@ -120,8 +120,8 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
             <Body>
               <Secured displayStyle={SecuredDisplayStyle.secured} />
               <Location>
-                {this.renderCity()}
                 {this.renderCountry()}
+                {this.renderCity()}
               </Location>
               <ConnectionPanelContainer />
             </Body>
@@ -168,8 +168,8 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
             <Body>
               <Secured displayStyle={SecuredDisplayStyle.unsecuring} />
               <Location>
-                <LocationRow />
                 {this.renderCountry()}
+                <LocationRow />
               </Location>
             </Body>
             <Footer>
@@ -188,8 +188,8 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
             <Body>
               <Secured displayStyle={displayStyle} />
               <Location>
-                <LocationRow />
                 {this.renderCountry()}
+                <LocationRow />
               </Location>
             </Body>
             <Footer>


### PR DESCRIPTION
This PR:
* Changes the order of the country and city in the main view to prevent the country from jumping up and down when switching state, and to make the order more logical (country, city, hostname)
* Adds an element to make sure that the city row always takes up the same space even if no city is displayed

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3512)
<!-- Reviewable:end -->
