### PR TITLE
Improve account data updates

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		58781CCE22AE8918009B9D8E /* RelayConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58781CC822AE7CA8009B9D8E /* RelayConstraints.swift */; };
 		58781CD522AFBA39009B9D8E /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58781CD422AFBA39009B9D8E /* RelaySelector.swift */; };
 		5878BA1426DD0B01004147D7 /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5823FA4F26CA690600283BF8 /* OSLogHandler.swift */; };
+		587988C728A2A01F00E3DF54 /* AccountDataThrottling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587988C628A2A01F00E3DF54 /* AccountDataThrottling.swift */; };
 		587A01FC23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587A01FB23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift */; };
 		587AD7C623421D7000E93A53 /* TunnelSettingsV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587AD7C523421D7000E93A53 /* TunnelSettingsV1.swift */; };
 		587AD7C723421D8600E93A53 /* TunnelSettingsV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587AD7C523421D7000E93A53 /* TunnelSettingsV1.swift */; };
@@ -465,6 +466,7 @@
 		5875960926F371FC00BF6711 /* Tunnel+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tunnel+Messaging.swift"; sourceTree = "<group>"; };
 		58781CC822AE7CA8009B9D8E /* RelayConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayConstraints.swift; sourceTree = "<group>"; };
 		58781CD422AFBA39009B9D8E /* RelaySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelector.swift; sourceTree = "<group>"; };
+		587988C628A2A01F00E3DF54 /* AccountDataThrottling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDataThrottling.swift; sourceTree = "<group>"; };
 		587A01FB23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorTunnelProviderHost.swift; sourceTree = "<group>"; };
 		587AD7C523421D7000E93A53 /* TunnelSettingsV1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TunnelSettingsV1.swift; sourceTree = "<group>"; };
 		587B7535266528A200DEF7E9 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
@@ -847,6 +849,7 @@
 			isa = PBXGroup;
 			children = (
 				5896CEF126972DEB00B0FAE8 /* AccountContentView.swift */,
+				587988C628A2A01F00E3DF54 /* AccountDataThrottling.swift */,
 				58C3A4B122456F1A00340BDB /* AccountInputGroupView.swift */,
 				58CCA01D2242787B004F3011 /* AccountTextField.swift */,
 				582AE30F2440A6CA00E6733A /* AccountTokenInput.swift */,
@@ -1305,6 +1308,7 @@
 				5891BF5125E66B1E006D6FB0 /* UIBarButtonItem+KeyboardNavigation.swift in Sources */,
 				587B75412668FD7800DEF7E9 /* AccountExpiryNotificationProvider.swift in Sources */,
 				585DA89926B0329200B8C587 /* PacketTunnelStatus.swift in Sources */,
+				587988C728A2A01F00E3DF54 /* AccountDataThrottling.swift in Sources */,
 				5896CEF226972DEB00B0FAE8 /* AccountContentView.swift in Sources */,
 				5840250122B1124600E4CFEC /* IPAddress+Codable.swift in Sources */,
 				5842102E282D3FC200F24E46 /* ResultBlockOperation.swift in Sources */,

--- a/ios/MullvadVPN/AccountDataThrottling.swift
+++ b/ios/MullvadVPN/AccountDataThrottling.swift
@@ -1,0 +1,80 @@
+//
+//  AccountDataThrottling.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 09/08/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+/// Struct used for throttling UI calls to update account data via tunnel manager.
+struct AccountDataThrottling {
+    /// Default cooldown interval between requests.
+    private static let defaultWaitInterval: TimeInterval = 60
+
+    /// Cooldown interval used when account has already expired.
+    private static let waitIntervalForExpiredAccount: TimeInterval = 10
+
+    /// Interval in days when account is considered to be close to expiry.
+    private static let closeToExpiryDays = 4
+
+    enum Condition {
+        /// Always update account data.
+        case always
+
+        /// Only update account data when account is close to expiry or already expired.
+        case whenCloseToExpiryAndBeyond
+    }
+
+    let tunnelManager: TunnelManager
+    private(set) var lastUpdate: Date?
+
+    init(tunnelManager: TunnelManager = .shared) {
+        self.tunnelManager = tunnelManager
+    }
+
+    mutating func requestUpdate(condition: Condition) {
+        guard let accountData = tunnelManager.deviceState.accountData else {
+            return
+        }
+
+        let now = Date()
+
+        switch condition {
+        case .always:
+            break
+
+        case .whenCloseToExpiryAndBeyond:
+            guard let closeToExpiry = Calendar.current.date(
+                byAdding: .day,
+                value: Self.closeToExpiryDays * -1,
+                to: accountData.expiry
+            ) else { return }
+
+            if closeToExpiry > now {
+                return
+            }
+        }
+
+        let waitInterval = accountData.expiry > now
+            ? Self.defaultWaitInterval
+            : Self.waitIntervalForExpiredAccount
+
+        let nextUpdateAfter = lastUpdate?.addingTimeInterval(waitInterval)
+        let comparisonResult = nextUpdateAfter?.compare(now) ?? .orderedAscending
+
+        switch comparisonResult {
+        case .orderedAscending, .orderedSame:
+            lastUpdate = Date()
+            tunnelManager.updateAccountData()
+
+        case .orderedDescending:
+            break
+        }
+    }
+
+    mutating func reset() {
+        lastUpdate = nil
+    }
+}

--- a/ios/MullvadVPN/CustomNavigationController.swift
+++ b/ios/MullvadVPN/CustomNavigationController.swift
@@ -56,11 +56,17 @@ class CustomNavigationController: UINavigationController, UINavigationBarDelegat
 
         // Only call super implementation when we want to pop the controller
         if shouldPop {
+            willPop(navigationItem: item)
+
             // Call super implementation
             return customNavigationController_navigationBar(navigationBar, shouldPop: item)
         } else {
             return shouldPop
         }
+    }
+
+    func willPop(navigationItem: UINavigationItem) {
+        // Override in subclasses
     }
 }
 


### PR DESCRIPTION
1. Throttle account data updates from UI with 10s cooldown when account has already expired, otherwise use 60s interval between requests.
2. Update account data as scene becomes active. If settings are on screen, do the regular update, if not then only update if account is close to expiry or already expired, otherwise do nothing. This is done this way to avoid spamming our backend when we don't really do anything with account expiry.
3. Add calls to update account data when navigating to account view and back to root settings. (See updated `SettingsNavigationController` and `SettingsNavigationControllerDelegate`)
4. Add additional method override to be able to tell when `CustomNavigationControler` is about to pop navigation item:

   ```swift
   func willPop(navigationItem: UINavigationItem)
   ```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3823)
<!-- Reviewable:end -->
