### PR TITLE
Don't reset firewall policy in disconnected state unnecessarily

### DIFF
--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -145,14 +145,14 @@ impl TunnelState for DisconnectedState {
                         .set_allow_lan(allow_lan)
                         .expect("Failed to set allow LAN parameter");
 
-                    Self::set_firewall_policy(shared_values, true);
+                    Self::set_firewall_policy(shared_values, false);
                 }
                 SameState(self.into())
             }
             Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
                 if shared_values.allowed_endpoint != endpoint {
                     shared_values.allowed_endpoint = endpoint;
-                    Self::set_firewall_policy(shared_values, true);
+                    Self::set_firewall_policy(shared_values, false);
                 }
                 let _ = tx.send(());
                 SameState(self.into())


### PR DESCRIPTION
Unless "always require VPN" is enabled, there's no need to update the firewall policy when toggling allow LAN on or off, or when setting the allowed endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3637)
<!-- Reviewable:end -->
