### PR TITLE
Add screenshots to e2e-tests

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,6 +19,9 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
+            - name: Checkout submodule
+              run: git submodule update --init ci/screenshots
+
             - name: Setup volta
               uses: volta-cli/action@v1
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /gui/scripts/ne_50m_admin_1_states_provinces_lines/
 /gui/scripts/out/
 /gui/src/main/management_interface/
-/gui/test/e2e/screenshots/
 /gui/test-results/
 /build/
 /dist

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "windows/windows-libraries"]
 	path = windows/windows-libraries
 	url = https://github.com/mullvad/windows-libraries
+[submodule "ci/screenshots"]
+	path = ci/screenshots
+	url = https://github.com/mullvad/mullvadvpn-app-screenshots

--- a/gui/playwright.config.ts
+++ b/gui/playwright.config.ts
@@ -1,8 +1,11 @@
 import { PlaywrightTestConfig } from '@playwright/test';
+import path from 'path';
+
 const config: PlaywrightTestConfig = {
   testDir: './test/e2e',
   maxFailures: 2,
   timeout: 60000,
+  snapshotDir: path.join(__dirname, '..', 'ci', 'screenshots', 'desktop'),
   expect: {
     toMatchSnapshot: {
       threshold: 0.1,

--- a/gui/playwright.config.ts
+++ b/gui/playwright.config.ts
@@ -4,6 +4,7 @@ import path from 'path';
 const config: PlaywrightTestConfig = {
   testDir: './test/e2e',
   maxFailures: 2,
+  retries: 3,
   timeout: 60000,
   snapshotDir: path.join(__dirname, '..', 'ci', 'screenshots', 'desktop'),
   expect: {

--- a/gui/test/e2e/daemon/location.spec.ts
+++ b/gui/test/e2e/daemon/location.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { Page } from 'playwright';
 
-import { GetByTestId } from '../utils';
+import { expectPageToHaveMatchingScreenshot, GetByTestId } from '../utils';
 import { startAppWithDaemon } from './daemon-utils';
 
 let page: Page;
@@ -22,5 +22,7 @@ test('App should have a country', async () => {
   const cityLabel = getByTestId('city');
   const noCityLabel = await cityLabel.count() === 0;
   expect(noCityLabel).toBeTruthy();
+
+  await expectPageToHaveMatchingScreenshot(page);
 });
 

--- a/gui/test/e2e/mocked/main.spec.ts
+++ b/gui/test/e2e/mocked/main.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import { Page } from 'playwright';
 
 import { startAppWithMocking } from './mocked-utils';
+import { expectPageToHaveMatchingScreenshot } from '../utils';
 
 let page: Page;
 
@@ -17,4 +18,6 @@ test('Validate title', async () => {
   const title = await page.title();
   expect(title).toBe('Mullvad VPN');
   await expect(page.locator('header')).toBeVisible();
+
+  await expectPageToHaveMatchingScreenshot(page);
 });

--- a/gui/test/e2e/mocked/settings.spec.ts
+++ b/gui/test/e2e/mocked/settings.spec.ts
@@ -3,6 +3,7 @@ import { Page } from 'playwright';
 
 import { SendMockIpcResponse, startAppWithMocking } from './mocked-utils';
 import { IAccountData } from '../../../src/shared/daemon-rpc-types';
+import { expectPageToHaveMatchingScreenshot } from '../utils';
 
 let page: Page;
 let sendMockIpcResponse: SendMockIpcResponse;
@@ -22,6 +23,8 @@ test('Settings Page', async () => {
 
   const closeButton = page.locator('button[aria-label="Close"]');
   await expect(closeButton).toBeVisible();
+
+  await expectPageToHaveMatchingScreenshot(page);
 });
 
 test('Account button should be displayed correctly', async () => {

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -1,4 +1,5 @@
 import { Locator, Page, _electron as electron, ElectronApplication } from 'playwright';
+import { expect } from '@playwright/test';
 
 export type GetByTestId = (id: string) => Locator;
 
@@ -46,3 +47,5 @@ export const getColor = (locator: Locator) => {
 export const getBackgroundColor = (locator: Locator) => {
   return getStyleProperty(locator, 'background-color');
 };
+
+export const expectPageToHaveMatchingScreenshot = (page: Page) => expect(page).toHaveScreenshot();

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -16,6 +16,12 @@ export const startApp = async (mainPath: string): Promise<StartAppResponse> => {
     args: [mainPath],
   });
 
+  await app.evaluate(({ webContents }) => {
+    return new Promise((resolve) => {
+      webContents.getAllWebContents()[0].on('did-finish-load', resolve);
+    });
+  });
+
   const page = await app.firstWindow();
 
   page.on('pageerror', (error) => {


### PR DESCRIPTION
- Add alternative to start e2e tests using daemon
- Prevent React from looking for devtools when running in CI
- Separate tests running with daemon from tests running with mocking
- Add locator for data-test-id
- Add test for ensuring country is set
- Add screenshots submodule
- Fix rebase reafactoring
- Cleanup .gitignore
- Setup config for snapshot dir
- Create snapshot utility function
- Add some screenshot tests
- Add checkout submodules in github actions

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3994)
<!-- Reviewable:end -->
