### PR TITLE
Fix slow login spinner during view transition

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -158,6 +158,7 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
             }
 
             is LoginViewModel.LoginUiState.TooManyDevicesError -> {
+                showLoading(overrideSpinnerWithErrorIcon = true)
                 openDeviceListFragment(uiState.accountToken)
             }
 
@@ -176,6 +177,7 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
     }
 
     private fun openDeviceListFragment(accountToken: String) {
+
         val deviceFragment = DeviceListFragment().apply {
             arguments = Bundle().apply { putString(ACCOUNT_TOKEN_ARGUMENT_KEY, accountToken) }
         }
@@ -199,19 +201,27 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
         paintNavigationBar(ContextCompat.getColor(requireContext(), R.color.darkBlue))
     }
 
-    private fun showLoading() {
+    private fun showLoading(overrideSpinnerWithErrorIcon: Boolean = false) {
         accountLogin.state = LoginState.InProgress
 
         title.setText(R.string.logging_in_title)
         subtitle.setText(R.string.logging_in_description)
 
-        loggingInStatus.visibility = View.VISIBLE
-        loginFailStatus.visibility = View.GONE
+        loggingInStatus.visibility = if (overrideSpinnerWithErrorIcon == false) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+
+        loginFailStatus.visibility = if (overrideSpinnerWithErrorIcon == false) {
+            View.GONE
+        } else {
+            View.VISIBLE
+        }
+
         loggedInStatus.visibility = View.GONE
 
         background.requestFocus()
-
-        accountLogin.state = LoginState.InProgress
 
         scrollToShow(loggingInStatus)
     }


### PR DESCRIPTION
This PR fixes an issue with the login spinner animation being slow during the transition to the device management view by switching the spinner to an error icon just before the view transition.

Git checklist:

~* [] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.~ (belongs to feature already in the changelog)
* [x] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3799)
<!-- Reviewable:end -->
