### PR TITLE
Fix modals not closing

### DIFF
--- a/gui/src/renderer/components/RedeemVoucher.tsx
+++ b/gui/src/renderer/components/RedeemVoucher.tsx
@@ -201,7 +201,7 @@ export function RedeemVoucherSubmitButton() {
   const disabled = submitting || response?.type === 'success';
 
   return (
-    <AppButton.GreenButton key="cancel" disabled={!valueValid || disabled} onClick={onSubmit}>
+    <AppButton.GreenButton disabled={!valueValid || disabled} onClick={onSubmit}>
       {messages.pgettext('redeem-voucher-view', 'Redeem')}
     </AppButton.GreenButton>
   );


### PR DESCRIPTION
Since React 18 runs the state setter callback asynchronously it fires after the ref has been updated which leads to an incorrect state. I fixed it by removing the ref and including both values in a state instead to force them to update together.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4024)
<!-- Reviewable:end -->
