### PR TITLE
Fix reconnect in blocked state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
 - Connect to TCP endpoints over IPv6 if IPv6 is enabled for WireGuard.
 - Fix udp2tcp not working when quantum-resistant tunnels are enabled.
 - Quit app gracefully if renderer process is killed or crashes.
+- Enable reconnect in blocked state in desktop app.
 
 #### Android
 - Fix unused dependencies loaded in the service/tile DI graph.

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -919,7 +919,7 @@ class ApplicationMain {
     // If there's a fallback state set then the app is in an assumed next state and need to check
     // if it's now reached or if the current state should be ignored and set as the fallback state.
     if (this.tunnelStateFallback) {
-      if (this.tunnelState.state === newState.state) {
+      if (this.tunnelState.state === newState.state || newState.state === 'error') {
         this.tunnelStateFallbackScheduler.cancel();
         this.tunnelStateFallback = undefined;
       } else {

--- a/gui/src/shared/connect-helper.ts
+++ b/gui/src/shared/connect-helper.ts
@@ -18,7 +18,9 @@ export function reconnectEnabled(
   tunnelState: TunnelState['state'],
 ) {
   return (
-    connectedToDaemon && loggedIn && (tunnelState === 'connected' || tunnelState === 'connecting')
+    connectedToDaemon &&
+    loggedIn &&
+    (tunnelState === 'connected' || tunnelState === 'connecting' || tunnelState === 'error')
   );
 }
 


### PR DESCRIPTION
This state enables reconnecting in the blocked state and also always allows the app to enter the blocked state no matter what state is expected to be the next one.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
