### PR TITLE
Switch to volta

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,12 +271,17 @@ storePassword = keystore-password
 
 1. *This can be skipped for Android builds*.
 
-   Get the latest version 16 release of Node.js and the latest version of npm. The Node.js version
-   is specified in `.nvmrc` and can be installed by running the following from any directory within
-   this repository:
+   Any Node.js version above 16 and the latest npm version should work. The exact Node.js and NPM
+   versions that we target are specified in `package.json` in the `volta` section. Those versions
+   will be used automatically if volta is installed and setup.
+
+   To install Volta, run:
    ```
-   nvm install --latest-npm
+   cargo install --git https://github.com/volta-cli/volta
+   volta setup
    ```
+   or follow the their instructions: https://github.com/volta-cli/volta.
+
 
    If installing Node.js manually then the latest version of npm can be installed by running:
    ```

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -103,9 +103,6 @@ build_ref() {
 
   # Make sure we have the latest Rust and Node toolchains before the build
   rustup update
-  if command -v nvm > /dev/null; then
-      nvm install --latest-npm
-  fi
 
   BUILD_ARGS=(--optimize --sign)
   if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/gui/package.json
+++ b/gui/package.json
@@ -98,7 +98,11 @@
     "pack:linux": "gulp pack-linux"
   },
   "engines": {
-    "node": ">=12",
-    "npm": ">=6.12"
+    "node": ">=16",
+    "npm": ">=8.3"
+  },
+  "volta": {
+    "node": "16.13.2",
+    "npm": "8.7.0"
   }
 }


### PR DESCRIPTION
This PR replaces `nvm` with [Volta](https://github.com/volta-cli/volta). This required adding a volta section to `package.json`, updating the readme, build server build script and GitHub Actions workflows.

To install Volta, run:
```
cargo install --git https://github.com/volta-cli/volta
volta setup
```
or follow the instructions in their repository.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3516)
<!-- Reviewable:end -->
