### PR TITLE
Add custom port option for WireGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add custom option to WireGuard port selector.
+
 ### Fixed
 
 #### macOS

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -114,6 +114,9 @@ msgstr ""
 msgid "CREATING SECURE CONNECTION"
 msgstr ""
 
+msgid "Custom"
+msgstr ""
+
 msgid "Default"
 msgstr ""
 
@@ -1510,6 +1513,14 @@ msgstr ""
 #. The hint displayed below the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from a wide range of ports."
+msgstr ""
+
+msgctxt "wireguard-settings-view"
+msgid "The automatic setting will randomly choose from the valid port ranges shown below."
+msgstr ""
+
+msgctxt "wireguard-settings-view"
+msgid "The custom port can be any value inside the valid ranges: %(portRanges)s."
 msgstr ""
 
 #. The hint displayed below the WireGuard IP version selector.

--- a/gui/src/main/relay-list.ts
+++ b/gui/src/main/relay-list.ts
@@ -1,12 +1,26 @@
-import { BridgeState, IRelayList, liftConstraint, RelaySettings } from '../shared/daemon-rpc-types';
+import {
+  BridgeState,
+  IRelayList,
+  IRelayListWithEndpointData,
+  liftConstraint,
+  RelaySettings,
+} from '../shared/daemon-rpc-types';
 import { IRelayListPair } from '../shared/ipc-schema';
 import { IpcMainEventChannel } from './ipc-event-channel';
 
 export default class RelayList {
-  private relays: IRelayList = { countries: [] };
+  private relays: IRelayListWithEndpointData = {
+    relayList: {
+      countries: [],
+    },
+    wireguardEndpointData: {
+      portRanges: [],
+      udp2tcpPorts: [],
+    },
+  };
 
   public setRelays(
-    newRelayList: IRelayList,
+    newRelayList: IRelayListWithEndpointData,
     relaySettings: RelaySettings,
     bridgeState: BridgeState,
   ) {
@@ -25,14 +39,18 @@ export default class RelayList {
   }
 
   private processRelays(
-    relayList: IRelayList,
+    relayList: IRelayListWithEndpointData,
     relaySettings: RelaySettings,
     bridgeState: BridgeState,
   ): IRelayListPair {
-    const filteredRelays = this.processRelaysForPresentation(relayList, relaySettings);
-    const filteredBridges = this.processBridgesForPresentation(relayList, bridgeState);
+    const filteredRelays = this.processRelaysForPresentation(relayList.relayList, relaySettings);
+    const filteredBridges = this.processBridgesForPresentation(relayList.relayList, bridgeState);
 
-    return { relays: filteredRelays, bridges: filteredBridges };
+    return {
+      relays: filteredRelays,
+      bridges: filteredBridges,
+      wireguardEndpointData: relayList.wireguardEndpointData,
+    };
   }
 
   private processRelaysForPresentation(
@@ -75,9 +93,7 @@ export default class RelayList {
       }))
       .filter((country) => country.cities.length > 0);
 
-    return {
-      countries: filteredCountries,
-    };
+    return { countries: filteredCountries };
   }
 
   private processBridgesForPresentation(

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -849,6 +849,9 @@ export default class AppRenderer {
 
     this.reduxActions.settings.updateRelayLocations(relays);
     this.reduxActions.settings.updateBridgeLocations(bridges);
+    this.reduxActions.settings.updateWireguardEndpointData(
+      this.relayListPair.wireguardEndpointData,
+    );
   }
 
   private setCurrentVersion(versionInfo: ICurrentAppVersionInfo) {

--- a/gui/src/renderer/components/Filter.tsx
+++ b/gui/src/renderer/components/Filter.tsx
@@ -191,10 +191,6 @@ function FilterByOwnership(props: IFilterByOwnershipProps) {
     () =>
       [
         {
-          label: messages.gettext('Any'),
-          value: Ownership.any,
-        },
-        {
           label: messages.pgettext('filter-view', 'Mullvad owned only'),
           value: Ownership.mullvadOwned,
         },
@@ -220,7 +216,13 @@ function FilterByOwnership(props: IFilterByOwnershipProps) {
       </Cell.CellButton>
 
       <Accordion expanded={expanded}>
-        <StyledSelector values={values} value={props.ownership} onSelect={props.setOwnership} />
+        <StyledSelector
+          items={values}
+          value={props.ownership}
+          onSelect={props.setOwnership}
+          automaticLabel={messages.gettext('Any')}
+          automaticValue={Ownership.any}
+        />
       </Accordion>
     </AriaInputGroup>
   );

--- a/gui/src/renderer/components/SelectLanguage.tsx
+++ b/gui/src/renderer/components/SelectLanguage.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { messages } from '../../shared/gettext';
 import { AriaInputGroup } from './AriaGroup';
-import Selector, { ISelectorItem } from './cell/Selector';
+import Selector, { SelectorItem } from './cell/Selector';
 import { CustomScrollbarsRef } from './CustomScrollbars';
 import { BackAction } from './KeyboardNavigation';
 import { Layout, SettingsContainer } from './Layout';
@@ -24,7 +24,7 @@ interface IProps {
 }
 
 interface IState {
-  source: Array<ISelectorItem<string>>;
+  source: Array<SelectorItem<string>>;
 }
 
 const StyledNavigationScrollbars = styled(NavigationScrollbars)({
@@ -79,7 +79,7 @@ export default class SelectLanguage extends React.Component<IProps, IState> {
                 <AriaInputGroup>
                   <StyledSelector
                     title=""
-                    values={this.state.source}
+                    items={this.state.source}
                     value={this.props.preferredLocale}
                     onSelect={this.props.setPreferredLocale}
                     selectedCellRef={this.selectedCellRef}

--- a/gui/src/renderer/components/VpnSettings.tsx
+++ b/gui/src/renderer/components/VpnSettings.tsx
@@ -17,7 +17,7 @@ import { useSelector } from '../redux/store';
 import * as AppButton from './AppButton';
 import { AriaDescription, AriaDetails, AriaInput, AriaInputGroup, AriaLabel } from './AriaGroup';
 import * as Cell from './cell';
-import Selector, { ISelectorItem } from './cell/Selector';
+import Selector, { SelectorItem } from './cell/Selector';
 import CustomDnsSettings from './CustomDnsSettings';
 import InfoButton, { InfoIcon } from './InfoButton';
 import { BackAction } from './KeyboardNavigation';
@@ -612,10 +612,10 @@ function TunnelProtocolSetting() {
   );
   const { updateRelaySettings } = useAppContext();
 
-  const setTunnelProtocol = useCallback(async (tunnelProtocol: TunnelProtocol | undefined) => {
+  const setTunnelProtocol = useCallback(async (tunnelProtocol: TunnelProtocol | null) => {
     const relayUpdate = RelaySettingsBuilder.normal()
       .tunnel.tunnelProtocol((config) => {
-        if (tunnelProtocol) {
+        if (tunnelProtocol !== null) {
           config.tunnelProtocol.exact(tunnelProtocol);
         } else {
           config.tunnelProtocol.any();
@@ -630,12 +630,8 @@ function TunnelProtocolSetting() {
     }
   }, []);
 
-  const tunnelProtocolItems: Array<ISelectorItem<TunnelProtocol | undefined>> = useMemo(
+  const tunnelProtocolItems: Array<SelectorItem<TunnelProtocol>> = useMemo(
     () => [
-      {
-        label: messages.gettext('Automatic'),
-        value: undefined,
-      },
       {
         label: strings.wireguard,
         value: 'wireguard',
@@ -653,9 +649,10 @@ function TunnelProtocolSetting() {
       <StyledSelectorContainer>
         <Selector
           title={messages.pgettext('vpn-settings-view', 'Tunnel protocol')}
-          values={tunnelProtocolItems}
-          value={tunnelProtocol}
+          items={tunnelProtocolItems}
+          value={tunnelProtocol ?? null}
           onSelect={setTunnelProtocol}
+          automaticValue={null}
         />
       </StyledSelectorContainer>
     </AriaInputGroup>

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import log from '../../shared/logging';
+import { removeNonNumericCharacters } from '../../shared/string-helpers';
 import { useAppContext } from '../context';
 import { createWireguardRelayUpdater } from '../lib/constraint-updater';
 import { useHistory } from '../lib/history';
@@ -19,7 +20,7 @@ import { useSelector } from '../redux/store';
 import * as AppButton from './AppButton';
 import { AriaDescription, AriaInput, AriaInputGroup, AriaLabel } from './AriaGroup';
 import * as Cell from './cell';
-import Selector, { ISelectorItem } from './cell/Selector';
+import Selector, { SelectorItem } from './cell/Selector';
 import { InfoIcon } from './InfoButton';
 import { BackAction } from './KeyboardNavigation';
 import { Layout, SettingsContainer } from './Layout';
@@ -38,10 +39,7 @@ const MAX_WIREGUARD_MTU_VALUE = 1420;
 const WIREUGARD_UDP_PORTS = [51820, 53];
 const UDP2TCP_PORTS = [80, 443, 5001];
 
-type OptionalPort = number | undefined;
-type OptionalIpVersion = IpVersion | undefined;
-
-function mapPortToSelectorItem(value: number): ISelectorItem<number> {
+function mapPortToSelectorItem(value: number): SelectorItem<number> {
   return { label: value.toString(), value };
 }
 
@@ -132,25 +130,21 @@ function PortSelector() {
   const relaySettings = useSelector((state) => state.settings.relaySettings);
   const { updateRelaySettings } = useAppContext();
 
-  const wireguardPortItems = useMemo(() => {
-    const automaticPort: ISelectorItem<OptionalPort> = {
-      label: messages.gettext('Automatic'),
-      value: undefined,
-    };
-
-    return [automaticPort].concat(WIREUGARD_UDP_PORTS.map(mapPortToSelectorItem));
-  }, []);
+  const wireguardPortItems = useMemo<Array<SelectorItem<number>>>(
+    () => WIREUGARD_UDP_PORTS.map(mapPortToSelectorItem),
+    [],
+  );
 
   const port = useMemo(() => {
-    const port = 'normal' in relaySettings ? relaySettings.normal.wireguard.port : undefined;
-    return port === 'any' ? undefined : port;
+    const port = 'normal' in relaySettings ? relaySettings.normal.wireguard.port : 'any';
+    return port === 'any' ? null : port;
   }, [relaySettings]);
 
   const setWireguardPort = useCallback(
-    async (port?: number) => {
+    async (port: number | null) => {
       const relayUpdate = createWireguardRelayUpdater(relaySettings)
         .tunnel.wireguard((wireguard) => {
-          if (port) {
+          if (port !== null) {
             wireguard.port.exact(port);
           } else {
             wireguard.port.any();
@@ -173,9 +167,26 @@ function PortSelector() {
         <Selector
           // TRANSLATORS: The title for the WireGuard port selector.
           title={messages.pgettext('wireguard-settings-view', 'Port')}
-          values={wireguardPortItems}
+          items={wireguardPortItems}
           value={port}
           onSelect={setWireguardPort}
+          automaticValue={null}
+          details={
+            <>
+              <ModalMessage>
+                {messages.pgettext(
+                  'wireguard-settings-view',
+                  'The automatic setting will randomly choose from the valid port ranges shown below.',
+                )}
+              </ModalMessage>
+              <ModalMessage>
+                {messages.pgettext(
+                  'wireguard-settings-view',
+                  'The custom port can be any value inside the valid ranges: 53, 4000-33433, 33565-51820, 52000-60000.',
+                )}
+              </ModalMessage>
+            </>
+          }
         />
       </StyledSelectorContainer>
       <Cell.Footer>
@@ -200,12 +211,8 @@ function ObfuscationSettings() {
   const obfuscationSettings = useSelector((state) => state.settings.obfuscationSettings);
 
   const obfuscationType = obfuscationSettings.selectedObfuscation;
-  const obfuscationTypeItems: ISelectorItem<ObfuscationType>[] = useMemo(
+  const obfuscationTypeItems: SelectorItem<ObfuscationType>[] = useMemo(
     () => [
-      {
-        label: messages.gettext('Automatic'),
-        value: ObfuscationType.auto,
-      },
       {
         label: messages.pgettext('wireguard-settings-view', 'On (UDP-over-TCP)'),
         value: ObfuscationType.udp2tcp,
@@ -242,9 +249,10 @@ function ObfuscationSettings() {
               )}
             </ModalMessage>
           }
-          values={obfuscationTypeItems}
+          items={obfuscationTypeItems}
           value={obfuscationType}
           onSelect={selectObfuscationType}
+          automaticValue={ObfuscationType.auto}
         />
       </StyledSelectorContainer>
     </AriaInputGroup>
@@ -256,14 +264,10 @@ function Udp2tcpPortSetting() {
   const obfuscationSettings = useSelector((state) => state.settings.obfuscationSettings);
 
   const port = liftConstraint(obfuscationSettings.udp2tcpSettings.port);
-  const portItems: ISelectorItem<LiftedConstraint<number>>[] = useMemo(() => {
-    const automaticItem: ISelectorItem<LiftedConstraint<number>> = {
-      label: messages.gettext('Automatic'),
-      value: 'any',
-    };
-
-    return [automaticItem].concat(UDP2TCP_PORTS.map(mapPortToSelectorItem));
-  }, []);
+  const portItems: SelectorItem<number>[] = useMemo(
+    () => UDP2TCP_PORTS.map(mapPortToSelectorItem),
+    [],
+  );
 
   const selectPort = useCallback(
     async (port: LiftedConstraint<number>) => {
@@ -292,12 +296,13 @@ function Udp2tcpPortSetting() {
               )}
             </ModalMessage>
           }
-          values={portItems}
+          items={portItems}
           value={port}
           onSelect={selectPort}
           disabled={obfuscationSettings.selectedObfuscation === ObfuscationType.off}
           expandable
           thinTitle
+          automaticValue={'any' as const}
         />
       </StyledSelectorContainer>
     </AriaInputGroup>
@@ -401,17 +406,12 @@ function IpVersionSetting() {
   const { updateRelaySettings } = useAppContext();
   const relaySettings = useSelector((state) => state.settings.relaySettings);
   const ipVersion = useMemo(() => {
-    const ipVersion =
-      'normal' in relaySettings ? relaySettings.normal.wireguard.ipVersion : undefined;
-    return ipVersion === 'any' ? undefined : ipVersion;
+    const ipVersion = 'normal' in relaySettings ? relaySettings.normal.wireguard.ipVersion : 'any';
+    return ipVersion === 'any' ? null : ipVersion;
   }, [relaySettings]);
 
-  const ipVersionItems: ISelectorItem<OptionalIpVersion>[] = useMemo(
+  const ipVersionItems: SelectorItem<IpVersion>[] = useMemo(
     () => [
-      {
-        label: messages.gettext('Automatic'),
-        value: undefined,
-      },
       {
         label: messages.gettext('IPv4'),
         value: 'ipv4',
@@ -425,10 +425,10 @@ function IpVersionSetting() {
   );
 
   const setIpVersion = useCallback(
-    async (ipVersion?: IpVersion) => {
+    async (ipVersion: IpVersion | null) => {
       const relayUpdate = createWireguardRelayUpdater(relaySettings)
         .tunnel.wireguard((wireguard) => {
-          if (ipVersion) {
+          if (ipVersion !== null) {
             wireguard.ipVersion.exact(ipVersion);
           } else {
             wireguard.ipVersion.any();
@@ -451,9 +451,10 @@ function IpVersionSetting() {
         <Selector
           // TRANSLATORS: The title for the WireGuard IP version selector.
           title={messages.pgettext('wireguard-settings-view', 'IP version')}
-          values={ipVersionItems}
+          items={ipVersionItems}
           value={ipVersion}
           onSelect={setIpVersion}
+          automaticValue={null}
         />
       </StyledSelectorContainer>
       <Cell.Footer>
@@ -474,10 +475,6 @@ function IpVersionSetting() {
       </Cell.Footer>
     </AriaInputGroup>
   );
-}
-
-function removeNonNumericCharacters(value: string) {
-  return value.replace(/[^0-9]/g, '');
 }
 
 function mtuIsValid(mtu: string): boolean {

--- a/gui/src/renderer/redux/settings/actions.ts
+++ b/gui/src/renderer/redux/settings/actions.ts
@@ -1,5 +1,10 @@
 import { IWindowsApplication } from '../../../shared/application-types';
-import { BridgeState, IDnsOptions, ObfuscationSettings } from '../../../shared/daemon-rpc-types';
+import {
+  BridgeState,
+  IDnsOptions,
+  IWireguardEndpointData,
+  ObfuscationSettings,
+} from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
 import { BridgeSettingsRedux, IRelayLocationRedux, RelaySettingsRedux } from './reducers';
 
@@ -21,6 +26,11 @@ export interface IUpdateRelayLocationsAction {
 export interface IUpdateBridgeLocationsAction {
   type: 'UPDATE_BRIDGE_LOCATIONS';
   bridgeLocations: IRelayLocationRedux[];
+}
+
+export interface IUpdateWireguardEndpointData {
+  type: 'UPDATE_WIREGUARD_ENDPOINT_DATA';
+  wireguardEndpointData: IWireguardEndpointData;
 }
 
 export interface IUpdateAllowLanAction {
@@ -93,6 +103,7 @@ export type SettingsAction =
   | IUpdateRelayAction
   | IUpdateRelayLocationsAction
   | IUpdateBridgeLocationsAction
+  | IUpdateWireguardEndpointData
   | IUpdateAllowLanAction
   | IUpdateEnableIpv6Action
   | IUpdateBlockWhenDisconnectedAction
@@ -134,6 +145,15 @@ function updateBridgeLocations(
   return {
     type: 'UPDATE_BRIDGE_LOCATIONS',
     bridgeLocations,
+  };
+}
+
+function updateWireguardEndpointData(
+  wireguardEndpointData: IWireguardEndpointData,
+): IUpdateWireguardEndpointData {
+  return {
+    type: 'UPDATE_WIREGUARD_ENDPOINT_DATA',
+    wireguardEndpointData,
   };
 }
 
@@ -239,6 +259,7 @@ export default {
   updateRelay,
   updateRelayLocations,
   updateBridgeLocations,
+  updateWireguardEndpointData,
   updateAllowLan,
   updateEnableIpv6,
   updateBlockWhenDisconnected,

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -3,6 +3,7 @@ import {
   BridgeState,
   IDnsOptions,
   IpVersion,
+  IWireguardEndpointData,
   LiftedConstraint,
   ObfuscationSettings,
   ObfuscationType,
@@ -82,6 +83,7 @@ export interface ISettingsReduxState {
   relaySettings: RelaySettingsRedux;
   relayLocations: IRelayLocationRedux[];
   bridgeLocations: IRelayLocationRedux[];
+  wireguardEndpointData: IWireguardEndpointData;
   allowLan: boolean;
   enableIpv6: boolean;
   bridgeSettings: BridgeSettingsRedux;
@@ -127,6 +129,7 @@ const initialState: ISettingsReduxState = {
   },
   relayLocations: [],
   bridgeLocations: [],
+  wireguardEndpointData: { portRanges: [], udp2tcpPorts: [] },
   allowLan: false,
   enableIpv6: true,
   bridgeSettings: {
@@ -189,6 +192,12 @@ export default function (
       return {
         ...state,
         bridgeLocations: action.bridgeLocations,
+      };
+
+    case 'UPDATE_WIREGUARD_ENDPOINT_DATA':
+      return {
+        ...state,
+        wireguardEndpointData: action.wireguardEndpointData,
       };
 
     case 'UPDATE_ALLOW_LAN':

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -119,7 +119,7 @@ export interface IProxyEndpoint {
 export type DaemonEvent =
   | { tunnelState: TunnelState }
   | { settings: ISettings }
-  | { relayList: IRelayList }
+  | { relayList: IRelayListWithEndpointData }
   | { appVersionInfo: IAppVersionInfo }
   | { device: DeviceEvent }
   | { deviceRemoval: Array<IDevice> };
@@ -224,8 +224,18 @@ export type RelaySettingsUpdate =
       customTunnelEndpoint: IRelaySettingsCustom;
     };
 
+export interface IRelayListWithEndpointData {
+  relayList: IRelayList;
+  wireguardEndpointData: IWireguardEndpointData;
+}
+
 export interface IRelayList {
   countries: IRelayListCountry[];
+}
+
+export interface IWireguardEndpointData {
+  portRanges: [number, number][];
+  udp2tcpPorts: number[];
 }
 
 export interface IRelayListCountry {

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -15,6 +15,7 @@ import {
   ILocation,
   IRelayList,
   ISettings,
+  IWireguardEndpointData,
   ObfuscationSettings,
   RelaySettingsUpdate,
   TunnelState,
@@ -45,6 +46,7 @@ export interface ITranslations {
 export interface IRelayListPair {
   relays: IRelayList;
   bridges: IRelayList;
+  wireguardEndpointData: IWireguardEndpointData;
 }
 
 export type LaunchApplicationResult = { success: true } | { error: string };

--- a/gui/src/shared/string-helpers.ts
+++ b/gui/src/shared/string-helpers.ts
@@ -5,3 +5,7 @@ export function capitalize(inputString: string): string {
 export function capitalizeEveryWord(inputString: string): string {
   return inputString.split(' ').map(capitalize).join(' ');
 }
+
+export function removeNonNumericCharacters(value: string) {
+  return value.replace(/[^0-9]/g, '');
+}

--- a/gui/test/e2e/setup/main.ts
+++ b/gui/test/e2e/setup/main.ts
@@ -10,6 +10,7 @@ import {
   IAppVersionInfo,
   ILocation,
   IRelayList,
+  IWireguardEndpointData,
 } from '../../../src/shared/daemon-rpc-types';
 import { messages, relayLocations } from '../../../src/shared/gettext';
 import { IGuiSettingsState } from '../../../src/shared/gui-settings-state';
@@ -101,6 +102,11 @@ class ApplicationMain {
     ],
   };
 
+  private wireguardEndpointData: IWireguardEndpointData = {
+    portRanges: [],
+    udp2tcpPorts: [],
+  };
+
   public constructor() {
     app.enableSandbox();
     app.on('ready', this.onReady);
@@ -153,7 +159,11 @@ class ApplicationMain {
       settings: this.settings,
       isPerformingPostUpgrade: false,
       deviceState: this.deviceState,
-      relayListPair: { relays: this.relayList, bridges: this.relayList },
+      relayListPair: {
+        relays: this.relayList,
+        bridges: this.relayList,
+        wireguardEndpointData: this.wireguardEndpointData,
+      },
       currentVersion: this.currentVersion,
       upgradeVersion: this.upgradeVersion,
       guiSettings: this.guiSettings,


### PR DESCRIPTION
This PR adds the ability to add custom options to the `Selector` component and uses it for the WireGuard port selector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3950)
<!-- Reviewable:end -->
