### PR TITLE
Don't fail ST driver installation if the device tree contains nameless callout driver devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Only use the most recent list of apps to split when resuming from hibernation/sleep if applying
   it was successful.
+- Don't fail install if the device tree contains nameless callout driver devices.
 
 #### Android
 - Fix crash sometimes occurring during account creation.

--- a/windows/driverlogic/src/driverlogic.cpp
+++ b/windows/driverlogic/src/driverlogic.cpp
@@ -91,9 +91,28 @@ std::unique_ptr<DeviceEnumerator> CreateSplitTunnelDeviceEnumerator()
 {
 	return DeviceEnumerator::Create(WFP_CALLOUTS_CLASS_ID, [](HDEVINFO deviceInfoSet, const SP_DEVINFO_DATA &deviceInfo)
 	{
-		auto candidateDeviceName = GetDeviceStringProperty(deviceInfoSet, deviceInfo, &DEVPKEY_NAME);
+		try
+		{
+			auto candidateDeviceName = GetDeviceStringProperty(deviceInfoSet, deviceInfo, &DEVPKEY_NAME);
 
-		return 0 == candidateDeviceName.compare(SPLIT_TUNNEL_DEVICE_NAME);
+			return 0 == candidateDeviceName.compare(SPLIT_TUNNEL_DEVICE_NAME);
+		}
+		catch (const common::error::WindowsException &e)
+		{
+			if (ERROR_NOT_FOUND == e.errorCode())
+			{
+				// DEVPKEY_NAME is not guaranteed to be set.
+				// If it isn't, just assume it's not a matching device.
+
+				return false;
+			}
+
+			throw;
+		}
+		catch (...)
+		{
+			throw;
+		}
 	});
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3889)
<!-- Reviewable:end -->
