### PR TITLE
Correct translation of the polish language alternative

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -74,7 +74,7 @@ const SUPPORTED_LOCALE_LIST = [
   { name: 'မြန်မာဘာသာ', code: 'my' },
   { name: 'Nederlands', code: 'nl' },
   { name: 'Norsk', code: 'nb' },
-  { name: 'Język polski', code: 'pl' },
+  { name: 'Polski', code: 'pl' },
   { name: 'Português', code: 'pt' },
   { name: 'Русский', code: 'ru' },
   { name: 'Svenska', code: 'sv' },


### PR DESCRIPTION
This PR corrects the name of the alternative for Polish in the language selector. It was reported by a user to the form provided by Alcanost.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3975)
<!-- Reviewable:end -->
