### PR TITLE
Fix settings title presentation

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -40,6 +40,7 @@ with the option to buy more time.
 ### Fixed
 - Improve random port distribution. Should be less biased towards port 53.
 - Fix invalid map camera position during the app launch and keep it up to date when multitasking.
+- Fix animation glitch when expanding partially visible cell in location picker.
 
 
 ## [2022.2] - 2022-04-28

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -796,7 +796,6 @@ extension SceneDelegate: SettingsNavigationControllerDelegate {
 extension SceneDelegate: ConnectViewControllerDelegate {
     func connectViewControllerShouldShowSelectLocationPicker(_ controller: ConnectViewController) {
         let contentController = makeSelectLocationController()
-        contentController.navigationItem.largeTitleDisplayMode = .never
         contentController.navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .done,
             target: self,

--- a/ios/MullvadVPN/SettingsNavigationController.swift
+++ b/ios/MullvadVPN/SettingsNavigationController.swift
@@ -49,7 +49,10 @@ class SettingsNavigationController: CustomNavigationController, SettingsViewCont
     init() {
         super.init(navigationBarClass: CustomNavigationBar.self, toolbarClass: nil)
 
-        setViewControllers([makeViewController(for: .root)], animated: false)
+        navigationBar.prefersLargeTitles = true
+
+        // Navigation controller ignores `prefersLargeTitles` when using `setViewControllers()`.
+        pushViewController(makeViewController(for: .root), animated: false)
     }
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -60,12 +63,6 @@ class SettingsNavigationController: CustomNavigationController, SettingsViewCont
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        navigationBar.prefersLargeTitles = true
     }
 
     override func willPop(navigationItem: UINavigationItem) {

--- a/ios/MullvadVPN/SettingsViewController.swift
+++ b/ios/MullvadVPN/SettingsViewController.swift
@@ -42,7 +42,6 @@ class SettingsViewController: UITableViewController, SettingsDataSourceDelegate,
             value: "Settings",
             comment: ""
         )
-        navigationItem.largeTitleDisplayMode = .always
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .done,
             target: self,


### PR DESCRIPTION
1. Use `pushViewController` when initializing `SettingsNavigationController` as or some reason `setViewControllers` ignores `prefersLargeTitles`.
2. Add CHANGELOG entry for [cell animation bug fix](https://github.com/mullvad/mullvadvpn-app/commit/cfe03f2c74e3803ea3819ae5a1e6977bbdfc191e) in location picker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3848)
<!-- Reviewable:end -->
