### PR TITLE
Set `hijack_dns` to `false` explicitly

### DIFF
--- a/mullvad-api/src/device.rs
+++ b/mullvad-api/src/device.rs
@@ -39,9 +39,13 @@ impl DevicesProxy {
         #[derive(serde::Serialize)]
         struct DeviceSubmission {
             pubkey: wireguard::PublicKey,
+            hijack_dns: bool,
         }
 
-        let submission = DeviceSubmission { pubkey };
+        let submission = DeviceSubmission {
+            pubkey,
+            hijack_dns: false,
+        };
 
         let service = self.handle.service.clone();
         let factory = self.handle.factory.clone();


### PR DESCRIPTION
The previous code was actually incorrect, because the default value is `true`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3528)
<!-- Reviewable:end -->
