### PR TITLE
Fix manual key rotation

### DIFF
--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -595,7 +595,7 @@ impl AccountManager {
         self.last_validation = None;
 
         if let Some(old_data) = self.data.take() {
-            if data.as_ref().map(|d| &d.device.id) == Some(&old_data.device.id) {
+            if data.as_ref().map(|d| &d.device.id) != Some(&old_data.device.id) {
                 tokio::spawn(self.logout_api_call(old_data));
             }
         }

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -307,7 +307,8 @@ impl AccountManager {
                             }
                             match self.initiate_key_rotation() {
                                 Ok(api_call) => {
-                                    current_api_call.set_oneshot_rotation(Box::pin(api_call))
+                                    current_api_call.set_oneshot_rotation(Box::pin(api_call));
+                                    self.rotation_requests.push(tx);
                                 },
                                 Err(err) =>  {
                                     let _ = tx.send(Err(err));


### PR DESCRIPTION
There were a couple of problems here:
1. The key rotation response was not sent back to the caller.
2. When updating the device, it was removed. The old device is only supposed to be removed when logging in to a new account or generating a new device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3530)
<!-- Reviewable:end -->
