### PR TITLE
Check API response code to determine if a device is valid

### DIFF
--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -47,6 +47,9 @@ pub const INVALID_VOUCHER: &str = "INVALID_VOUCHER";
 /// Error code returned by the Mullvad API if the account token is invalid.
 pub const INVALID_ACCOUNT: &str = "INVALID_ACCOUNT";
 
+/// Error code returned by the Mullvad API if the device does not exist.
+pub const DEVICE_NOT_FOUND: &str = "DEVICE_NOT_FOUND";
+
 /// Error code returned by the Mullvad API if the access token is invalid.
 pub const INVALID_ACCESS_TOKEN: &str = "INVALID_ACCESS_TOKEN";
 

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -584,7 +584,6 @@ pub async fn parse_rest_response(
 pub async fn handle_error_response<T>(response: Response) -> Result<T> {
     let status = response.status();
     let error_message = match status {
-        hyper::StatusCode::NOT_FOUND => "Not found",
         hyper::StatusCode::METHOD_NOT_ALLOWED => "Method not allowed",
         status => match get_body_length(&response) {
             0 => status.canonical_reason().unwrap_or("Unexpected error"),


### PR DESCRIPTION
Previously, the response didn't contain a custom status code in the response body, so the device was inferred to be invalid if the HTTP status code was 404. This may cause a device to be "revoked" if an endpoint is removed/deprecated or deployed incorrectly, so this PR switches to using the custom json response code instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3574)
<!-- Reviewable:end -->
