### PR TITLE
Disable too many devices continue button when logging in

### DIFF
--- a/gui/src/renderer/components/TooManyDevices.tsx
+++ b/gui/src/renderer/components/TooManyDevices.tsx
@@ -102,6 +102,7 @@ export default function TooManyDevices() {
   const { removeDevice, login, cancelLogin } = useAppContext();
   const accountToken = useSelector((state) => state.account.accountToken)!;
   const devices = useSelector((state) => state.account.devices);
+  const loginState = useSelector((state) => state.account.status);
 
   const onRemoveDevice = useCallback(
     async (deviceId: string) => {
@@ -119,6 +120,8 @@ export default function TooManyDevices() {
   const iconSource = getIconSource(devices);
   const title = getTitle(devices);
   const subtitle = getSubtitle(devices);
+
+  const continueButtonDisabled = devices.length === 5 || loginState.type !== 'too many devices';
 
   return (
     <ModalContainer>
@@ -145,7 +148,7 @@ export default function TooManyDevices() {
             {devices !== undefined && (
               <StyledFooter>
                 <AppButton.ButtonGroup>
-                  <AppButton.GreenButton onClick={continueLogin} disabled={devices.length === 5}>
+                  <AppButton.GreenButton onClick={continueLogin} disabled={continueButtonDisabled}>
                     {
                       // TRANSLATORS: Button for continuing login process.
                       messages.pgettext('device-management', 'Continue with login')


### PR DESCRIPTION
Currently it's possible to press the "Continue with login"-button multiple times when in the too many devices view. This results in telling the daemon to login multiple times. This PR fixes this by disabling the button after pressing it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3572)
<!-- Reviewable:end -->
