### PR TITLE
Add OpenSSL related crates to deny.toml ban section

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -76,7 +76,13 @@ wildcards = "warn"
 highlight = "all"
 
 allow = []
-deny = []
+deny = [
+    # We are using Rustls for TLS. We don't want to accidentally pull in
+    # anything OpenSSL related
+    { name = "openssl-sys" },
+    { name = "openssl-src" },
+    { name = "openssl-probe" },
+]
 skip = []
 skip-tree = []
 


### PR DESCRIPTION
We use Rustls for TLS. We don't want to accidentally pull in
OpenSSL for anything. Both because it would bloat the binaries,
and because we would then potentially be vulnerable to OpenSSL
CVEs. Which is something we don't monitor since we are not actively
using it

At the time of submitting this PR, the CI will fail. Since #3712 needs to be merged first in order to get rid of `openssl-probe`. I use this as a test to see that the `cargo deny` CI job actually works :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3715)
<!-- Reviewable:end -->
