### PR TITLE
Windows auto set mtu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Add device management to the Android app. This simplifies knowing which device is which and adds
   the option to log other devices out when the account already has five devices.
+#### Windows
+- Windows daemon now looks up the MTU on the default interface and uses this MTU instead of the
+  default 1500. The 1500 is still the fallback if this for some reason fails. This may stop
+  fragmentation.
 
 ### Changed
 - Reject invalid WireGuard ports in the CLI.

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -197,7 +197,7 @@ impl TunnelMonitor {
             + Clone
             + 'static,
     {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         args.runtime
             .block_on(Self::assign_mtu(&args.route_manager, params));
         let config = wireguard::config::Config::from_parameters(params)?;
@@ -223,7 +223,7 @@ impl TunnelMonitor {
         })
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     fn set_mtu(params: &mut wireguard_types::TunnelParameters, peer_mtu: u16) {
         const IPV4_HEADER_SIZE: u16 = 20;
         const IPV6_HEADER_SIZE: u16 = 40;
@@ -248,18 +248,21 @@ impl TunnelMonitor {
         params.options.mtu = Some(tunnel_mtu);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     async fn assign_mtu(
         route_manager: &RouteManagerHandle,
         params: &mut wireguard_types::TunnelParameters,
     ) {
         // Only calculate the mtu automatically if the user has not set any
         if params.options.mtu.is_none() {
-            if let Ok(mtu) = route_manager
+            match route_manager
                 .get_mtu_for_route(params.connection.peer.endpoint.ip())
                 .await
             {
-                Self::set_mtu(params, mtu);
+                Ok(mtu) => Self::set_mtu(params, mtu),
+                Err(e) => {
+                    log::error!("Could not get the MTU for route {}", e);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR makes the Windows daemon look up the MTU of the default interface and use that as the default in the Wireguard tunnel.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3703)
<!-- Reviewable:end -->
