### PR TITLE
Change the default multihop entry location to Sweden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Line wrap the file at 100 chars.                                              Th
 - Update Electron from 18.0.3 to 19.0.13.
 - Expand allowed range of multicast destinations to include all of `239.0.0.0/8` (administratively
   scoped addresses), when local network sharing is enabled.
+- Default to selecting Sweden as the entry location when using WireGuard multihop. Previously,
+  a random location was used.
 
 #### Windows
 - Remove dependency on `ipconfig.exe`. Call `DnsFlushResolverCache` to flush the DNS cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ Line wrap the file at 100 chars.                                              Th
 - Add obfuscation settings under "WireGuard settings".
 
 #### Windows
-- Windows daemon now looks up the MTU on the default interface and uses this MTU instead of the
-  default 1500. The 1500 is still the fallback if this for some reason fails. This may stop
-  fragmentation.
 - The default VPN protocol is slowly being changed from OpenVPN to WireGuard.
   The app fetches the ratio between the protocols from the API.
 

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -419,7 +419,7 @@ pub struct TransportPort {
     pub port: Constraint<u16>,
 }
 
-/// [`Constraint`]s applicable to OpenVPN relay servers.
+/// [`Constraint`]s applicable to OpenVPN relays.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct OpenVpnConstraints {
     pub port: Constraint<TransportPort>,
@@ -440,7 +440,7 @@ impl fmt::Display for OpenVpnConstraints {
     }
 }
 
-/// [`Constraint`]s applicable to WireGuard relay servers.
+/// [`Constraint`]s applicable to WireGuard relays.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct WireguardConstraints {

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     relay_constraints::{
         BridgeConstraints, BridgeSettings, BridgeState, Constraint, LocationConstraint,
         ObfuscationSettings, RelayConstraints, RelaySettings, RelaySettingsUpdate,
-        SelectedObfuscation,
+        SelectedObfuscation, WireguardConstraints,
     },
     wireguard,
 };
@@ -120,6 +120,10 @@ impl Default for Settings {
         Settings {
             relay_settings: RelaySettings::Normal(RelayConstraints {
                 location: Constraint::Only(LocationConstraint::Country("se".to_owned())),
+                wireguard_constraints: WireguardConstraints {
+                    entry_location: Constraint::Only(LocationConstraint::Country("se".to_owned())),
+                    ..Default::default()
+                },
                 ..Default::default()
             }),
             bridge_settings: BridgeSettings::Normal(BridgeConstraints::default()),


### PR DESCRIPTION
Since `any` cannot be selected in the GUI, and since `se` is the default location for the exit, this is a better default than `any`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3931)
<!-- Reviewable:end -->
