### PR TITLE
Redact home dir for device paths

### DIFF
--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -674,6 +674,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
+    fn redacts_home_dir() {
+        let assert_redacts_home_dir = |home_dir, test_str| {
+            let input = format!(r"pre {}\remaining\path post", test_str);
+            let actual = redact_home_dir_inner(&input, Some(PathBuf::from(home_dir)));
+            assert_eq!(r"pre ~\remaining\path post", actual);
+        };
+
+        let home_dir = r"C:\Users\user";
+
+        assert_redacts_home_dir(home_dir, r"\Device\HarddiskVolume1\Users\user");
+        assert_redacts_home_dir(home_dir, r"C:\Users\user");
+    }
+
+    #[test]
     fn doesnt_redact_not_guid() {
         assert_does_not_redact("23123ab-12ab-89cd-45ef-012345678901");
         assert_does_not_redact("GGGGGGGG-GGGG-GGGG-GGGG-GGGGGGGGGGGG");

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -18,6 +18,7 @@ use std::{
         fs::OpenOptionsExt,
         io::{AsRawHandle, RawHandle},
     },
+    path::Path,
     ptr,
     time::Duration,
 };
@@ -354,7 +355,7 @@ impl DeviceHandle {
                     log::debug!(
                         "{}\nPath: {}",
                         error.display_chain_with_msg("Ignoring path on unmounted volume"),
-                        app.as_ref().to_string_lossy()
+                        Path::new(app.as_ref()).display()
                     );
                 }
                 Err(error) => return Err(error),
@@ -368,7 +369,7 @@ impl DeviceHandle {
 
         log::debug!("Excluded device paths:");
         for path in &device_paths {
-            log::debug!("    {:?}", path);
+            log::debug!("    {}", Path::new(&path).display());
         }
 
         let config = make_process_config(&device_paths);


### PR DESCRIPTION
This PR updates the problem report tool to redact `*\Users\<current user>` from any path, including excluded device paths. Also, device paths are logged more nicely (using `\` instead of `\\`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3664)
<!-- Reviewable:end -->
