### PR TITLE
Add HEAD argument to git tag --points-at

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -379,8 +379,7 @@ esac
 popd
 
 SEMVER_VERSION=$(echo "$PRODUCT_VERSION" | sed -Ee 's/($|-.*)/.0\1/g')
-# `git tag --points-at` defaults to point at HEAD
-current_head_commit_tag=$(git tag --points-at)
+current_head_commit_tag=$(git tag --points-at HEAD)
 for semver_path in dist/*"$SEMVER_VERSION"*; do
     # If there is a tag for this commit then we append that to the produced artifacts
     # We don't want to change the actual PRODUCT_VERSION as metadata in the form of +<metadata> is ignored by electron builder etc


### PR DESCRIPTION
`git tag --points-at` does not default to HEAD in earlier git versions

The build servers do not have a recent enough git version to support `git tag --points-at` instead we need to provide `HEAD` as an argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3563)
<!-- Reviewable:end -->
