### PR TITLE
Fix Android cache by setting rust version to 1.60.0

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -51,7 +51,7 @@ jobs:
               if: steps.cache-native-libs.outputs.cache-hit != 'true'
               uses: ATiltedTree/setup-rust@v1.0.4
               with:
-                  rust-version: stable
+                  rust-version: 1.60.0
                   targets: x86_64-linux-android
 
             - name: Configure Go


### PR DESCRIPTION
Setting version '1.60.0' rather than 'stable' ensures that the rust
action 'ATiltedTree/setup-rust' uses a per-rust-version unique key
internally. Fixes an issue with the action failing due to the cache
being invalid/corrupt.

Cache keys used:
Before: rustup-linux-stable--x86_64-linux-android
After:  rustup-linux-1.60.0--x86_64-linux-android

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3513)
<!-- Reviewable:end -->
