### PR TITLE
Fix app occasionally getting stuck in the offline state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Only use the most recent list of apps to split when resuming from hibernation/sleep if applying
   it was successful.
+- Fix app occasionally getting stuck in the offline state after being suspended.
 
 ### Security
 #### Android


### PR DESCRIPTION
`PowerManagementListener` previously only retained the most recent event. Since `ResumeSuspend` is sometimes sent at the same time as `ResumeAutomatic`, receivers would potentially only see one of the events. This PR fixes this by using a broadcast channel instead of `watch`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3727)
<!-- Reviewable:end -->
