### PR TITLE
Disable settings button while logging in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Refresh device data when opening the account view to ensure the local data is up-to-date and that
   the device hasn't been revoked.
+- Disable settings button during login.
 
 ### Fixed
 - Connect to TCP endpoints over IPv6 if IPv6 is enabled for WireGuard.

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/LoginFragment.kt
@@ -212,6 +212,7 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
 
     private fun showLoading(overrideSpinnerWithErrorIcon: Boolean = false) {
         accountLogin.state = LoginState.InProgress
+        headerBar.setSettingsButtonEnabled(false)
 
         title.setText(R.string.logging_in_title)
         subtitle.setText(R.string.logging_in_description)
@@ -244,6 +245,7 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
         loggedInStatus.visibility = View.VISIBLE
 
         accountLogin.state = LoginState.Success
+        headerBar.setSettingsButtonEnabled(false)
 
         scrollToShow(loggedInStatus)
     }
@@ -257,6 +259,7 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
         loggedInStatus.visibility = View.GONE
 
         accountLogin.state = LoginState.InProgress
+        headerBar.setSettingsButtonEnabled(true)
 
         scrollToShow(loggingInStatus)
     }
@@ -270,6 +273,7 @@ class LoginFragment : BaseFragment(), NavigationBarPainter {
         loggedInStatus.visibility = View.GONE
 
         accountLogin.state = LoginState.Failure
+        headerBar.setSettingsButtonEnabled(true)
 
         scrollToShow(accountLogin)
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/HeaderBar.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/HeaderBar.kt
@@ -21,6 +21,7 @@ class HeaderBar @JvmOverloads constructor(
     defStyleRes: Int = 0
 ) : LinearLayout(context, attributes, defStyleAttr, defStyleRes), StatusBarPainter {
     private val container = LayoutInflater.from(context).inflate(R.layout.header_bar, this)
+    private val settingsButton = findViewById<View>(R.id.settings)
 
     private val disabledColor = ContextCompat.getColor(context, android.R.color.transparent)
     private val securedColor = ContextCompat.getColor(context, R.color.green)
@@ -43,10 +44,17 @@ class HeaderBar @JvmOverloads constructor(
         gravity = Gravity.CENTER_VERTICAL
         orientation = HORIZONTAL
 
-        findViewById<View>(R.id.settings).setOnClickListener {
-            (context as? MainActivity)?.openSettings()
+        settingsButton.apply {
+            isEnabled = true
+            setOnClickListener {
+                (context as? MainActivity)?.openSettings()
+            }
         }
 
         tunnelState = null
+    }
+
+    fun setSettingsButtonEnabled(isEnabled: Boolean) {
+        settingsButton.isEnabled = isEnabled
     }
 }


### PR DESCRIPTION
Disabling the settings button during login will prevent some strange UI behavior. It also doesn't make much sense to open it while the login is loading.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3901)
<!-- Reviewable:end -->
