### PR TITLE
Replace winapi with windows-sys in the remaining crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
  "serde",
  "talpid-types",
  "tokio",
- "winapi",
+ "windows-sys",
  "winres",
 ]
 
@@ -1609,6 +1609,7 @@ dependencies = [
  "uuid",
  "winapi",
  "windows-service",
+ "windows-sys",
  "winres",
 ]
 
@@ -1693,7 +1694,7 @@ dependencies = [
  "talpid-types",
  "tokio",
  "uuid",
- "winapi",
+ "windows-sys",
  "winres",
 ]
 
@@ -1736,8 +1737,7 @@ dependencies = [
  "talpid-types",
  "tokio",
  "widestring 0.5.1",
- "winapi",
- "winres",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3153,7 +3153,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
- "winapi",
+ "windows-sys",
  "winres",
 ]
 
@@ -3163,7 +3163,7 @@ version = "0.1.0"
 dependencies = [
  "rs-release",
  "talpid-dbus",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -34,7 +34,12 @@ clap_complete = { version = "3.0" }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
-winapi = "0.3"
+
+[target.'cfg(windows)'.build-dependencies.windows-sys]
+version = "0.36.1"
+features = [
+    "Win32_System_SystemServices",
+]
 
 [package.metadata.winres]
 ProductName = "Mullvad VPN"

--- a/mullvad-cli/build.rs
+++ b/mullvad-cli/build.rs
@@ -1,5 +1,10 @@
 use std::{env, fs, path::PathBuf};
 
+#[cfg(windows)]
+fn make_lang_id(p: u16, s: u16) -> u16 {
+    (s << 10) | p
+}
+
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let product_version = env!("CARGO_PKG_VERSION").replacen(".0", "", 1);
@@ -10,9 +15,9 @@ fn main() {
         let mut res = winres::WindowsResource::new();
         res.set("ProductVersion", &product_version);
         res.set_icon("../dist-assets/icon.ico");
-        res.set_language(winapi::um::winnt::MAKELANGID(
-            winapi::um::winnt::LANG_ENGLISH,
-            winapi::um::winnt::SUBLANG_ENGLISH_US,
+        res.set_language(make_lang_id(
+            windows_sys::Win32::System::SystemServices::LANG_ENGLISH as u16,
+            windows_sys::Win32::System::SystemServices::SUBLANG_ENGLISH_US as u16,
         ));
         res.compile().expect("Unable to generate windows resources");
     }

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -52,12 +52,30 @@ simple-signal = "1.1"
 ctrlc = "3.0"
 duct = "0.13"
 windows-service = "0.5.0"
-winapi = { version = "0.3", features = ["errhandlingapi", "handleapi", "libloaderapi", "ntlsa", "synchapi", "tlhelp32", "winbase", "winerror", "winuser"] }
+winapi = { version = "0.3", features = ["winnt", "excpt"] }
 dirs-next = "2.0"
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.1"
+features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Security_Authentication_Identity",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_Kernel",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+]
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
-winapi = "0.3"
+
+[target.'cfg(windows)'.build-dependencies.windows-sys]
+version = "0.36.1"
+features = [
+    "Win32_System_SystemServices",
+]
 
 [package.metadata.winres]
 ProductName = "Mullvad VPN"

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -1,5 +1,10 @@
 use std::{env, fs, path::PathBuf, process::Command};
 
+#[cfg(windows)]
+fn make_lang_id(p: u16, s: u16) -> u16 {
+    (s << 10) | p
+}
+
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
@@ -12,9 +17,9 @@ fn main() {
         let mut res = winres::WindowsResource::new();
         res.set("ProductVersion", &product_version);
         res.set_icon("../dist-assets/icon.ico");
-        res.set_language(winapi::um::winnt::MAKELANGID(
-            winapi::um::winnt::LANG_ENGLISH,
-            winapi::um::winnt::SUBLANG_ENGLISH_US,
+        res.set_language(make_lang_id(
+            windows_sys::Win32::System::SystemServices::LANG_ENGLISH as u16,
+            windows_sys::Win32::System::SystemServices::SUBLANG_ENGLISH_US as u16,
         ));
         println!("cargo:rerun-if-env-changed=MULLVAD_ADD_MANIFEST");
         if env::var("MULLVAD_ADD_MANIFEST")

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -30,7 +30,12 @@ duct = "0.13"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
-winapi = "0.3"
+
+[target.'cfg(windows)'.build-dependencies.windows-sys]
+version = "0.36.1"
+features = [
+    "Win32_System_SystemServices",
+]
 
 
 [package.metadata.winres]

--- a/mullvad-problem-report/build.rs
+++ b/mullvad-problem-report/build.rs
@@ -1,5 +1,10 @@
 use std::{env, fs, path::PathBuf};
 
+#[cfg(windows)]
+fn make_lang_id(p: u16, s: u16) -> u16 {
+    (s << 10) | p
+}
+
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
@@ -11,9 +16,9 @@ fn main() {
         let mut res = winres::WindowsResource::new();
         res.set("ProductVersion", &product_version);
         res.set_icon("../dist-assets/icon.ico");
-        res.set_language(winapi::um::winnt::MAKELANGID(
-            winapi::um::winnt::LANG_ENGLISH,
-            winapi::um::winnt::SUBLANG_ENGLISH_US,
+        res.set_language(make_lang_id(
+            windows_sys::Win32::System::SystemServices::LANG_ENGLISH as u16,
+            windows_sys::Win32::System::SystemServices::SUBLANG_ENGLISH_US as u16,
         ));
         res.compile().expect("Unable to generate windows resources");
     }

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -29,16 +29,15 @@ talpid-core = { path = "../talpid-core" }
 talpid-types = { path = "../talpid-types" }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.6", features = ["securitybaseapi", "impl-default", "impl-debug", "handleapi", "psapi"]}
 widestring = "0.5"
 
-[target.'cfg(windows)'.build-dependencies]
-winres = "0.1"
-winapi = "0.3"
-
-[package.metadata.winres]
-ProductName = "Mullvad VPN"
-CompanyName = "Mullvad VPN AB"
-LegalCopyright = "(c) 2022 Mullvad VPN AB"
-InternalName = "mullvad-setup"
-OriginalFilename = "mullvad-setup.exe"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.1"
+features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Com",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Threading",
+    "Win32_UI_Shell",
+]

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -30,7 +30,12 @@ tonic-build = { version = "0.5", default-features = false, features = ["transpor
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
-winapi = "0.3"
+
+[target.'cfg(windows)'.build-dependencies.windows-sys]
+version = "0.36.1"
+features = [
+    "Win32_System_SystemServices",
+]
 
 [package.metadata.winres]
 ProductName = "Mullvad VPN"

--- a/talpid-openvpn-plugin/build.rs
+++ b/talpid-openvpn-plugin/build.rs
@@ -1,3 +1,8 @@
+#[cfg(windows)]
+fn make_lang_id(p: u16, s: u16) -> u16 {
+    (s << 10) | p
+}
+
 fn main() {
     const PROTO_FILE: &str = "proto/openvpn_plugin.proto";
     tonic_build::compile_protos(PROTO_FILE).unwrap();
@@ -9,9 +14,9 @@ fn main() {
         let mut res = winres::WindowsResource::new();
         res.set("ProductVersion", &product_version);
         res.set_icon("../dist-assets/icon.ico");
-        res.set_language(winapi::um::winnt::MAKELANGID(
-            winapi::um::winnt::LANG_ENGLISH,
-            winapi::um::winnt::SUBLANG_ENGLISH_US,
+        res.set_language(make_lang_id(
+            windows_sys::Win32::System::SystemServices::LANG_ENGLISH as u16,
+            windows_sys::Win32::System::SystemServices::SUBLANG_ENGLISH_US as u16,
         ));
         res.compile().expect("Unable to generate windows resources");
     }

--- a/talpid-platform-metadata/Cargo.toml
+++ b/talpid-platform-metadata/Cargo.toml
@@ -12,5 +12,11 @@ publish = false
 rs-release = "0.1.7"
 talpid-dbus = { path = "../talpid-dbus" }
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.6", features = ["winbase"] }
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.36.1"
+features = [
+    "Win32_Foundation",
+    "Win32_System_LibraryLoader",
+    "Win32_System_SystemInformation",
+    "Win32_System_SystemServices",
+]


### PR DESCRIPTION
Continuation of https://github.com/mullvad/mullvadvpn-app/pull/3862.

There are some missing macros in `windows-sys`. `winapi` is still used for some of these.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3873)
<!-- Reviewable:end -->
