### PR TITLE
Enter blocking state atomically when service is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Add device management to the Android app. This simplifies knowing which device is which and adds
   the option to log other devices out when the account already has five devices.
+
 #### Windows
 - Windows daemon now looks up the MTU on the default interface and uses this MTU instead of the
   default 1500. The 1500 is still the fallback if this for some reason fails. This may stop
@@ -64,6 +65,11 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Prevent location request responses from being received outside the tunnel when in the connected
   state.
+
+#### Windows
+- Fix potential leak window when stopping the service and auto-connect is enabled and always require
+  VPN is disabled. When stopped, usually due to a reboot, the daemon would disconnect before
+  entering a blocking state.
 
 
 ## [2022.3-beta2] - 2022-06-29

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -758,13 +758,6 @@ where
             }
         }
 
-        // If auto-connect is enabled, block all traffic before shutting down to ensure
-        // that no traffic can leak during boot.
-        #[cfg(windows)]
-        if self.settings.auto_connect {
-            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
-        }
-
         self.finalize().await;
         Ok(())
     }
@@ -2144,6 +2137,13 @@ where
     }
 
     fn trigger_shutdown_event(&mut self) {
+        // If auto-connect is enabled, block all traffic before shutting down to ensure
+        // that no traffic can leak during boot.
+        #[cfg(windows)]
+        if self.settings.auto_connect {
+            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
+        }
+
         self.state.shutdown(&self.tunnel_state);
         self.disconnect_tunnel();
     }


### PR DESCRIPTION
There exists a small potential leak window when stopping the service and auto-connect is enabled:

```
[2022-07-13 11:37:45.058][talpid_core::firewall][INFO] Resetting firewall policy
[2022-07-13 11:37:45.160][mullvad_daemon][DEBUG] New tunnel state: Disconnected
[2022-07-13 11:37:45.171][talpid_core::firewall][INFO] Applying firewall policy: Blocked. Allowing LAN. Allowing endpoint 45.83.222.100:443/TCP for mullvad-problem-report.exe mullvad-daemon.exe
```

The firewall is supposed to block until the daemon has restarted, but in this particular case, the firewall state would be wiped prior to the blocking filters being added.

This is only relevant when always require VPN is disabled and auto-connect is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3745)
<!-- Reviewable:end -->
