### PR TITLE
Make dispatch workflow work with verify script

### DIFF
--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -38,7 +38,8 @@ jobs:
                 echo "git rev-list origin/master --count after: "
                 git rev-list origin/master --count
 
-                commit_depth=${{ github.event.pull_request.commits }}
+                commit_depth_pr=${{ github.event.pull_request.commits }}
+                commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
                 if [[ -n "$commit_depth" ]]; then
                     # Prepare enough depth for diffs with master, currently hard-coded but should probably be
                     # whatever branch is merged into

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -34,7 +34,7 @@ jobs:
                 git rev-list --all --count
 
                 git fetch --shallow-exclude=master
-                git fetch --shallow-exclude=master
+                #git fetch --shallow-exclude=master
 
                 #commit_depth_pr=${{ github.event.pull_request.commits }}
                 #echo "Input: ${{ github.event.inputs.commitDepth }}"

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -39,9 +39,9 @@ jobs:
                 git rev-list origin/master --count
 
                 commit_depth=${{ github.event.pull_request.commits }}
-                if [[ -n "$commit_depth" ]]; then
+                #if [[ -n "$commit_depth" ]]; then
                     # Prepare enough depth for diffs with master, currently hard-coded but should probably be
                     # whatever branch is merged into
                     #git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
-                fi
+                #fi
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -30,7 +30,7 @@ jobs:
                 echo "git rev-list --all --count before: "
                 git rev-list --all --count
 
-                git fetch --shallow-exclude=master
+                #git fetch --shallow-exclude=master
 
                 echo "git rev-list --all --count after: "
                 git rev-list --all --count

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -36,11 +36,11 @@ jobs:
                 echo "Input: ${{ github.event.inputs.commitDepth }}"
                 commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
                 echo "Commit depth: $commit_depth"
-                if [[ -n "$commit_depth" ]]; then
-                    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
-                    # whatever branch is merged into
-                    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
-                fi
+                  #if [[ -n "$commit_depth" ]]; then
+                  #    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
+                  #    # whatever branch is merged into
+                  #    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
+                  #fi
 
                 echo "git rev-list --all --count after: "
                 git rev-list --all --count

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -12,6 +12,12 @@ on:
             - android/gradle/verification-metadata.xml
             - android/gradle/wrapper/gradle-wrapper.properties
     workflow_dispatch:
+      inputs:
+        commitDepth:
+          description: 'Commit depth which must include origin/master'
+        required: true
+        default: '50' 
+        type: string
 jobs:
     verify-signatures:
         runs-on: ubuntu-latest
@@ -28,5 +34,11 @@ jobs:
                 git rev-list --all --count
 
                 echo "git rev-list origin/master --count after: "
-                git rev-list origin/master --count
+                #git rev-list origin/master --count
+                commit_depth=${{ github.event.pull_request.commits }}
+                if [[ -n "$commit_depth" ]]; then
+                    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
+                    # whatever branch is merged into
+                    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
+                fi
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -36,11 +36,12 @@ jobs:
                 echo "Input: ${{ github.event.inputs.commitDepth }}"
                 commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
                 echo "Commit depth: $commit_depth"
-                  #if [[ -n "$commit_depth" ]]; then
-                  #    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
-                  #    # whatever branch is merged into
-                  #    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
-                  #fi
+                if [[ -n "$commit_depth" ]]; then
+                    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
+                    # whatever branch is merged into
+                    echo "Fetching with a depth of $commit_depth + 1"
+                    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
+                fi
 
                 echo "git rev-list --all --count after: "
                 git rev-list --all --count

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -33,18 +33,19 @@ jobs:
                 echo "git rev-list --all --count before: "
                 git rev-list --all --count
 
-                #git fetch --shallow-exclude=master
+                git fetch --shallow-exclude=master
+                git fetch --shallow-exclude=master
 
-                commit_depth_pr=${{ github.event.pull_request.commits }}
-                echo "Input: ${{ github.event.inputs.commitDepth }}"
-                commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
-                echo "Commit depth: $commit_depth"
-                if [[ -n "$commit_depth" ]]; then
-                    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
-                    # whatever branch is merged into
-                    echo "Fetching with a depth of $commit_depth + 1"
-                    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
-                fi
+                #commit_depth_pr=${{ github.event.pull_request.commits }}
+                #echo "Input: ${{ github.event.inputs.commitDepth }}"
+                #commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
+                #echo "Commit depth: $commit_depth"
+                #if [[ -n "$commit_depth" ]]; then
+                #    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
+                #    # whatever branch is merged into
+                #    echo "Fetching with a depth of $commit_depth + 1"
+                #    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
+                #fi
 
                 echo "git rev-list --all --count after: "
                 git rev-list --all --count

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,10 +21,23 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
+                echo "git rev-list --all --count"
+                git rev-list --all --count
+                echo "Deepen loop"
+                while [ -z $( git merge-base ${{github.base_ref}} HEAD ) ]; do     
+                    git fetch --deepen=10 origin ${{github.base_ref}} HEAD;
+                done
+                echo "git rev-list --all --count"
+                git rev-list --all --count
+                echo "git fetch --shallow-exclude=master"
                 git fetch --shallow-exclude=master
                 # We must fetch twice in order for this to work with workflow-dispatch
                 # It is not clear why this is, but the github actions environment is a shallow repo
                 # clone which will only have the rev-list history after the second fetch.
+                echo "git rev-list --all --count"
+                git rev-list --all --count
+
+                echo "git fetch --shallow-exclude=master"
                 git fetch --shallow-exclude=master
 
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -27,6 +27,9 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
+                echo "git status"
+                git status
+
                 echo "git rev-list --all --count before: "
                 git rev-list --all --count
 

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -33,8 +33,8 @@ jobs:
                 echo "git rev-list --all --count before: "
                 git rev-list --all --count
 
-                git fetch --shallow-exclude=master
-                git fetch --shallow-exclude=master
+                git fetch --shallow-exclude=master -vvv
+                git fetch --shallow-exclude=master -vvv
 
                 #commit_depth_pr=${{ github.event.pull_request.commits }}
                 #echo "Input: ${{ github.event.inputs.commitDepth }}"

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -28,6 +28,6 @@ jobs:
             - name: Verify signatures
               run: |
                 git fetch --shallow-exclude=master
-                git fetch --shallow-exclude=master
+                #git fetch --shallow-exclude=master
 
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -32,12 +32,6 @@ jobs:
 
                 #git fetch --shallow-exclude=master
 
-                echo "git rev-list --all --count after: "
-                git rev-list --all --count
-
-                echo "git rev-list origin/master --count after: "
-                git rev-list origin/master --count
-
                 commit_depth_pr=${{ github.event.pull_request.commits }}
                 echo "Input: ${{ github.event.inputs.commitDepth }}"
                 commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
@@ -47,4 +41,11 @@ jobs:
                     # whatever branch is merged into
                     git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
                 fi
+
+                echo "git rev-list --all --count after: "
+                git rev-list --all --count
+
+                echo "git rev-list origin/master --count after: "
+                git rev-list origin/master --count
+
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -27,30 +27,7 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
-                echo "git status"
-                git status
-
-                echo "git rev-list --all --count before: "
-                git rev-list --all --count
-
-                git fetch --shallow-exclude=master -vvv
-                git fetch --shallow-exclude=master -vvv
-
-                #commit_depth_pr=${{ github.event.pull_request.commits }}
-                #echo "Input: ${{ github.event.inputs.commitDepth }}"
-                #commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
-                #echo "Commit depth: $commit_depth"
-                #if [[ -n "$commit_depth" ]]; then
-                #    # Prepare enough depth for diffs with master, currently hard-coded but should probably be
-                #    # whatever branch is merged into
-                #    echo "Fetching with a depth of $commit_depth + 1"
-                #    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
-                #fi
-
-                echo "git rev-list --all --count after: "
-                git rev-list --all --count
-
-                echo "git rev-list origin/master --count after: "
-                git rev-list origin/master --count
+                git fetch --shallow-exclude=master
+                git fetch --shallow-exclude=master
 
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,5 +21,6 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
+                # Unnecessary comment
                 git fetch --shallow-exclude=master
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,16 +21,10 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
-                echo "First fetch"
                 git fetch --shallow-exclude=master
-                echo "git rev-list origin/master..HEAD --oneline"
-                git rev-list origin/master..HEAD --oneline
                 # We must fetch twice in order for this to work with workflow-dispatch
                 # It is not clear why this is, but the github actions environment is a shallow repo
                 # clone which will only have the rev-list history after the second fetch.
-                echo "Second fetch"
                 git fetch --shallow-exclude=master
-                echo "git rev-list origin/master..HEAD --oneline"
-                git rev-list origin/master..HEAD --oneline
 
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -14,10 +14,10 @@ on:
     workflow_dispatch:
       inputs:
         commitDepth:
-          description: 'Commit depth which must include origin/master'
-        required: true
-        default: '50' 
-        type: string
+          description: "Commit depth which must include origin/master"
+          required: true
+          default: '50' 
+          type: string
 jobs:
     verify-signatures:
         runs-on: ubuntu-latest

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -29,16 +29,19 @@ jobs:
               run: |
                 echo "git rev-list --all --count before: "
                 git rev-list --all --count
+
                 git fetch --shallow-exclude=master
+
                 echo "git rev-list --all --count after: "
                 git rev-list --all --count
 
                 echo "git rev-list origin/master --count after: "
-                #git rev-list origin/master --count
+                git rev-list origin/master --count
+
                 commit_depth=${{ github.event.pull_request.commits }}
                 if [[ -n "$commit_depth" ]]; then
                     # Prepare enough depth for diffs with master, currently hard-coded but should probably be
                     # whatever branch is merged into
-                    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
+                    #git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
                 fi
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -27,6 +27,6 @@ jobs:
                 echo "git rev-list --all --count after: "
                 git rev-list --all --count
 
-                echo "git rev-list --count after: "
-                git rev-list --count
+                echo "git rev-list origin/master --count after: "
+                git rev-list origin/master --count
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -22,5 +22,5 @@ jobs:
             - name: Verify signatures
               run: |
                 # Unnecessary comment
-                git fetch --shallow-exclude=master
+                #git fetch --shallow-exclude=master
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -12,12 +12,6 @@ on:
             - android/gradle/verification-metadata.xml
             - android/gradle/wrapper/gradle-wrapper.properties
     workflow_dispatch:
-      inputs:
-        commitDepth:
-          description: "Commit depth which must include origin/master"
-          required: true
-          default: '50' 
-          type: string
 jobs:
     verify-signatures:
         runs-on: ubuntu-latest
@@ -28,6 +22,9 @@ jobs:
             - name: Verify signatures
               run: |
                 git fetch --shallow-exclude=master
+                # We must fetch twice in order for this to work with workflow-dispatch
+                # It is not clear why this is, but the github actions environment is a shallow repo
+                # clone which will only have the rev-list history after the second fetch.
                 git fetch --shallow-exclude=master
 
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,7 +21,9 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
-                echo "the amount of commits we have in repo: "
+                echo "the amount of commits we have in repo before: "
                 git rev-list --all --count
                 git fetch --shallow-exclude=master
+                echo "the amount of commits we have in repo after: "
+                git rev-list --all --count
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,6 +21,7 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
-                # Unnecessary comment
-                #git fetch --shallow-exclude=master
+                echo "the amount of commits we have in repo: "
+                git rev-list --all --count
+                git fetch --shallow-exclude=master
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,10 +21,16 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
+                echo "First fetch"
                 git fetch --shallow-exclude=master
+                echo "git rev-list origin/master..HEAD --oneline"
+                git rev-list origin/master..HEAD --oneline
                 # We must fetch twice in order for this to work with workflow-dispatch
                 # It is not clear why this is, but the github actions environment is a shallow repo
                 # clone which will only have the rev-list history after the second fetch.
+                echo "Second fetch"
                 git fetch --shallow-exclude=master
+                echo "git rev-list origin/master..HEAD --oneline"
+                git rev-list origin/master..HEAD --oneline
 
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,10 +21,5 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
-                commits=${{ github.event.pull_request.commits }}
-                if [[ -n "$commits" ]]; then
-                    # Prepare enough depth for diffs with master, currently hard-coded but should probably be 
-                    # whatever branch is merged into
-                    git fetch --depth="$(( commits + 1 ))" origin ${{ github.head_ref }} master
-                fi
+                git fetch --shallow-exclude=master
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -39,7 +39,9 @@ jobs:
                 git rev-list origin/master --count
 
                 commit_depth_pr=${{ github.event.pull_request.commits }}
+                echo "Input: ${{ github.event.inputs.commitDepth }}"
                 commit_depth=${commit_depth_pr:-${{ github.event.inputs.commitDepth }}}
+                echo "Commit depth: $commit_depth"
                 if [[ -n "$commit_depth" ]]; then
                     # Prepare enough depth for diffs with master, currently hard-coded but should probably be
                     # whatever branch is merged into

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -39,9 +39,9 @@ jobs:
                 git rev-list origin/master --count
 
                 commit_depth=${{ github.event.pull_request.commits }}
-                #if [[ -n "$commit_depth" ]]; then
+                if [[ -n "$commit_depth" ]]; then
                     # Prepare enough depth for diffs with master, currently hard-coded but should probably be
                     # whatever branch is merged into
-                    #git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
-                #fi
+                    git fetch --depth="$(( commit_depth + 1 ))" origin ${{ github.head_ref }} master
+                fi
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -34,7 +34,7 @@ jobs:
                 git rev-list --all --count
 
                 git fetch --shallow-exclude=master
-                #git fetch --shallow-exclude=master
+                git fetch --shallow-exclude=master
 
                 #commit_depth_pr=${{ github.event.pull_request.commits }}
                 #echo "Input: ${{ github.event.inputs.commitDepth }}"

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -21,9 +21,12 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
             - name: Verify signatures
               run: |
-                echo "the amount of commits we have in repo before: "
+                echo "git rev-list --all --count before: "
                 git rev-list --all --count
                 git fetch --shallow-exclude=master
-                echo "the amount of commits we have in repo after: "
+                echo "git rev-list --all --count after: "
                 git rev-list --all --count
+
+                echo "git rev-list --count after: "
+                git rev-list --count
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -28,6 +28,6 @@ jobs:
             - name: Verify signatures
               run: |
                 git fetch --shallow-exclude=master
-                #git fetch --shallow-exclude=master
+                git fetch --shallow-exclude=master
 
                 ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master

--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -58,8 +58,8 @@ locked_down_paths=$(\
 
 unsigned_commits_exist=0
 for locked_path in $locked_down_paths; do
-    echo "git rev-list --oneline "$whitelisted_commit"..HEAD results:"
-    git rev-list --oneline "$whitelisted_commit"..HEAD
+    echo "git rev-list --oneline "$whitelisted_commit"..HEAD "$SCRIPT_DIR/../$locked_path" results:"
+    git rev-list --oneline "$whitelisted_commit"..HEAD "$SCRIPT_DIR/../$locked_path"
     locked_path_commit_hashes=$(git rev-list --oneline "$whitelisted_commit"..HEAD \
         "$SCRIPT_DIR/../$locked_path" | awk '{print $1}')
 

--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -57,19 +57,12 @@ locked_down_paths=$(\
     | awk '{print $2}')
 
 unsigned_commits_exist=0
-echo "git rev-list --oneline "$whitelisted_commit"..HEAD"
-git rev-list --oneline "$whitelisted_commit"..HEAD
 
 for locked_path in $locked_down_paths; do
-    echo "git rev-list --oneline "$whitelisted_commit"..HEAD "$SCRIPT_DIR/../$locked_path" results:"
-    git rev-list --oneline "$whitelisted_commit"..HEAD "$SCRIPT_DIR/../$locked_path"
-
     locked_path_commit_hashes=$(git rev-list --oneline "$whitelisted_commit"..HEAD \
         "$SCRIPT_DIR/../$locked_path" | awk '{print $1}')
 
     for commit in $locked_path_commit_hashes; do
-        echo "Verifying $commit..."
-
         if ! git verify-commit "$commit" 2> /dev/null; then
             echo "Commit $commit which changed $locked_path is not signed."
             unsigned_commits_exist=1

--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -58,6 +58,8 @@ locked_down_paths=$(\
 
 unsigned_commits_exist=0
 for locked_path in $locked_down_paths; do
+    echo "git rev-list --oneline "$whitelisted_commit"..HEAD results:"
+    git rev-list --oneline "$whitelisted_commit"..HEAD
     locked_path_commit_hashes=$(git rev-list --oneline "$whitelisted_commit"..HEAD \
         "$SCRIPT_DIR/../$locked_path" | awk '{print $1}')
 

--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -62,6 +62,7 @@ for locked_path in $locked_down_paths; do
         "$SCRIPT_DIR/../$locked_path" | awk '{print $1}')
 
     for commit in $locked_path_commit_hashes; do
+        echo "Verifying $commit..."
         if ! git verify-commit "$commit" 2> /dev/null; then
             echo "Commit $commit which changed $locked_path is not signed."
             unsigned_commits_exist=1

--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -57,14 +57,19 @@ locked_down_paths=$(\
     | awk '{print $2}')
 
 unsigned_commits_exist=0
+echo "git rev-list --oneline "$whitelisted_commit"..HEAD"
+git rev-list --oneline "$whitelisted_commit"..HEAD
+
 for locked_path in $locked_down_paths; do
     echo "git rev-list --oneline "$whitelisted_commit"..HEAD "$SCRIPT_DIR/../$locked_path" results:"
     git rev-list --oneline "$whitelisted_commit"..HEAD "$SCRIPT_DIR/../$locked_path"
+
     locked_path_commit_hashes=$(git rev-list --oneline "$whitelisted_commit"..HEAD \
         "$SCRIPT_DIR/../$locked_path" | awk '{print $1}')
 
     for commit in $locked_path_commit_hashes; do
         echo "Verifying $commit..."
+
         if ! git verify-commit "$commit" 2> /dev/null; then
             echo "Commit $commit which changed $locked_path is not signed."
             unsigned_commits_exist=1


### PR DESCRIPTION
Dispatch workflow could previously not run the verification script
correctly since it could only get the appropriate commit depth when a
pull request was made. Change this so that a dispatched workflow has a
input for the commit depth which defaults to 50. This should make it
play ball for testing purposes which is when we need dispatch workflow
to function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3906)
<!-- Reviewable:end -->
