### PR TITLE
Fix missing back action context for changes dialog

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -37,6 +37,7 @@ import { Scheduler } from '../shared/scheduler';
 import AppRouter from './components/AppRouter';
 import { Changelog } from './components/Changelog';
 import ErrorBoundary from './components/ErrorBoundary';
+import KeyboardNavigation from './components/KeyboardNavigation';
 import MacOsScrollbarDetection from './components/MacOsScrollbarDetection';
 import { ModalContainer } from './components/Modal';
 import PlatformWindowContainer from './containers/PlatformWindowContainer';
@@ -273,8 +274,10 @@ export default class AppRenderer {
             <PlatformWindowContainer>
               <ErrorBoundary>
                 <ModalContainer>
-                  <AppRouter />
-                  <Changelog />
+                  <KeyboardNavigation>
+                    <AppRouter />
+                    <Changelog />
+                  </KeyboardNavigation>
                   {window.env.platform === 'darwin' && <MacOsScrollbarDetection />}
                 </ModalContainer>
               </ErrorBoundary>

--- a/gui/src/renderer/components/AppRouter.tsx
+++ b/gui/src/renderer/components/AppRouter.tsx
@@ -24,7 +24,6 @@ import {
 } from './ExpiredAccountAddTime';
 import FilterByProvider from './FilterByProvider';
 import Focus, { IFocusHandle } from './Focus';
-import KeyboardNavigation from './KeyboardNavigation';
 import Launch from './Launch';
 import MainView from './MainView';
 import SplitTunnelingSettings from './SplitTunnelingSettings';
@@ -74,40 +73,34 @@ class AppRouter extends React.Component<IHistoryProps & IAppContext, IAppRoutesS
     const location = this.state.currentLocation;
 
     return (
-      <KeyboardNavigation>
-        <Focus ref={this.focusRef}>
-          <TransitionContainer onTransitionEnd={this.onNavigation} {...this.state.transition}>
-            <TransitionView viewId={location.key || ''}>
-              <Switch key={location.key} location={location}>
-                <Route exact path={RoutePath.launch} component={Launch} />
-                <Route exact path={RoutePath.login} component={LoginPage} />
-                <Route exact path={RoutePath.tooManyDevices} component={TooManyDevices} />
-                <Route exact path={RoutePath.deviceRevoked} component={DeviceRevokedView} />
-                <Route exact path={RoutePath.main} component={MainView} />
-                <Route exact path={RoutePath.redeemVoucher} component={VoucherInput} />
-                <Route
-                  exact
-                  path={RoutePath.voucherSuccess}
-                  component={VoucherVerificationSuccess}
-                />
-                <Route exact path={RoutePath.timeAdded} component={TimeAdded} />
-                <Route exact path={RoutePath.setupFinished} component={SetupFinished} />
-                <Route exact path={RoutePath.settings} component={SettingsPage} />
-                <Route exact path={RoutePath.selectLanguage} component={SelectLanguagePage} />
-                <Route exact path={RoutePath.accountSettings} component={AccountPage} />
-                <Route exact path={RoutePath.preferences} component={PreferencesPage} />
-                <Route exact path={RoutePath.advancedSettings} component={AdvancedSettingsPage} />
-                <Route exact path={RoutePath.wireguardSettings} component={WireguardSettingsPage} />
-                <Route exact path={RoutePath.openVpnSettings} component={OpenVPNSettingsPage} />
-                <Route exact path={RoutePath.splitTunneling} component={SplitTunnelingSettings} />
-                <Route exact path={RoutePath.support} component={SupportPage} />
-                <Route exact path={RoutePath.selectLocation} component={SelectLocationPage} />
-                <Route exact path={RoutePath.filterByProvider} component={FilterByProvider} />
-              </Switch>
-            </TransitionView>
-          </TransitionContainer>
-        </Focus>
-      </KeyboardNavigation>
+      <Focus ref={this.focusRef}>
+        <TransitionContainer onTransitionEnd={this.onNavigation} {...this.state.transition}>
+          <TransitionView viewId={location.key || ''}>
+            <Switch key={location.key} location={location}>
+              <Route exact path={RoutePath.launch} component={Launch} />
+              <Route exact path={RoutePath.login} component={LoginPage} />
+              <Route exact path={RoutePath.tooManyDevices} component={TooManyDevices} />
+              <Route exact path={RoutePath.deviceRevoked} component={DeviceRevokedView} />
+              <Route exact path={RoutePath.main} component={MainView} />
+              <Route exact path={RoutePath.redeemVoucher} component={VoucherInput} />
+              <Route exact path={RoutePath.voucherSuccess} component={VoucherVerificationSuccess} />
+              <Route exact path={RoutePath.timeAdded} component={TimeAdded} />
+              <Route exact path={RoutePath.setupFinished} component={SetupFinished} />
+              <Route exact path={RoutePath.settings} component={SettingsPage} />
+              <Route exact path={RoutePath.selectLanguage} component={SelectLanguagePage} />
+              <Route exact path={RoutePath.accountSettings} component={AccountPage} />
+              <Route exact path={RoutePath.preferences} component={PreferencesPage} />
+              <Route exact path={RoutePath.advancedSettings} component={AdvancedSettingsPage} />
+              <Route exact path={RoutePath.wireguardSettings} component={WireguardSettingsPage} />
+              <Route exact path={RoutePath.openVpnSettings} component={OpenVPNSettingsPage} />
+              <Route exact path={RoutePath.splitTunneling} component={SplitTunnelingSettings} />
+              <Route exact path={RoutePath.support} component={SupportPage} />
+              <Route exact path={RoutePath.selectLocation} component={SelectLocationPage} />
+              <Route exact path={RoutePath.filterByProvider} component={FilterByProvider} />
+            </Switch>
+          </TransitionView>
+        </TransitionContainer>
+      </Focus>
     );
   }
 

--- a/gui/src/renderer/components/KeyboardNavigation.tsx
+++ b/gui/src/renderer/components/KeyboardNavigation.tsx
@@ -5,7 +5,7 @@ import { useHistory } from '../lib/history';
 import { disableDismissForRoutes, RoutePath } from '../lib/routes';
 
 interface IKeyboardNavigationProps {
-  children: React.ReactElement;
+  children: React.ReactElement | Array<React.ReactElement>;
 }
 
 // Listens for and handles keyboard shortcuts


### PR DESCRIPTION
This PR fixes a crash when the changes dialog is shown. The issue was that the back action context provider didn't wrap the changes dialog. This was solved by moving the keyboard navigation component further up the tree.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3589)
<!-- Reviewable:end -->
