### PR TITLE
Tunnel sim: pass relay cache tracker during initialization

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private var logger: Logger!
 
     #if targetEnvironment(simulator)
-    private let simulatorTunnelProvider = SimulatorTunnelProviderHost()
+    private var simulatorTunnelProviderHost: SimulatorTunnelProviderHost?
     #endif
 
     private let operationQueue: AsyncOperationQueue = {
@@ -47,7 +47,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         #if targetEnvironment(simulator)
         // Configure mock tunnel provider on simulator
-        SimulatorTunnelProvider.shared.delegate = simulatorTunnelProvider
+        simulatorTunnelProviderHost = SimulatorTunnelProviderHost(
+            relayCacheTracker: .shared
+        )
+        SimulatorTunnelProvider.shared.delegate = simulatorTunnelProviderHost
         #endif
 
         registerBackgroundTasks()

--- a/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
@@ -21,9 +21,14 @@ class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
     private var selectorResult: RelaySelectorResult?
     private let urlSession = REST.makeURLSession()
     private var proxiedRequests = [UUID: URLSessionDataTask]()
+    private let relayCacheTracker: RelayCacheTracker
 
     private let providerLogger = Logger(label: "SimulatorTunnelProviderHost")
     private let dispatchQueue = DispatchQueue(label: "SimulatorTunnelProviderHostQueue")
+
+    init(relayCacheTracker: RelayCacheTracker) {
+        self.relayCacheTracker = relayCacheTracker
+    }
 
     override func startTunnel(
         options: [String: NSObject]?,
@@ -158,7 +163,7 @@ class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
     }
 
     private func pickRelay() throws -> RelaySelectorResult {
-        let cachedRelays = try RelayCacheTracker.shared.getCachedRelays()
+        let cachedRelays = try relayCacheTracker.getCachedRelays()
         let tunnelSettings = try SettingsManager.readSettings()
 
         return try RelaySelector.evaluate(


### PR DESCRIPTION
Pass `RelayCacheTracker` when initializing `SimulatorTunnelProviderHost`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4111)
<!-- Reviewable:end -->
