### PR TITLE
Fix missing IPC event unregistration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Fix unused dependencies loaded in the service/tile DI graph.
+- Fix missing IPC message unregistration causing multiple copies of some messages to be received.
 
 ### Security
 #### Android

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionManager.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionManager.kt
@@ -42,6 +42,7 @@ class ServiceConnectionManager(
 
         override fun onServiceDisconnected(className: ComponentName) {
             Log.d("mullvad", "UI lost the connection to the service")
+            _connectionState.value.readyContainer()?.onDestroy()
             notify(ServiceConnectionState.Disconnected)
         }
     }
@@ -54,12 +55,14 @@ class ServiceConnectionManager(
     }
 
     fun unbind() {
+        _connectionState.value.readyContainer()?.onDestroy()
         context.unbindService(serviceConnection)
         notify(ServiceConnectionState.Disconnected)
         vpnPermissionRequestHandler = null
     }
 
     fun onDestroy() {
+        _connectionState.value.readyContainer()?.onDestroy()
         serviceNotifier.unsubscribeAll()
         notify(ServiceConnectionState.Disconnected)
         vpnPermissionRequestHandler = null


### PR DESCRIPTION
The app is not unregistering from events before unbinding from the service, which result in messages (duplicates) delivered to old message handlers after the service has been bound again. This issue has been hidden in the current implementation as the messages were not propagated further within the app.

The issue is fixed by making sure to unregister before unbinding.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3646)
<!-- Reviewable:end -->
