### PR TITLE
Fix incorrect display of time added view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Line wrap the file at 100 chars.                                              Th
 - Use the entry endpoint when the relay selector fails to find a relay using the preferred
   constraints and the tunnel protocol is "any". Previously, the entry endpoint was ignored in this
   case.
+- Fix time added view displayed due to incorrect local clock.
 
 #### Windows
 - Fix "Open Mullvad VPN" tray context menu item not working after toggling unpinned window setting.

--- a/gui/src/renderer/components/MainView.tsx
+++ b/gui/src/renderer/components/MainView.tsx
@@ -7,6 +7,8 @@ import { useHistory } from '../lib/history';
 import { RoutePath } from '../lib/routes';
 import { useSelector } from '../redux/store';
 
+type ExpiryData = { show: false } | { show: true; expiry: string | undefined };
+
 export default function MainView() {
   const history = useHistory();
   const accountExpiry = useSelector((state) => state.account.expiry);
@@ -15,19 +17,26 @@ export default function MainView() {
     (state) => state.account.status.type === 'ok' && state.account.status.method === 'new_account',
   );
 
-  const [showAccountExpired, setShowAccountExpired] = useState<boolean>(
-    isNewAccount || accountHasExpired,
+  const [showAccountExpired, setShowAccountExpired] = useState<ExpiryData>(() =>
+    isNewAccount || accountHasExpired ? { show: true, expiry: accountExpiry } : { show: false },
   );
 
   useEffect(() => {
-    if (accountHasExpired) {
-      setShowAccountExpired(true);
-    } else if (showAccountExpired && !accountHasExpired) {
+    if (
+      accountHasExpired &&
+      (!showAccountExpired.show || showAccountExpired.expiry !== accountExpiry)
+    ) {
+      setShowAccountExpired({ show: true, expiry: accountExpiry });
+    } else if (
+      showAccountExpired.show &&
+      accountExpiry !== showAccountExpired.expiry &&
+      !accountHasExpired
+    ) {
       history.push(RoutePath.timeAdded);
     }
   }, [showAccountExpired, accountHasExpired]);
 
-  if (showAccountExpired) {
+  if (showAccountExpired.show) {
     return <ExpiredAccountErrorViewContainer />;
   } else {
     return <ConnectPage />;


### PR DESCRIPTION
This PR fixes a bug where the time added view was displayed erroneous due to an incorrect local clock. The solution is to require the expiry to change for the expiry to be considered as new credit.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
