### PR TITLE
Remove shutdown GRPC.

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -284,6 +284,7 @@ pub enum DaemonCommand {
     /// Register settings for WireGuard obfuscator
     SetObfuscationSettings(ResponseTx<(), settings::Error>, ObfuscationSettings),
     /// Makes the daemon exit the main loop and quit.
+    #[cfg(target_os = "android")]
     Shutdown,
     /// Saves the target tunnel state and enters a blocking state. The state is restored
     /// upon restart.
@@ -1032,6 +1033,7 @@ where
             SetObfuscationSettings(tx, settings) => {
                 self.on_set_obfuscation_settings(tx, settings).await
             }
+            #[cfg(target_os = "android")]
             Shutdown => self.trigger_shutdown_event(false),
             PrepareRestart => self.on_prepare_restart(),
             #[cfg(target_os = "android")]

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -111,12 +111,6 @@ impl ManagementService for ManagementServiceImpl {
         Ok(Response::new(()))
     }
 
-    async fn shutdown(&self, _: Request<()>) -> ServiceResult<()> {
-        log::debug!("shutdown");
-        self.send_command_to_daemon(DaemonCommand::Shutdown)?;
-        Ok(Response::new(()))
-    }
-
     async fn factory_reset(&self, _: Request<()>) -> ServiceResult<()> {
         #[cfg(not(target_os = "android"))]
         {

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -293,7 +293,7 @@ impl DaemonInterface {
     }
 
     pub fn shutdown(&self) -> Result<()> {
-        self.send_command(DaemonCommand::Shutdown)
+        self.command_sender.shutdown().map_err(Error::NoDaemon)
     }
 
     pub fn submit_voucher(&self, voucher: String) -> Result<VoucherSubmission> {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -18,7 +18,6 @@ service ManagementService {
 	// Control the daemon and receive events
 	rpc EventsListen(google.protobuf.Empty) returns (stream DaemonEvent) {}
 	rpc PrepareRestart(google.protobuf.Empty) returns (google.protobuf.Empty) {}
-	rpc Shutdown(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 	rpc FactoryReset(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
 	rpc GetCurrentVersion(google.protobuf.Empty) returns (google.protobuf.StringValue) {}


### PR DESCRIPTION
The shutdown GRPC isn't used by any client that we know of. The shutdown command itself is only useful on Android - thus the shutdown method is removed from the GRPC interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3944)
<!-- Reviewable:end -->
