### PR TITLE
Display login error if failed to fetch device list

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -55,7 +55,12 @@ import {
   VoucherResponse,
 } from '../shared/daemon-rpc-types';
 import log from '../shared/logging';
-import { CommunicationError, InvalidAccountError, TooManyDevicesError } from './errors';
+import {
+  CommunicationError,
+  InvalidAccountError,
+  ListDevicesError,
+  TooManyDevicesError,
+} from './errors';
 import { ManagementServiceClient } from './management_interface/management_interface_grpc_pb';
 import * as grpcTypes from './management_interface/management_interface_pb';
 
@@ -527,12 +532,16 @@ export class DaemonRpc {
   }
 
   public async listDevices(accountToken: AccountToken): Promise<Array<IDevice>> {
-    const response = await this.callString<grpcTypes.DeviceList>(
-      this.client.listDevices,
-      accountToken,
-    );
+    try {
+      const response = await this.callString<grpcTypes.DeviceList>(
+        this.client.listDevices,
+        accountToken,
+      );
 
-    return response.getDevicesList().map(convertFromDevice);
+      return response.getDevicesList().map(convertFromDevice);
+    } catch {
+      throw new ListDevicesError();
+    }
   }
 
   public async removeDevice(deviceRemoval: IDeviceRemoval): Promise<void> {

--- a/gui/src/main/errors.ts
+++ b/gui/src/main/errors.ts
@@ -21,3 +21,9 @@ export class TooManyDevicesError extends Error {
     super('Too many devices');
   }
 }
+
+export class ListDevicesError extends Error {
+  constructor() {
+    super('Failed to fetch list of devices');
+  }
+}

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -299,9 +299,18 @@ export default class AppRenderer {
     } catch (e) {
       const error = e as Error;
       if (error.message === 'Too many devices') {
-        actions.account.loginTooManyDevices(error);
-        this.loginState = 'too many devices';
-        this.history.reset(RoutePath.tooManyDevices, transitions.push);
+        try {
+          await this.fetchDevices(accountToken);
+
+          actions.account.loginTooManyDevices(error);
+          this.loginState = 'too many devices';
+
+          this.history.reset(RoutePath.tooManyDevices, transitions.push);
+        } catch (e) {
+          const error = e as Error;
+          log.error('Failed to fetch device list');
+          actions.account.loginFailed(error);
+        }
       } else {
         actions.account.loginFailed(error);
       }

--- a/gui/src/renderer/components/TooManyDevices.tsx
+++ b/gui/src/renderer/components/TooManyDevices.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { sprintf } from 'sprintf-js';
 import styled from 'styled-components';
 
@@ -99,7 +99,7 @@ const StyledRemoveSpinner = styled(ImageView)({
 
 export default function TooManyDevices() {
   const history = useHistory();
-  const { fetchDevices, removeDevice, login, cancelLogin } = useAppContext();
+  const { removeDevice, login, cancelLogin } = useAppContext();
   const accountToken = useSelector((state) => state.account.accountToken)!;
   const devices = useSelector((state) => state.account.devices);
 
@@ -115,8 +115,6 @@ export default function TooManyDevices() {
     cancelLogin();
     history.reset(RoutePath.login, transitions.pop);
   }, [history.reset, cancelLogin]);
-
-  useEffect(() => void fetchDevices(accountToken), []);
 
   const iconSource = getIconSource(devices);
   const title = getTitle(devices);


### PR DESCRIPTION
This PR makes the app stay in the login screen and show "Login failed" if there's an error fetching the device list when there are too many devices on the account.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3571)
<!-- Reviewable:end -->
