### PR TITLE
Fix android foreground and tile state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix unused dependencies loaded in the service/tile DI graph.
 - Fix missing IPC message unregistration causing multiple copies of some messages to be received.
+- Fix quick settings tile being unresponsive and causing crashes on some devices.
+- Fix quick settings tile not working when the device is locked. It will now prompt the user to
+  unlock the device before attempting to toggle the tunnel state.
 
 ### Security
 #### Android

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -87,7 +87,7 @@ class ForegroundNotificationManager(
         }
     }
 
-    private fun showOnForeground() {
+    fun showOnForeground() {
         service.startForeground(
             TunnelStateNotification.NOTIFICATION_ID,
             tunnelStateNotification.build()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onStart
 import net.mullvad.mullvadvpn.model.DeviceState
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.service.endpoint.ConnectionProxy
@@ -55,9 +56,13 @@ class ForegroundNotificationManager(
 
         intermittentDaemon.registerListener(this) { daemon ->
             jobTracker.newBackgroundJob("notificationLoggedInJob") {
-                daemon?.deviceStateUpdates?.collect { deviceState ->
-                    loggedIn = deviceState is DeviceState.LoggedIn
-                }
+                daemon?.deviceStateUpdates
+                    ?.onStart {
+                        emit(daemon.getAndEmitDeviceState())
+                    }
+                    ?.collect { deviceState ->
+                        loggedIn = deviceState is DeviceState.LoggedIn
+                    }
             }
         }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -5,12 +5,12 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
-import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ipc.ServiceConnection
@@ -19,10 +19,6 @@ import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
 class MullvadTileService : TileService() {
-    private var secured by observable(false) { _, _, _ ->
-        updateTileState()
-    }
-
     private val scope = MainScope()
     private var listenerJob: Job? = null
 
@@ -38,7 +34,7 @@ class MullvadTileService : TileService() {
 
     override fun onClick() {
         val intent = Intent(this, MullvadVpnService::class.java).apply {
-            action = if (secured) {
+            action = if (qsTile.state == Tile.STATE_ACTIVE) {
                 MullvadVpnService.KEY_DISCONNECT_ACTION
             } else {
                 MullvadVpnService.KEY_CONNECT_ACTION
@@ -60,31 +56,44 @@ class MullvadTileService : TileService() {
         ServiceConnection(this@MullvadTileService, scope)
             .tunnelState
             .debounce(300L)
-            .collect { updateTunnelState(it.first, it.second) }
+            .map { (tunnelState, connectionState) -> mapToTileState(tunnelState, connectionState) }
+            .collect {
+                updateTileState(it)
+            }
     }
 
-    private fun updateTunnelState(
+    private fun mapToTileState(
         tunnelState: TunnelState,
         connectionState: ServiceResult.ConnectionState
-    ) {
-        secured = if (connectionState == ServiceResult.ConnectionState.CONNECTED) {
+    ): Int {
+        return if (connectionState == ServiceResult.ConnectionState.CONNECTED) {
             when (tunnelState) {
-                is TunnelState.Disconnected -> false
-                is TunnelState.Connecting -> true
-                is TunnelState.Connected -> true
+                is TunnelState.Disconnected -> Tile.STATE_INACTIVE
+                is TunnelState.Connecting -> Tile.STATE_ACTIVE
+                is TunnelState.Connected -> Tile.STATE_ACTIVE
                 is TunnelState.Disconnecting -> {
-                    tunnelState.actionAfterDisconnect == ActionAfterDisconnect.Reconnect
+                    if (tunnelState.actionAfterDisconnect == ActionAfterDisconnect.Reconnect) {
+                        Tile.STATE_ACTIVE
+                    } else {
+                        Tile.STATE_INACTIVE
+                    }
                 }
-                is TunnelState.Error -> tunnelState.errorState.isBlocking
+                is TunnelState.Error -> {
+                    if (tunnelState.errorState.isBlocking) {
+                        Tile.STATE_ACTIVE
+                    } else {
+                        Tile.STATE_INACTIVE
+                    }
+                }
             }
         } else {
-            false
+            Tile.STATE_INACTIVE
         }
     }
 
-    private fun updateTileState() {
+    private fun updateTileState(newState: Int) {
         qsTile?.apply {
-            if (secured) {
+            if (newState == Tile.STATE_ACTIVE) {
                 state = Tile.STATE_ACTIVE
                 icon = securedIcon
 
@@ -99,7 +108,6 @@ class MullvadTileService : TileService() {
                     subtitle = resources.getText(R.string.unsecured)
                 }
             }
-
             updateTile()
         }
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -30,8 +30,6 @@ class MullvadTileService : TileService() {
     private lateinit var unsecuredIcon: Icon
 
     override fun onCreate() {
-        super.onCreate()
-
         securedIcon = Icon.createWithResource(this, R.drawable.small_logo_white)
         unsecuredIcon = Icon.createWithResource(this, R.drawable.small_logo_black)
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadTileService.kt
@@ -37,17 +37,14 @@ class MullvadTileService : TileService() {
     }
 
     override fun onClick() {
-        super.onClick()
-
-        val intent = Intent(this, MullvadVpnService::class.java)
-
-        if (secured) {
-            intent.action = MullvadVpnService.KEY_DISCONNECT_ACTION
-            startService(intent)
-        } else {
-            intent.action = MullvadVpnService.KEY_CONNECT_ACTION
-            startForegroundService(intent)
+        val intent = Intent(this, MullvadVpnService::class.java).apply {
+            action = if (secured) {
+                MullvadVpnService.KEY_DISCONNECT_ACTION
+            } else {
+                MullvadVpnService.KEY_CONNECT_ACTION
+            }
         }
+        startForegroundService(intent)
     }
 
     override fun onStartListening() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -114,6 +114,12 @@ class MullvadVpnService : TalpidVpnService() {
         val startResult = super.onStartCommand(intent, flags, startId)
         var quitCommand = false
 
+        // Always promote to foreground if connect/disconnect actions are provided to mitigate cases
+        // where the service would potentially otherwise be too slow running `startForeground`.
+        if (intent?.action == KEY_CONNECT_ACTION || intent?.action == KEY_DISCONNECT_ACTION) {
+            notificationManager.showOnForeground()
+        }
+
         notificationManager.updateNotification()
 
         if (!keyguardManager.isDeviceLocked) {


### PR DESCRIPTION
This PR aims to fix a few issues related to the tile service:
* Improve how/when the vpn service starts as a foreground service to avoid getting killed by the system for being too slow.
* Handle tile clicks when the device is locked, which will prompt the user to unlock the device.
* Simplify internal state handling in the tile service.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3695)
<!-- Reviewable:end -->
