### PR TITLE
Add a margin to the max MTU of the tunnel

### DIFF
--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -223,8 +223,16 @@ impl TunnelMonitor {
         })
     }
 
+    /// Set the MTU in the tunnel parameters based on the inputted device MTU and some
+    /// calculations. `peer_mtu` is the detected device MTU.
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     fn set_mtu(params: &mut wireguard_types::TunnelParameters, peer_mtu: u16) {
+        // Some users experience fragmentation issues even when we take the interface MTU and
+        // subtract the header sizes. This is likely due to some program that they use which does
+        // not change the interface MTU but adds its own header onto the outgoing packets. For this
+        // reason we subtract some extra bytes from our MTU in order to give other programs some
+        // safety margin.
+        const MTU_SAFETY_MARGIN: u16 = 60;
         const IPV4_HEADER_SIZE: u16 = 20;
         const IPV6_HEADER_SIZE: u16 = 40;
         const WIREGUARD_HEADER_SIZE: u16 = 40;
@@ -234,8 +242,8 @@ impl TunnelMonitor {
                 true => IPV6_HEADER_SIZE,
             };
         // The largest peer MTU that we allow
-        const MAX_PEER_MTU: u16 = 1500;
-        // The minimum allowed MTU size for our tunnel in IPv6 is 1280
+        const MAX_PEER_MTU: u16 = 1500 - MTU_SAFETY_MARGIN;
+        // The minimum allowed MTU size for our tunnel in IPv6 is 1280 and 576 for IPv4
         const MIN_IPV4_MTU: u16 = 576;
         const MIN_IPV6_MTU: u16 = 1280;
         let min_mtu = match params.generic_options.enable_ipv6 {
@@ -248,6 +256,8 @@ impl TunnelMonitor {
         params.options.mtu = Some(tunnel_mtu);
     }
 
+    /// Detects the MTU of the device, calculates what the virtual device MTU should be and sets
+    /// that in the tunnel parameters.
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     async fn assign_mtu(
         route_manager: &RouteManagerHandle,


### PR DESCRIPTION
Some users experienced issues when the new update increased the default MTU size for packets from 1380 to 1420. This is likely due to some program causing packets to exceed the device limit (usually 1500) and then fragmenting the packets. This PR reduces the mullvad interface MTU by a buffer of 60 bytes which means that even if some program causes a packet to be bigger as long as this increase is not bigger than 60 bytes it should not fragment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3846)
<!-- Reviewable:end -->
