### PR TITLE
Fix in-app notification url crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix quick settings tile being unresponsive and causing crashes on some devices.
 - Fix quick settings tile not working when the device is locked. It will now prompt the user to
   unlock the device before attempting to toggle the tunnel state.
+- Fix crash when clicking in-app URL notifications. 
 
 #### Windows
 - Only use the most recent list of apps to split when resuming from hibernation/sleep if applying

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrl.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrl.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.ui.notification
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.net.Uri
 
 abstract class NotificationWithUrl(
@@ -11,7 +12,10 @@ abstract class NotificationWithUrl(
     private val url = Uri.parse(context.getString(urlId))
 
     protected val openUrl: suspend () -> Unit = {
-        context.startActivity(Intent(Intent.ACTION_VIEW, url))
+        val intent = Intent(Intent.ACTION_VIEW, url).apply {
+            flags = FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(intent)
     }
 
     init {


### PR DESCRIPTION
Fixes a crash occurring when in-app notifications are used to open URLs. 

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3762)
<!-- Reviewable:end -->
