### PR TITLE
Add support for Linux ARM64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - GUI: Add electron flags to run Wayland native if in a compositor/desktop known to work well
+- Add support for Linux ARM64.
 
 ### Changed
 - Reject invalid WireGuard ports in the CLI.

--- a/build.sh
+++ b/build.sh
@@ -255,8 +255,8 @@ function build {
 
     if [[ -n $current_target ]]; then
         local cargo_output_dir="$CARGO_TARGET_DIR/$current_target/$RUST_BUILD_MODE"
-        # To make it easier to package universal builds on macOS the binaries are located in a
-        # directory with the name of the target triple.
+        # To make it easier to package multiple targets, the binaries are
+        # located in a directory with the name of the target triple.
         local destination_dir="dist-assets/$current_target"
         mkdir -p "$destination_dir"
     else

--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,16 @@ fi
 CARGO_ARGS=()
 NPM_PACK_ARGS=()
 
+if [[ -n ${TARGETS:-""} ]]; then
+    NPM_PACK_ARGS+=(--targets "${TARGETS[*]}")
+fi
+
 if [[ "$UNIVERSAL" == "true" ]]; then
+    if [[ -n ${TARGETS:-""} ]]; then
+        log_error "'TARGETS' and '--universal' cannot be specified simultaneously."
+        exit 1
+    fi
+
     TARGETS=(x86_64-apple-darwin aarch64-apple-darwin)
     NPM_PACK_ARGS+=(--universal)
 fi

--- a/build.sh
+++ b/build.sh
@@ -206,8 +206,13 @@ function sign_win {
 function build {
     local current_target=${1:-""}
     local for_target_string=""
+    local stripbin="strip"
     if [[ -n $current_target ]]; then
         for_target_string=" for $current_target"
+
+        if [[ "$current_target" == "aarch64-unknown-linux-gnu" && "$(uname -m)" != "aarch64" ]]; then
+            stripbin="aarch64-linux-gnu-strip"
+        fi
     fi
 
     ################################################################################
@@ -282,7 +287,7 @@ function build {
             cp "$source" "$destination"
         else
             log_info "Stripping $source => $destination"
-            strip "$source" -o "$destination"
+            "${stripbin}" "$source" -o "$destination"
         fi
 
         if [[ "$SIGN" == "true" && "$(uname -s)" == "MINGW"* ]]; then

--- a/env.sh
+++ b/env.sh
@@ -6,7 +6,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 case "$(uname -s)" in
   Linux*)
-    HOST="x86_64-unknown-linux-gnu"
+    arch="$(uname -m)"
+    HOST="${arch}-unknown-linux-gnu"
     ;;
   Darwin*)
     arch="$(uname -m)"

--- a/gui/scripts/build-proto.sh
+++ b/gui/scripts/build-proto.sh
@@ -5,7 +5,8 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
-PLATFORM="$(uname -s)-$(uname -m)"
+ARCH="$(uname -m)"
+PLATFORM="$(uname -s)-${ARCH}"
 MANAGEMENT_INTERFACE_PROTO_BUILD_DIR=${MANAGEMENT_INTERFACE_PROTO_BUILD_DIR:-}
 NODE_MODULES_DIR="$(cd ../node_modules/.bin && pwd)"
 PROTO_DIR="../../mullvad-management-interface/proto"
@@ -21,14 +22,14 @@ fi
 mkdir -p $DESTINATION_DIR
 mkdir -p $TYPES_DESTINATION_DIR
 
-if [[ "${PLATFORM}" == "Darwin-arm64" ]]; then
+if [[ "${ARCH,,}" == "arm64" || "${ARCH,,}" == "aarch64" ]]; then
     if [[ -n "${MANAGEMENT_INTERFACE_PROTO_BUILD_DIR}" ]]; then
       cp $MANAGEMENT_INTERFACE_PROTO_BUILD_DIR/*.js $DESTINATION_DIR
       cp $MANAGEMENT_INTERFACE_PROTO_BUILD_DIR/*.ts $TYPES_DESTINATION_DIR
     else
-      >&2 echo "Building management interface proto files on Apple Silicon is not supported"
+      >&2 echo "Building management interface proto files on aarch64 is not supported"
       >&2 echo "(see https://github.com/grpc/grpc-node/issues/1497)."
-      >&2 echo "Please build the proto files on another platform using build_mi_proto.sh script,"
+      >&2 echo "Please build the proto files on another platform using build-proto.sh script,"
       >&2 echo "and set MANAGEMENT_INTERFACE_PROTO_BUILD_DIR environment variable to the directory of the build."
       exit 1
     fi

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -88,16 +88,26 @@ function unix_target_triple {
 function build_unix {
     echo "Building wireguard-go for $1"
 
-    # Flags for cross compiling for M1 macs
-    if [[ "$(unix_target_triple)" != "$1" && "$1" == "aarch64-apple-darwin" ]]; then
-        export CGO_ENABLED=1
-        export GOOS=darwin
-        export GOARCH=arm64
-        export CC="$(xcrun -sdk $SDKROOT --find clang) -arch $GOARCH -isysroot $SDKROOT"
-        export CFLAGS="-isysroot $SDKROOT -arch $GOARCH -I$SDKROOT/usr/include"
-        export LD_LIBRARY_PATH="$SDKROOT/usr/lib"
-        export CGO_CFLAGS="-isysroot $SDKROOT -arch $GOARCH"
-        export CGO_LDFLAGS="-isysroot $SDKROOT -arch $GOARCH"
+    # Flags for cross compiling
+    if [[ "$(unix_target_triple)" != "$1" ]]; then
+        # Linux arm
+        if [[ "$1" == "aarch64-unknown-linux-gnu" ]]; then
+            export CGO_ENABLED=1
+            export GOARCH=arm64
+            export CC=aarch64-linux-gnu-gcc
+        fi
+
+        # Apple silicon
+        if [[ "$1" == "aarch64-apple-darwin" ]]; then
+            export CGO_ENABLED=1
+            export GOOS=darwin
+            export GOARCH=arm64
+            export CC="$(xcrun -sdk $SDKROOT --find clang) -arch $GOARCH -isysroot $SDKROOT"
+            export CFLAGS="-isysroot $SDKROOT -arch $GOARCH -I$SDKROOT/usr/include"
+            export LD_LIBRARY_PATH="$SDKROOT/usr/lib"
+            export CGO_CFLAGS="-isysroot $SDKROOT -arch $GOARCH"
+            export CGO_LDFLAGS="-isysroot $SDKROOT -arch $GOARCH"
+        fi
     fi
 
     pushd libwg

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -70,7 +70,8 @@ function build_windows {
 function unix_target_triple {
     local platform="$(uname -s)"
     if [[ ("${platform}" == "Linux") ]]; then
-        echo "x86_64-unknown-linux-gnu"
+        local arch="$(uname -m)"
+        echo "${arch}-unknown-linux-gnu"
     elif [[ ("${platform}" == "Darwin") ]]; then
         local arch="$(uname -m)"
         if [[ ("${arch}" == "arm64") ]]; then


### PR DESCRIPTION
This makes it possible to build the app for Linux ARM. It can be done either via cross-compilation or by building it on an ARM host (with the caveat that `grpc-tools` will refuse to generate code for the management interface .proto (https://github.com/mullvad/mullvadvpn-app/pull/2500) in the latter case).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3853)
<!-- Reviewable:end -->
