### PR TITLE
Bump go version in GitHub actions

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -58,7 +58,7 @@ jobs:
               if: steps.cache-native-libs.outputs.cache-hit != 'true'
               uses: actions/setup-go@v3
               with:
-                  go-version: 1.16
+                  go-version: 1.18.1
 
             - name: Configure Android NDK
               if: steps.cache-native-libs.outputs.cache-hit != 'true'

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -56,7 +56,7 @@ jobs:
 
             - name: Configure Go
               if: steps.cache-native-libs.outputs.cache-hit != 'true'
-              uses: actions/setup-go@v2.1.3
+              uses: actions/setup-go@v3
               with:
                   go-version: 1.16
 

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -55,7 +55,7 @@ jobs:
             - name: Install Go
               uses: actions/setup-go@v3
               with:
-                  go-version: 1.16
+                  go-version: 1.18.1
 
             - name: Install build dependencies
               run: sudo apt-get install libdbus-1-dev
@@ -77,7 +77,7 @@ jobs:
             - name: Install Go
               uses: actions/setup-go@v3
               with:
-                  go-version: 1.16
+                  go-version: 1.18.1
 
             - name: Build and test crates
               run: ./ci/check-rust.sh
@@ -118,7 +118,7 @@ jobs:
             - name: Install Go
               uses: actions/setup-go@v3
               with:
-                  go-version: 1.16
+                  go-version: 1.18.1
 
             - name: Install msbuild
               uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -53,7 +53,7 @@ jobs:
                   rust-version: ${{ matrix.rust }}
 
             - name: Install Go
-              uses: actions/setup-go@v2.1.3
+              uses: actions/setup-go@v3
               with:
                   go-version: 1.16
 
@@ -75,7 +75,7 @@ jobs:
                   rust-version: stable
 
             - name: Install Go
-              uses: actions/setup-go@v2.1.3
+              uses: actions/setup-go@v3
               with:
                   go-version: 1.16
 
@@ -116,7 +116,7 @@ jobs:
                   rust-version: stable
 
             - name: Install Go
-              uses: actions/setup-go@v2.1.3
+              uses: actions/setup-go@v3
               with:
                   go-version: 1.16
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -28,7 +28,7 @@ jobs:
                   ${{ runner.os }}-spm-
 
             - name: Setup go-lang
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@v3
               with:
                   go-version: '1.16.5'
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Setup go-lang
               uses: actions/setup-go@v3
               with:
-                  go-version: '1.16.5'
+                  go-version: 1.18.1
 
             - name: Prepare iOS simulator
               run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update -y && apt install build-essential \
 
 # Install golang
 ENV GOLANG_VERSION 1.16
-# Found on https://go.dev/dl/
+# Checksum from: https://go.dev/dl/
 ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
 RUN curl -Lo go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
 	echo $(sha256sum go.tgz) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN apt update -y && apt install build-essential \
 
 
 # Install golang
-ENV GOLANG_VERSION 1.16
+ENV GOLANG_VERSION 1.18.1
 # Checksum from: https://go.dev/dl/
-ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
+ENV GOLANG_HASH b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
 RUN curl -Lo go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
 	echo $(sha256sum go.tgz) && \
 	echo "${GOLANG_HASH} go.tgz" | sha256sum -c - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN apt update -y && apt install build-essential \
 
 # Install golang
 ENV GOLANG_VERSION 1.16
-# Found on https://golang.org/dl/
+# Found on https://go.dev/dl/
 ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
-RUN curl -Lo go.tgz https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+RUN curl -Lo go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
 	echo $(sha256sum go.tgz) && \
 	echo "${GOLANG_HASH} go.tgz" | sha256sum -c - && \
 	tar -C /usr/local -xzf go.tgz && \

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -44,9 +44,9 @@ ENV ANDROID_NDK_HOME="/opt/android/android-ndk-r20b" \
     NDK_TOOLCHAIN_DIR="/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
 # Install golang
-ENV GOLANG_VERSION 1.16
+ENV GOLANG_VERSION 1.18.1
 # Checksum from: https://go.dev/dl/
-ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
+ENV GOLANG_HASH b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
 COPY goruntime-boottime-over-monotonic.diff /tmp/goruntime-boottime-over-monotonic.diff
 RUN cd /tmp && \
     curl -sf -L -o go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -47,7 +47,7 @@ ENV ANDROID_NDK_HOME="/opt/android/android-ndk-r20b" \
 COPY goruntime-boottime-over-monotonic.diff /tmp/goruntime-boottime-over-monotonic.diff
 
 RUN cd /tmp && \
-    curl -sf -L -O https://dl.google.com/go/go1.16.linux-amd64.tar.gz && \
+    curl -sf -L -O https://go.dev/dl/go1.16.linux-amd64.tar.gz && \
     echo "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2 go1.16.linux-amd64.tar.gz" | sha256sum -c && \
     cd /opt && \
     tar -xzf /tmp/go1.16.linux-amd64.tar.gz && \

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -43,17 +43,19 @@ RUN cd /tmp && \
 ENV ANDROID_NDK_HOME="/opt/android/android-ndk-r20b" \
     NDK_TOOLCHAIN_DIR="/opt/android/android-ndk-r20b/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
-# Install Go
+# Install golang
+ENV GOLANG_VERSION 1.16
+# Checksum from: https://go.dev/dl/
+ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
 COPY goruntime-boottime-over-monotonic.diff /tmp/goruntime-boottime-over-monotonic.diff
-
 RUN cd /tmp && \
-    curl -sf -L -O https://go.dev/dl/go1.16.linux-amd64.tar.gz && \
-    echo "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2 go1.16.linux-amd64.tar.gz" | sha256sum -c && \
+    curl -sf -L -o go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    echo "$GOLANG_HASH go.tgz" | sha256sum -c && \
     cd /opt && \
-    tar -xzf /tmp/go1.16.linux-amd64.tar.gz && \
+    tar -xzf /tmp/go.tgz && \
     patch -p1 -f -N -r- -d "/opt/go" < /tmp/goruntime-boottime-over-monotonic.diff && \
     mkdir /opt/go/go-path && \
-    rm /tmp/goruntime-boottime-over-monotonic.diff /tmp/go1.16.linux-amd64.tar.gz
+    rm /tmp/goruntime-boottime-over-monotonic.diff /tmp/go.tgz
 
 ENV GOROOT=/opt/go GOPATH=/opt/go/go-path PATH=${PATH}:/opt/go/bin
 

--- a/android/fdroid-build/init.sh
+++ b/android/fdroid-build/init.sh
@@ -21,7 +21,7 @@ rustup target add \
 
 # Install Go
 cd "$HOME"
-curl -sf -L -O https://golang.org/dl/go1.16.linux-amd64.tar.gz
+curl -sf -L -O https://go.dev/dl/go1.16.linux-amd64.tar.gz
 echo "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2 go1.16.linux-amd64.tar.gz" | sha256sum -c
 tar -xzvf go1.16.linux-amd64.tar.gz
 patch -p1 -f -N -r- -d "$HOME/go" < "$REPO_DIR/wireguard/libwg/goruntime-boottime-over-monotonic.diff"

--- a/android/fdroid-build/init.sh
+++ b/android/fdroid-build/init.sh
@@ -19,11 +19,14 @@ rustup target add \
     aarch64-linux-android \
     armv7-linux-androideabi
 
-# Install Go
+# Install golang
+GOLANG_VERSION="1.16"
+# Checksum from: https://golang.org/dl/
+GOLANG_HASH="013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
 cd "$HOME"
-curl -sf -L -O https://go.dev/dl/go1.16.linux-amd64.tar.gz
-echo "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2 go1.16.linux-amd64.tar.gz" | sha256sum -c
-tar -xzvf go1.16.linux-amd64.tar.gz
+curl -sf -L -o go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz
+echo "$GOLANG_HASH go.tgz" | sha256sum -c
+tar -xzvf go.tgz
 patch -p1 -f -N -r- -d "$HOME/go" < "$REPO_DIR/wireguard/libwg/goruntime-boottime-over-monotonic.diff"
 
 # Configure Cargo for cross-compilation

--- a/android/fdroid-build/init.sh
+++ b/android/fdroid-build/init.sh
@@ -20,9 +20,9 @@ rustup target add \
     armv7-linux-androideabi
 
 # Install golang
-GOLANG_VERSION="1.16"
+GOLANG_VERSION="1.18.1"
 # Checksum from: https://golang.org/dl/
-GOLANG_HASH="013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
+GOLANG_HASH="b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334"
 cd "$HOME"
 curl -sf -L -o go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz
 echo "$GOLANG_HASH go.tgz" | sha256sum -c

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -23,7 +23,7 @@ default: $(DESTDIR)/libwg.so
 GOBUILDARCH := $(NDK_GO_ARCH_MAP_$(shell uname -m))
 GOBUILDOS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GOBUILDVERSION := 1.12
-GOBUILDTARBALL := https://dl.google.com/go/go$(GOBUILDVERSION).$(GOBUILDOS)-$(GOBUILDARCH).tar.gz
+GOBUILDTARBALL := https://go.dev/dl/go$(GOBUILDVERSION).$(GOBUILDOS)-$(GOBUILDARCH).tar.gz
 GOBUILDVERSION_NEEDED := go version go$(GOBUILDVERSION) $(GOBUILDOS)/$(GOBUILDARCH)
 
 $(DESTDIR)/libwg.so:

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -22,7 +22,8 @@ default: $(DESTDIR)/libwg.so
 
 GOBUILDARCH := $(NDK_GO_ARCH_MAP_$(shell uname -m))
 GOBUILDOS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-GOBUILDVERSION := 1.12
+GOBUILDVERSION := 1.18.1
+# TODO: Add checksum?
 GOBUILDTARBALL := https://go.dev/dl/go$(GOBUILDVERSION).$(GOBUILDOS)-$(GOBUILDARCH).tar.gz
 GOBUILDVERSION_NEEDED := go version go$(GOBUILDVERSION) $(GOBUILDOS)/$(GOBUILDARCH)
 

--- a/wireguard/libwg/Dockerfile_AndroidPatchedGoruntime
+++ b/wireguard/libwg/Dockerfile_AndroidPatchedGoruntime
@@ -27,8 +27,8 @@ RUN cd /tmp && \
 ENV ANDROID_NDK_HOME="/opt/android/android-ndk-r20b"
 ENV NDK_TOOLCHAIN_DIR="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
-ENV GOLANG_VERSION 1.16
-ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
+ENV GOLANG_VERSION 1.18.1
+ENV GOLANG_HASH b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
 
 # Install Go-lang and patch it to use the appropriate monotonic clock
 COPY goruntime-boottime-over-monotonic.diff /opt/goruntime-boottime-over-monotonic.diff

--- a/wireguard/libwg/Dockerfile_AndroidPatchedGoruntime
+++ b/wireguard/libwg/Dockerfile_AndroidPatchedGoruntime
@@ -33,7 +33,7 @@ ENV GOLANG_HASH 013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2
 # Install Go-lang and patch it to use the appropriate monotonic clock
 COPY goruntime-boottime-over-monotonic.diff /opt/goruntime-boottime-over-monotonic.diff
 RUN cd /tmp && \
-    curl -sf -L -o go.tgz https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    curl -sf -L -o go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     echo "${GOLANG_HASH} go.tgz" | sha256sum -c - && \
     cd /opt && \
     tar -xzf /tmp/go.tgz && \

--- a/wireguard/libwg/go.mod
+++ b/wireguard/libwg/go.mod
@@ -1,6 +1,6 @@
 module github.com/mullvad/mullvadvpn-app/wireguard/libwg
 
-go 1.16
+go 1.18
 
 require (
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect


### PR DESCRIPTION
Bump `setup-go` action version and go version.

TODO:
* [ ] Build docker image(s) and upload to quay.
* [ ] Update hashes/checksums in scripts relying on the built docker image(s).
* [ ] Ensure all builds/scripts are working.

Git checklist:

~* [] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.~ (only affects GH actions)
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3537)
<!-- Reviewable:end -->
