### PR TITLE
Include port in 'mullvad status -v' output when obfuscation is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Line wrap the file at 100 chars.                                              Th
 - Enable reconnect in blocked state in desktop app.
 - Fix error handling during device removal in the desktop app.
 - Enable interface settings when app is logged out
+- Fix 'mullvad status -v' to include the port of the endpoint when connecting over TCP.
 
 #### Windows
 - Only use the most recent list of apps to split when resuming from hibernation/sleep if applying


### PR DESCRIPTION
Previously, `mullvad status -v` did not include the port when obfuscation was enabled:

```
mullvad status -v
Connected to se-got-wg-101 (185.213.154.70/TCP) in Gothenburg, Sweden
```

The PR fixes this to include the port:

```
mullvad status -v
Connected to se-got-wg-101 (185.213.154.70:80/TCP) in Gothenburg, Sweden
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3887)
<!-- Reviewable:end -->
