### PR TITLE
Add initial support for PQ secure tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add option to filter relays by ownership in the desktop apps.
 - Include creation timestamp for devices in the CLI.
+- Add support for quantum-resistant PSK exchange.
 
 ### Changed
 - List devices on an account sorted by creation date, oldest to newest, instead of alphabetically.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "system-configuration",
  "talpid-dbus",
  "talpid-platform-metadata",
+ "talpid-relay-config-client",
  "talpid-time",
  "talpid-types",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +184,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bindgen"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap 2.34.0",
+ "env_logger 0.9.0",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
+]
+
+[[package]]
+name = "build-deps"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f14468960818ce4f3e3553c32d524446687884f8e7af5d3e252331d8a87e43"
+dependencies = [
+ "glob",
 ]
 
 [[package]]
@@ -251,6 +292,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -313,6 +363,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +401,7 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.14.2",
 ]
 
 [[package]]
@@ -334,7 +410,16 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678db4c39c013cc68b54d372bce2efc58e30a0337c497c9032fd196802df3bc3"
 dependencies = [
- "clap",
+ "clap 3.0.14",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -420,6 +505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr_core"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+dependencies = [
+ "cty",
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +532,12 @@ dependencies = [
  "nix 0.23.1",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "curve25519-dalek"
@@ -1020,6 +1121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "h2"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1550,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1658,12 @@ checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1673,7 +1796,7 @@ version = "2022.2.0-beta1"
 dependencies = [
  "base64",
  "chrono",
- "clap",
+ "clap 3.0.14",
  "clap_complete",
  "env_logger 0.8.4",
  "err-derive",
@@ -1697,7 +1820,7 @@ dependencies = [
  "android_logger",
  "cfg-if 1.0.0",
  "chrono",
- "clap",
+ "clap 3.0.14",
  "ctrlc",
  "dirs-next",
  "duct",
@@ -1779,8 +1902,8 @@ dependencies = [
  "mullvad-types",
  "nix 0.23.1",
  "parity-tokio-ipc",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "talpid-types",
  "tokio",
  "tonic",
@@ -1801,7 +1924,7 @@ dependencies = [
 name = "mullvad-problem-report"
 version = "2022.2.0-beta1"
 dependencies = [
- "clap",
+ "clap 3.0.14",
  "dirs-next",
  "duct",
  "env_logger 0.8.4",
@@ -1845,7 +1968,7 @@ dependencies = [
 name = "mullvad-setup"
 version = "2022.2.0-beta1"
 dependencies = [
- "clap",
+ "clap 3.0.14",
  "env_logger 0.8.4",
  "err-derive",
  "lazy_static",
@@ -2024,6 +2147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify"
 version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2254,29 @@ dependencies = [
  "derive-try-from-primitive",
  "log",
  "serde",
+]
+
+[[package]]
+name = "oqs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9534d1e8a22731bcd9fb97be6f6597503dcc4d86fd72e8a9deec214481884cc6"
+dependencies = [
+ "cstr_core",
+ "libc",
+ "oqs-sys",
+]
+
+[[package]]
+name = "oqs-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667693ecaa5afb140d88242bced5f259c9c2e2f477418f13b47834d784ed2b12"
+dependencies = [
+ "bindgen",
+ "build-deps",
+ "cmake",
+ "libc",
 ]
 
 [[package]]
@@ -2231,6 +2387,12 @@ name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -2468,7 +2630,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.8.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
 ]
 
 [[package]]
@@ -2483,8 +2655,8 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "tempfile",
  "which",
 ]
@@ -2503,13 +2675,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.8.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -2753,6 +2948,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -3092,6 +3293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,6 +3368,12 @@ checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -3267,7 +3480,7 @@ dependencies = [
  "parity-tokio-ipc",
  "parking_lot 0.11.2",
  "pfctl",
- "prost",
+ "prost 0.8.0",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.7.3",
@@ -3321,7 +3534,7 @@ dependencies = [
  "log",
  "openvpn-plugin",
  "parity-tokio-ipc",
- "prost",
+ "prost 0.8.0",
  "talpid-types",
  "tokio",
  "tonic",
@@ -3338,6 +3551,20 @@ dependencies = [
  "rs-release",
  "talpid-dbus",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "talpid-relay-config-client"
+version = "0.1.0"
+dependencies = [
+ "oqs",
+ "prost 0.8.0",
+ "prost-types 0.9.0",
+ "talpid-types",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tower",
 ]
 
 [[package]]
@@ -3382,6 +3609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3566,8 +3802,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.8.0",
+ "prost-derive 0.8.0",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3849,6 +4085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3906,6 +4148,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "talpid-core",
     "talpid-dbus",
     "talpid-platform-metadata",
+    "talpid-relay-config-client",
     "talpid-time",
     "mullvad-management-interface",
     "tunnel-obfuscation",

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -37,6 +37,7 @@ fn create_wireguard_subcommand() -> clap::App<'static> {
         .about("Manage options for Wireguard tunnels")
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(create_wireguard_mtu_subcommand())
+        .subcommand(create_wireguard_quantum_resistant_tunnel_subcommand())
         .subcommand(create_wireguard_keys_subcommand());
     #[cfg(windows)]
     {
@@ -55,6 +56,14 @@ fn create_wireguard_mtu_subcommand() -> clap::App<'static> {
         .subcommand(clap::App::new("get"))
         .subcommand(clap::App::new("unset"))
         .subcommand(clap::App::new("set").arg(clap::Arg::new("mtu").required(true)))
+}
+
+fn create_wireguard_quantum_resistant_tunnel_subcommand() -> clap::App<'static> {
+    clap::App::new("quantum-resistant-tunnel")
+        .about("EXPERIMENTAL: Enables quantum-resistant PSK exchange in the tunnel")
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(clap::App::new("get"))
+        .subcommand(clap::App::new("set").arg(clap::Arg::new("policy").required(true)))
 }
 
 fn create_wireguard_keys_subcommand() -> clap::App<'static> {
@@ -163,6 +172,14 @@ impl Tunnel {
                 _ => unreachable!("unhandled command"),
             },
 
+            Some(("quantum-resistant-tunnel", matches)) => match matches.subcommand() {
+                Some(("get", _)) => Self::process_wireguard_quantum_resistant_tunnel_get().await,
+                Some(("set", matches)) => {
+                    Self::process_wireguard_quantum_resistant_tunnel_set(matches).await
+                }
+                _ => unreachable!("unhandled command"),
+            },
+
             #[cfg(windows)]
             Some(("use-wireguard-nt", matches)) => match matches.subcommand() {
                 Some(("get", _)) => Self::process_wireguard_use_wg_nt_get().await,
@@ -200,6 +217,45 @@ impl Tunnel {
         let mut rpc = new_rpc_client().await?;
         rpc.set_wireguard_mtu(0).await?;
         println!("Wireguard MTU has been unset");
+        Ok(())
+    }
+
+    async fn process_wireguard_quantum_resistant_tunnel_get() -> Result<()> {
+        let tunnel_options = Self::get_tunnel_options().await?;
+        if tunnel_options.wireguard.unwrap().use_pq_safe_psk {
+            println!("enabled");
+        } else {
+            println!("disabled");
+        }
+        Ok(())
+    }
+
+    async fn process_wireguard_quantum_resistant_tunnel_set(
+        matches: &clap::ArgMatches,
+    ) -> Result<()> {
+        let new_state = matches.value_of("policy").unwrap() == "on";
+        let mut rpc = new_rpc_client().await?;
+        let settings = rpc.get_settings(()).await?;
+        let multihop_is_enabled = settings
+            .into_inner()
+            .relay_settings
+            .unwrap()
+            .endpoint
+            .and_then(|endpoint| {
+                if let types::relay_settings::Endpoint::Normal(settings) = endpoint {
+                    Some(settings.wireguard_constraints.unwrap().use_multihop)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(false);
+        if multihop_is_enabled {
+            return Err(Error::CommandFailed(
+                "PQ PSK exchange does not work when multihop is enabled",
+            ));
+        }
+        rpc.set_quantum_resistant_tunnel(new_state).await?;
+        println!("Updated quantum resistant tunnel setting");
         Ok(())
     }
 

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -109,6 +109,15 @@ fn format_relay_connection(relay_info: &TunnelStateRelayInfo, verbose: bool) -> 
     } else {
         String::new()
     };
+    let quantum_resistant = if verbose {
+        if endpoint.quantum_resistant {
+            "\nQuantum resistant tunnel: true".to_string()
+        } else {
+            "\nQuantum resistant tunnel: false".to_string()
+        }
+    } else {
+        String::new()
+    };
 
     let mut bridge_type = String::new();
     let mut obfuscator_type = String::new();
@@ -127,7 +136,7 @@ fn format_relay_connection(relay_info: &TunnelStateRelayInfo, verbose: bool) -> 
     }
 
     format!(
-        "{exit_endpoint}{first_hop}{bridge}{obfuscator}{tunnel_type}{bridge_type}{obfuscator_type}",
+        "{exit_endpoint}{first_hop}{bridge}{obfuscator}{tunnel_type}{quantum_resistant}{bridge_type}{obfuscator_type}",
         first_hop = first_hop.unwrap_or(String::new()),
         bridge = bridge.unwrap_or(String::new()),
         obfuscator = obfuscator.unwrap_or(String::new()),

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -220,6 +220,8 @@ pub enum DaemonCommand {
     SetBridgeState(ResponseTx<(), settings::Error>, BridgeState),
     /// Set if IPv6 should be enabled in the tunnel
     SetEnableIpv6(ResponseTx<(), settings::Error>, bool),
+    /// Set whether to enable PQ PSK exchange in the tunnel
+    SetQuantumResistantTunnel(ResponseTx<(), settings::Error>, bool),
     /// Set DNS options or servers to use
     SetDnsOptions(ResponseTx<(), settings::Error>, DnsOptions),
     /// Toggle macOS network check leak
@@ -979,6 +981,9 @@ where
             }
             SetBridgeState(tx, bridge_state) => self.on_set_bridge_state(tx, bridge_state).await,
             SetEnableIpv6(tx, enable_ipv6) => self.on_set_enable_ipv6(tx, enable_ipv6).await,
+            SetQuantumResistantTunnel(tx, enable_pq) => {
+                self.on_set_quantum_resistant_tunnel(tx, enable_pq).await
+            }
             SetDnsOptions(tx, dns_servers) => self.on_set_dns_options(tx, dns_servers).await,
             SetWireguardMtu(tx, mtu) => self.on_set_wireguard_mtu(tx, mtu).await,
             SetWireguardRotationInterval(tx, interval) => {
@@ -1950,6 +1955,36 @@ where
             Err(e) => {
                 log::error!("{}", e.display_chain_with_msg("Unable to save settings"));
                 Self::oneshot_send(tx, Err(e), "set_enable_ipv6 response");
+            }
+        }
+    }
+
+    async fn on_set_quantum_resistant_tunnel(
+        &mut self,
+        tx: ResponseTx<(), settings::Error>,
+        use_pq_safe_psk: bool,
+    ) {
+        let save_result = self
+            .settings
+            .set_quantum_resistant_tunnel(use_pq_safe_psk)
+            .await;
+        match save_result {
+            Ok(settings_changed) => {
+                Self::oneshot_send(tx, Ok(()), "set_quantum_resistant_tunnel response");
+                if settings_changed {
+                    self.parameters_generator
+                        .set_tunnel_options(&self.settings.tunnel_options);
+                    self.event_listener
+                        .notify_settings(self.settings.to_settings());
+                    if self.get_connected_tunnel_type() == Some(TunnelType::Wireguard) {
+                        log::info!("Reconnecting because the PQ safety setting changed");
+                        self.reconnect_tunnel();
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("{}", e.display_chain_with_msg("Unable to save settings"));
+                Self::oneshot_send(tx, Err(e), "set_quantum_resistant_tunnel response");
             }
         }
     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1058,7 +1058,7 @@ where
                 }
             }
             PrivateDeviceEvent::RotatedKey(_) => {
-                if let Some(TunnelType::Wireguard) = self.get_target_tunnel_type() {
+                if self.get_target_tunnel_type() == Some(TunnelType::Wireguard) {
                     self.schedule_reconnect(WG_RECONNECT_DELAY);
                 }
             }
@@ -1688,7 +1688,7 @@ where
                         .set_tunnel_options(&self.settings.tunnel_options);
                     self.event_listener
                         .notify_settings(self.settings.to_settings());
-                    if let Some(TunnelType::Wireguard) = self.get_connected_tunnel_type() {
+                    if let Some(TunnelType::Wireguard) = self.get_target_tunnel_type() {
                         log::info!("Initiating tunnel restart");
                         self.reconnect_tunnel();
                     }
@@ -1839,7 +1839,7 @@ where
                         .set_tunnel_options(&self.settings.tunnel_options);
                     self.event_listener
                         .notify_settings(self.settings.to_settings());
-                    if let Some(TunnelType::OpenVpn) = self.get_connected_tunnel_type() {
+                    if self.get_target_tunnel_type() == Some(TunnelType::OpenVpn) {
                         log::info!(
                             "Initiating tunnel restart because the OpenVPN mssfix setting changed"
                         );
@@ -1976,7 +1976,7 @@ where
                         .set_tunnel_options(&self.settings.tunnel_options);
                     self.event_listener
                         .notify_settings(self.settings.to_settings());
-                    if self.get_connected_tunnel_type() == Some(TunnelType::Wireguard) {
+                    if self.get_target_tunnel_type() == Some(TunnelType::Wireguard) {
                         log::info!("Reconnecting because the PQ safety setting changed");
                         self.reconnect_tunnel();
                     }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -373,6 +373,17 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_settings_error)
     }
 
+    async fn set_quantum_resistant_tunnel(&self, request: Request<bool>) -> ServiceResult<()> {
+        let enable = request.into_inner();
+        log::debug!("set_quantum_resistant_tunnel({})", enable);
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::SetQuantumResistantTunnel(tx, enable))?;
+        self.wait_for_result(rx)
+            .await?
+            .map(Response::new)
+            .map_err(map_settings_error)
+    }
+
     #[cfg(not(target_os = "android"))]
     async fn set_dns_options(&self, request: Request<types::DnsOptions>) -> ServiceResult<()> {
         let options = DnsOptions::try_from(request.into_inner()).map_err(map_protobuf_type_err)?;

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -236,6 +236,22 @@ impl SettingsPersister {
         self.update(should_save).await
     }
 
+    pub async fn set_quantum_resistant_tunnel(
+        &mut self,
+        use_pq_safe_psk: bool,
+    ) -> Result<bool, Error> {
+        let should_save = Self::update_field(
+            &mut self
+                .settings
+                .tunnel_options
+                .wireguard
+                .options
+                .use_pq_safe_psk,
+            use_pq_safe_psk,
+        );
+        self.update(should_save).await
+    }
+
     pub async fn set_dns_options(&mut self, options: DnsOptions) -> Result<bool, Error> {
         let should_save =
             Self::update_field(&mut self.settings.tunnel_options.dns_options, options);

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -435,6 +435,7 @@ message TunnelOptions {
 		uint32 mtu = 1;
 		google.protobuf.Duration rotation_interval = 2;
 		bool use_wireguard_nt = 3;
+		bool use_pq_safe_psk = 4;
 	}
 	message GenericOptions {
 		bool enable_ipv6 = 1;

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -194,9 +194,10 @@ message TunnelEndpoint {
 	string address = 1;
 	TransportProtocol protocol = 2;
 	TunnelType tunnel_type = 3;
-	ProxyEndpoint proxy = 4;
-	ObfuscationEndpoint obfuscation = 5;
-	Endpoint entry_endpoint = 6;
+	bool quantum_resistant = 4;
+	ProxyEndpoint proxy = 5;
+	ObfuscationEndpoint obfuscation = 6;
+	Endpoint entry_endpoint = 7;
 }
 
 enum ObfuscationType {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -43,6 +43,7 @@ service ManagementService {
 	rpc SetOpenvpnMssfix(google.protobuf.UInt32Value) returns (google.protobuf.Empty) {}
 	rpc SetWireguardMtu(google.protobuf.UInt32Value) returns (google.protobuf.Empty) {}
 	rpc SetEnableIpv6(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
+	rpc SetQuantumResistantTunnel(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
 	rpc SetDnsOptions(DnsOptions) returns (google.protobuf.Empty) {}
 
 	// Account management

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -35,6 +35,7 @@ impl From<talpid_types::net::TunnelEndpoint> for TunnelEndpoint {
                 net::TunnelType::Wireguard => i32::from(TunnelType::Wireguard),
                 net::TunnelType::OpenVpn => i32::from(TunnelType::Openvpn),
             },
+            quantum_resistant: endpoint.quantum_resistant,
             proxy: endpoint.proxy.map(|proxy_ep| ProxyEndpoint {
                 address: proxy_ep.endpoint.address.to_string(),
                 protocol: i32::from(TransportProtocol::from(proxy_ep.endpoint.protocol)),

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -1189,6 +1189,7 @@ impl TryFrom<ConnectionConfig> for mullvad_types::ConnectionConfig {
                             public_key,
                             allowed_ips,
                             endpoint,
+                            psk: None,
                         },
                         exit_peer: None,
                         ipv4_gateway,

--- a/mullvad-management-interface/src/types.rs
+++ b/mullvad-management-interface/src/types.rs
@@ -680,6 +680,7 @@ impl From<&mullvad_types::settings::TunnelOptions> for TunnelOptions {
                 use_wireguard_nt: options.wireguard.options.use_wireguard_nt,
                 #[cfg(not(windows))]
                 use_wireguard_nt: false,
+                use_pq_safe_psk: options.wireguard.options.use_pq_safe_psk,
             }),
             generic: Some(tunnel_options::GenericOptions {
                 enable_ipv6: options.generic.enable_ipv6,
@@ -1417,6 +1418,7 @@ impl TryFrom<TunnelOptions> for mullvad_types::settings::TunnelOptions {
                     } else {
                         None
                     },
+                    use_pq_safe_psk: wireguard_options.use_pq_safe_psk,
                     #[cfg(windows)]
                     use_wireguard_nt: wireguard_options.use_wireguard_nt,
                 },

--- a/mullvad-relay-selector/src/matcher.rs
+++ b/mullvad-relay-selector/src/matcher.rs
@@ -189,6 +189,7 @@ impl WireguardMatcher {
             public_key: data.public_key,
             endpoint: SocketAddr::new(host, port),
             allowed_ips: all_of_the_internet(),
+            psk: None,
         };
         Some(MullvadEndpoint::Wireguard(MullvadWireguardEndpoint {
             peer: peer_config,

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -113,7 +113,8 @@ impl Default for RotationInterval {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(
     target_os = "android",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -26,6 +26,7 @@ regex = "1.1.0"
 shell-escape = "0.1"
 talpid-types = { path = "../talpid-types" }
 talpid-time = { path = "../talpid-time" }
+talpid-relay-config-client = { path = "../talpid-relay-config-client" }
 uuid = { version = "0.8", features = ["v4"] }
 zeroize = "1"
 chrono = "0.4.19"

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -6,7 +6,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
 };
 use subslice::SubsliceExt;
-use talpid_types::net;
+use talpid_types::net::{self, AllowedTunnelTraffic};
 
 pub use pfctl::Error;
 
@@ -119,6 +119,7 @@ impl Firewall {
                 tunnel,
                 allow_lan,
                 allowed_endpoint,
+                allowed_tunnel_traffic,
             } => {
                 let mut rules = vec![self.get_allow_relay_rule(*peer_endpoint)?];
                 rules.push(self.get_allowed_endpoint_rule(allowed_endpoint.endpoint)?);
@@ -128,7 +129,9 @@ impl Firewall {
                 rules.append(&mut self.get_block_dns_rules()?);
 
                 if let Some(tunnel) = tunnel {
-                    rules.push(self.get_allow_tunnel_rule(&tunnel.interface)?);
+                    rules.push(
+                        self.get_allow_tunnel_rule(&tunnel.interface, allowed_tunnel_traffic)?,
+                    );
                 }
 
                 if *allow_lan {
@@ -154,7 +157,10 @@ impl Firewall {
                 // can't leak to the wrong IPs in the tunnel or on the LAN.
                 rules.append(&mut self.get_block_dns_rules()?);
 
-                rules.push(self.get_allow_tunnel_rule(tunnel.interface.as_str())?);
+                rules.push(self.get_allow_tunnel_rule(
+                    tunnel.interface.as_str(),
+                    &AllowedTunnelTraffic::All,
+                )?);
 
                 if *allow_lan {
                     rules.append(&mut self.get_allow_lan_rules()?);
@@ -318,14 +324,34 @@ impl Firewall {
         Ok(vec![block_tcp_dns_rule, block_udp_dns_rule])
     }
 
-    fn get_allow_tunnel_rule(&self, tunnel_interface: &str) -> Result<pfctl::FilterRule> {
-        Ok(self
+    fn get_allow_tunnel_rule(
+        &self,
+        tunnel_interface: &str,
+        allowed_traffic: &AllowedTunnelTraffic,
+    ) -> Result<Option<pfctl::FilterRule>> {
+        let mut base_rule = self
             .create_rule_builder(FilterRuleAction::Pass)
             .quick(true)
             .interface(tunnel_interface)
             .keep_state(pfctl::StatePolicy::Keep)
-            .tcp_flags(Self::get_tcp_flags())
-            .build()?)
+            .tcp_flags(Self::get_tcp_flags());
+        match allowed_traffic {
+            AllowedTunnelTraffic::Only(addr, protocol) => {
+                use talpid_types::net::Protocol::*;
+                let pfctl_proto = match protocol {
+                    Udp => pfctl::Proto::Udp,
+                    Tcp => pfctl::Proto::Tcp,
+                    IcmpV4 => pfctl::Proto::Icmp,
+                    IcmpV6 => pfctl::Proto::IcmpV6,
+                };
+                base_rule = base_rule.to(*addr).proto(pfctl_proto);
+            }
+            AllowedTunnelTraffic::All => {}
+            AllowedTunnelTraffic::None => {
+                return Ok(None);
+            }
+        };
+        Ok(Some(base_rule.build()?))
     }
 
     fn get_allow_loopback_rules(&self) -> Result<Vec<pfctl::FilterRule>> {

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -155,12 +155,13 @@ impl fmt::Display for FirewallPolicy {
                 tunnel,
                 allow_lan,
                 allowed_endpoint,
+                allowed_tunnel_traffic,
                 ..
             } => {
                 if let Some(tunnel) = tunnel {
                     write!(
                         f,
-                        "Connecting to {} over \"{}\" (ip: {}, v4 gw: {}, v6 gw: {:?}), {} LAN. Allowing endpoint {}",
+                        "Connecting to {} over \"{}\" (ip: {}, v4 gw: {}, v6 gw: {:?}, allowed in-tunnel traffic: {}), {} LAN. Allowing endpoint {}",
                         peer_endpoint,
                         tunnel.interface,
                         tunnel
@@ -171,6 +172,7 @@ impl fmt::Display for FirewallPolicy {
                             .join(","),
                         tunnel.ipv4_gateway,
                         tunnel.ipv6_gateway,
+                        allowed_tunnel_traffic,
                         if *allow_lan { "Allowing" } else { "Blocking" },
                         allowed_endpoint,
                     )

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(windows)]
 use std::path::PathBuf;
-use talpid_types::net::{AllowedEndpoint, Endpoint};
+use talpid_types::net::{AllowedEndpoint, AllowedTunnelTraffic, Endpoint};
 
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]
@@ -111,6 +111,8 @@ pub enum FirewallPolicy {
         allow_lan: bool,
         /// Host that should be reachable while connecting.
         allowed_endpoint: AllowedEndpoint,
+        /// Networks for which to permit in-tunnel traffic.
+        allowed_tunnel_traffic: AllowedTunnelTraffic,
         /// A process that is allowed to send packets to the relay.
         #[cfg(windows)]
         relay_client: PathBuf,

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -192,7 +192,18 @@ impl TunnelMonitor {
         let monitor = wireguard::WireguardMonitor::start(
             runtime,
             config,
-            Some(params.connection.peer.public_key.clone()),
+            if params.options.use_pq_safe_psk {
+                Some(
+                    params
+                        .connection
+                        .exit_peer
+                        .as_ref()
+                        .map(|peer| peer.public_key.clone())
+                        .unwrap_or(params.connection.peer.public_key.clone()),
+                )
+            } else {
+                None
+            },
             log.as_ref().map(|p| p.as_path()),
             resource_dir,
             on_event,

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -8,7 +8,7 @@ use std::{
 };
 #[cfg(not(target_os = "android"))]
 use talpid_types::net::openvpn as openvpn_types;
-use talpid_types::net::{wireguard as wireguard_types, TunnelParameters};
+use talpid_types::net::{wireguard as wireguard_types, AllowedTunnelTraffic, TunnelParameters};
 
 #[cfg(target_os = "android")]
 pub use self::tun_provider::TunConfig;
@@ -69,7 +69,7 @@ pub enum TunnelEvent {
     /// Sent when the tunnel fails to connect due to an authentication error.
     AuthFailed(Option<String>),
     /// Sent when the tunnel interface has been created, before routes are set up.
-    InterfaceUp(TunnelMetadata),
+    InterfaceUp(TunnelMetadata, AllowedTunnelTraffic),
     /// Sent when the tunnel comes up and is ready for traffic.
     Up(TunnelMetadata),
     /// Sent when the tunnel goes down.

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -192,6 +192,7 @@ impl TunnelMonitor {
         let monitor = wireguard::WireguardMonitor::start(
             runtime,
             config,
+            Some(params.connection.peer.public_key.clone()),
             log.as_ref().map(|p| p.as_path()),
             resource_dir,
             on_event,

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -873,9 +873,10 @@ mod event_server {
             request: Request<EventDetails>,
         ) -> std::result::Result<Response<()>, tonic::Status> {
             let env = request.into_inner().env;
-            (self.on_event)(super::TunnelEvent::InterfaceUp(Self::get_tunnel_metadata(
-                &env,
-            )?))
+            (self.on_event)(super::TunnelEvent::InterfaceUp(
+                Self::get_tunnel_metadata(&env)?,
+                talpid_types::net::AllowedTunnelTraffic::All,
+            ))
             .await;
             Ok(Response::new(()))
         }

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -6,6 +6,7 @@ use std::{
 use talpid_types::net::{obfuscation::ObfuscatorConfig, wireguard, GenericTunnelOptions};
 
 /// Config required to set up a single WireGuard tunnel
+#[derive(Clone)]
 pub struct Config {
     /// Contains tunnel endpoint specific config
     pub tunnel: wireguard::TunnelConfig,

--- a/talpid-core/src/tunnel/wireguard/config.rs
+++ b/talpid-core/src/tunnel/wireguard/config.rs
@@ -148,6 +148,9 @@ impl Config {
                 .add("public_key", peer.public_key.as_bytes().as_ref())
                 .add("endpoint", peer.endpoint.to_string().as_str())
                 .add("replace_allowed_ips", "true");
+            if let Some(ref psk) = peer.psk {
+                wg_conf.add("preshared_key", psk.as_bytes().as_ref());
+            }
             for addr in &peer.allowed_ips {
                 wg_conf.add("allowed_ip", addr.to_string().as_str());
             }

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -644,9 +644,7 @@ pub(crate) trait Tunnel: Send {
     fn set_config(
         &self,
         _config: Config,
-    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), TunnelError>> + Send + 'static>> {
-        unimplemented!()
-    }
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), TunnelError>> + Send>>;
 }
 
 /// Errors to be returned from WireGuard implementations, namely implementers of the Tunnel trait

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/netlink_tunnel.rs
@@ -1,3 +1,7 @@
+use std::pin::Pin;
+
+use futures::Future;
+
 use super::{
     super::stats::{Stats, StatsMap},
     wg_message::DeviceNla,
@@ -108,5 +112,21 @@ impl Tunnel for NetlinkTunnel {
         });
 
         result
+    }
+
+    fn set_config(
+        &self,
+        config: Config,
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), TunnelError>> + Send + 'static>> {
+        let mut wg = self.netlink_connections.wg_handle.clone();
+        let interface_index = self.interface_index;
+        Box::pin(async move {
+            wg.set_config(interface_index, &config)
+                .await
+                .map_err(|err| {
+                    log::error!("Failed to fetch WireGuard device config: {}", err);
+                    TunnelError::SetConfigError
+                })
+        })
     }
 }

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/wg_message.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/wg_message.rs
@@ -81,12 +81,16 @@ impl DeviceMessage {
         for peer in config.peers.iter() {
             let peer_endpoint = InetAddr::from_std(&peer.endpoint);
             let allowed_ips = peer.allowed_ips.iter().map(From::from).collect();
-            peers.push(PeerMessage(vec![
+            let mut peer_nlas = vec![
                 PeerNla::PublicKey(*peer.public_key.as_bytes()),
                 PeerNla::Endpoint(peer_endpoint),
                 PeerNla::AllowedIps(allowed_ips),
                 PeerNla::Flags(WGPEER_F_REPLACE_ALLOWEDIPS),
-            ]));
+            ];
+            if let Some(psk) = peer.psk.as_ref() {
+                peer_nlas.push(PeerNla::PresharedKey(psk.as_bytes().clone()));
+            }
+            peers.push(PeerMessage(peer_nlas));
         }
 
         let nlas = vec![

--- a/talpid-relay-config-client/Cargo.toml
+++ b/talpid-relay-config-client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "talpid-relay-config-client"
+version = "0.1.0"
+authors = ["Mullvad VPN"]
+description = "Uses relays to set up PQ-safe peers, etc."
+license = "GPL-3.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+talpid-types = { path = "../talpid-types" }
+tonic = "0.5"
+prost = "0.8"
+prost-types = "0.9"
+tower = "0.4"
+tokio = "1"
+oqs = { version = "0.7.0", default-features = false, features = ["kems"] }
+
+[build-dependencies]
+tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"] }

--- a/talpid-relay-config-client/build.rs
+++ b/talpid-relay-config-client/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    const PROTO_FILE: &str = "proto/feature.proto";
+    tonic_build::compile_protos(PROTO_FILE).unwrap();
+    println!("cargo:rerun-if-changed={}", PROTO_FILE);
+}

--- a/talpid-relay-config-client/proto/feature.proto
+++ b/talpid-relay-config-client/proto/feature.proto
@@ -1,0 +1,36 @@
+//
+// If you need to (re)generate the gRPC code, see prerequisites
+// 
+// 	https://grpc.io/docs/languages/go/quickstart/
+// 
+// and then run 
+// 
+// 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative feature.proto
+// 
+// from this directory.
+//
+
+syntax = "proto3";
+
+option go_package = "github.com/mullvad/wg-manager/server/feature";
+
+package feature;
+
+service PostQuantumSecure {
+	rpc PskExchange(PskRequest) returns (PskResponse) {}
+}
+
+message PskRequest {
+	bytes wg_pubkey = 1;
+	bytes wg_psk_pubkey = 2;
+	OqsPubkey oqs_pubkey = 3;
+}
+
+message OqsPubkey {
+	string algorithm_name = 1;
+	bytes key_data = 2;
+}
+
+message PskResponse {
+	bytes ciphertext = 1;
+}

--- a/talpid-relay-config-client/src/lib.rs
+++ b/talpid-relay-config-client/src/lib.rs
@@ -56,7 +56,6 @@ pub async fn push_pq_key(
     Ok((oqs_key, psk))
 }
 
-#[cfg(target_os = "windows")]
 async fn generate_key() -> Result<(kem::PublicKey, SecretKey), Error> {
     let (tx, rx) = tokio::sync::oneshot::channel();
 
@@ -74,12 +73,6 @@ async fn generate_key() -> Result<(kem::PublicKey, SecretKey), Error> {
         .unwrap();
 
     rx.await.unwrap()
-}
-
-#[cfg(not(target_os = "windows"))]
-async fn generate_key() -> Result<(kem::PublicKey, SecretKey), Error> {
-    let kem = Kem::new(ALGORITHM).map_err(Error::OqsError)?;
-    kem.keypair().map_err(Error::OqsError)
 }
 
 fn algorithm_to_string(algorithm: &Algorithm) -> String {

--- a/talpid-relay-config-client/src/lib.rs
+++ b/talpid-relay-config-client/src/lib.rs
@@ -1,0 +1,75 @@
+use std::net::IpAddr;
+
+use oqs::kem::{Algorithm, Kem};
+use talpid_types::net::wireguard::{PresharedKey, PrivateKey, PublicKey};
+use tonic::transport::{Channel, Endpoint, Uri};
+
+mod types {
+    tonic::include_proto!("feature");
+}
+
+type RelayConfigService = types::post_quantum_secure_client::PostQuantumSecureClient<Channel>;
+
+const CONFIG_SERVICE_PORT: u16 = 1337;
+const ALGORITHM: Algorithm = Algorithm::ClassicMcEliece8192128f;
+
+#[derive(Debug)]
+pub enum Error {
+    GrpcTransportError(tonic::transport::Error),
+    GrpcError(tonic::Status),
+    OqsError(oqs::Error),
+    InvalidCiphertext,
+}
+
+// TODO: consider binding to the tunnel interface here, on non-windows platforms
+pub async fn push_pq_key(
+    service_address: IpAddr,
+    current_pubkey: PublicKey,
+) -> Result<(PrivateKey, PresharedKey), Error> {
+    let oqs_key = PrivateKey::new_from_random();
+
+    let kem = Kem::new(ALGORITHM).map_err(Error::OqsError)?;
+    let (pubkey, secret) = kem.keypair().map_err(Error::OqsError)?;
+
+    let mut client = new_client(service_address).await?;
+    let response = client
+        .psk_exchange(types::PskRequest {
+            wg_pubkey: current_pubkey.as_bytes().to_vec(),
+            wg_psk_pubkey: oqs_key.public_key().as_bytes().to_vec(),
+            oqs_pubkey: Some(types::OqsPubkey {
+                algorithm_name: algorithm_to_string(&ALGORITHM),
+                key_data: pubkey.into_vec(),
+            }),
+        })
+        .await
+        .map_err(Error::GrpcError)?;
+
+    let ciphertext = response.into_inner().ciphertext;
+    let ciphertext = kem
+        .ciphertext_from_bytes(&ciphertext)
+        .ok_or(Error::InvalidCiphertext)?;
+    let psk = kem
+        .decapsulate(&secret, ciphertext)
+        .map(|key| PresharedKey::from(<[u8; 32]>::try_from(key.as_ref()).unwrap()))
+        .map_err(Error::OqsError)?;
+    Ok((oqs_key, psk))
+}
+
+fn algorithm_to_string(algorithm: &Algorithm) -> String {
+    match algorithm {
+        Algorithm::ClassicMcEliece8192128f => "Classic-McEliece-8192128f".to_string(),
+        _ => unimplemented!(),
+    }
+}
+
+async fn new_client(addr: IpAddr) -> Result<RelayConfigService, Error> {
+    let channel = Endpoint::from_shared(format!("tcp://{addr}:{CONFIG_SERVICE_PORT}"))
+        .expect("Failed to construct URI")
+        .connect_with_connector(tower::service_fn(move |_: Uri| {
+            tokio::net::TcpStream::connect((addr, CONFIG_SERVICE_PORT))
+        }))
+        .await
+        .map_err(Error::GrpcTransportError)?;
+
+    Ok(RelayConfigService::new(channel))
+}

--- a/talpid-relay-config-client/src/main.rs
+++ b/talpid-relay-config-client/src/main.rs
@@ -1,7 +1,6 @@
-use std::net::{Ipv4Addr, IpAddr};
+use std::net::{IpAddr, Ipv4Addr};
 
 use talpid_types::net::wireguard::PrivateKey;
-
 
 #[tokio::main]
 async fn main() {

--- a/talpid-relay-config-client/src/main.rs
+++ b/talpid-relay-config-client/src/main.rs
@@ -1,0 +1,19 @@
+use std::net::{Ipv4Addr, IpAddr};
+
+use talpid_types::net::wireguard::PrivateKey;
+
+
+#[tokio::main]
+async fn main() {
+    let current_private_key = PrivateKey::new_from_random();
+
+    let (private_key, psk) = talpid_relay_config_client::push_pq_key(
+        IpAddr::V4(Ipv4Addr::new(10, 64, 0, 1)),
+        current_private_key.public_key(),
+    )
+    .await
+    .unwrap();
+
+    println!("private key: {:?}", private_key);
+    println!("psk: {:?}", psk);
+}

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -285,6 +285,16 @@ pub enum AllowedTunnelTraffic {
     Only(SocketAddr, Protocol),
 }
 
+impl fmt::Display for AllowedTunnelTraffic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match *self {
+            AllowedTunnelTraffic::None => "None".fmt(f),
+            AllowedTunnelTraffic::All => "All".fmt(f),
+            AllowedTunnelTraffic::Only(addr, proto) => write!(f, "{}/{}", addr, proto),
+        }
+    }
+}
+
 /// A protocol: UDP, TCP, or ICMP.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Protocol {
@@ -292,6 +302,17 @@ pub enum Protocol {
     Tcp,
     IcmpV4,
     IcmpV6,
+}
+
+impl fmt::Display for Protocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Protocol::Udp => "UDP".fmt(f),
+            Protocol::Tcp => "TCP".fmt(f),
+            Protocol::IcmpV4 => "ICMPv4".fmt(f),
+            Protocol::IcmpV6 => "ICMPv6".fmt(f),
+        }
+    }
 }
 
 impl From<TransportProtocol> for Protocol {

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -29,6 +29,7 @@ impl TunnelParameters {
         match self {
             TunnelParameters::OpenVpn(params) => TunnelEndpoint {
                 tunnel_type: TunnelType::OpenVpn,
+                quantum_resistant: false,
                 endpoint: params.config.endpoint,
                 proxy: params.proxy.as_ref().map(|proxy| proxy.get_endpoint()),
                 obfuscation: None,
@@ -36,6 +37,7 @@ impl TunnelParameters {
             },
             TunnelParameters::Wireguard(params) => TunnelEndpoint {
                 tunnel_type: TunnelType::Wireguard,
+                quantum_resistant: params.options.use_pq_safe_psk,
                 endpoint: params
                     .connection
                     .get_exit_endpoint()
@@ -136,6 +138,8 @@ pub struct TunnelEndpoint {
     pub endpoint: Endpoint,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub tunnel_type: TunnelType,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub quantum_resistant: bool,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub proxy: Option<proxy::ProxyEndpoint>,
     #[cfg_attr(target_os = "android", jnix(skip))]

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -278,6 +278,31 @@ impl fmt::Display for AllowedEndpoint {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum AllowedTunnelTraffic {
+    None,
+    All,
+    Only(SocketAddr, Protocol),
+}
+
+/// A protocol: UDP, TCP, or ICMP.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum Protocol {
+    Udp,
+    Tcp,
+    IcmpV4,
+    IcmpV6,
+}
+
+impl From<TransportProtocol> for Protocol {
+    fn from(proto: TransportProtocol) -> Self {
+        match proto {
+            TransportProtocol::Udp => Protocol::Udp,
+            TransportProtocol::Tcp => Protocol::Tcp,
+        }
+    }
+}
+
 /// IP protocol version.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -80,6 +80,8 @@ pub struct TunnelOptions {
         jnix(map = "|maybe_mtu| maybe_mtu.map(|mtu| mtu as i32)")
     )]
     pub mtu: Option<u16>,
+    /// Obtain a PSK using the relay config client.
+    pub use_pq_safe_psk: bool,
     /// Temporary switch for wireguard-nt
     #[cfg(windows)]
     #[serde(default = "default_wgnt_setting")]
@@ -96,6 +98,7 @@ impl Default for TunnelOptions {
     fn default() -> Self {
         Self {
             mtu: None,
+            use_pq_safe_psk: false,
             #[cfg(windows)]
             use_wireguard_nt: default_wgnt_setting(),
         }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -55,6 +55,8 @@ pub struct PeerConfig {
     pub allowed_ips: Vec<IpNetwork>,
     /// IP address of the WireGuard server.
     pub endpoint: SocketAddr,
+    /// Preshared key.
+    pub psk: Option<PresharedKey>,
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]
@@ -253,12 +255,37 @@ impl fmt::Display for PublicKey {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PresharedKey([u8; 32]);
+
+impl PresharedKey {
+    /// Get the PSK as bytes
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
 
 impl From<[u8; 32]> for PresharedKey {
     fn from(key: [u8; 32]) -> PresharedKey {
         PresharedKey(key)
+    }
+}
+
+impl Serialize for PresharedKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_key(&self.0, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PresharedKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_key(deserializer)
     }
 }
 

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -68,6 +68,7 @@ pub struct TunnelConfig {
 
 /// Options in [`TunnelParameters`] that apply to any WireGuard connection.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(
     target_os = "android",

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -253,6 +253,15 @@ impl fmt::Display for PublicKey {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct PresharedKey([u8; 32]);
+
+impl From<[u8; 32]> for PresharedKey {
+    fn from(key: [u8; 32]) -> PresharedKey {
+        PresharedKey(key)
+    }
+}
+
 fn serialize_key<S>(key: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -30,7 +30,8 @@ public:
 		const WinFwEndpoint &relay,
 		const std::wstring &relayClient,
 		const std::optional<std::wstring> &tunnelInterfaceAlias,
-		const std::optional<WinFwAllowedEndpoint> &allowedEndpoint
+		const std::optional<WinFwAllowedEndpoint> &allowedEndpoint,
+		const WinFwAllowedTunnelTraffic &allowedTunnelTraffic
 	);
 
 	bool applyPolicyConnected

--- a/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
@@ -36,6 +36,8 @@ std::unique_ptr<ConditionProtocol> CreateProtocolCondition(WinFwProtocol protoco
 	{
 		case WinFwProtocol::Tcp: return ConditionProtocol::Tcp();
 		case WinFwProtocol::Udp: return ConditionProtocol::Udp();
+		case WinFwProtocol::Icmp: return ConditionProtocol::Icmp();
+		case WinFwProtocol::IcmpV6: return ConditionProtocol::IcmpV6();
 		default:
 		{
 			THROW_ERROR("Missing case handler in switch clause");

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
@@ -4,20 +4,68 @@
 #include <libwfp/filterbuilder.h>
 #include <libwfp/conditionbuilder.h>
 #include <libwfp/conditions/conditioninterface.h>
+#include <libwfp/conditions/conditionip.h>
+#include <libwfp/conditions/conditionport.h>
+#include <libwfp/conditions/conditionprotocol.h>
+#include <libcommon/error.h>
 
 using namespace wfp::conditions;
+
+namespace
+{
+
+std::unique_ptr<ConditionProtocol> CreateProtocolCondition(WinFwProtocol protocol)
+{
+	switch (protocol)
+	{
+		case WinFwProtocol::Tcp: return ConditionProtocol::Tcp();
+		case WinFwProtocol::Udp: return ConditionProtocol::Udp();
+		case WinFwProtocol::Icmp: return ConditionProtocol::Icmp();
+		case WinFwProtocol::IcmpV6: return ConditionProtocol::IcmpV6();
+		default:
+		{
+			THROW_ERROR("Missing case handler in switch clause");
+		}
+	};
+}
+
+bool ProtocolHasPort(WinFwProtocol protocol)
+{
+	switch (protocol)
+	{
+		case WinFwProtocol::Tcp:
+		case WinFwProtocol::Udp:
+			return true;
+		case WinFwProtocol::Icmp:
+		case WinFwProtocol::IcmpV6:
+			return false;
+		default:
+		{
+			THROW_ERROR("Missing case handler in switch clause");
+		}
+	};
+}
+
+}
 
 namespace rules::baseline
 {
 
-PermitVpnTunnel::PermitVpnTunnel(const std::wstring &tunnelInterfaceAlias)
+PermitVpnTunnel::PermitVpnTunnel(
+	const std::wstring &tunnelInterfaceAlias,
+	const std::optional<Endpoint> &onlyEndpoint
+)
 	: m_tunnelInterfaceAlias(tunnelInterfaceAlias)
+	, m_tunnelOnlyEndpoint(onlyEndpoint)
 {
 }
 
 bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
 {
 	wfp::FilterBuilder filterBuilder;
+
+	bool includeV4 = !m_tunnelOnlyEndpoint.has_value() || m_tunnelOnlyEndpoint->ip.type() == wfp::IpAddress::Ipv4;
+	bool includeV6 = !m_tunnelOnlyEndpoint.has_value() || m_tunnelOnlyEndpoint->ip.type() == wfp::IpAddress::Ipv6;
 
 	//
 	// #1 Permit outbound connections, IPv4.
@@ -33,10 +81,21 @@ bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
 		.weight(wfp::FilterBuilder::WeightClass::Medium)
 		.permit();
 
+	if (includeV4)
 	{
 		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
 
 		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+
+		if (m_tunnelOnlyEndpoint.has_value())
+		{
+			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
+			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
+			{
+				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
+			}
+			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
+		}
 
 		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
 		{
@@ -53,11 +112,26 @@ bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
 		.name(L"Permit outbound connections on tunnel interface (IPv6)")
 		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
 
-	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+	if (includeV6)
+	{
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
 
-	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
 
-	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+		if (m_tunnelOnlyEndpoint.has_value())
+		{
+			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
+			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
+			{
+				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
+			}
+			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
+		}
+
+		return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+	}
+
+	return true;
 }
 
 }

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <winfw/rules/ifirewallrule.h>
+#include <winfw/winfw.h>
+#include <libwfp/ipaddress.h>
 #include <string>
+#include <optional>
 
 namespace rules::baseline
 {
@@ -10,13 +13,23 @@ class PermitVpnTunnel : public IFirewallRule
 {
 public:
 
-	PermitVpnTunnel(const std::wstring &tunnelInterfaceAlias);
+	struct Endpoint {
+		wfp::IpAddress ip;
+		uint16_t port;
+		WinFwProtocol protocol;
+	};
+
+	PermitVpnTunnel(
+		const std::wstring &tunnelInterfaceAlias,
+		const std::optional<Endpoint> &onlyEndpoint
+	);
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
 
 	const std::wstring m_tunnelInterfaceAlias;
+	const std::optional<Endpoint> m_tunnelOnlyEndpoint;
 };
 
 }

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.cpp
@@ -4,20 +4,68 @@
 #include <libwfp/filterbuilder.h>
 #include <libwfp/conditionbuilder.h>
 #include <libwfp/conditions/conditioninterface.h>
+#include <libwfp/conditions/conditionip.h>
+#include <libwfp/conditions/conditionport.h>
+#include <libwfp/conditions/conditionprotocol.h>
+#include <libcommon/error.h>
 
 using namespace wfp::conditions;
+
+namespace
+{
+
+std::unique_ptr<ConditionProtocol> CreateProtocolCondition(WinFwProtocol protocol)
+{
+	switch (protocol)
+	{
+		case WinFwProtocol::Tcp: return ConditionProtocol::Tcp();
+		case WinFwProtocol::Udp: return ConditionProtocol::Udp();
+		case WinFwProtocol::Icmp: return ConditionProtocol::Icmp();
+		case WinFwProtocol::IcmpV6: return ConditionProtocol::IcmpV6();
+		default:
+		{
+			THROW_ERROR("Missing case handler in switch clause");
+		}
+	};
+}
+
+bool ProtocolHasPort(WinFwProtocol protocol)
+{
+	switch (protocol)
+	{
+		case WinFwProtocol::Tcp:
+		case WinFwProtocol::Udp:
+			return true;
+		case WinFwProtocol::Icmp:
+		case WinFwProtocol::IcmpV6:
+			return false;
+		default:
+		{
+			THROW_ERROR("Missing case handler in switch clause");
+		}
+	};
+}
+
+}
 
 namespace rules::baseline
 {
 
-PermitVpnTunnelService::PermitVpnTunnelService(const std::wstring &tunnelInterfaceAlias)
+PermitVpnTunnelService::PermitVpnTunnelService(
+	const std::wstring &tunnelInterfaceAlias,
+	const std::optional<PermitVpnTunnel::Endpoint> &onlyEndpoint
+)
 	: m_tunnelInterfaceAlias(tunnelInterfaceAlias)
+	, m_tunnelOnlyEndpoint(onlyEndpoint)
 {
 }
 
 bool PermitVpnTunnelService::apply(IObjectInstaller &objectInstaller)
 {
 	wfp::FilterBuilder filterBuilder;
+
+	bool includeV4 = !m_tunnelOnlyEndpoint.has_value() || m_tunnelOnlyEndpoint->ip.type() == wfp::IpAddress::Ipv4;
+	bool includeV6 = !m_tunnelOnlyEndpoint.has_value() || m_tunnelOnlyEndpoint->ip.type() == wfp::IpAddress::Ipv6;
 
 	//
 	// #1 Permit inbound connections, IPv4.
@@ -35,26 +83,54 @@ bool PermitVpnTunnelService::apply(IObjectInstaller &objectInstaller)
 
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4);
 
-	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
-
-	if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+	if (includeV4)
 	{
-		return false;
+		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+
+		if (m_tunnelOnlyEndpoint.has_value())
+		{
+			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
+			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
+			{
+				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
+			}
+			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
+		}
+
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
 	}
 
 	//
 	// #2 Permit inbound connections, IPv6.
 	//
 
-	filterBuilder
-		.key(MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6())
-		.name(L"Permit inbound connections on tunnel interface (IPv6)")
-		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+	if (includeV6)
+	{
+		filterBuilder
+			.key(MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6())
+			.name(L"Permit inbound connections on tunnel interface (IPv6)")
+			.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
 
-	conditionBuilder.reset(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
-	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+		conditionBuilder.reset(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
 
-	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+		if (m_tunnelOnlyEndpoint.has_value())
+		{
+			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
+			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
+			{
+				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
+			}
+			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
+		}
+
+		return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+	}
+
+	return true;
 }
 
 }

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <winfw/rules/ifirewallrule.h>
+#include <winfw/rules/baseline/permitvpntunnel.h>
+#include <winfw/winfw.h>
+#include <libwfp/ipaddress.h>
 #include <string>
+#include <optional>
 
 namespace rules::baseline
 {
@@ -10,13 +14,17 @@ class PermitVpnTunnelService : public IFirewallRule
 {
 public:
 
-	PermitVpnTunnelService(const std::wstring &tunnelInterfaceAlias);
+	PermitVpnTunnelService(
+		const std::wstring &tunnelInterfaceAlias,
+		const std::optional<PermitVpnTunnel::Endpoint> &onlyEndpoint
+	);
 
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
 
 	const std::wstring m_tunnelInterfaceAlias;
+	const std::optional<PermitVpnTunnel::Endpoint> m_tunnelOnlyEndpoint;
 };
 
 }

--- a/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
+++ b/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
@@ -37,6 +37,8 @@ std::unique_ptr<ConditionProtocol> CreateProtocolCondition(WinFwProtocol protoco
 	{
 		case WinFwProtocol::Tcp: return ConditionProtocol::Tcp();
 		case WinFwProtocol::Udp: return ConditionProtocol::Udp();
+		case WinFwProtocol::Icmp: return ConditionProtocol::Icmp();
+		case WinFwProtocol::IcmpV6: return ConditionProtocol::IcmpV6();
 		default:
 		{
 			THROW_ERROR("Missing case handler in switch clause");

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -233,7 +233,8 @@ WinFw_ApplyPolicyConnecting(
 	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
 	const wchar_t *tunnelInterfaceAlias,
-	const WinFwAllowedEndpoint *allowedEndpoint
+	const WinFwAllowedEndpoint *allowedEndpoint,
+	const WinFwAllowedTunnelTraffic *allowedTunnelTraffic
 )
 {
 	if (nullptr == g_fwContext)
@@ -258,12 +259,18 @@ WinFw_ApplyPolicyConnecting(
 			THROW_ERROR("Invalid argument: relayClient");
 		}
 
+		if (nullptr == allowedTunnelTraffic)
+		{
+			THROW_ERROR("Invalid argument: allowedTunnelTraffic");
+		}
+
 		return g_fwContext->applyPolicyConnecting(
 			*settings,
 			*relay,
 			relayClient,
 			tunnelInterfaceAlias != nullptr ? std::make_optional(tunnelInterfaceAlias) : std::nullopt,
-			MakeOptional(allowedEndpoint)
+			MakeOptional(allowedEndpoint),
+			*allowedTunnelTraffic
 		) ? WINFW_POLICY_STATUS_SUCCESS : WINFW_POLICY_STATUS_GENERAL_FAILURE;
 	}
 	catch (common::error::WindowsException &err)

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -32,7 +32,9 @@ WinFwSettings;
 enum WinFwProtocol : uint8_t
 {
 	Tcp = 0,
-	Udp = 1
+	Udp = 1,
+	Icmp = 2,
+	IcmpV6 = 3
 };
 
 typedef struct tag_WinFwEndpoint
@@ -54,6 +56,20 @@ typedef struct tag_WinFwAllowedEndpoint
 	WinFwEndpoint endpoint;
 }
 WinFwAllowedEndpoint;
+
+enum WinFwAllowedTunnelTrafficType : uint8_t
+{
+	None,
+	All,
+	Only
+};
+
+typedef struct tag_WinFwAllowedTunnelTraffic
+{
+	WinFwAllowedTunnelTrafficType type;
+	WinFwEndpoint *endpoint;
+}
+WinFwAllowedTunnelTraffic;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Functions
@@ -139,7 +155,7 @@ enum WINFW_POLICY_STATUS
 // Apply restrictions in the firewall that block all traffic, except:
 // - What is specified by settings
 // - Communication with the relay server
-// - Non-DNS traffic inside the VPN tunnel
+// - Specified in-tunnel traffic, except DNS.
 //
 extern "C"
 WINFW_LINKAGE
@@ -150,7 +166,8 @@ WinFw_ApplyPolicyConnecting(
 	const WinFwEndpoint *relay,
 	const wchar_t *relayClient,
 	const wchar_t *tunnelInterfaceAlias,
-	const WinFwAllowedEndpoint *allowedEndpoint
+	const WinFwAllowedEndpoint *allowedEndpoint,
+	const WinFwAllowedTunnelTraffic *allowedTunnelTraffic
 );
 
 //


### PR DESCRIPTION
This PR adds a WireGuard tunnel option to enable PQ safe PSK exchange with the relay gRPC service, currently running on `tcp://10.64.0.1:1337` on a few select servers. The feature can currently only be enabled in the CLI by running `mullvad tunnel wireguard quantum-resistant-tunnel set on`.