### PR TITLE
Send one ICMP packet when connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Line wrap the file at 100 chars.                                              Th
 - Update Electron from 16.0.4 to 18.0.3.
 - Randomize bridge selection with a bias in favor of close bridges.
 - Make login field keep previous value when submitting an incorrect account number in desktop app.
+- Decrease the time it takes to connect to WireGuard relays by sending an ICMP packet immediately.
 
 ### Fixed
 - Fix the sometimes incorrect time added text after adding time to the account.

--- a/talpid-core/src/tunnel/wireguard/connectivity_check.rs
+++ b/talpid-core/src/tunnel/wireguard/connectivity_check.rs
@@ -107,6 +107,8 @@ impl ConnectivityMonitor {
     // checks if the tunnel has ever worked. Intended to check if a connection to a tunnel is
     // successfull at the start of a connection.
     pub(super) fn establish_connectivity(&mut self, retry_attempt: u32) -> Result<bool, Error> {
+        // Send initial ping to prod WireGuard into connecting.
+        self.pinger.send_icmp().map_err(Error::PingError)?;
         self.establish_connectivity_inner(
             retry_attempt,
             ESTABLISH_TIMEOUT,


### PR DESCRIPTION
Connectivity check was slightly broken in that it wasn't sending any traffic as soon as it started. This should greatly improve the latency to connect. 
