### PR TITLE
Detect mtu on wireguard bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add option to filter relays by ownership in the desktop apps.
 
+#### Linux
+- Automatically attempt to detect and set the correct MTU for Wireguard tunnels.
+
 ### Changed
 - Display consistent colors regardless of monitor color profile.
 


### PR DESCRIPTION
Patches a bug caused by an incorrect assumption that a route node will only either have an IP or a device. Also turns a panic into an error to avoid future crashes.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3655)
<!-- Reviewable:end -->
