### PR TITLE
Add command line switch for force display of changes dialog

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -106,7 +106,10 @@ const SANDBOX_DISABLED = app.commandLine.hasSwitch('no-sandbox');
 
 const ALLOWED_PERMISSIONS = ['clipboard-sanitized-write'];
 
-const QUIT_WITHOUT_DISCONNECT_FLAG = '--quit-without-disconnect';
+enum Options {
+  quitWithoutDisconnect = '--quit-without-disconnect',
+  showChanges = '--show-changes',
+}
 
 enum AppQuitStage {
   unready,
@@ -260,6 +263,7 @@ class ApplicationMain {
   private quitWithoutDisconnect = false;
 
   private changelog?: IChangelog;
+  private forceShowChanges = process.argv.includes(Options.showChanges);
 
   private navigationHistory?: IHistoryObject;
   private scrollPositions: ScrollPositions = {};
@@ -275,7 +279,7 @@ class ApplicationMain {
 
     // This ensures that only a single instance is running at the same time, but also exits if
     // there's no already running instance when the quit without disconnect flag is supplied.
-    if (!app.requestSingleInstanceLock() || process.argv.includes(QUIT_WITHOUT_DISCONNECT_FLAG)) {
+    if (!app.requestSingleInstanceLock() || process.argv.includes(Options.quitWithoutDisconnect)) {
       this.quitWithoutDisconnect = true;
       app.quit();
       return;
@@ -327,7 +331,7 @@ class ApplicationMain {
 
   private addSecondInstanceEventHandler() {
     app.on('second-instance', (_event, argv, _workingDirectory) => {
-      if (argv.includes(QUIT_WITHOUT_DISCONNECT_FLAG)) {
+      if (argv.includes(Options.quitWithoutDisconnect)) {
         // Quit if another instance is started with the quit without disconnect flag.
         this.quitWithoutDisconnect = true;
         app.quit();
@@ -1288,6 +1292,7 @@ class ApplicationMain {
       windowsSplitTunnelingApplications: this.windowsSplitTunnelingApplications,
       macOsScrollbarVisibility: this.macOsScrollbarVisibility,
       changelog: this.changelog ?? [],
+      forceShowChanges: this.forceShowChanges,
       navigationHistory: this.navigationHistory,
       scrollPositions: this.scrollPositions,
     }));

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -229,7 +229,7 @@ export default class AppRenderer {
     this.setUpgradeVersion(initialState.upgradeVersion);
     this.setGuiSettings(initialState.guiSettings);
     this.storeAutoStart(initialState.autoStart);
-    this.setChangelog(initialState.changelog);
+    this.setChangelog(initialState.changelog, initialState.forceShowChanges);
 
     if (initialState.macOsScrollbarVisibility !== undefined) {
       this.reduxActions.userInterface.setMacOsScrollbarVisibility(
@@ -950,8 +950,9 @@ export default class AppRenderer {
     this.reduxActions.settings.updateAutoStart(autoStart);
   }
 
-  private setChangelog(changelog: IChangelog) {
+  private setChangelog(changelog: IChangelog, forceShowChanges: boolean) {
     this.reduxActions.userInterface.setChangelog(changelog);
+    this.reduxActions.userInterface.setForceShowChanges(forceShowChanges);
   }
 
   private async updateLocation() {

--- a/gui/src/renderer/components/Changelog.tsx
+++ b/gui/src/renderer/components/Changelog.tsx
@@ -1,7 +1,9 @@
+import { useCallback } from 'react';
 import styled from 'styled-components';
 
 import { messages } from '../../shared/gettext';
 import { useAppContext } from '../context';
+import { useBoolean } from '../lib/utilityHooks';
 import { useSelector } from '../redux/store';
 import * as AppButton from './AppButton';
 import { hugeText, smallText } from './common-styles';
@@ -33,20 +35,29 @@ export function Changelog() {
     (state) => state.settings.guiSettings.changelogDisplayedForVersion,
   );
   const changelog = useSelector((state) => state.userInterface.changelog);
+  const initialForceShowChanges = useSelector((state) => state.userInterface.forceShowChanges);
 
   const { setDisplayedChangelog } = useAppContext();
 
+  const [forceShowChanges, , stopForceShowChanges] = useBoolean(initialForceShowChanges);
+
+  const close = useCallback(() => {
+    setDisplayedChangelog();
+    stopForceShowChanges();
+  }, []);
+
   const visible =
-    changelogDisplayedForVersion !== currentVersion &&
-    changelog.length > 0 &&
-    !window.env.development &&
-    !/-dev-[0-9a-f]{6}$/.test(currentVersion);
+    forceShowChanges ||
+    (changelogDisplayedForVersion !== currentVersion &&
+      changelog.length > 0 &&
+      !window.env.development &&
+      !/-dev-[0-9a-f]{6}$/.test(currentVersion));
 
   return (
     <ModalAlert
       isOpen={visible}
       buttons={[
-        <AppButton.BlueButton key="close" onClick={setDisplayedChangelog}>
+        <AppButton.BlueButton key="close" onClick={close}>
           {
             // TRANSLATORS: This is a button which closes a dialog.
             messages.gettext('Got it!')

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -51,6 +51,11 @@ export interface ISetChangelog {
   changelog: IChangelog;
 }
 
+export interface ISetForceShowChanges {
+  type: 'SET_FORCE_SHOW_CHANGES';
+  forceShowChanges: boolean;
+}
+
 export interface ISetIsPerformingPostUpgrade {
   type: 'SET_IS_PERFORMING_POST_UPGRADE';
   isPerformingPostUpgrade: boolean;
@@ -67,6 +72,7 @@ export type UserInterfaceAction =
   | ISetMacOsScrollbarVisibility
   | ISetConnectedToDaemon
   | ISetChangelog
+  | ISetForceShowChanges
   | ISetIsPerformingPostUpgrade;
 
 function updateLocale(locale: string): IUpdateLocaleAction {
@@ -141,6 +147,13 @@ function setChangelog(changelog: IChangelog): ISetChangelog {
   };
 }
 
+function setForceShowChanges(forceShowChanges: boolean): ISetForceShowChanges {
+  return {
+    type: 'SET_FORCE_SHOW_CHANGES',
+    forceShowChanges,
+  };
+}
+
 function setIsPerformingPostUpgrade(isPerformingPostUpgrade: boolean): ISetIsPerformingPostUpgrade {
   return {
     type: 'SET_IS_PERFORMING_POST_UPGRADE',
@@ -159,5 +172,6 @@ export default {
   setMacOsScrollbarVisibility,
   setConnectedToDaemon,
   setChangelog,
+  setForceShowChanges,
   setIsPerformingPostUpgrade,
 };

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -11,6 +11,7 @@ export interface IUserInterfaceReduxState {
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
   connectedToDaemon: boolean;
   changelog: IChangelog;
+  forceShowChanges: boolean;
   isPerformingPostUpgrade: boolean;
 }
 
@@ -22,6 +23,7 @@ const initialState: IUserInterfaceReduxState = {
   macOsScrollbarVisibility: undefined,
   connectedToDaemon: false,
   changelog: [],
+  forceShowChanges: false,
   isPerformingPostUpgrade: false,
 };
 
@@ -67,6 +69,12 @@ export default function (
       return {
         ...state,
         changelog: action.changelog,
+      };
+
+    case 'SET_FORCE_SHOW_CHANGES':
+      return {
+        ...state,
+        forceShowChanges: action.forceShowChanges,
       };
 
     case 'SET_IS_PERFORMING_POST_UPGRADE':

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -71,6 +71,7 @@ export interface IAppStateSnapshot {
   windowsSplitTunnelingApplications?: IWindowsApplication[];
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
   changelog: IChangelog;
+  forceShowChanges: boolean;
   navigationHistory?: IHistoryObject;
   scrollPositions: ScrollPositions;
 }


### PR DESCRIPTION
This PR adds a command line switch (`--show-changes`) that shows the changes dialog on start.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3592)
<!-- Reviewable:end -->
