### PR TITLE
Update jnix to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,6 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "uuid",
- "webpki 0.21.4",
 ]
 
 [[package]]
@@ -1651,8 +1650,8 @@ dependencies = [
  "mullvad-types",
  "nix 0.23.1",
  "parity-tokio-ipc",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "talpid-types",
  "tokio",
  "tonic",
@@ -2295,17 +2294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2320,8 +2309,8 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
 ]
@@ -2340,36 +2329,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
- "prost 0.8.0",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -2622,7 +2588,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -3083,7 +3049,7 @@ dependencies = [
  "parity-tokio-ipc",
  "parking_lot 0.11.2",
  "pfctl",
- "prost 0.8.0",
+ "prost",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
@@ -3140,7 +3106,7 @@ dependencies = [
  "log",
  "openvpn-plugin",
  "parity-tokio-ipc",
- "prost 0.8.0",
+ "prost",
  "talpid-types",
  "tokio",
  "tonic",
@@ -3173,8 +3139,7 @@ version = "0.1.0"
 dependencies = [
  "classic-mceliece-rust",
  "log",
- "prost 0.8.0",
- "prost-types 0.9.0",
+ "prost",
  "rand 0.8.5",
  "talpid-types",
  "tokio",
@@ -3328,7 +3293,7 @@ checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -3401,8 +3366,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.8.0",
- "prost-derive 0.8.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3834,16 +3799,6 @@ checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,12 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,15 +360,12 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.8.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
- "ascii",
- "byteorder",
- "either",
+ "bytes",
  "memchr",
- "unreachable",
 ]
 
 [[package]]
@@ -1288,15 +1279,15 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jni"
-version = "0.14.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981310da491a4f0f815238097d0d43d8072732b5ae5f8bd0d8eadf5bf245402"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
 dependencies = [
  "cesu8",
  "combine",
- "error-chain",
  "jni-sys",
  "log",
+ "thiserror",
  "walkdir",
 ]
 
@@ -1308,23 +1299,23 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jnix"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1aa8ee934c87d39f4ce8d180ac50c7eee455e99b8faaeda98adae4e71a0145"
+checksum = "aecfa741840d59de75e6e9e2985ee44b6794cbc0b2074899089be6bf7ffa0afc"
 dependencies = [
  "jni",
  "jnix-macros",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
 name = "jnix-macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a28c447e7a02784315280fb972e692b21ae7c18a44bfb37fce670946dc2dba"
+checksum = "002f4dfe6d97ae88c33f3489c0d31ffc6f81d9a492de98ff113b127d73bafff8"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3709,15 +3700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3750,12 +3732,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = "1.0"
 tokio = { version = "1.8", features = ["macros", "time", "rt-multi-thread", "net", "io-std", "io-util", "fs"] }
 tokio-rustls = "0.23"
 rustls-pemfile = "0.2"
-webpki = { version = "0.21", features =  [] }
 lazy_static = "1.1.0"
 
 mullvad-types = { path = "../mullvad-types" }

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -14,7 +14,7 @@ crate_type = ["cdylib"]
 err-derive = "0.3.1"
 futures = "0.3"
 ipnetwork = "0.16"
-jnix = { version = "0.4", features = ["derive"] }
+jnix = { version = "0.5", features = ["derive"] }
 lazy_static = "1"
 log = "0.4"
 log-panics = "2"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -20,4 +20,4 @@ rand = "0.8"
 talpid-types = { path = "../talpid-types" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.4", features = ["derive"] }
+jnix = { version = "0.5", features = ["derive"] }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -51,7 +51,7 @@ nix = "0.23"
 
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.4", features = ["derive"] }
+jnix = { version = "0.5", features = ["derive"] }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -13,7 +13,6 @@ rand = "0.8"
 talpid-types = { path = "../talpid-types" }
 tonic = "0.5"
 prost = "0.8"
-prost-types = "0.9"
 tower = "0.4"
 tokio = "1"
 classic-mceliece-rust = { version = "2.0.0", features = ["mceliece8192128f"] }

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -16,4 +16,4 @@ rand = "0.8.5"
 err-derive = "0.3.1"
 
 [target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.4", features = ["derive"] }
+jnix = { version = "0.5", features = ["derive"] }


### PR DESCRIPTION
This makes the derive macro for `FromJava` work on simple enums. See https://github.com/mullvad/jnix/pull/49.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3936)
<!-- Reviewable:end -->
