### PR TITLE
Detect missing changelog entries for Android correctly in prepare release script

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -77,18 +77,27 @@ fi
 set -e
 
 echo "Commiting metadata changes to git..."
-git commit -S -m "Updating version in package files" \
-    gui/package.json \
-    gui/package-lock.json \
+
+git commit -S -m "Update crate versions to $PRODUCT_VERSION" \
     mullvad-daemon/Cargo.toml \
     mullvad-cli/Cargo.toml \
     mullvad-problem-report/Cargo.toml \
     mullvad-setup/Cargo.toml \
     mullvad-exclude/Cargo.toml \
     talpid-openvpn-plugin/Cargo.toml \
-    Cargo.lock \
-    android/app/build.gradle.kts \
-    dist-assets/windows/version.h
+    Cargo.lock
+
+if [[ "$DESKTOP" == "true" ]]; then
+    git commit -S -m "Update desktop app versions to $PRODUCT_VERSION" \
+        gui/package.json \
+        gui/package-lock.json \
+        dist-assets/windows/version.h
+fi
+
+if [[ "$ANDROID" == "true" ]]; then
+    git commit -S -m "Update Android app version to $PRODUCT_VERSION" \
+        android/app/build.gradle.kts
+fi
 
 NEW_TAGS=""
 

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -51,7 +51,13 @@ if [[ $DESKTOP == "true" && $(grep "CHANGE THIS BEFORE A RELEASE" gui/changes.tx
     exit 1
 fi
 
-if [[ $(grep "^## \\[$PRODUCT_VERSION\\] - " CHANGELOG.md) == "" ]]; then
+if [[ "$DESKTOP" == "true" && $(grep "^## \\[$PRODUCT_VERSION\\] - " CHANGELOG.md) == "" ]]; then
+    echo "It looks like you did not add $PRODUCT_VERSION to the changelog?"
+    echo "Please make sure the changelog is up to date and correct before you proceed."
+    exit 1
+fi
+
+if [[ "$ANDROID" == "true" && $(grep "^## \\[android/$PRODUCT_VERSION\\] - " CHANGELOG.md) == "" ]]; then
     echo "It looks like you did not add $PRODUCT_VERSION to the changelog?"
     echo "Please make sure the changelog is up to date and correct before you proceed."
     exit 1

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -90,15 +90,17 @@ git commit -S -m "Updating version in package files" \
     android/app/build.gradle.kts \
     dist-assets/windows/version.h
 
-echo "Tagging current git commit with release tag $PRODUCT_VERSION..."
-
 NEW_TAGS=""
 
 if [[ "$ANDROID" == "true" ]]; then
+    echo "Tagging current git commit with release tag android/$PRODUCT_VERSION..."
+
     git tag -s "android/$PRODUCT_VERSION" -m "android/$PRODUCT_VERSION"
     NEW_TAGS+=" android/$PRODUCT_VERSION"
 fi
 if [[ "$DESKTOP" == "true" ]]; then
+    echo "Tagging current git commit with release tag $PRODUCT_VERSION..."
+
     git tag -s $PRODUCT_VERSION -m $PRODUCT_VERSION
     NEW_TAGS+=" $PRODUCT_VERSION"
 fi


### PR DESCRIPTION
This PR simply fixes `prepare-release.sh` to look for `[android/$PRODUCT_VERSION]` instead of `[$PRODUCT_VERSION]` in the changelog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3960)
<!-- Reviewable:end -->
