### PR TITLE
Remove serde derivations from TunnelStateTransition

### DIFF
--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -8,9 +8,7 @@ use std::net::IpAddr;
 
 /// Event emitted from the states in `talpid_core::tunnel_state_machine` when the tunnel state
 /// machine enters a new state.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "state", content = "details")]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TunnelStateTransition {
     /// No connection is established and network is unsecured.
     Disconnected,


### PR DESCRIPTION
`TunnelStateTransition` doesn't need to implement neither of the serialization .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3668)
<!-- Reviewable:end -->
