### PR TITLE
Make intents only available when device is unlocked

### DIFF
--- a/ios/MullvadVPN/Info.plist
+++ b/ios/MullvadVPN/Info.plist
@@ -28,6 +28,12 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>INIntentsRestrictedWhileLocked</key>
+	<array>
+		<string>StartVPNIntent</string>
+		<string>StopVPNIntent</string>
+		<string>ReconnectVPNIntent</string>
+	</array>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>StartVPNIntent</string>


### PR DESCRIPTION
As the title suggests, intents should only be runnable when device is unlocked and Siri is nicely suggesting to unlock the device before performing the requested action, i.e "Stop VPN".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3810)
<!-- Reviewable:end -->
