### PR TITLE
Continue device check if the API request is aborted

### DIFF
--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -84,6 +84,13 @@ impl Error {
         }
     }
 
+    pub fn is_aborted(&self) -> bool {
+        match self {
+            Error::Aborted => true,
+            _ => false,
+        }
+    }
+
     /// Returns a new instance for which `abortable_stream::Aborted` is mapped to `Self::Aborted`.
     fn map_aborted(self) -> Self {
         if let Error::HyperError(error) = &self {

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -182,10 +182,26 @@ impl PrivateDeviceEvent {
 
 impl Error {
     pub fn is_network_error(&self) -> bool {
-        if let Error::OtherRestError(error) = self {
+        if let Error::OtherRestError(error) = self.unpack() {
             error.is_network_error()
         } else {
             false
+        }
+    }
+
+    pub fn is_aborted(&self) -> bool {
+        if let Error::OtherRestError(error) = self.unpack() {
+            error.is_aborted()
+        } else {
+            false
+        }
+    }
+
+    fn unpack(&self) -> &Error {
+        if let Error::ResponseFailure(ref inner) = self {
+            &*inner
+        } else {
+            self
         }
     }
 }
@@ -891,7 +907,7 @@ impl TunnelStateChangeHandler {
                                 "{}",
                                 error.display_chain_with_msg("Failed to check device validity")
                             );
-                            if error.is_network_error() {
+                            if error.is_network_error() || error.is_aborted() {
                                 check_validity.store(true, Ordering::SeqCst);
                             }
                         }


### PR DESCRIPTION
In a reconnect loop, if a device check (after 3 attempts) fails due to a network error, it will be repeated after another 3 attempts. Otherwise, this check is not repeated. This is somewhat wrong because the tunnel transitions may drop in-flight API requests. If the check fails for this reason, it should also be repeated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3567)
<!-- Reviewable:end -->
