### PR TITLE
Reset known location when connecting to a custom relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Line wrap the file at 100 chars.                                              Th
 - Experimental: Upgrade the support for quantum-resistant WireGuard tunnels to a newer protocol.
 
 ### Fixed
+- Reset known location when connecting to a custom relay.
+
 #### Linux
 - Fix app crashing immediately when using some icon themes.
 

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -41,7 +41,6 @@ struct InnerParametersGenerator {
     tunnel_options: TunnelOptions,
     account_manager: AccountManagerHandle,
 
-    // TODO: Move this to `RelaySelector`?
     last_generated_relays: Option<LastSelectedRelays>,
 }
 
@@ -124,6 +123,7 @@ impl InnerParametersGenerator {
         let _data = self.device().await?;
         match self.relay_selector.get_relay(retry_attempt) {
             Ok((SelectedRelay::Custom(custom_relay), _bridge, _obfsucator)) => {
+                self.last_generated_relays = None;
                 custom_relay
                     // TODO: generate proxy settings for custom tunnels
                     .to_tunnel_parameters(self.tunnel_options.clone(), None)


### PR DESCRIPTION
Previously, when connecting to a custom relay, the daemon would include details for the last non-custom relay when returning the location in tunnel state transitions and when responding to `GetCurrentLocation`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/3999)
<!-- Reviewable:end -->
