### PR TITLE
Don't rely on the stdout message from ipconfig, it's localized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix quick settings tile not working when the device is locked. It will now prompt the user to
   unlock the device before attempting to toggle the tunnel state.
 
+#### Windows
+- Fix DNS issue on non-English Windows installations. Don't parse the output of ipconfig.exe
+  to determine if the tool succeeded.
+
 ### Security
 #### Android
 - Prevent location request responses from being received outside the tunnel when in the connected


### PR DESCRIPTION
The output of CLI tools on Windows can basically never be trusted. They are very often localized. This simply removes the parsing of stdout from `ipconfig.exe`. Since I'm not aware of any other way to check if the call succeeded I'm just going to not check it at all. Hopefully it will never fail, and if it does I don't think it will have too much harm.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3707)
<!-- Reviewable:end -->
