### PR TITLE
MUL22-02 for macOS - maintain blocking firewall rules during system shutdown. 

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2166,6 +2166,11 @@ where
             self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
         }
 
+        #[cfg(target_os = "macos")]
+        if *self.target_state == TargetState::Secured {
+            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
+        }
+
         self.state.shutdown(&self.tunnel_state);
         self.disconnect_tunnel();
     }


### PR DESCRIPTION
Since detecting a shutdown event on macOS would require us to add some bindings to `core-foundation`, for now on macOS the daemon will always leave blocking rules when exiting.