### PR TITLE
Remove unused GH path

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -4,7 +4,6 @@ on:
     pull_request:
         paths:
             - .github/workflows/clippy.yml
-            - ci/check-clippy.sh
             - clippy.toml
             - '**/*.rs'
     # Check if requested manually from the Actions tab


### PR DESCRIPTION
Seems like when `ci/check-clippy.sh` was removed this watch path was not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4114)
<!-- Reviewable:end -->
