### PR TITLE
Make build script use correct node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,29 +275,21 @@ storePassword = keystore-password
    versions that we target are specified in `package.json` in the `volta` section. Those versions
    will be used automatically if volta is installed and setup.
 
-   To install Volta, run:
+   To install Volta on Linux and macOS, run:
    ```
    cargo install --git https://github.com/volta-cli/volta
    volta setup
    ```
    or follow the their instructions: https://github.com/volta-cli/volta.
 
+   #### Windows
+   Install the `msi` hosted here: https://github.com/volta-cli/volta.
+
 
    If installing Node.js manually then the latest version of npm can be installed by running:
    ```
    npm install -g npm
    ```
-   #### macOS
-   ```bash
-   brew install node
-   ```
-
-   #### Linux
-   Just download and unpack the `node-v16.xxxx.tar.xz` tarball and add its `bin` directory to your
-   `PATH`.
-
-   #### Windows
-   Download the Node.js installer from the official website.
 
 1. Install Go (ideally version `1.16`) by following the [official
    instructions](https://golang.org/doc/install).  Newer versions may work

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ function log_info {
 RUSTC_VERSION=$(rustc --version)
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"target"}
 
-PRODUCT_VERSION=$(node -p "require('./gui/package.json').version" | sed -Ee 's/\.0//g')
+PRODUCT_VERSION=$(cd gui/; node -p "require('./package.json').version" | sed -Ee 's/\.0//g')
 
 # If compiler optimization and artifact compression should be turned on or not
 OPTIMIZE="false"


### PR DESCRIPTION
This PR makes the build script use the correct node version. And also removes the instructions for how to manually install node from the readme.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3521)
<!-- Reviewable:end -->
