### PR TITLE
Fix remaining details around custom WireGuard port

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1510,11 +1510,6 @@ msgctxt "wireguard-settings-view"
 msgid "Set %(wireguard)s MTU value. Valid range: %(min)d - %(max)d."
 msgstr ""
 
-#. The hint displayed below the WireGuard port selector.
-msgctxt "wireguard-settings-view"
-msgid "The automatic setting will randomly choose from a wide range of ports."
-msgstr ""
-
 msgctxt "wireguard-settings-view"
 msgid "The automatic setting will randomly choose from the valid port ranges shown below."
 msgstr ""

--- a/gui/src/renderer/components/OpenVpnSettings.tsx
+++ b/gui/src/renderer/components/OpenVpnSettings.tsx
@@ -465,7 +465,7 @@ function MssFixSetting() {
         </AriaLabel>
         <AriaInput>
           <Cell.AutoSizingTextInput
-            value={mssfix ? mssfix.toString() : ''}
+            initialValue={mssfix ? mssfix.toString() : ''}
             inputMode={'numeric'}
             maxLength={4}
             placeholder={messages.gettext('Default')}

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -214,19 +214,6 @@ function PortSelector() {
           }
         />
       </StyledSelectorContainer>
-      <Cell.CellFooter>
-        <AriaDescription>
-          <Cell.CellFooterText>
-            {
-              // TRANSLATORS: The hint displayed below the WireGuard port selector.
-              messages.pgettext(
-                'wireguard-settings-view',
-                'The automatic setting will randomly choose from a wide range of ports.',
-              )
-            }
-          </Cell.CellFooterText>
-        </AriaDescription>
-      </Cell.CellFooter>
     </AriaInputGroup>
   );
 }

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -526,7 +526,7 @@ function MtuSetting() {
         </AriaLabel>
         <AriaInput>
           <Cell.AutoSizingTextInput
-            value={mtu ? mtu.toString() : ''}
+            initialValue={mtu ? mtu.toString() : ''}
             inputMode={'numeric'}
             maxLength={4}
             placeholder={messages.gettext('Default')}

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -162,15 +162,10 @@ function PortSelector() {
     [relaySettings],
   );
 
-  const setCustomPort = useCallback(
-    async (port: string) => {
-      await setWireguardPort(parseInt(port));
-    },
-    [setWireguardPort],
-  );
+  const parseValue = useCallback((port: string) => parseInt(port), []);
 
   const validateValue = useCallback(
-    (value) => allowedPortRanges.some(([start, end]) => value >= start && value <= end),
+    (value: number) => allowedPortRanges.some(([start, end]) => value >= start && value <= end),
     [allowedPortRanges],
   );
 
@@ -187,9 +182,9 @@ function PortSelector() {
           items={wireguardPortItems}
           value={port}
           onSelect={setWireguardPort}
-          onSelectCustom={setCustomPort}
           inputPlaceholder={messages.pgettext('wireguard-settings-view', 'Port')}
           automaticValue={null}
+          parseValue={parseValue}
           modifyValue={removeNonNumericCharacters}
           validateValue={validateValue}
           maxLength={5}


### PR DESCRIPTION
This PR fixes the remaining issues with the custom WireGuard port option. The improvements include:
- Footer has been removed since same information is shown in info-dialog
- Input is now emptied when selecting other item after writing invalid port
- Focus now remains in input if custom row is pressed when already focused.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3993)
<!-- Reviewable:end -->
