### PR TITLE
Replace winapi with windows-sys in talpid-core

### DIFF
--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -81,7 +81,7 @@ subslice = "0.2"
 [target.'cfg(windows)'.dependencies]
 widestring = "0.5"
 winreg = { version = "0.7", features = ["transactions"] }
-winapi = { version = "0.3.6", features = ["combaseapi", "handleapi", "ifdef", "ioapiset", "knownfolders", "libloaderapi", "netioapi", "psapi", "shlobj", "stringapiset", "synchapi", "tlhelp32", "winbase", "winioctl", "winuser", "dbt"] }
+winapi = { version = "0.3.6", features = ["ws2def"] }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 memoffset = "0.6"
 
@@ -89,7 +89,22 @@ memoffset = "0.6"
 version = "0.36.1"
 features = [
     "Win32_Foundation",
+    "Win32_Globalization",
+    "Win32_System_Com",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Ioctl",
+    "Win32_System_IO",
     "Win32_System_LibraryLoader",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Registry",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_System_WindowsProgramming",
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
 ]
 
 [build-dependencies]

--- a/talpid-core/src/dns/windows/mod.rs
+++ b/talpid-core/src/dns/windows/mod.rs
@@ -1,7 +1,7 @@
 use crate::windows::{guid_from_luid, luid_from_alias, string_from_guid};
 use std::{io, net::IpAddr};
 use talpid_types::ErrorExt;
-use winapi::shared::guiddef::GUID;
+use windows_sys::core::GUID;
 use winreg::{
     enums::{HKEY_LOCAL_MACHINE, KEY_SET_VALUE},
     transaction::Transaction,

--- a/talpid-core/src/routing/windows.rs
+++ b/talpid-core/src/routing/windows.rs
@@ -8,6 +8,7 @@ use futures::{
     StreamExt,
 };
 use std::{collections::HashSet, net::IpAddr};
+use windows_sys::Win32::NetworkManagement::IpHelper::NET_LUID_LH;
 use winnet::WinNetAddrFamily;
 
 /// Windows routing errors.
@@ -187,14 +188,13 @@ impl RouteManager {
 
 fn get_mtu_for_route(addr_family: WinNetAddrFamily) -> Result<Option<u16>> {
     use crate::windows::AddressFamily;
-    use winapi::shared::ifdef::NET_LUID;
     match winnet::get_best_default_route(addr_family) {
         Ok(Some(route)) => {
             let addr_family = match addr_family {
                 WinNetAddrFamily::IPV4 => AddressFamily::Ipv4,
                 WinNetAddrFamily::IPV6 => AddressFamily::Ipv6,
             };
-            let luid = NET_LUID {
+            let luid = NET_LUID_LH {
                 Value: route.interface_luid,
             };
             let interface_row = crate::windows::get_ip_interface_entry(addr_family, &luid)

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -23,26 +23,22 @@ use std::{
     time::Duration,
 };
 use talpid_types::ErrorExt;
-use winapi::{
-    shared::{
-        in6addr::IN6_ADDR,
-        inaddr::IN_ADDR,
-        minwindef::{FALSE, TRUE},
-        ntdef::NTSTATUS,
-        winerror::{
-            ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_INVALID_PARAMETER, ERROR_IO_PENDING,
-        },
+use windows_sys::Win32::{
+    Foundation::{
+        ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_INVALID_PARAMETER, ERROR_IO_PENDING,
+        HANDLE, NTSTATUS, WAIT_FAILED,
     },
-    um::{
-        ioapiset::{DeviceIoControl, GetOverlappedResult},
-        minwinbase::OVERLAPPED,
-        synchapi::{WaitForMultipleObjects, WaitForSingleObject},
-        tlhelp32::TH32CS_SNAPPROCESS,
-        winbase::{
-            FILE_FLAG_OVERLAPPED, INFINITE, WAIT_ABANDONED, WAIT_ABANDONED_0, WAIT_FAILED,
+    Networking::WinSock::{IN6_ADDR, IN_ADDR},
+    Storage::FileSystem::FILE_FLAG_OVERLAPPED,
+    System::{
+        Diagnostics::ToolHelp::TH32CS_SNAPPROCESS,
+        Ioctl::{FILE_ANY_ACCESS, METHOD_BUFFERED, METHOD_NEITHER},
+        Threading::{
+            WaitForMultipleObjects, WaitForSingleObject, WAIT_ABANDONED, WAIT_ABANDONED_0,
             WAIT_OBJECT_0,
         },
-        winioctl::{FILE_ANY_ACCESS, METHOD_BUFFERED, METHOD_NEITHER},
+        WindowsProgramming::INFINITE,
+        IO::{DeviceIoControl, GetOverlappedResult, OVERLAPPED},
     },
 };
 
@@ -842,7 +838,7 @@ pub unsafe fn device_io_control_buffer_async(
     let input_len = input.map(|input| input.len()).unwrap_or(0);
 
     let result = DeviceIoControl(
-        device.as_raw_handle(),
+        device.as_raw_handle() as HANDLE,
         ioctl_code,
         input_ptr,
         u32::try_from(input_len).map_err(|_error| {
@@ -883,16 +879,16 @@ pub fn get_overlapped_result(
     let event = overlapped.get_event().unwrap();
 
     // SAFETY: This is a valid event object.
-    unsafe { wait_for_single_object(event.as_raw_handle(), None) }?;
+    unsafe { wait_for_single_object(event.as_handle(), None) }?;
 
     // SAFETY: The handle and overlapped object are valid.
     let mut returned_bytes = 0u32;
     let result = unsafe {
         GetOverlappedResult(
-            device.as_raw_handle(),
+            device.as_raw_handle() as HANDLE,
             overlapped.as_mut_ptr(),
             &mut returned_bytes,
-            FALSE,
+            0,
         )
     };
     if result == 0 {
@@ -906,10 +902,7 @@ pub fn get_overlapped_result(
 /// # Safety
 ///
 /// * `object` must be a valid object that can be signaled, such as an event object.
-pub unsafe fn wait_for_single_object(
-    object: RawHandle,
-    timeout: Option<Duration>,
-) -> io::Result<()> {
+pub unsafe fn wait_for_single_object(object: HANDLE, timeout: Option<Duration>) -> io::Result<()> {
     let timeout = match timeout {
         Some(timeout) => u32::try_from(timeout.as_millis()).map_err(|_error| {
             io::Error::new(io::ErrorKind::InvalidInput, "the duration is too long")
@@ -931,16 +924,13 @@ pub unsafe fn wait_for_single_object(
 /// # Safety
 ///
 /// * `objects` must be a slice of valid objects that can be signaled, such as event objects.
-pub unsafe fn wait_for_multiple_objects(
-    objects: &[RawHandle],
-    wait_all: bool,
-) -> io::Result<RawHandle> {
+pub unsafe fn wait_for_multiple_objects(objects: &[HANDLE], wait_all: bool) -> io::Result<HANDLE> {
     let objects_len = u32::try_from(objects.len())
         .map_err(|_error| io::Error::new(io::ErrorKind::InvalidInput, "too many objects"))?;
     let result = WaitForMultipleObjects(
         objects_len,
         objects.as_ptr(),
-        if wait_all { TRUE } else { FALSE },
+        if wait_all { 1 } else { 0 },
         INFINITE,
     );
     let signaled_index = if result >= WAIT_OBJECT_0 && result < WAIT_OBJECT_0 + objects_len {

--- a/talpid-core/src/tunnel/wireguard/wireguard_go.rs
+++ b/talpid-core/src/tunnel/wireguard/wireguard_go.rs
@@ -168,8 +168,8 @@ impl WgGoTunnel {
 
         let has_ipv6 = config.tunnel.addresses.iter().any(|addr| addr.is_ipv6());
         let setup_handle = tokio::spawn(async move {
-            use winapi::shared::ifdef::NET_LUID;
-            let luid = NET_LUID {
+            use windows_sys::Win32::NetworkManagement::IpHelper::NET_LUID_LH;
+            let luid = NET_LUID_LH {
                 Value: interface_luid,
             };
             log::debug!("Waiting for tunnel IP interfaces to arrive");
@@ -214,13 +214,15 @@ impl WgGoTunnel {
         default_route: winnet::WinNetDefaultRoute,
         _ctx: *mut libc::c_void,
     ) {
-        use winapi::shared::{ifdef::NET_LUID, netioapi::ConvertInterfaceLuidToIndex};
+        use windows_sys::Win32::NetworkManagement::IpHelper::{
+            ConvertInterfaceLuidToIndex, NET_LUID_LH,
+        };
         use winnet::WinNetDefaultRouteChangeEventType::*;
 
         let iface_idx: u32 = match event_type {
             DefaultRouteChanged => {
                 let mut iface_idx = 0u32;
-                let iface_luid = NET_LUID {
+                let iface_luid = NET_LUID_LH {
                     Value: default_route.interface_luid,
                 };
                 let status =


### PR DESCRIPTION
As above. `talpid-core` still depends on `winapi` for a single struct, as the most recent version of `socket2` on crates.io does not use `windows-sys` yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3862)
<!-- Reviewable:end -->
