### PR TITLE
Improve build script version computation feedback

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -5,8 +5,12 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
-
+echo "Computing build version..."
+echo ""
 PRODUCT_VERSION=$(cargo run -q --bin mullvad-version versionName)
+echo "Building Mullvad VPN $PRODUCT_VERSION for Android"
+echo ""
+
 BUILD_TYPE="release"
 GRADLE_BUILD_TYPE="release"
 GRADLE_TASK="assembleRelease"
@@ -56,7 +60,6 @@ if [[ "$BUILD_TYPE" == "release" && "$PRODUCT_VERSION" != *"-dev-"* ]]; then
     CARGO_ARGS+=" --locked"
 fi
 
-echo "Building Mullvad VPN $PRODUCT_VERSION for Android"
 pushd "$SCRIPT_DIR/android"
 
 # Fallback to the system-wide gradle command if the gradlew script is removed.

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,9 @@ source scripts/utils/log
 RUSTC_VERSION=$(rustc --version)
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"target"}
 
+echo "Computing build version..."
 PRODUCT_VERSION=$(cargo run -q --bin mullvad-version)
+log_header "Building Mullvad VPN $PRODUCT_VERSION"
 
 # If compiler optimization and artifact compression should be turned on or not
 OPTIMIZE="false"
@@ -150,8 +152,6 @@ fi
 ################################################################################
 # Compile and build
 ################################################################################
-
-log_header "Building Mullvad VPN $PRODUCT_VERSION"
 
 # Sign all binaries passed as arguments to this function
 function sign_win {


### PR DESCRIPTION
This PR aims to improve the developer UX when building the desktop and Android apps by printing some feedback. Both rely on the `mullvad-version` tool that first needs to be built, which might take some time on a fresh machine as it needs to first fetch the cargo index.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4067)
<!-- Reviewable:end -->
