### PR TITLE
Add swift-format

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,11 +2,29 @@ name: iOS app
 on:
     pull_request:
         paths:
-            - .github/workflows/ios.yml
-            - ios/**
+            - ".github/workflows/ios.yml"
+            - "ios/.swiftformat"
+            - "ios/**/*.swift"
     # Build if requested manually from the Actions tab
     workflow_dispatch:
 jobs:
+    check-formatting:
+        name: Check formatting
+        runs-on: macos-11
+        steps:
+            - name: Install SwiftFormat
+              run: |
+                brew update
+                brew upgrade swiftformat
+
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Check formatting
+              run: |
+                swiftformat --version
+                swiftformat --lint .
+
     test:
         name: Unit tests
         runs-on: macos-11
@@ -17,10 +35,10 @@ jobs:
             source_packages_dir: .spm
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Configure cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: ios/${{ env.source_packages_dir }}
                 key: ${{ runner.os }}-spm-${{ hashFiles('ios/**/Package.resolved') }}
@@ -28,7 +46,7 @@ jobs:
                   ${{ runner.os }}-spm-
 
             - name: Setup go-lang
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@v3
               with:
                   go-version: '1.16.5'
 

--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -1,0 +1,14 @@
+# file options
+--exclude Build, .spm, MullvadVPNScreenshots/SnapshotHelper.swift
+
+# general options
+--swiftversion 5.5
+
+# format options
+--indent 4
+--maxwidth 100
+--wraparguments before-first
+--wrapcollections before-first
+--wrapternary before-operators
+--redundanttype inferred
+--disable initCoderUnavailable, redundantReturn, unusedArguments, redundantRawValues, preferKeyPath

--- a/ios/README.md
+++ b/ios/README.md
@@ -12,6 +12,28 @@ instructions document.
 [changelog]: CHANGELOG.md
 [Configure Xcode project]: BuildInstructions.md#configure-xcode-project
 
+## Code formatting
+
+The codebase is formatted using [SwiftFormat](https://github.com/nicklockwood/SwiftFormat). Please 
+format all contributions using the latest version of formatter.
+
+```
+swiftformat ios/
+```
+
+Install the latest version of SwiftFormat via Homebrew:
+
+```
+brew install swiftformat
+```
+
+CI uses the latest version available on Homebrew to check formatting, so please keep your local 
+installation up to date, if you see it complain:
+
+```
+brew upgrade swiftformat 
+```
+
 ## Screenshots for AppStore
 
 The process of taking AppStore screenshots is automated using a UI Testing bundle and Snapshot tool,


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

After careful examination of [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) and [Apple swift-format](https://github.com/apple/swift-format) I think I lean towards the former tool as it seems to be feature rich and well documented.

This PR adds [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) support on Github actions but does not reformat the entire codebase, which I think deserves a separate PR once we're light on unmerged changes.

The latest `SwiftFormat` can be installed via Homebrew:

```brew install swiftformat```

Use the following command to format the source code within the repository:

```
cd ios
swiftformat .
```

To view the complete list of supported rules, run:

```
swiftformat --ruleinfo
```

## Basic configuration

- Swift 5.5
- 4 space indentation
- 100 character limit per line

## Rule overrides

- `--wraparguments before-first`

  ```diff
  - foo(bar: Int,
  -     baz: String)

  + foo(
  +   bar: Int,
  +   baz: String
  + )

  - class Foo<Bar,
  -           Baz>
  
  + class Foo<
  +   Bar,
  +   Baz
  + >
  ```

- `--wrapternary before-operator`

  ```diff
  - let result = condition ? "Truthy statement" : "False statement"
  + let result = condition
  +     ? "Truthy statement"
  +     : "False statement"
  ```

- `--wrapcollections before-first`:

  ```diff
  - let foo = [bar,
               baz,
  -            quuz]

  + let foo = [
  +   bar,
      baz,
  +   quuz
  + ]
  ```

- `redundanttype`

  ```diff
  - let view: UIView = UIView()
  + let view = UIView()
  ```

## Disabled rules

- `initCoderUnavailable` - Add @available(*, unavailable) attribute to required `init(coder:)` when it hasn't been implemented.

  ```diff
  + @available(*, unavailable)
    required init?(coder aDecoder: NSCoder) {
      fatalError("init(coder:) has not been implemented")
    }
  ```

- `redundantReturn` - all returns become implicit (i.e no `return` statement). Subjective, I dislike implicit returns in Swift.
- `unusedArguments` - replaces all unused arguments with `_`. Subjective, I don't think it has to be enforced. I think there are legit cases in closures, but it can be done manually by developers.
- `redundantRawValues` -  Remove redundant raw string values for enum cases. Subjective, I think it can do some harm, for example settings store keys cannot be renamed without performing migration for older versions of the app. On the other side, normally, raw values are not specified by hand when `enum` is inherited from a primitive type.
  
  ```diff
    enum Foo: String {
  -   case bar = "bar"
      case baz = "quux"
    }

    enum Foo: String {
  +   case bar
      case baz = "quux"
    }
  ```
- `preferKeyPath` - Convert trivial map `{ $0.foo }` closures to keyPath-based syntax. Subjective. I am not used to this expression style that much. Although I don't mind if others on the team do that, I'd probably write closure by hand. Hence I feel like it does not have to be enforced.

  ```diff
  - let barArray = fooArray.map { $0.bar }
  + let barArray = fooArray.map(\.bar)

  - let barArray = fooArray.compactMap { $0.optionalBar }
  + let barArray = fooArray.compactMap(\.optionalBar)
  ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3756)
<!-- Reviewable:end -->
