### PR TITLE
Pass tunnel manager into transport monitor

### DIFF
--- a/ios/MullvadVPN/TransportMonitor/PacketTunnelTransport.swift
+++ b/ios/MullvadVPN/TransportMonitor/PacketTunnelTransport.swift
@@ -16,13 +16,19 @@ final class PacketTunnelTransport: RESTTransport {
         return "packet-tunnel"
     }
 
+    let tunnelManager: TunnelManager
+
+    init(tunnelManager: TunnelManager) {
+        self.tunnelManager = tunnelManager
+    }
+
     func sendRequest(
         _ request: URLRequest,
         completion: @escaping (Data?, URLResponse?, Error?) -> Void
     ) throws -> Cancellable {
         let proxyRequest = try ProxyURLRequest(id: UUID(), urlRequest: request)
 
-        return try TunnelManager.shared.sendRequest(proxyRequest) { result in
+        return try tunnelManager.sendRequest(proxyRequest) { result in
             switch result {
             case .cancelled:
                 completion(nil, nil, URLError(.cancelled))

--- a/ios/MullvadVPN/TransportMonitor/TransportMonitor.swift
+++ b/ios/MullvadVPN/TransportMonitor/TransportMonitor.swift
@@ -10,11 +10,17 @@ import Foundation
 import MullvadREST
 
 class TransportMonitor: TunnelObserver {
-    private let packetTunnelTransport = PacketTunnelTransport()
-    private let urlSessionTransport = URLSessionTransport(urlSession: REST.makeURLSession())
+    private let tunnelManager: TunnelManager
+    private let packetTunnelTransport: PacketTunnelTransport
+    private let urlSessionTransport: URLSessionTransport
 
-    init() {
-        TunnelManager.shared.addObserver(self)
+    init(tunnelManager: TunnelManager = .shared) {
+        self.tunnelManager = tunnelManager
+
+        packetTunnelTransport = PacketTunnelTransport(tunnelManager: tunnelManager)
+        urlSessionTransport = URLSessionTransport(urlSession: REST.makeURLSession())
+
+        tunnelManager.addObserver(self)
 
         setTransports()
     }
@@ -45,8 +51,8 @@ class TransportMonitor: TunnelObserver {
     private func setTransports() {
         REST.TransportRegistry.shared.setTransport(
             stateUpdated(
-                tunnelState: TunnelManager.shared.tunnelStatus.state,
-                deviceState: TunnelManager.shared.deviceState
+                tunnelState: tunnelManager.tunnelStatus.state,
+                deviceState: tunnelManager.deviceState
             )
         )
     }


### PR DESCRIPTION
This PR makes `PacketTunnelTransport` and `TransportMonitor` accept `TunnelManager` input. This should eventually enable us to get rid of `.shared` instance of `TunnelManager` and pass an individual instance during initialization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4108)
<!-- Reviewable:end -->
