### PR TITLE
Add custom size for spinner + refactor text view

### DIFF
--- a/ios/MullvadVPN/CustomTextView.swift
+++ b/ios/MullvadVPN/CustomTextView.swift
@@ -81,6 +81,8 @@ class CustomTextView: UITextView {
         }
     }
 
+    private var notificationObserver: Any?
+
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
 
@@ -112,7 +114,7 @@ class CustomTextView: UITextView {
         self.textContainer.lineFragmentPadding = 0
 
         // Handle placeholder visibility
-        NotificationCenter.default.addObserver(
+        notificationObserver = NotificationCenter.default.addObserver(
             forName: NSTextStorage.didProcessEditingNotification,
             object: textStorage,
             queue: OperationQueue.main) { [weak self] (note) in
@@ -124,6 +126,12 @@ class CustomTextView: UITextView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if let notificationObserver = notificationObserver {
+            NotificationCenter.default.removeObserver(notificationObserver)
+        }
     }
 
     override func updateConstraints() {

--- a/ios/MullvadVPN/CustomTextView.swift
+++ b/ios/MullvadVPN/CustomTextView.swift
@@ -6,16 +6,14 @@
 //  Copyright © 2020 Mullvad VPN AB. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
-private let kTextViewCornerRadius = CGFloat(4)
-
 class CustomTextView: UITextView {
+    private static let textViewCornerRadius: CGFloat = 4
 
     var roundCorners: Bool = true {
         didSet {
-            layer.cornerRadius = roundCorners ? kTextViewCornerRadius : 0
+            layer.cornerRadius = roundCorners ? Self.textViewCornerRadius : 0
         }
     }
 
@@ -76,7 +74,7 @@ class CustomTextView: UITextView {
         }
         get {
             if roundCorners {
-                return UIBezierPath(roundedRect: accessibilityFrame, cornerRadius: kTextViewCornerRadius)
+                return UIBezierPath(roundedRect: accessibilityFrame, cornerRadius: Self.textViewCornerRadius)
             } else {
                 return UIBezierPath(rect: accessibilityFrame)
             }
@@ -105,7 +103,7 @@ class CustomTextView: UITextView {
 
         // Set visual appearance
         textColor = UIColor.TextField.textColor
-        layer.cornerRadius = kTextViewCornerRadius
+        layer.cornerRadius = Self.textViewCornerRadius
         clipsToBounds = true
 
         // Set content padding


### PR DESCRIPTION
Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.

Git checklist:

* [x] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

1. Add `custom` size for spinner. It will be used in device management controller where remove buttons have slightly larger size than predefined spinners.
2. Spinner: use `UIScene` notification in place of `UIApplication` notification on iOS 13+.
3. Refactor `CustomTextView` and clean up notification observer on `deinit`. Keep forgetting to remove block based observer (https://oleb.net/blog/2018/01/notificationcenter-removeobserver/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3793)
<!-- Reviewable:end -->
