### PR TITLE
Upgrade Electron from 18.0.3 to 19.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 - Prune bridges far away from the selected relay.
 - Stay connected when desktop app is killed or crashes. The only situation where the app now
   disconnects on quit is when the user presses the quit button.
+- Update Electron from 18.0.3 to 19.0.13.
 
 #### Windows
 - Remove dependency on `ipconfig.exe`. Call `DnsFlushResolverCache` to flush the DNS cache.

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -54,7 +54,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
         "cross-env": "^5.1.3",
-        "electron": "^18.0.3",
+        "electron": "^19.0.13",
         "electron-builder": "^23.0.8",
         "electron-devtools-installer": "^3.2.0",
         "electron-mocha": "^11.0.2",
@@ -4939,13 +4939,13 @@
       }
     },
     "node_modules/electron": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.5.tgz",
-      "integrity": "sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==",
+      "version": "19.0.13",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.13.tgz",
+      "integrity": "sha512-11Ne0VJy8L1GU7sGcbJHhkAz73szR27uP4vmfUVGlppC/ipA39AUkdzqiQoPC/F1EJdjEOBvHySG8K8Xe9yETA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
@@ -18256,12 +18256,12 @@
       }
     },
     "electron": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.5.tgz",
-      "integrity": "sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==",
+      "version": "19.0.13",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.13.tgz",
+      "integrity": "sha512-11Ne0VJy8L1GU7sGcbJHhkAz73szR27uP4vmfUVGlppC/ipA39AUkdzqiQoPC/F1EJdjEOBvHySG8K8Xe9yETA==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       }

--- a/gui/package.json
+++ b/gui/package.json
@@ -60,7 +60,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "cross-env": "^5.1.3",
-    "electron": "^18.0.3",
+    "electron": "^19.0.13",
     "electron-builder": "^23.0.8",
     "electron-devtools-installer": "^3.2.0",
     "electron-mocha": "^11.0.2",


### PR DESCRIPTION
This PR upgrade Electron from 18.0.3 to 19.0.13. Due to an incompatibility with `nan`, which is a dependency of `nseventmonitor`, it wasn't possible to upgrade to Electron 20. I will perform that upgrade when it's possible.

Changelog for Electron 19:
https://github.com/electron/electron/releases/tag/v19.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3856)
<!-- Reviewable:end -->
