### PR TITLE
Refactor android account cache to repository

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import net.mullvad.mullvadvpn.applist.ApplicationsIconManager
 import net.mullvad.mullvadvpn.applist.ApplicationsProvider
 import net.mullvad.mullvadvpn.ipc.EventDispatcher
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
@@ -37,9 +38,11 @@ val uiModule = module {
     }
 
     single { ServiceConnectionManager(androidContext()) }
+
+    single { AccountCache(get()) }
     single { DeviceRepository(get()) }
     viewModel { LoginViewModel(get(), get()) }
-    viewModel { DeviceRevokedViewModel(get()) }
+    viewModel { DeviceRevokedViewModel(get(), get()) }
     viewModel { DeviceListViewModel(get()) }
 }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import net.mullvad.mullvadvpn.applist.ApplicationsIconManager
 import net.mullvad.mullvadvpn.applist.ApplicationsProvider
 import net.mullvad.mullvadvpn.ipc.EventDispatcher
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
@@ -39,7 +39,7 @@ val uiModule = module {
 
     single { ServiceConnectionManager(androidContext()) }
 
-    single { AccountCache(get()) }
+    single { AccountRepository(get()) }
     single { DeviceRepository(get()) }
     viewModel { LoginViewModel(get(), get()) }
     viewModel { DeviceRevokedViewModel(get(), get()) }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.ui.widget.CopyableInformationView
@@ -25,6 +26,9 @@ import org.joda.time.DateTime
 import org.koin.android.ext.android.inject
 
 class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
+
+    // Injected dependencies
+    private val accountCache: AccountCache by inject()
     private val deviceRepository: DeviceRepository by inject()
 
     override val isSecureScreen = true

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AccountFragment.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.ui.widget.CopyableInformationView
@@ -28,7 +28,7 @@ import org.koin.android.ext.android.inject
 class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
     // Injected dependencies
-    private val accountCache: AccountCache by inject()
+    private val accountRepository: AccountRepository by inject()
     private val deviceRepository: DeviceRepository by inject()
 
     override val isSecureScreen = true
@@ -105,7 +105,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
 
         view.findViewById<Button>(R.id.logout).setOnClickAction("logout", jobTracker) {
-            accountCache.logout()
+            accountRepository.logout()
         }
 
         accountNumberView = view.findViewById<CopyableInformationView>(R.id.account_number).apply {
@@ -121,7 +121,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
 
     override fun onSafelyStart() {
         jobTracker.newUiJob("updateAccountExpiry") {
-            accountCache.accountExpiryState
+            accountRepository.accountExpiryState
                 .map { state -> state.date() }
                 .collect { expiryDate ->
                     currentAccountExpiry = expiryDate
@@ -140,7 +140,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
         }
 
         sitePaymentButton.updateAuthTokenCache(authTokenCache)
-        accountCache.fetchAccountExpiry()
+        accountRepository.fetchAccountExpiry()
     }
 
     override fun onSafelyStop() {
@@ -162,7 +162,7 @@ class AccountFragment : ServiceDependentFragment(OnNoService.GoBack) {
             accountExpiryView.information = expiryFormatter.format(accountExpiry.toDate())
         } else {
             accountExpiryView.information = null
-            accountCache.fetchAccountExpiry()
+            accountRepository.fetchAccountExpiry()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -13,7 +13,7 @@ import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.notification.AccountExpiryNotification
 import net.mullvad.mullvadvpn.ui.notification.TunnelStateNotification
 import net.mullvad.mullvadvpn.ui.notification.VersionInfoNotification
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.widget.HeaderBar
 import net.mullvad.mullvadvpn.ui.widget.NotificationBanner
 import net.mullvad.mullvadvpn.ui.widget.SwitchLocationButton
@@ -26,7 +26,7 @@ class ConnectFragment :
     ServiceDependentFragment(OnNoService.GoToLaunchScreen), NavigationBarPainter {
 
     // Injected dependencies
-    private val accountCache: AccountCache by inject()
+    private val accountRepository: AccountRepository by inject()
 
     private lateinit var actionButton: ConnectActionButton
     private lateinit var switchLocationButton: SwitchLocationButton
@@ -59,7 +59,13 @@ class ConnectFragment :
             notifications.apply {
                 register(TunnelStateNotification(parentActivity, connectionProxy))
                 register(VersionInfoNotification(parentActivity, appVersionInfoCache))
-                register(AccountExpiryNotification(parentActivity, authTokenCache, accountCache))
+                register(
+                    AccountExpiryNotification(
+                        parentActivity,
+                        authTokenCache,
+                        accountRepository
+                    )
+                )
             }
         }
 
@@ -107,7 +113,7 @@ class ConnectFragment :
         }
 
         jobTracker.newUiJob("updateAccountExpiry") {
-            accountCache.accountExpiryState
+            accountRepository.accountExpiryState
                 .map { state -> state.date() }
                 .collect { expiryDate ->
                     if (expiryDate?.isBeforeNow == true) {
@@ -182,7 +188,7 @@ class ConnectFragment :
             val millisUntilExpiration = expiration.millis - DateTime.now().millis
 
             delay(millisUntilExpiration)
-            accountCache.fetchAccountExpiry()
+            accountRepository.fetchAccountExpiry()
 
             // If the account ran out of time but is still connected, fetching the expiry again will
             // fail. Therefore, after a timeout of 5 seconds the app will assume the account time

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -13,15 +13,21 @@ import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.ui.notification.AccountExpiryNotification
 import net.mullvad.mullvadvpn.ui.notification.TunnelStateNotification
 import net.mullvad.mullvadvpn.ui.notification.VersionInfoNotification
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.widget.HeaderBar
 import net.mullvad.mullvadvpn.ui.widget.NotificationBanner
 import net.mullvad.mullvadvpn.ui.widget.SwitchLocationButton
 import org.joda.time.DateTime
+import org.koin.android.ext.android.inject
 
 val KEY_IS_TUNNEL_INFO_EXPANDED = "is_tunnel_info_expanded"
 
 class ConnectFragment :
     ServiceDependentFragment(OnNoService.GoToLaunchScreen), NavigationBarPainter {
+
+    // Injected dependencies
+    private val accountCache: AccountCache by inject()
+
     private lateinit var actionButton: ConnectActionButton
     private lateinit var switchLocationButton: SwitchLocationButton
     private lateinit var headerBar: HeaderBar

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.ui.widget.HeaderBar
 import net.mullvad.mullvadvpn.ui.widget.RedeemVoucherButton
@@ -24,7 +24,7 @@ import org.koin.android.ext.android.inject
 class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
     // Injected dependencies
-    private val accountCache: AccountCache by inject()
+    private val accountRepository: AccountRepository by inject()
 
     private lateinit var headerBar: HeaderBar
 
@@ -81,7 +81,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
 
     override fun onSafelyStart() {
         jobTracker.newUiJob("updateAccountExpiry") {
-            accountCache.accountExpiryState
+            accountRepository.accountExpiryState
                 .map { state -> state.date() }
                 .collect { expiryDate ->
                     checkExpiry(expiryDate)
@@ -90,7 +90,7 @@ class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen)
 
         jobTracker.newBackgroundJob("pollAccountData") {
             while (true) {
-                accountCache.fetchAccountExpiry()
+                accountRepository.fetchAccountExpiry()
                 delay(POLL_INTERVAL)
             }
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.widget.Button
 import net.mullvad.mullvadvpn.ui.widget.HeaderBar
 import net.mullvad.mullvadvpn.ui.widget.RedeemVoucherButton
@@ -18,8 +19,13 @@ import net.mullvad.mullvadvpn.ui.widget.SitePaymentButton
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 import net.mullvad.talpid.tunnel.ErrorStateCause
 import org.joda.time.DateTime
+import org.koin.android.ext.android.inject
 
 class OutOfTimeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
+
+    // Injected dependencies
+    private val accountCache: AccountCache by inject()
+
     private lateinit var headerBar: HeaderBar
 
     private lateinit var sitePaymentButton: SitePaymentButton

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.VoucherSubmissionError
 import net.mullvad.mullvadvpn.model.VoucherSubmissionResult
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.VoucherRedeemer
 import net.mullvad.mullvadvpn.ui.widget.Button
@@ -31,7 +31,7 @@ const val FULL_VOUCHER_CODE_LENGTH = "XXXX-XXXX-XXXX-XXXX".length
 class RedeemVoucherDialogFragment : DialogFragment() {
 
     // Injected dependencies
-    private val accountCache: AccountCache by inject()
+    private val accountRepository: AccountRepository by inject()
     private val serviceConnectionManager: ServiceConnectionManager by inject()
 
     private val jobTracker = JobTracker()
@@ -60,7 +60,7 @@ class RedeemVoucherDialogFragment : DialogFragment() {
         }
 
         jobTracker.newUiJob("updateExpiry") {
-            accountCache.accountExpiryState.collect { accountExpiry = it.date() }
+            accountRepository.accountExpiryState.collect { accountExpiry = it.date() }
         }
 
         updateRedeemButton()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/RedeemVoucherDialogFragment.kt
@@ -29,6 +29,9 @@ import org.koin.android.ext.android.inject
 const val FULL_VOUCHER_CODE_LENGTH = "XXXX-XXXX-XXXX-XXXX".length
 
 class RedeemVoucherDialogFragment : DialogFragment() {
+
+    // Injected dependencies
+    private val accountCache: AccountCache by inject()
     private val serviceConnectionManager: ServiceConnectionManager by inject()
 
     private val jobTracker = JobTracker()
@@ -37,7 +40,6 @@ class RedeemVoucherDialogFragment : DialogFragment() {
     private lateinit var errorMessage: TextView
     private lateinit var voucherInput: EditText
 
-    private var accountCache: AccountCache? = null
     private var accountExpiry: DateTime? = null
     private var redeemButton: Button? = null
     private var voucherRedeemer: VoucherRedeemer? = null
@@ -54,16 +56,11 @@ class RedeemVoucherDialogFragment : DialogFragment() {
         parentActivity = context as MainActivity
 
         serviceConnectionManager.serviceNotifier.subscribe(this) { connection ->
-            accountCache = connection?.accountCache
             voucherRedeemer = connection?.voucherRedeemer
         }
 
-        accountCache?.apply {
-            jobTracker.newUiJob("updateExpiry") {
-                accountCache?.accountExpiryState?.collect { state ->
-                    accountExpiry = state.date()
-                }
-            }
+        jobTracker.newUiJob("updateExpiry") {
+            accountCache.accountExpiryState.collect { accountExpiry = it.date() }
         }
 
         updateRedeemButton()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ServiceDependentFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
@@ -13,7 +12,6 @@ import net.mullvad.mullvadvpn.ui.serviceconnection.CustomDns
 import net.mullvad.mullvadvpn.ui.serviceconnection.LocationInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.RelayListListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
-import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionDeviceDataSource
 import net.mullvad.mullvadvpn.ui.serviceconnection.SettingsListener
 import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
 
@@ -33,9 +31,6 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
 
     private var state = State.Uninitialized
 
-    lateinit var accountCache: AccountCache
-        private set
-
     lateinit var appVersionInfoCache: AppVersionInfoCache
         private set
 
@@ -46,9 +41,6 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
         private set
 
     lateinit var customDns: CustomDns
-        private set
-
-    lateinit var deviceDataSource: ServiceConnectionDeviceDataSource
         private set
 
     lateinit var locationInfoCache: LocationInfoCache
@@ -66,11 +58,9 @@ abstract class ServiceDependentFragment(private val onNoService: OnNoService) :
     override fun onNewServiceConnection(serviceConnectionContainer: ServiceConnectionContainer) {
         // This method is always either called first or after an `onNoServiceConnection`, so the
         // initialization of the fields doesn't have to be synchronized
-        accountCache = serviceConnectionContainer.accountCache
         appVersionInfoCache = serviceConnectionContainer.appVersionInfoCache
         authTokenCache = serviceConnectionContainer.authTokenCache
         connectionProxy = serviceConnectionContainer.connectionProxy
-        deviceDataSource = serviceConnectionContainer.deviceDataSource
         customDns = serviceConnectionContainer.customDns
         locationInfoCache = serviceConnectionContainer.locationInfoCache
         relayListListener = serviceConnectionContainer.relayListListener

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/SettingsFragment.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.DeviceState
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
@@ -24,7 +24,7 @@ import net.mullvad.mullvadvpn.ui.widget.NavigateCell
 import org.koin.android.ext.android.inject
 
 class SettingsFragment : ServiceAwareFragment(), StatusBarPainter, NavigationBarPainter {
-    private val accountCache: AccountCache by inject()
+    private val accountRepository: AccountRepository by inject()
     private val deviceRepository: DeviceRepository by inject()
 
     private lateinit var accountMenu: AccountCell
@@ -131,14 +131,14 @@ class SettingsFragment : ServiceAwareFragment(), StatusBarPainter, NavigationBar
 
     private fun configureListeners() {
         jobTracker.newUiJob("updateAccountExpiry") {
-            accountCache.accountExpiryState
+            accountRepository.accountExpiryState
                 .map { state -> state.date() }
                 .collect { expiryDate ->
                     accountMenu.accountExpiry = expiryDate
                 }
         }
 
-        accountCache.fetchAccountExpiry()
+        accountRepository.fetchAccountExpiry()
 
         versionInfoCache?.onUpdate = {
             jobTracker.newUiJob("updateVersionInfo") {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.widget.HeaderBar
 import net.mullvad.mullvadvpn.ui.widget.RedeemVoucherButton
@@ -23,6 +24,9 @@ import org.koin.android.ext.android.inject
 val POLL_INTERVAL: Long = 15 /* s */ * 1000 /* ms */
 
 class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
+
+    // Injected dependencies
+    private val accountCache: AccountCache by inject()
     private val deviceRepository: DeviceRepository by inject()
 
     private lateinit var accountLabel: TextView

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.widget.HeaderBar
 import net.mullvad.mullvadvpn.ui.widget.RedeemVoucherButton
@@ -26,7 +26,7 @@ val POLL_INTERVAL: Long = 15 /* s */ * 1000 /* ms */
 class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
 
     // Injected dependencies
-    private val accountCache: AccountCache by inject()
+    private val accountRepository: AccountRepository by inject()
     private val deviceRepository: DeviceRepository by inject()
 
     private lateinit var accountLabel: TextView
@@ -73,14 +73,14 @@ class WelcomeFragment : ServiceDependentFragment(OnNoService.GoToLaunchScreen) {
         }
 
         jobTracker.newUiJob("checkAccountExpiry") {
-            accountCache.accountExpiryState.collect {
+            accountRepository.accountExpiryState.collect {
                 checkExpiry(it.date())
             }
         }
 
         jobTracker.newBackgroundJob("pollAccountData") {
             while (true) {
-                accountCache.fetchAccountExpiry()
+                accountRepository.fetchAccountExpiry()
                 delay(POLL_INTERVAL)
             }
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/AccountExpiryNotification.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.ui.notification
 import android.content.Context
 import kotlinx.coroutines.flow.collect
 import net.mullvad.mullvadvpn.R
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.AuthTokenCache
 import net.mullvad.mullvadvpn.util.TimeLeftFormatter
 import org.joda.time.DateTime
@@ -11,7 +11,7 @@ import org.joda.time.DateTime
 class AccountExpiryNotification(
     context: Context,
     authTokenCache: AuthTokenCache,
-    private val accountCache: AccountCache
+    private val accountRepository: AccountRepository
 ) : NotificationWithUrlWithToken(context, authTokenCache, R.string.account_url) {
     private val timeLeftFormatter = TimeLeftFormatter(context.resources)
 
@@ -22,7 +22,7 @@ class AccountExpiryNotification(
 
     override fun onResume() {
         jobTracker.newUiJob("updateAccountExpiry") {
-            accountCache.accountExpiryState.collect { state ->
+            accountRepository.accountExpiryState.collect { state ->
                 updateAccountExpiry(state.date())
             }
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountRepository.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AccountRepository.kt
@@ -19,7 +19,7 @@ import net.mullvad.mullvadvpn.model.AccountExpiry
 import net.mullvad.mullvadvpn.model.AccountHistory
 import net.mullvad.mullvadvpn.util.flatMapReadyConnectionOrDefault
 
-class AccountCache(
+class AccountRepository(
     private val serviceConnectionManager: ServiceConnectionManager,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionAccountDataSource.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionAccountDataSource.kt
@@ -1,0 +1,60 @@
+package net.mullvad.mullvadvpn.ui.serviceconnection
+
+import android.os.Messenger
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
+import net.mullvad.mullvadvpn.ipc.Event
+import net.mullvad.mullvadvpn.ipc.EventDispatcher
+import net.mullvad.mullvadvpn.ipc.Request
+
+class ServiceConnectionAccountDataSource(
+    private val connection: Messenger,
+    private val dispatcher: EventDispatcher
+) {
+    val accountCreationResult = callbackFlow {
+        val handler: (Event.AccountCreationEvent) -> Unit = { event ->
+            trySend(event.result)
+        }
+        dispatcher.registerHandler(Event.AccountCreationEvent::class, handler)
+        awaitClose {
+            // The current dispatcher doesn't support unregistration of handlers.
+        }
+    }
+
+    val accountExpiry = callbackFlow {
+        val handler: (Event.AccountExpiryEvent) -> Unit = { event ->
+            trySend(event.expiry)
+        }
+        dispatcher.registerHandler(Event.AccountExpiryEvent::class, handler)
+        awaitClose {
+            // The current dispatcher doesn't support unregistration of handlers.
+        }
+    }
+
+    val accountHistory = callbackFlow {
+        val handler: (Event.AccountHistoryEvent) -> Unit = { event ->
+            trySend(event.history)
+        }
+        dispatcher.registerHandler(Event.AccountHistoryEvent::class, handler)
+        awaitClose {
+            // The current dispatcher doesn't support unregistration of handlers.
+        }
+    }
+
+    val loginEvents = callbackFlow {
+        val handler: (Event.LoginEvent) -> Unit = { event ->
+            trySend(event)
+        }
+        dispatcher.registerHandler(Event.LoginEvent::class, handler)
+        awaitClose {
+            // The current dispatcher doesn't support unregistration of handlers.
+        }
+    }
+
+    fun createAccount() = connection.send(Request.CreateAccount.message)
+    fun login(accountToken: String) = connection.send(Request.Login(accountToken).message)
+    fun logout() = connection.send(Request.Logout.message)
+    fun fetchAccountExpiry() = connection.send(Request.FetchAccountExpiry.message)
+    fun fetchAccountHistory() = connection.send(Request.FetchAccountHistory.message)
+    fun clearAccountHistory() = connection.send(Request.ClearAccountHistory.message)
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionContainer.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/ServiceConnectionContainer.kt
@@ -33,7 +33,7 @@ class ServiceConnectionContainer(
         named(SERVICE_CONNECTION_SCOPE), this
     )
 
-    val accountCache = AccountCache(connection, dispatcher)
+    val accountDataSource = ServiceConnectionAccountDataSource(connection, dispatcher)
     val authTokenCache = AuthTokenCache(connection, dispatcher)
     val connectionProxy = ConnectionProxy(connection, dispatcher)
     val deviceDataSource = ServiceConnectionDeviceDataSource(connection, dispatcher)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModel.kt
@@ -10,14 +10,16 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import net.mullvad.mullvadvpn.compose.state.DeviceRevokedUiState
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.talpid.util.callbackFlowFromSubscription
 
-// TODO: Refactor AccountCache and ConnectionProxy and inject those rather than injecting
+// TODO: Refactor ConnectionProxy to be easily injectable rather than injecting
 //  ServiceConnectionManager here.
 class DeviceRevokedViewModel(
     private val serviceConnectionManager: ServiceConnectionManager,
+    private val accountCache: AccountCache,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
 
@@ -46,7 +48,7 @@ class DeviceRevokedViewModel(
             if (container.connectionProxy.state.isSecured()) {
                 container.connectionProxy.disconnect()
             }
-            container.accountCache.logout()
+            accountCache.logout()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import net.mullvad.mullvadvpn.compose.state.DeviceRevokedUiState
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.talpid.util.callbackFlowFromSubscription
@@ -19,7 +19,7 @@ import net.mullvad.talpid.util.callbackFlowFromSubscription
 //  ServiceConnectionManager here.
 class DeviceRevokedViewModel(
     private val serviceConnectionManager: ServiceConnectionManager,
-    private val accountCache: AccountCache,
+    private val accountRepository: AccountRepository,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
 
@@ -48,7 +48,7 @@ class DeviceRevokedViewModel(
             if (container.connectionProxy.state.isSecured()) {
                 container.connectionProxy.disconnect()
             }
-            accountCache.logout()
+            accountRepository.logout()
         }
     }
 

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModelTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import net.mullvad.mullvadvpn.compose.state.DeviceRevokedUiState
 import net.mullvad.mullvadvpn.model.TunnelState
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
@@ -28,6 +29,9 @@ import org.junit.Before
 import org.junit.Test
 
 class DeviceRevokedViewModelTest {
+
+    @MockK
+    private lateinit var mockedAccountCache: AccountCache
 
     @MockK
     private lateinit var mockedServiceConnectionManager: ServiceConnectionManager
@@ -44,6 +48,7 @@ class DeviceRevokedViewModelTest {
         every { mockedServiceConnectionManager.connectionState } returns serviceConnectionState
         viewModel = DeviceRevokedViewModel(
             mockedServiceConnectionManager,
+            mockedAccountCache,
             TestCoroutineDispatcher()
         )
     }
@@ -100,7 +105,7 @@ class DeviceRevokedViewModelTest {
         val mockedContainer = mockk<ServiceConnectionContainer>().also {
             every { it.connectionProxy.state } returns TunnelState.Disconnected
             every { it.connectionProxy.disconnect() } just Runs
-            every { it.accountCache.logout() } just Runs
+            every { mockedAccountCache.logout() } just Runs
         }
         serviceConnectionState.value = ServiceConnectionState.ConnectedReady(mockedContainer)
 
@@ -109,7 +114,7 @@ class DeviceRevokedViewModelTest {
 
         // Assert
         verify {
-            mockedContainer.accountCache.logout()
+            mockedAccountCache.logout()
         }
     }
 
@@ -119,7 +124,7 @@ class DeviceRevokedViewModelTest {
         val mockedContainer = mockk<ServiceConnectionContainer>().also {
             every { it.connectionProxy.state } returns TunnelState.Connected(mockk(), mockk())
             every { it.connectionProxy.disconnect() } just Runs
-            every { it.accountCache.logout() } just Runs
+            every { mockedAccountCache.logout() } just Runs
         }
         serviceConnectionState.value = ServiceConnectionState.ConnectedReady(mockedContainer)
 
@@ -129,7 +134,7 @@ class DeviceRevokedViewModelTest {
         // Assert
         verifyOrder {
             mockedContainer.connectionProxy.disconnect()
-            mockedContainer.accountCache.logout()
+            mockedAccountCache.logout()
         }
     }
 

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModelTest.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import net.mullvad.mullvadvpn.compose.state.DeviceRevokedUiState
 import net.mullvad.mullvadvpn.model.TunnelState
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
@@ -31,7 +31,7 @@ import org.junit.Test
 class DeviceRevokedViewModelTest {
 
     @MockK
-    private lateinit var mockedAccountCache: AccountCache
+    private lateinit var mockedAccountRepository: AccountRepository
 
     @MockK
     private lateinit var mockedServiceConnectionManager: ServiceConnectionManager
@@ -48,7 +48,7 @@ class DeviceRevokedViewModelTest {
         every { mockedServiceConnectionManager.connectionState } returns serviceConnectionState
         viewModel = DeviceRevokedViewModel(
             mockedServiceConnectionManager,
-            mockedAccountCache,
+            mockedAccountRepository,
             TestCoroutineDispatcher()
         )
     }
@@ -105,7 +105,7 @@ class DeviceRevokedViewModelTest {
         val mockedContainer = mockk<ServiceConnectionContainer>().also {
             every { it.connectionProxy.state } returns TunnelState.Disconnected
             every { it.connectionProxy.disconnect() } just Runs
-            every { mockedAccountCache.logout() } just Runs
+            every { mockedAccountRepository.logout() } just Runs
         }
         serviceConnectionState.value = ServiceConnectionState.ConnectedReady(mockedContainer)
 
@@ -114,7 +114,7 @@ class DeviceRevokedViewModelTest {
 
         // Assert
         verify {
-            mockedAccountCache.logout()
+            mockedAccountRepository.logout()
         }
     }
 
@@ -124,7 +124,7 @@ class DeviceRevokedViewModelTest {
         val mockedContainer = mockk<ServiceConnectionContainer>().also {
             every { it.connectionProxy.state } returns TunnelState.Connected(mockk(), mockk())
             every { it.connectionProxy.disconnect() } just Runs
-            every { mockedAccountCache.logout() } just Runs
+            every { mockedAccountRepository.logout() } just Runs
         }
         serviceConnectionState.value = ServiceConnectionState.ConnectedReady(mockedContainer)
 
@@ -134,7 +134,7 @@ class DeviceRevokedViewModelTest {
         // Assert
         verifyOrder {
             mockedContainer.connectionProxy.disconnect()
-            mockedAccountCache.logout()
+            mockedAccountRepository.logout()
         }
     }
 

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
@@ -22,7 +22,6 @@ import net.mullvad.mullvadvpn.model.LoginResult
 import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
-import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionState
 import org.junit.Before
 import org.junit.Test
@@ -36,15 +35,12 @@ class LoginViewModelTest {
     private lateinit var mockedDeviceRepository: DeviceRepository
 
     @MockK
-    private lateinit var mockedServiceConnectionManager: ServiceConnectionManager
-
-    @MockK
     private lateinit var mockedServiceConnectionContainer: ServiceConnectionContainer
 
     private lateinit var loginViewModel: LoginViewModel
 
     private val accountCreationTestEvents = MutableSharedFlow<AccountCreationResult>()
-    private val accountHistoryTestEvents = MutableSharedFlow<AccountHistory>()
+    private val accountHistoryTestEvents = MutableStateFlow<AccountHistory>(AccountHistory.Missing)
     private val loginTestEvents = MutableSharedFlow<Event.LoginEvent>()
 
     private val serviceConnectionState =
@@ -58,15 +54,13 @@ class LoginViewModelTest {
         every { mockedAccountCache.accountCreationEvents } returns accountCreationTestEvents
         every { mockedAccountCache.accountHistoryEvents } returns accountHistoryTestEvents
         every { mockedAccountCache.loginEvents } returns loginTestEvents
-        every { mockedServiceConnectionManager.connectionState } returns serviceConnectionState
-        every { mockedServiceConnectionContainer.accountCache } returns mockedAccountCache
 
         serviceConnectionState.value =
             ServiceConnectionState.ConnectedReady(mockedServiceConnectionContainer)
 
         loginViewModel = LoginViewModel(
+            mockedAccountCache,
             mockedDeviceRepository,
-            mockedServiceConnectionManager,
             TestCoroutineDispatcher()
         )
     }

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
@@ -19,7 +19,7 @@ import net.mullvad.mullvadvpn.model.AccountCreationResult
 import net.mullvad.mullvadvpn.model.AccountHistory
 import net.mullvad.mullvadvpn.model.DeviceListEvent
 import net.mullvad.mullvadvpn.model.LoginResult
-import net.mullvad.mullvadvpn.ui.serviceconnection.AccountCache
+import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionState
@@ -29,7 +29,7 @@ import org.junit.Test
 class LoginViewModelTest {
 
     @MockK
-    private lateinit var mockedAccountCache: AccountCache
+    private lateinit var mockedAccountRepository: AccountRepository
 
     @MockK
     private lateinit var mockedDeviceRepository: DeviceRepository
@@ -51,15 +51,15 @@ class LoginViewModelTest {
         Dispatchers.setMain(TestCoroutineDispatcher())
         MockKAnnotations.init(this, relaxUnitFun = true)
 
-        every { mockedAccountCache.accountCreationEvents } returns accountCreationTestEvents
-        every { mockedAccountCache.accountHistoryEvents } returns accountHistoryTestEvents
-        every { mockedAccountCache.loginEvents } returns loginTestEvents
+        every { mockedAccountRepository.accountCreationEvents } returns accountCreationTestEvents
+        every { mockedAccountRepository.accountHistoryEvents } returns accountHistoryTestEvents
+        every { mockedAccountRepository.loginEvents } returns loginTestEvents
 
         serviceConnectionState.value =
             ServiceConnectionState.ConnectedReady(mockedServiceConnectionContainer)
 
         loginViewModel = LoginViewModel(
-            mockedAccountCache,
+            mockedAccountRepository,
             mockedDeviceRepository,
             TestCoroutineDispatcher()
         )
@@ -163,7 +163,7 @@ class LoginViewModelTest {
     @Test
     fun testClearingAccountHistory() = runBlockingTest {
         loginViewModel.clearAccountHistory()
-        verify { mockedAccountCache.clearAccountHistory() }
+        verify { mockedAccountRepository.clearAccountHistory() }
     }
 
     private suspend fun <T> FlowTurbine<T>.skipDefaultItem() where T : Any? {


### PR DESCRIPTION
Refactor the android app account cache into a repository which makes it possible to inject and easier to test.

Git checklist:

~* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.~ (refactoring)
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3718)
<!-- Reviewable:end -->
