### PR TITLE
Migrate a given percentage of windows users to WG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Line wrap the file at 100 chars.                                              Th
 - Windows daemon now looks up the MTU on the default interface and uses this MTU instead of the
   default 1500. The 1500 is still the fallback if this for some reason fails. This may stop
   fragmentation.
+- The default VPN protocol is slowly being changed from OpenVPN to WireGuard.
+  The app fetches the ratio between the protocols from the API.
 
 #### Linux
 - GUI: Add electron flags to run Wayland native if in a compositor/desktop known to work well

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,7 @@ dependencies = [
  "jnix",
  "lazy_static",
  "log",
+ "rand 0.8.5",
  "regex",
  "serde",
  "talpid-types",

--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -45,10 +45,13 @@ constraints, following default ones will take effect:
 
 - If no tunnel protocol is specified for tunnel endpoints, then the behavior is different on Windows
   and other platforms.
-  - On Windows, OpenVPN is used.
   - On MacOS and Linux, first two connection attempts will use WireGuard, over a random port at
     first and then port 53. From the third attempt onwards, OpenVPN will be used, alternating
     between UDP on any port and TCP on port 443.
+  - On Windows, a migration to WireGuard is ongoing and a percentage value provided by the API tells
+    clients to randomly decide if they will use WireGuard as a default or OpenVPN as a default.
+    The client's decision will persist over time.
+    If the client decides to use WireGuard it will have the same behavior as MacOS and Linux.
 
 - If the tunnel protocol is specified as WireGuard without any other protocol constraints, then the
   transport protocol is not applicable as only UDP endpoints exist and any port will be matched.

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -477,6 +477,16 @@ pub struct AppVersionResponse {
     pub latest: AppVersion,
     pub latest_stable: Option<AppVersion>,
     pub latest_beta: AppVersion,
+    #[serde(default = "default_wg_threshold")]
+    pub x_threshold_wg_default: f32,
+}
+
+/// Temporary function that will be removed later. Used to generate default wg_threshold.
+/// In case there is no `x_threshold_wg_default` returned by the API result we interpret that to
+/// mean that the migration is done and WireGuard should be the default. In that case the threshold
+/// value should be 1.0
+fn default_wg_threshold() -> f32 {
+    1.0
 }
 
 impl AppVersionProxy {

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -15,6 +15,7 @@ lazy_static = "1.1.0"
 log = "0.4"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
+rand = "0.8"
 
 talpid-types = { path = "../talpid-types" }
 

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 #[cfg(target_os = "android")]
 use jnix::IntoJava;
+use rand::Rng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(target_os = "windows")]
 use std::{collections::HashSet, path::PathBuf};
@@ -88,9 +89,21 @@ pub struct Settings {
     /// Split tunneling settings
     #[cfg(windows)]
     pub split_tunnel: SplitTunnelSettings,
+    /// Temporary variable for a random number between 0 and 1 that determines if the user should
+    /// use wireguard or openvpn when the automatic feature is set. This variable will be removed
+    /// in future versions.
+    /// A value of -1.0 implies that the variable should be initialized to a random number.
+    /// NOTE: This field will be removed completely in future versions.
+    #[serde(default = "out_of_range_wg_migration_rand_num")]
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub wg_migration_rand_num: f32,
     /// Specifies settings schema version
     #[cfg_attr(target_os = "android", jnix(skip))]
     settings_version: SettingsVersion,
+}
+
+fn out_of_range_wg_migration_rand_num() -> f32 {
+    -1.0
 }
 
 #[cfg(windows)]
@@ -120,6 +133,7 @@ impl Default for Settings {
             auto_connect: false,
             tunnel_options: TunnelOptions::default(),
             show_beta_releases: false,
+            wg_migration_rand_num: rand::thread_rng().gen_range(0.0..=1.0),
             #[cfg(windows)]
             split_tunnel: SplitTunnelSettings::default(),
             settings_version: CURRENT_SETTINGS_VERSION,

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -15,7 +15,7 @@ lazy_static::lazy_static! {
 
 /// AppVersionInfo represents the current stable and the current latest release versions of the
 /// Mullvad VPN app.
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct AppVersionInfo {
@@ -35,6 +35,11 @@ pub struct AppVersionInfo {
     pub latest_beta: AppVersion,
     /// Whether should update to newer version
     pub suggested_upgrade: Option<AppVersion>,
+    /// Temporary field provided by the API used to decide if a user should default to Wireguard or
+    /// OpenVpn. Represents the percentage of users which should use Wireguard.
+    /// NOTE: This field will be removed completely in future versions.
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub wg_migration_threshold: f32,
 }
 
 pub type AppVersion = String;


### PR DESCRIPTION
Retrieve a percentage from the version check API response.
Use this percentage to decide if a user should use WG or OpenVpn as
their "automatic" default option.

Currently not implemented for windows or functioning and contains dbg
statements.

Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3748)
<!-- Reviewable:end -->
