### PR TITLE
Fix PQ secure tunnels not working when connecting over TCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Connect to TCP endpoints over IPv6 if IPv6 is enabled for WireGuard.
+- Fix udp2tcp not working when quantum-resistant tunnels are enabled.
 
 #### Android
 - Fix unused dependencies loaded in the service/tile DI graph.


### PR DESCRIPTION
Previously, WireGuard tunnels would break after the PQ key exchange when `udp2tcp` was in use. This was because `udp2tcp` connected the UDP socket to the source of the first incoming datagram. When updating the WireGuard config, the old endpoint socket is apparently replaced in most implementations. The new client is unable to connect to the local `udp2tcp` server because the "session" is tied to the previous source address.

This PR solves the issue by creating a new `udp2tcp` instance before updating the WireGuard config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3743)
<!-- Reviewable:end -->
