### PR TITLE
Fix version injection script to not use GNU extensions

### DIFF
--- a/version-metadata.sh
+++ b/version-metadata.sh
@@ -62,8 +62,11 @@ function inject_version {
 
     echo "Setting Rust crate versions to $semver_version"
     # Rust crates
-    sed -i.bak -Ee "0,/^version = \"[^\"]+\"\$/s/^version = \"[^\"]+\"\$/version = \"$semver_version\"/g" \
-        "${MANIFESTS[@]}"
+    for toml in "${MANIFESTS[@]}"; do
+        cp "$toml" "$toml.bak"
+        awk "BEGIN { matches=0; } matches==0 && /^version = \"[^\"]+\"$/ \
+             { print \"version = \\\"$semver_version\\\"\"; matches++; next; } { print }" "$toml.bak" > "$toml"
+    done
 
     if [[ "$DESKTOP" == "true" ]]; then
         echo "Setting desktop version to $semver_version"


### PR DESCRIPTION
The [previous change](https://github.com/mullvad/mullvadvpn-app/pull/3874) to this script used a GNU extension to replace the versions. So injecting the version failed on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3910)
<!-- Reviewable:end -->
