### PR TITLE
Fix relay location cell layout + add multiline support

### DIFF
--- a/ios/MullvadVPN/SelectLocationCell.swift
+++ b/ios/MullvadVPN/SelectLocationCell.swift
@@ -106,6 +106,12 @@ class SelectLocationCell: UITableViewCell {
 
         locationLabel.font = UIFont.systemFont(ofSize: 17)
         locationLabel.textColor = .white
+        locationLabel.lineBreakMode = .byWordWrapping
+        locationLabel.numberOfLines = 0
+        if #available(iOS 14.0, *) {
+            // See: https://stackoverflow.com/q/46200027/351305
+            locationLabel.lineBreakStrategy = []
+        }
 
         tickImageView.tintColor = .white
 
@@ -135,7 +141,7 @@ class SelectLocationCell: UITableViewCell {
             statusIndicator.centerYAnchor.constraint(equalTo: tickImageView.centerYAnchor),
 
             locationLabel.leadingAnchor.constraint(equalTo: statusIndicator.trailingAnchor, constant: 12),
-            locationLabel.trailingAnchor.constraint(greaterThanOrEqualTo: collapseButton.leadingAnchor, constant: 0),
+            locationLabel.trailingAnchor.constraint(lessThanOrEqualTo: collapseButton.leadingAnchor),
             locationLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
             locationLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
 


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

- Add multiline support to location labels to account for "System transparency [BETA]" group of relays that are currently being clipped out.
- Fix label layout where previously the trailing edge of label would stick to the leading edge of collapse button or grow past it when too long. It should actually grow until collapse button but not past it. In ASCII words: `[label] < [collapse button]` and not `[label] >= [collapse button]`.

![image](https://user-images.githubusercontent.com/704044/170340907-2c0054bb-e29c-4b5b-8eae-2a59763183de.png)

Fixes it to look as following:

<img width="294" alt="Screenshot 2022-05-25 at 20 32 54" src="https://user-images.githubusercontent.com/704044/170341211-3cecfbe3-5c0d-43af-b8cc-278d4540338d.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3612)
<!-- Reviewable:end -->
