### PR TITLE
Fix hyper features

### DIFF
--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.21", features = ["serde"] }
 err-derive = "0.3.1"
 futures = "0.3"
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "stream"] }
+hyper = { version = "0.14", features = ["client", "stream", "http1", "tcp" ] }
 ipnetwork = "0.16"
 log = "0.4"
 regex = "1"


### PR DESCRIPTION
Currently, `mullvad-api` doesn't build due to it's `hyper` dependency not having all the features it needs. I've added both of the features now. This didn't affect us since `tonic` would use the `full` feature of `hyper`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4039)
<!-- Reviewable:end -->
