### PR TITLE
Cleanup GH actions (iOS)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -31,6 +31,9 @@ jobs:
         env:
             SOURCE_PACKAGES_PATH: .spm
         steps:
+            - name: Install xcbeautify
+              run: brew install xcbeautify
+
             - name: Checkout repository
               uses: actions/checkout@v3
 
@@ -77,7 +80,7 @@ jobs:
 
             - name: Run tests
               run: |
-                  xcodebuild test \
+                  set -o pipefail && xcodebuild test \
                       -project MullvadVPN.xcodeproj \
                       -scheme MullvadVPN \
                       -skip-testing:MullvadVPNScreenshots \
@@ -85,5 +88,5 @@ jobs:
                       -clonedSourcePackagesDirPath "${SOURCE_PACKAGES_PATH}" \
                       CODE_SIGN_IDENTITY="" \
                       CODE_SIGNING_REQUIRED=NO \
-                      ONLY_ACTIVE_ARCH=YES
+                      ONLY_ACTIVE_ARCH=YES | xcbeautify
               working-directory: ios

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -28,11 +28,8 @@ jobs:
     test:
         name: Unit tests
         runs-on: macos-11
-        strategy:
-            matrix:
-                destination: ['platform=iOS Simulator,OS=13.7,name=iPhone 8']
         env:
-            source_packages_dir: .spm
+            SOURCE_PACKAGES_PATH: .spm
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
@@ -40,7 +37,7 @@ jobs:
             - name: Configure cache
               uses: actions/cache@v3
               with:
-                path: ios/${{ env.source_packages_dir }}
+                path: ios/${{ env.SOURCE_PACKAGES_PATH }}
                 key: ${{ runner.os }}-spm-${{ hashFiles('ios/**/Package.resolved') }}
                 restore-keys: |
                   ${{ runner.os }}-spm-
@@ -78,32 +75,15 @@ jobs:
                   mv Package.resolved.out Package.resolved
               working-directory: ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
 
-            - name: Run MullvadVPNTests
+            - name: Run tests
               run: |
                   xcodebuild test \
                       -project MullvadVPN.xcodeproj \
-                      -scheme MullvadVPNTests \
-                      -destination "${destination}" \
+                      -scheme MullvadVPN \
+                      -skip-testing:MullvadVPNScreenshots \
+                      -destination "platform=iOS Simulator,OS=13.7,name=iPhone 8" \
                       -clonedSourcePackagesDirPath "${SOURCE_PACKAGES_PATH}" \
                       CODE_SIGN_IDENTITY="" \
                       CODE_SIGNING_REQUIRED=NO \
                       ONLY_ACTIVE_ARCH=YES
               working-directory: ios
-              env:
-                  destination: ${{ matrix.destination }}
-                  SOURCE_PACKAGES_PATH: ${{ env.source_packages_dir }}
-
-            - name: Run OperationsTests
-              run: |
-                  xcodebuild test \
-                      -project MullvadVPN.xcodeproj \
-                      -scheme OperationsTests \
-                      -destination "${destination}" \
-                      -clonedSourcePackagesDirPath "${SOURCE_PACKAGES_PATH}" \
-                      CODE_SIGN_IDENTITY="" \
-                      CODE_SIGNING_REQUIRED=NO \
-                      ONLY_ACTIVE_ARCH=YES
-              working-directory: ios
-              env:
-                  destination: ${{ matrix.destination }}
-                  SOURCE_PACKAGES_PATH: ${{ env.source_packages_dir }}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -2870,7 +2870,7 @@
 				MARKETING_VERSION = 2022.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER).PacketTunnel";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/PacketTunnel/ObjcBridgingHeader.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/PacketTunnel/ObjCBridgingHeader.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -2893,7 +2893,7 @@
 				MARKETING_VERSION = 2022.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER).PacketTunnel";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/PacketTunnel/ObjcBridgingHeader.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/PacketTunnel/ObjCBridgingHeader.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -556,7 +556,7 @@ final class TunnelManager {
         _ proxyRequest: ProxyURLRequest,
         completionHandler: @escaping (OperationCompletion<ProxyURLResponse, Error>) -> Void
     ) throws -> Cancellable {
-        if let tunnel {
+        if let tunnel = tunnel {
             return tunnel.sendRequest(proxyRequest, completionHandler: completionHandler)
         } else {
             throw UnsetTunnelError()


### PR DESCRIPTION
- Run all tests but ignore screenshots UI tests bundle. This has a nice side-effect of building the entire app before running tests, because screenshots target is dependent on `MullvadVPN`.
- Fix compiler error when running on older Xcode.
- Fix letter case in `ObjCBridgingHeader.h` which was referenced as `ObjcBridgingHeader.h` in Xcode project.
- Pipe `xcodebuild` through `xcbeautify` to produce a better build log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4118)
<!-- Reviewable:end -->
