### PR TITLE
Make `udp-over-tcp` quieter

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -43,7 +43,7 @@ pub const SILENCED_CRATES: &[&str] = &[
     "trust_dns_server",
     "trust_dns_resolver",
 ];
-const SLIGHTLY_SILENCED_CRATES: &[&str] = &["mnl", "nftnl"];
+const SLIGHTLY_SILENCED_CRATES: &[&str] = &["mnl", "nftnl", "udp_over_tcp"];
 
 const COLORS: ColoredLevelConfig = ColoredLevelConfig {
     error: Color::Red,


### PR DESCRIPTION
`udp-over-tcp` makes a lot of noise when the log level is set to `trace`, logging this for every send/recv:
```
[2022-04-25 16:05:50.001][udp_over_tcp::forward_traffic][TRACE] Forwarded 112 bytes UDP->TCP
[2022-04-25 16:05:50.001][udp_over_tcp::forward_traffic][TRACE] Forwarded 112 bytes UDP->TCP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 112 bytes UDP->TCP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 1312 byte TCP->UDP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 1312 byte TCP->UDP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 1312 byte TCP->UDP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 1312 byte TCP->UDP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 1312 byte TCP->UDP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 1312 byte TCP->UDP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 112 bytes UDP->TCP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 112 bytes UDP->TCP
[2022-04-25 16:05:50.002][udp_over_tcp::forward_traffic][TRACE] Forwarded 112 bytes UDP->TCP
...
```

This silences it slightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3525)
<!-- Reviewable:end -->
