### PR TITLE
Fix expiry fetch and notification

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -67,7 +67,7 @@ class AccountExpiryNotification(
         val expiryDate = expiry.date()
         val durationUntilExpiry = expiryDate?.remainingTime()
 
-        if (durationUntilExpiry?.isCloseToExpiry() == true) {
+        if (accountCache.isNewAccount.not() && durationUntilExpiry?.isCloseToExpiry() == true) {
             val notification = build(expiryDate, durationUntilExpiry)
             channel.notificationManager.notify(NOTIFICATION_ID, notification)
             jobTracker.newUiJob("scheduleUpdate") { scheduleUpdate() }


### PR DESCRIPTION
Fixes expiry fetching which was broken due to switching from `StateFlow` to `SharedFlow` in `MullvadDaemon`. Also ensures that the expiration notification isn't show if the account is newly created.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3752)
<!-- Reviewable:end -->
