### PR TITLE
Fix logging of DNS changes

### DIFF
--- a/talpid-core/src/dns/macos.rs
+++ b/talpid-core/src/dns/macos.rs
@@ -125,7 +125,7 @@ impl State {
                     }
                     Some(new_settings) => {
                         if new_settings.address_set() != expected_settings.address_set() {
-                            let servers = expected_settings.server_addresses().join(",");
+                            let servers = new_settings.server_addresses().join(",");
                             log::debug!("Detected DNS change [{}] for {}", servers, *path);
                             self.backup.insert(path.to_string(), Some(new_settings));
                             true


### PR DESCRIPTION
Instead of logging the received DNS config changes, the wanted DNS config was being logged, which is the exact opposite of helpful. So I've changed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3515)
<!-- Reviewable:end -->
