### PR TITLE
Correct bash shebang

### DIFF
--- a/ios/build-wireguard-go.sh
+++ b/ios/build-wireguard-go.sh
@@ -25,7 +25,7 @@ fi
 RESOLVED_SOURCE_PACKAGES_PATH="$( cd "$SOURCE_PACKAGES_PATH" && pwd -P )"
 if [ "$RESOLVED_SOURCE_PACKAGES_PATH" == "" ]; then
   echo "Failed to resolve the SourcePackages path: $SOURCE_PACKAGES_PATH"
-  exit -1
+  exit 1
 fi
 
 # Compile the path to the Makefile directory

--- a/ios/build-wireguard-go.sh
+++ b/ios/build-wireguard-go.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 # build-wireguard-go.sh
 # A helper build script for WireGuardGoBridge via ExternalBuildSystem target in Xcode.
 #

--- a/ios/prebuild.sh
+++ b/ios/prebuild.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ -z "$PROJECT_DIR" ]; then
   echo "This script is intended to be executed by Xcode"


### PR DESCRIPTION
Fixing #3617, #3618 and #3619.

@albin-mullvad Does it even make sense to edit `gradlew` or should we let it be?

@pronebird is the change from `exit -1` into `exit 1` going to break something? I don't think negative exit codes are very standard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3625)
<!-- Reviewable:end -->
