### PR TITLE
Add flag that prevents navigation from resetting 2 minutes after blur

### DIFF
--- a/gui/tasks/electron.js
+++ b/gui/tasks/electron.js
@@ -1,10 +1,17 @@
 const { spawn } = require('child_process');
 const electron = require('electron');
 
+const DISABLE_RESET_NAVIGATION = '--disable-reset-navigation';
+
 let subprocess;
 
 function startElectron(done) {
-  subprocess = spawn(electron, ['.'], {
+  const args = [];
+  if (process.argv.includes(DISABLE_RESET_NAVIGATION)) {
+    args.push(DISABLE_RESET_NAVIGATION);
+  }
+
+  subprocess = spawn(electron, ['.', ...args], {
     env: { ...process.env, NODE_ENV: 'development' },
     stdio: 'inherit',
   });


### PR DESCRIPTION
This PR adds the flag `--disable-reset-navigation` which disables the timer that is activated on blur and when fired resets the navigation to the main view. This flag is only available when running the app in development and is useful when working on the same view for a long time. Before this I had to navigate back to the view I was working on if I spent more than two minutes between each test.

Git checklist:

* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3769)
<!-- Reviewable:end -->
