### PR TITLE
Don't disconnect on GUI crash or when killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Line wrap the file at 100 chars.                                              Th
 - Reorganize settings into more logical categories.
 - Upgrade wireguard-go to 20220703234212 (Windows: v0.5.3).
 - Prune bridges far away from the selected relay.
+- Stay connected when desktop app is killed or crashes. The only situation where the app now
+  disconnects on quit is when the user presses the quit button.
 
 #### Windows
 - Remove dependency on `ipconfig.exe`. Call `DnsFlushResolverCache` to flush the DNS cache.

--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -11,6 +11,8 @@ if which systemctl &> /dev/null; then
     fi
 fi
 
+# This can be removed when 2022.4 is unsupported. That version is the last version where
+# before-remove.sh doesn't kill the GUI on upgrade.
 pkill -x "mullvad-gui" || true
 
 rm -f /var/cache/mullvad-vpn/relays.json

--- a/dist-assets/linux/before-remove.sh
+++ b/dist-assets/linux/before-remove.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
+pkill -x "mullvad-gui" || true
+
 is_number_re='^[0-9]+$'
 # Check if we're running during an upgrade step on Fedora
 # https://fedoraproject.org/wiki/Packaging:Scriptlets#Syntax
@@ -17,8 +19,6 @@ fi
 # the user might've disabled or stopped the service themselves already
 systemctl stop mullvad-daemon.service || true
 systemctl disable mullvad-daemon.service || true
-
-pkill -x "mullvad-gui" || true
 
 /opt/Mullvad\ VPN/resources/mullvad-setup reset-firewall || echo "Failed to reset firewall"
 /opt/Mullvad\ VPN/resources/mullvad-setup remove-device || echo "Failed to remove device from account"

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -1155,7 +1155,7 @@
 
 	Pop $FullUninstall
 
-	nsExec::Exec '"$INSTDIR\Mullvad VPN.exe" --quit-without-disconnect' $0
+	nsExec::Exec `taskkill /t /im "${APP_EXECUTABLE_FILENAME}"` $0
 	Sleep 500
 	nsExec::Exec `taskkill /f /t /im "${APP_EXECUTABLE_FILENAME}"` $0
 

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -55,7 +55,6 @@ const linuxSplitTunneling = process.platform === 'linux' && require('./linux-spl
 const windowsSplitTunneling = process.platform === 'win32' && require('./windows-split-tunneling');
 
 enum CommandLineOptions {
-  quitWithoutDisconnect = '--quit-without-disconnect',
   showChanges = '--show-changes',
   disableResetNavigation = '--disable-reset-navigation', // development only
 }
@@ -126,12 +125,8 @@ class ApplicationMain
 
     this.overrideAppPaths();
 
-    // This ensures that only a single instance is running at the same time, but also exits if
-    // there's no already running instance when the quit without disconnect flag is supplied.
-    if (
-      !app.requestSingleInstanceLock() ||
-      process.argv.includes(CommandLineOptions.quitWithoutDisconnect)
-    ) {
+    // This ensures that only a single instance is running at the same time.
+    if (!app.requestSingleInstanceLock()) {
       app.quit();
       return;
     }
@@ -221,14 +216,8 @@ class ApplicationMain
   };
 
   private addSecondInstanceEventHandler() {
-    app.on('second-instance', (_event, argv, _workingDirectory) => {
-      if (argv.includes(CommandLineOptions.quitWithoutDisconnect)) {
-        // Quit if another instance is started with the quit without disconnect flag.
-        app.quit();
-      } else {
-        // If no action was provided to the new instance the window is opened.
-        this.userInterface?.showWindow();
-      }
+    app.on('second-instance', (_event, _argv, _workingDirectory) => {
+      this.userInterface?.showWindow();
     });
   }
 


### PR DESCRIPTION
This PR changes the behavior of the electron app to not disconnect when it's killed or crashes. The only way to disconnect on quit is when the user presses the quit-button.

This made it possible to remove the `--quit-without-disconnect` flag and to kill the app before the daemon on Linux and to not force kill it on Windows. Unfortunately we still need to keep the code that kills the previous app in `before-install.sh` and the corresponding part in `installer.nsh` to support upgrading from older versions of the app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3855)
<!-- Reviewable:end -->
