### PR TITLE
Stop reconnecting when the account runs out of time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix error handling during device removal in the desktop app.
 - Enable interface settings when app is logged out
 - Fix 'mullvad status -v' to include the port of the endpoint when connecting over TCP.
+- Stop reconnecting when the account has run out of time.
 
 #### Windows
 - Only use the most recent list of apps to split when resuming from hibernation/sleep if applying

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -56,6 +56,10 @@ pub enum Error {
     InvalidDevice,
     #[error(display = "Invalid account")]
     InvalidAccount,
+    #[error(display = "Invalid voucher code")]
+    InvalidVoucher,
+    #[error(display = "The voucher has already been used")]
+    UsedVoucher,
     #[error(display = "Failed to read or write device cache")]
     DeviceIoError(#[error(source)] io::Error),
     #[error(display = "Failed parse device cache")]

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -303,6 +303,7 @@ enum AccountManagerCommand {
     RotateKey(ResponseTx<()>),
     SetRotationInterval(RotationInterval, ResponseTx<()>),
     ValidateDevice(ResponseTx<()>),
+    CheckExpiry(ResponseTx<DateTime<Utc>>),
     Shutdown(oneshot::Sender<()>),
 }
 
@@ -351,6 +352,11 @@ impl AccountManagerHandle {
             .await
     }
 
+    pub async fn check_expiry(&self) -> Result<DateTime<Utc>, Error> {
+        self.send_command(|tx| AccountManagerCommand::CheckExpiry(tx))
+            .await
+    }
+
     pub async fn shutdown(self) {
         let (tx, rx) = oneshot::channel();
         let _ = self
@@ -373,12 +379,14 @@ impl AccountManagerHandle {
 
 pub(crate) struct AccountManager {
     cacher: DeviceCacher,
+    account_service: AccountService,
     device_service: DeviceService,
     data: PrivateDeviceState,
     rotation_interval: RotationInterval,
     listeners: Vec<Box<dyn Sender<PrivateDeviceEvent> + Send>>,
     last_validation: Option<SystemTime>,
     validation_requests: Vec<ResponseTx<()>>,
+    expiry_requests: Vec<ResponseTx<DateTime<Utc>>>,
     rotation_requests: Vec<ResponseTx<()>>,
     data_requests: Vec<ResponseTx<PrivateDeviceState>>,
 }
@@ -403,12 +411,14 @@ impl AccountManager {
         let device_service = DeviceService::new(rest_handle, api_availability);
         let manager = AccountManager {
             cacher,
+            account_service: account_service.clone(),
             device_service: device_service.clone(),
             data: data.clone(),
             rotation_interval: initial_rotation_interval,
             listeners: vec![Box::new(listener_tx)],
             last_validation: None,
             validation_requests: vec![],
+            expiry_requests: vec![],
             rotation_requests: vec![],
             data_requests: vec![],
         };
@@ -489,6 +499,9 @@ impl AccountManager {
                         Some(AccountManagerCommand::ValidateDevice(tx)) => {
                             self.handle_validation_request(tx, &mut current_api_call);
                         },
+                        Some(AccountManagerCommand::CheckExpiry(tx)) => {
+                            self.handle_expiry_request(tx, &mut current_api_call);
+                        },
 
                         None => {
                             break;
@@ -539,6 +552,31 @@ impl AccountManager {
         }
     }
 
+    fn handle_expiry_request(
+        &mut self,
+        tx: ResponseTx<DateTime<Utc>>,
+        current_api_call: &mut api::CurrentApiCall,
+    ) {
+        if current_api_call.is_logging_in() {
+            let _ = tx.send(Err(Error::AccountChange));
+            return;
+        }
+        if current_api_call.is_checking_expiry() {
+            self.expiry_requests.push(tx);
+            return;
+        }
+
+        match self.expiry_call() {
+            Ok(call) => {
+                current_api_call.set_expiry_check(Box::pin(call));
+                self.expiry_requests.push(tx);
+            }
+            Err(err) => {
+                let _ = tx.send(Err(err));
+            }
+        }
+    }
+
     async fn consume_api_result(
         &mut self,
         result: api::ApiResult,
@@ -549,6 +587,7 @@ impl AccountManager {
             Login(data, tx) => self.consume_login(data, tx).await,
             Rotation(rotation_response) => self.consume_rotation_result(rotation_response).await,
             Validation(data_response) => self.consume_validation(data_response, api_call).await,
+            ExpiryCheck(data_response) => self.consume_expiry_result(data_response).await,
         }
     }
 
@@ -561,6 +600,27 @@ impl AccountManager {
             tx.send(async { self.set(PrivateDeviceEvent::Login(device_response?)).await }.await);
         let data = self.data.clone();
         Self::drain_requests(&mut self.data_requests, || Ok(data.clone()));
+    }
+
+    async fn consume_expiry_result(&mut self, response: Result<DateTime<Utc>, Error>) {
+        match response {
+            Ok(expiry) => {
+                Self::drain_requests(&mut self.expiry_requests, || Ok(expiry));
+            }
+            Err(Error::InvalidAccount) => {
+                self.invalidate_current_data(|| Error::InvalidAccount).await;
+            }
+            Err(Error::InvalidDevice) => {
+                self.invalidate_current_data(|| Error::InvalidDevice).await;
+            }
+            Err(err) => {
+                log::error!("Failed to check account expiry: {}", err);
+                let cloneable_err = Arc::new(err);
+                Self::drain_requests(&mut self.expiry_requests, || {
+                    Err(Error::ResponseFailure(cloneable_err.clone()))
+                });
+            }
+        }
     }
 
     async fn consume_validation(
@@ -646,11 +706,10 @@ impl AccountManager {
                 match self.set(PrivateDeviceEvent::RotatedKey(config)).await {
                     Ok(_) => {
                         Self::drain_requests(&mut self.rotation_requests, || Ok(()));
-
                         Self::drain_requests(&mut self.validation_requests, || Ok(()));
                     }
                     Err(err) => {
-                        self.drain_requests_with_err(err);
+                        self.drain_device_requests_with_err(err);
                     }
                 }
             }
@@ -661,12 +720,12 @@ impl AccountManager {
                 self.invalidate_current_data(|| Error::InvalidDevice).await;
             }
             Err(err) => {
-                self.drain_requests_with_err(err);
+                self.drain_device_requests_with_err(err);
             }
         }
     }
 
-    fn drain_requests_with_err(&mut self, err: Error) {
+    fn drain_device_requests_with_err(&mut self, err: Error) {
         let cloneable_err = Arc::new(err);
         Self::drain_requests(&mut self.rotation_requests, || {
             Err(Error::ResponseFailure(cloneable_err.clone()))
@@ -713,6 +772,7 @@ impl AccountManager {
 
         Self::drain_requests(&mut self.validation_requests, || Err(err_constructor()));
         Self::drain_requests(&mut self.rotation_requests, || Err(err_constructor()));
+        Self::drain_requests(&mut self.expiry_requests, || Err(err_constructor()));
 
         self.listeners
             .retain(|listener| listener.send(PrivateDeviceEvent::Revoked).is_ok());
@@ -838,6 +898,13 @@ impl AccountManager {
     fn validation_call(&self) -> Result<impl Future<Output = Result<Device, Error>>, Error> {
         let old_config = self.data.device().ok_or(Error::NoDevice)?;
         Ok(self.fetch_device_config(old_config))
+    }
+
+    fn expiry_call(&self) -> Result<impl Future<Output = Result<DateTime<Utc>, Error>>, Error> {
+        let old_config = self.data.device().ok_or(Error::NoDevice)?;
+        let account_token = old_config.account_token.clone();
+        let account_service = self.account_service.clone();
+        Ok(async move { account_service.check_expiry_2(account_token).await })
     }
 
     fn needs_validation(&mut self) -> bool {

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -232,6 +232,8 @@ pub(crate) enum PrivateDeviceEvent {
     Updated(PrivateAccountAndDevice),
     /// The key was rotated.
     RotatedKey(PrivateAccountAndDevice),
+    /// Emitted when the account expiry is fetched.
+    AccountExpiry(DateTime<Utc>),
 }
 
 #[derive(err_derive::Error, Debug)]
@@ -248,6 +250,7 @@ impl TryFrom<PrivateDeviceEvent> for DeviceEvent {
             PrivateDeviceEvent::Revoked => DeviceEventCause::Revoked,
             PrivateDeviceEvent::Updated(_) => DeviceEventCause::Updated,
             PrivateDeviceEvent::RotatedKey(_) => DeviceEventCause::RotatedKey,
+            PrivateDeviceEvent::AccountExpiry(_) => return Err(PrivateOnlyEvent),
         };
         let new_state = DeviceState::from(event.state().ok_or(PrivateOnlyEvent)?);
         Ok(DeviceEvent { cause, new_state })
@@ -262,6 +265,7 @@ impl PrivateDeviceEvent {
             PrivateDeviceEvent::RotatedKey(config) => Some(PrivateDeviceState::LoggedIn(config)),
             PrivateDeviceEvent::Logout => Some(PrivateDeviceState::LoggedOut),
             PrivateDeviceEvent::Revoked => Some(PrivateDeviceState::Revoked),
+            PrivateDeviceEvent::AccountExpiry(_) => None,
         }
     }
 }
@@ -605,6 +609,9 @@ impl AccountManager {
     async fn consume_expiry_result(&mut self, response: Result<DateTime<Utc>, Error>) {
         match response {
             Ok(expiry) => {
+                let event = PrivateDeviceEvent::AccountExpiry(expiry.clone());
+                self.listeners
+                    .retain(|listener| listener.send(event.clone()).is_ok());
                 Self::drain_requests(&mut self.expiry_requests, || Ok(expiry));
             }
             Err(Error::InvalidAccount) => {

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -1066,10 +1066,12 @@ impl TunnelStateChangeHandler {
                         if !check_validity.swap(false, Ordering::SeqCst) {
                             return;
                         }
-                        if let Err(error) = handle.validate_device().await {
+                        if let Err(error) = Self::check_validity(handle).await {
                             log::error!(
                                 "{}",
-                                error.display_chain_with_msg("Failed to check device validity")
+                                error.display_chain_with_msg(
+                                    "Failed to check device or account validity"
+                                )
                             );
                             if error.is_network_error() || error.is_aborted() {
                                 check_validity.store(true, Ordering::SeqCst);
@@ -1084,5 +1086,10 @@ impl TunnelStateChangeHandler {
             }
             _ => (),
         }
+    }
+
+    pub async fn check_validity(handle: AccountManagerHandle) -> Result<(), Error> {
+        handle.validate_device().await?;
+        handle.check_expiry().await.map(|_expiry| ())
     }
 }

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -6,7 +6,7 @@ use futures::{
 
 use mullvad_api::rest;
 use mullvad_types::{
-    account::AccountToken,
+    account::{AccountToken, VoucherSubmission},
     device::{
         AccountAndDevice, Device, DeviceEvent, DeviceEventCause, DeviceId, DeviceName, DevicePort,
         DeviceState,
@@ -307,6 +307,7 @@ enum AccountManagerCommand {
     RotateKey(ResponseTx<()>),
     SetRotationInterval(RotationInterval, ResponseTx<()>),
     ValidateDevice(ResponseTx<()>),
+    SubmitVoucher(String, ResponseTx<VoucherSubmission>),
     CheckExpiry(ResponseTx<DateTime<Utc>>),
     Shutdown(oneshot::Sender<()>),
 }
@@ -353,6 +354,11 @@ impl AccountManagerHandle {
 
     pub async fn validate_device(&self) -> Result<(), Error> {
         self.send_command(AccountManagerCommand::ValidateDevice)
+            .await
+    }
+
+    pub async fn submit_voucher(&self, voucher: String) -> Result<VoucherSubmission, Error> {
+        self.send_command(move |tx| AccountManagerCommand::SubmitVoucher(voucher, tx))
             .await
     }
 
@@ -503,6 +509,9 @@ impl AccountManager {
                         Some(AccountManagerCommand::ValidateDevice(tx)) => {
                             self.handle_validation_request(tx, &mut current_api_call);
                         },
+                        Some(AccountManagerCommand::SubmitVoucher(voucher, tx)) => {
+                            self.handle_voucher_submission(tx, voucher, &mut current_api_call);
+                        },
                         Some(AccountManagerCommand::CheckExpiry(tx)) => {
                             self.handle_expiry_request(tx, &mut current_api_call);
                         },
@@ -556,6 +565,34 @@ impl AccountManager {
         }
     }
 
+    fn handle_voucher_submission(
+        &mut self,
+        tx: ResponseTx<VoucherSubmission>,
+        voucher: String,
+        current_api_call: &mut api::CurrentApiCall,
+    ) {
+        if current_api_call.is_logging_in() {
+            let _ = tx.send(Err(Error::AccountChange));
+            return;
+        }
+
+        let create_submission = move || {
+            let old_config = self.data.device().ok_or(Error::NoDevice)?;
+            let account_token = old_config.account_token.clone();
+            let account_service = self.account_service.clone();
+            Ok(async move { account_service.submit_voucher(account_token, voucher).await })
+        };
+
+        match create_submission() {
+            Ok(call) => {
+                current_api_call.set_voucher_submission(Box::pin(call), tx);
+            }
+            Err(err) => {
+                let _ = tx.send(Err(err));
+            }
+        }
+    }
+
     fn handle_expiry_request(
         &mut self,
         tx: ResponseTx<DateTime<Utc>>,
@@ -591,6 +628,9 @@ impl AccountManager {
             Login(data, tx) => self.consume_login(data, tx).await,
             Rotation(rotation_response) => self.consume_rotation_result(rotation_response).await,
             Validation(data_response) => self.consume_validation(data_response, api_call).await,
+            VoucherSubmission(data_response, tx) => {
+                self.consume_voucher_result(data_response, tx).await
+            }
             ExpiryCheck(data_response) => self.consume_expiry_result(data_response).await,
         }
     }
@@ -606,12 +646,37 @@ impl AccountManager {
         Self::drain_requests(&mut self.data_requests, || Ok(data.clone()));
     }
 
+    async fn consume_voucher_result(
+        &mut self,
+        response: Result<VoucherSubmission, Error>,
+        tx: ResponseTx<VoucherSubmission>,
+    ) {
+        match &response {
+            Ok(submission) => {
+                // Send expiry update event
+                let event = PrivateDeviceEvent::AccountExpiry(submission.new_expiry);
+                self.listeners
+                    .retain(|listener| listener.send(event.clone()).is_ok());
+            }
+            Err(Error::InvalidAccount) => {
+                self.revoke_device(|| Error::InvalidAccount).await;
+            }
+            Err(Error::InvalidDevice) => {
+                self.revoke_device(|| Error::InvalidDevice).await;
+            }
+            Err(err) => log::error!("Failed to submit voucher: {}", err),
+        }
+        let _ = tx.send(response);
+    }
+
     async fn consume_expiry_result(&mut self, response: Result<DateTime<Utc>, Error>) {
         match response {
             Ok(expiry) => {
+                // Send expiry update event
                 let event = PrivateDeviceEvent::AccountExpiry(expiry.clone());
                 self.listeners
                     .retain(|listener| listener.send(event.clone()).is_ok());
+
                 Self::drain_requests(&mut self.expiry_requests, || Ok(expiry));
             }
             Err(Error::InvalidAccount) => {

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -608,10 +608,10 @@ impl AccountManager {
                 Self::drain_requests(&mut self.expiry_requests, || Ok(expiry));
             }
             Err(Error::InvalidAccount) => {
-                self.invalidate_current_data(|| Error::InvalidAccount).await;
+                self.revoke_device(|| Error::InvalidAccount).await;
             }
             Err(Error::InvalidDevice) => {
-                self.invalidate_current_data(|| Error::InvalidDevice).await;
+                self.revoke_device(|| Error::InvalidDevice).await;
             }
             Err(err) => {
                 log::error!("Failed to check account expiry: {}", err);
@@ -666,10 +666,10 @@ impl AccountManager {
                 }
             }
             Err(Error::InvalidAccount) => {
-                self.invalidate_current_data(|| Error::InvalidAccount).await;
+                self.revoke_device(|| Error::InvalidAccount).await;
             }
             Err(Error::InvalidDevice) => {
-                self.invalidate_current_data(|| Error::InvalidDevice).await;
+                self.revoke_device(|| Error::InvalidDevice).await;
             }
             Err(err) => {
                 log::error!("Failed to validate device: {}", err);
@@ -714,10 +714,10 @@ impl AccountManager {
                 }
             }
             Err(Error::InvalidAccount) => {
-                self.invalidate_current_data(|| Error::InvalidAccount).await;
+                self.revoke_device(|| Error::InvalidAccount).await;
             }
             Err(Error::InvalidDevice) => {
-                self.invalidate_current_data(|| Error::InvalidDevice).await;
+                self.revoke_device(|| Error::InvalidDevice).await;
             }
             Err(err) => {
                 self.drain_device_requests_with_err(err);
@@ -759,7 +759,7 @@ impl AccountManager {
         })
     }
 
-    async fn invalidate_current_data(&mut self, err_constructor: impl Fn() -> Error) {
+    async fn revoke_device(&mut self, err_constructor: impl Fn() -> Error) {
         log::debug!("Invalidating the current device");
 
         if let Err(err) = self.cacher.write(&PrivateDeviceState::Revoked).await {

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -426,6 +426,8 @@ fn map_rest_error(error: rest::Error) -> Error {
             mullvad_api::DEVICE_NOT_FOUND => Error::InvalidDevice,
             mullvad_api::INVALID_ACCOUNT => Error::InvalidAccount,
             mullvad_api::MAX_DEVICES_REACHED => Error::MaxDevicesReached,
+            mullvad_api::INVALID_VOUCHER => Error::InvalidVoucher,
+            mullvad_api::VOUCHER_USED => Error::UsedVoucher,
             _ => Error::OtherRestError(error),
         },
         error => Error::OtherRestError(error),

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -315,10 +315,10 @@ impl AccountService {
     }
 
     pub async fn submit_voucher(
-        &mut self,
+        &self,
         account_token: AccountToken,
         voucher: String,
-    ) -> Result<VoucherSubmission, rest::Error> {
+    ) -> Result<VoucherSubmission, Error> {
         let mut proxy = self.proxy.clone();
         let api_handle = self.api_availability.clone();
         let result = retry_future_n(
@@ -332,7 +332,7 @@ impl AccountService {
             self.initial_check_abort_handle.abort();
             self.api_availability.resume_background();
         }
-        result
+        result.map_err(map_rest_error)
     }
 }
 

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -310,6 +310,10 @@ impl AccountService {
         result
     }
 
+    pub async fn check_expiry_2(&self, token: AccountToken) -> Result<DateTime<Utc>, Error> {
+        self.check_expiry(token).await.map_err(map_rest_error)
+    }
+
     pub async fn submit_voucher(
         &mut self,
         account_token: AccountToken,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1071,8 +1071,9 @@ where
             }
             _ => (),
         }
-        self.event_listener
-            .notify_device_event(DeviceEvent::from(event));
+        if let Ok(event) = DeviceEvent::try_from(event) {
+            self.event_listener.notify_device_event(event);
+        }
     }
 
     async fn handle_device_migration_event(

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1069,6 +1069,25 @@ where
                     self.schedule_reconnect(WG_RECONNECT_DELAY);
                 }
             }
+            PrivateDeviceEvent::AccountExpiry(expiry)
+                if *self.target_state == TargetState::Secured =>
+            {
+                if expiry >= &chrono::Utc::now() {
+                    if let TunnelState::Error(ref state) = self.tunnel_state {
+                        if matches!(state.cause(), ErrorStateCause::AuthFailed(_)) {
+                            log::debug!("Reconnecting since the account has time on it");
+                            self.connect_tunnel();
+                        }
+                    }
+                } else {
+                    if self.get_target_tunnel_type() == Some(TunnelType::Wireguard) {
+                        log::debug!("Entering blocking state since the account is out of time");
+                        self.send_tunnel_command(TunnelCommand::Block(ErrorStateCause::AuthFailed(
+                            None,
+                        )))
+                    }
+                }
+            }
             _ => (),
         }
         if let Ok(event) = DeviceEvent::try_from(event) {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -126,6 +126,9 @@ pub enum Error {
     #[error(display = "Failed to update device")]
     UpdateDeviceError(#[error(source)] device::Error),
 
+    #[error(display = "Failed to submit voucher")]
+    VoucherSubmission(#[error(source)] device::Error),
+
     #[cfg(target_os = "linux")]
     #[error(display = "Unable to initialize split tunneling")]
     InitSplitTunneling(#[error(source)] split_tunnel::Error),
@@ -1317,21 +1320,17 @@ where
         tx: ResponseTx<VoucherSubmission, Error>,
         voucher: String,
     ) {
-        if let Ok(Some(device)) = self.account_manager.data().await.map(|s| s.into_device()) {
-            let mut account = self.account_manager.account_service.clone();
-            tokio::spawn(async move {
-                Self::oneshot_send(
-                    tx,
-                    account
-                        .submit_voucher(device.account_token, voucher)
-                        .await
-                        .map_err(Error::RestError),
-                    "submit_voucher response",
-                );
-            });
-        } else {
-            Self::oneshot_send(tx, Err(Error::NoAccountToken), "submit_voucher response");
-        }
+        let manager = self.account_manager.clone();
+        tokio::spawn(async move {
+            Self::oneshot_send(
+                tx,
+                manager
+                    .submit_voucher(voucher)
+                    .await
+                    .map_err(Error::VoucherSubmission),
+                "submit_voucher response",
+            );
+        });
     }
 
     fn on_get_relay_locations(&mut self, tx: oneshot::Sender<RelayList>) {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -954,6 +954,7 @@ fn map_daemon_error(error: crate::Error) -> Status {
         DaemonError::ListDevicesError(error) => map_device_error(&error),
         DaemonError::RemoveDeviceError(error) => map_device_error(&error),
         DaemonError::UpdateDeviceError(error) => map_device_error(&error),
+        DaemonError::VoucherSubmission(error) => map_device_error(&error),
         #[cfg(windows)]
         DaemonError::SplitTunnelError(error) => map_split_tunnel_error(error),
         DaemonError::AccountHistory(error) => map_account_history_error(error),


### PR DESCRIPTION
This PR updates the daemon to check whether there is time left on the account when failing to connect. Previously, the daemon would try to reconnect forever. Now it will enter the error state with the cause set to `AuthFailed`.

It also fixes an issue with voucher submissions. Previously, switching to another account while redeeming a voucher did not interrupt the redeeming of that voucher.

Related: https://github.com/mullvad/mullvadvpn-app/pull/3907, https://github.com/mullvad/mullvadvpn-app/issues/3881