### PR TITLE
Upgrade the classic-mceliece-rust library to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,11 +344,13 @@ dependencies = [
 
 [[package]]
 name = "classic-mceliece-rust"
-version = "1.0.1"
-source = "git+https://github.com/mullvad/classic-mceliece-rust?rev=5130d9e3bfbf54735177e15636a643366c250b78#5130d9e3bfbf54735177e15636a643366c250b78"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0022efd83c4782eb5db72d205319ecf145ae0c8f5f55987538510f0c24b39991"
 dependencies = [
  "rand 0.8.5",
  "sha3",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,9 +269,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead",
  "chacha20",
@@ -4024,18 +4024,18 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -16,12 +16,7 @@ prost = "0.8"
 prost-types = "0.9"
 tower = "0.4"
 tokio = "1"
-
-[dependencies.classic-mceliece-rust]
-git = "https://github.com/mullvad/classic-mceliece-rust"
-rev = "5130d9e3bfbf54735177e15636a643366c250b78"
-version = "1.0.1"
-features = ["mceliece8192128f"]
+classic-mceliece-rust = { version = "2.0.0", features = ["mceliece8192128f"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/talpid-tunnel-config-client/src/kem.rs
+++ b/talpid-tunnel-config-client/src/kem.rs
@@ -1,67 +1,25 @@
-use std::fmt;
-
-use super::Error;
-
-use classic_mceliece_rust::{
-    crypto_kem_dec, crypto_kem_keypair, CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES,
-};
+use classic_mceliece_rust::keypair_boxed;
 use talpid_types::net::wireguard::PresharedKey;
 
-const STACK_SIZE: usize = 8 * 1024 * 1024;
-pub use classic_mceliece_rust::CRYPTO_CIPHERTEXTBYTES;
+const STACK_SIZE: usize = 2 * 1024 * 1024;
 
-#[derive(Debug)]
-pub struct PublicKey(Box<[u8; CRYPTO_PUBLICKEYBYTES]>);
+pub use classic_mceliece_rust::{Ciphertext, PublicKey, SecretKey, CRYPTO_CIPHERTEXTBYTES};
 
-impl PublicKey {
-    pub fn into_vec(self) -> Vec<u8> {
-        (self.0 as Box<[u8]>).into_vec()
-    }
-}
-
-pub struct SecretKey(Box<[u8; CRYPTO_SECRETKEYBYTES]>);
-
-impl fmt::Debug for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SecretKey").finish()
-    }
-}
-
-pub async fn generate_keys() -> Result<(PublicKey, SecretKey), Error> {
+pub async fn generate_keys() -> (PublicKey<'static>, SecretKey<'static>) {
     let (tx, rx) = tokio::sync::oneshot::channel();
-
-    let gen_key = move || {
-        let mut rng = rand::thread_rng();
-        let mut pubkey = Box::new([0u8; CRYPTO_PUBLICKEYBYTES]);
-        let mut secret = Box::new([0u8; CRYPTO_SECRETKEYBYTES]);
-        crypto_kem_keypair(&mut pubkey, &mut secret, &mut rng).map_err(|error| {
-            log::error!("KEM keypair generation failed: {error}");
-            Error::KeyGenerationFailed
-        })?;
-
-        Ok((PublicKey(pubkey), SecretKey(secret)))
-    };
 
     std::thread::Builder::new()
         .stack_size(STACK_SIZE)
         .spawn(move || {
-            let _ = tx.send(gen_key());
+            let keypair = keypair_boxed(&mut rand::thread_rng());
+            let _ = tx.send(keypair);
         })
         .unwrap();
 
     rx.await.unwrap()
 }
 
-pub fn decapsulate(
-    secret: &SecretKey,
-    ciphertext: &[u8; CRYPTO_CIPHERTEXTBYTES],
-) -> Result<PresharedKey, Error> {
-    let mut psk = [0u8; CRYPTO_BYTES];
-
-    crypto_kem_dec(&mut psk, ciphertext, &secret.0).map_err(|error| {
-        log::error!("KEM decapsulation failed: {error}");
-        Error::DecapsulationError
-    })?;
-
-    Ok(PresharedKey::from(psk))
+pub fn decapsulate(secret: &SecretKey, ciphertext: &Ciphertext) -> PresharedKey {
+    let shared_secret = classic_mceliece_rust::decapsulate_boxed(ciphertext, secret);
+    PresharedKey::from(*shared_secret.as_array())
 }


### PR DESCRIPTION
WIP. Upgrading to the (not yet released) version `2.0.0` of `classic-mceliece-rust`. This is to verify that the proposed library API is sane before publishing. See https://github.com/Colfenor/classic-mceliece-rust/pull/28

I hade to upgrade `chacha20poly1305` also. Since the version we had was pinning `zeroize` to an older version than what `classic-mceliece-rust` required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3877)
<!-- Reviewable:end -->
