### PR TITLE
Don't update the ST paths copy if applying the config fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Fix DNS issue on non-English Windows installations. Don't parse the output of ipconfig.exe
   to determine if the tool succeeded.
+- Only use the most recent list of apps to split when resuming from hibernation/sleep if applying
+  it was successful.
 
 ### Security
 #### Android

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -454,8 +454,8 @@ impl SplitTunnel {
                                     error.display_chain_with_msg("Failed to update path monitor")
                                 );
                             }
+                            *monitored_paths_guard = paths.to_vec();
                         }
-                        *monitored_paths_guard = paths.to_vec();
 
                         result
                     }


### PR DESCRIPTION
Previously, if one had tried to update the list of apps to split but applying the config failed, that new config would still be reapplied after resuming from sleep. That's unexpected: The list should always be synchronized with the paths that are actively being split.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3719)
<!-- Reviewable:end -->
