### PR TITLE
Add power management event listener

### DIFF
--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(target_os = "linux")]
 use crate::routing::RouteManagerHandle;
+#[cfg(target_os = "windows")]
+use crate::windows::window::PowerManagementListener;
 use futures::channel::mpsc::UnboundedSender;
 #[cfg(target_os = "android")]
 use talpid_types::android::AndroidContext;
@@ -44,6 +46,7 @@ pub async fn spawn_monitor(
     sender: UnboundedSender<bool>,
     #[cfg(target_os = "linux")] route_manager: RouteManagerHandle,
     #[cfg(target_os = "android")] android_context: AndroidContext,
+    #[cfg(target_os = "windows")] power_mgmt_rx: PowerManagementListener,
 ) -> Result<MonitorHandle, Error> {
     let monitor = if !*FORCE_DISABLE_OFFLINE_MONITOR {
         Some(
@@ -53,6 +56,8 @@ pub async fn spawn_monitor(
                 route_manager,
                 #[cfg(target_os = "android")]
                 android_context,
+                #[cfg(target_os = "windows")]
+                power_mgmt_rx,
             )
             .await?,
         )

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -238,6 +238,9 @@ impl TunnelStateMachine {
         #[cfg(target_os = "macos")]
         let filtering_resolver = crate::resolver::start_resolver().await?;
 
+        #[cfg(target_os = "windows")]
+        let power_mgmt_rx = crate::windows::window::PowerManagementListener::new();
+
         #[cfg(windows)]
         let split_tunnel =
             split_tunnel::SplitTunnel::new(runtime.clone(), command_tx.clone(), volume_update_rx)
@@ -288,6 +291,8 @@ impl TunnelStateMachine {
                 .map_err(Error::InitRouteManagerError)?,
             #[cfg(target_os = "android")]
             android_context,
+            #[cfg(target_os = "windows")]
+            power_mgmt_rx,
         )
         .await
         .map_err(Error::OfflineMonitorError)?;


### PR DESCRIPTION
Move the code for monitoring power events out of the offline monitor module into a general `PowerManagementListener` type. Mainly done in order to make it reusable (i.e., for `split_tunnel`) in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3650)
<!-- Reviewable:end -->
