### PR TITLE
Improve device revoked state detection in electron app

### DIFF
--- a/gui/src/main/tray-icon-controller.ts
+++ b/gui/src/main/tray-icon-controller.ts
@@ -5,7 +5,7 @@ import { sprintf } from 'sprintf-js';
 import { promisify } from 'util';
 
 import { connectEnabled, disconnectEnabled, reconnectEnabled } from '../shared/connect-helper';
-import { AccountToken, ILocation, TunnelState } from '../shared/daemon-rpc-types';
+import { ILocation, TunnelState } from '../shared/daemon-rpc-types';
 import { messages, relayLocations } from '../shared/gettext';
 import log from '../shared/logging';
 import KeyframeAnimation from './keyframe-animation';
@@ -102,15 +102,9 @@ export default class TrayIconController {
     animation.play({ end: frame });
   }
 
-  public setContextMenu(
-    connectedToDaemon: boolean,
-    accountToken: AccountToken | undefined,
-    tunnelState: TunnelState,
-  ) {
+  public setContextMenu(connectedToDaemon: boolean, loggedIn: boolean, tunnelState: TunnelState) {
     if (process.platform === 'linux') {
-      this.tray.setContextMenu(
-        this.createContextMenu(connectedToDaemon, accountToken, tunnelState),
-      );
+      this.tray.setContextMenu(this.createContextMenu(connectedToDaemon, loggedIn, tunnelState));
     }
   }
 
@@ -119,14 +113,8 @@ export default class TrayIconController {
     this.tray?.setToolTip(tooltip);
   }
 
-  public popUpContextMenu(
-    connectedToDaemon: boolean,
-    accountToken: AccountToken | undefined,
-    tunnelState: TunnelState,
-  ) {
-    this.tray.popUpContextMenu(
-      this.createContextMenu(connectedToDaemon, accountToken, tunnelState),
-    );
+  public popUpContextMenu(connectedToDaemon: boolean, loggedIn: boolean, tunnelState: TunnelState) {
+    this.tray.popUpContextMenu(this.createContextMenu(connectedToDaemon, loggedIn, tunnelState));
   }
 
   private createTooltipText(connectedToDaemon: boolean, tunnelState: TunnelState): string {
@@ -267,7 +255,7 @@ export default class TrayIconController {
 
   private createContextMenu(
     connectedToDaemon: boolean,
-    accountToken: AccountToken | undefined,
+    loggedIn: boolean,
     tunnelState: TunnelState,
   ) {
     const template: Electron.MenuItemConstructorOptions[] = [
@@ -281,13 +269,13 @@ export default class TrayIconController {
       {
         id: 'connect',
         label: messages.gettext('Connect'),
-        enabled: connectEnabled(connectedToDaemon, accountToken, tunnelState.state),
+        enabled: connectEnabled(connectedToDaemon, loggedIn, tunnelState.state),
         click: this.connect,
       },
       {
         id: 'reconnect',
         label: messages.gettext('Reconnect'),
-        enabled: reconnectEnabled(connectedToDaemon, accountToken, tunnelState.state),
+        enabled: reconnectEnabled(connectedToDaemon, loggedIn, tunnelState.state),
         click: this.reconnect,
       },
       {

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { formatDate, hasExpired } from '../../shared/account-expiry';
-import { AccountToken, IDevice } from '../../shared/daemon-rpc-types';
+import { AccountToken, DeviceState } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import {
   AccountContainer,
@@ -39,7 +39,7 @@ interface IProps {
   onClose: () => void;
   onBuyMore: () => Promise<void>;
   updateAccountData: () => void;
-  getDevice: () => Promise<IDevice | undefined>;
+  getDeviceState: () => Promise<DeviceState | undefined>;
 }
 
 interface IState {
@@ -189,10 +189,12 @@ export default class Account extends React.Component<IProps, IState> {
     this.setState({ logoutDialogState: 'checking-ports' });
     this.props.prepareLogout();
 
-    const device = await this.props.getDevice();
-    if (device === undefined) {
-      this.onHideLogoutConfirmationDialog();
-    } else if (device.ports !== undefined && device.ports.length > 0) {
+    const deviceState = await this.props.getDeviceState();
+    if (
+      deviceState?.type === 'logged in' &&
+      deviceState.accountAndDevice.device?.ports !== undefined &&
+      deviceState.accountAndDevice.device.ports.length > 0
+    ) {
       this.setState({ logoutDialogState: 'confirm' });
     } else {
       this.props.onLogout();

--- a/gui/src/renderer/components/LocationRow.tsx
+++ b/gui/src/renderer/components/LocationRow.tsx
@@ -18,8 +18,6 @@ interface IButtonColorProps {
 }
 
 const buttonColor = (props: IButtonColorProps) => {
-  console.log(props.location, 'city' in props.location);
-
   const background =
     'hostname' in props.location
       ? colors.blue20

--- a/gui/src/renderer/containers/AccountPage.tsx
+++ b/gui/src/renderer/containers/AccountPage.tsx
@@ -29,7 +29,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, props: IHistoryProps & IApp
     },
     onBuyMore: () => props.app.openLinkWithAuth(links.purchase),
     updateAccountData: () => props.app.updateAccountData(),
-    getDevice: () => props.app.getDevice(),
+    getDeviceState: () => props.app.getDeviceState(),
   };
 };
 

--- a/gui/src/renderer/redux/account/actions.ts
+++ b/gui/src/renderer/redux/account/actions.ts
@@ -1,4 +1,4 @@
-import { AccountToken, IDevice, IDeviceConfig } from '../../../shared/daemon-rpc-types';
+import { AccountToken, IDevice } from '../../../shared/daemon-rpc-types';
 
 interface IStartLoginAction {
   type: 'START_LOGIN';
@@ -107,11 +107,11 @@ function startLogin(accountToken: AccountToken): IStartLoginAction {
   };
 }
 
-function loggedIn(deviceConfig: IDeviceConfig): ILoggedInAction {
+function loggedIn(accountToken: AccountToken, device?: IDevice): ILoggedInAction {
   return {
     type: 'LOGGED_IN',
-    accountToken: deviceConfig.accountToken,
-    deviceName: deviceConfig.device?.name,
+    accountToken,
+    deviceName: device?.name,
   };
 }
 
@@ -172,11 +172,15 @@ function createAccountFailed(error: Error): ICreateAccountFailed {
   };
 }
 
-function accountCreated(deviceConfig: IDeviceConfig, expiry: string): IAccountCreated {
+function accountCreated(
+  accountToken: AccountToken,
+  device: IDevice | undefined,
+  expiry: string,
+): IAccountCreated {
   return {
     type: 'ACCOUNT_CREATED',
-    accountToken: deviceConfig.accountToken,
-    deviceName: deviceConfig.device?.name,
+    accountToken: accountToken,
+    deviceName: device?.name,
     expiry,
   };
 }

--- a/gui/src/shared/connect-helper.ts
+++ b/gui/src/shared/connect-helper.ts
@@ -1,28 +1,24 @@
-import { AccountToken, TunnelState } from './daemon-rpc-types';
+import { TunnelState } from './daemon-rpc-types';
 
 export function connectEnabled(
   connectedToDaemon: boolean,
-  accountToken: AccountToken | undefined,
+  loggedIn: boolean,
   tunnelState: TunnelState['state'],
 ) {
   return (
     connectedToDaemon &&
-    accountToken !== undefined &&
-    accountToken !== '' &&
+    loggedIn &&
     (tunnelState === 'disconnected' || tunnelState === 'disconnecting' || tunnelState === 'error')
   );
 }
 
 export function reconnectEnabled(
   connectedToDaemon: boolean,
-  accountToken: AccountToken | undefined,
+  loggedIn: boolean,
   tunnelState: TunnelState['state'],
 ) {
   return (
-    connectedToDaemon &&
-    accountToken !== undefined &&
-    accountToken !== '' &&
-    (tunnelState === 'connected' || tunnelState === 'connecting')
+    connectedToDaemon && loggedIn && (tunnelState === 'connected' || tunnelState === 'connecting')
   );
 }
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -114,7 +114,7 @@ export type DaemonEvent =
   | { settings: ISettings }
   | { relayList: IRelayList }
   | { appVersionInfo: IAppVersionInfo }
-  | { device: IDeviceEvent }
+  | { device: DeviceEvent }
   | { deviceRemoval: Array<IDevice> };
 
 export interface ITunnelStateRelayInfo {
@@ -333,15 +333,19 @@ export interface IAppVersionInfo {
   suggestedIsBeta?: boolean;
 }
 
-export interface IDeviceEvent {
-  deviceConfig?: IDeviceConfig;
-  remote?: boolean;
-}
-
-export interface IDeviceConfig {
+export interface IAccountAndDevice {
   accountToken: AccountToken;
   device?: IDevice;
 }
+
+export type LoggedInDeviceState = { type: 'logged in'; accountAndDevice: IAccountAndDevice };
+export type LoggedOutDeviceState = { type: 'logged out' | 'revoked' };
+
+export type DeviceState = LoggedInDeviceState | LoggedOutDeviceState;
+
+export type DeviceEvent =
+  | { type: 'logged in' | 'updated' | 'rotated_key'; deviceState: LoggedInDeviceState }
+  | { type: 'logged out' | 'revoked'; deviceState: LoggedOutDeviceState };
 
 export interface IDevice {
   id: string;

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -5,11 +5,11 @@ import {
   AccountToken,
   BridgeSettings,
   BridgeState,
+  DeviceEvent,
+  DeviceState,
   IAccountData,
   IAppVersionInfo,
   IDevice,
-  IDeviceConfig,
-  IDeviceEvent,
   IDeviceRemoval,
   IDnsOptions,
   ILocation,
@@ -62,8 +62,7 @@ export interface IAppStateSnapshot {
   tunnelState: TunnelState;
   settings: ISettings;
   isPerformingPostUpgrade: boolean;
-  deviceConfig?: IDeviceConfig;
-  hasReceivedDeviceConfig: boolean;
+  deviceState?: DeviceState;
   relayListPair: IRelayListPair;
   currentVersion: ICurrentAppVersionInfo;
   upgradeVersion: IAppVersionInfo;
@@ -182,7 +181,7 @@ export const ipcSchema = {
   },
   account: {
     '': notifyRenderer<IAccountData | undefined>(),
-    device: notifyRenderer<IDeviceEvent>(),
+    device: notifyRenderer<DeviceEvent>(),
     devices: notifyRenderer<Array<IDevice>>(),
     create: invoke<void, string>(),
     login: invoke<AccountToken, void>(),
@@ -190,7 +189,7 @@ export const ipcSchema = {
     getWwwAuthToken: invoke<void, string>(),
     submitVoucher: invoke<string, VoucherResponse>(),
     updateData: send<void>(),
-    getDevice: invoke<void, IDevice | undefined>(),
+    getDeviceState: invoke<void, DeviceState>(),
     listDevices: invoke<AccountToken, Array<IDevice>>(),
     removeDevice: invoke<IDeviceRemoval, void>(),
   },


### PR DESCRIPTION
This PR:
* Updates the frontend to use the updated device rpc call
* Initializes into the revoked view if that's the first received state
* Fixes fetching of device when logging out.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3579)
<!-- Reviewable:end -->
