### PR TITLE
Fix transition when navigating from device revoked to login

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -367,9 +367,9 @@ export default class AppRenderer {
     this.loginState = 'none';
   };
 
-  public async logout() {
+  public async logout(transition = transitions.dismiss) {
     try {
-      this.history.reset(RoutePath.login, transitions.dismiss);
+      this.history.reset(RoutePath.login, transition);
       await IpcRendererEventChannel.account.logout();
     } catch (e) {
       const error = e as Error;
@@ -378,8 +378,7 @@ export default class AppRenderer {
   }
 
   public leaveRevokedDevice = async () => {
-    await this.logout();
-    this.resetNavigation();
+    await this.logout(transitions.pop);
     await this.disconnectTunnel();
   };
 


### PR DESCRIPTION
This PR fixes a bug where two different transitions are displayed when navigating from the device revoked view to the login view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3928)
<!-- Reviewable:end -->
