### PR TITLE
Explicitly export activity and services

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,12 @@
                  android:banner="@drawable/banner"
                  android:name=".MullvadApplication"
                  tools:ignore="GoogleAppIndexingWarning">
+        <!--
+            MainActivity
+            Must be exported in order to be launchable.
+        -->
         <activity android:name="net.mullvad.mullvadvpn.ui.MainActivity"
+                  android:exported="true"
                   android:label="@string/app_name"
                   android:launchMode="singleTask"
                   android:configChanges="orientation|screenSize|screenLayout"
@@ -39,7 +44,14 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
             </intent-filter>
         </activity>
+        <!--
+            MullvadVpnService
+            It's unclear in the documentation whether the service must/should be exported or not,
+            however as it's protected by the bind vpn permission
+            (android.permission.BIND_VPN_SERVICE) it's protected against third party apps/services.
+        -->
         <service android:name="net.mullvad.mullvadvpn.service.MullvadVpnService"
+                 android:exported="true"
                  android:permission="android.permission.BIND_VPN_SERVICE"
                  android:process=":mullvadvpn_daemon"
                  android:stopWithTask="false">
@@ -56,10 +68,16 @@
                 <action android:name="net.mullvad.mullvadvpn.quit_action" />
             </intent-filter>
         </service>
+        <!--
+            MullvadTileService
+            Tile services must be exported and protected by the bind tile permission
+            (android.permission.BIND_QUICK_SETTINGS_TILE).
+        -->
         <service android:name="net.mullvad.mullvadvpn.service.MullvadTileService"
+                 android:exported="true"
+                 android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
                  android:label="@string/toggle_vpn"
                  android:icon="@drawable/small_logo_black"
-                 android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
                  android:process=":mullvadvpn_tile">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />


### PR DESCRIPTION
Explicitly set export configuration for activity and services as it's required when targeting Android 12 and can be generally considered a good security practice.

This commit also adds brief documentation in the manifest to motivate
the export configuration.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3890)
<!-- Reviewable:end -->
