### PR TITLE
fix spelling error in line 156

### DIFF
--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -153,7 +153,7 @@ fn format_endpoint(hostname: &String, protocol_enum: i32, addr: Option<&str>) ->
 fn print_error_state(error_state: &ErrorState) {
     if error_state.blocking_error.is_some() {
         eprintln!("Mullvad daemon failed to setup firewall rules!");
-        eprintln!("Deamon cannot block traffic from flowing, non-local traffic will leak");
+        eprintln!("Daemon cannot block traffic from flowing, non-local traffic will leak");
     }
 
     match ErrorStateCause::from_i32(error_state.cause) {


### PR DESCRIPTION
changed "Deamon cannot block traffic from flowing, non-local traffic will leak" to say "Daemon" instead

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3621)
<!-- Reviewable:end -->
