### PR TITLE
Silence crate `tower` from the logs

### DIFF
--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -31,6 +31,7 @@ pub const SILENCED_CRATES: &[&str] = &[
     "tokio_reactor",
     "tokio_threadpool",
     "tokio_util",
+    "tower",
     "want",
     "ws",
     "mio",


### PR DESCRIPTION
I saw when trying out the PQ builds of the app that `tower` was `DEBUG` logging to `daemon.log`. I don't think these messages will be helpful in debugging issues, so I will silence it, same way we do with most other third party crates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3633)
<!-- Reviewable:end -->
