### PR TITLE
Disable capture from camera

### DIFF
--- a/ios/MullvadVPN/AccountTextField.swift
+++ b/ios/MullvadVPN/AccountTextField.swift
@@ -55,6 +55,15 @@ class AccountTextField: CustomTextField, UITextFieldDelegate {
         }
     }
 
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if #available(iOS 15.0, *) {
+            if action == #selector(captureTextFromCamera(_:)) {
+                return false
+            }
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
     // MARK: - UITextFieldDelegate
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR disables a feature to capture text from camera in login text field. Our `UITextField` implementation does not play well with it and crashes the app. This is a duct tape solution and in the future I'd look into improving the text input view, perhaps by using a custom text storage type.