### PR TITLE
Enable interface settings when logged out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Line wrap the file at 100 chars.                                              Th
 - Quit app gracefully if renderer process is killed or crashes.
 - Enable reconnect in blocked state in desktop app.
 - Fix error handling during device removal in the desktop app.
+- Enable interface settings when app is logged out
 
 #### Windows
 - Only use the most recent list of apps to split when resuming from hibernation/sleep if applying

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -63,7 +63,7 @@ export default function Support() {
                 )}
 
                 <StyledSettingsContent>
-                  {showSubSettings && (
+                  {showSubSettings ? (
                     <>
                       <Cell.Group>
                         <AccountButton />
@@ -77,6 +77,10 @@ export default function Support() {
                         </Cell.Group>
                       )}
                     </>
+                  ) : (
+                    <Cell.Group>
+                      <InterfaceSettingsButton />
+                    </Cell.Group>
                   )}
 
                   <Cell.Group>


### PR DESCRIPTION
This PR enables interface settings when logged out since there are no settings in that view that requires an account, and the language setting needs to be available at all times.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3869)
<!-- Reviewable:end -->
