### PR TITLE
Fix unused dependencies loaded in the Android service/tile DI graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Be more scrupulous about removing temporary files used by the installer and uninstaller.
 
+#### Android
+- Fix unused dependencies loaded in the service/tile DI graph.
+
 ### Security
 #### Android
 - Prevent location request responses from being received outside the tunnel when in the connected

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/MullvadApplication.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/MullvadApplication.kt
@@ -1,20 +1,19 @@
 package net.mullvad.mullvadvpn
 
 import android.app.Application
-import net.mullvad.mullvadvpn.di.appModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
+/**
+ * In Android, separate instances of the application class (MullvadApplication) will be instantiated
+ * for each process. That also means that a only common logic should be placed here.
+ */
 class MullvadApplication : Application() {
-
     override fun onCreate() {
         super.onCreate()
-        // start Koin!
+        // Used to create/start separate DI graphs for each process. Avoid non-common classes etc.
         startKoin {
-            // declare used Android context
             androidContext(this@MullvadApplication)
-            // declare modules
-            modules(appModule)
         }
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -14,7 +14,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.dsl.onClose
 
-val appModule = module {
+val uiModule = module {
 
     single<PackageManager> { androidContext().packageManager }
     single<String>(named(SELF_PACKAGE_NAME)) { androidContext().packageName }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -10,6 +10,7 @@ import android.net.VpnService
 import android.os.Bundle
 import android.os.IBinder
 import android.os.Messenger
+import android.util.Log
 import android.view.WindowManager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -18,11 +19,15 @@ import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.dataproxy.MullvadProblemReport
+import net.mullvad.mullvadvpn.di.uiModule
 import net.mullvad.mullvadvpn.service.MullvadVpnService
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnection
 import net.mullvad.talpid.util.EventNotifier
+import org.koin.core.context.loadKoinModules
+import org.koin.core.context.unloadKoinModules
 
 open class MainActivity : FragmentActivity() {
+
     val problemReport = MullvadProblemReport()
     val serviceNotifier = EventNotifier<ServiceConnection?>(null)
 
@@ -64,6 +69,8 @@ open class MainActivity : FragmentActivity() {
     var backButtonHandler: (() -> Boolean)? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        loadKoinModules(uiModule)
+
         requestedOrientation = if (deviceIsTv) {
             ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         } else {
@@ -85,7 +92,7 @@ open class MainActivity : FragmentActivity() {
     }
 
     override fun onStart() {
-        android.util.Log.d("mullvad", "Starting main activity")
+        Log.d("mullvad", "Starting main activity")
         super.onStart()
 
         val intent = Intent(this, MullvadVpnService::class.java)
@@ -107,8 +114,9 @@ open class MainActivity : FragmentActivity() {
     }
 
     override fun onStop() {
-        android.util.Log.d("mullvad", "Stoping main activity")
+        Log.d("mullvad", "Stoping main activity")
         unbindService(serviceConnectionManager)
+        unloadKoinModules(uiModule)
 
         super.onStop()
 

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/di/UiModuleTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/di/UiModuleTest.kt
@@ -16,11 +16,11 @@ import org.koin.core.scope.Scope
 import org.koin.test.KoinTest
 import org.koin.test.KoinTestRule
 
-class AppModuleTest : KoinTest {
+class UiModuleTest : KoinTest {
 
     @get:Rule
     val koinTestRule = KoinTestRule.create {
-        modules(appModule)
+        modules(uiModule)
     }
 
     @After


### PR DESCRIPTION
Fixes an issue with a UI specific DI module being loaded for all processes, even though it's only meant for the UI/Activity process.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3604)
<!-- Reviewable:end -->
