### PR TITLE
Set mtu on wireguard

### DIFF
--- a/talpid-core/src/routing/mod.rs
+++ b/talpid-core/src/routing/mod.rs
@@ -22,7 +22,7 @@ pub use imp::{Error, RouteManager};
 
 pub use imp::RouteManagerHandle;
 
-/// A netowrk route with a specific network node, destinaiton and an optional metric.
+/// A network route with a specific network node, destinaiton and an optional metric.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub struct Route {
     node: Node,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -115,7 +115,7 @@ impl ConnectingState {
         let (tunnel_close_tx, tunnel_close_rx) = oneshot::channel();
         let (tunnel_close_event_tx, tunnel_close_event_rx) = oneshot::channel();
 
-        let tunnel_parameters = parameters.clone();
+        let mut tunnel_parameters = parameters.clone();
 
         tokio::task::spawn_blocking(move || {
             let start = Instant::now();
@@ -141,7 +141,7 @@ impl ConnectingState {
 
             let block_reason = match TunnelMonitor::start(
                 runtime,
-                &tunnel_parameters,
+                &mut tunnel_parameters,
                 &log_dir,
                 &resource_dir,
                 on_tunnel_event,


### PR DESCRIPTION
Draft for setting the MTU of the wireguard tunnel.
When starting the Wireguard tunnel checks the MTU for the route to the connection endpoint and then sets the MTU in the Wireguard parameters to whatever is lesser between the provided MTU and 1400.  We also log when the provided MTU is different from 1500 in order to detect weirdness.

Next steps include detecting a better MTU over a real network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3609)
<!-- Reviewable:end -->
