### PR TITLE
Reset the device check counter in the error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix error handling during device removal in the desktop app.
 - Enable interface settings when app is logged out
 - Fix 'mullvad status -v' to include the port of the endpoint when connecting over TCP.
+- Check whether the device is valid when reconnecting from the error state.
 
 #### Windows
 - Only use the most recent list of apps to split when resuming from hibernation/sleep if applying

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -980,7 +980,7 @@ impl TunnelStateChangeHandler {
                 if endpoint.tunnel_type != TunnelType::Wireguard {
                     return;
                 }
-                self.wg_retry_attempt += 1;
+                self.wg_retry_attempt = self.wg_retry_attempt.wrapping_add(1);
                 if self.wg_retry_attempt % WG_DEVICE_CHECK_THRESHOLD == 0 {
                     let handle = self.manager.clone();
                     let check_validity = self.check_validity.clone();

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -1000,7 +1000,9 @@ impl TunnelStateChangeHandler {
                     });
                 }
             }
-            TunnelStateTransition::Connected(_) | TunnelStateTransition::Disconnected => {
+            TunnelStateTransition::Error(_)
+            | TunnelStateTransition::Connected(_)
+            | TunnelStateTransition::Disconnected => {
                 self.check_validity.store(true, Ordering::SeqCst);
                 self.wg_retry_attempt = 0;
             }


### PR DESCRIPTION
Previously, failing to reconnect when in the error state would not cause the daemon to check if the device was valid after a few failed attempts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3907)
<!-- Reviewable:end -->
