### PR TITLE
Connect to tcp2udp endpoints over IPv6 (if enabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Line wrap the file at 100 chars.                                              Th
 - Remove WireGuard view as it's no longer needed with the new way of managing devices.
 
 ### Fixed
+- Connect to TCP endpoints over IPv6 if IPv6 is enabled for WireGuard.
+
 #### Android
 - Fix unused dependencies loaded in the service/tile DI graph.
 - Fix missing IPC message unregistration causing multiple copies of some messages to be received.

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -903,7 +903,7 @@ impl RelaySelector {
         &self,
         obfuscation_settings: &Udp2TcpObfuscationSettings,
         relay: &Relay,
-        _endpoint: &MullvadWireguardEndpoint,
+        endpoint: &MullvadWireguardEndpoint,
         retry_attempt: u32,
     ) -> Option<SelectedObfuscator> {
         let udp2tcp_ports = &self.parsed_relays.lock().locations.wireguard.udp2tcp_ports;
@@ -916,7 +916,7 @@ impl RelaySelector {
         };
         udp2tcp_endpoint
             .map(|udp2tcp_endpoint| ObfuscatorConfig::Udp2Tcp {
-                endpoint: SocketAddr::new(relay.ipv4_addr_in.into(), *udp2tcp_endpoint),
+                endpoint: SocketAddr::new(endpoint.peer.endpoint.ip(), *udp2tcp_endpoint),
             })
             .map(|config| SelectedObfuscator {
                 config,


### PR DESCRIPTION
Previously, the IP setting was ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3739)
<!-- Reviewable:end -->
