### PR TITLE
Disable badge for tunnel state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 #### Android
 - Lowered default MTU to 1280 on Android.
+- Disable app icon badge for tunnel state notification/status.
 
 ### Removed
 #### Android

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -41,6 +41,7 @@ class AccountExpiryNotification(
         R.string.account_time_notification_channel_name,
         R.string.account_time_notification_channel_description,
         NotificationManager.IMPORTANCE_HIGH,
+        true,
         true
     )
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -15,7 +15,8 @@ class NotificationChannel(
     name: Int,
     description: Int,
     importance: Int,
-    isVibrationEnabled: Boolean
+    isVibrationEnabled: Boolean,
+    isBadgeEnabled: Boolean
 ) {
     private val badgeColor by lazy {
         context.getColor(R.color.colorPrimary)
@@ -30,7 +31,7 @@ class NotificationChannel(
         val channel = NotificationChannelCompat.Builder(id, importance)
             .setName(channelName)
             .setDescription(channelDescription)
-            .setShowBadge(true)
+            .setShowBadge(isBadgeEnabled)
             .setVibrationEnabled(isVibrationEnabled)
             .build()
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -24,6 +24,7 @@ class TunnelStateNotification(val context: Context) {
         R.string.foreground_notification_channel_name,
         R.string.foreground_notification_channel_description,
         NotificationManager.IMPORTANCE_MIN,
+        false,
         false
     )
 


### PR DESCRIPTION
Skip showing a app icon badge for the tunnel state and instead just keep it for expiration notifications. 

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3735)
<!-- Reviewable:end -->
