### PR TITLE
Move default settings to its own file

### DIFF
--- a/gui/src/main/default-settings.ts
+++ b/gui/src/main/default-settings.ts
@@ -1,0 +1,70 @@
+import { ISettings, ObfuscationType, Ownership } from '../shared/daemon-rpc-types';
+
+export function getDefaultSettings(): ISettings {
+  return {
+    allowLan: false,
+    autoConnect: false,
+    blockWhenDisconnected: false,
+    showBetaReleases: false,
+    splitTunnel: {
+      enableExclusions: false,
+      appsList: [],
+    },
+    relaySettings: {
+      normal: {
+        location: 'any',
+        tunnelProtocol: 'any',
+        providers: [],
+        ownership: Ownership.any,
+        openvpnConstraints: {
+          port: 'any',
+          protocol: 'any',
+        },
+        wireguardConstraints: {
+          port: 'any',
+          ipVersion: 'any',
+          useMultihop: false,
+          entryLocation: 'any',
+        },
+      },
+    },
+    bridgeSettings: {
+      normal: {
+        location: 'any',
+        providers: [],
+        ownership: Ownership.any,
+      },
+    },
+    bridgeState: 'auto',
+    tunnelOptions: {
+      generic: {
+        enableIpv6: false,
+      },
+      openvpn: {
+        mssfix: undefined,
+      },
+      wireguard: {
+        mtu: undefined,
+      },
+      dns: {
+        state: 'default',
+        defaultOptions: {
+          blockAds: false,
+          blockTrackers: false,
+          blockMalware: false,
+          blockAdultContent: false,
+          blockGambling: false,
+        },
+        customOptions: {
+          addresses: [],
+        },
+      },
+    },
+    obfuscationSettings: {
+      selectedObfuscation: ObfuscationType.auto,
+      udp2tcpSettings: {
+        port: 'any',
+      },
+    },
+  };
+}

--- a/gui/src/main/settings.ts
+++ b/gui/src/main/settings.ts
@@ -1,9 +1,10 @@
 import BridgeSettingsBuilder from '../shared/bridge-settings-builder';
-import { ISettings, ObfuscationType, Ownership } from '../shared/daemon-rpc-types';
+import { ISettings } from '../shared/daemon-rpc-types';
 import { ICurrentAppVersionInfo } from '../shared/ipc-types';
 import log from '../shared/logging';
 import { getOpenAtLogin, setOpenAtLogin } from './autostart';
 import { DaemonRpc } from './daemon-rpc';
+import { getDefaultSettings } from './default-settings';
 import GuiSettings from './gui-settings';
 import { IpcMainEventChannel } from './ipc-event-channel';
 
@@ -15,72 +16,7 @@ export interface SettingsDelegate {
 export default class Settings implements Readonly<ISettings> {
   private guiSettings = new GuiSettings();
 
-  private settingsValue: ISettings = {
-    allowLan: false,
-    autoConnect: false,
-    blockWhenDisconnected: false,
-    showBetaReleases: false,
-    splitTunnel: {
-      enableExclusions: false,
-      appsList: [],
-    },
-    relaySettings: {
-      normal: {
-        location: 'any',
-        tunnelProtocol: 'any',
-        providers: [],
-        ownership: Ownership.any,
-        openvpnConstraints: {
-          port: 'any',
-          protocol: 'any',
-        },
-        wireguardConstraints: {
-          port: 'any',
-          ipVersion: 'any',
-          useMultihop: false,
-          entryLocation: 'any',
-        },
-      },
-    },
-    bridgeSettings: {
-      normal: {
-        location: 'any',
-        providers: [],
-        ownership: Ownership.any,
-      },
-    },
-    bridgeState: 'auto',
-    tunnelOptions: {
-      generic: {
-        enableIpv6: false,
-      },
-      openvpn: {
-        mssfix: undefined,
-      },
-      wireguard: {
-        mtu: undefined,
-      },
-      dns: {
-        state: 'default',
-        defaultOptions: {
-          blockAds: false,
-          blockTrackers: false,
-          blockMalware: false,
-          blockAdultContent: false,
-          blockGambling: false,
-        },
-        customOptions: {
-          addresses: [],
-        },
-      },
-    },
-    obfuscationSettings: {
-      selectedObfuscation: ObfuscationType.auto,
-      udp2tcpSettings: {
-        port: 'any',
-      },
-    },
-  };
+  private settingsValue = getDefaultSettings();
 
   public constructor(
     private delegate: SettingsDelegate,


### PR DESCRIPTION
This PR moves the default settings in the main process to its own file to make it reusable in separate main implementation for e2e tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3905)
<!-- Reviewable:end -->
