### PR TITLE
Stop logging to a file in early boot blocking service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.
 
+#### Linux
+- Don't prevent early boot service from running if logging to a file fails.
+
 
 ## [2022.5-beta2] - 2022-10-05
 ### Added


### PR DESCRIPTION
Since some configurations mount `/var/` later in the boot process, logging will fail. To work around this, the behavior is changed so that if file logging doesn't work, it can rely solely on `stdout` logging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4008)
<!-- Reviewable:end -->
