### PR TITLE
Fix cropped notification

### DIFF
--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -73,7 +73,7 @@ export default function NotificationArea(props: IProps) {
 
     if (notification) {
       return (
-        <NotificationBanner className={props.className} visible>
+        <NotificationBanner className={props.className}>
           <NotificationIndicator type={notification.indicator} />
           <NotificationContent role="status" aria-live="polite">
             <NotificationTitle>{notification.title}</NotificationTitle>
@@ -89,7 +89,7 @@ export default function NotificationArea(props: IProps) {
     }
   }
 
-  return <NotificationBanner className={props.className} visible={false} aria-hidden={true} />;
+  return <NotificationBanner className={props.className} aria-hidden={true} />;
 }
 
 interface INotificationActionWrapperProps {

--- a/gui/src/renderer/components/NotificationBanner.tsx
+++ b/gui/src/renderer/components/NotificationBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { colors } from '../../config.json';
@@ -138,7 +138,7 @@ export function NotificationBanner(props: INotificationBannerProps) {
     prevChildren.current = props.children ?? prevChildren.current;
   }, [props.children]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const newHeight =
       props.children !== undefined ? contentRef.current?.getBoundingClientRect().height ?? 0 : 0;
     if (newHeight !== contentHeight) {

--- a/gui/src/renderer/index.html
+++ b/gui/src/renderer/index.html
@@ -2,6 +2,13 @@
 <html>
   <head>
     <title>Mullvad VPN</title>
+    <link rel="preload" href="../../assets/fonts/SourceSansPro-Bold.ttf" as="font" />
+    <link rel="preload" href="../../assets/fonts/NotoSansMyanmar-Bold.ttf" as="font" />
+    <link rel="preload" href="../../assets/fonts/NotoSansThai-Bold.ttf" as="font" />
+    <link rel="preload" href="../../assets/fonts/SourceSansPro-SemiBold.ttf" as="font" />
+    <link rel="preload" href="../../assets/fonts/OpenSans-Bold.ttf" as="font" />
+    <link rel="preload" href="../../assets/fonts/OpenSans-Semibold.ttf" as="font" />
+    <link rel="preload" href="../../assets/fonts/OpenSans-Regular.ttf" as="font" />
     <link rel="stylesheet" href="../../assets/css/style.css" />
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
     <meta charset="UTF-8">


### PR DESCRIPTION
This PR fixes the issues of notifications being cropped if it's shown when the app starts and consists of a few lines of text. The cause was that the font hadn't loaded yet when the `NotificaitonBanner` component measured the size of the notificaiton to figure out how big it should be.

To fix this I added the fonts to preloads. While working on this I also refactored `NotificationBanner` to make it less complicated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3930)
<!-- Reviewable:end -->
