### PR TITLE
Treat dev deb package versions as newer, all else equal

### DIFF
--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -343,15 +343,16 @@ function getMacArch() {
 }
 
 // Replace '-' between components with a tilde to make the version comparison understand that
-// YYYY.NN > YYYY.NN-betaN > YYYY.NN-betaN-dev-HHHHHH.
+// YYYY.NN-dev-HHHHHH > YYYY.NN > YYYY.NN-betaN-dev-HHHHHH > YYYY.NN-betaN.
 function getDebVersion() {
   const { major, minor, prerelease } = parseSemver(version);
-  const versionParts = [`${major}.${minor}`];
   if (prerelease[0]) {
-    // Replace first '-' with a '~' since the first one is the one between 'betaN' and 'dev-hash'.
-    versionParts.push(prerelease[0].replace('-', '~'));
+    if (prerelease[0].toLowerCase().startsWith('beta')) {
+      return `${major}.${minor}~${prerelease[0]}`;
+    }
+    return `${major}.${minor}-${prerelease[0]}`;
   }
-  return versionParts.join('~');
+  return `${major}.${minor}`;
 }
 
 packWin.displayName = 'builder-win';


### PR DESCRIPTION
For example, `2022.1-beta1-dev-HHHHHH` is newer than `2022.1-beta1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3541)
<!-- Reviewable:end -->
