### PR TITLE
Fix logout not working in the GUI when the API is not reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix time added view displayed due to incorrect local clock.
+- Fix logout failing if the API cannot be reached in the GUI.
 
 #### Windows
 - Be more scrupulous about removing temporary files used by the installer and uninstaller.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1385,7 +1385,12 @@ class ApplicationMain {
     IpcMainEventChannel.account.handleUpdateData(() => this.updateAccountData());
 
     IpcMainEventChannel.account.handleGetDeviceState(async () => {
-      await this.daemonRpc.updateDevice();
+      try {
+        await this.daemonRpc.updateDevice();
+      } catch (e) {
+        const error = e as Error;
+        log.warn(`Failed to update device info: ${error.message}`);
+      }
       return this.daemonRpc.getDevice();
     });
     IpcMainEventChannel.account.handleListDevices((accountToken: AccountToken) => {

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -279,7 +279,7 @@ impl Error {
         }
     }
 
-    fn unpack(&self) -> &Error {
+    pub fn unpack(&self) -> &Error {
         if let Error::ResponseFailure(ref inner) = self {
             &*inner
         } else {


### PR DESCRIPTION
The GUI did not handle errors when trying to fetch the current device state and simply failed if the device could not be updated. This PR fixes this by falling back on the last known state an error occurs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3614)
<!-- Reviewable:end -->
