### PR TITLE
Remove TAP driver support for openvpn

### DIFF
--- a/talpid-core/src/process/openvpn.rs
+++ b/talpid-core/src/process/openvpn.rs
@@ -47,29 +47,12 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--route-noexec"],
     #[cfg(windows)]
     &["--ip-win32", "ipapi"],
+    #[cfg(windows)]
+    &["--windows-driver", "wintun"],
 ];
 
 static ALLOWED_TLS1_3_CIPHERS: &[&str] =
     &["TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256"];
-
-/// Tun driver to use, specified using `--windows-driver`.
-#[derive(Clone)]
-pub enum WindowsDriver {
-    /// TAP adapter driver
-    TapWindows6,
-    /// Wintun driver
-    Wintun,
-}
-
-impl WindowsDriver {
-    /// Return string to use with the `--windows-driver` option.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            WindowsDriver::TapWindows6 => "tap-windows6",
-            WindowsDriver::Wintun => "wintun",
-        }
-    }
-}
 
 /// An OpenVPN process builder, providing control over the different arguments that the OpenVPN
 /// binary accepts.
@@ -87,8 +70,6 @@ pub struct OpenVpnCommand {
     log: Option<PathBuf>,
     tunnel_options: net::openvpn::TunnelOptions,
     proxy_settings: Option<net::openvpn::ProxySettings>,
-    #[cfg(windows)]
-    windows_driver: Option<WindowsDriver>,
     tunnel_alias: Option<OsString>,
     enable_ipv6: bool,
     proxy_port: Option<u16>,
@@ -111,8 +92,6 @@ impl OpenVpnCommand {
             log: None,
             tunnel_options: net::openvpn::TunnelOptions::default(),
             proxy_settings: None,
-            #[cfg(windows)]
-            windows_driver: None,
             tunnel_alias: None,
             enable_ipv6: true,
             proxy_port: None,
@@ -178,13 +157,6 @@ impl OpenVpnCommand {
     /// Sets extra options
     pub fn tunnel_options(&mut self, tunnel_options: &net::openvpn::TunnelOptions) -> &mut Self {
         self.tunnel_options = tunnel_options.clone();
-        self
-    }
-
-    /// Sets the driver to use for tunneling
-    #[cfg(windows)]
-    pub fn windows_driver(&mut self, driver: Option<WindowsDriver>) -> &mut Self {
-        self.windows_driver = driver;
         self
     }
 
@@ -275,12 +247,6 @@ impl OpenVpnCommand {
         if let Some(ref tunnel_device) = self.tunnel_alias {
             args.push(OsString::from("--dev-node"));
             args.push(tunnel_device.clone());
-        }
-
-        #[cfg(windows)]
-        if let Some(ref windows_driver) = self.windows_driver {
-            args.push(OsString::from("--windows-driver"));
-            args.push(OsString::from(windows_driver.as_str()));
         }
 
         args.extend(Self::tls_cipher_arguments().iter().map(OsString::from));

--- a/talpid-core/src/tunnel/openvpn/mod.rs
+++ b/talpid-core/src/tunnel/openvpn/mod.rs
@@ -685,10 +685,7 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
             .enable_ipv6(params.generic_options.enable_ipv6)
             .ca(resource_dir.join("ca.crt"));
         #[cfg(windows)]
-        {
-            cmd.tunnel_alias(Some(alias));
-            cmd.windows_driver(Some(crate::process::openvpn::WindowsDriver::Wintun));
-        }
+        cmd.tunnel_alias(Some(alias));
         if let Some(proxy_settings) = params.proxy.clone().take() {
             cmd.proxy_settings(proxy_settings);
         }


### PR DESCRIPTION
It's not very useful to keep this option since we're only ever going to use Wintun.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3919)
<!-- Reviewable:end -->
