### PR TITLE
Fix line breaks in notification banner

### DIFF
--- a/ios/MullvadVPN/NotificationBannerView.swift
+++ b/ios/MullvadVPN/NotificationBannerView.swift
@@ -41,6 +41,10 @@ class NotificationBannerView: UIView {
         textLabel.textColor = UIColor.InAppNotificationBanner.titleColor
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping
+        if #available(iOS 14.0, *) {
+            // See: https://stackoverflow.com/q/46200027/351305
+            textLabel.lineBreakStrategy = []
+        }
         return textLabel
     }()
 
@@ -51,6 +55,10 @@ class NotificationBannerView: UIView {
         textLabel.textColor = UIColor.InAppNotificationBanner.bodyColor
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping
+        if #available(iOS 14.0, *) {
+            // See: https://stackoverflow.com/q/46200027/351305
+            textLabel.lineBreakStrategy = []
+        }
         return textLabel
     }()
 

--- a/ios/MullvadVPN/TermsOfServiceContentView.swift
+++ b/ios/MullvadVPN/TermsOfServiceContentView.swift
@@ -25,8 +25,6 @@ class TermsOfServiceContentView: UIView {
         )
         titleLabel.lineBreakMode = .byWordWrapping
         if #available(iOS 14.0, *) {
-            // Disable the new line break strategy used by UIKit that moves at least two words
-            // to the next line which makes the title look odd.
             // See: https://stackoverflow.com/q/46200027/351305
             titleLabel.lineBreakStrategy = []
         }


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

This PR resets the line break strategy to default (pre-iOS 14). Modern iOS tends to break lines in such fashion that second line has at least two words. This probably has good intentions but often results in in-app notification banner having a lot of blank space on first line. This is nothing new, we used this fix elsewhere before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3789)
<!-- Reviewable:end -->
