### PR TITLE
Update Github PR template (tells third party contributors about localizations and translations)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,19 @@
-Describe **what** this PR changes. **Why** this is wanted. And, if needed, **how** it does it.
+<!--
+PR checklist (just intended as a reminder for the PR author. No need to fill it in):
 
-Git checklist:
+* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
+* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
+* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
+      And, if needed, **how** it does it.
 
-* [ ] Describe the change in **`CHANGELOG.md`** under the `[Unreleased]` header.
-* [ ] Check that commits follow the [Mullvad coding guidelines](https://github.com/mullvad/coding-guidelines)
+👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
+  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
+👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
+
+## Translations and localization
+
+Do you want to contribute translations/localization to this app?
+* If you want to correct an existing translation, please fill in this form instead of submitting
+  a PR with changes to the PO/xml files: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
+* We can't accept translations to new languages from third party contributors.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,17 @@ While we appreciate your interest in helping us to improve Mullvad VPN, please u
 choosing which submitted changes to merge is fully at our discretion, based upon our development
 plans for the app.
 
+### Localization / translations
+
+The app is translated and proofread via a third party company. We can't take in user improvements
+to the translations directly, since we can't verify their correctness. All translations have to
+go via the translation company. As a result, if you want to improve an existing
+translation, please don't edit the PO files and submit to us. Instead fill in your suggested
+improvement in [this spreadsheet], and the translation company will pick it up and process the
+suggestion after a while.
+
+[this spreadsheet]: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
+
 ### Copyright and ownership of contributed code and changes
 
 Any code, binaries, tools, documentation, graphics, or any other material that you submit to this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,16 +42,6 @@ author of the entire contribution and grant us the full right to use, publish, c
 the entire, or part of, your contribution under the terms defined by the GPL 3.0 license at any
 point in time.
 
-### Toolchain versions
+### Code style and design
 
-All Rust code must work on the latest stable release of Rust as well as the latest Mullvad beta
-release. It should also work on nightly Rust, but this can, from time to time, be overlooked when
-nightly is broken.
-
-All JavaScript code must work with Node 8 and 9.
-
-### Code formatting
-
-All Rust code in this repository must always be formatted with the latest available version of
-rustfmt (`rustfmt-nightly` at the moment). Please run `./format.sh` to automatically format
-the entire repository.
+Please follow the [coding guidelines](https://github.com/mullvad/coding-guidelines).


### PR DESCRIPTION
Adds instructions about localization to third party contributors. We have never been able to effectively accept third party contributions to translations. But our translation company 

Also updates the format to be in comments. There is no need for any of this to be part of the visible PR description. Please leave it commented out or remove this before publishing PRs. All of this is just reminders for the author. Not something that is intended as part of the actual PR message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3804)
<!-- Reviewable:end -->
