### PR TITLE
Bump chrono to 0.4.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,15 +285,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.43",
+ "wasm-bindgen",
  "winapi",
 ]
 


### PR DESCRIPTION
The update fixes a potential segfault in `chrono` due to its use of `localtime_r`, which may segfault if some other thread calls `std::env::set_var` ([RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159)). When this issue was fixed, the CVE was [unyanked](https://github.com/rustsec/advisory-db/commit/36705ccc1d51930b238e11dd9a279aed55927e3a).

This is also related to [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071), which is the same thing problem but for `time-rs`. RUSTSEC-2020-0071 is still ignored by `cargo-audit.yml`.

It did not affect the app in practice, as it never sets environment variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3818)
<!-- Reviewable:end -->
