### PR TITLE
Lower wg_migration_threshold to 0.75 in dev builds

### DIFF
--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -478,7 +478,10 @@ fn dev_version_cache() -> AppVersionInfo {
         latest_stable: PRODUCT_VERSION.to_owned(),
         latest_beta: PRODUCT_VERSION.to_owned(),
         suggested_upgrade: None,
-        wg_migration_threshold: 1.0,
+        // Use WireGuard on 75% of dev builds. So we can manually modify
+        // wg_migration_rand_num in the settings and verify that the migration
+        // works as expected.
+        wg_migration_threshold: 0.75,
     }
 }
 


### PR DESCRIPTION
It was previously set to 1.0 for dev builds. Meaning it was impossible to test the behavior, because it would always use WireGuard

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3865)
<!-- Reviewable:end -->
