### PR TITLE
Use mullvad-version for deb version

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -71,7 +71,6 @@
         "gulp-typescript": "^5.0.1",
         "playwright": "^1.26.1",
         "prettier": "^2.2.1",
-        "semver": "^7.3.8",
         "sinon": "^14.0.1",
         "ts-node": "^10.9.1",
         "tsc-watch": "^5.0.3",

--- a/gui/package.json
+++ b/gui/package.json
@@ -77,7 +77,6 @@
     "gulp-typescript": "^5.0.1",
     "playwright": "^1.26.1",
     "prettier": "^2.2.1",
-    "semver": "^7.3.8",
     "sinon": "^14.0.1",
     "ts-node": "^10.9.1",
     "tsc-watch": "^5.0.3",

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -2,9 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const builder = require('electron-builder');
 const { Arch } = require('electron-builder');
-const parseSemver = require('semver/functions/parse');
 const { notarize } = require('electron-notarize');
-const { version } = require('../package.json');
 const { execFileSync } = require('child_process');
 
 const noCompression = process.argv.includes('--no-compression');
@@ -415,12 +413,14 @@ function getMacArch() {
 // Replace '-' between components with a tilde to make the version comparison understand that
 // YYYY.NN-dev-HHHHHH > YYYY.NN > YYYY.NN-betaN-dev-HHHHHH > YYYY.NN-betaN.
 function getDebVersion() {
-  const { major, minor, prerelease } = parseSemver(version);
-  if (prerelease[0]) {
-    if (prerelease[0].toLowerCase().startsWith('beta')) {
-      return `${major}.${minor}~${prerelease[0]}`;
+  const [version, ...prereleaseParts] = productVersion([]).split('-');
+  const [major, minor] = version.split('.');
+  const prerelease = prereleaseParts.join('-');
+  if (prerelease) {
+    if (prerelease.toLowerCase().startsWith('beta')) {
+      return `${major}.${minor}~${prerelease}`;
     }
-    return `${major}.${minor}-${prerelease[0]}`;
+    return `${major}.${minor}-${prerelease}`;
   }
   return `${major}.${minor}`;
 }


### PR DESCRIPTION
This PR switches the deb version to be generated using `mullvad-version`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4051)
<!-- Reviewable:end -->
