### PR TITLE
Reconnect when connecting to the tunnel config service fails for any reason

### DIFF
--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -109,14 +109,12 @@ fn format_relay_connection(relay_info: &TunnelStateRelayInfo, verbose: bool) -> 
     } else {
         String::new()
     };
-    let quantum_resistant = if verbose {
-        if endpoint.quantum_resistant {
-            "\nQuantum resistant tunnel: true".to_string()
-        } else {
-            "\nQuantum resistant tunnel: false".to_string()
-        }
+    let quantum_resistant = if !verbose {
+        ""
+    } else if endpoint.quantum_resistant {
+        "\nQuantum resistant tunnel: yes"
     } else {
-        String::new()
+        "\nQuantum resistant tunnel: no"
     };
 
     let mut bridge_type = String::new();

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -492,6 +492,10 @@ fn should_retry(error: &tunnel::Error, retry_attempt: u32) -> bool {
     match error {
         tunnel::Error::WireguardTunnelMonitoringError(Error::CreateObfuscatorError(_)) => true,
 
+        tunnel::Error::WireguardTunnelMonitoringError(Error::PskNegotiationError(
+            talpid_tunnel_config_client::Error::GrpcConnectError(_),
+        )) => true,
+
         #[cfg(not(windows))]
         tunnel::Error::WireguardTunnelMonitoringError(Error::TunnelError(
             TunnelError::RecoverableStartWireguardError,


### PR DESCRIPTION
In practice, this means that the app will try to connect to a different server if it stumbles upon a server that does not yet support PQ, when quantum-resistant tunnels are enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3688)
<!-- Reviewable:end -->
