### PR TITLE
Set state of custom DNS toggle button immediately

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -206,6 +206,14 @@ class AdvancedFragment : BaseFragment() {
         }
 
         customDnsToggle = view.findViewById<ToggleCell>(R.id.enable_custom_dns).apply {
+            state = serviceConnectionManager.customDns().let { customDns ->
+                if (customDns?.isCustomDnsEnabled() == true) {
+                    CellSwitch.State.ON
+                } else {
+                    CellSwitch.State.OFF
+                }
+            }
+
             listener = { state ->
                 jobTracker.newBackgroundJob("toggleCustomDns") {
                     if (state == CellSwitch.State.ON) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/AdvancedFragment.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
@@ -56,7 +57,7 @@ class AdvancedFragment : BaseFragment() {
     @Deprecated("Refactor code to instead rely on Lifecycle.")
     private val jobTracker = JobTracker()
 
-    val shared = serviceConnectionManager.connectionState
+    val sharedCustomDnsInstance = serviceConnectionManager.connectionState
         .flatMapLatest { state ->
             if (state is ServiceConnectionState.ConnectedReady) {
                 flowOf(state.container)
@@ -93,9 +94,12 @@ class AdvancedFragment : BaseFragment() {
                 }
 
                 launch {
-                    shared
-                        .flatMapLatest {
-                            callbackFlowFromNotifier(it.onEnabledChanged)
+                    sharedCustomDnsInstance
+                        .flatMapLatest { customDnsInstance ->
+                            callbackFlowFromNotifier(customDnsInstance.onEnabledChanged)
+                                .onStart {
+                                    emit(customDnsInstance.isCustomDnsEnabled())
+                                }
                         }
                         .collect { isEnabled ->
                             customDnsAdapter?.updateState(isEnabled)
@@ -110,7 +114,7 @@ class AdvancedFragment : BaseFragment() {
                 }
 
                 launch {
-                    shared
+                    sharedCustomDnsInstance
                         .flatMapLatest {
                             callbackFlowFromNotifier(it.onDnsServersChanged)
                         }
@@ -206,14 +210,6 @@ class AdvancedFragment : BaseFragment() {
         }
 
         customDnsToggle = view.findViewById<ToggleCell>(R.id.enable_custom_dns).apply {
-            state = serviceConnectionManager.customDns().let { customDns ->
-                if (customDns?.isCustomDnsEnabled() == true) {
-                    CellSwitch.State.ON
-                } else {
-                    CellSwitch.State.OFF
-                }
-            }
-
             listener = { state ->
                 jobTracker.newBackgroundJob("toggleCustomDns") {
                     if (state == CellSwitch.State.ON) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/CustomDns.kt
@@ -28,6 +28,10 @@ class CustomDns(private val connection: Messenger, private val settingsListener:
         connection.send(Request.SetEnableCustomDns(false).message)
     }
 
+    fun isCustomDnsEnabled(): Boolean {
+        return onEnabledChanged.latestEvent ?: false
+    }
+
     fun addDnsServer(server: InetAddress): Boolean {
         val didntAlreadyHaveServer = !onDnsServersChanged.latestEvent.contains(server)
 


### PR DESCRIPTION
The custom DNS toggle button would switch it's state back to being off after being inflated again, when the advanced settings fragment is inflated for the 2nd time in the lifecycle of the app. I presume this is because the button's state is only set when changes arrive from the daemon, and it isn't initialized to a known good state by default.

I've changed it so that a known good state is opportunistically applied, but this change might be somewhat crude.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3808)
<!-- Reviewable:end -->
