### PR TITLE
Lower default MTU to 1280 on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Line wrap the file at 100 chars.                                              Th
 - Pause API interactions when the daemon has not been used for 3 days.
 - Simplified output of `mullvad status` command.
 
+#### Android
+- Lowered default MTU to 1280 on Android.
+
 ### Fixed
 - Fix the sometimes incorrect time added text after adding time to the account.
 - Fix scrollbar no longer responsive and usable when covered by other elements.

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -30,7 +30,13 @@ pub struct Config {
     pub obfuscator_config: Option<ObfuscatorConfig>,
 }
 
+#[cfg(not(target_os = "android"))]
 const DEFAULT_MTU: u16 = 1380;
+
+/// Set the MTU to the lowest possible whilst still allowing for IPv6 to help with wireless
+/// carriers that do a lot of encapsulation.
+#[cfg(target_os = "android")]
+const DEFAULT_MTU: u16 = 1280;
 
 /// Configuration errors
 #[derive(err_derive::Error, Debug)]


### PR DESCRIPTION
Lowering the default MTU on Android to 1280. I tested this with 4g, 5g and WiFi, and I couldn't measure any difference that couldn't be noise, so I think this is a rather safe change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3562)
<!-- Reviewable:end -->
