### PR TITLE
Update package lists before installing dependency in CI

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -59,7 +59,9 @@ jobs:
                   go-version: 1.16
 
             - name: Install build dependencies
-              run: sudo apt-get install libdbus-1-dev
+              run: |
+                sudo apt-get update
+                sudo apt-get install libdbus-1-dev
 
             - name: Build and test crates
               run: ./ci/check-rust.sh


### PR DESCRIPTION
Seems like the CI is failing to install `libdbus-dev-1` without updating it's package lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3564)
<!-- Reviewable:end -->
