### PR TITLE
Fix possible inconsistent state when logging out device

### DIFF
--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -549,19 +549,21 @@ impl AccountManager {
 
     async fn logout(&mut self, tx: ResponseTx<()>) {
         Self::drain_requests(&mut self.data_requests, || Err(Error::AccountChange));
-        let data = match self.data.take() {
-            Some(it) => it,
-            _ => return,
-        };
+        if self.data.is_none() {
+            return;
+        }
         if let Err(err) = self.cacher.write(None).await {
             let _ = tx.send(Err(err));
             return;
         }
 
+        // Cannot panic: `data.is_none() == false`.
+        let old_data = self.data.take().unwrap();
+
         self.listeners
             .retain(|listener| listener.send(InnerDeviceEvent::Logout).is_ok());
 
-        let logout_call = tokio::spawn(Box::pin(self.logout_api_call(data)));
+        let logout_call = tokio::spawn(Box::pin(self.logout_api_call(old_data)));
 
         tokio::spawn(async move {
             let _response = tokio::time::timeout(LOGOUT_TIMEOUT, logout_call).await;

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -550,6 +550,7 @@ impl AccountManager {
     async fn logout(&mut self, tx: ResponseTx<()>) {
         Self::drain_requests(&mut self.data_requests, || Err(Error::AccountChange));
         if self.data.is_none() {
+            let _ = tx.send(Ok(()));
             return;
         }
         if let Err(err) = self.cacher.write(None).await {


### PR DESCRIPTION
This PR fixes two issues:
* In the unlikely event of I/O errors, the device was removed in memory but no logout event nor API request was sent. I've fixed it so that it recovers properly.
* Logging out without a device set didn't return a correct result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3535)
<!-- Reviewable:end -->
