### PR TITLE
Adjust bridge selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 - Reject invalid WireGuard ports in the CLI.
 - Reorganize settings into more logical categories.
 - Upgrade wireguard-go to 20220703234212 (Windows: v0.5.3).
+- Prune bridges far away from the selected relay.
 
 #### Windows
 - Remove dependency on `ipconfig.exe`. Call `DnsFlushResolverCache` to flush the DNS cache.


### PR DESCRIPTION
This PR causes bridges farther away than 1500 km to be pruned from selection, while always keeping the five closest bridges to the relay selection. The weights for distant bridges were also lowered somewhat.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3833)
<!-- Reviewable:end -->
