### PR TITLE
Fix login not focused when submitted after failure

### DIFF
--- a/gui/src/renderer/components/Login.tsx
+++ b/gui/src/renderer/components/Login.tsx
@@ -79,8 +79,7 @@ export default class Login extends React.Component<IProps, IState> {
   public componentDidUpdate(prevProps: IProps, _prevState: IState) {
     if (
       this.props.loginState.type !== prevProps.loginState.type &&
-      this.props.loginState.type === 'failed' &&
-      !this.shouldResetLoginError
+      this.props.loginState.type === 'failed'
     ) {
       this.shouldResetLoginError = true;
 


### PR DESCRIPTION
This PR fixes a bug where the login input wasn't focused after failing after a second submit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3866)
<!-- Reviewable:end -->
