### PR TITLE
Add overflow hidden to ModalContent to prevent scrollbar from appearing during transition

### DIFF
--- a/gui/src/renderer/components/Modal.tsx
+++ b/gui/src/renderer/components/Modal.tsx
@@ -21,6 +21,7 @@ const ModalContent = styled.div({
   left: 0,
   right: 0,
   bottom: 0,
+  overflow: 'hidden',
 });
 
 const ModalBackground = styled.div({}, (props: { visible: boolean }) => ({


### PR DESCRIPTION
Fix bug where `ModalContent` becomes scrollable during view transitions.
![image](https://user-images.githubusercontent.com/3668602/189355218-45e31cbd-b42d-41f9-a2e0-a37a8ce8414e.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3918)
<!-- Reviewable:end -->
