### PR TITLE
Bump binaries subrepo to fix MUL22-01 (win-split-tunneling upgrade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ Line wrap the file at 100 chars.                                              Th
   system service is being stopped by the user intentionally. This is to prevent leaks that might
   occur during system shutdown.
 
+#### Windows
+- Fix incomplete validation of input buffers in `win-split-tunnel` driver that could result
+  in out-of-bounds reads. Fixes 2022 Mullvad app audit issue item `MUL22-01`.
+
 #### Linux
 - Added traffic blocking during early boot, before the daemon starts, to prevent leaks in the case
   that the system service starts after a networking daemon has already configured a network


### PR DESCRIPTION
Just bumps the binaries submodule to get the new split tunneling driver for Windows that fixes *MUL22-01*. See https://github.com/mullvad/mullvadvpn-app-binaries/pull/98

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3951)
<!-- Reviewable:end -->
