### PR TITLE
Refactor SetAccountOperation and more

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -48,7 +48,6 @@ jobs:
             - name: Build and test
               run: |
                   xcodebuild test \
-                      -quiet \
                       -project MullvadVPN.xcodeproj \
                       -scheme MullvadVPNTests \
                       -destination "${destination}" \

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -259,6 +259,14 @@
 		58D67A0A26D7AE3300557C3C /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5823FA4F26CA690600283BF8 /* OSLogHandler.swift */; };
 		58DF28A52417CB4B00E836B0 /* AppStorePaymentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF28A42417CB4B00E836B0 /* AppStorePaymentManager.swift */; };
 		58DF5B7F2852778600E92647 /* OperationSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF5B7E2852778600E92647 /* OperationSmokeTests.swift */; };
+		58DF5B742851FF3F00E92647 /* InputOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF5B732851FF3F00E92647 /* InputOperation.swift */; };
+		58DF5B762852108E00E92647 /* InputInjectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF5B752852108E00E92647 /* InputInjectionBuilder.swift */; };
+		58DF5B782852178600E92647 /* OperationInputInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF5B772852178600E92647 /* OperationInputInjectionTests.swift */; };
+		58DF5B79285217F300E92647 /* TransformOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58059DDB28465E8F002B1049 /* TransformOperation.swift */; };
+		58DF5B7A285217FA00E92647 /* InputInjectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF5B752852108E00E92647 /* InputInjectionBuilder.swift */; };
+		58DF5B7B285217FE00E92647 /* InputOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF5B732851FF3F00E92647 /* InputOperation.swift */; };
+		58DF5B7C28521A9F00E92647 /* ResultOperation+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58059DDF2846823E002B1049 /* ResultOperation+Output.swift */; };
+		58DF5B7D28521AAC00E92647 /* OutputOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58059DDD28468158002B1049 /* OutputOperation.swift */; };
 		58E0A98827C8F46300FE6BDD /* Tunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E0A98727C8F46300FE6BDD /* Tunnel.swift */; };
 		58E20771274672CA00DE5D77 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E20770274672CA00DE5D77 /* LaunchViewController.swift */; };
 		58E6771F24ADFE7800AA26E7 /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E6771E24ADFE7800AA26E7 /* SettingsNavigationController.swift */; };
@@ -537,6 +545,9 @@
 		58D0C7A023F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MullvadVPNScreenshots.swift; sourceTree = "<group>"; };
 		58DF28A42417CB4B00E836B0 /* AppStorePaymentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorePaymentManager.swift; sourceTree = "<group>"; };
 		58DF5B7E2852778600E92647 /* OperationSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationSmokeTests.swift; sourceTree = "<group>"; };
+		58DF5B732851FF3F00E92647 /* InputOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputOperation.swift; sourceTree = "<group>"; };
+		58DF5B752852108E00E92647 /* InputInjectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputInjectionBuilder.swift; sourceTree = "<group>"; };
+		58DF5B772852178600E92647 /* OperationInputInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationInputInjectionTests.swift; sourceTree = "<group>"; };
 		58E0A98727C8F46300FE6BDD /* Tunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tunnel.swift; sourceTree = "<group>"; };
 		58E20770274672CA00DE5D77 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		58E6771E24ADFE7800AA26E7 /* SettingsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
@@ -640,14 +651,16 @@
 				589D28782846250500F9A7B3 /* AsyncOperationQueue.swift */,
 				589D287F28462CB000F9A7B3 /* BackgroundObserver.swift */,
 				589D28812846306C00F9A7B3 /* GroupOperation.swift */,
+				58DF5B752852108E00E92647 /* InputInjectionBuilder.swift */,
+				58DF5B732851FF3F00E92647 /* InputOperation.swift */,
 				5840BE34279EDB16002836BA /* OperationCompletion.swift */,
 				589D28772846250500F9A7B3 /* OperationCondition.swift */,
 				589D28792846250500F9A7B3 /* OperationObserver.swift */,
 				58059DDD28468158002B1049 /* OutputOperation.swift */,
 				5820675D26E6839900655B05 /* PresentAlertOperation.swift */,
 				5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */,
-				58F7D26427EB50A300E4D821 /* ResultOperation.swift */,
 				5842102D282D3FC200F24E46 /* ResultBlockOperation.swift */,
+				58F7D26427EB50A300E4D821 /* ResultOperation.swift */,
 				58059DE128468255002B1049 /* ResultOperation+Fallible.swift */,
 				58059DDF2846823E002B1049 /* ResultOperation+Output.swift */,
 				58059DDB28465E8F002B1049 /* TransformOperation.swift */,
@@ -802,6 +815,7 @@
 			isa = PBXGroup;
 			children = (
 				58DF5B7E2852778600E92647 /* OperationSmokeTests.swift */,
+				58DF5B772852178600E92647 /* OperationInputInjectionTests.swift */,
 				583E1E292848DF67004838B3 /* OperationObserverTests.swift */,
 				580CBFB72848D503007878F0 /* OperationConditionTests.swift */,
 				582AE3112440CA0D00E6733A /* AccountTokenInputTests.swift */,
@@ -1226,6 +1240,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				58DF5B7A285217FA00E92647 /* InputInjectionBuilder.swift in Sources */,
 				582AE3132440CA2700E6733A /* AccountTokenInput.swift in Sources */,
 				58CAF4EF26025954007C5886 /* SimulatorTunnelProvider.swift in Sources */,
 				583E1E232848DE1C004838B3 /* OperationCompletion.swift in Sources */,
@@ -1248,10 +1263,12 @@
 				5896AE88246D7FAF005B36CB /* CustomDateComponentsFormatting.swift in Sources */,
 				5857F23824C8446700CF6F47 /* AsyncBlockOperation.swift in Sources */,
 				582AE3122440CA0D00E6733A /* AccountTokenInputTests.swift in Sources */,
+				58DF5B782852178600E92647 /* OperationInputInjectionTests.swift in Sources */,
 				585DA8A526B14EE000B8C587 /* PacketTunnelStatus.swift in Sources */,
 				58B0A2A9238EE6A100BC001D /* RelayConstraints.swift in Sources */,
 				583E1E282848DE1C004838B3 /* BackgroundObserver.swift in Sources */,
 				5807E2C2243203D000F5FF30 /* StringTests.swift in Sources */,
+				58DF5B7B285217FE00E92647 /* InputOperation.swift in Sources */,
 				5819C2142726CC8D00D6EC38 /* DataSourceSnapshotTests.swift in Sources */,
 				585DA8A326B14E0D00B8C587 /* ServerRelaysResponse.swift in Sources */,
 				583E1E1E2848DE1C004838B3 /* OperationCondition.swift in Sources */,
@@ -1259,11 +1276,14 @@
 				5820676226E75D8500655B05 /* REST.swift in Sources */,
 				58A8055E2716EA6700681642 /* AnyIPAddress.swift in Sources */,
 				583E1E1B2848DE1C004838B3 /* ResultOperation+Fallible.swift in Sources */,
+				58DF5B7D28521AAC00E92647 /* OutputOperation.swift in Sources */,
+				58DF5B79285217F300E92647 /* TransformOperation.swift in Sources */,
 				5857F23024C843ED00CF6F47 /* ChainedError.swift in Sources */,
 				58A8BE81239FBE62006B74AC /* IPEndpoint.swift in Sources */,
 				58871D2325D535D2002297FA /* IPAddressRange+Codable.swift in Sources */,
 				580CBFB82848D503007878F0 /* OperationConditionTests.swift in Sources */,
 				583E1E202848DE1C004838B3 /* OperationObserver.swift in Sources */,
+				58DF5B7C28521A9F00E92647 /* ResultOperation+Output.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1305,6 +1325,7 @@
 				58F1311527E0B2AB007AC5BC /* Result+Extensions.swift in Sources */,
 				585DA88426B0270700B8C587 /* ServerRelaysResponse.swift in Sources */,
 				5875960726F36B3A00BF6711 /* TunnelIPCError.swift in Sources */,
+				58DF5B742851FF3F00E92647 /* InputOperation.swift in Sources */,
 				58F8AC0E25D3F8CE002BE0ED /* ProblemReportReviewViewController.swift in Sources */,
 				58CCA010224249A1004F3011 /* ConnectViewController.swift in Sources */,
 				58059DE02846823E002B1049 /* ResultOperation+Output.swift in Sources */,
@@ -1333,6 +1354,7 @@
 				58FEEB58260B662E00A621A8 /* AutomaticKeyboardResponder.swift in Sources */,
 				5846227326E22A160035F7C2 /* AppStorePaymentObserver.swift in Sources */,
 				58F2E146276A2C9900A79513 /* StopTunnelOperation.swift in Sources */,
+				58DF5B762852108E00E92647 /* InputInjectionBuilder.swift in Sources */,
 				585DA87A26B024F900B8C587 /* RelayCacheError.swift in Sources */,
 				5856D13727450A8A00DFD627 /* UIImage+TintColor.swift in Sources */,
 				58CB0EE024B86751001EF0D8 /* RESTAPIProxy.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		5801C9A527A14B2A0031566A /* TunnelManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5801C9A427A14B2A0031566A /* TunnelManagerState.swift */; };
+		58059DDC28465E8F002B1049 /* TransformOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58059DDB28465E8F002B1049 /* TransformOperation.swift */; };
+		58059DDE28468158002B1049 /* OutputOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58059DDD28468158002B1049 /* OutputOperation.swift */; };
+		58059DE02846823E002B1049 /* ResultOperation+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58059DDF2846823E002B1049 /* ResultOperation+Output.swift */; };
 		58059DE228468255002B1049 /* ResultOperation+Fallible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58059DE128468255002B1049 /* ResultOperation+Fallible.swift */; };
 		5806767C27048E9B00C858CB /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CE5E7B224146470008646E /* PacketTunnelProvider.swift */; };
 		5807483B27DB8A980020ECBF /* WireGuardKitTypes in Frameworks */ = {isa = PBXBuildFile; productRef = 5807483A27DB8A980020ECBF /* WireGuardKitTypes */; };
@@ -343,6 +346,9 @@
 
 /* Begin PBXFileReference section */
 		5801C9A427A14B2A0031566A /* TunnelManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelManagerState.swift; sourceTree = "<group>"; };
+		58059DDB28465E8F002B1049 /* TransformOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformOperation.swift; sourceTree = "<group>"; };
+		58059DDD28468158002B1049 /* OutputOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputOperation.swift; sourceTree = "<group>"; };
+		58059DDF2846823E002B1049 /* ResultOperation+Output.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResultOperation+Output.swift"; sourceTree = "<group>"; };
 		58059DE128468255002B1049 /* ResultOperation+Fallible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResultOperation+Fallible.swift"; sourceTree = "<group>"; };
 		5807E2BF2432038B00F5FF30 /* String+Split.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Split.swift"; sourceTree = "<group>"; };
 		5807E2C1243203D000F5FF30 /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
@@ -637,11 +643,14 @@
 				5840BE34279EDB16002836BA /* OperationCompletion.swift */,
 				589D28772846250500F9A7B3 /* OperationCondition.swift */,
 				589D28792846250500F9A7B3 /* OperationObserver.swift */,
+				58059DDD28468158002B1049 /* OutputOperation.swift */,
 				5820675D26E6839900655B05 /* PresentAlertOperation.swift */,
 				5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */,
 				58F7D26427EB50A300E4D821 /* ResultOperation.swift */,
 				5842102D282D3FC200F24E46 /* ResultBlockOperation.swift */,
 				58059DE128468255002B1049 /* ResultOperation+Fallible.swift */,
+				58059DDF2846823E002B1049 /* ResultOperation+Output.swift */,
+				58059DDB28465E8F002B1049 /* TransformOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -1298,6 +1307,7 @@
 				5875960726F36B3A00BF6711 /* TunnelIPCError.swift in Sources */,
 				58F8AC0E25D3F8CE002BE0ED /* ProblemReportReviewViewController.swift in Sources */,
 				58CCA010224249A1004F3011 /* ConnectViewController.swift in Sources */,
+				58059DE02846823E002B1049 /* ResultOperation+Output.swift in Sources */,
 				588BCF282816D664009ADCEC /* RESTResponseHandler.swift in Sources */,
 				58554F77280AFD5C00013055 /* RESTTaskIdentifier.swift in Sources */,
 				58BFA5C622A7C97F00A6173D /* RelayCacheTracker.swift in Sources */,
@@ -1423,6 +1433,7 @@
 				584592612639B4A200EF967F /* ConsentContentView.swift in Sources */,
 				58B5A895280AACC4009FDE99 /* RESTRequestFactory.swift in Sources */,
 				584EBDBD2747C98F00A0C9FD /* NSAttributedString+Markdown.swift in Sources */,
+				58059DDC28465E8F002B1049 /* TransformOperation.swift in Sources */,
 				5875960A26F371FC00BF6711 /* TunnelIPCSession.swift in Sources */,
 				58FB865E26EA284E00F188BC /* LogFormatting.swift in Sources */,
 				585DA88726B0277200B8C587 /* RESTError.swift in Sources */,
@@ -1444,6 +1455,7 @@
 				58FD5BF22424F7D700112C88 /* UserInterfaceInteractionRestriction.swift in Sources */,
 				5811DE50239014550011EB53 /* NEVPNStatus+Debug.swift in Sources */,
 				58C3A4B222456F1B00340BDB /* AccountInputGroupView.swift in Sources */,
+				58059DDE28468158002B1049 /* OutputOperation.swift in Sources */,
 				589D287B2846250500F9A7B3 /* AsyncOperationQueue.swift in Sources */,
 				58F840B22464491D0044E708 /* ChainedError.swift in Sources */,
 				588BCF24280FE43D009ADCEC /* RESTDevicesProxy.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		58D0C7A223F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D0C7A023F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift */; };
 		58D67A0A26D7AE3300557C3C /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5823FA4F26CA690600283BF8 /* OSLogHandler.swift */; };
 		58DF28A52417CB4B00E836B0 /* AppStorePaymentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF28A42417CB4B00E836B0 /* AppStorePaymentManager.swift */; };
+		58DF5B7F2852778600E92647 /* OperationSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DF5B7E2852778600E92647 /* OperationSmokeTests.swift */; };
 		58E0A98827C8F46300FE6BDD /* Tunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E0A98727C8F46300FE6BDD /* Tunnel.swift */; };
 		58E20771274672CA00DE5D77 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E20770274672CA00DE5D77 /* LaunchViewController.swift */; };
 		58E6771F24ADFE7800AA26E7 /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E6771E24ADFE7800AA26E7 /* SettingsNavigationController.swift */; };
@@ -529,6 +530,7 @@
 		58D0C79F23F1CECF00FE9BA7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		58D0C7A023F1CECF00FE9BA7 /* MullvadVPNScreenshots.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MullvadVPNScreenshots.swift; sourceTree = "<group>"; };
 		58DF28A42417CB4B00E836B0 /* AppStorePaymentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorePaymentManager.swift; sourceTree = "<group>"; };
+		58DF5B7E2852778600E92647 /* OperationSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationSmokeTests.swift; sourceTree = "<group>"; };
 		58E0A98727C8F46300FE6BDD /* Tunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tunnel.swift; sourceTree = "<group>"; };
 		58E20770274672CA00DE5D77 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		58E6771E24ADFE7800AA26E7 /* SettingsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
@@ -790,6 +792,7 @@
 		58B0A2A1238EE67E00BC001D /* MullvadVPNTests */ = {
 			isa = PBXGroup;
 			children = (
+				58DF5B7E2852778600E92647 /* OperationSmokeTests.swift */,
 				583E1E292848DF67004838B3 /* OperationObserverTests.swift */,
 				580CBFB72848D503007878F0 /* OperationConditionTests.swift */,
 				582AE3112440CA0D00E6733A /* AccountTokenInputTests.swift */,
@@ -1228,6 +1231,7 @@
 				585DA8A626B14F5100B8C587 /* SSLPinningURLSessionDelegate.swift in Sources */,
 				58B0A2AC238EE6D500BC001D /* IPAddress+Codable.swift in Sources */,
 				58B0A2AD238EE6EC00BC001D /* MullvadEndpoint.swift in Sources */,
+				58DF5B7F2852778600E92647 /* OperationSmokeTests.swift in Sources */,
 				58FAEDF4245088B300CB0F5B /* KeychainError.swift in Sources */,
 				583E1E252848DE1C004838B3 /* ResultOperation.swift in Sources */,
 				583E1E262848DE1C004838B3 /* ResultBlockOperation.swift in Sources */,

--- a/ios/MullvadVPN/Operations/AsyncOperation.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperation.swift
@@ -40,12 +40,61 @@ import Foundation
 
 /// A base implementation of an asynchronous operation
 class AsyncOperation: Operation {
-    /// A state lock used for manipulating the operation state in a thread safe fashion.
+    /// Mutex lock used for guarding critical sections of operation lifecycle.
+    private let operationLock = NSRecursiveLock()
+
+    /// Mutex lock used to guard `state` and `isCancelled` properties.
+    ///
+    /// This lock must not encompass KVO hooks such as `willChangeValue` and `didChangeValue` to
+    /// prevent deadlocks, since KVO observers may synchronously query the operation state on a
+    /// different thread.
+    ///
+    /// `operationLock` should be used along with `stateLock` to ensure internal state consistency
+    /// when multiple access to `state` or `isCancelled` is necessary, such as when testing
+    /// the value before modifying it.
     private let stateLock = NSRecursiveLock()
 
+    /// Backing variable for `state`.
+    /// Access must be guarded with `stateLock`.
+    private var _state: State = .initialized
+
+    /// Backing variable for `_isCancelled`.
+    /// Access must be guarded with `stateLock`.
+    private var __isCancelled: Bool = false
+
     /// Operation state.
-    @objc private var state: State = .initialized
-    private var _isCancelled = false
+    @objc private var state: State {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+
+            return _state
+        }
+        set(newState) {
+            willChangeValue(for: \.state)
+            stateLock.lock()
+            assert(_state < newState)
+            _state = newState
+            stateLock.unlock()
+            didChangeValue(for: \.state)
+        }
+    }
+
+    private var _isCancelled: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+
+            return __isCancelled
+        }
+        set {
+            willChangeValue(for: \.isCancelled)
+            stateLock.lock()
+            __isCancelled = newValue
+            stateLock.unlock()
+            didChangeValue(for: \.isCancelled)
+        }
+    }
 
     final override var isReady: Bool {
         stateLock.lock()
@@ -57,11 +106,11 @@ class AsyncOperation: Operation {
         }
 
         // Mark operation ready when cancelled, so that operation queue could flush it faster.
-        guard !_isCancelled else {
+        guard !__isCancelled else {
             return true
         }
 
-        switch state {
+        switch _state {
         case .initialized, .pending, .evaluatingConditions:
             return false
 
@@ -71,23 +120,14 @@ class AsyncOperation: Operation {
     }
 
     final override var isExecuting: Bool {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
         return state == .executing
     }
 
     final override var isFinished: Bool {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
         return state == .finished
     }
 
     final override var isCancelled: Bool {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
         return _isCancelled
     }
 
@@ -100,17 +140,17 @@ class AsyncOperation: Operation {
     private var _observers: [OperationObserver] = []
 
     final var observers: [OperationObserver] {
-        stateLock.lock()
-        defer { stateLock.unlock() }
+        operationLock.lock()
+        defer { operationLock.unlock() }
 
         return _observers
     }
 
     final func addObserver(_ observer: OperationObserver) {
-        stateLock.lock()
+        operationLock.lock()
         assert(state < .executing)
         _observers.append(observer)
-        stateLock.unlock()
+        operationLock.unlock()
         observer.didAttach(to: self)
     }
 
@@ -119,26 +159,26 @@ class AsyncOperation: Operation {
     private var _conditions: [OperationCondition] = []
 
     final var conditions: [OperationCondition] {
-        stateLock.lock()
-        defer { stateLock.unlock() }
+        operationLock.lock()
+        defer { operationLock.unlock() }
 
         return _conditions
     }
 
     func addCondition(_ condition: OperationCondition) {
-        stateLock.lock()
+        operationLock.lock()
         assert(state < .evaluatingConditions)
         _conditions.append(condition)
-        stateLock.unlock()
+        operationLock.unlock()
     }
 
     private func evaluateConditions() {
         guard !_conditions.isEmpty else {
-            setState(.ready)
+            state = .ready
             return
         }
 
-        setState(.evaluatingConditions)
+        state = .evaluatingConditions
 
         var results = [Bool](repeating: false, count: _conditions.count)
         let group = DispatchGroup()
@@ -159,8 +199,8 @@ class AsyncOperation: Operation {
     }
 
     private func didEvaluateConditions(_ results: [Bool]) {
-        stateLock.lock()
-        defer { stateLock.unlock() }
+        operationLock.lock()
+        defer { operationLock.unlock() }
 
         guard state < .ready else { return }
 
@@ -169,7 +209,7 @@ class AsyncOperation: Operation {
             cancel()
         }
 
-        setState(.ready)
+        state = .ready
     }
 
     // MARK: -
@@ -179,9 +219,37 @@ class AsyncOperation: Operation {
     init(dispatchQueue: DispatchQueue? = nil) {
         self.dispatchQueue = dispatchQueue ?? DispatchQueue(label: "AsyncOperation.dispatchQueue")
         super.init()
+
+        addObserver(self, forKeyPath: "isReady", options: [], context: &Self.observerContext)
+    }
+
+    deinit {
+        removeObserver(self, forKeyPath: "isReady", context: &Self.observerContext)
     }
 
     // MARK: - KVO
+
+    private static var observerContext = 0
+
+    override func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey : Any]?,
+        context: UnsafeMutableRawPointer?
+    )
+    {
+        if context == &Self.observerContext {
+            checkReadiness()
+            return
+        }
+
+        super.observeValue(
+            forKeyPath: keyPath,
+            of: object,
+            change: change,
+            context: context
+        )
+    }
 
     @objc class func keyPathsForValuesAffectingIsReady() -> Set<String> {
         return ["state"]
@@ -211,17 +279,17 @@ class AsyncOperation: Operation {
     }
 
     private func _start() {
-        stateLock.lock()
+        operationLock.lock()
         if _isCancelled {
-            stateLock.unlock()
+            operationLock.unlock()
             finish()
         } else {
-            setState(.executing)
+            state = .executing
 
             for observer in _observers {
                 observer.operationDidStart(self)
             }
-            stateLock.unlock()
+            operationLock.unlock()
 
             main()
         }
@@ -234,15 +302,12 @@ class AsyncOperation: Operation {
     final override func cancel() {
         var notifyDidCancel = false
 
-        stateLock.lock()
+        operationLock.lock()
         if !_isCancelled {
-            willChangeValue(for: \.isCancelled)
             _isCancelled = true
-            didChangeValue(for: \.isCancelled)
-
             notifyDidCancel = true
         }
-        stateLock.unlock()
+        operationLock.unlock()
 
         super.cancel()
 
@@ -260,12 +325,12 @@ class AsyncOperation: Operation {
     func finish() {
         var notifyDidFinish = false
 
-        stateLock.lock()
+        operationLock.lock()
         if state < .finished {
-            setState(.finished)
+            state = .finished
             notifyDidFinish = true
         }
-        stateLock.unlock()
+        operationLock.unlock()
 
         if notifyDidFinish {
             dispatchQueue.async {
@@ -280,56 +345,27 @@ class AsyncOperation: Operation {
 
     // MARK: - Private
 
-    private func setState(_ newState: State) {
-        willChangeValue(for: \.state)
-        assert(state < newState)
-        state = newState
-        didChangeValue(for: \.state)
-    }
-
-    private func dependenciesDidFinish() {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
-        guard state == .pending && !_isCancelled else { return }
-
-        precondition(super.isReady, "Expect super.isReady to be true.")
-
-        evaluateConditions()
-    }
-
     func didEnqueue() {
-        stateLock.lock()
+        operationLock.lock()
+        defer { operationLock.unlock() }
+
         guard state == .initialized else {
-            stateLock.unlock()
             return
         }
-        setState(.pending)
-        stateLock.unlock()
 
-        let group = DispatchGroup()
-        var observers = [NSKeyValueObservation]()
-
-        for dependency in dependencies {
-            group.enter()
-
-            let observer = dependency.observe(\.isFinished, options: [.initial]) { dependency, _ in
-                if dependency.isFinished {
-                    group.leave()
-                }
-            }
-
-            observers.append(observer)
-        }
-
-        group.notify(queue: dispatchQueue) {
-            for observer in observers {
-                observer.invalidate()
-            }
-
-            self.dependenciesDidFinish()
-        }
+        state = .pending
     }
+
+    private func checkReadiness() {
+        operationLock.lock()
+
+        if state == .pending, !_isCancelled, super.isReady {
+            evaluateConditions()
+        }
+
+        operationLock.unlock()
+    }
+
 
     // MARK: - Subclass overrides
 

--- a/ios/MullvadVPN/Operations/AsyncOperationQueue.swift
+++ b/ios/MullvadVPN/Operations/AsyncOperationQueue.swift
@@ -37,11 +37,9 @@ class AsyncOperationQueue: OperationQueue {
         }
 
         if wait {
-            let blockOperation = BlockOperation()
-            blockOperation.addDependencies(operations)
-
-            addOperation(blockOperation)
-            blockOperation.waitUntilFinished()
+            for operation in operations {
+                operation.waitUntilFinished()
+            }
         }
     }
 }

--- a/ios/MullvadVPN/Operations/InputInjectionBuilder.swift
+++ b/ios/MullvadVPN/Operations/InputInjectionBuilder.swift
@@ -1,0 +1,77 @@
+//
+//  InputInjectionBuilder.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 09/06/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+protocol OperationInputContext {
+    associatedtype Input
+
+    func reduce() -> Input?
+}
+
+class InputInjectionBuilder<OperationType, Context> where OperationType: InputOperation {
+    typealias InputBlock = (inout Context) -> Void
+
+    private let operation: OperationType
+    private var context: Context
+    private var inputBlocks: [InputBlock] = []
+
+    init(operation: OperationType, context: Context) {
+        self.operation = operation
+        self.context = context
+    }
+
+    func inject<T>(
+        from dependency: T,
+        assignOutputTo keyPath: WritableKeyPath<Context, T.Output?>
+    ) -> Self
+        where T: OutputOperation
+    {
+        return inject(from: dependency) { context, output in
+            context[keyPath: keyPath] = output
+        }
+    }
+
+    func inject<T>(
+        from dependency: T,
+        via block: @escaping (inout Context, T.Output) -> Void
+    ) -> Self
+        where T: OutputOperation
+    {
+        inputBlocks.append { context in
+            if let output = dependency.output {
+                block(&context, output)
+            }
+        }
+
+        operation.addDependency(dependency)
+
+        return self
+    }
+
+    func reduce(_ reduceBlock: @escaping (Context) -> OperationType.Input?) {
+        operation.setInputBlock {
+            for inputBlock in self.inputBlocks {
+                inputBlock(&self.context)
+            }
+
+            return reduceBlock(self.context)
+        }
+    }
+}
+
+extension InputInjectionBuilder
+    where Context: OperationInputContext,
+          Context.Input == OperationType.Input
+{
+    func reduce() {
+        reduce { context in
+            return context.reduce()
+        }
+    }
+}

--- a/ios/MullvadVPN/Operations/InputOperation.swift
+++ b/ios/MullvadVPN/Operations/InputOperation.swift
@@ -1,0 +1,47 @@
+//
+//  InputOperation.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 09/06/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+protocol InputOperation: Operation {
+    associatedtype Input
+
+    var input: Input? { get }
+
+    func setInputBlock(_ block: @escaping () -> Input?)
+
+    func inject<T>(from dependency: T)
+        where T: OutputOperation, T.Output == Input
+
+    func inject<T>(from dependency: T, via block: @escaping (T.Output) -> Input)
+        where T: OutputOperation
+}
+
+extension InputOperation {
+    func inject<T>(from dependency: T) where T: OutputOperation, T.Output == Input {
+        inject(from: dependency, via: { $0 })
+    }
+
+    func inject<T>(from dependency: T, via block: @escaping (T.Output) -> Input)
+        where T: OutputOperation
+    {
+        setInputBlock {
+            return dependency.output.map { value in
+                return block(value)
+            }
+        }
+        addDependency(dependency)
+    }
+
+    func injectMany<Context>(context: Context) -> InputInjectionBuilder<Self, Context> {
+        return InputInjectionBuilder(
+            operation: self,
+            context: context
+        )
+    }
+}

--- a/ios/MullvadVPN/Operations/OutputOperation.swift
+++ b/ios/MullvadVPN/Operations/OutputOperation.swift
@@ -1,0 +1,15 @@
+//
+//  OutputOperation.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 31/05/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+protocol OutputOperation: Operation {
+    associatedtype Output
+
+    var output: Output? { get }
+}

--- a/ios/MullvadVPN/Operations/ResultOperation+Output.swift
+++ b/ios/MullvadVPN/Operations/ResultOperation+Output.swift
@@ -1,0 +1,15 @@
+//
+//  ResultOperation+Output.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 31/05/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension ResultOperation: OutputOperation {
+    var output: Success? {
+        return completion?.value
+    }
+}

--- a/ios/MullvadVPN/Operations/TransformOperation.swift
+++ b/ios/MullvadVPN/Operations/TransformOperation.swift
@@ -1,0 +1,127 @@
+//
+//  TransformOperation.swift
+//  AsyncOperationQueueTest
+//
+//  Created by pronebird on 31/05/2022.
+//
+
+import Foundation
+
+final class TransformOperation<Input, Output, Failure: Error>: ResultOperation<Output, Failure> {
+    typealias ExecutionBlock = ((Input, TransformOperation<Input, Output, Failure>) -> Void)
+    typealias ThrowingExecutionBlock = ((Input) throws -> Output)
+
+    private var input: Input?
+    private var executionBlock: ExecutionBlock?
+    private var configurationBlocks: [() -> Void] = []
+    private var cancellationBlocks: [() -> Void] = []
+
+    init(
+        dispatchQueue: DispatchQueue? = nil,
+        input: Input? = nil,
+        block: ExecutionBlock? = nil
+    )
+    {
+        self.input = input
+        self.executionBlock = block
+
+        super.init(dispatchQueue: dispatchQueue)
+    }
+
+    convenience init(
+        dispatchQueue: DispatchQueue?,
+        input: Input? = nil,
+        block: @escaping ThrowingExecutionBlock
+    )
+    {
+        self.init(
+            dispatchQueue: dispatchQueue,
+            input: input,
+            block: Self.wrapThrowingBlock(block)
+        )
+    }
+
+    override func main() {
+        for configurationBlock in configurationBlocks {
+            configurationBlock()
+        }
+
+        configurationBlocks.removeAll()
+
+        guard let input = input, let executionBlock = executionBlock else {
+            finish(completion: .cancelled)
+            return
+        }
+
+        executionBlock(input, self)
+    }
+
+    override func operationDidCancel() {
+        let blocks = cancellationBlocks
+        cancellationBlocks.removeAll()
+
+        for block in blocks {
+            block()
+        }
+    }
+
+    override func operationDidFinish() {
+        cancellationBlocks.removeAll()
+        executionBlock = nil
+    }
+
+    func setExecutionBlock(_ block: @escaping ExecutionBlock) {
+        dispatchQueue.async {
+            assert(!self.isExecuting && !self.isFinished)
+            self.executionBlock = block
+        }
+    }
+
+    func setExecutionBlock(_ block: @escaping ThrowingExecutionBlock) {
+        setExecutionBlock(Self.wrapThrowingBlock(block))
+    }
+
+    func addCancellationBlock(_ block: @escaping () -> Void) {
+        dispatchQueue.async {
+            if self.isCancelled {
+                block()
+            } else {
+                self.cancellationBlocks.append(block)
+            }
+        }
+    }
+
+    func inject<T>(from dependency: T) where T: OutputOperation, T.Output == Input {
+        inject(from: dependency, via: { $0 })
+    }
+
+    func inject<T>(from dependency: T, via block: @escaping (T.Output) -> Input) where T: OutputOperation {
+        dispatchQueue.async {
+            self.configurationBlocks.append { [weak self] in
+                guard let self = self else { return }
+
+                if let output = dependency.output {
+                    self.input = block(output)
+                }
+            }
+
+        }
+        addDependency(dependency)
+    }
+
+    private class func wrapThrowingBlock(_ executionBlock: @escaping ThrowingExecutionBlock) -> ExecutionBlock {
+        return { input, operation in
+            do {
+                let value = try executionBlock(input)
+
+                operation.finish(completion: .success(value))
+            } catch {
+                let castedError = error as! Failure
+
+                operation.finish(completion: .failure(castedError))
+            }
+        }
+    }
+
+}
+

--- a/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
@@ -33,6 +33,32 @@ enum SetAccountAction {
     }
 }
 
+private struct SetAccountResult {
+    let accountData: StoredAccountData
+    let privateKey: PrivateKey
+    let device: REST.Device
+}
+
+private struct SetAccountContext: OperationInputContext {
+    var accountData: StoredAccountData?
+    var privateKey: PrivateKey?
+    var device: REST.Device?
+
+    func reduce() -> SetAccountResult? {
+        guard let accountData = accountData,
+              let privateKey = privateKey,
+              let device = device else {
+                  return nil
+              }
+
+        return SetAccountResult(
+            accountData: accountData,
+            privateKey: privateKey,
+            device: device
+        )
+    }
+}
+
 class SetAccountOperation: ResultOperation<StoredAccountData?, TunnelManager.Error> {
     typealias WillDeleteVPNConfigurationHandler = () -> Void
 
@@ -40,10 +66,12 @@ class SetAccountOperation: ResultOperation<StoredAccountData?, TunnelManager.Err
     private let accountsProxy: REST.AccountsProxy
     private let devicesProxy: REST.DevicesProxy
     private let action: SetAccountAction
-    private var task: Cancellable?
-
     private var willDeleteVPNConfigurationHandler: WillDeleteVPNConfigurationHandler?
-    private let logger = Logger(label: "TunnelManager.SetAccountOperation")
+
+    private let logger = Logger(label: "SetAccountOperation")
+    private let operationQueue = AsyncOperationQueue()
+
+    private var children: [Operation] = []
 
     init(
         dispatchQueue: DispatchQueue,
@@ -51,8 +79,7 @@ class SetAccountOperation: ResultOperation<StoredAccountData?, TunnelManager.Err
         accountsProxy: REST.AccountsProxy,
         devicesProxy: REST.DevicesProxy,
         action: SetAccountAction,
-        willDeleteVPNConfigurationHandler: @escaping WillDeleteVPNConfigurationHandler,
-        completionHandler: @escaping CompletionHandler
+        willDeleteVPNConfigurationHandler: @escaping WillDeleteVPNConfigurationHandler
     )
     {
         self.state = state
@@ -61,284 +88,385 @@ class SetAccountOperation: ResultOperation<StoredAccountData?, TunnelManager.Err
         self.action = action
         self.willDeleteVPNConfigurationHandler = willDeleteVPNConfigurationHandler
 
-        super.init(
-            dispatchQueue: dispatchQueue,
-            completionQueue: dispatchQueue,
-            completionHandler: completionHandler
-        )
+        super.init(dispatchQueue: dispatchQueue)
     }
 
     override func main() {
-        if let tunnelSettings = self.state.tunnelSettings {
-            self.deleteDevice(
-                accountNumber: tunnelSettings.account.number,
-                deviceIdentifier: tunnelSettings.device.identifier
-            )
-        } else {
-            self.fetchAccountData()
-        }
-    }
+        var enqueueOperations: [AsyncOperation] = []
 
-    private func deleteDevice(accountNumber: String, deviceIdentifier: String) {
-        logger.debug("Delete current device...")
+        // 1. Delete current device.
+        var deleteDeviceOperation: AsyncOperation?
 
-        task = devicesProxy.deleteDevice(
-            accountNumber: accountNumber,
-            identifier: deviceIdentifier,
-            retryStrategy: .default,
-            completion: { [weak self] completion in
-                self?.dispatchQueue.async {
-                    self?.didDeleteDevice(completion)
-                }
-            })
-    }
+        if let tunnelSettings = state.tunnelSettings {
+            deleteDeviceOperation = ResultBlockOperation<Void, TunnelManager.Error>(
+                dispatchQueue: dispatchQueue
+            ) { operation in
+                self.logger.debug("Delete current device...")
 
-    private func didDeleteDevice(_ completion: OperationCompletion<Bool, REST.Error>) {
-        let mappedCompletion = completion.mapError { error -> TunnelManager.Error in
-            logger.error(chainedError: error, message: "Failed to delete device.")
+                let task = self.devicesProxy.deleteDevice(
+                    accountNumber: tunnelSettings.account.number,
+                    identifier: tunnelSettings.device.identifier,
+                    retryStrategy: .default
+                ) { completion in
+                    let mappedCompletion = completion.mapError { error -> TunnelManager.Error in
+                        self.logger.error(chainedError: error, message: "Failed to delete device.")
 
-            return .deleteDevice(error)
-        }
-
-        guard let isDeleted = mappedCompletion.value else {
-            finish(completion: mappedCompletion.assertNoSuccess())
-            return
-        }
-
-        if isDeleted {
-            logger.debug("Deleted device.")
-        } else {
-            logger.debug("Device is already deleted.")
-        }
-
-        state.tunnelSettings = nil
-
-        deleteSettingsAndVPNConfiguration { error in
-            if let error = error {
-                self.finish(completion: .failure(error))
-            } else {
-                self.fetchAccountData()
-            }
-        }
-    }
-
-    private func fetchAccountData() {
-        switch action {
-        case .unset:
-            logger.debug("Account number is unset.")
-
-            finish(completion: .success(nil))
-
-        case .new:
-            logger.debug("Create new account...")
-
-            task = accountsProxy.createAccount(retryStrategy: .default) { [weak self] completion in
-                self?.dispatchQueue.async {
-                    self?.didCreateAccount(completion: completion)
-                }
-            }
-
-        case .existing(let accountNumber):
-            logger.debug("Request account data...")
-
-            task = accountsProxy.getAccountData(
-                accountNumber: accountNumber,
-                retryStrategy: .default,
-                completion: { [weak self] completion in
-                    self?.dispatchQueue.async {
-                        self?.didReceiveAccountData(accountNumber: accountNumber, completion: completion)
+                        return .deleteDevice(error)
                     }
-                })
-        }
-    }
 
-    private func didCreateAccount(completion: OperationCompletion<REST.NewAccountData, REST.Error>) {
-        let mappedCompletion = completion.mapError { error -> TunnelManager.Error in
-            logger.error(
-                chainedError: AnyChainedError(error),
-                message: "Failed to create new account."
-            )
+                    guard let isDeleted = mappedCompletion.value else {
+                        operation.finish(completion: mappedCompletion.assertNoSuccess())
+                        return
+                    }
 
-            return .createAccount(error)
-        }
+                    if isDeleted {
+                        self.logger.debug("Deleted device.")
+                    } else {
+                        self.logger.debug("Device is already deleted.")
+                    }
 
-        guard let newAccountData = mappedCompletion.value else {
-            finish(completion: mappedCompletion.assertNoSuccess())
-            return
-        }
-
-        logger.debug("Created new account. Updating settings...")
-
-        createDevice(
-            storedAccountData: StoredAccountData(
-                identifier: newAccountData.id,
-                number: newAccountData.number,
-                expiry: newAccountData.expiry
-            )
-        )
-    }
-
-    private func didReceiveAccountData(accountNumber: String, completion: OperationCompletion<REST.AccountData, REST.Error>) {
-        let mappedCompletion = completion.mapError { error -> TunnelManager.Error in
-            logger.error(
-                chainedError: AnyChainedError(error),
-                message: "Failed to receive account data."
-            )
-
-            return .getAccountData(error)
-        }
-
-        guard let accountData = mappedCompletion.value else {
-            finish(completion: mappedCompletion.assertNoSuccess())
-            return
-        }
-
-        logger.debug("Received account data.")
-
-        createDevice(
-            storedAccountData: StoredAccountData(
-                identifier: accountData.id,
-                number: accountNumber,
-                expiry: accountData.expiry
-            )
-        )
-    }
-
-    private func createDevice(storedAccountData: StoredAccountData) {
-        logger.debug("Store last used account.")
-
-        do {
-            try SettingsManager.setLastUsedAccount(storedAccountData.number)
-        } catch {
-            logger.error(
-                chainedError: AnyChainedError(error),
-                message: "Failed to store last used account number."
-            )
-        }
-
-        logger.debug("Create device...")
-
-        let privateKey = PrivateKey()
-
-        let request = REST.CreateDeviceRequest(
-            publicKey: privateKey.publicKey,
-            hijackDNS: false
-        )
-
-        task = devicesProxy.createDevice(
-            accountNumber: storedAccountData.number,
-            request: request,
-            retryStrategy: .default,
-            completion: { [weak self] completion in
-                self?.dispatchQueue.async {
-                    self?.didCreateDevice(
-                        storedAccountData: storedAccountData,
-                        privateKey: privateKey,
-                        completion: completion
-                    )
+                    operation.finish(completion: .success(()))
                 }
-            })
-    }
 
-    private func didCreateDevice(
-        storedAccountData: StoredAccountData,
-        privateKey: PrivateKey,
-        completion: OperationCompletion<REST.Device, REST.Error>
-    )
-    {
-        let mappedCompletion = completion.mapError { error -> TunnelManager.Error in
-            logger.error(chainedError: error, message: "Failed to create device.")
-            return .createDevice(error)
+                operation.addCancellationBlock {
+                    task.cancel()
+                }
+            }
+
+            enqueueOperations.append(deleteDeviceOperation!)
         }
 
-        guard let device = mappedCompletion.value else {
-            finish(completion: mappedCompletion.assertNoSuccess())
-            return
-        }
+        // 2. Delete settings.
 
-        logger.debug("Created device. Saving settings...")
+        let deleteSettingsOperation = ResultBlockOperation<Void, TunnelManager.Error>(
+            dispatchQueue: dispatchQueue
+        ) { operation in
+            self.logger.debug("Delete settings.")
 
-        let tunnelSettings = TunnelSettingsV2(
-            account: storedAccountData,
-            device: StoredDeviceData(
-                creationDate: device.created,
-                identifier: device.id,
-                name: device.name,
-                hijackDNS: device.hijackDNS,
-                ipv4Address: device.ipv4Address,
-                ipv6Address: device.ipv6Address,
-                wgKeyData: StoredWgKeyData(
-                    creationDate: Date(),
-                    privateKey: privateKey
+            do {
+                try SettingsManager.deleteSettings()
+            } catch .itemNotFound as KeychainError {
+                self.logger.debug("Settings are already deleted.")
+            } catch {
+                self.logger.error(
+                    chainedError: AnyChainedError(error),
+                    message: "Failed to delete settings."
                 )
-            ),
-            relayConstraints: RelayConstraints(),
-            dnsSettings: DNSSettings()
+                operation.finish(completion: .failure(.deleteSettings(error)))
+                return
+            }
+
+            // Tell the caller to unsubscribe from VPN status notifications.
+            self.willDeleteVPNConfigurationHandler?()
+            self.willDeleteVPNConfigurationHandler = nil
+
+            // Reset tunnel state to disconnected
+            self.state.tunnelStatus.reset(to: .disconnected)
+
+            // Remove tunnel settins
+            self.state.tunnelSettings = nil
+
+            // Finish immediately if tunnel provider is not set.
+            guard let tunnel = self.state.tunnel else {
+                operation.finish(completion: .success(()))
+                return
+            }
+
+            // Remove VPN configuration
+            tunnel.removeFromPreferences { error in
+                self.dispatchQueue.async {
+                    // Ignore error but log it
+                    if let error = error {
+                        self.logger.error(
+                            chainedError: AnyChainedError(error),
+                            message: "Failed to remove VPN configuration."
+                        )
+                    }
+
+                    self.state.setTunnel(nil, shouldRefreshTunnelState: false)
+
+                    operation.finish(completion: .success(()))
+                }
+            }
+        }
+
+        deleteSettingsOperation.addCondition(
+            NoFailedDependenciesCondition(ignoreCancellations: false)
         )
 
-        do {
-            try SettingsManager.writeSettings(tunnelSettings)
+        if let deleteDeviceOperation = deleteDeviceOperation {
+            deleteSettingsOperation.addDependency(deleteDeviceOperation)
+        }
 
-            state.tunnelSettings = tunnelSettings
+        enqueueOperations.append(deleteSettingsOperation)
 
-            finish(completion: .success(storedAccountData))
-        } catch {
-            logger.error(
-                chainedError: AnyChainedError(error),
-                message: "Failed to write settings."
+        // 3. Get or create account.
+
+        if let accountOperation = getAccountDataOperation() {
+            accountOperation.addCondition(
+                NoFailedDependenciesCondition(ignoreCancellations: false)
             )
-            finish(completion: .failure(.writeSettings(error)))
-        }
-    }
+            accountOperation.addDependency(deleteSettingsOperation)
 
-    private func deleteSettingsAndVPNConfiguration(
-        completionHandler: @escaping (TunnelManager.Error?) -> Void
-    ) {
-        // Delete keychain entry.
-        do {
-            try SettingsManager.deleteSettings()
-        } catch .itemNotFound as KeychainError {
-            logger.debug("Settings are already deleted.")
-        } catch {
-            logger.error(
-                chainedError: AnyChainedError(error),
-                message: "Failed to delete settings."
-            )
-            completionHandler(.deleteSettings(error))
-            return
-        }
+            // 4. Create device.
 
-        // Tell the caller to unsubscribe from VPN status notifications.
-        willDeleteVPNConfigurationHandler?()
-        willDeleteVPNConfigurationHandler = nil
+            let createDeviceOperation = TransformOperation<
+                StoredAccountData,
+                (PrivateKey, REST.Device),
+                TunnelManager.Error
+            >(dispatchQueue: dispatchQueue)
 
-        // Reset tunnel state to disconnected
-        state.tunnelStatus.reset(to: .disconnected)
+            createDeviceOperation.setExecutionBlock { storedAccountData, operation in
+                self.logger.debug("Store last used account.")
 
-        // Remove tunnel settins
-        state.tunnelSettings = nil
-
-        // Finish immediately if tunnel provider is not set.
-        guard let tunnel = state.tunnel else {
-            completionHandler(nil)
-            return
-        }
-
-        // Remove VPN configuration
-        tunnel.removeFromPreferences { error in
-            self.dispatchQueue.async {
-                // Ignore error but log it
-                if let error = error {
+                do {
+                    try SettingsManager.setLastUsedAccount(storedAccountData.number)
+                } catch {
                     self.logger.error(
                         chainedError: AnyChainedError(error),
-                        message: "Failed to remove VPN configuration."
+                        message: "Failed to store last used account number."
                     )
                 }
 
-                self.state.setTunnel(nil, shouldRefreshTunnelState: false)
+                self.logger.debug("Create device...")
 
-                completionHandler(nil)
+                let privateKey = PrivateKey()
+
+                let request = REST.CreateDeviceRequest(
+                    publicKey: privateKey.publicKey,
+                    hijackDNS: false
+                )
+
+                let task = self.devicesProxy.createDevice(
+                    accountNumber: storedAccountData.number,
+                    request: request,
+                    retryStrategy: .default
+                ) { completion in
+                    let mappedCompletion = completion
+                        .map { device in
+                            return (privateKey, device)
+                        }
+                        .mapError { error -> TunnelManager.Error in
+                            self.logger.error(chainedError: error, message: "Failed to create device.")
+                            return .createDevice(error)
+                        }
+
+                    operation.finish(completion: mappedCompletion)
+                }
+
+                operation.addCancellationBlock {
+                    task.cancel()
+                }
             }
+
+            createDeviceOperation.addCondition(
+                NoFailedDependenciesCondition(ignoreCancellations: false)
+            )
+
+            createDeviceOperation.inject(from: accountOperation)
+
+            // 5. Save settings.
+
+            let saveSettingsOperation = TransformOperation<
+                SetAccountResult,
+                StoredAccountData,
+                TunnelManager.Error
+            >(dispatchQueue: dispatchQueue)
+
+            saveSettingsOperation.setExecutionBlock { input, operation in
+                self.logger.debug("Saving settings...")
+
+                let device = input.device
+                let tunnelSettings = TunnelSettingsV2(
+                    account: input.accountData,
+                    device: StoredDeviceData(
+                        creationDate: device.created,
+                        identifier: device.id,
+                        name: device.name,
+                        hijackDNS: device.hijackDNS,
+                        ipv4Address: device.ipv4Address,
+                        ipv6Address: device.ipv6Address,
+                        wgKeyData: StoredWgKeyData(
+                            creationDate: Date(),
+                            privateKey: input.privateKey
+                        )
+                    ),
+                    relayConstraints: RelayConstraints(),
+                    dnsSettings: DNSSettings()
+                )
+
+                do {
+                    try SettingsManager.writeSettings(tunnelSettings)
+
+                    self.state.tunnelSettings = tunnelSettings
+
+                    operation.finish(completion: .success(input.accountData))
+                } catch {
+                    self.logger.error(
+                        chainedError: AnyChainedError(error),
+                        message: "Failed to write settings."
+                    )
+                    operation.finish(completion: .failure(.writeSettings(error)))
+                }
+            }
+
+            saveSettingsOperation.addCondition(
+                NoFailedDependenciesCondition(ignoreCancellations: false)
+            )
+
+            saveSettingsOperation.injectMany(context: SetAccountContext())
+                .inject(from: accountOperation, assignOutputTo: \.accountData)
+                .inject(from: createDeviceOperation, via: { context, output in
+                    let (privateKey, device) = output
+
+                    context.privateKey = privateKey
+                    context.device = device
+                })
+                .reduce()
+
+            saveSettingsOperation.addBlockObserver(
+                OperationBlockObserver(didFinish: { operation in
+                    self.completeOperation(accountData: operation.output)
+                })
+            )
+
+            enqueueOperations.append(contentsOf: [
+                accountOperation,
+                createDeviceOperation,
+                saveSettingsOperation
+            ])
+        } else {
+            // Add finishing operation.
+            let finishingOperation = BlockOperation()
+            finishingOperation.completionBlock = { [weak self] in
+                self?.completeOperation(accountData: nil)
+            }
+            finishingOperation.addDependencies(enqueueOperations)
+            operationQueue.addOperation(finishingOperation)
+        }
+
+
+        // 6. Enqueue child operations.
+
+        children = enqueueOperations
+
+        operationQueue.addOperations(enqueueOperations, waitUntilFinished: false)
+    }
+
+    override func operationDidCancel() {
+        operationQueue.cancelAllOperations()
+    }
+
+    private func completeOperation(accountData: StoredAccountData?) {
+        guard !isCancelled else {
+            finish(completion: .cancelled)
+            return
+        }
+
+        let errors = children.compactMap { operation -> TunnelManager.Error? in
+            let fallibleOperation = operation as? FallibleOperation
+
+            return fallibleOperation?.error as? TunnelManager.Error
+        }
+
+        if let error = errors.first {
+            finish(completion: .failure(error))
+        } else {
+            finish(completion: .success(accountData))
+        }
+    }
+
+    private func getAccountDataOperation() -> ResultOperation<StoredAccountData, TunnelManager.Error>?
+    {
+        switch action {
+        case .new:
+            let operation = ResultBlockOperation<
+                StoredAccountData,
+                TunnelManager.Error
+            >(dispatchQueue: dispatchQueue)
+
+            operation.setExecutionBlock { operation in
+                self.logger.debug("Create new account...")
+
+                let task = self.accountsProxy.createAccount(retryStrategy: .default) { completion in
+                    let mappedCompletion = completion.mapError { error -> TunnelManager.Error in
+                        self.logger.error(
+                            chainedError: AnyChainedError(error),
+                            message: "Failed to create new account."
+                        )
+
+                        return .createAccount(error)
+                    }
+
+                    guard let newAccountData = mappedCompletion.value else {
+                        operation.finish(completion: mappedCompletion.assertNoSuccess())
+                        return
+                    }
+
+                    self.logger.debug("Created new account.")
+
+                    let storedAccountData = StoredAccountData(
+                        identifier: newAccountData.id,
+                        number: newAccountData.number,
+                        expiry: newAccountData.expiry
+                    )
+
+                    operation.finish(completion: .success(storedAccountData))
+                }
+
+                operation.addCancellationBlock {
+                    task.cancel()
+                }
+            }
+
+            return operation
+
+        case .existing(let accountNumber):
+            let operation = ResultBlockOperation<
+                StoredAccountData, TunnelManager.Error
+            >(dispatchQueue: dispatchQueue)
+
+            operation.setExecutionBlock { operation in
+                self.logger.debug("Request account data...")
+
+                let task = self.accountsProxy.getAccountData(
+                    accountNumber: accountNumber,
+                    retryStrategy: .default
+                ) { completion in
+                    let mappedCompletion = completion.mapError { error -> TunnelManager.Error in
+                        self.logger.error(
+                            chainedError: AnyChainedError(error),
+                            message: "Failed to receive account data."
+                        )
+
+                        return .getAccountData(error)
+                    }
+
+                    guard let accountData = mappedCompletion.value else {
+                        operation.finish(completion: mappedCompletion.assertNoSuccess())
+                        return
+                    }
+
+                    self.logger.debug("Received account data.")
+
+                    let storedAccountData = StoredAccountData(
+                        identifier: accountData.id,
+                        number: accountNumber,
+                        expiry: accountData.expiry
+                    )
+
+                    operation.finish(completion: .success(storedAccountData))
+                }
+
+                operation.addCancellationBlock {
+                    task.cancel()
+                }
+            }
+
+            return operation
+
+        case .unset:
+            return nil
         }
     }
 }

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -349,18 +349,20 @@ final class TunnelManager: TunnelManagerStateDelegate {
                 // Cancel last VPN status mapping operation
                 self.lastMapConnectionStatusOperation?.cancel()
                 self.lastMapConnectionStatusOperation = nil
-            },
-            completionHandler: { [weak self] completion in
-                guard let self = self else { return }
-
-                dispatchPrecondition(condition: .onQueue(self.stateQueue))
-
-                self.updatePrivateKeyRotationTimer()
-
-                DispatchQueue.main.async {
-                    completionHandler(completion)
-                }
             })
+
+        operation.completionQueue = stateQueue
+        operation.completionHandler = { [weak self] completion in
+            guard let self = self else { return }
+
+            dispatchPrecondition(condition: .onQueue(self.stateQueue))
+
+            self.updatePrivateKeyRotationTimer()
+
+            DispatchQueue.main.async {
+                completionHandler(completion)
+            }
+        }
 
         operation.addObserver(BackgroundObserver(name: action.taskName, cancelUponExpiration: true))
 

--- a/ios/MullvadVPNTests/OperationInputInjectionTests.swift
+++ b/ios/MullvadVPNTests/OperationInputInjectionTests.swift
@@ -1,0 +1,90 @@
+//
+//  OperationInputInjectionTests.swift
+//  MullvadVPNTests
+//
+//  Created by pronebird on 09/06/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import XCTest
+
+class OperationInputInjectionTests: XCTestCase {
+
+    func testInject() throws {
+        let provider = ResultBlockOperation<Int, Error> {
+            return 1
+        }
+
+        let consumer = TransformOperation<Int, Int, Error> { input in
+            return input + 1
+        }
+
+        consumer.inject(from: provider)
+
+        let operationQueue = AsyncOperationQueue()
+
+        operationQueue.addOperations([provider, consumer], waitUntilFinished: true)
+
+        XCTAssertEqual(consumer.output, 2)
+    }
+
+    func testInjectVia() throws {
+        let provider = ResultBlockOperation<Int, Error> {
+            return 1
+        }
+
+        let consumer = TransformOperation<String, Int, Error> { input in
+            return Int(input)!
+        }
+
+        consumer.inject(from: provider) { output in
+            return "\(output)"
+        }
+
+        let operationQueue = AsyncOperationQueue()
+
+        operationQueue.addOperations([provider, consumer], waitUntilFinished: true)
+
+        XCTAssertEqual(consumer.output, 1)
+    }
+
+    func testInjectMany() throws {
+        struct Context: OperationInputContext {
+            var a: Int?
+            var b: Int?
+
+            func reduce() -> Int? {
+                guard let a = a, let b = b else { return nil }
+
+                return a + b
+            }
+        }
+
+        let operationQueue = AsyncOperationQueue()
+
+        let providerA = ResultBlockOperation<Int, Error> {
+            return 1
+        }
+
+        let providerB = ResultBlockOperation<Int, Error> {
+            return 2
+        }
+
+        let consumer = TransformOperation<Int, String, Error> { input in
+            return "\(input)"
+        }
+
+        consumer.injectMany(context: Context())
+            .inject(from: providerA, assignOutputTo: \.a)
+            .inject(from: providerB, assignOutputTo: \.b)
+            .reduce()
+
+        operationQueue.addOperations(
+            [providerA, providerB, consumer],
+            waitUntilFinished: true
+        )
+
+        XCTAssertEqual(consumer.output, "3")
+    }
+
+}

--- a/ios/MullvadVPNTests/OperationSmokeTests.swift
+++ b/ios/MullvadVPNTests/OperationSmokeTests.swift
@@ -1,0 +1,39 @@
+//
+//  OperationSmokeTests.swift
+//  MullvadVPNTests
+//
+//  Created by pronebird on 09/06/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import XCTest
+
+class OperationSmokeTests: XCTestCase {
+
+    func testBatch() {
+        let expect = expectation(description: "Expect all operations to finish.")
+        let operationQueue = AsyncOperationQueue()
+
+        let operations = (1...500).flatMap { i -> [Operation] in
+            let parent = BlockOperation()
+            parent.cancel()
+
+            let child = AsyncBlockOperation {
+                print("Execute block operation \(i)")
+            }
+
+            child.addDependency(parent)
+            child.addCondition(NoFailedDependenciesCondition(ignoreCancellations: true))
+
+            return [parent, child]
+        }
+
+        DispatchQueue.global().async {
+            operationQueue.addOperations(operations, waitUntilFinished: true)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+}


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Refactor `SetAccountOperation` and break down that maze on multiple sub-operations.
2. Revert to KVO observer for `isReady`. It's nasty since we modify `isReady` too, which causes a recursive call to observers.

    However, I found no better way to know when `dependencies` finished execution, since previous attempt to use KVO on each individual dependency randomly fails to report when operation flips `isFinished = true`. That came out as a result of running stress tests, which I have added now too.
3. Introduce secondary lock in `AsyncOperation` to account for issues with KVO deadlocks. Since KVO observer may attempt to access operation `state` in a synchronous call on a different dispatch queue. 
    - `operationLock` is used for critical sections in operation lifecycle.
    -  `stateLock` is used to guard access to operation `state` and `isCancelled`.
4. Add `TransformOperation` that supports receiving `Input` and producing `Result<Output, Failure: Error>`.
5. Add `InputOperation` and `OutputOperation` protocol to setup formal relationship between producing and receiving operations.
6. Add `InputInjectionBuilder` that helps to collect `output` of many operations into the `input` of the target operation.