### PR TITLE
Sort device list by age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add option to filter relays by ownership in the desktop apps.
+- Include creation timestamp for devices in the CLI.
 
 ### Changed
+- List devices on an account sorted by creation date, oldest to newest, instead of alphabetically.
+
 #### Android
 - Lowered default MTU to 1280 on Android.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,7 @@ dependencies = [
 name = "mullvad-management-interface"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "err-derive",
  "futures",
  "lazy_static",

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RemoveDeviceEvent.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/RemoveDeviceEvent.kt
@@ -6,6 +6,5 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class RemoveDeviceEvent(
     val accountToken: String,
-    val removedDevice: Device,
     val newDevices: ArrayList<Device>
 ) : Parcelable

--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -1476,11 +1476,13 @@ function convertFromDeviceRemoval(deviceRemoval: grpcTypes.RemoveDeviceEvent): A
 }
 
 function convertFromDevice(device: grpcTypes.Device): IDevice {
+  const created = ensureExists(device.getCreated(), "no 'created' field for device").toDate();
   const asObject = device.toObject();
 
   return {
     ...asObject,
     ports: asObject.portsList.map((port) => port.id),
+    created: created,
   };
 }
 

--- a/gui/src/renderer/redux/account/actions.ts
+++ b/gui/src/renderer/redux/account/actions.ts
@@ -213,7 +213,7 @@ function updateAccountExpiry(expiry?: string): IUpdateAccountExpiryAction {
 function updateDevices(devices: Array<IDevice>): IUpdateDevicesAction {
   return {
     type: 'UPDATE_DEVICES',
-    devices: devices.sort((a, b) => a.name.localeCompare(b.name)),
+    devices: devices.sort((a, b) => a.created.getDate() - b.created.getDate()),
   };
 }
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -359,6 +359,7 @@ export interface IDevice {
   id: string;
   name: string;
   ports?: Array<string>;
+  created: Date;
 }
 
 export interface IDeviceRemoval {

--- a/mullvad-api/src/device.rs
+++ b/mullvad-api/src/device.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use http::{Method, StatusCode};
 use mullvad_types::{
     account::AccountToken,
@@ -23,6 +24,8 @@ struct DeviceResponse {
     ipv4_address: ipnetwork::Ipv4Network,
     ipv6_address: ipnetwork::Ipv6Network,
     ports: Vec<DevicePort>,
+    hijack_dns: bool,
+    created: DateTime<Utc>,
 }
 
 impl DevicesProxy {
@@ -71,6 +74,8 @@ impl DevicesProxy {
                 ipv4_address,
                 ipv6_address,
                 ports,
+                hijack_dns,
+                created,
                 ..
             } = response;
 
@@ -80,6 +85,8 @@ impl DevicesProxy {
                     name,
                     pubkey,
                     ports,
+                    hijack_dns,
+                    created,
                 },
                 mullvad_types::wireguard::AssociatedAddresses {
                     ipv4_address,

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -157,6 +157,19 @@ pub struct PrivateDevice {
     pub name: DeviceName,
     pub wg_data: wireguard::WireguardData,
     pub ports: Vec<DevicePort>,
+    // FIXME: Reasonable default to avoid migration code for the field,
+    // as it was previously missing.
+    // This attribute may be removed once upgrades from `2022.2-beta1`
+    // no longer need to be supported.
+    #[serde(default)]
+    pub hijack_dns: bool,
+    // FIXME: Incorrect but reasonable default to avoid migration code
+    // for the field, as it was previously missing.
+    // The value is corrected when the device is validated or updated.
+    // This attribute may be removed once upgrades from `2022.2-beta1`
+    // no longer need to be supported.
+    #[serde(default = "Utc::now")]
+    pub created: DateTime<Utc>,
 }
 
 impl PrivateDevice {
@@ -174,6 +187,8 @@ impl PrivateDevice {
             name: device.name,
             wg_data,
             ports: device.ports,
+            hijack_dns: device.hijack_dns,
+            created: device.created,
         })
     }
 
@@ -186,6 +201,8 @@ impl PrivateDevice {
         self.id = device.id;
         self.ports = device.ports;
         self.name = device.name;
+        self.hijack_dns = device.hijack_dns;
+        self.created = device.created;
         Ok(())
     }
 }
@@ -197,6 +214,8 @@ impl From<PrivateDevice> for Device {
             ports: device.ports,
             pubkey: device.wg_data.private_key.public_key(),
             name: device.name,
+            hijack_dns: device.hijack_dns,
+            created: device.created,
         }
     }
 }

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -126,6 +126,8 @@ impl DeviceService {
                     name: "unknown device".to_string(),
                     pubkey: talpid_types::net::wireguard::PublicKey::from([0u8; 32]),
                     ports: vec![],
+                    hijack_dns: false,
+                    created: Utc::now(),
                 },
                 devices,
             ))

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1393,10 +1393,11 @@ where
             let result = device_service
                 .remove_device(account_token.clone(), device_id)
                 .await
-                .map(move |(removed_device, new_devices)| {
+                .map(move |new_devices| {
+                    // FIXME: We should be able to get away with only returning the removed ID,
+                    //        and not have to request the list from the API.
                     event_listener.notify_remove_device_event(RemoveDeviceEvent {
                         account_token,
-                        removed_device,
                         new_devices,
                     });
                 });

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+chrono = { version = "0.4.19" }
 err-derive = "0.3.1"
 mullvad-types = { path = "../mullvad-types" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -580,6 +580,8 @@ message Device {
 	string name = 2;
 	bytes pubkey = 3;
 	repeated DevicePort ports = 4;
+	bool hijack_dns = 5;
+	google.protobuf.Timestamp created = 6;
 }
 
 message DevicePort {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -621,6 +621,5 @@ message DeviceEvent {
 
 message RemoveDeviceEvent {
 	string account_token = 1;
-	Device removed_device = 2;
-	repeated Device new_device_list = 3;
+	repeated Device new_device_list = 2;
 }

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -281,7 +281,6 @@ impl From<mullvad_types::device::RemoveDeviceEvent> for RemoveDeviceEvent {
     fn from(event: mullvad_types::device::RemoveDeviceEvent) -> Self {
         RemoveDeviceEvent {
             account_token: event.account_token,
-            removed_device: Some(Device::from(event.removed_device)),
             new_device_list: event.new_devices.into_iter().map(Device::from).collect(),
         }
     }

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -217,6 +217,11 @@ impl From<mullvad_types::device::Device> for Device {
             name: device.name,
             pubkey: device.pubkey.as_bytes().to_vec(),
             ports: device.ports.into_iter().map(DevicePort::from).collect(),
+            hijack_dns: device.hijack_dns,
+            created: Some(Timestamp {
+                seconds: device.created.timestamp(),
+                nanos: 0,
+            }),
         }
     }
 }
@@ -808,6 +813,19 @@ impl TryFrom<Device> for mullvad_types::device::Device {
                 .into_iter()
                 .map(mullvad_types::device::DevicePort::from)
                 .collect(),
+            hijack_dns: device.hijack_dns,
+            created: chrono::DateTime::from_utc(
+                chrono::NaiveDateTime::from_timestamp(
+                    device
+                        .created
+                        .ok_or(FromProtobufTypeError::InvalidArgument(
+                            "missing 'created' field",
+                        ))?
+                        .seconds,
+                    0,
+                ),
+                chrono::Utc,
+            ),
         })
     }
 }

--- a/mullvad-types/src/device.rs
+++ b/mullvad-types/src/device.rs
@@ -1,4 +1,5 @@
 use crate::account::AccountToken;
+use chrono::{DateTime, Utc};
 #[cfg(target_os = "android")]
 use jnix::IntoJava;
 use serde::{Deserialize, Serialize};
@@ -21,6 +22,10 @@ pub struct Device {
     #[cfg_attr(target_os = "android", jnix(map = "|key| *key.as_bytes()"))]
     pub pubkey: PublicKey,
     pub ports: Vec<DevicePort>,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub hijack_dns: bool,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub created: DateTime<Utc>,
 }
 
 impl Eq for Device {}

--- a/mullvad-types/src/device.rs
+++ b/mullvad-types/src/device.rs
@@ -137,6 +137,5 @@ pub struct DeviceEvent {
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct RemoveDeviceEvent {
     pub account_token: AccountToken,
-    pub removed_device: Device,
     pub new_devices: Vec<Device>,
 }


### PR DESCRIPTION
Changes:
* Sort devices chronologically (oldest first) in the "Too many devices" view
* Sort devices chronologically when calling `mullvad list-devices`.
* Show device creation in CLI device list.
* Add `hijack_dns` and `created` fields to `device.json`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3611)
<!-- Reviewable:end -->
