### PR TITLE
Fix tunnel info expansion state on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Fix crash sometimes occurring during account creation.
+- Fix tunnel info expansion state not remembered during pause and resume.
 
 
 ## [2022.4] - 2022-08-19

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -13,6 +13,7 @@ import net.mullvad.mullvadvpn.ui.serviceconnection.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.DeviceRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.SplitTunneling
+import net.mullvad.mullvadvpn.viewmodel.ConnectViewModel
 import net.mullvad.mullvadvpn.viewmodel.DeviceListViewModel
 import net.mullvad.mullvadvpn.viewmodel.DeviceRevokedViewModel
 import net.mullvad.mullvadvpn.viewmodel.LoginViewModel
@@ -49,9 +50,12 @@ val uiModule = module {
 
     single { AccountRepository(get()) }
     single { DeviceRepository(get()) }
-    viewModel { LoginViewModel(get(), get()) }
+
+    // View models
+    viewModel { ConnectViewModel() }
     viewModel { DeviceRevokedViewModel(get(), get()) }
     viewModel { DeviceListViewModel(get(), get()) }
+    viewModel { LoginViewModel(get(), get()) }
 }
 
 const val APPS_SCOPE = "APPS_SCOPE"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LocationInfo.kt
@@ -9,7 +9,11 @@ import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.net.Endpoint
 import net.mullvad.talpid.net.TransportProtocol
 
-class LocationInfo(val parentView: View, val context: Context) {
+class LocationInfo(
+    parentView: View,
+    private val context: Context,
+    private val onToggleTunnelInfo: () -> Unit
+) {
     private val hostnameColorCollapsed = context.getColor(R.color.white40)
     private val hostnameColorExpanded = context.getColor(R.color.white)
 
@@ -24,7 +28,12 @@ class LocationInfo(val parentView: View, val context: Context) {
 
     private var endpoint: Endpoint? = null
     private var isTunnelInfoVisible = false
+
     var isTunnelInfoExpanded = false
+        set(value) {
+            field = value
+            updateTunnelInfo()
+        }
 
     var location: GeoIpLocation? = null
         set(value) {
@@ -60,12 +69,7 @@ class LocationInfo(val parentView: View, val context: Context) {
         }
 
     init {
-        tunnelInfo.setOnClickListener { toggleTunnelInfo() }
-    }
-
-    private fun toggleTunnelInfo() {
-        isTunnelInfoExpanded = !isTunnelInfoExpanded
-        updateTunnelInfo()
+        tunnelInfo.setOnClickListener { onToggleTunnelInfo() }
     }
 
     private fun updateTunnelInfo() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModel.kt
@@ -1,0 +1,14 @@
+package net.mullvad.mullvadvpn.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class ConnectViewModel : ViewModel() {
+    private val _isTunnelInfoExpanded = MutableStateFlow(false)
+    val isTunnelInfoExpanded = _isTunnelInfoExpanded.asStateFlow()
+
+    fun toggleTunnelInfoExpansion() {
+        _isTunnelInfoExpanded.value = _isTunnelInfoExpanded.value.not()
+    }
+}


### PR DESCRIPTION
Ensures that the tunnel info expansion state is remembered across the
pause/resume flow. This is done by replacing the previous state handling
with a view model.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3880)
<!-- Reviewable:end -->
