### PR TITLE
Replace the remaining mentions of Always require VPN

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -324,10 +324,6 @@ msgid "%(city)s (%(hostname)s)"
 msgstr ""
 
 msgctxt "connect-view"
-msgid "Always require VPN"
-msgstr ""
-
-msgctxt "connect-view"
 msgid "Congrats!"
 msgstr ""
 
@@ -396,7 +392,7 @@ msgid "You have no more VPN time left on this account."
 msgstr ""
 
 msgctxt "connect-view"
-msgid "You need to disable \"Always require VPN\" in order to access the Internet to add time."
+msgid "You need to disable \"Lockdown mode\" in order to access the Internet to add time."
 msgstr ""
 
 msgctxt "connect-view"
@@ -545,7 +541,7 @@ msgid "Rented only"
 msgstr ""
 
 msgctxt "in-app-notifications"
-msgid "\"Always require VPN\" is enabled."
+msgid "\"%(lockdownModeSettingName)s\" is enabled."
 msgstr ""
 
 msgctxt "in-app-notifications"
@@ -646,9 +642,9 @@ msgstr ""
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
 #. Available placeholder:
-#. %(alwaysRequireVpnSettingsName)s - The translation of "Always require VPN"
+#. %(lockdownModeSettingName)s - The translation of "Lockdown mode"
 msgctxt "login-view"
-msgid "**%(alwaysRequireVpnSettingsName)s** is enabled. Disable it to unblock your connection."
+msgid "**%(lockdownModeSettingName)s** is enabled. Disable it to unblock your connection."
 msgstr ""
 
 msgctxt "login-view"

--- a/gui/src/renderer/components/ExpiredAccountErrorView.tsx
+++ b/gui/src/renderer/components/ExpiredAccountErrorView.tsx
@@ -206,7 +206,7 @@ export default class ExpiredAccountErrorView extends React.Component<
         <ModalMessage>
           {messages.pgettext(
             'connect-view',
-            'You need to disable "Always require VPN" in order to access the Internet to add time.',
+            'You need to disable "Lockdown mode" in order to access the Internet to add time.',
           )}
         </ModalMessage>
         <ModalMessage>
@@ -216,7 +216,7 @@ export default class ExpiredAccountErrorView extends React.Component<
           )}
         </ModalMessage>
         <StyledModalCellContainer>
-          <Cell.Label>{messages.pgettext('connect-view', 'Always require VPN')}</Cell.Label>
+          <Cell.Label>{messages.pgettext('vpn-settings-view', 'Lockdown mode')}</Cell.Label>
           <Cell.Switch
             isOn={this.props.blockWhenDisconnected}
             onChange={this.props.setBlockWhenDisconnected}

--- a/gui/src/renderer/components/Login.tsx
+++ b/gui/src/renderer/components/Login.tsx
@@ -441,19 +441,19 @@ function BlockMessage() {
     }
   }, [blockWhenDisconnected, tunnelState, setBlockWhenDisconnected, disconnectTunnel]);
 
-  const alwaysRequireVpnSettingsName = messages.pgettext('vpn-settings-view', 'Lockdown mode');
+  const lockdownModeSettingName = messages.pgettext('vpn-settings-view', 'Lockdown mode');
   const message = formatMarkdown(
     blockWhenDisconnected
       ? sprintf(
           // TRANSLATORS: This is a warning message shown when the app is blocking the users
           // TRANSLATORS: internet connection while logged out.
           // TRANSLATORS: Available placeholder:
-          // TRANSLATORS: %(alwaysRequireVpnSettingsName)s - The translation of "Always require VPN"
+          // TRANSLATORS: %(lockdownModeSettingName)s - The translation of "Lockdown mode"
           messages.pgettext(
             'login-view',
-            '**%(alwaysRequireVpnSettingsName)s** is enabled. Disable it to unblock your connection.',
+            '**%(lockdownModeSettingName)s** is enabled. Disable it to unblock your connection.',
           ),
-          { alwaysRequireVpnSettingsName },
+          { lockdownModeSettingName },
         )
       : // This makes the translator comment appear on it's own line.
         // TRANSLATORS: This is a warning message shown when the app is blocking the users

--- a/gui/src/shared/notifications/block-when-disconnected.ts
+++ b/gui/src/shared/notifications/block-when-disconnected.ts
@@ -23,7 +23,11 @@ export class BlockWhenDisconnectedNotificationProvider implements InAppNotificat
   }
 
   public getInAppNotification(): InAppNotification {
-    let subtitle = messages.pgettext('in-app-notifications', '"Always require VPN" is enabled.');
+    const lockdownModeSettingName = messages.pgettext('vpn-settings-view', 'Lockdown mode');
+    let subtitle = sprintf(
+      messages.pgettext('in-app-notifications', '"%(lockdownModeSettingName)s" is enabled.'),
+      { lockdownModeSettingName },
+    );
     if (this.context.hasExcludedApps) {
       subtitle = `${subtitle} ${sprintf(
         messages.pgettext(


### PR DESCRIPTION
This PR replaces a the remaining occurrences of the string "Always require VPN". All other occurrances was replaced a while ago but these were forgotten about.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3871)
<!-- Reviewable:end -->
