### PR TITLE
Fix opacity for unavailable multihop endpoints

### DIFF
--- a/gui/src/renderer/components/LocationRow.tsx
+++ b/gui/src/renderer/components/LocationRow.tsx
@@ -121,7 +121,7 @@ function LocationRow(props: IProps, ref: React.Ref<HTMLDivElement>) {
 
   return (
     <>
-      <Container ref={ref}>
+      <Container ref={ref} disabled={props.disabled}>
         <Button
           ref={buttonRef}
           onClick={handleClick}


### PR DESCRIPTION
Fixes a minor regression introduced in this PR: https://github.com/mullvad/mullvadvpn-app/pull/3568. Text was white for relays/locations that were already selected as the exit or entry endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3679)
<!-- Reviewable:end -->
