### PR TITLE
Prevent redux updates during transition

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -369,6 +369,7 @@ export default class AppRenderer {
 
   public async logout() {
     try {
+      this.history.reset(RoutePath.login, transitions.dismiss);
       await IpcRendererEventChannel.account.logout();
     } catch (e) {
       const error = e as Error;
@@ -647,7 +648,7 @@ export default class AppRenderer {
             [RoutePath.launch]: transitions.push,
             [RoutePath.main]: transitions.pop,
             [RoutePath.deviceRevoked]: transitions.pop,
-            '*': transitions.none,
+            '*': transitions.dismiss,
           },
           [RoutePath.main]: {
             [RoutePath.launch]: transitions.push,

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
 import { formatDate, hasExpired } from '../../shared/account-expiry';
-import { AccountToken, DeviceState } from '../../shared/daemon-rpc-types';
+import { DeviceState } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
+import { useSelector } from '../redux/store';
 import {
   AccountContainer,
   AccountFooter,
@@ -27,10 +28,6 @@ import { NavigationBar, NavigationItems, TitleBarItem } from './NavigationBar';
 import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 
 interface IProps {
-  deviceName?: string;
-  accountToken?: AccountToken;
-  accountExpiry?: string;
-  expiryLocale: string;
   isOffline: boolean;
   prepareLogout: () => void;
   cancelLogout: () => void;
@@ -81,27 +78,21 @@ export default class Account extends React.Component<IProps, IState> {
                   <AccountRowLabel>
                     {messages.pgettext('device-management', 'Device name')}
                   </AccountRowLabel>
-                  <DeviceRowValue>{this.props.deviceName}</DeviceRowValue>
+                  <DeviceNameRow />
                 </AccountRow>
 
                 <AccountRow>
                   <AccountRowLabel>
                     {messages.pgettext('account-view', 'Account number')}
                   </AccountRowLabel>
-                  <AccountRowValue
-                    as={AccountTokenLabel}
-                    accountToken={this.props.accountToken || ''}
-                  />
+                  <AccountNumberRow />
                 </AccountRow>
 
                 <AccountRow>
                   <AccountRowLabel>
                     {messages.pgettext('account-view', 'Paid until')}
                   </AccountRowLabel>
-                  <FormattedAccountExpiry
-                    expiry={this.props.accountExpiry}
-                    locale={this.props.expiryLocale}
-                  />
+                  <AccountExpiryRow />
                 </AccountRow>
               </AccountRows>
 
@@ -209,6 +200,22 @@ export default class Account extends React.Component<IProps, IState> {
   private onHideLogoutConfirmationDialog = () => {
     this.setState({ logoutDialogVisible: false });
   };
+}
+
+function AccountNumberRow() {
+  const accountToken = useSelector((state) => state.account.accountToken);
+  return <AccountRowValue as={AccountTokenLabel} accountToken={accountToken || ''} />;
+}
+
+function AccountExpiryRow() {
+  const accountExpiry = useSelector((state) => state.account.expiry);
+  const expiryLocale = useSelector((state) => state.userInterface.locale);
+  return <FormattedAccountExpiry expiry={accountExpiry} locale={expiryLocale} />;
+}
+
+function DeviceNameRow() {
+  const deviceName = useSelector((state) => state.account.deviceName);
+  return <DeviceRowValue>{deviceName}</DeviceRowValue>;
 }
 
 function FormattedAccountExpiry(props: { expiry?: string; locale: string }) {

--- a/gui/src/renderer/components/Account.tsx
+++ b/gui/src/renderer/components/Account.tsx
@@ -157,7 +157,7 @@ export default class Account extends React.Component<IProps, IState> {
       this.state.logoutDialogStage === 'checking-ports'
         ? []
         : [
-            <AppButton.RedButton key="logout" onClick={this.props.onLogout}>
+            <AppButton.RedButton key="logout" onClick={this.confirmLogout}>
               {
                 // TRANSLATORS: Confirmation button when logging out
                 messages.pgettext('device-management', 'Log out anyway')
@@ -187,9 +187,13 @@ export default class Account extends React.Component<IProps, IState> {
     ) {
       this.setState({ logoutDialogStage: 'confirm' });
     } else {
-      this.props.onLogout();
-      this.onHideLogoutConfirmationDialog();
+      this.confirmLogout();
     }
+  };
+
+  private confirmLogout = () => {
+    this.onHideLogoutConfirmationDialog();
+    this.props.onLogout();
   };
 
   private cancelLogout = () => {

--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import { ITransitionSpecification } from '../lib/history';
+import { PauseRendering } from '../lib/pause-rendering';
 
 interface ITransitioningViewProps {
   viewId: string;
@@ -155,28 +156,32 @@ export default class TransitionContainer extends React.Component<IProps, IState>
 
   public render() {
     const disableUserInteraction =
-      this.state.itemQueue.length > 0 || this.state.nextItem ? true : false;
+      this.state.itemQueue.length > 0 || this.state.nextItem !== undefined;
 
     return (
       <StyledTransitionContainer disableUserInteraction={disableUserInteraction}>
         {this.state.currentItem && (
-          <StyledTransitionContent
+          <PauseRendering
             key={this.state.currentItem.view.props.viewId}
-            ref={this.currentContentRef}
-            transition={this.state.currentItemStyle}
-            onTransitionEnd={this.onTransitionEnd}>
-            {this.state.currentItem.view}
-          </StyledTransitionContent>
+            pause={disableUserInteraction}>
+            <StyledTransitionContent
+              ref={this.currentContentRef}
+              transition={this.state.currentItemStyle}
+              onTransitionEnd={this.onTransitionEnd}>
+              {this.state.currentItem.view}
+            </StyledTransitionContent>
+          </PauseRendering>
         )}
 
         {this.state.nextItem && (
-          <StyledTransitionContent
-            key={this.state.nextItem.view.props.viewId}
-            ref={this.nextContentRef}
-            transition={this.state.nextItemStyle}
-            onTransitionEnd={this.onTransitionEnd}>
-            {this.state.nextItem.view}
-          </StyledTransitionContent>
+          <PauseRendering key={this.state.nextItem.view.props.viewId}>
+            <StyledTransitionContent
+              ref={this.nextContentRef}
+              transition={this.state.nextItemStyle}
+              onTransitionEnd={this.onTransitionEnd}>
+              {this.state.nextItem.view}
+            </StyledTransitionContent>
+          </PauseRendering>
         )}
       </StyledTransitionContainer>
     );

--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import { ITransitionSpecification } from '../lib/history';
-import { PauseRendering } from '../lib/pause-rendering';
+import { WillExit } from '../lib/will-exit';
 
 interface ITransitioningViewProps {
   viewId: string;
@@ -155,33 +155,30 @@ export default class TransitionContainer extends React.Component<IProps, IState>
   }
 
   public render() {
-    const disableUserInteraction =
-      this.state.itemQueue.length > 0 || this.state.nextItem !== undefined;
+    const willExit = this.state.itemQueue.length > 0 || this.state.nextItem !== undefined;
 
     return (
-      <StyledTransitionContainer disableUserInteraction={disableUserInteraction}>
+      <StyledTransitionContainer disableUserInteraction={willExit}>
         {this.state.currentItem && (
-          <PauseRendering
-            key={this.state.currentItem.view.props.viewId}
-            pause={disableUserInteraction}>
+          <WillExit key={this.state.currentItem.view.props.viewId} value={willExit}>
             <StyledTransitionContent
               ref={this.currentContentRef}
               transition={this.state.currentItemStyle}
               onTransitionEnd={this.onTransitionEnd}>
               {this.state.currentItem.view}
             </StyledTransitionContent>
-          </PauseRendering>
+          </WillExit>
         )}
 
         {this.state.nextItem && (
-          <PauseRendering key={this.state.nextItem.view.props.viewId}>
+          <WillExit key={this.state.nextItem.view.props.viewId} value={false}>
             <StyledTransitionContent
               ref={this.nextContentRef}
               transition={this.state.nextItemStyle}
               onTransitionEnd={this.onTransitionEnd}>
               {this.state.nextItem.view}
             </StyledTransitionContent>
-          </PauseRendering>
+          </WillExit>
         )}
       </StyledTransitionContainer>
     );

--- a/gui/src/renderer/containers/AccountPage.tsx
+++ b/gui/src/renderer/containers/AccountPage.tsx
@@ -9,10 +9,6 @@ import accountActions from '../redux/account/actions';
 import { IReduxState, ReduxDispatch } from '../redux/store';
 
 const mapStateToProps = (state: IReduxState) => ({
-  deviceName: state.account.deviceName,
-  accountToken: state.account.accountToken,
-  accountExpiry: state.account.expiry,
-  expiryLocale: state.userInterface.locale,
   isOffline: state.connection.isBlocked,
 });
 const mapDispatchToProps = (dispatch: ReduxDispatch, props: IHistoryProps & IAppContext) => {

--- a/gui/src/renderer/lib/will-exit.tsx
+++ b/gui/src/renderer/lib/will-exit.tsx
@@ -1,0 +1,13 @@
+import React, { useContext } from 'react';
+
+// This context tells its subtree if it should stop rendering or not. This is useful during
+// transitions, e.g. on log out, since data might be updated which makes the disappearing view
+// update a lot during the transition. There's currently no support for unpausing, which can be
+// added later if needed.
+const willExitContext = React.createContext<boolean>(false);
+
+export const WillExit = willExitContext.Provider;
+
+export function useWillExit() {
+  return useContext(willExitContext);
+}

--- a/gui/src/renderer/redux/store.ts
+++ b/gui/src/renderer/redux/store.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { useSelector as useReduxSelector } from 'react-redux';
 import { combineReducers, compose, createStore, Dispatch } from 'redux';
 
-import { usePause } from '../lib/pause-rendering';
+import { useWillExit } from '../lib/will-exit';
 import accountActions, { AccountAction } from './account/actions';
 import accountReducer, { IAccountReduxState } from './account/reducers';
 import connectionActions, { ConnectionAction } from './connection/actions';
@@ -66,16 +66,16 @@ function composeEnhancers(): typeof compose {
     : compose();
 }
 
-// This hook adds typing to state to make use simpler. It also prevents the state from update if the
-// ReduxPause context has been told to pause updates caused by new values in the redux state.
+// This hook adds type to state to make use simpler. It also prevents the state from update if the
+// WillExit context value is true.
 export function useSelector<R>(fn: (state: IReduxState) => R): R {
-  const [paused] = usePause();
   const value = useReduxSelector(fn);
-  const valueBeforePause = useRef(value);
+  const valueBeforeExit = useRef(value);
+  const willExit = useWillExit();
 
-  if (!paused) {
-    valueBeforePause.current = value;
+  if (!willExit) {
+    valueBeforeExit.current = value;
   }
 
-  return paused ? valueBeforePause.current : value;
+  return valueBeforeExit.current;
 }


### PR DESCRIPTION
This PR adds a transition when logging out. This initially resulted in two issue. The first issue was the the account number and expiry in the account view was cleared in the beginning of the transition. The other one was a visual glitch happening when a modal was unmounted during the view transition.

To solve this I add a context for stopping updates during transitions. This can now prevent `useSelector` from returning updated values while paused.

The visual glitch was solved by using the paused-context to prevent unmounting of modals while paused.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3913)
<!-- Reviewable:end -->
