### PR TITLE
Improve android buildscripts

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx8192M -Dkotlin.daemon.jvm.options\="-Xmx8192M"

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -123,7 +123,12 @@ for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
     STRIPPED_LIB_PATH="$SCRIPT_DIR/android/app/build/extraJni/$ABI/libmullvad_jni.so"
     UNSTRIPPED_LIB_PATH="$SCRIPT_DIR/target/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
 
-    $STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+
+    if [[ "$BUILD_TYPE" != "debug" ]]; then
+        $STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+    else
+        cp "$UNSTRIPPED_LIB_PATH" "$STRIPPED_LIB_PATH"
+    fi
 done
 
 echo "Updating relays.json..."

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -16,6 +16,7 @@ FILE_SUFFIX=""
 CARGO_ARGS="--release"
 EXTRA_WGGO_ARGS=""
 BUILD_BUNDLE="no"
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"target"}
 
 while [ ! -z "${1:-""}" ]; do
     if [[ "${1:-""}" == "--dev-build" ]]; then
@@ -120,14 +121,14 @@ for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
     cargo build $CARGO_ARGS --target "$TARGET" --package mullvad-jni
 
     STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/${LLVM_TRIPLE}-strip"
-    STRIPPED_LIB_PATH="$SCRIPT_DIR/android/app/build/extraJni/$ABI/libmullvad_jni.so"
-    UNSTRIPPED_LIB_PATH="$SCRIPT_DIR/target/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
+    TARGET_LIB_PATH="$SCRIPT_DIR/android/app/build/extraJni/$ABI/libmullvad_jni.so"
+    UNSTRIPPED_LIB_PATH="$CARGO_TARGET_DIR/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
 
 
     if [[ "$BUILD_TYPE" != "debug" ]]; then
-        $STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+        $STRIP_TOOL --strip-debug --strip-unneeded -o "$TARGET_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
     else
-        cp "$UNSTRIPPED_LIB_PATH" "$STRIPPED_LIB_PATH"
+        cp "$UNSTRIPPED_LIB_PATH" "$TARGET_LIB_PATH"
     fi
 done
 


### PR DESCRIPTION
I've changed two small things in the `build-apk.sh` script for developer (_my own_) quality of life. Firstly, the development builds won't strip debug symbols so that stack traces are actually legible. Secondly, I've changed the buildscript to use `CARGO_TARGET_DIR` to find the cargo target directory instead of assuming it will always be relative to the build script.

If you feel strongly about any of these changes, I'm open to not making them - but let's have a discussion about it then :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3864)
<!-- Reviewable:end -->
