### PR TITLE
Update post quantum experiment V0 -> V1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,6 +3232,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -15,7 +15,7 @@ tonic = "0.8"
 prost = "0.11"
 tower = "0.4"
 tokio = "1"
-classic-mceliece-rust = { version = "2.0.0", features = ["mceliece8192128f"] }
+classic-mceliece-rust = { version = "2.0.0", features = ["mceliece460896f"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/talpid-tunnel-config-client/examples/psk-exchange.rs
+++ b/talpid-tunnel-config-client/examples/psk-exchange.rs
@@ -1,24 +1,25 @@
-use std::{
-    io,
-    net::{IpAddr, Ipv4Addr},
-};
+//! Example client implementing the quantum resistant tunnel PSK exchange.
+//! Useful to test this crate's implementation.
 
+use std::net::IpAddr;
 use talpid_types::net::wireguard::PublicKey;
 
 #[tokio::main]
 async fn main() {
-    println!("Make sure you're connected to a WireGuard peer and enter your public key: ");
+    let mut args = std::env::args().skip(1);
+    let tuncfg_server_ip: IpAddr = args
+        .next()
+        .expect("Give tuncfg server IP as first argument")
+        .parse()
+        .expect("tuncfg ip argument not a valid IP");
+    let pubkey_string = args
+        .next()
+        .expect("Give WireGuard public key as second argument");
+    let pubkey = PublicKey::from_base64(pubkey_string.trim()).expect("Invalid public key");
 
-    let mut pubkey_s = String::new();
-    io::stdin()
-        .read_line(&mut pubkey_s)
-        .expect("Failed to read from stdin");
-    let pubkey = PublicKey::from_base64(pubkey_s.trim()).expect("Invalid public key");
-
-    let (private_key, psk) =
-        talpid_tunnel_config_client::push_pq_key(IpAddr::V4(Ipv4Addr::new(10, 64, 0, 1)), pubkey)
-            .await
-            .unwrap();
+    let (private_key, psk) = talpid_tunnel_config_client::push_pq_key(tuncfg_server_ip, pubkey)
+        .await
+        .unwrap();
 
     println!("private key: {:?}", private_key);
     println!("psk: {:?}", psk);

--- a/talpid-tunnel-config-client/examples/tuncfg-server.rs
+++ b/talpid-tunnel-config-client/examples/tuncfg-server.rs
@@ -1,0 +1,84 @@
+//! A server implementation of the tuncfg PskExchangeExperimentalV1 RPC to test
+//! the client side implementation.
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+mod proto {
+    tonic::include_proto!("tunnel_config");
+}
+use classic_mceliece_rust::{PublicKey, CRYPTO_PUBLICKEYBYTES};
+use proto::{
+    post_quantum_secure_server::{PostQuantumSecure, PostQuantumSecureServer},
+    PskRequestExperimentalV0, PskRequestExperimentalV1, PskResponseExperimentalV0,
+    PskResponseExperimentalV1,
+};
+use talpid_types::net::wireguard::PresharedKey;
+
+use tonic::{transport::Server, Request, Response, Status};
+
+#[derive(Debug, Default)]
+pub struct PostQuantumSecureImpl {}
+
+#[tonic::async_trait]
+impl PostQuantumSecure for PostQuantumSecureImpl {
+    async fn psk_exchange_experimental_v0(
+        &self,
+        _request: Request<PskRequestExperimentalV0>,
+    ) -> Result<Response<PskResponseExperimentalV0>, Status> {
+        unimplemented!("Use V1 instead");
+    }
+
+    async fn psk_exchange_experimental_v1(
+        &self,
+        request: Request<PskRequestExperimentalV1>,
+    ) -> Result<Response<PskResponseExperimentalV1>, Status> {
+        let mut rng = rand::thread_rng();
+        let request = request.into_inner();
+
+        println!("wg_pubkey: {:?}", request.wg_pubkey);
+        println!("wg_psk_pubkey: {:?}", request.wg_psk_pubkey);
+
+        // The ciphertexts that will be returned to the client
+        let mut ciphertexts = Vec::new();
+        // The final PSK that is computed by XORing together all the KEM outputs.
+        let mut psk_data = Box::new([0u8; 32]);
+
+        for kem_pubkey in request.kem_pubkeys {
+            println!("\tKEM algorithm: {}", kem_pubkey.algorithm_name);
+            let (ciphertext, shared_secret) = match kem_pubkey.algorithm_name.as_str() {
+                "Classic-McEliece-460896f" => {
+                    let key_data: [u8; CRYPTO_PUBLICKEYBYTES] =
+                        kem_pubkey.key_data.as_slice().try_into().unwrap();
+                    let public_key = PublicKey::from(&key_data);
+                    let (ciphertext, shared_secret) =
+                        classic_mceliece_rust::encapsulate_boxed(&public_key, &mut rng);
+                    (ciphertext.as_array().to_vec(), *shared_secret.as_array())
+                }
+                name => panic!("Unsupported KEM algorithm: {name}"),
+            };
+
+            ciphertexts.push(ciphertext);
+            println!("\tshared secret: {:?}", shared_secret);
+            for (psk_byte, shared_secret_byte) in psk_data.iter_mut().zip(shared_secret.iter()) {
+                *psk_byte ^= shared_secret_byte;
+            }
+        }
+
+        let psk = PresharedKey::from(psk_data);
+        println!("psk: {:?}", psk);
+        println!("==============================================");
+        Ok(Response::new(PskResponseExperimentalV1 { ciphertexts }))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "127.0.0.1:1337".parse()?;
+    let server = PostQuantumSecureImpl::default();
+
+    Server::builder()
+        .add_service(PostQuantumSecureServer::new(server))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/talpid-tunnel-config-client/proto/tunnel_config.proto
+++ b/talpid-tunnel-config-client/proto/tunnel_config.proto
@@ -1,15 +1,3 @@
-//
-// If you need to (re)generate the gRPC code, see prerequisites
-//
-// 	https://grpc.io/docs/languages/go/quickstart/
-//
-// and then run
-//
-// 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative tunnel_config.proto
-//
-// from this directory.
-//
-
 syntax = "proto3";
 
 option go_package = "github.com/mullvad/wg-manager/server/tuncfg";
@@ -19,7 +7,71 @@ package tunnel_config;
 service PostQuantumSecure {
   // PskExchangeExperimentalV0 uses the common API defined by LibOQS.  See:
   // https://github.com/open-quantum-safe/liboqs
+  // This endpoint is deprecated in favor for `PskExchangeExperimentalV1`. Please use that instead.
   rpc PskExchangeExperimentalV0(PskRequestExperimentalV0) returns (PskResponseExperimentalV0) {}
+
+  // Allows deriving a preshared key (PSK) using one or multiple PQ-secure key-encapsulation
+  // mechanisms (KEM). The preshared key is added to WireGuard's preshared-key field in a new
+  // ephemeral peer (PQ-peer). This makes the tunnel resistant towards attacks using
+  // quantum computers.
+  //
+  // The VPN server associates the PQ-peer with the peer who performed the exchange. Any
+  // already existing PQ-peer for the normal peer is replaced. Each normal peer can have
+  // at most one PQ-peer.
+  //
+  // The PQ-peer is mutually exclusive to the normal peer. The server keeps both peers in memory,
+  // but only one of them is loaded into WireGuard at any point in time. A handshake from the
+  // normal peer unloads the corresponding PQ-peer from WireGuard and vice versa.
+  //
+  // A new peer is negotiated for PQ to avoid a premature break of the tunnel used for negotiation.
+  // A tunnel would break prematurely if the preshared key is applied before the normal peer
+  // received the server's contribution to the KEM exchange. This cannot occur now because
+  // the client decides when to switch to the PQ-secure tunnel. This design also allows
+  // the client to switch back to using a non-PQ-secure tunnel at any point.
+  //
+  // The negotiated PQ-peer is ephemeral. The server gives no guarantees how long it will be
+  // valid and working. The client should negotiate a new PQ-peer every time it establishes a new
+  // tunnel to the server.
+  //
+  // The full exchange requires just a single request-response round trip between the VPN client
+  // and the VPN server.
+  //
+  // # Request-response format
+  //
+  // The request from the VPN client contains:
+  //   * `wg_pubkey` - The public key used by the current tunnel (that the request travels inside).
+  //   * `wg_psk_pubkey` - A newly generated ephemeral WireGuard public key for the PQ-peer.
+  //     The server will associate the derived PSK with this public key.
+  //   * `kem_pubkeys` - A list describing the KEM algorithms. Must have at least one entry.
+  //                     The same KEM must not be listed more than once. Each list item contains:
+  //     * `algorithm_name` - The name of the KEM, including which variant. Should be the same
+  //       name/format that `liboqs` uses.
+  //     * `key_data` - The client's public key for this KEM. Will be used by the server to
+  //       encapsulate the shared secret for this KEM.
+  //
+  // The response from the VPN server contains:
+  //   * `ciphertexts` - A list of the ciphertexts (the encapsulated shared secrets) for all
+  //     public keys in `kem_pubkeys` in the request, in the same order as in the request.
+  //
+  // # Deriving the WireGuard PSK
+  //
+  // The PSK to be used in WireGuard's preshared-key field is computed by XORing the resulting
+  // shared secrets of all the KEM algorithms. All currently supported and planned to be
+  // supported algorithms output 32 bytes, so this is trivial.
+  //
+  // Since the PSK provided to WireGuard is directly fed into a HKDF, it is not important that
+  // the entropy in the PSK is uniformly distributed. The actual keys used for encrypting the
+  // data channel will have uniformly distributed entropy anyway, thanks to the HKDF.
+  // But even if that was not true, since both CME and Kyber run SHAKE256 as the last step
+  // of their internal key derivation, the output they produce are uniformly distributed.
+  //
+  // If we later want to support another type of KEM that produce longer or shorter output,
+  // we can hash that secret into a 32 byte hash before proceeding to the XOR step.
+  //
+  // Mixing with XOR (A = B ^ C) is fine since nothing about A is revealed even if one of B or C
+  // is known. Both B *and* C must be known to compute any bit in A. This means all involved
+  // KEM algorithms must be broken before the PSK can be computed by an attacker.
+  rpc PskExchangeExperimentalV1(PskRequestExperimentalV1) returns (PskResponseExperimentalV1) {}
 }
 
 message PskRequestExperimentalV0 {
@@ -35,4 +87,19 @@ message KemPubkeyExperimentalV0 {
 
 message PskResponseExperimentalV0 {
   bytes ciphertext = 1;
+}
+
+message PskRequestExperimentalV1 {
+  bytes wg_pubkey = 1;
+  bytes wg_psk_pubkey = 2;
+  repeated KemPubkeyExperimentalV1 kem_pubkeys = 3;
+}
+
+message KemPubkeyExperimentalV1 {
+  string algorithm_name = 1;
+  bytes key_data = 2;
+}
+
+message PskResponseExperimentalV1 {
+  repeated bytes ciphertexts = 1;
 }

--- a/talpid-tunnel-config-client/src/classic_mceliece.rs
+++ b/talpid-tunnel-config-client/src/classic_mceliece.rs
@@ -1,5 +1,9 @@
 use classic_mceliece_rust::{keypair_boxed, SharedSecret};
 
+/// The `keypair_boxed` function needs just under 1 MiB of stack in debug
+/// builds. Even though it probably works to run it directly on the main
+/// thread on all OSes, we take this precaution and always generate the huge
+/// keys on a separate thread with a large enough stack.
 const STACK_SIZE: usize = 2 * 1024 * 1024;
 
 pub use classic_mceliece_rust::{Ciphertext, PublicKey, SecretKey, CRYPTO_CIPHERTEXTBYTES};

--- a/talpid-tunnel-config-client/src/classic_mceliece.rs
+++ b/talpid-tunnel-config-client/src/classic_mceliece.rs
@@ -1,5 +1,4 @@
-use classic_mceliece_rust::keypair_boxed;
-use talpid_types::net::wireguard::PresharedKey;
+use classic_mceliece_rust::{keypair_boxed, SharedSecret};
 
 const STACK_SIZE: usize = 2 * 1024 * 1024;
 
@@ -19,7 +18,6 @@ pub async fn generate_keys() -> (PublicKey<'static>, SecretKey<'static>) {
     rx.await.unwrap()
 }
 
-pub fn decapsulate(secret: &SecretKey, ciphertext: &Ciphertext) -> PresharedKey {
-    let shared_secret = classic_mceliece_rust::decapsulate_boxed(ciphertext, secret);
-    PresharedKey::from(*shared_secret.as_array())
+pub fn decapsulate(secret: &SecretKey, ciphertext: &Ciphertext) -> SharedSecret<'static> {
+    classic_mceliece_rust::decapsulate_boxed(ciphertext, secret)
 }

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -84,7 +84,9 @@ pub async fn push_pq_key(
         }
     })?;
 
-    let mut psk_data = [0u8; 32];
+    // Store the PSK data on the heap. So it can be passed around and then zeroized on drop without
+    // being stored in a bunch of places on the stack.
+    let mut psk_data = Box::new([0u8; 32]);
     // Decapsulate Classic McEliece and mix into PSK
     {
         let ciphertext_array =

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.13"
 x25519-dalek = { version = "2.0.0-pre.1" }
 rand = "0.8.5"
 err-derive = "0.3.1"
+zeroize = "1.5.7"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.5", features = ["derive"] }


### PR DESCRIPTION
Work in progress! Coming up with the new `PostQuantumSecure` proto definition for the next iteration of the post quantum secure tunnels.

The changes/improvements from the last/current iteration include:

* Change the used CME variant to `Classic-McEliece-460896f`. This has significantly smaller keys that take significantly less time to generate. Feedback from the people behind the CME algorithm tell us this is safe enough.
* Make the protocol allow multiple KEMs in the same key exchange request. This allows future apps to mix two types of PQ secure KEMs in case one of them proves to be weak over time.

### Why the CME variant with the `f` at the end?

The variant with the “f” at the end uses a semi-systematic matrix as part of the key generation process. Empirical benchmarking has shown that the variant with suffix "f" is slightly faster in its key-generation compared to the systematic variant (the one without the "f" suffix).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3946)
<!-- Reviewable:end -->
