### PR TITLE
Improve README.md code block readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ sc.exe start mullvadvpn
 
 Edit the systemd unit file via `systemctl edit mullvad-daemon.service`:
 
-```systemd
+```ini
 [Service]
 Environment="TALPID_DISABLE_OFFLINE_MONITOR=1"
 ```


### PR DESCRIPTION
Set language of `mullvad-daemon.service` code block to `ini` for syntax highlighting (It's the same thing done in `vim` editor), which can improve the readability a little bit.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4020)
<!-- Reviewable:end -->
