### PR TITLE
Trigger android gh build on master updates

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -27,6 +27,10 @@ on:
           description: 'Override container image'
           type: string
           required: false
+    # Build if master is updated to ensure up-to-date caches are available
+    push:
+      branches:
+        - master
 jobs:
     prepare:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR aims to build if master is updated to ensure up-to-date caches are available for other builds. The main benefit is that PR builds will be quicker since it doesn't have to build wireguard-go and the daemon.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4119)
<!-- Reviewable:end -->
