### PR TITLE
Make desktop build image find dbus with pkg-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,13 +47,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- --default-toolchain stable --profile minimal --target aarch64-unknown-linux-gnu -y
 
 ENV PATH=/root/.cargo/bin:$PATH
-
-RUN echo '[target.aarch64-unknown-linux-gnu]\n\
-linker = "aarch64-linux-gnu-gcc"\n\
-\n\
-[target.aarch64-unknown-linux-gnu.dbus]\n\
-rustc-link-search = ["/usr/aarch64-linux-gnu/lib"]\n\
-rustc-link-lib = ["dbus-1"]' > /root/.cargo/config.toml
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc" \
+    PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu
 
 # === Volta for npm + node ===
 


### PR DESCRIPTION
Getting rid of populating `/root/.cargo/config.toml` to make it build for ARM64. Instead set the linker manually and set a variable that makes `pkg-config` work cross-platform automatically. Then we don't need to specify the paths to `dbus-1`, pkg-config will find it for us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4091)
<!-- Reviewable:end -->
