### PR TITLE
Refactor device removal out of daemon struct

### DIFF
--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -4,7 +4,7 @@ use futures::{
     stream::StreamExt,
 };
 
-use mullvad_api::{availability::ApiAvailabilityHandle, rest};
+use mullvad_api::rest;
 use mullvad_types::{
     account::AccountToken,
     device::{AccountAndDevice, Device, DeviceEvent, DeviceId, DeviceName, DevicePort},
@@ -201,7 +201,6 @@ enum AccountManagerCommand {
     RotateKey(ResponseTx<()>),
     SetRotationInterval(RotationInterval, ResponseTx<()>),
     ValidateDevice(ResponseTx<()>),
-    ReceiveEvents(Box<dyn Sender<PrivateDeviceEvent> + Send>, ResponseTx<()>),
     Shutdown(oneshot::Sender<()>),
 }
 
@@ -253,16 +252,6 @@ impl AccountManagerHandle {
             .await
     }
 
-    pub async fn receive_events(
-        &self,
-        events_tx: impl Sender<PrivateDeviceEvent> + Send + 'static,
-    ) -> Result<(), Error> {
-        self.send_command(|tx| {
-            AccountManagerCommand::ReceiveEvents(Box::new(events_tx) as Box<_>, tx)
-        })
-        .await
-    }
-
     pub async fn shutdown(self) {
         let (tx, rx) = oneshot::channel();
         let _ = self
@@ -298,12 +287,13 @@ pub(crate) struct AccountManager {
 impl AccountManager {
     pub async fn spawn(
         rest_handle: rest::MullvadRestHandle,
-        api_availability: ApiAvailabilityHandle,
         settings_dir: &Path,
         initial_rotation_interval: RotationInterval,
+        listener_tx: impl Sender<PrivateDeviceEvent> + Send + 'static,
     ) -> Result<AccountManagerHandle, Error> {
         let (cacher, data) = DeviceCacher::new(settings_dir).await?;
         let token = data.as_ref().map(|state| state.account_token.clone());
+        let api_availability = rest_handle.availability.clone();
         let account_service =
             service::spawn_account_service(rest_handle.clone(), token, api_availability.clone());
 
@@ -315,7 +305,7 @@ impl AccountManager {
             device_service: device_service.clone(),
             data,
             rotation_interval: initial_rotation_interval,
-            listeners: vec![],
+            listeners: vec![Box::new(listener_tx)],
             last_validation: None,
             validation_requests: vec![],
             rotation_requests: vec![],
@@ -397,9 +387,6 @@ impl AccountManager {
                         }
                         Some(AccountManagerCommand::ValidateDevice(tx)) => {
                             self.handle_validation_request(tx, &mut current_api_call);
-                        }
-                        Some(AccountManagerCommand::ReceiveEvents(events_tx, tx)) => {
-                            let _ = tx.send(Ok(self.listeners.push(events_tx)));
                         },
 
                         None => {

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -862,6 +862,7 @@ impl DeviceCacher {
         let _ = tokio::task::spawn_blocking(move || drop(std_file)).await;
     }
 }
+
 /// Checks if the current device is valid if a WireGuard tunnel cannot be set up
 /// after multiple attempts.
 pub(crate) struct TunnelStateChangeHandler {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -599,20 +599,16 @@ where
 
         let account_manager = device::AccountManager::spawn(
             api_handle.clone(),
-            api_availability.clone(),
             &settings_dir,
             settings
                 .tunnel_options
                 .wireguard
                 .rotation_interval
                 .unwrap_or_default(),
+            internal_event_tx.to_specialized_sender(),
         )
         .await
         .map_err(Error::LoadAccountManager)?;
-        account_manager
-            .receive_events(internal_event_tx.to_specialized_sender())
-            .await
-            .map_err(Error::LoadAccountManager)?;
         let data = account_manager
             .data()
             .await

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -597,7 +597,7 @@ where
             migrations::MigrationComplete::new(true)
         };
 
-        let account_manager = device::AccountManager::spawn(
+        let (account_manager, data) = device::AccountManager::spawn(
             api_handle.clone(),
             &settings_dir,
             settings
@@ -609,10 +609,6 @@ where
         )
         .await
         .map_err(Error::LoadAccountManager)?;
-        let data = account_manager
-            .data()
-            .await
-            .map_err(Error::LoadAccountManager)?;
 
         let account_history = account_history::AccountHistory::new(
             &settings_dir,


### PR DESCRIPTION
Small refactoring PR in the same vein as some earlier PRs: #3555, #3550.

Unrelatedly, this removes the `ReceiveEvents` command from the account manager, since we'll likely only need one listener.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3556)
<!-- Reviewable:end -->
