### PR TITLE
Fix apt lists clean up in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt update -y && apt install build-essential \
 	binutils \
 	curl \
 	p7zip-full \
-	git -y
+	git -y && \
+	rm -rf /var/lib/apt/lists/*
 
 
 # Install golang
@@ -21,8 +22,7 @@ RUN curl -Lo go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && 
 	echo $(sha256sum go.tgz) && \
 	echo "${GOLANG_HASH} go.tgz" | sha256sum -c - && \
 	tar -C /usr/local -xzf go.tgz && \
-	rm go.tgz && \
-	rm -rf /var/lib/apt/lists/*
+	rm go.tgz
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
Origin apt list clean up won't really work as they're not in the same Docker image layer.

With proper modification, we could get a tidier Docker image:

```
REPOSITORY  TAG         IMAGE ID       CREATED         SIZE
after       latest      09dd0aa54dbe   2 minutes ago   891MB
before      latest      685bb4ca12d5   5 minutes ago   908MB
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4023)
<!-- Reviewable:end -->
