### PR TITLE
Stop appending `format!(...)` to existing strings

### DIFF
--- a/android/translations-converter/src/android/string_value.rs
+++ b/android/translations-converter/src/android/string_value.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{
-    fmt::{self, Display, Formatter},
+    fmt::{self, Display, Formatter, Write},
     ops::Deref,
 };
 
@@ -74,7 +74,7 @@ impl StringValue {
                 output.push('%');
             } else {
                 // String doesn't have a parameter index, so it is added
-                output.push_str(&format!("%{}$", index + offset));
+                write!(&mut output, "%{}$", index + offset).expect("formatting failed");
             }
 
             output.push_str(part);

--- a/mullvad-exclude/src/main.rs
+++ b/mullvad-exclude/src/main.rs
@@ -1,6 +1,8 @@
 #[cfg(target_os = "linux")]
 use nix::unistd::{execvp, getgid, getpid, getuid, setgid, setuid};
 #[cfg(target_os = "linux")]
+use std::fmt::Write as _;
+#[cfg(target_os = "linux")]
 use std::{
     convert::Infallible,
     env,
@@ -59,7 +61,7 @@ fn main() {
             let mut s = format!("{}", e);
             let mut source = e.source();
             while let Some(error) = source {
-                s.push_str(&format!("\nCaused by: {}", error));
+                write!(&mut s, "\nCaused by: {}", error).expect("formatting failed");
                 source = error.source();
             }
             eprintln!("{}", s);

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(rust_2018_idioms)]
 
-use std::{error::Error, fmt};
+use std::{error::Error, fmt, fmt::Write};
 
 #[cfg(target_os = "android")]
 pub mod android;
@@ -24,7 +24,7 @@ impl<E: Error> ErrorExt for E {
         let mut s = format!("Error: {}", self);
         let mut source = self.source();
         while let Some(error) = source {
-            s.push_str(&format!("\nCaused by: {}", error));
+            write!(&mut s, "\nCaused by: {}", error).expect("formatting failed");
             source = error.source();
         }
         s
@@ -34,7 +34,7 @@ impl<E: Error> ErrorExt for E {
         let mut s = format!("Error: {}\nCaused by: {}", msg, self);
         let mut source = self.source();
         while let Some(error) = source {
-            s.push_str(&format!("\nCaused by: {}", error));
+            write!(&mut s, "\nCaused by: {}", error).expect("formatting failed");
             source = error.source();
         }
         s


### PR DESCRIPTION
Clippy rejects `s.push_str(&format!(...))`, due to the extra copy (see [this](https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string)). This PR fixes that.

Note: This lint was added in [Rust 1.62](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-162).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3721)
<!-- Reviewable:end -->
