### PR TITLE
MUL22-02 for Linux - maintain blocking firewall rules during system shutdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,10 +74,13 @@ Line wrap the file at 100 chars.                                              Th
 - Don't fail install if the device tree contains nameless callout driver devices.
 
 ### Security
-#### Linux
 - Added traffic blocking during early boot, before the daemon starts, to prevent leaks in the case
   that the system service starts after a networking daemon has already configured a network
   interface.
+- When the system process is being shut down and the target state is _secured_, maintain the
+  blocking firewall rules unless it's possible to deduce that the system isn't shutting down and the
+  system service is being stopped by the user intentionally. This is to prevent leaks that might
+  occur during system shutdown.
 
 
 ## [android/2022.2-beta2] - 2022-09-09

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ dependencies = [
  "serde_json",
  "simple-signal",
  "talpid-core",
+ "talpid-dbus",
  "talpid-platform-metadata",
  "talpid-time",
  "talpid-types",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -34,6 +34,7 @@ mullvad-relay-selector = { path = "../mullvad-relay-selector" }
 mullvad-types = { path = "../mullvad-types" }
 mullvad-api = { path = "../mullvad-api" }
 talpid-core = { path = "../talpid-core" }
+talpid-dbus = { path = "../talpid-dbus" }
 talpid-types = { path = "../talpid-types" }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 talpid-time = { path = "../talpid-time" }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -22,6 +22,7 @@ mod migrations;
 pub mod rpc_uniqueness_check;
 pub mod runtime;
 pub mod settings;
+pub mod shutdown;
 mod target_state;
 mod tunnel;
 pub mod version;
@@ -2159,11 +2160,9 @@ where
         }
     }
 
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
     fn trigger_shutdown_event(&mut self, user_init_shutdown: bool) {
         // Block all traffic before shutting down to ensure that no traffic can leak on boot or
         // shutdown.
-        #[cfg(windows)]
         if !user_init_shutdown
             && (*self.target_state == TargetState::Secured || self.settings.auto_connect)
         {

--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -27,4 +27,29 @@ mod platform {
     }
 }
 
+/// Returns true if systemd successfully reported that the machine is not shutting down or entering
+/// maintenance. If obtaining this information fails, the return value will be `false` and it will
+/// be assumed that the machine is shutting down.
+#[cfg(target_os = "linux")]
+pub fn is_shutdown_user_initiated() -> bool {
+    match talpid_dbus::systemd::is_host_running() {
+        Ok(is_host_running) => is_host_running,
+        Err(err) => {
+            log::error!(
+                "{}",
+                talpid_types::ErrorExt::display_chain_with_msg(
+                    &err,
+                    "Failed to determine if host is shutting down, assuming it is shutting down"
+                )
+            );
+            false
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn is_shutdown_user_initiated() -> bool {
+    false
+}
+
 pub use self::platform::*;

--- a/talpid-dbus/src/lib.rs
+++ b/talpid-dbus/src/lib.rs
@@ -4,6 +4,7 @@ pub use dbus;
 use dbus::blocking::SyncConnection;
 use std::sync::{Arc, Mutex};
 pub mod network_manager;
+pub mod systemd;
 pub mod systemd_resolved;
 
 lazy_static::lazy_static! {

--- a/talpid-dbus/src/systemd.rs
+++ b/talpid-dbus/src/systemd.rs
@@ -1,0 +1,67 @@
+use dbus::blocking::{stdintf::org_freedesktop_dbus::Properties, Proxy, SyncConnection};
+use std::{sync::Arc, time::Duration};
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(err_derive::Error, Debug)]
+#[error(no_from)]
+pub enum Error {
+    #[error(display = "Failed to create a DBus connection")]
+    ConnectError(#[error(source)] dbus::Error),
+
+    #[error(display = "Failed to read SystemState property")]
+    ReadSystemStateError(#[error(source)] dbus::Error),
+}
+
+const SYSTEMD_BUS: &str = "org.freedesktop.systemd1";
+const SYSTEMD_PATH: &str = "/org/freedesktop/systemd1";
+const MANAGER_INTERFACE: &str = "org.freedesktop.systemd1.Manager";
+const SYSTEM_STATE: &str = "SystemState";
+const SYSTEM_STATE_STARTING: &str = "starting";
+const SYSTEM_STATE_INITIALIZING: &str = "initializing";
+const SYSTEM_STATE_RUNNING: &str = "running";
+const SYSTEM_STATE_DEGRADED: &str = "degraded";
+
+const RPC_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Returns true if the host is not shutting down or entering maintenance mode or some other weird
+/// state.
+pub fn is_host_running() -> Result<bool> {
+    Systemd::new()?.system_is_running()
+}
+
+struct Systemd {
+    pub dbus_connection: Arc<SyncConnection>,
+}
+
+impl Systemd {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            dbus_connection: crate::get_connection().map_err(Error::ConnectError)?,
+        })
+    }
+
+    fn system_is_running(&self) -> Result<bool> {
+        self.as_manager_object()
+            .get(MANAGER_INTERFACE, SYSTEM_STATE)
+            .map(|state: String| {
+                ![
+                    SYSTEM_STATE_STARTING,
+                    SYSTEM_STATE_INITIALIZING,
+                    SYSTEM_STATE_RUNNING,
+                    SYSTEM_STATE_DEGRADED,
+                ]
+                .contains(&state.as_str())
+            })
+            .map_err(Error::ReadSystemStateError)
+    }
+
+    fn as_manager_object(&self) -> Proxy<'_, &SyncConnection> {
+        Proxy::new(
+            SYSTEMD_BUS,
+            SYSTEMD_PATH,
+            RPC_TIMEOUT,
+            &self.dbus_connection,
+        )
+    }
+}


### PR DESCRIPTION
Due to the ordering of shutdown events, the mullvad daemon will most often be shut down while network interfaces are still configured and working, which allows for a time window where arbitrary processes can send network traffic outside of the tunnel, even if the user never intended for this. 

To fix this, the daemon will not clear it's firewall rules during shutdown if the user didn't explicitly disconnect before the daemon is being stopped, unless `systemd` is reachable over D-Bus and it's reporting that the system is not shutting down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3940)
<!-- Reviewable:end -->
