### PR TITLE
Update grpc-tools with m1 support

### DIFF
--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -139,18 +139,18 @@ variable to `aarch64-unknown-linux-gnu`:
 TARGETS="aarch64-unknown-linux-gnu" ./build.sh
 ```
 
-## Notes on building on ARM64 hosts
+## Notes on building on ARM64 Linux hosts
 
 Due to inability to build the management interface proto files on ARM64 (see
 [this](https://github.com/grpc/grpc-node/issues/1497) issue), building on ARM64 must be done in
 2 stages:
 
-1. Build management interface proto files on a non-ARM64 platform
+1. Build management interface proto files on another platform than arm64 Linux
 2. Use the built proto files during the main build by setting the
    `MANAGEMENT_INTERFACE_PROTO_BUILD_DIR` environment variable to the path the proto files
 
-To build the management interface proto files there is a script (execute it on a non-ARM64
-platform):
+To build the management interface proto files there is a script (execute it on another platform than
+ARM64 Linux):
 
 ```bash
 cd gui/scripts

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -86,7 +86,7 @@
         "npm": ">=8.3"
       },
       "optionalDependencies": {
-        "grpc-tools": "^1.11.2",
+        "grpc-tools": "^1.11.3",
         "nseventmonitor": "^1.0.2"
       }
     },
@@ -7339,9 +7339,9 @@
       "dev": true
     },
     "node_modules/grpc-tools": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.2.tgz",
-      "integrity": "sha512-4+EgpnnkJraamY++oyBCw5Hp9huRYfgakjNVKbiE3PgO9Tv5ydVlRo7ZyGJ0C0SEiA7HhbVc1sNNtIyK7FiEtg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.3.tgz",
+      "integrity": "sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -20274,9 +20274,9 @@
       }
     },
     "grpc-tools": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.2.tgz",
-      "integrity": "sha512-4+EgpnnkJraamY++oyBCw5Hp9huRYfgakjNVKbiE3PgO9Tv5ydVlRo7ZyGJ0C0SEiA7HhbVc1sNNtIyK7FiEtg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.3.tgz",
+      "integrity": "sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==",
       "optional": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.5"

--- a/gui/package.json
+++ b/gui/package.json
@@ -29,7 +29,7 @@
     "styled-components": "^5.1.1"
   },
   "optionalDependencies": {
-    "grpc-tools": "^1.11.2",
+    "grpc-tools": "^1.11.3",
     "nseventmonitor": "^1.0.2"
   },
   "devDependencies": {

--- a/gui/scripts/build-proto.sh
+++ b/gui/scripts/build-proto.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
 ARCH="$(uname -m)"
-PLATFORM="$(uname -s)-${ARCH}"
+PLATFORM="$(uname -s)"
 MANAGEMENT_INTERFACE_PROTO_BUILD_DIR=${MANAGEMENT_INTERFACE_PROTO_BUILD_DIR:-}
 NODE_MODULES_DIR="$(cd ../node_modules/.bin && pwd)"
 PROTO_DIR="../../mullvad-management-interface/proto"
@@ -22,7 +22,7 @@ fi
 mkdir -p $DESTINATION_DIR
 mkdir -p $TYPES_DESTINATION_DIR
 
-if [[ "${ARCH,,}" == "arm64" || "${ARCH,,}" == "aarch64" ]]; then
+if [[ "$PLATFORM" == "Linux" && ("${ARCH,,}" == "arm64" || "${ARCH,,}" == "aarch64") ]]; then
     if [[ -n "${MANAGEMENT_INTERFACE_PROTO_BUILD_DIR}" ]]; then
       cp $MANAGEMENT_INTERFACE_PROTO_BUILD_DIR/*.js $DESTINATION_DIR
       cp $MANAGEMENT_INTERFACE_PROTO_BUILD_DIR/*.ts $TYPES_DESTINATION_DIR


### PR DESCRIPTION
This PR upgrades `grpc-tools` to `1.11.3` which enables proto build on ARM64 macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4002)
<!-- Reviewable:end -->
