### PR TITLE
Pass dispatch queue to AsyncOperation and throw errors from AddressStore

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		5840250422B11AB700E4CFEC /* MullvadEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */; };
 		5840250522B11AB700E4CFEC /* MullvadEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */; };
 		5840BE35279EDB16002836BA /* OperationCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5840BE34279EDB16002836BA /* OperationCompletion.swift */; };
+		5842102E282D3FC200F24E46 /* ResultBlockOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5842102D282D3FC200F24E46 /* ResultBlockOperation.swift */; };
 		584592612639B4A200EF967F /* ConsentContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584592602639B4A200EF967F /* ConsentContentView.swift */; };
 		5846226526E0D9630035F7C2 /* ProductsRequestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */; };
 		5846227126E229F20035F7C2 /* AppStoreSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846227026E229F20035F7C2 /* AppStoreSubscription.swift */; };
@@ -406,6 +407,7 @@
 		5840250022B1124600E4CFEC /* IPAddress+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IPAddress+Codable.swift"; sourceTree = "<group>"; };
 		5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadEndpoint.swift; sourceTree = "<group>"; };
 		5840BE34279EDB16002836BA /* OperationCompletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCompletion.swift; sourceTree = "<group>"; };
+		5842102D282D3FC200F24E46 /* ResultBlockOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultBlockOperation.swift; sourceTree = "<group>"; };
 		584592602639B4A200EF967F /* ConsentContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentContentView.swift; sourceTree = "<group>"; };
 		5845F841236CBACD00B2D93C /* TunnelIPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelIPC.swift; sourceTree = "<group>"; };
 		5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsRequestOperation.swift; sourceTree = "<group>"; };
@@ -664,6 +666,7 @@
 				5820675D26E6839900655B05 /* PresentAlertOperation.swift */,
 				5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */,
 				58F7D26427EB50A300E4D821 /* ResultOperation.swift */,
+				5842102D282D3FC200F24E46 /* ResultBlockOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -1322,6 +1325,7 @@
 				585DA89926B0329200B8C587 /* PacketTunnelStatus.swift in Sources */,
 				5896CEF226972DEB00B0FAE8 /* AccountContentView.swift in Sources */,
 				5840250122B1124600E4CFEC /* IPAddress+Codable.swift in Sources */,
+				5842102E282D3FC200F24E46 /* ResultBlockOperation.swift in Sources */,
 				5857F24724C882D700CF6F47 /* SelectLocationNavigationController.swift in Sources */,
 				5846227126E229F20035F7C2 /* AppStoreSubscription.swift in Sources */,
 				5820675B26E6576800655B05 /* RelayCache.swift in Sources */,

--- a/ios/MullvadVPN/AddressCache/AddressCacheTracker.swift
+++ b/ios/MullvadVPN/AddressCache/AddressCacheTracker.swift
@@ -85,7 +85,7 @@ extension AddressCache {
 
         func updateEndpoints(completionHandler: ((_ completion: OperationCompletion<CacheUpdateResult, Error>) -> Void)? = nil) -> Cancellable {
             let operation = UpdateAddressCacheOperation(
-                queue: stateQueue,
+                dispatchQueue: stateQueue,
                 apiProxy: apiProxy,
                 store: store,
                 updateInterval: Self.updateInterval,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -180,7 +180,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let operationQueue = OperationQueue()
 
-        let updateAddressCacheOperation = AsyncBlockOperation { operation in
+        let updateAddressCacheOperation = AsyncBlockOperation(dispatchQueue: .main) { operation in
             let handle = self.addressCacheTracker.updateEndpoints { completion in
                 addressCacheFetchResult = completion.backgroundFetchResult
                 operation.finish()
@@ -191,7 +191,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-        let updateRelaysOperation = AsyncBlockOperation { operation in
+        let updateRelaysOperation = AsyncBlockOperation(dispatchQueue: .main) { operation in
             let handle = RelayCache.Tracker.shared.updateRelays { completion in
                 switch completion {
                 case .success(let result):
@@ -211,7 +211,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-        let rotatePrivateKeyOperation = AsyncBlockOperation { operation in
+        let rotatePrivateKeyOperation = AsyncBlockOperation(dispatchQueue: .main) { operation in
             let handle = TunnelManager.shared.rotatePrivateKey { completion in
                 switch completion {
                 case .success(let rotationResult):

--- a/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncBlockOperation.swift
@@ -10,54 +10,42 @@ import Foundation
 
 /// Asynchronous block operation
 class AsyncBlockOperation: AsyncOperation {
-    private let stateLock = NSLock()
-
     private var executionBlock: ((AsyncBlockOperation) -> Void)?
     private var cancellationBlocks: [() -> Void] = []
 
-    init(block: @escaping (AsyncBlockOperation) -> Void) {
+    init(dispatchQueue: DispatchQueue?, block: @escaping (AsyncBlockOperation) -> Void) {
         executionBlock = block
+        super.init(dispatchQueue: dispatchQueue)
     }
 
     override func main() {
-        stateLock.lock()
         let block = executionBlock
         executionBlock = nil
-        stateLock.unlock()
 
         block?(self)
     }
 
-    override func finish() {
-        stateLock.lock()
-        cancellationBlocks.removeAll()
-        executionBlock = nil
-        stateLock.unlock()
-
-        super.finish()
-    }
-
-    override func cancel() {
-        super.cancel()
-
-        stateLock.lock()
+    override func operationDidCancel() {
         let blocks = cancellationBlocks
         cancellationBlocks.removeAll()
-        stateLock.unlock()
 
         for block in blocks {
             block()
         }
     }
 
+    override func operationDidFinish() {
+        cancellationBlocks.removeAll()
+        executionBlock = nil
+    }
+
     func addCancellationBlock(_ block: @escaping () -> Void) {
-        stateLock.lock()
-        if isCancelled {
-            stateLock.unlock()
-            block()
-        } else {
-            cancellationBlocks.append(block)
-            stateLock.unlock()
+        dispatchQueue.async {
+            if self.isCancelled {
+                block()
+            } else {
+                self.cancellationBlocks.append(block)
+            }
         }
     }
 }

--- a/ios/MullvadVPN/Operations/ResultBlockOperation.swift
+++ b/ios/MullvadVPN/Operations/ResultBlockOperation.swift
@@ -1,0 +1,73 @@
+//
+//  ResultBlockOperation.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 12/05/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+class ResultBlockOperation<Success, Failure: Error>: ResultOperation<Success, Failure> {
+    typealias ExecutionBlock = (ResultBlockOperation<Success, Failure>) -> Void
+
+    private var executionBlock: ExecutionBlock?
+    private var cancellationBlocks: [() -> Void] = []
+
+    convenience init(dispatchQueue: DispatchQueue?, executionBlock: @escaping ExecutionBlock) {
+        self.init(
+            dispatchQueue: dispatchQueue,
+            executionBlock: executionBlock,
+            completionQueue: nil,
+            completionHandler: nil
+        )
+    }
+
+    init(
+        dispatchQueue: DispatchQueue?,
+        executionBlock: @escaping ExecutionBlock,
+        completionQueue: DispatchQueue?,
+        completionHandler: CompletionHandler?
+    )
+    {
+        self.executionBlock = executionBlock
+
+        super.init(
+            dispatchQueue: dispatchQueue,
+            completionQueue: completionQueue,
+            completionHandler: completionHandler
+        )
+    }
+
+    override func main() {
+        let block = executionBlock
+        executionBlock = nil
+
+        block?(self)
+    }
+
+    override func operationDidCancel() {
+        let blocks = cancellationBlocks
+        cancellationBlocks.removeAll()
+
+        for block in blocks {
+            block()
+        }
+    }
+
+    override func operationDidFinish() {
+        cancellationBlocks.removeAll()
+        executionBlock = nil
+    }
+
+    func addCancellationBlock(_ block: @escaping () -> Void) {
+        dispatchQueue.async {
+            if self.isCancelled {
+                block()
+            } else {
+                self.cancellationBlocks.append(block)
+            }
+        }
+    }
+}
+

--- a/ios/MullvadVPN/REST/RESTAccessTokenManager.swift
+++ b/ios/MullvadVPN/REST/RESTAccessTokenManager.swift
@@ -31,7 +31,9 @@ extension REST {
             completionHandler: @escaping (OperationCompletion<REST.AccessTokenData, REST.Error>) -> Void
         ) -> Cancellable
         {
-            let operation = ResultBlockOperation<REST.AccessTokenData, REST.Error> { operation in
+            let operation = ResultBlockOperation<REST.AccessTokenData, REST.Error>(
+                dispatchQueue: dispatchQueue
+            ) { operation in
                 if let tokenData = self.tokens[accountNumber], tokenData.expiry > Date() {
                     operation.finish(completion: .success(tokenData))
                     return

--- a/ios/MullvadVPN/TunnelIPC/TunnelIPCSession.swift
+++ b/ios/MullvadVPN/TunnelIPC/TunnelIPCSession.swift
@@ -23,7 +23,7 @@ extension TunnelIPC {
 
         func reloadTunnelSettings(completionHandler: @escaping (OperationCompletion<(), TunnelIPC.Error>) -> Void) -> Cancellable {
             let operation = RequestOperation(
-                queue: queue,
+                dispatchQueue: queue,
                 tunnel: tunnel,
                 request: .reloadTunnelSettings,
                 options: TunnelIPC.RequestOptions(),
@@ -37,7 +37,7 @@ extension TunnelIPC {
 
         func getTunnelStatus(completionHandler: @escaping (OperationCompletion<PacketTunnelStatus, TunnelIPC.Error>) -> Void) -> Cancellable {
             let operation = RequestOperation<PacketTunnelStatus>(
-                queue: queue,
+                dispatchQueue: queue,
                 tunnel: tunnel,
                 request: .getTunnelStatus,
                 options: TunnelIPC.RequestOptions(),

--- a/ios/MullvadVPN/TunnelManager/SetTunnelSettingsOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetTunnelSettingsOperation.swift
@@ -11,42 +11,37 @@ import Foundation
 class SetTunnelSettingsOperation: ResultOperation<(), TunnelManager.Error> {
     typealias ModificationHandler = (inout TunnelSettings) -> Void
 
-    private let queue: DispatchQueue
     private let state: TunnelManager.State
     private let modificationBlock: ModificationHandler
 
-    init(queue: DispatchQueue, state: TunnelManager.State, modificationBlock: @escaping ModificationHandler, completionHandler: @escaping CompletionHandler) {
-        self.queue = queue
+    init(dispatchQueue: DispatchQueue, state: TunnelManager.State, modificationBlock: @escaping ModificationHandler, completionHandler: @escaping CompletionHandler) {
         self.state = state
         self.modificationBlock = modificationBlock
 
-        super.init(completionQueue: queue, completionHandler: completionHandler)
+        super.init(
+            dispatchQueue: dispatchQueue,
+            completionQueue: dispatchQueue,
+            completionHandler: completionHandler
+        )
     }
 
     override func main() {
-        queue.async {
-            guard !self.isCancelled else {
-                self.finish(completion: .cancelled)
-                return
-            }
+        guard let accountToken = state.tunnelInfo?.token else {
+            finish(completion: .failure(.unsetAccount))
+            return
+        }
 
-            guard let accountToken = self.state.tunnelInfo?.token else {
-                self.finish(completion: .failure(.unsetAccount))
-                return
-            }
+        let result = TunnelSettingsManager.update(searchTerm: .accountToken(accountToken)) { tunnelSettings in
+            modificationBlock(&tunnelSettings)
+        }
 
-            let result = TunnelSettingsManager.update(searchTerm: .accountToken(accountToken)) { tunnelSettings in
-                self.modificationBlock(&tunnelSettings)
-            }
+        switch result {
+        case .success(let newTunnelSettings):
+            state.tunnelInfo?.tunnelSettings = newTunnelSettings
+            finish(completion: .success(()))
 
-            switch result {
-            case .success(let newTunnelSettings):
-                self.state.tunnelInfo?.tunnelSettings = newTunnelSettings
-                self.finish(completion: .success(()))
-
-            case .failure(let error):
-                self.finish(completion: .failure(.updateTunnelSettings(error)))
-            }
+        case .failure(let error):
+            finish(completion: .failure(.updateTunnelSettings(error)))
         }
     }
 }

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -176,7 +176,7 @@ final class TunnelManager: TunnelManagerStateDelegate {
     /// The given account token is used to ensure that the system tunnel was configured for the same
     /// account. The system tunnel is removed in case of inconsistency.
     func loadTunnel(accountToken: String?, completionHandler: @escaping (TunnelManager.Error?) -> Void) {
-        let operation = LoadTunnelOperation(queue: stateQueue, state: state, accountToken: accountToken) { [weak self] completion in
+        let operation = LoadTunnelOperation(dispatchQueue: stateQueue, state: state, accountToken: accountToken) { [weak self] completion in
             guard let self = self else { return }
 
             dispatchPrecondition(condition: .onQueue(self.stateQueue))
@@ -207,7 +207,7 @@ final class TunnelManager: TunnelManagerStateDelegate {
 
     func startTunnel() {
         let operation = StartTunnelOperation(
-            queue: stateQueue,
+            dispatchQueue: stateQueue,
             state: state,
             encodeErrorHandler: { [weak self] error in
                 guard let self = self else { return }
@@ -241,7 +241,7 @@ final class TunnelManager: TunnelManagerStateDelegate {
     }
 
     func stopTunnel() {
-        let operation = StopTunnelOperation(queue: stateQueue, state: state) { [weak self] completion in
+        let operation = StopTunnelOperation(dispatchQueue: stateQueue, state: state) { [weak self] completion in
             guard let self = self else { return }
 
             dispatchPrecondition(condition: .onQueue(self.stateQueue))
@@ -350,7 +350,7 @@ final class TunnelManager: TunnelManagerStateDelegate {
     }
 
     func regeneratePrivateKey(completionHandler: ((TunnelManager.Error?) -> Void)? = nil) {
-        let operation = ReplaceKeyOperation.operationForKeyRegeneration(queue: stateQueue, state: state, apiProxy: apiProxy) { [weak self] completion in
+        let operation = ReplaceKeyOperation.operationForKeyRegeneration(dispatchQueue: stateQueue, state: state, apiProxy: apiProxy) { [weak self] completion in
             guard let self = self else { return }
 
             dispatchPrecondition(condition: .onQueue(self.stateQueue))
@@ -387,7 +387,7 @@ final class TunnelManager: TunnelManagerStateDelegate {
 
     func rotatePrivateKey(completionHandler: @escaping (OperationCompletion<KeyRotationResult, TunnelManager.Error>) -> Void) -> Cancellable {
         let operation = ReplaceKeyOperation.operationForKeyRotation(
-            queue: stateQueue,
+            dispatchQueue: stateQueue,
             state: state,
             apiProxy: apiProxy,
             rotationInterval: TunnelManagerConfiguration.privateKeyRotationInterval
@@ -571,7 +571,7 @@ final class TunnelManager: TunnelManagerStateDelegate {
 
     private func makeSetAccountOperation(accountToken: String?, completionHandler: @escaping (OperationCompletion<(), TunnelManager.Error>) -> Void) -> Operation {
         return SetAccountOperation(
-            queue: stateQueue,
+            dispatchQueue: stateQueue,
             state: state,
             apiProxy: apiProxy,
             accountToken: accountToken,
@@ -600,7 +600,7 @@ final class TunnelManager: TunnelManagerStateDelegate {
 
     private func scheduleTunnelSettingsUpdate(taskName: String, modificationBlock: @escaping (inout TunnelSettings) -> Void, completionHandler: @escaping (TunnelManager.Error?) -> Void) {
         let operation = SetTunnelSettingsOperation(
-            queue: stateQueue,
+            dispatchQueue: stateQueue,
             state: state,
             modificationBlock: modificationBlock,
             completionHandler: { [weak self] completion in


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- Add `dispatchQueue` parameter to `AsyncOperation` initializer that enables developer to provide the queue used for synchronization. This queue is used to execute `main()` operation body.
- Add `operationDidCancel` and `operationDidFinish` methods that are called on the `dispatchQueue` as operation either cancelled or finished.
- Add new functional helpers to `OperationCompletion`.
- `AddressStore` will `throw` errors instead of returning `Result`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3597)
<!-- Reviewable:end -->
