### PR TITLE
Update Package.resolved (v2)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -45,6 +45,21 @@ jobs:
                   cp Screenshots.xcconfig.template Screenshots.xcconfig
               working-directory: ios/Configurations
 
+            - name: Convert Package.resolved v2 -> v1
+              run: |
+                  jq '{
+                    "object": {
+                      "pins": .pins | map({
+                        "package": .identity,
+                        "repositoryURL": .location,
+                        "state": .state
+                      })
+                    },
+                    "version": 1
+                  }' Package.resolved > Package.resolved.out
+                  mv Package.resolved.out Package.resolved
+              working-directory: ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
+
             - name: Build and test
               run: |
                   xcodebuild test \

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,22 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
-        }
-      },
-      {
-        "package": "WireGuardKit",
-        "repositoryURL": "https://github.com/mullvad/wireguard-apple.git",
-        "state": {
-          "branch": "mullvad-master",
-          "revision": "eeb980058f5bff593868e34b718b4519a3236dcc",
-          "version": null
-        }
+  "pins" : [
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "173f567a2dfec11d74588eea82cecea555bdc0bc",
+        "version" : "1.4.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "wireguard-apple",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mullvad/wireguard-apple.git",
+      "state" : {
+        "revision" : "eeb980058f5bff593868e34b718b4519a3236dcc"
+      }
+    }
+  ],
+  "version" : 2
 }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR updates the `Package.resolved` manifest to the newest which is what Xcode 13.3 (perhaps) or newer use. For CI job, there is a small `jq` script that maps v2 to v1 manifest. Hopefully we'll drop that in the future or Xcode will ship a compatibility patch. All in all the conversion is fine for CI as the `revision` is preserved and this is all we really need when pulling dependencies for CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3693)
<!-- Reviewable:end -->
