### PR TITLE
Stop IPv6 geolocation requests when in-tunnel IPv6 is disabled

### DIFF
--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -11,6 +11,7 @@ const URI_V6: &str = "https://ipv6.am.i.mullvad.net/json";
 
 pub async fn send_location_request(
     request_sender: RequestServiceHandle,
+    use_ipv6: bool,
 ) -> Result<GeoIpLocation, Error> {
     let v4_sender = request_sender.clone();
     let v4_future = async move {
@@ -19,27 +20,35 @@ pub async fn send_location_request(
     };
     let v6_sender = request_sender.clone();
     let v6_future = async move {
-        let location = send_location_request_internal(URI_V6, v6_sender).await?;
-        Ok::<GeoIpLocation, Error>(GeoIpLocation::from(location))
+        if use_ipv6 {
+            Some(
+                send_location_request_internal(URI_V6, v6_sender)
+                    .await
+                    .map(GeoIpLocation::from),
+            )
+        } else {
+            None
+        }
     };
 
     let (v4_result, v6_result) = join!(v4_future, v6_future);
 
     match (v4_result, v6_result) {
-        (Ok(mut v4), Ok(v6)) => {
+        (Ok(mut v4), Some(Ok(v6))) => {
             v4.ipv6 = v6.ipv6;
             v4.mullvad_exit_ip = v4.mullvad_exit_ip && v6.mullvad_exit_ip;
             Ok(v4)
         }
-        (Ok(v4), Err(e)) => {
+        (Ok(v4), None) => Ok(v4),
+        (Ok(v4), Some(Err(e))) => {
             log_network_error(e, "IPv6");
             Ok(v4)
         }
-        (Err(e), Ok(v6)) => {
+        (Err(e), Some(Ok(v6))) => {
             log_network_error(e, "IPv4");
             Ok(v6)
         }
-        (Err(e_v4), Err(_)) => Err(e_v4),
+        (Err(e_v4), _) => Err(e_v4),
     }
 }
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1246,8 +1246,9 @@ where
 
     async fn get_geo_location(&mut self) -> impl Future<Output = Result<GeoIpLocation, ()>> {
         let rest_service = self.api_runtime.rest_handle().await;
-        async {
-            geoip::send_location_request(rest_service)
+        let use_ipv6 = self.settings.tunnel_options.generic.enable_ipv6;
+        async move {
+            geoip::send_location_request(rest_service, use_ipv6)
                 .await
                 .map_err(|e| {
                     log::warn!("Unable to fetch GeoIP location: {}", e.display_chain());


### PR DESCRIPTION
Stop sending IPv6 geolocation requests if IPv6 is disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3983)
<!-- Reviewable:end -->
