### PR TITLE
Rebuild ST driver process tree when the daemon starts

### DIFF
--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -156,7 +156,7 @@ struct EventThreadContext {
 unsafe impl Send for EventThreadContext {}
 
 impl SplitTunnel {
-    /// Initialize the driver.
+    /// Initialize the split tunnel device.
     pub fn new(
         runtime: tokio::runtime::Handle,
         daemon_tx: Weak<mpsc::UnboundedSender<TunnelCommand>>,


### PR DESCRIPTION
This is mainly to ensure that everything is fully reset when fast startup is enabled (which is just hibernation for services, including devices/drivers).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3649)
<!-- Reviewable:end -->
