### PR TITLE
Cleanup operations interface

### DIFF
--- a/ios/Operations/AsyncBlockOperation.swift
+++ b/ios/Operations/AsyncBlockOperation.swift
@@ -1,6 +1,6 @@
 //
 //  AsyncBlockOperation.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 06/07/2020.
 //  Copyright © 2020 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/AsyncOperation.swift
+++ b/ios/Operations/AsyncOperation.swift
@@ -1,6 +1,6 @@
 //
 //  AsyncOperation.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 01/06/2020.
 //  Copyright © 2020 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/AsyncOperation.swift
+++ b/ios/Operations/AsyncOperation.swift
@@ -417,12 +417,6 @@ public extension Operation {
     }
 }
 
-public extension Operation {
-    var operationName: String {
-        return name ?? "\(self)"
-    }
-}
-
 public protocol OperationBlockObserverSupport {}
 extension AsyncOperation: OperationBlockObserverSupport {}
 

--- a/ios/Operations/AsyncOperation.swift
+++ b/ios/Operations/AsyncOperation.swift
@@ -409,8 +409,8 @@ open class AsyncOperation: Operation {
     }
 }
 
-public extension Operation {
-    func addDependencies(_ dependencies: [Operation]) {
+extension Operation {
+    public func addDependencies(_ dependencies: [Operation]) {
         for dependency in dependencies {
             addDependency(dependency)
         }
@@ -420,8 +420,8 @@ public extension Operation {
 public protocol OperationBlockObserverSupport {}
 extension AsyncOperation: OperationBlockObserverSupport {}
 
-public extension OperationBlockObserverSupport where Self: AsyncOperation {
-    func addBlockObserver(_ observer: OperationBlockObserver<Self>) {
+extension OperationBlockObserverSupport where Self: AsyncOperation {
+    public func addBlockObserver(_ observer: OperationBlockObserver<Self>) {
         addObserver(observer)
     }
 }

--- a/ios/Operations/AsyncOperationQueue.swift
+++ b/ios/Operations/AsyncOperationQueue.swift
@@ -1,6 +1,6 @@
 //
 //  AsyncOperationQueue.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 30/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/BackgroundObserver.swift
+++ b/ios/Operations/BackgroundObserver.swift
@@ -1,6 +1,6 @@
 //
 //  BackgroundObserver.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 31/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/GroupOperation.swift
+++ b/ios/Operations/GroupOperation.swift
@@ -1,6 +1,6 @@
 //
 //  GroupOperation.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 31/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/InputInjectionBuilder.swift
+++ b/ios/Operations/InputInjectionBuilder.swift
@@ -84,11 +84,11 @@ public final class InputInjectionBuilder<OperationType, Context>
     }
 }
 
-public extension InputInjectionBuilder
+extension InputInjectionBuilder
     where Context: OperationInputContext,
     Context.Input == OperationType.Input
 {
-    func reduce() {
+    public func reduce() {
         reduce { context in
             return context.reduce()
         }

--- a/ios/Operations/InputInjectionBuilder.swift
+++ b/ios/Operations/InputInjectionBuilder.swift
@@ -1,6 +1,6 @@
 //
 //  InputInjectionBuilder.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 09/06/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/InputOperation.swift
+++ b/ios/Operations/InputOperation.swift
@@ -22,12 +22,12 @@ public protocol InputOperation: Operation {
         where T: OutputOperation
 }
 
-public extension InputOperation {
-    func inject<T>(from dependency: T) where T: OutputOperation, T.Output == Input {
+extension InputOperation {
+    public func inject<T>(from dependency: T) where T: OutputOperation, T.Output == Input {
         inject(from: dependency, via: { $0 })
     }
 
-    func inject<T>(from dependency: T, via block: @escaping (T.Output) -> Input)
+    public func inject<T>(from dependency: T, via block: @escaping (T.Output) -> Input)
         where T: OutputOperation
     {
         setInputBlock {
@@ -38,7 +38,7 @@ public extension InputOperation {
         addDependency(dependency)
     }
 
-    func injectMany<Context>(context: Context) -> InputInjectionBuilder<Self, Context> {
+    public func injectMany<Context>(context: Context) -> InputInjectionBuilder<Self, Context> {
         return InputInjectionBuilder(
             operation: self,
             context: context

--- a/ios/Operations/InputOperation.swift
+++ b/ios/Operations/InputOperation.swift
@@ -1,6 +1,6 @@
 //
 //  InputOperation.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 09/06/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/OperationCompletion.swift
+++ b/ios/Operations/OperationCompletion.swift
@@ -1,6 +1,6 @@
 //
 //  OperationCompletion.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 24/01/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/OperationCondition.swift
+++ b/ios/Operations/OperationCondition.swift
@@ -1,6 +1,6 @@
 //
 //  OperationCondition.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 30/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/OperationObserver.swift
+++ b/ios/Operations/OperationObserver.swift
@@ -1,6 +1,6 @@
 //
 //  OperationObserver.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 30/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/OutputOperation.swift
+++ b/ios/Operations/OutputOperation.swift
@@ -1,6 +1,6 @@
 //
 //  OutputOperation.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 31/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/ResultBlockOperation.swift
+++ b/ios/Operations/ResultBlockOperation.swift
@@ -1,6 +1,6 @@
 //
 //  ResultBlockOperation.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 12/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/ResultOperation+Output.swift
+++ b/ios/Operations/ResultOperation+Output.swift
@@ -1,6 +1,6 @@
 //
 //  ResultOperation+Output.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 31/05/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/ResultOperation.swift
+++ b/ios/Operations/ResultOperation.swift
@@ -1,6 +1,6 @@
 //
 //  ResultOperation.swift
-//  MullvadVPN
+//  Operations
 //
 //  Created by pronebird on 23/03/2022.
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.

--- a/ios/Operations/TransformOperation.swift
+++ b/ios/Operations/TransformOperation.swift
@@ -1,8 +1,9 @@
 //
 //  TransformOperation.swift
-//  AsyncOperationQueueTest
+//  Operations
 //
 //  Created by pronebird on 31/05/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
 //
 
 import Foundation


### PR DESCRIPTION
1. Remove `public extension` in favor of explicitly marking ACL for members.
2. Update source header to reflect the location of source files.
3. Add missing copyright in one of source headers.
4. Remove `Operation.operationName` as it's unused.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4080)
<!-- Reviewable:end -->
