### PR TITLE
REST: clean up access levels

### DIFF
--- a/ios/MullvadREST/RESTAPIProxy.swift
+++ b/ios/MullvadREST/RESTAPIProxy.swift
@@ -216,7 +216,7 @@ extension REST {
         case newContent(_ etag: String?, _ value: ServerRelaysResponse)
     }
 
-    fileprivate struct CreateApplePaymentRequest: Encodable {
+    private struct CreateApplePaymentRequest: Encodable {
         let receiptString: Data
     }
 
@@ -250,16 +250,16 @@ extension REST {
         }
     }
 
-    fileprivate struct CreateApplePaymentRawResponse: Decodable {
+    private struct CreateApplePaymentRawResponse: Decodable {
         let timeAdded: Int
         let newExpiry: Date
     }
 
     public struct ProblemReportRequest: Encodable {
-        let address: String
-        let message: String
-        let log: String
-        let metadata: [String: String]
+        public let address: String
+        public let message: String
+        public let log: String
+        public let metadata: [String: String]
 
         public init(address: String, message: String, log: String, metadata: [String: String]) {
             self.address = address

--- a/ios/MullvadREST/RESTAuthenticationProxy.swift
+++ b/ios/MullvadREST/RESTAuthenticationProxy.swift
@@ -57,12 +57,12 @@ extension REST {
         }
     }
 
-    public struct AccessTokenData: Decodable {
+    struct AccessTokenData: Decodable {
         let accessToken: String
         let expiry: Date
     }
 
-    fileprivate struct AccessTokenRequest: Encodable {
+    private struct AccessTokenRequest: Encodable {
         let accountNumber: String
     }
 }


### PR DESCRIPTION
1. Declare all properties of `ProblemReportRequest` as public.
2. Replace `fileprivate` with `private` ACL where it makes no difference.
3. Mark `AccessTokenData` internal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4079)
<!-- Reviewable:end -->
