### PR TITLE
Show obfuscation endpoint as in-data

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -27,6 +27,7 @@ import {
   IDnsOptions,
   IErrorState,
   ILocation,
+  IObfuscationEndpoint,
   IOpenVpnConstraints,
   IOpenVpnTunnelData,
   IProxyEndpoint,
@@ -40,6 +41,7 @@ import {
   ITunnelStateRelayInfo,
   IWireguardConstraints,
   IWireguardTunnelData,
+  ObfuscationType,
   ProxySettings,
   ProxyType,
   RelayLocation,
@@ -899,6 +901,9 @@ function convertFromTunnelStateRelayInfo(
         tunnelType: convertFromTunnelType(state.tunnelEndpoint.tunnelType),
         protocol: convertFromTransportProtocol(state.tunnelEndpoint.protocol),
         proxy: state.tunnelEndpoint.proxy && convertFromProxyEndpoint(state.tunnelEndpoint.proxy),
+        obfuscationEndpoint:
+          state.tunnelEndpoint.obfuscation &&
+          convertFromObfuscationEndpoint(state.tunnelEndpoint.obfuscation),
         entryEndpoint:
           state.tunnelEndpoint.entryEndpoint &&
           convertFromEntryEndpoint(state.tunnelEndpoint.entryEndpoint),
@@ -927,6 +932,20 @@ function convertFromProxyEndpoint(proxyEndpoint: grpcTypes.ProxyEndpoint.AsObjec
     ...proxyEndpoint,
     protocol: convertFromTransportProtocol(proxyEndpoint.protocol),
     proxyType: proxyTypeMap[proxyEndpoint.proxyType],
+  };
+}
+
+function convertFromObfuscationEndpoint(
+  obfuscationEndpoint: grpcTypes.ObfuscationEndpoint.AsObject,
+): IObfuscationEndpoint {
+  const obfuscationTypes: Record<grpcTypes.ObfuscationType, ObfuscationType> = {
+    [grpcTypes.ObfuscationType.UDP2TCP]: 'udp2tcp',
+  };
+
+  return {
+    ...obfuscationEndpoint,
+    protocol: convertFromTransportProtocol(obfuscationEndpoint.protocol),
+    obfuscationType: obfuscationTypes[obfuscationEndpoint.obfuscationType],
   };
 }
 

--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { colors } from '../../config.json';
 import {
+  ObfuscationType,
   ProxyType,
   proxyTypeToString,
   RelayProtocol,
@@ -29,6 +30,10 @@ export interface IBridgeData extends IEndpoint {
   bridgeType: ProxyType;
 }
 
+export interface IObfuscationData extends IEndpoint {
+  obfuscationType: ObfuscationType;
+}
+
 export interface IOutAddress {
   ipv4?: string;
   ipv6?: string;
@@ -43,6 +48,7 @@ interface IProps {
   entryLocationInAddress?: IInAddress;
   bridgeInfo?: IBridgeData;
   outAddress?: IOutAddress;
+  obfuscationEndpoint?: IObfuscationData;
   onToggle: () => void;
   className?: string;
 }
@@ -126,10 +132,12 @@ export default class ConnectionPanel extends React.Component<IProps> {
     );
   }
 
-  private getEntryPoint() {
-    const { inAddress, entryLocationInAddress, bridgeInfo } = this.props;
+  private getEntryPoint(): IEndpoint | undefined {
+    const { obfuscationEndpoint, inAddress, entryLocationInAddress, bridgeInfo } = this.props;
 
-    if (entryLocationInAddress && inAddress) {
+    if (obfuscationEndpoint) {
+      return obfuscationEndpoint;
+    } else if (entryLocationInAddress && inAddress) {
       return entryLocationInAddress;
     } else if (bridgeInfo && inAddress) {
       return bridgeInfo;

--- a/gui/src/renderer/containers/ConnectionPanelContainer.tsx
+++ b/gui/src/renderer/containers/ConnectionPanelContainer.tsx
@@ -5,6 +5,7 @@ import { ITunnelEndpoint, parseSocketAddress } from '../../shared/daemon-rpc-typ
 import ConnectionPanel, {
   IBridgeData,
   IInAddress,
+  IObfuscationData,
   IOutAddress,
 } from '../components/ConnectionPanel';
 import { IReduxState, ReduxDispatch } from '../redux/store';
@@ -50,6 +51,21 @@ function tunnelEndpointToBridgeData(endpoint: ITunnelEndpoint): IBridgeData | un
   };
 }
 
+function tunnelEndpointToObfuscationEndpoint(
+  endpoint: ITunnelEndpoint,
+): IObfuscationData | undefined {
+  if (!endpoint.obfuscationEndpoint) {
+    return undefined;
+  }
+
+  return {
+    ip: endpoint.obfuscationEndpoint.address,
+    port: endpoint.obfuscationEndpoint.port,
+    protocol: endpoint.obfuscationEndpoint.protocol,
+    obfuscationType: endpoint.obfuscationEndpoint.obfuscationType,
+  };
+}
+
 const mapStateToProps = (state: IReduxState) => {
   const status = state.connection.status;
 
@@ -73,6 +89,11 @@ const mapStateToProps = (state: IReduxState) => {
       ? tunnelEndpointToBridgeData(status.details.endpoint)
       : undefined;
 
+  const obfuscationEndpoint: IObfuscationData | undefined =
+    (status.state === 'connecting' || status.state === 'connected') && status.details
+      ? tunnelEndpointToObfuscationEndpoint(status.details.endpoint)
+      : undefined;
+
   return {
     isOpen: state.userInterface.connectionPanelVisible,
     hostname: state.connection.hostname,
@@ -82,6 +103,7 @@ const mapStateToProps = (state: IReduxState) => {
     entryLocationInAddress,
     bridgeInfo,
     outAddress,
+    obfuscationEndpoint,
   };
 };
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -61,6 +61,7 @@ export function tunnelTypeToString(tunnel: TunnelType): string {
 }
 
 export type RelayProtocol = 'tcp' | 'udp';
+export type ObfuscationType = 'udp2tcp';
 
 export type Constraint<T> = 'any' | { only: T };
 export type LiftedConstraint<T> = 'any' | T;
@@ -86,12 +87,20 @@ export interface ITunnelEndpoint {
   protocol: RelayProtocol;
   tunnelType: TunnelType;
   proxy?: IProxyEndpoint;
+  obfuscationEndpoint?: IObfuscationEndpoint;
   entryEndpoint?: IEndpoint;
 }
 
 export interface IEndpoint {
   address: string;
   transportProtocol: RelayProtocol;
+}
+
+export interface IObfuscationEndpoint {
+  address: string;
+  port: number;
+  protocol: RelayProtocol;
+  obfuscationType: ObfuscationType;
 }
 
 export interface IProxyEndpoint {


### PR DESCRIPTION
This PR adds the obfuscation endpoint to the endpoint state and shows that information for the `in` field in the connection panel.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3536)
<!-- Reviewable:end -->
