### PR TITLE
Fix disabled login button on login failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix crash sometimes occurring during account creation.
 - Fix tunnel info expansion state not remembered during pause and resume.
 - Fix crash caused by view transitions due to a timit issue.
+- Fix disabled login button on login failure. Instead, the login button will now still be enabled
+  on login failures to let the user re-attempt the login.
 
 
 ## [2022.4] - 2022-08-19

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -12,7 +12,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.extension.requireMainActivity
@@ -127,7 +129,14 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
     }
 
     private fun CoroutineScope.launchUpdateUiOnViewModelStateChanges() = launch {
-        loginViewModel.uiState.collect { uiState -> updateUi(uiState) }
+        loginViewModel.uiState
+            .onEach {
+                // Adds a short delay to prevent loading spinner flickering.
+                if (it.isLoading().not()) {
+                    delay(MINIMUM_LOADING_SPINNER_TIME_MILLIS)
+                }
+            }
+            .collect { uiState -> updateUi(uiState) }
     }
 
     private fun updateUi(uiState: LoginViewModel.LoginUiState) {
@@ -268,5 +277,9 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
     private fun scrollToShow(view: View) {
         val rectangle = Rect(0, 0, view.width, view.height)
         scrollArea.requestChildRectangleOnScreen(view, rectangle, false)
+    }
+
+    companion object {
+        private const val MINIMUM_LOADING_SPINNER_TIME_MILLIS = 200L
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AccountInput.kt
@@ -144,7 +144,7 @@ class AccountInput : LinearLayout {
 
     private fun failureState() {
         button.visibility = View.VISIBLE
-        setButtonEnabled(false)
+        setButtonEnabled(true)
 
         input.apply {
             setTextColor(errorTextColor)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModel.kt
@@ -39,6 +39,10 @@ class LoginViewModel(
         data class TooManyDevicesError(val accountToken: String) : LoginUiState()
         object TooManyDevicesMissingListError : LoginUiState()
         data class OtherError(val errorMessage: String) : LoginUiState()
+
+        fun isLoading(): Boolean {
+            return this is Loading
+        }
     }
 
     fun clearAccountHistory() = accountRepository.clearAccountHistory()


### PR DESCRIPTION
This PR aims to change/fix the behavior of the login button when a login error occurs. Rather than disabling the login button, it will now be possible to re-attempt the login. This behavior is aligned with the desktop behavior.

This PR also includes a minor flickering fix.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3898)
<!-- Reviewable:end -->
