### PR TITLE
Trim custom errors

### DIFF
--- a/ios/MullvadVPN/AppStorePaymentManager/AppStorePaymentManagerError.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager/AppStorePaymentManagerError.swift
@@ -21,7 +21,7 @@ extension AppStorePaymentManager {
         case storePayment(Swift.Error)
 
         /// Failure to read the AppStore receipt.
-        case readReceipt(AppStoreReceipt.Error)
+        case readReceipt(Swift.Error)
 
         /// Failure to send the AppStore receipt to backend.
         case sendReceipt(REST.Error)

--- a/ios/MullvadVPN/AppStorePaymentManager/SendAppStoreReceiptOperation.swift
+++ b/ios/MullvadVPN/AppStorePaymentManager/SendAppStoreReceiptOperation.swift
@@ -60,7 +60,7 @@ class SendAppStoreReceiptOperation: ResultOperation<
 
             case let .failure(error):
                 self.logger.error(
-                    chainedError: error,
+                    chainedError: AnyChainedError(error),
                     message: "Failed to fetch the AppStore receipt."
                 )
                 self.finish(completion: .failure(.readReceipt(error)))

--- a/ios/MullvadVPN/DisplayChainedError.swift
+++ b/ios/MullvadVPN/DisplayChainedError.swift
@@ -136,11 +136,14 @@ extension AppStorePaymentManager.Error: DisplayChainedError {
             }
 
         case let .readReceipt(readReceiptError):
-            switch readReceiptError {
-            case let .refresh(storeError):
-                let skErrorMessage = (storeError as? SKError)?.errorDescription ?? storeError
-                    .localizedDescription
-
+            if readReceiptError is AppStoreReceiptNotFound {
+                return NSLocalizedString(
+                    "RECEIPT_NOT_FOUND_ERROR",
+                    tableName: "AppStorePaymentManager",
+                    value: "AppStore receipt is not found on disk.",
+                    comment: ""
+                )
+            } else if let storeError = readReceiptError as? SKError {
                 return String(
                     format: NSLocalizedString(
                         "REFRESH_RECEIPT_ERROR",
@@ -148,9 +151,9 @@ extension AppStorePaymentManager.Error: DisplayChainedError {
                         value: "Cannot refresh the AppStore receipt: %@",
                         comment: ""
                     ),
-                    skErrorMessage
+                    storeError.localizedDescription
                 )
-            case let .io(ioError):
+            } else {
                 return String(
                     format: NSLocalizedString(
                         "READ_RECEIPT_ERROR",
@@ -158,14 +161,7 @@ extension AppStorePaymentManager.Error: DisplayChainedError {
                         value: "Cannot read the AppStore receipt from disk: %@",
                         comment: ""
                     ),
-                    ioError.localizedDescription
-                )
-            case .doesNotExist:
-                return NSLocalizedString(
-                    "RECEIPT_NOT_FOUND_ERROR",
-                    tableName: "AppStorePaymentManager",
-                    value: "AppStore receipt is not found on disk.",
-                    comment: ""
+                    readReceiptError.localizedDescription
                 )
             }
 

--- a/ios/MullvadVPN/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/ProblemReportViewController.swift
@@ -283,8 +283,7 @@ class ProblemReportViewController: UIViewController, UITextFieldDelegate, Condit
 
     @objc func handleViewLogsButtonTap() {
         let reviewController = ProblemReportReviewViewController(
-            reportString: consolidatedLog
-                .string
+            reportString: consolidatedLog.string
         )
         let navigationController = UINavigationController(rootViewController: reviewController)
 


### PR DESCRIPTION
- Remove `AppStoreReceipt.Error` and instead return the underlying error. `AppStoreReceiptNotFound` is added to treat a special case when App Store receipt is not found on disk.
- Remove `ConsolidatedAppLog.Error` type and pass `String` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3835)
<!-- Reviewable:end -->
