### PR TITLE
Move dockerfile LABEL statements to after FROM to work with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@
 #
 # And add -e TARGETS="aarch64-unknown-linux-gnu" to build for ARM64
 
-LABEL org.opencontainers.image.source=https://github.com/mullvad/mullvadvpn-app
-LABEL org.opencontainers.image.description="Mullvad VPN app Linux build container"
-LABEL org.opencontainers.image.licenses=GPL-3.0
-
 # Debian 10 is the oldest supported distro. It has the oldest glibc that we support
 # This checksum points to a 10.13-slim image.
 FROM debian@sha256:557ee531b81ce380d012d83b7bb56211572e5d6088d3e21a3caef7d7ed7f718b
+
+LABEL org.opencontainers.image.source=https://github.com/mullvad/mullvadvpn-app
+LABEL org.opencontainers.image.description="Mullvad VPN app Linux build container"
+LABEL org.opencontainers.image.licenses=GPL-3.0
 
 # === Define toolchain versions and paths ===
 


### PR DESCRIPTION
Apparently `docker` does not accept LABELs before `FROM`, but `podman` does :shrug:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4084)
<!-- Reviewable:end -->
