### PR TITLE
Fix fish completions path on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ Line wrap the file at 100 chars.                                              Th
   it was successful.
 - Don't fail install if the device tree contains nameless callout driver devices.
 
+#### macOS
+- Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.
+
 ### Security
 - When the system process is being shut down and the target state is _secured_, maintain the
   blocking firewall rules unless it's possible to deduce that the system isn't shutting down and the

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -49,7 +49,16 @@ EOM
 )
 
 ZSH_COMPLETIONS_DIR="/usr/local/share/zsh/site-functions/"
-FISH_COMPLETIONS_DIR="/usr/local/share/fish/vendor_completions.d/"
+
+BREW_PREFIX=$(brew --prefix)
+if [[ "$?" -eq 0 ]]; then
+    FISH_COMPLETIONS_DIR="${BREW_PREFIX}/share/fish/vendor_completions.d/"
+    if [[ ! -d "$FISH_COMPLETIONS_DIR" ]]; then
+        FISH_COMPLETIONS_DIR="/usr/local/share/fish/vendor_completions.d/"
+    fi
+else
+    FISH_COMPLETIONS_DIR="/usr/local/share/fish/vendor_completions.d/"
+fi
 
 launchctl unload -w $DAEMON_PLIST_PATH
 cp "$LOG_DIR/daemon.log" "$LOG_DIR/old-install-daemon.log" \
@@ -66,9 +75,9 @@ mkdir -p /usr/local/bin
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad" /usr/local/bin/mullvad
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-problem-report" /usr/local/bin/mullvad-problem-report
 
-if [ -d "$FISH_COMPLETIONS_DIR" ]; then
-    ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad.fish" $FISH_COMPLETIONS_DIR
-fi
-
 mkdir -p "$ZSH_COMPLETIONS_DIR"
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/_mullvad" "$ZSH_COMPLETIONS_DIR/_mullvad"
+
+if [[ -d "$FISH_COMPLETIONS_DIR" ]]; then
+    ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad.fish" "$FISH_COMPLETIONS_DIR/mullvad.fish"
+fi

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -28,11 +28,15 @@ sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup remove-devi
 echo "Removing zsh shell completion symlink ..."
 sudo rm -f /usr/local/share/zsh/site-functions/_mullvad
 
-FISH_COMPLETIONS_PATH="/usr/local/share/fish/vendor_completions.d/mullvad.fish"
-if [ -h "$FISH_COMPLETIONS_PATH" ]; then
-    echo "Removing fish shell completion symlink ..."
+echo "Removing fish shell completion symlink ..."
+
+BREW_PREFIX=$(brew --prefix)
+if [[ "$?" -eq 0 ]]; then
+    FISH_COMPLETIONS_PATH="${BREW_PREFIX}/share/fish/vendor_completions.d/mullvad.fish"
     sudo rm -f "$FISH_COMPLETIONS_PATH"
 fi
+FISH_COMPLETIONS_PATH="/usr/local/share/fish/vendor_completions.d/mullvad.fish"
+sudo rm -f "$FISH_COMPLETIONS_PATH"
 
 echo "Removing CLI symlinks from /usr/local/bin/ ..."
 sudo rm -f /usr/local/bin/mullvad /usr/local/bin/mullvad-problem-report


### PR DESCRIPTION
`/usr/local/share/fish/vendor_completions.d/` does not exist in `$fish_complete_path` on Apple Silicon Macs, as ARM binaries reside in `/opt/homebrew`. This PR creates a link to the completions in `$(brew --prefix)/share/fish/vendor_completions.d/` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3954)
<!-- Reviewable:end -->
