### PR TITLE
Fix android view transition crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix crash sometimes occurring during account creation.
 - Fix tunnel info expansion state not remembered during pause and resume.
+- Fix crash caused by view transitions due to a timit issue.
 
 
 ## [2022.4] - 2022-08-19

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -247,7 +247,7 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
             )
             replace(R.id.main_fragment, SelectLocationFragment())
             addToBackStack(null)
-            commit()
+            commitAllowingStateLoss()
         }
     }
 
@@ -255,7 +255,7 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
         jobTracker.newUiJob("openOutOfTimeScreen") {
             parentFragmentManager.beginTransaction().apply {
                 replace(R.id.main_fragment, OutOfTimeFragment())
-                commit()
+                commitAllowingStateLoss()
             }
         }
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -191,7 +191,7 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
             )
             replace(R.id.main_fragment, deviceFragment)
             addToBackStack(null)
-            commit()
+            commitAllowingStateLoss()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -144,7 +144,7 @@ open class MainActivity : FragmentActivity() {
             )
             replace(R.id.main_fragment, SettingsFragment())
             addToBackStack(null)
-            commit()
+            commitAllowingStateLoss()
         }
     }
 
@@ -188,7 +188,7 @@ open class MainActivity : FragmentActivity() {
     private fun openLaunchView() {
         supportFragmentManager.beginTransaction().apply {
             replace(R.id.main_fragment, LaunchFragment())
-            commit()
+            commitAllowingStateLoss()
         }
     }
 
@@ -214,7 +214,7 @@ open class MainActivity : FragmentActivity() {
 
         supportFragmentManager.beginTransaction().apply {
             replace(R.id.main_fragment, fragment)
-            commit()
+            commitAllowingStateLoss()
         }
     }
 
@@ -231,7 +231,7 @@ open class MainActivity : FragmentActivity() {
         clearBackStack()
         supportFragmentManager.beginTransaction().apply {
             replace(R.id.main_fragment, LoginFragment())
-            commit()
+            commitAllowingStateLoss()
         }
     }
 
@@ -244,7 +244,7 @@ open class MainActivity : FragmentActivity() {
                 R.anim.fragment_exit_to_right
             )
             replace(R.id.main_fragment, DeviceRevokedFragment())
-            commit()
+            commitAllowingStateLoss()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/OutOfTimeFragment.kt
@@ -196,7 +196,7 @@ class OutOfTimeFragment : BaseFragment() {
     private fun advanceToConnectScreen() {
         parentFragmentManager.beginTransaction().apply {
             replace(R.id.main_fragment, ConnectFragment())
-            commit()
+            commitAllowingStateLoss()
         }
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ProblemReportFragment.kt
@@ -153,7 +153,7 @@ class ProblemReportFragment : BaseFragment() {
             )
             replace(R.id.main_fragment, ViewLogsFragment())
             addToBackStack(null)
-            commit()
+            commitAllowingStateLoss()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/WelcomeFragment.kt
@@ -194,7 +194,7 @@ class WelcomeFragment : BaseFragment() {
     private fun advanceToConnectScreen() {
         parentFragmentManager.beginTransaction().apply {
             replace(R.id.main_fragment, ConnectFragment())
-            commit()
+            commitAllowingStateLoss()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragments/DeviceListFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragments/DeviceListFragment.kt
@@ -85,7 +85,7 @@ class DeviceListFragment : Fragment() {
         }
         parentFragmentManager.beginTransaction().apply {
             replace(R.id.main_fragment, loginFragment)
-            commit()
+            commitAllowingStateLoss()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NavigateCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/NavigateCell.kt
@@ -46,7 +46,7 @@ open class NavigateCell : Cell {
                 )
                 replace(R.id.main_fragment, fragment)
                 addToBackStack(null)
-                commit()
+                commitAllowingStateLoss()
             }
         }
     }


### PR DESCRIPTION
Fixes a crash during view transitions reported by some devices in the Google Play Console. The crash is caused by an attempted transition after the _instance state_ has been saved. However, as the app doesn't rely on the _instance state_ for state handling (we use view models instead), we can allow a _instance state_ loss.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3883)
<!-- Reviewable:end -->
