### PR TITLE
Fix app crashing when trying to set svg to window icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 
+#### Linux
+- Fix app crashing immediately when using some icon themes.
+
 #### macOS
 - Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.
 

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -422,9 +422,14 @@ class ApplicationMain
     }
 
     if (process.platform === 'linux') {
-      const icon = await findIconPath('mullvad-vpn');
-      if (icon) {
-        this.userInterface.setWindowIcon(icon);
+      try {
+        const icon = await findIconPath('mullvad-vpn', ['png']);
+        if (icon) {
+          this.userInterface.setWindowIcon(icon);
+        }
+      } catch (e) {
+        const error = e as Error;
+        log.error('Failed to set window icon:', error.message);
       }
     }
 

--- a/gui/src/main/linux-desktop-entry.ts
+++ b/gui/src/main/linux-desktop-entry.ts
@@ -219,10 +219,12 @@ export async function getImageDataUrl(imagePath: string): Promise<string> {
 }
 
 // Returns the path of the icon with the specified name. If none is found it returns undefined.
-export async function findIconPath(name: string): Promise<string | undefined> {
+export async function findIconPath(
+  name: string,
+  allowedExtensions = ['svg', 'png'],
+): Promise<string | undefined> {
   // Chromium doesn't support .xpm files
-  const extensions = ['svg', 'png'];
-  return findIcon(name, extensions, [
+  return findIcon(name, allowedExtensions, [
     getIconDirectories(),
     await getGtkThemeDirectories(),
     // Begin with preferred sized but if nothing matches other sizes should be considered as well.


### PR DESCRIPTION
This PR fixes the issue where the app crashes while starting when trying to set the window icon to an SVG. This was the case with e.g. the Papirus icon pack. It's been solved by not using SVGs for the window icon. Fixes https://github.com/mullvad/mullvadvpn-app/issues/3981,

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3987)
<!-- Reviewable:end -->
