### PR TITLE
Add Hyprland as wayland compatible

### DIFF
--- a/dist-assets/linux/mullvad-gui-launcher.sh
+++ b/dist-assets/linux/mullvad-gui-launcher.sh
@@ -8,7 +8,7 @@ else
     SANDBOX_FLAG=""
 fi
 
-SUPPORTED_COMPOSITORS="sway river"
+SUPPORTED_COMPOSITORS="sway river Hyprland"
 if [ "${XDG_SESSION_TYPE:-""}"  = "wayland" ] && \
     echo " $SUPPORTED_COMPOSITORS " | \
     grep -qi -e " ${XDG_CURRENT_DESKTOP:-""} " -e " ${XDG_SESSION_DESKTOP:-""} "


### PR DESCRIPTION
This PR adds Hyprland to the list of Wayland compatible composers since it was reported in https://github.com/mullvad/mullvadvpn-app/issues/3062 that it works fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4078)
<!-- Reviewable:end -->
