### PR TITLE
Add e2e test for account expiry notifications

### DIFF
--- a/gui/src/renderer/components/NotificationArea.tsx
+++ b/gui/src/renderer/components/NotificationArea.tsx
@@ -96,11 +96,18 @@ export default function NotificationArea(props: IProps) {
 
     if (notification) {
       return (
-        <NotificationBanner className={props.className}>
-          <NotificationIndicator $type={notification.indicator} />
+        <NotificationBanner className={props.className} data-testid="notificationBanner">
+          <NotificationIndicator
+            $type={notification.indicator}
+            data-testid="notificationIndicator"
+          />
           <NotificationContent role="status" aria-live="polite">
-            <NotificationTitle>{notification.title}</NotificationTitle>
-            <NotificationSubtitle>{formatHtml(notification.subtitle ?? '')}</NotificationSubtitle>
+            <NotificationTitle data-testid="notificationTitle">
+              {notification.title}
+            </NotificationTitle>
+            <NotificationSubtitle data-testid="notificationSubTitle">
+              {formatHtml(notification.subtitle ?? '')}
+            </NotificationSubtitle>
           </NotificationContent>
           {notification.action && <NotificationActionWrapper action={notification.action} />}
         </NotificationBanner>

--- a/gui/test/e2e/mocked/notifications.spec.ts
+++ b/gui/test/e2e/mocked/notifications.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+import { Page } from 'playwright';
+
+import { colors } from '../../../src/config.json';
+import { IAccountData } from '../../../src/shared/daemon-rpc-types';
+import { getBackgroundColor } from '../utils';
+import { MockedTestUtils, startMockedApp } from './mocked-utils';
+
+let page: Page;
+let util: MockedTestUtils;
+
+test.beforeAll(async () => {
+  ({ page, util } = await startMockedApp());
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+/**
+ * Expires soon
+ */
+test('App should notify user about account expiring soon', async () => {
+  await util.sendMockIpcResponse<IAccountData>({
+    channel: 'account-',
+    response: { expiry: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString() },
+  });
+
+  const title = page.getByTestId('notificationTitle');
+  await expect(title).toContainText(/account credit expires soon/i);
+
+  let subTitle = page.getByTestId('notificationSubTitle');
+  await expect(subTitle).toContainText(/1 day left\. buy more credit\./i);
+
+  const indicator = page.getByTestId('notificationIndicator');
+  const indicatorColor = await getBackgroundColor(indicator);
+  expect(indicatorColor).toBe(colors.yellow);
+
+  await util.sendMockIpcResponse<IAccountData>({
+    channel: 'account-',
+    response: { expiry: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString() },
+  });
+  subTitle = page.getByTestId('notificationSubTitle');
+  await expect(subTitle).toContainText(/2 days left\. buy more credit\./i);
+
+  await util.sendMockIpcResponse<IAccountData>({
+    channel: 'account-',
+    response: { expiry: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString() },
+  });
+  subTitle = page.getByTestId('notificationSubTitle');
+  await expect(subTitle).toContainText(/less than a day left\. buy more credit\./i);
+});


### PR DESCRIPTION
This PR adds an e2e test to verify the output of notifications when an account is close to expire.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/spreadsheets/d/1JeWs5Fzen2oWrMCmZKvue_iAM4VUlhwTWnodBQYz0c0/edit#gid=1649013858
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3947)
<!-- Reviewable:end -->
