### PR TITLE
Update netlink crates to support later kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,9 +1745,9 @@ checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.2.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac48279d5062bdf175bdbcb6b58ff1d6b0ecd54b951f7a0ff4bc0550fe903ccb"
+checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1757,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.8.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76aed5d3b6e3929713bf1e1334a11fd65180b6d9f5d7c8572664c48b122604f8"
+checksum = "f5dee5ed749373c298237fe694eb0a51887f4cc1a27370c8464bac4382348f1a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1771,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-utils"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fcfb6f758b66e964b2339596d94078218d96aad5b32003e8e2a1d23c27a6784"
+checksum = "25af9cf0dc55498b7bd94a1508af7a78706aa0ab715a73c5169273e03c84845e"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1783,25 +1783,26 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd06e90449ae973fe3888c1ff85949604ef5189b4ac9a2ae39518da1e00762d"
+checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
  "bytes",
  "futures",
  "log",
  "netlink-packet-core",
  "netlink-sys",
+ "thiserror",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
 name = "netlink-sys"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48ea34ea0678719815c3753155067212f853ad2d8ef4a49167bae7f7c254188"
+checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
 dependencies = [
+ "bytes",
  "futures",
  "libc",
  "log",
@@ -1842,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -1855,15 +1856,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -2568,15 +2567,15 @@ checksum = "d4a874cf4a0b9bc283edaa65d81d62368b84b1a8e56196e4885ca4701fd49972"
 
 [[package]]
 name = "rtnetlink"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9a6200d18ec1acfc218ce71363dcc9b6075f399220f903fdfeacd476a876ef"
+checksum = "46f1cfa18f8cebe685373a2697915d7e0db3b4554918bba118385e0f71f258a7"
 dependencies = [
  "futures",
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix 0.22.3",
+ "nix 0.24.2",
  "thiserror",
  "tokio",
 ]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -56,12 +56,12 @@ jnix = { version = "0.4", features = ["derive"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = "0.10"
 resolv-conf = "0.7"
-rtnetlink = "0.8"
-netlink-packet-core = "0.2"
-netlink-packet-utils = "0.4"
-netlink-packet-route = "0.8"
-netlink-proto = "0.7"
-netlink-sys = "0.7"
+rtnetlink = "0.11"
+netlink-packet-core = "0.4.2"
+netlink-packet-utils = "0.5.1"
+netlink-packet-route = "0.13"
+netlink-proto = "0.10"
+netlink-sys = "0.8.3"
 nftnl = { version = "0.6.2", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2.2", features = ["mnl-1-0-4"] }
 which = { version = "4.0", default-features = false }

--- a/talpid-core/src/routing/linux.rs
+++ b/talpid-core/src/routing/linux.rs
@@ -2,6 +2,7 @@ use crate::routing::{
     imp::{CallbackMessage, RouteManagerCommand},
     NetNode, Node, RequiredRoute, Route,
 };
+use netlink_sys::AsyncSocket;
 use std::{
     collections::{BTreeMap, HashSet},
     io,
@@ -144,7 +145,11 @@ impl RouteManagerImpl {
 
         let mgroup_flags = RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_ROUTE | RTMGRP_LINK | RTMGRP_NOTIFY;
         let addr = SocketAddr::new(0, mgroup_flags);
-        connection.socket_mut().bind(&addr).map_err(Error::Bind)?;
+        connection
+            .socket_mut()
+            .socket_mut()
+            .bind(&addr)
+            .map_err(Error::Bind)?;
 
         tokio::spawn(connection);
 

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/mod.rs
@@ -309,8 +309,7 @@ impl WireguardConnection {
 }
 
 fn consume_netlink_error<
-    T,
-    I: NetlinkDeserializable<T> + Clone + Eq + std::fmt::Debug,
+    I: NetlinkDeserializable + Clone + Eq + std::fmt::Debug,
     F: Fn(rtnetlink::Error) -> Error,
 >(
     message: NetlinkMessage<I>,

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/nl_message.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/nl_message.rs
@@ -36,7 +36,7 @@ impl NetlinkControlMessage {
     }
 }
 
-impl NetlinkSerializable<NetlinkControlMessage> for NetlinkControlMessage {
+impl NetlinkSerializable for NetlinkControlMessage {
     fn message_type(&self) -> u16 {
         libc::GENL_ID_CTRL as u16
     }
@@ -57,7 +57,7 @@ impl From<NetlinkControlMessage> for NetlinkPayload<NetlinkControlMessage> {
     }
 }
 
-impl NetlinkDeserializable<NetlinkControlMessage> for NetlinkControlMessage {
+impl NetlinkDeserializable for NetlinkControlMessage {
     type Error = DecodeError;
     fn deserialize(
         _header: &NetlinkHeader,

--- a/talpid-core/src/tunnel/wireguard/wireguard_kernel/wg_message.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_kernel/wg_message.rs
@@ -146,7 +146,7 @@ impl DeviceMessage {
     }
 }
 
-impl NetlinkSerializable<DeviceMessage> for DeviceMessage {
+impl NetlinkSerializable for DeviceMessage {
     fn message_type(&self) -> u16 {
         self.message_type
     }
@@ -171,7 +171,7 @@ impl From<DeviceMessage> for NetlinkPayload<DeviceMessage> {
     }
 }
 
-impl NetlinkDeserializable<DeviceMessage> for DeviceMessage {
+impl NetlinkDeserializable for DeviceMessage {
     type Error = Error;
     fn deserialize(header: &NetlinkHeader, payload: &[u8]) -> Result<DeviceMessage, Self::Error> {
         let command = Self::read_genlmsghdr(payload)?;


### PR DESCRIPTION
Signed-off-by: Emīls Piņķis <emils@mullvad.net>

The older `rtnetlink` crates that were used in `talpid-core` were not compatible with newer [kernels](https://github.com/little-dude/netlink/pull/274), so I've updated them to the latest releases. This should fix #3768.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3775)
<!-- Reviewable:end -->
