### PR TITLE
Pause API interactions when no daemon commands are received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Line wrap the file at 100 chars.                                              Th
 - Randomize bridge selection with a bias in favor of close bridges.
 - Make login field keep previous value when submitting an incorrect account number in desktop app.
 - Decrease the time it takes to connect to WireGuard relays by sending an ICMP packet immediately.
+- Pause API interactions when the daemon has not been used for 3 days.
 
 ### Fixed
 - Fix the sometimes incorrect time added text after adding time to the account.

--- a/mullvad-api/src/availability.rs
+++ b/mullvad-api/src/availability.rs
@@ -66,49 +66,54 @@ pub struct ApiAvailabilityHandle {
 
 impl ApiAvailabilityHandle {
     pub fn suspend(&self) {
-        log::debug!("Suspending API requests");
         let mut state = self.state.lock().unwrap();
         if !state.suspended {
+            log::debug!("Suspending API requests");
+
             state.suspended = true;
             let _ = self.tx.send(*state);
         }
     }
 
     pub fn unsuspend(&self) {
-        log::debug!("Unsuspending API requests");
         let mut state = self.state.lock().unwrap();
         if state.suspended {
+            log::debug!("Unsuspending API requests");
+
             state.suspended = false;
             let _ = self.tx.send(*state);
         }
     }
 
     pub fn pause_background(&self) {
-        log::debug!("Pausing background API requests");
         let mut state = self.state.lock().unwrap();
         if !state.pause_background {
+            log::debug!("Pausing background API requests");
+
             state.pause_background = true;
             let _ = self.tx.send(*state);
         }
     }
 
     pub fn resume_background(&self) {
-        log::debug!("Resuming background API requests");
         let mut state = self.state.lock().unwrap();
         if state.pause_background {
+            log::debug!("Resuming background API requests");
+
             state.pause_background = false;
             let _ = self.tx.send(*state);
         }
     }
 
     pub fn set_offline(&self, offline: bool) {
-        if offline {
-            log::debug!("Pausing API requests due to being offline");
-        } else {
-            log::debug!("Resuming API requests due to coming online");
-        }
         let mut state = self.state.lock().unwrap();
         if state.offline != offline {
+            if offline {
+                log::debug!("Pausing API requests due to being offline");
+            } else {
+                log::debug!("Resuming API requests due to coming online");
+            }
+
             state.offline = offline;
             let _ = self.tx.send(*state);
         }

--- a/mullvad-api/src/availability.rs
+++ b/mullvad-api/src/availability.rs
@@ -1,10 +1,15 @@
 use std::{
     future::Future,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 use tokio::sync::broadcast;
 
 const CHANNEL_CAPACITY: usize = 100;
+
+/// Pause background requests if [ApiAvailabilityHandle::reset_inactivity_timer] hasn't been
+/// called for this long.
+const INACTIVITY_TIME: Duration = Duration::from_secs(3 * 24 * 60 * 60);
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
@@ -18,6 +23,7 @@ pub struct State {
     suspended: bool,
     pause_background: bool,
     offline: bool,
+    inactive: bool,
 }
 
 impl State {
@@ -26,7 +32,7 @@ impl State {
     }
 
     pub fn is_background_paused(&self) -> bool {
-        self.offline || self.pause_background || self.suspended
+        self.offline || self.pause_background || self.suspended || self.inactive
     }
 
     pub fn is_offline(&self) -> bool {
@@ -37,13 +43,22 @@ impl State {
 pub struct ApiAvailability {
     state: Arc<Mutex<State>>,
     tx: broadcast::Sender<State>,
+
+    inactivity_timer: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl ApiAvailability {
     pub fn new(initial_state: State) -> Self {
         let (tx, _rx) = broadcast::channel(CHANNEL_CAPACITY);
         let state = Arc::new(Mutex::new(initial_state));
-        ApiAvailability { state, tx }
+
+        let availability = ApiAvailability {
+            state,
+            tx,
+            inactivity_timer: Arc::new(Mutex::new(None)),
+        };
+        availability.handle().reset_inactivity_timer();
+        availability
     }
 
     pub fn get_state(&self) -> State {
@@ -54,6 +69,15 @@ impl ApiAvailability {
         ApiAvailabilityHandle {
             state: self.state.clone(),
             tx: self.tx.clone(),
+            inactivity_timer: self.inactivity_timer.clone(),
+        }
+    }
+}
+
+impl Drop for ApiAvailability {
+    fn drop(&mut self) {
+        if let Some(timer) = self.inactivity_timer.lock().unwrap().take() {
+            timer.abort();
         }
     }
 }
@@ -62,9 +86,45 @@ impl ApiAvailability {
 pub struct ApiAvailabilityHandle {
     state: Arc<Mutex<State>>,
     tx: broadcast::Sender<State>,
+    inactivity_timer: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl ApiAvailabilityHandle {
+    /// Reset task that automatically pauses API requests due inactivity,
+    /// starting it if it's not currently running.
+    pub fn reset_inactivity_timer(&self) {
+        log::trace!("Restarting API inactivity check");
+
+        let self_ = self.clone();
+
+        let mut inactivity_timer = self.inactivity_timer.lock().unwrap();
+        if let Some(timer) = inactivity_timer.take() {
+            timer.abort();
+        }
+
+        self.set_active();
+
+        *inactivity_timer = Some(tokio::spawn(async move {
+            talpid_time::sleep(INACTIVITY_TIME).await;
+            self_.set_inactive();
+        }));
+    }
+
+    /// Stops timer that pauses API requests due to inactivity.
+    pub fn stop_inactivity_timer(&self) {
+        log::trace!("Stopping API inactivity check");
+
+        let mut inactivity_timer = self.inactivity_timer.lock().unwrap();
+        if let Some(timer) = inactivity_timer.take() {
+            timer.abort();
+        }
+        self.set_active();
+    }
+
+    fn inactivity_timer_running(&self) -> bool {
+        self.inactivity_timer.lock().unwrap().is_some()
+    }
+
     pub fn suspend(&self) {
         let mut state = self.state.lock().unwrap();
         if !state.suspended {
@@ -96,11 +156,32 @@ impl ApiAvailabilityHandle {
     }
 
     pub fn resume_background(&self) {
+        if self.inactivity_timer_running() {
+            self.reset_inactivity_timer();
+        }
+
         let mut state = self.state.lock().unwrap();
         if state.pause_background {
             log::debug!("Resuming background API requests");
-
             state.pause_background = false;
+            let _ = self.tx.send(*state);
+        }
+    }
+
+    fn set_inactive(&self) {
+        let mut state = self.state.lock().unwrap();
+        if !state.inactive {
+            log::debug!("Pausing background API requests due to inactivity");
+            state.inactive = true;
+            let _ = self.tx.send(*state);
+        }
+    }
+
+    fn set_active(&self) {
+        let mut state = self.state.lock().unwrap();
+        if state.inactive {
+            log::debug!("Resuming background API requests due to activity");
+            state.inactive = false;
             let _ = self.tx.send(*state);
         }
     }

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -63,4 +63,12 @@ impl TunnelState {
             _ => false,
         }
     }
+
+    /// Returns true if the tunnel state is in the disconnected state.
+    pub fn is_disconnected(&self) -> bool {
+        match self {
+            TunnelState::Disconnected => true,
+            _ => false,
+        }
+    }
 }


### PR DESCRIPTION
This PR makes it so that API requests are paused after some interval (currently 3 days) has elapsed, provided that no daemon commands were received during that time. This makes the daemon a bit less talkative even if the current account is still valid. The timer is only enabled when the tunnel state is not `disconnected`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3531)
<!-- Reviewable:end -->
