### PR TITLE
Intents: accept tunnel manager instance

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -79,11 +79,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, handlerFor intent: INIntent) -> Any? {
         switch intent {
         case is StartVPNIntent:
-            return StartVPNIntentHandler()
+            return StartVPNIntentHandler(tunnelManager: .shared)
         case is StopVPNIntent:
-            return StopVPNIntentHandler()
+            return StopVPNIntentHandler(tunnelManager: .shared)
         case is ReconnectVPNIntent:
-            return ReconnectVPNIntentHandler()
+            return ReconnectVPNIntentHandler(tunnelManager: .shared)
         default:
             return nil
         }

--- a/ios/MullvadVPN/IntentHandlers.swift
+++ b/ios/MullvadVPN/IntentHandlers.swift
@@ -9,8 +9,14 @@
 import Foundation
 
 final class StartVPNIntentHandler: NSObject, StartVPNIntentHandling {
+    private let tunnelManager: TunnelManager
+
+    init(tunnelManager: TunnelManager) {
+        self.tunnelManager = tunnelManager
+    }
+
     func handle(intent: StartVPNIntent, completion: @escaping (StartVPNIntentResponse) -> Void) {
-        TunnelManager.shared.startTunnel { operationCompletion in
+        tunnelManager.startTunnel { operationCompletion in
             let code: StartVPNIntentResponseCode = operationCompletion.isSuccess
                 ? .success
                 : .failure
@@ -22,8 +28,14 @@ final class StartVPNIntentHandler: NSObject, StartVPNIntentHandling {
 }
 
 final class StopVPNIntentHandler: NSObject, StopVPNIntentHandling {
+    private let tunnelManager: TunnelManager
+
+    init(tunnelManager: TunnelManager) {
+        self.tunnelManager = tunnelManager
+    }
+
     func handle(intent: StopVPNIntent, completion: @escaping (StopVPNIntentResponse) -> Void) {
-        TunnelManager.shared.stopTunnel { operationCompletion in
+        tunnelManager.stopTunnel { operationCompletion in
             let code: StopVPNIntentResponseCode = operationCompletion.isSuccess
                 ? .success
                 : .failure
@@ -35,12 +47,16 @@ final class StopVPNIntentHandler: NSObject, StopVPNIntentHandling {
 }
 
 final class ReconnectVPNIntentHandler: NSObject, ReconnectVPNIntentHandling {
+    private let tunnelManager: TunnelManager
+
+    init(tunnelManager: TunnelManager) {
+        self.tunnelManager = tunnelManager
+    }
+
     func handle(
         intent: ReconnectVPNIntent,
         completion: @escaping (ReconnectVPNIntentResponse) -> Void
     ) {
-        let tunnelManager = TunnelManager.shared
-
         tunnelManager.reconnectTunnel(selectNewRelay: true) { operationCompletion in
             let error = operationCompletion.error
 
@@ -52,7 +68,7 @@ final class ReconnectVPNIntentHandler: NSObject, ReconnectVPNIntentHandling {
             }
 
             if shouldStartTunnel {
-                tunnelManager.startTunnel { operationCompletion in
+                self.tunnelManager.startTunnel { operationCompletion in
                     completion(
                         ReconnectVPNIntentResponse(
                             code: operationCompletion.isSuccess ? .success : .failure,


### PR DESCRIPTION
This PR removes the use of `TunnelManager.shared`  and instead provides a way to pass an instance on `TunnelManager` during initialization. For now we pass `.shared` to make master compilable, but the follow up PR will fix that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4105)
<!-- Reviewable:end -->
