### PR TITLE
Update too many devices message

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -534,6 +534,10 @@ msgctxt "device-management"
 msgid "Log out anyway"
 msgstr ""
 
+msgctxt "device-management"
+msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
+msgstr ""
+
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
@@ -567,10 +571,6 @@ msgstr ""
 
 msgctxt "device-management"
 msgid "You have removed this device. To connect again, you will need to log back in."
-msgstr ""
-
-msgctxt "device-management"
-msgid "You have too many active devices. Please log out of at least one by removing it from the list below. You can find the corresponding nickname under the device’s Account settings."
 msgstr ""
 
 #. The message displayed to the user in case of critical error in the GUI

--- a/gui/src/renderer/components/TooManyDevices.tsx
+++ b/gui/src/renderer/components/TooManyDevices.tsx
@@ -309,7 +309,7 @@ function getSubtitle(devices?: Array<IDevice>): string | undefined {
     if (devices.length === 5) {
       return messages.pgettext(
         'device-management',
-        'You have too many active devices. Please log out of at least one by removing it from the list below. You can find the corresponding nickname under the device’s Account settings.',
+        'Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings.',
       );
     } else {
       return messages.pgettext(


### PR DESCRIPTION
This PR updates the message in the too many devices view. The main change is that "nickname" has been replaced with "device name".

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3543)
<!-- Reviewable:end -->
