### PR TITLE
Fix incorrect version replacement in version-metadata.sh

### DIFF
--- a/version-metadata.sh
+++ b/version-metadata.sh
@@ -62,7 +62,7 @@ function inject_version {
 
     echo "Setting Rust crate versions to $semver_version"
     # Rust crates
-    sed -i.bak -Ee "s/^version = \"[^\"]+\"\$/version = \"$semver_version\"/g" \
+    sed -i.bak -Ee "0,/^version = \"[^\"]+\"\$/s/^version = \"[^\"]+\"\$/version = \"$semver_version\"/g" \
         "${MANIFESTS[@]}"
 
     if [[ "$DESKTOP" == "true" ]]; then


### PR DESCRIPTION
Previously, `version-metadata.sh` would replace any line in the toml file matching `^version = "[^\]+"$`. This didn't work when a package version was specified in a separate section. For example, `0.36.1` would be replaced here:

```
[dependencies.windows-sys]
version = "0.36.1"
```

This PR simply updates the script to replace the first occurrence only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3874)
<!-- Reviewable:end -->
