### PR TITLE
Refactor AuthFailed error

### DIFF
--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -1,4 +1,4 @@
-use mullvad_types::{location::GeoIpLocation, states::TunnelState};
+use mullvad_types::{auth_failed::AuthFailed, location::GeoIpLocation, states::TunnelState};
 use talpid_types::{
     net::{Endpoint, TunnelEndpoint},
     tunnel::ErrorState,
@@ -166,6 +166,26 @@ fn print_error_state(error_state: &ErrorState) {
             println!("Blocked: {}", cause);
             println!("Your kernel might be terribly out of date or missing nftables");
         }
+        talpid_types::tunnel::ErrorStateCause::AuthFailed(Some(auth_failed)) => {
+            println!(
+                "Blocked: Authentication with remote server failed: {}",
+                get_auth_failed_message(AuthFailed::from(auth_failed.as_str()))
+            );
+        }
         cause => println!("Blocked: {}", cause),
+    }
+}
+
+const fn get_auth_failed_message(auth_failed: AuthFailed) -> &'static str {
+    const INVALID_ACCOUNT_MSG: &str = "You've logged in with an account number that is not valid. Please log out and try another one.";
+    const EXPIRED_ACCOUNT_MSG: &str = "You have no more VPN time left on this account. Please log in on our website to buy more credit.";
+    const TOO_MANY_CONNECTIONS_MSG: &str = "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly.";
+    const UNKNOWN_MSG: &str = "Unknown error.";
+
+    match auth_failed {
+        AuthFailed::InvalidAccount => INVALID_ACCOUNT_MSG,
+        AuthFailed::ExpiredAccount => EXPIRED_ACCOUNT_MSG,
+        AuthFailed::TooManyConnections => TOO_MANY_CONNECTIONS_MSG,
+        AuthFailed::Unknown => UNKNOWN_MSG,
     }
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -41,6 +41,7 @@ use mullvad_relay_selector::{
 };
 use mullvad_types::{
     account::{AccountData, AccountToken, VoucherSubmission},
+    auth_failed::AuthFailed,
     device::{Device, DeviceEvent, DeviceEventCause, DeviceId, DeviceState, RemoveDeviceEvent},
     location::GeoIpLocation,
     relay_constraints::{BridgeSettings, BridgeState, ObfuscationSettings, RelaySettingsUpdate},
@@ -1099,7 +1100,7 @@ where
                 } else if self.get_target_tunnel_type() == Some(TunnelType::Wireguard) {
                     log::debug!("Entering blocking state since the account is out of time");
                     self.send_tunnel_command(TunnelCommand::Block(ErrorStateCause::AuthFailed(
-                        None,
+                        Some(AuthFailed::ExpiredAccount.as_str().to_string()),
                     )))
                 }
             }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -126,6 +126,13 @@ message ErrorState {
 		SPLIT_TUNNEL_ERROR = 8;
 	}
 
+	enum AuthFailedError {
+		UNKNOWN = 0;
+		INVALID_ACCOUNT = 1;
+		EXPIRED_ACCOUNT = 2;
+		TOO_MANY_CONNECTIONS = 3;
+	}
+
 	enum GenerationError {
 		NO_MATCHING_RELAY = 0;
 		NO_MATCHING_BRIDGE_RELAY = 1;
@@ -149,7 +156,7 @@ message ErrorState {
 	FirewallPolicyError blocking_error = 2;
 
 	// AUTH_FAILED
-	string auth_fail_reason = 3;
+	AuthFailedError auth_failed_error = 3;
 	// TUNNEL_PARAMETER_ERROR
 	GenerationError parameter_error = 4;
 	// SET_FIREWALL_POLICY_ERROR

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -35,6 +35,18 @@ impl<'a> From<&'a str> for AuthFailed {
     }
 }
 
+impl AuthFailed {
+    pub fn as_str(&self) -> &'static str {
+        use AuthFailed::*;
+        match self {
+            InvalidAccount => "[INVALID_ACCOUNT]",
+            ExpiredAccount => "[EXPIRED_ACCOUNT]",
+            TooManyConnections => "[TOO_MANY_CONNECTIONS]",
+            Unknown => "[Unknown]",
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct UnexpectedErrorStateCause(());
 

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -1,66 +1,70 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::fmt;
+use talpid_types::tunnel::ErrorStateCause;
 
-/// Used by frontends to parse [`talpid_types::tunnel::ErrorStateCause::AuthFailed`], which may be
-/// returned in [`talpid_types::tunnel::ErrorStateCause`] when there is a failure to authenticate
+/// Used to parse [`talpid_types::tunnel::ErrorStateCause::AuthFailed`], which may be returned
+/// in [`talpid_types::tunnel::ErrorStateCause`] when there is a failure to authenticate
 /// with a remote server.
 #[derive(Debug)]
-pub struct AuthFailed {
-    reason: AuthFailedInner,
-}
-
-#[derive(Debug)]
-enum AuthFailedInner {
+pub enum AuthFailed {
     InvalidAccount,
     ExpiredAccount,
-    TooManyConnectons,
-    Unknown(String, String),
+    TooManyConnections,
+    Unknown,
 }
 
 // These strings should match up with gui/packages/desktop/src/renderer/lib/auth-failure.js
 const INVALID_ACCOUNT_MSG: &str = "You've logged in with an account number that is not valid. Please log out and try another one.";
 const EXPIRED_ACCOUNT_MSG: &str = "You have no more VPN time left on this account. Please log in on our website to buy more credit.";
 const TOO_MANY_CONNECTIONS_MSG: &str = "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly.";
+const UNKNOWN_MSG: &str = "Unknown error.";
 
-impl<'a> From<&'a str> for AuthFailedInner {
-    fn from(reason: &'a str) -> AuthFailedInner {
-        use self::AuthFailedInner::*;
+impl<'a> From<&'a str> for AuthFailed {
+    fn from(reason: &'a str) -> AuthFailed {
+        use AuthFailed::*;
         match parse_string(reason) {
-            Some(("INVALID_ACCOUNT", _)) => InvalidAccount,
-            Some(("EXPIRED_ACCOUNT", _)) => ExpiredAccount,
-            Some(("TOO_MANY_CONNECTIONS", _)) => TooManyConnectons,
-            Some((unknown_reason, message)) => {
+            Some("INVALID_ACCOUNT") => InvalidAccount,
+            Some("EXPIRED_ACCOUNT") => ExpiredAccount,
+            Some("TOO_MANY_CONNECTIONS") => TooManyConnections,
+            Some(fail_id) => {
                 log::warn!(
-                    "Received AUTH_FAILED message with unknown reason: {}",
-                    reason
+                    "Received AUTH_FAILED message with unknown failure ID: {}",
+                    fail_id
                 );
-                Unknown(unknown_reason.to_string(), message.to_string())
+                Unknown
             }
             None => {
                 log::warn!("Received invalid AUTH_FAILED message: {}", reason);
-                Unknown("UNKNOWN".to_string(), reason.to_string())
+                Unknown
             }
         }
     }
 }
 
-impl<'a> From<&'a str> for AuthFailed {
-    fn from(reason: &'a str) -> AuthFailed {
-        AuthFailed {
-            reason: AuthFailedInner::from(reason),
+#[derive(Debug)]
+pub struct UnexpectedErrorStateCause(());
+
+impl TryFrom<&ErrorStateCause> for AuthFailed {
+    type Error = UnexpectedErrorStateCause;
+
+    fn try_from(cause: &ErrorStateCause) -> Result<Self, Self::Error> {
+        match cause {
+            ErrorStateCause::AuthFailed(Some(reason)) => Ok(AuthFailed::from(reason.as_str())),
+            ErrorStateCause::AuthFailed(None) => Ok(AuthFailed::Unknown),
+            _ => Err(UnexpectedErrorStateCause(())),
         }
     }
 }
 
 impl fmt::Display for AuthFailed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::AuthFailedInner::*;
-        match self.reason {
-            InvalidAccount => write!(f, "{}", INVALID_ACCOUNT_MSG),
-            ExpiredAccount => write!(f, "{}", EXPIRED_ACCOUNT_MSG),
-            TooManyConnectons => write!(f, "{}", TOO_MANY_CONNECTIONS_MSG),
-            Unknown(_, ref reason) => write!(f, "{}", reason),
+        use AuthFailed::*;
+        match self {
+            InvalidAccount => f.write_str(INVALID_ACCOUNT_MSG),
+            ExpiredAccount => f.write_str(EXPIRED_ACCOUNT_MSG),
+            TooManyConnections => f.write_str(TOO_MANY_CONNECTIONS_MSG),
+            Unknown => f.write_str(UNKNOWN_MSG),
         }
     }
 }
@@ -68,16 +72,14 @@ impl fmt::Display for AuthFailed {
 // Expects to take a string like "[INVALID_ACCOUNT] This is not a valid Mullvad account".
 // The example input string would be split into:
 // * "INVALID_ACCOUNT" - the ID of the failure reason.
-// * "This is not a valid Mullvad account" - the human readable message of the failure reason.
+// * "This is not a valid Mullvad account" - human-readable message (ignored).
 // In the case that the message has preceeding whitespace, it will be trimmed.
-fn parse_string(reason: &str) -> Option<(&str, &str)> {
+fn parse_string(reason: &str) -> Option<&str> {
     lazy_static! {
-        static ref REASON_REGEX: Regex = Regex::new(r"^\[(\w+)\]\s*(.*)$").unwrap();
+        static ref REASON_REGEX: Regex = Regex::new(r"^\[(\w+)\]\s*").unwrap();
     }
     let captures = REASON_REGEX.captures(reason)?;
-    let reason = captures.get(1).map(|m| m.as_str())?;
-    let message = captures.get(2).map(|m| m.as_str())?;
-    Some((reason, message))
+    captures.get(1).map(|m| m.as_str())
 }
 
 #[cfg(test)]
@@ -87,15 +89,15 @@ mod tests {
     #[test]
     fn test_parsing() {
         let tests = vec![
-            (Some(("INVALID_ACCOUNT", "This is not a valid Mullvad account" )),
+            (Some("INVALID_ACCOUNT"),
                 "[INVALID_ACCOUNT] This is not a valid Mullvad account"),
-            (Some(("EXPIRED_ACCOUNT", "This account has no time left")),
+            (Some("EXPIRED_ACCOUNT"),
              "[EXPIRED_ACCOUNT] This account has no time left"),
-            (Some(("TOO_MANY_CONNECTIONS", "This Mullvad account is already used by the maximum number of simultaneous connections")),
+            (Some("TOO_MANY_CONNECTIONS"),
             "[TOO_MANY_CONNECTIONS] This Mullvad account is already used by the maximum number of simultaneous connections"),
             (None, "[Incomplete String"),
-            (Some(("REASON_REASON", "")), "[REASON_REASON]"),
-            (Some(("REASON_REASON", "A")), "[REASON_REASON]A"),
+            (Some("REASON_REASON"), "[REASON_REASON]"),
+            (Some("REASON_REASON"), "[REASON_REASON]A"),
             (None, "incomplete]"),
             (None, ""),
         ];

--- a/mullvad-types/src/auth_failed.rs
+++ b/mullvad-types/src/auth_failed.rs
@@ -1,6 +1,5 @@
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::fmt;
 use talpid_types::tunnel::ErrorStateCause;
 
 /// Used to parse [`talpid_types::tunnel::ErrorStateCause::AuthFailed`], which may be returned
@@ -13,12 +12,6 @@ pub enum AuthFailed {
     TooManyConnections,
     Unknown,
 }
-
-// These strings should match up with gui/packages/desktop/src/renderer/lib/auth-failure.js
-const INVALID_ACCOUNT_MSG: &str = "You've logged in with an account number that is not valid. Please log out and try another one.";
-const EXPIRED_ACCOUNT_MSG: &str = "You have no more VPN time left on this account. Please log in on our website to buy more credit.";
-const TOO_MANY_CONNECTIONS_MSG: &str = "This account has too many simultaneous connections. Disconnect another device or try connecting again shortly.";
-const UNKNOWN_MSG: &str = "Unknown error.";
 
 impl<'a> From<&'a str> for AuthFailed {
     fn from(reason: &'a str) -> AuthFailed {
@@ -53,18 +46,6 @@ impl TryFrom<&ErrorStateCause> for AuthFailed {
             ErrorStateCause::AuthFailed(Some(reason)) => Ok(AuthFailed::from(reason.as_str())),
             ErrorStateCause::AuthFailed(None) => Ok(AuthFailed::Unknown),
             _ => Err(UnexpectedErrorStateCause(())),
-        }
-    }
-}
-
-impl fmt::Display for AuthFailed {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use AuthFailed::*;
-        match self {
-            InvalidAccount => f.write_str(INVALID_ACCOUNT_MSG),
-            ExpiredAccount => f.write_str(EXPIRED_ACCOUNT_MSG),
-            TooManyConnections => f.write_str(TOO_MANY_CONNECTIONS_MSG),
-            Unknown => f.write_str(UNKNOWN_MSG),
         }
     }
 }


### PR DESCRIPTION
This PR refactors the management interface to return structured errors instead of strings for `AuthFailed`. Failing to connect to a WireGuard relay when the account is out of time will now enter the error state due to `AuthFailed::EXPIRED_ACCOUNT`.

This PR does not touch `ErrorStateCause` in `talpid-types`, as accounts do not exist in that layer. Currently, the correct fix entails duplicating all tunnel states in `mullvad-types`. This would be somewhat pointless to do before the TSM has been refactored.

Related: #3965

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3971)
<!-- Reviewable:end -->
