### PR TITLE
Remove temporary files used during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Remove WireGuard view as it's no longer needed with the new way of managing devices.
 
+### Fixed
+#### Windows
+- Be more scrupulous about removing temporary files used by the installer and uninstaller.
+
 ### Security
 #### Android
 - Prevent location request responses from being received outside the tunnel when in the connected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
-### Android
+### Changed
 #### Android
 - Lowered default MTU to 1280 on Android.
 

--- a/windows/nsis-plugins/src/log/log.cpp
+++ b/windows/nsis-plugins/src/log/log.cpp
@@ -19,6 +19,8 @@ Logger *g_logger = nullptr;
 namespace
 {
 
+bool g_pinned = false;
+
 std::wstring PopString()
 {
 	//
@@ -45,6 +47,11 @@ EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
 void PinDll()
 {
+	if (g_pinned)
+	{
+		return;
+	}
+
 	//
 	// Apparently NSIS loads and unloads the plugin module for EVERY call it makes to the plugin.
 	// This makes it kind of difficult to maintain state.
@@ -68,6 +75,8 @@ void PinDll()
 	{
 		LoadLibraryW(self);
 	}
+
+	g_pinned = true;
 }
 
 std::vector<std::wstring> BlockToRows(const std::wstring &textBlock)


### PR DESCRIPTION
The NSIS installer/uninstaller leaves some files in `%TEMP%` that remain even after uninstalling:

```
mullvad-setup.exe
winfw.dll
driverlogic.exe
mullvad-split-tunnel/
nsXXX.tmp/log.dll
```

Most are straightforward to delete.

`log.dll` is not cleaned up because the module isn't freed until the process dies. NSIS normally unloads plugins after each function call. `log.dll` has global state, so it increases its own reference count by a ton to avoid being unloaded.

Unfortunately, NSIS is inconsistent and calls `FreeLibrary()` many more times than it calls `LoadLibrary()`, so we have no idea how many times to decrement the refcount. As a workaround, `FreeLibrary()` is called until the module is freed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3580)
<!-- Reviewable:end -->
