### PR TITLE
Add server ownership relay constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add device management to desktop app. This simplifies knowing which device is which and adds the
   option to log out other devices when there are already 5 connected when logging in.
 - Add tray icon tooltip with connection info in desktop app.
+- Add relay and bridge constraints for restricting relay selection to rented or Mullvad-owned
+  relays.
 
 #### Windows
 - Detect mounting and dismounting of volumes, such as VeraCrypt volumes or USB drives,

--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -35,6 +35,7 @@ Endpoints may be filtered by:
   like WireGuard
 - entry port
 - location (country, city, hostname)
+- provider
 
 ### Default constraints for tunnel endpoints
 
@@ -67,10 +68,14 @@ relay is picked, then a random endpoint that matches the constraints from the re
 
 ## Bridge endpoint constraints
 
-Currently, the only explicit constraints for bridges is the location, and the transport protocol is
-supposedly inferred by the selected bridge- but for now, the daemon only supports TCP bridges, so
-only TCP bridges are being selected. If no location constraint is specified explicitly, then the
-relay location will be used.
+The explicit constraints are:
+
+- location
+- provider
+
+The transport protocol is supposedly inferred by the selected bridge- but for now, the daemon only
+supports TCP bridges, so only TCP bridges are being selected. If no location constraint is specified
+explicitly, then the relay location will be used.
 
 ### Selecting a bridge endpoint between filtered relays
 

--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -11,10 +11,10 @@
 
 The relay selector's main purpose is to pick a single Mullvad relay from a list of relays taking
 into account certain user-configurable criteria.  Relays can be filtered by their _location_
-(country, city, hostname) and by the protocols and ports they support (transport protocol, tunnel
-protocol, port).  The constraints are user specified and stored in the settings.  The default value
-for location constraints restricts relay selection to relays from Sweden. The default protocol
-constraints default to _auto_, which implies specific behavior.
+(country, city, hostname), by the protocols and ports they support (transport protocol, tunnel
+protocol, port), and by other constraints.  The constraints are user specified and stored in the
+settings. The default value for location constraints restricts relay selection to relays from Sweden.
+The default protocol constraints default to _auto_, which implies specific behavior.
 
 Generally, the filtering process consists of going through each relay in our relay list and
 removing relay and endpoint combinations that do not match the constraints outlined above. The
@@ -36,6 +36,7 @@ Endpoints may be filtered by:
 - entry port
 - location (country, city, hostname)
 - provider
+- ownership (Mullvad-owned or rented)
 
 ### Default constraints for tunnel endpoints
 
@@ -72,6 +73,7 @@ The explicit constraints are:
 
 - location
 - provider
+- ownership
 
 The transport protocol is supposedly inferred by the selected bridge- but for now, the daemon only
 supports TCP bridges, so only TCP bridges are being selected. If no location constraint is specified

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -124,6 +124,17 @@ impl Command for Relay {
                             )
                     )
                     .subcommand(
+                        clap::App::new("ownership")
+                            .about("Filters relays based on ownership. The 'list' \
+                                   command shows the available relays and whether they're rented.")
+                            .arg(
+                                clap::Arg::new("ownership")
+                                .help("Ownership preference, or 'any' for no preference.")
+                                .possible_values(&["any", "owned", "rented"])
+                                .required(true)
+                            )
+                    )
+                    .subcommand(
                         clap::App::new("tunnel")
                             .about("Set tunnel protocol-specific constraints.")
                             .setting(clap::AppSettings::SubcommandRequiredElseHelp)
@@ -226,6 +237,8 @@ impl Relay {
             self.set_hostname(relay_matches).await
         } else if let Some(providers_matches) = matches.subcommand_matches("provider") {
             self.set_providers(providers_matches).await
+        } else if let Some(ownership_matches) = matches.subcommand_matches("ownership") {
+            self.set_ownership(ownership_matches).await
         } else if let Some(matches) = matches.subcommand_matches("tunnel") {
             if let Some(tunnel_matches) = matches.subcommand_matches("openvpn") {
                 self.set_openvpn_constraints(tunnel_matches).await
@@ -483,6 +496,21 @@ impl Relay {
         .await
     }
 
+    async fn set_ownership(&self, matches: &clap::ArgMatches) -> Result<()> {
+        let ownership = parse_ownership_constraint(matches.value_of("ownership").unwrap());
+        self.update_constraints(types::RelaySettingsUpdate {
+            r#type: Some(types::relay_settings_update::Type::Normal(
+                types::NormalRelaySettingsUpdate {
+                    ownership: Some(types::OwnershipUpdate {
+                        ownership: ownership as i32,
+                    }),
+                    ..Default::default()
+                },
+            )),
+        })
+        .await
+    }
+
     async fn set_openvpn_constraints(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut openvpn_constraints = {
             let mut rpc = new_rpc_client().await?;
@@ -646,12 +674,17 @@ impl Relay {
                         (false, true) => "WireGuard",
                         _ => unreachable!("Bug in relay filtering earlier on"),
                     };
+                    let ownership = if relay.owned {
+                        "Mullvad-owned"
+                    } else {
+                        "rented"
+                    };
                     let mut addresses = vec![&relay.ipv4_addr_in];
                     if !relay.ipv6_addr_in.is_empty() {
                         addresses.push(&relay.ipv6_addr_in);
                     }
                     println!(
-                        "\t\t{} ({}) - {}, hosted by {}",
+                        "\t\t{} ({}) - {}, hosted by {} ({ownership})",
                         relay.hostname,
                         addresses.iter().join(", "),
                         support_msg,
@@ -799,5 +832,14 @@ fn parse_transport_port(
         (Constraint::Only(_), Constraint::Any) => Err(Error::InvalidCommand(
             "a transport protocol must be given to select a specific port",
         )),
+    }
+}
+
+pub fn parse_ownership_constraint(constraint: &str) -> types::Ownership {
+    match constraint {
+        "any" => types::Ownership::Any,
+        "owned" => types::Ownership::MullvadOwned,
+        "rented" => types::Ownership::Rented,
+        _ => unreachable!(),
     }
 }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -239,10 +239,17 @@ message GeoIpLocation {
 	string obfuscator_hostname = 11;
 }
 
+enum Ownership {
+	ANY = 0;
+	MULLVAD_OWNED = 1;
+	RENTED = 2;
+}
+
 message BridgeSettings {
 	message BridgeConstraints {
 		RelayLocation location = 1;
 		repeated string providers = 2;
+		Ownership ownership = 3;
 	}
 
 	message LocalProxySettings {
@@ -335,6 +342,7 @@ message NormalRelaySettings {
 	TunnelTypeConstraint tunnel_type = 3;
 	WireguardConstraints wireguard_constraints = 4;
 	OpenvpnConstraints openvpn_constraints = 5;
+	Ownership ownership = 6;
 }
 
 // Constraints are only updated for fields that are provided
@@ -344,6 +352,7 @@ message NormalRelaySettingsUpdate {
 	TunnelTypeUpdate tunnel_type = 3;
 	WireguardConstraints wireguard_constraints = 4;
 	OpenvpnConstraints openvpn_constraints = 5;
+	OwnershipUpdate ownership = 6;
 }
 
 message ProviderUpdate {
@@ -361,6 +370,10 @@ message TransportPort {
 
 message OpenvpnConstraints {
 	TransportPort port = 1;
+}
+
+message OwnershipUpdate {
+	Ownership ownership = 1;
 }
 
 enum IpVersion {

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -1727,6 +1727,7 @@ mod test {
     const WIREGUARD_MULTIHOP_CONSTRAINTS: RelayConstraints = RelayConstraints {
         location: Constraint::Any,
         providers: Constraint::Any,
+        ownership: Constraint::Any,
         wireguard_constraints: WireguardConstraints {
             use_multihop: true,
             port: Constraint::Any,
@@ -1742,6 +1743,7 @@ mod test {
     const WIREGUARD_SINGLEHOP_CONSTRAINTS: RelayConstraints = RelayConstraints {
         location: Constraint::Any,
         providers: Constraint::Any,
+        ownership: Constraint::Any,
         wireguard_constraints: WireguardConstraints {
             use_multihop: false,
             port: Constraint::Any,


### PR DESCRIPTION
This adds support to the relay selector and CLI for filtering relays and bridges by server ownership. For example, you can choose to only connect to Mullvad-owned servers by running `mullvad relay set ownership owned`. To filter out all Mullvad-owned servers, run `mullvad relay set ownership rented`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3554)
<!-- Reviewable:end -->
