### PR TITLE
Update location cell

### DIFF
--- a/ios/MullvadVPN/LocationDataSource.swift
+++ b/ios/MullvadVPN/LocationDataSource.swift
@@ -20,7 +20,7 @@ protocol LocationDataSourceItemProtocol {
 
 class LocationDataSource: NSObject, UITableViewDataSource {
     typealias CellProviderBlock = (UITableView, IndexPath, LocationDataSourceItemProtocol)
-        -> UITableViewCell?
+        -> UITableViewCell
     typealias CellConfiguratorBlock = (UITableViewCell, IndexPath, LocationDataSourceItemProtocol)
         -> Void
 
@@ -431,7 +431,7 @@ class LocationDataSource: NSObject, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         assert(indexPath.section == 0)
         let item = item(for: indexPath)!
-        let cell = cellProvider(tableView, indexPath, item)!
+        let cell = cellProvider(tableView, indexPath, item)
 
         cellConfigurator(cell, indexPath, item)
 

--- a/ios/MullvadVPN/LocationDataSource.swift
+++ b/ios/MullvadVPN/LocationDataSource.swift
@@ -344,6 +344,26 @@ class LocationDataSource: NSObject, UITableViewDataSource {
             }
         }
 
+        let scrollToInsertedIndexPaths = { [weak tableView] (changeSet: ChangeSet) in
+            guard let lastInsertedIndexPath = changeSet.insertIndexPaths.last,
+                  let lastUpdatedIndexPath = changeSet.updateIndexPaths.last,
+                  let visibleIndexPaths = tableView?.indexPathsForVisibleRows,
+                  let lastVisibleIndexPath = visibleIndexPaths.last,
+                  lastInsertedIndexPath >= lastVisibleIndexPath
+            else {
+                return
+            }
+            if changeSet.insertIndexPaths.count >= visibleIndexPaths.count {
+                tableView?.scrollToRow(at: lastUpdatedIndexPath, at: .top, animated: true)
+            } else {
+                tableView?.scrollToRow(
+                    at: lastInsertedIndexPath,
+                    at: .bottom,
+                    animated: true
+                )
+            }
+        }
+
         if animated {
             guard let changeSet = applyChanges() else { return }
             tableView.performBatchUpdates {
@@ -357,6 +377,7 @@ class LocationDataSource: NSObject, UITableViewDataSource {
                     cellUpdater(tableView, indexPath, item)
                 }
             } completion: { finished in
+                scrollToInsertedIndexPaths(changeSet)
                 restoreSelection()
                 completion?()
             }

--- a/ios/MullvadVPN/LocationDataSource.swift
+++ b/ios/MullvadVPN/LocationDataSource.swift
@@ -19,14 +19,14 @@ protocol LocationDataSourceItemProtocol {
 }
 
 class LocationDataSource: NSObject, UITableViewDataSource {
-    private var nodeByLocation = [RelayLocation: Node]()
-    private var locationList = [RelayLocation]()
-    private var rootNode = makeRootNode()
-
     typealias CellProviderBlock = (UITableView, IndexPath, LocationDataSourceItemProtocol)
         -> UITableViewCell?
     typealias CellConfiguratorBlock = (UITableViewCell, IndexPath, LocationDataSourceItemProtocol)
         -> Void
+
+    private var nodeByLocation = [RelayLocation: Node]()
+    private var locationList = [RelayLocation]()
+    private var rootNode = makeRootNode()
 
     private let tableView: UITableView
     private let cellProvider: CellProviderBlock

--- a/ios/MullvadVPN/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/SelectLocationViewController.swift
@@ -89,14 +89,14 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
 
         dataSource = LocationDataSource(
             tableView: tableView,
-            cellProvider: { [weak self] tableView, indexPath, item -> UITableViewCell? in
-                guard let self = self else { return nil }
-
-                let cell = tableView.dequeueReusableCell(
+            cellProvider: { tableView, indexPath, item in
+                return tableView.dequeueReusableCell(
                     withIdentifier: Self.cellReuseIdentifier,
                     for: indexPath
                 )
-                    as! SelectLocationCell
+            },
+            cellConfigurator: { [weak self] cell, indexPath, item in
+                guard let cell = cell as? SelectLocationCell else { return }
 
                 cell.accessibilityIdentifier = item.location.stringRepresentation
                 cell.isDisabled = !item.isActive
@@ -106,15 +106,6 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
                 cell.didCollapseHandler = { [weak self] cell in
                     self?.collapseCell(cell)
                 }
-
-                return cell
-            },
-            cellUpdater: { tableView, indexPath, item in
-                guard let cell = tableView.cellForRow(at: indexPath) as? SelectLocationCell else {
-                    assertionFailure()
-                    return
-                }
-                cell.isExpanded = item.showsChildren
             }
         )
 

--- a/ios/MullvadVPN/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/SelectLocationViewController.swift
@@ -108,6 +108,13 @@ class SelectLocationViewController: UIViewController, UITableViewDelegate {
                 }
 
                 return cell
+            },
+            cellUpdater: { tableView, indexPath, item in
+                guard let cell = tableView.cellForRow(at: indexPath) as? SelectLocationCell else {
+                    assertionFailure()
+                    return
+                }
+                cell.isExpanded = item.showsChildren
             }
         )
 


### PR DESCRIPTION
Small request that does 2 things:
1. Fixes an unexpected table view layout (see 1.mov below) while updating rows in case the cell is partially out of visible area. The current implementation relies on estimated heights to calculate table view geometry, reloading rows asks the data source for a new cell which causes the table view to recalculate heights. As documentation says, if reloading rows is unnecessary, it may be better to update cell directly. This PR introduces a closure block to update cells without reloading its row.

https://user-images.githubusercontent.com/50764345/184208736-3438d4f9-7dea-4018-a2d0-d51f417d5fd0.MOV

2. Adds table view scrolling to the expanded locations if they weren’t visible.

https://user-images.githubusercontent.com/50764345/184208794-d898b01d-38a5-497b-a4fa-ddebb3f4fb50.MOV

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3828)
<!-- Reviewable:end -->
