### PR TITLE
Remove expectation of `/var/log/` being writeable during early boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.
 
+#### Linux
+- Remove last filesystem dependency of early boot blocking unit.
+
 
 ### Changed
 - Update Electron from 19.0.13 to 21.1.1.

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -23,7 +23,7 @@ const EARLY_BOOT_LOG_FILENAME: &str = "early-boot-fw.log";
 
 fn main() {
     let config = cli::get_config();
-    let log_dir = init_logging(config).unwrap_or_else(|error| {
+    let log_dir = init_daemon_logging(config).unwrap_or_else(|error| {
         eprintln!("{}", error);
         std::process::exit(1)
     });
@@ -46,38 +46,48 @@ fn main() {
     std::process::exit(exit_code);
 }
 
-fn init_logging(config: &cli::Config) -> Result<Option<PathBuf>, String> {
-    let log_dir = get_log_dir(config)?;
-    let log_path = |filename| log_dir.as_ref().map(|dir| dir.join(filename));
-
-    let initialize_logging = |log_file: Option<PathBuf>| -> Result<_, String> {
-        logging::init_logger(
-            config.log_level,
-            log_file.as_ref(),
-            config.log_stdout_timestamps,
-        )
-        .map_err(|e| e.display_chain_with_msg("Unable to initialize logger"))?;
-        log_panics::init();
-        exception_logging::enable();
-        version::log_version();
-        Ok(())
-    };
-
+fn init_daemon_logging(config: &cli::Config) -> Result<Option<PathBuf>, String> {
     #[cfg(target_os = "linux")]
     if config.initialize_firewall_and_exit {
-        if initialize_logging(log_path(EARLY_BOOT_LOG_FILENAME)).is_err() {
-            let _ = initialize_logging(None);
-        }
-
+        init_early_boot_logging(config);
         return Ok(None);
     }
 
-    initialize_logging(log_path(DAEMON_LOG_FILENAME))?;
+    let log_dir = get_log_dir(config)?;
+    let log_path = |filename| log_dir.as_ref().map(|dir| dir.join(filename));
+
+    init_logger(config, log_path(DAEMON_LOG_FILENAME))?;
 
     if let Some(ref log_dir) = log_dir {
         log::info!("Logging to {}", log_dir.display());
     }
     Ok(log_dir)
+}
+
+#[cfg(target_os = "linux")]
+fn init_early_boot_logging(config: &cli::Config) {
+    // If it's possible to log to the filesystem - attempt to do so, but failing that mustn't stop
+    // the daemon from starting here.
+    if let Ok(Some(log_dir)) = get_log_dir(config) {
+        if init_logger(config, Some(log_dir.join(EARLY_BOOT_LOG_FILENAME))).is_ok() {
+            return;
+        }
+    }
+
+    let _ = init_logger(config, None);
+}
+
+fn init_logger(config: &cli::Config, log_file: Option<PathBuf>) -> Result<(), String> {
+    logging::init_logger(
+        config.log_level,
+        log_file.as_ref(),
+        config.log_stdout_timestamps,
+    )
+    .map_err(|e| e.display_chain_with_msg("Unable to initialize logger"))?;
+    log_panics::init();
+    exception_logging::enable();
+    version::log_version();
+    Ok(())
 }
 
 fn get_log_dir(config: &cli::Config) -> Result<Option<PathBuf>, String> {


### PR DESCRIPTION
During early boot, the daemon will attempt to create the log directory and set the correct permissions for it - and if it fails it won't continue. In the early boot case, this is now changed so that the early boot firewall rules are still being applied.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4099)
<!-- Reviewable:end -->
