### PR TITLE
MUL22-02 for Windows - maintain blocking firewall rules during system shutdown.

### DIFF
--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -9,7 +9,6 @@ pub struct Config {
     pub log_stdout_timestamps: bool,
     pub run_as_service: bool,
     pub register_service: bool,
-    pub restart_service: bool,
     #[cfg(target_os = "linux")]
     pub initialize_firewall_and_exit: bool,
 }
@@ -38,7 +37,6 @@ pub fn create_config() -> Config {
         cfg!(target_os = "linux") && matches.is_present("initialize-early-boot-firewall");
     let run_as_service = cfg!(windows) && matches.is_present("run_as_service");
     let register_service = cfg!(windows) && matches.is_present("register_service");
-    let restart_service = cfg!(windows) && matches.is_present("restart_service");
 
     Config {
         #[cfg(target_os = "linux")]
@@ -48,7 +46,6 @@ pub fn create_config() -> Config {
         log_stdout_timestamps,
         run_as_service,
         register_service,
-        restart_service,
     }
 }
 
@@ -106,11 +103,6 @@ fn create_app() -> App<'static> {
             Arg::new("register_service")
                 .long("register-service")
                 .help("Register itself as a system service"),
-        )
-        .arg(
-            Arg::new("restart_service")
-                .long("restart-service")
-                .help("Restarts the existing system service"),
         )
     }
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -91,12 +91,6 @@ fn get_log_dir(config: &cli::Config) -> Result<Option<PathBuf>, String> {
 async fn run_platform(config: &cli::Config, log_dir: Option<PathBuf>) -> Result<(), String> {
     if config.run_as_service {
         system_service::run()
-    } else if config.restart_service {
-        let restart_result = system_service::restart_service().map_err(|e| e.display_chain());
-        if restart_result.is_ok() {
-            log::info!("Restarted the service.");
-        }
-        restart_result
     } else {
         if config.register_service {
             let install_result = system_service::install_service().map_err(|e| e.display_chain());
@@ -144,7 +138,7 @@ async fn run_standalone(log_dir: Option<PathBuf>) -> Result<(), String> {
     let daemon = create_daemon(log_dir).await?;
 
     let shutdown_handle = daemon.shutdown_handle();
-    shutdown::set_shutdown_signal_handler(move || shutdown_handle.shutdown())
+    shutdown::set_shutdown_signal_handler(move || shutdown_handle.shutdown(true))
         .map_err(|e| e.display_chain())?;
 
     daemon.run().await.map_err(|e| e.display_chain())?;


### PR DESCRIPTION
Previously, the daemon did keep blocking rules after exit if auto-connect was enabled. This means that there's a small leak window on shutdown if auto-connect (and always require VPN) is disabled. This PR changes the behavior of the daemon to always block on exit if the system is shutting down instead.

Related: #3940.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3942)
<!-- Reviewable:end -->
