### PR TITLE
Add notification permision for android 13

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-feature android:name="android.hardware.touchscreen"
                   android:required="false" />
     <uses-feature android:name="android.hardware.faketouch"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/VpnServiceModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/VpnServiceModule.kt
@@ -1,0 +1,9 @@
+package net.mullvad.mullvadvpn.di
+
+import androidx.core.app.NotificationManagerCompat
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+
+val vpnServiceModule = module {
+    single { NotificationManagerCompat.from(androidContext()) }
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -12,12 +12,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.di.vpnServiceModule
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.service.endpoint.ServiceEndpoint
 import net.mullvad.mullvadvpn.service.notifications.AccountExpiryNotification
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.talpid.TalpidVpnService
+import org.koin.core.context.loadKoinModules
 
 class MullvadVpnService : TalpidVpnService() {
     companion object {
@@ -66,6 +68,7 @@ class MullvadVpnService : TalpidVpnService() {
         super.onCreate()
         Log.d(TAG, "Initializing service")
 
+        loadKoinModules(vpnServiceModule)
         daemonInstance = DaemonInstance(this)
         keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -16,6 +16,7 @@ import net.mullvad.mullvadvpn.service.endpoint.AccountCache
 import net.mullvad.mullvadvpn.util.Intermittent
 import net.mullvad.mullvadvpn.util.JobTracker
 import net.mullvad.mullvadvpn.util.SdkUtils
+import net.mullvad.mullvadvpn.util.SdkUtils.isNotificationPermissionGranted
 import org.joda.time.DateTime
 import org.joda.time.Duration
 
@@ -69,8 +70,10 @@ class AccountExpiryNotification(
         val durationUntilExpiry = expiryDate?.remainingTime()
 
         if (accountCache.isNewAccount.not() && durationUntilExpiry?.isCloseToExpiry() == true) {
-            val notification = build(expiryDate, durationUntilExpiry)
-            channel.notificationManager.notify(NOTIFICATION_ID, notification)
+            if (context.isNotificationPermissionGranted()) {
+                val notification = build(expiryDate, durationUntilExpiry)
+                channel.notificationManager.notify(NOTIFICATION_ID, notification)
+            }
             jobTracker.newUiJob("scheduleUpdate") { scheduleUpdate() }
         } else {
             channel.notificationManager.cancel(NOTIFICATION_ID)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/NotificationChannel.kt
@@ -41,33 +41,43 @@ class NotificationChannel(
     fun buildNotification(
         intent: PendingIntent,
         title: String,
-        deleteIntent: PendingIntent? = null
+        deleteIntent: PendingIntent? = null,
+        isOngoing: Boolean = false
     ): Notification {
-        return buildNotification(intent, title, emptyList(), deleteIntent)
+        return buildNotification(intent, title, emptyList(), deleteIntent, isOngoing)
     }
 
     fun buildNotification(
         intent: PendingIntent,
         title: Int,
-        deleteIntent: PendingIntent? = null
+        deleteIntent: PendingIntent? = null,
+        isOngoing: Boolean = false
     ): Notification {
-        return buildNotification(intent, title, emptyList(), deleteIntent)
+        return buildNotification(intent, title, emptyList(), deleteIntent, isOngoing)
     }
 
     fun buildNotification(
         pendingIntent: PendingIntent,
         title: Int,
         actions: List<NotificationCompat.Action>,
-        deleteIntent: PendingIntent? = null
+        deleteIntent: PendingIntent? = null,
+        isOngoing: Boolean = false
     ): Notification {
-        return buildNotification(pendingIntent, context.getString(title), actions, deleteIntent)
+        return buildNotification(
+            pendingIntent,
+            context.getString(title),
+            actions,
+            deleteIntent,
+            isOngoing
+        )
     }
 
     private fun buildNotification(
         pendingIntent: PendingIntent,
         title: String,
         actions: List<NotificationCompat.Action>,
-        deleteIntent: PendingIntent? = null
+        deleteIntent: PendingIntent? = null,
+        isOngoing: Boolean = false
     ): Notification {
         val builder = NotificationCompat.Builder(context, id)
             .setSmallIcon(R.drawable.small_logo_black)
@@ -75,7 +85,7 @@ class NotificationChannel(
             .setContentTitle(title)
             .setContentIntent(pendingIntent)
             .setVisibility(visibility)
-
+            .setOngoing(isOngoing)
         for (action in actions) {
             builder.addAction(action)
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -55,6 +55,15 @@ class TunnelStateNotification(val context: Context) {
             }
         }
 
+    private val shouldDisplayOngoingNotification: Boolean
+        get() = when (tunnelState) {
+            is TunnelState.Connected -> true
+            is TunnelState.Disconnected,
+            is TunnelState.Connecting,
+            is TunnelState.Disconnecting,
+            is TunnelState.Error -> false
+        }
+
     private var reconnecting = false
     private var showingReconnecting = false
 
@@ -98,7 +107,12 @@ class TunnelStateNotification(val context: Context) {
             emptyList()
         }
 
-        return channel.buildNotification(pendingIntent, notificationText, actions)
+        return channel.buildNotification(
+            pendingIntent,
+            notificationText,
+            actions,
+            isOngoing = shouldDisplayOngoingNotification
+        )
     }
 
     private fun buildAction(): NotificationCompat.Action {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/SdkUtils.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/SdkUtils.kt
@@ -1,6 +1,9 @@
 package net.mullvad.mullvadvpn.util
 
+import android.Manifest
 import android.app.PendingIntent
+import android.content.Context
+import android.content.pm.PackageManager
 import android.net.VpnService
 import android.os.Build
 import android.service.quicksettings.Tile
@@ -12,6 +15,12 @@ object SdkUtils {
         } else {
             PendingIntent.FLAG_UPDATE_CURRENT
         }
+    }
+
+    fun Context.isNotificationPermissionGranted(): Boolean {
+        return (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) ||
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
     }
 
     fun VpnService.Builder.setMeteredIfSupported(isMetered: Boolean) {


### PR DESCRIPTION
This PR adds the Android 13 notification permission and prevents the foreground notification from being dismissed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3970)
<!-- Reviewable:end -->
