### PR TITLE
Ensure android app is reinstalled in gh actions

### DIFF
--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/ui/fragments/SplitTunnelingFragmentTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/ui/fragments/SplitTunnelingFragmentTest.kt
@@ -152,7 +152,7 @@ class SplitTunnelingFragmentTest : KoinTest {
         onView(withRecyclerView(R.id.recyclerView).atPositionOnView(0, R.id.itemText))
             .check(matches(withText("Test App Name")))
 
-        onView(withRecyclerView(R.id.recyclerView).atPosition(0)).perform(click())
+        onView(withRecyclerView(R.id.recyclerView).atPositionOnView(0)).perform(click())
 
         coVerifyAll {
             mockedViewModel.listItems

--- a/ci/run-android-instrumented-tests.sh
+++ b/ci/run-android-instrumented-tests.sh
@@ -5,11 +5,25 @@ LOG_FILE_NAME="mullvad.instrumentation_data_proto"
 LOG_FILE_PATH="/sdcard/$LOG_FILE_NAME"
 LOG_FAILURE_MESSAGE="FAILURES\!\!\!"
 
-adb install -r -t "$APK_BASE_DIR/debug/app-debug.apk"
+echo "Running instrumented tests..."
+echo ""
+
+echo "### Ensure uninstalled ###"
+adb uninstall net.mullvad.mullvadvpn || echo "App package not installed"
+adb uninstall net.mullvad.mullvadvpn.test || echo "Test package not installed"
+echo ""
+
+echo "### Install ###"
+adb install -t "$APK_BASE_DIR/debug/app-debug.apk"
 adb install "$APK_BASE_DIR/androidTest/debug/app-debug-androidTest.apk"
+echo ""
+
+echo "### Start tests ###"
 adb shell am instrument -w -f "$LOG_FILE_NAME" net.mullvad.mullvadvpn.test/androidx.test.runner.AndroidJUnitRunner
+echo ""
 
 # Print log so that it shows as part of GitHub Actions logs etc
+echo "### Logs ###"
 adb shell cat "$LOG_FILE_PATH"
 
 if adb shell grep -q "$LOG_FAILURE_MESSAGE" "$LOG_FILE_PATH"; then


### PR DESCRIPTION
This PR aims to make the instrumentation more robust as it avoids any potential signature mismatch (which is acceptable in a ci environment). It also makes sure that no app data/cache is left from previous runs.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4110)
<!-- Reviewable:end -->
