### PR TITLE
Allow administratively scoped v4 multicast range when LAN sharing is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Line wrap the file at 100 chars.                                              Th
 - Stay connected when desktop app is killed or crashes. The only situation where the app now
   disconnects on quit is when the user presses the quit button.
 - Update Electron from 18.0.3 to 19.0.13.
+- Expand allowed range of multicast destinations to include all of `239.0.0.0/8` (administratively
+  scoped addresses), when local network sharing is enabled.
 
 #### Windows
 - Remove dependency on `ipconfig.exe`. Call `DnsFlushResolverCache` to flush the DNS cache.

--- a/docs/security.md
+++ b/docs/security.md
@@ -81,15 +81,15 @@ The following network traffic is allowed or blocked independent of state:
      * `169.254.0.0/16` (Link-local IPv4 range)
      * `fe80::/10` (Link-local IPv6 range)
      * `fc00::/7` (Unique local address (ULA) range)
-   * Outgoing to any IP in a local, unroutable, multicast network, meaning these:
+   * Outgoing to any IP in globally unroutable multicast networks, meaning these:
      * `224.0.0.0/24` (Local subnet IPv4 multicast)
-     * `239.255.0.0/16` (IPv4 local scope. eg. SSDP and mDNS)
+     * `239.0.0.0/8` (Administratively scoped IPv4 multicast. E.g. SSDP and mDNS)
      * `255.255.255.255/32` (Broadcasts to the local network)
      * `ff01::/16` (Interface-local multicast. Local to a single interface on a node.)
      * `ff02::/16` (Link-local IPv6 multicast. IPv6 equivalent of `224.0.0.0/24`)
      * `ff03::/16` (Realm-local IPv6 multicast)
      * `ff04::/16` (Admin-local IPv6 multicast)
-     * `ff05::/16` (Site-local IPv6 multicast. Is routable, but should never leave the "site")
+     * `ff05::/16` (Site-local IPv6 multicast)
    * Incoming DHCPv4 requests and outgoing responses (be a DHCPv4 server):
      * Incoming UDP from `*:68` to `255.255.255.255:67`
      * Outgoing UDP from `*:67` to `*:68`

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -44,8 +44,8 @@ lazy_static! {
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(255, 255, 255, 255), 32).unwrap()),
         // Local subnetwork multicast. Not routable
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
-        // Local scope (mDNS and SSDP) address
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 255, 0, 0), 16).unwrap()),
+        // Admin-local IPv4 multicast.
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 0, 0, 0), 8).unwrap()),
         // Interface-local IPv6 multicast.
         IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff01, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
         // Link-local IPv6 multicast. IPv6 equivalent of 224.0.0.0/24

--- a/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitlan.cpp
@@ -63,8 +63,8 @@ bool PermitLan::applyIpv4(IObjectInstaller &objectInstaller) const
 	// Local subnet multicast.
 	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 224, 0, 0, 0 }), 24)));
 
-	// Local scope (SSDP and mDNS)
-	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 239, 255, 0, 0 }), 16)));
+	// Admin-local scope (e.g., SSDP and mDNS)
+	conditionBuilder.add_condition(ConditionIp::Remote(wfp::IpNetwork(wfp::IpAddress::Literal({ 239, 0, 0, 0 }), 8)));
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }


### PR DESCRIPTION
All of `239.0.0.0/8` is not valid on the internet. This PR updates the firewall rules to permit that entire range. Fixes https://github.com/mullvad/mullvadvpn-app/issues/3753.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3858)
<!-- Reviewable:end -->
