### PR TITLE
Use derive attribute for default enum variants

### DIFF
--- a/mullvad-daemon/src/migrations/v3.rs
+++ b/mullvad-daemon/src/migrations/v3.rs
@@ -6,17 +6,12 @@ use std::net::IpAddr;
 // Section for vendoring types and values that
 // this settings version depend on. See `mod.rs`.
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum DnsState {
+    #[default]
     Default,
     Custom,
-}
-
-impl Default for DnsState {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 /// DNS config

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -497,18 +497,13 @@ pub enum BridgeSettings {
     Custom(ProxySettings),
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SelectedObfuscation {
     Auto,
+    #[default]
     Off,
     Udp2Tcp,
-}
-
-impl Default for SelectedObfuscation {
-    fn default() -> Self {
-        SelectedObfuscation::Off
-    }
 }
 
 impl fmt::Display for SelectedObfuscation {

--- a/mullvad-types/src/settings/dns.rs
+++ b/mullvad-types/src/settings/dns.rs
@@ -3,17 +3,12 @@ use jnix::{jni::objects::JObject, FromJava, IntoJava, JnixEnv};
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum DnsState {
+    #[default]
     Default,
     Custom,
-}
-
-impl Default for DnsState {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 /// DNS config

--- a/talpid-core/src/winnet.rs
+++ b/talpid-core/src/winnet.rs
@@ -81,18 +81,13 @@ pub fn ensure_best_metric_for_interface(interface_alias: &str) -> Result<bool, E
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 #[allow(dead_code)]
 #[repr(u32)]
 pub enum WinNetAddrFamily {
+    #[default]
     IPV4 = 0,
     IPV6 = 1,
-}
-
-impl Default for WinNetAddrFamily {
-    fn default() -> Self {
-        WinNetAddrFamily::IPV4
-    }
 }
 
 impl WinNetAddrFamily {

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -300,17 +300,12 @@ impl fmt::Display for AllowedTunnelTraffic {
 }
 
 /// IP protocol version.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IpVersion {
+    #[default]
     V4,
     V6,
-}
-
-impl Default for IpVersion {
-    fn default() -> IpVersion {
-        IpVersion::V4
-    }
 }
 
 impl fmt::Display for IpVersion {


### PR DESCRIPTION
This means `Default` doesn't have to be manually implemented for (most) enums.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3722)
<!-- Reviewable:end -->
