### PR TITLE
Add custom overlays above labels

### DIFF
--- a/ios/MullvadVPN/ConnectViewController.swift
+++ b/ios/MullvadVPN/ConnectViewController.swift
@@ -518,7 +518,7 @@ class ConnectViewController: UIViewController, MKMapViewDelegate, RootContainmen
         // Replace the default map tiles
         tileOverlay.canReplaceMapContent = true
 
-        contentView.mapView.addOverlay(tileOverlay)
+        contentView.mapView.addOverlay(tileOverlay, level: .aboveLabels)
     }
 
     private func loadGeoJSONData() {
@@ -534,7 +534,7 @@ class ConnectViewController: UIViewController, MKMapViewDelegate, RootContainmen
             let data = try Data(contentsOf: fileURL)
             let overlays = try GeoJSON.decodeGeoJSON(data)
 
-            contentView.mapView.addOverlays(overlays)
+            contentView.mapView.addOverlays(overlays, level: .aboveLabels)
         } catch {
             logger.error(chainedError: AnyChainedError(error), message: "Failed to load geojson.")
         }


### PR DESCRIPTION
It looks like I made a mistake assuming that map labels aren't entirely disabled when using custom overlay replacing map content. This PR adds custom overlays above labels to hide them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3949)
<!-- Reviewable:end -->
