### PR TITLE
Always continue on error

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -38,7 +38,7 @@ jobs:
             matrix:
                 rust: [stable, beta, nightly]
 
-        continue-on-error: ${{ matrix.rust == 'nightly' }}
+        continue-on-error: true
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository


### PR DESCRIPTION
Makes sure that the CI job failing does not cancel the other CI jobs. Necessary right now because beta fails causing stable and nightly jobs to be cancelled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3832)
<!-- Reviewable:end -->
