### PR TITLE
Rework output of status subcommand in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Line wrap the file at 100 chars.                                              Th
 - Make login field keep previous value when submitting an incorrect account number in desktop app.
 - Decrease the time it takes to connect to WireGuard relays by sending an ICMP packet immediately.
 - Pause API interactions when the daemon has not been used for 3 days.
+- Simplified output of `mullvad status` command.
 
 ### Fixed
 - Fix the sometimes incorrect time added text after adding time to the account.

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -34,7 +34,7 @@ impl Command for Connect {
             if let Some(mut receiver) = receiver_option {
                 while let Some(state) = receiver.next().await {
                     let state = state?;
-                    format::print_state(&state);
+                    format::print_state(&state, false);
                     match state.state.unwrap() {
                         State::Connected(_) => return Ok(()),
                         State::Error(_) => return Err(Error::CommandFailed("connect")),

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -34,7 +34,7 @@ impl Command for Disconnect {
             if let Some(mut receiver) = receiver_option {
                 while let Some(state) = receiver.next().await {
                     let state = state?;
-                    format::print_state(&state);
+                    format::print_state(&state, false);
                     match state.state.unwrap() {
                         Disconnected(_) => return Ok(()),
                         _ => {}

--- a/mullvad-cli/src/cmds/reconnect.rs
+++ b/mullvad-cli/src/cmds/reconnect.rs
@@ -34,7 +34,7 @@ impl Command for Reconnect {
             if let Some(mut receiver) = receiver_option {
                 while let Some(state) = receiver.next().await {
                     let state = state?;
-                    format::print_state(&state);
+                    format::print_state(&state, false);
                     match state.state.unwrap() {
                         State::Connected(_) => return Ok(()),
                         State::Error(_) => return Err(Error::CommandFailed("reconnect")),


### PR DESCRIPTION
The output of the status command is reworked to show hostnames instead of IP addresses and trim the fat. The extra information (tunnel protocols, IP addrresses) are now available with the verbose flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3540)
<!-- Reviewable:end -->
