### PR TITLE
Validate device after 2 failed WireGuard attempts

### DIFF
--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -41,7 +41,7 @@ const LOGOUT_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Validate the current device once for every `WG_DEVICE_CHECK_THRESHOLD` failed attempts
 /// to set up a WireGuard tunnel.
-const WG_DEVICE_CHECK_THRESHOLD: usize = 3;
+const WG_DEVICE_CHECK_THRESHOLD: usize = 2;
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {


### PR DESCRIPTION
As it stands currently, the daemon won't try to validate it's device data until after the 3rd time it will attempt to connect to a WireGuard relay. Without setting a tunnel protocol constraint, most users won't ever hit the third time unless they cannot connect to OpenVPN relays too. To increase the chances of a validation, I've lowered the threshold for a validation to 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3573)
<!-- Reviewable:end -->
