### PR TITLE
Remove ICMP protocol from options that block tunnel traffic

### DIFF
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -340,15 +340,9 @@ impl Firewall {
             .keep_state(pfctl::StatePolicy::Keep)
             .tcp_flags(Self::get_tcp_flags());
         match allowed_traffic {
-            AllowedTunnelTraffic::Only(addr, protocol) => {
-                use talpid_types::net::Protocol::*;
-                let pfctl_proto = match protocol {
-                    Udp => pfctl::Proto::Udp,
-                    Tcp => pfctl::Proto::Tcp,
-                    IcmpV4 => pfctl::Proto::Icmp,
-                    IcmpV6 => pfctl::Proto::IcmpV6,
-                };
-                base_rule = base_rule.to(*addr).proto(pfctl_proto);
+            AllowedTunnelTraffic::Only(endpoint) => {
+                let pfctl_proto = as_pfctl_proto(endpoint.protocol);
+                base_rule = base_rule.to(endpoint.address).proto(pfctl_proto);
             }
             AllowedTunnelTraffic::All => {}
             AllowedTunnelTraffic::None => {

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -174,12 +174,12 @@ impl Firewall {
 
         let allowed_tun_ip;
         let allowed_tunnel_endpoint =
-            if let AllowedTunnelTraffic::Only(addr, proto) = allowed_tunnel_traffic {
-                allowed_tun_ip = widestring_ip(addr.ip());
+            if let AllowedTunnelTraffic::Only(endpoint) = allowed_tunnel_traffic {
+                allowed_tun_ip = widestring_ip(endpoint.address.ip());
                 Some(WinFwEndpoint {
                     ip: allowed_tun_ip.as_ptr(),
-                    port: addr.port(),
-                    protocol: WinFwProt::from(*proto),
+                    port: endpoint.address.port(),
+                    protocol: WinFwProt::from(endpoint.protocol),
                 })
             } else {
                 None
@@ -303,7 +303,7 @@ mod winfw {
     use super::{widestring_ip, AllowedEndpoint, AllowedTunnelTraffic, Error, WideCString};
     use crate::logging::windows::LogSink;
     use libc;
-    use talpid_types::net::{Protocol, TransportProtocol};
+    use talpid_types::net::TransportProtocol;
 
     pub struct WinFwAllowedEndpointContainer {
         _clients: Box<[WideCString]>,
@@ -397,8 +397,6 @@ mod winfw {
     pub enum WinFwProt {
         Tcp = 0u8,
         Udp = 1u8,
-        IcmpV4 = 2u8,
-        IcmpV6 = 3u8,
     }
 
     impl From<TransportProtocol> for WinFwProt {
@@ -406,17 +404,6 @@ mod winfw {
             match prot {
                 TransportProtocol::Tcp => WinFwProt::Tcp,
                 TransportProtocol::Udp => WinFwProt::Udp,
-            }
-        }
-    }
-
-    impl From<Protocol> for WinFwProt {
-        fn from(prot: Protocol) -> WinFwProt {
-            match prot {
-                Protocol::Tcp => WinFwProt::Tcp,
-                Protocol::Udp => WinFwProt::Udp,
-                Protocol::IcmpV4 => WinFwProt::IcmpV4,
-                Protocol::IcmpV6 => WinFwProt::IcmpV6,
             }
         }
     }

--- a/talpid-core/src/tunnel/wireguard/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/mod.rs
@@ -21,7 +21,7 @@ use std::io;
 use std::{
     borrow::Cow,
     convert::Infallible,
-    net::{IpAddr, SocketAddrV4},
+    net::IpAddr,
     path::Path,
     pin::Pin,
     sync::{mpsc as sync_mpsc, Arc, Mutex},
@@ -30,7 +30,10 @@ use std::{
 #[cfg(windows)]
 use talpid_types::BoxedError;
 use talpid_types::{
-    net::{obfuscation::ObfuscatorConfig, wireguard::PublicKey, AllowedTunnelTraffic, Protocol},
+    net::{
+        obfuscation::ObfuscatorConfig, wireguard::PublicKey, AllowedTunnelTraffic, Endpoint,
+        TransportProtocol,
+    },
     ErrorExt,
 };
 use tunnel_obfuscation::{
@@ -262,10 +265,11 @@ impl WireguardMonitor {
                 .await?;
 
             let allowed_traffic = if psk_negotiation.is_some() {
-                AllowedTunnelTraffic::Only(
-                    SocketAddrV4::new(config.ipv4_gateway, 1337).into(),
-                    Protocol::Tcp,
-                )
+                AllowedTunnelTraffic::Only(Endpoint::new(
+                    config.ipv4_gateway,
+                    talpid_tunnel_config_client::CONFIG_SERVICE_PORT,
+                    TransportProtocol::Tcp,
+                ))
             } else {
                 AllowedTunnelTraffic::All
             };

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -41,7 +41,9 @@ impl std::error::Error for Error {
 
 type RelayConfigService = proto::post_quantum_secure_client::PostQuantumSecureClient<Channel>;
 
-const CONFIG_SERVICE_PORT: u16 = 1337;
+/// Port used by the tunnel config service.
+pub const CONFIG_SERVICE_PORT: u16 = 1337;
+
 const ALGORITHM_NAME: &str = "Classic-McEliece-8192128f";
 
 /// Generates a new WireGuard key pair and negotiates a PSK with the relay in a PQ-safe

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -287,7 +287,7 @@ impl fmt::Display for AllowedEndpoint {
 pub enum AllowedTunnelTraffic {
     None,
     All,
-    Only(SocketAddr, Protocol),
+    Only(Endpoint),
 }
 
 impl fmt::Display for AllowedTunnelTraffic {
@@ -295,36 +295,7 @@ impl fmt::Display for AllowedTunnelTraffic {
         match *self {
             AllowedTunnelTraffic::None => "None".fmt(f),
             AllowedTunnelTraffic::All => "All".fmt(f),
-            AllowedTunnelTraffic::Only(addr, proto) => write!(f, "{}/{}", addr, proto),
-        }
-    }
-}
-
-/// A protocol: UDP, TCP, or ICMP.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Protocol {
-    Udp,
-    Tcp,
-    IcmpV4,
-    IcmpV6,
-}
-
-impl fmt::Display for Protocol {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Protocol::Udp => "UDP".fmt(f),
-            Protocol::Tcp => "TCP".fmt(f),
-            Protocol::IcmpV4 => "ICMPv4".fmt(f),
-            Protocol::IcmpV6 => "ICMPv6".fmt(f),
-        }
-    }
-}
-
-impl From<TransportProtocol> for Protocol {
-    fn from(proto: TransportProtocol) -> Self {
-        match proto {
-            TransportProtocol::Udp => Protocol::Udp,
-            TransportProtocol::Tcp => Protocol::Tcp,
+            AllowedTunnelTraffic::Only(endpoint) => endpoint.fmt(f),
         }
     }
 }

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
@@ -54,10 +54,7 @@ bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
 		if (m_tunnelOnlyEndpoint.has_value())
 		{
 			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
-			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
-			{
-				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
-			}
+			conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
 			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
 		}
 
@@ -85,10 +82,7 @@ bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
 		if (m_tunnelOnlyEndpoint.has_value())
 		{
 			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
-			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
-			{
-				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
-			}
+			conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
 			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
 		}
 

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.cpp
@@ -54,10 +54,7 @@ bool PermitVpnTunnelService::apply(IObjectInstaller &objectInstaller)
 		if (m_tunnelOnlyEndpoint.has_value())
 		{
 			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
-			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
-			{
-				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
-			}
+			conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
 			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
 		}
 
@@ -84,10 +81,7 @@ bool PermitVpnTunnelService::apply(IObjectInstaller &objectInstaller)
 		if (m_tunnelOnlyEndpoint.has_value())
 		{
 			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
-			if (ProtocolHasPort(m_tunnelOnlyEndpoint->protocol))
-			{
-				conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
-			}
+			conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
 			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
 		}
 

--- a/windows/winfw/src/winfw/rules/shared.cpp
+++ b/windows/winfw/src/winfw/rules/shared.cpp
@@ -45,25 +45,6 @@ std::unique_ptr<wfp::conditions::ConditionProtocol> CreateProtocolCondition(WinF
 	{
 		case WinFwProtocol::Tcp: return ConditionProtocol::Tcp();
 		case WinFwProtocol::Udp: return ConditionProtocol::Udp();
-		case WinFwProtocol::Icmp: return ConditionProtocol::Icmp();
-		case WinFwProtocol::IcmpV6: return ConditionProtocol::IcmpV6();
-		default:
-		{
-			THROW_ERROR("Missing case handler in switch clause");
-		}
-	};
-}
-
-bool ProtocolHasPort(WinFwProtocol protocol)
-{
-	switch (protocol)
-	{
-		case WinFwProtocol::Tcp:
-		case WinFwProtocol::Udp:
-			return true;
-		case WinFwProtocol::Icmp:
-		case WinFwProtocol::IcmpV6:
-			return false;
 		default:
 		{
 			THROW_ERROR("Missing case handler in switch clause");

--- a/windows/winfw/src/winfw/rules/shared.h
+++ b/windows/winfw/src/winfw/rules/shared.h
@@ -15,6 +15,4 @@ void SplitAddresses(const IpSet &in, IpSet &outIpv4, IpSet &outIpv6);
 
 std::unique_ptr<wfp::conditions::ConditionProtocol> CreateProtocolCondition(WinFwProtocol protocol);
 
-bool ProtocolHasPort(WinFwProtocol protocol);
-
 }

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -33,8 +33,6 @@ enum WinFwProtocol : uint8_t
 {
 	Tcp = 0,
 	Udp = 1,
-	Icmp = 2,
-	IcmpV6 = 3
 };
 
 typedef struct tag_WinFwEndpoint


### PR DESCRIPTION
Since blocking non-ICMP traffic while connecting is unnecessary (worse than not doing so, even), this PR removes that option for the `AllowedTunnelTraffic` type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3663)
<!-- Reviewable:end -->
