### PR TITLE
Trim down on extension galore

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -17,7 +17,9 @@ import UIKit
 import UserNotifications
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate,
+    StorePaymentManagerDelegate
+{
     private var logger: Logger!
 
     #if targetEnvironment(simulator)
@@ -324,11 +326,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ]
         UNUserNotificationCenter.current().delegate = self
     }
-}
 
-// MARK: - AppStorePaymentManagerDelegate
+    // MARK: - StorePaymentManagerDelegate
 
-extension AppDelegate: StorePaymentManagerDelegate {
     func storePaymentManager(
         _ manager: StorePaymentManager,
         didRequestAccountTokenFor payment: SKPayment
@@ -338,11 +338,9 @@ extension AppDelegate: StorePaymentManagerDelegate {
         // number.
         return TunnelManager.shared.deviceState.accountData?.number
     }
-}
 
-// MARK: - UNUserNotificationCenterDelegate
+    // MARK: - UNUserNotificationCenterDelegate
 
-extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -13,7 +13,14 @@ import Operations
 import RelayCache
 import UIKit
 
-class SceneDelegate: UIResponder {
+class SceneDelegate: UIResponder, UIWindowSceneDelegate, UISplitViewControllerDelegate,
+    UIAdaptivePresentationControllerDelegate, RootContainerViewControllerDelegate,
+    LoginViewControllerDelegate, DeviceManagementViewControllerDelegate,
+    SettingsNavigationControllerDelegate, ConnectViewControllerDelegate,
+    OutOfTimeViewControllerDelegate, SelectLocationViewControllerDelegate,
+    RevokedDeviceViewControllerDelegate, NotificationManagerDelegate, TunnelObserver,
+    RelayCacheTrackerObserver
+{
     private let logger = Logger(label: "SceneDelegate")
 
     var window: UIWindow?
@@ -87,11 +94,9 @@ class SceneDelegate: UIResponder {
             window?.makeKeyAndVisible()
         }
     }
-}
 
-// MARK: - UIWindowSceneDelegate
+    // MARK: - UIWindowSceneDelegate
 
-extension SceneDelegate: UIWindowSceneDelegate {
     func scene(
         _ scene: UIScene,
         willConnectTo session: UISceneSession,
@@ -139,11 +144,9 @@ extension SceneDelegate: UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {}
 
     func sceneDidEnterBackground(_ scene: UIScene) {}
-}
 
-// MARK: - OutOfTimeViewControllerDelegate
+    // MARK: - OutOfTimeViewControllerDelegate
 
-extension SceneDelegate: OutOfTimeViewControllerDelegate {
     func outOfTimeViewControllerDidBeginPayment(_ controller: OutOfTimeViewController) {
         setEnableSettingsButton(isEnabled: false, from: controller)
     }
@@ -151,11 +154,9 @@ extension SceneDelegate: OutOfTimeViewControllerDelegate {
     func outOfTimeViewControllerDidEndPayment(_ controller: OutOfTimeViewController) {
         setEnableSettingsButton(isEnabled: true, from: controller)
     }
-}
 
-// MARK: - RootContainerViewControllerDelegate
+    // MARK: - RootContainerViewControllerDelegate
 
-extension SceneDelegate: RootContainerViewControllerDelegate {
     func rootContainerViewControllerShouldShowSettings(
         _ controller: RootContainerViewController,
         navigateTo route: SettingsNavigationRoute?,
@@ -211,9 +212,7 @@ extension SceneDelegate: RootContainerViewControllerDelegate {
         }
         return true
     }
-}
 
-extension SceneDelegate {
     private func setupPadUI() {
         let tunnelManager = TunnelManager.shared
         let selectLocationController = makeSelectLocationController()
@@ -562,11 +561,9 @@ extension SceneDelegate {
             fatalError()
         }
     }
-}
 
-// MARK: - LoginViewControllerDelegate
+    // MARK: - LoginViewControllerDelegate
 
-extension SceneDelegate: LoginViewControllerDelegate {
     func loginViewController(
         _ controller: LoginViewController,
         shouldHandleLoginAction action: LoginAction,
@@ -684,11 +681,9 @@ extension SceneDelegate: LoginViewControllerDelegate {
             container.setEnableSettingsButton(isEnabled)
         }
     }
-}
 
-// MARK: - DeviceManagementViewControllerDelegate
+    // MARK: - DeviceManagementViewControllerDelegate
 
-extension SceneDelegate: DeviceManagementViewControllerDelegate {
     func deviceManagementViewControllerDidCancel(_ controller: DeviceManagementViewController) {
         controller.rootContainerController?.popViewController(animated: true)
     }
@@ -704,11 +699,9 @@ extension SceneDelegate: DeviceManagementViewControllerDelegate {
             }
         }
     }
-}
 
-// MARK: - SettingsNavigationControllerDelegate
+    // MARK: - SettingsNavigationControllerDelegate
 
-extension SceneDelegate: SettingsNavigationControllerDelegate {
     func settingsNavigationController(
         _ controller: SettingsNavigationController,
         willNavigateTo route: SettingsNavigationRoute
@@ -732,11 +725,9 @@ extension SceneDelegate: SettingsNavigationControllerDelegate {
             controller.dismiss(animated: true)
         }
     }
-}
 
-// MARK: - ConnectViewControllerDelegate
+    // MARK: - ConnectViewControllerDelegate
 
-extension SceneDelegate: ConnectViewControllerDelegate {
     func connectViewControllerShouldShowSelectLocationPicker(_ controller: ConnectViewController) {
         let contentController = makeSelectLocationController()
         contentController.navigationItem.rightBarButtonItem = UIBarButtonItem(
@@ -754,22 +745,18 @@ extension SceneDelegate: ConnectViewControllerDelegate {
     @objc private func handleDismissSelectLocationController(_ sender: Any) {
         selectLocationViewController?.dismiss(animated: true)
     }
-}
 
-// MARK: - NotificationManagerDelegate
+    // MARK: - NotificationManagerDelegate
 
-extension SceneDelegate: NotificationManagerDelegate {
     func notificationManagerDidUpdateInAppNotifications(
         _ manager: NotificationManager,
         notifications: [InAppNotificationDescriptor]
     ) {
         connectController?.notificationController.setNotifications(notifications, animated: true)
     }
-}
 
-// MARK: - SelectLocationViewControllerDelegate
+    // MARK: - SelectLocationViewControllerDelegate
 
-extension SceneDelegate: SelectLocationViewControllerDelegate {
     func selectLocationViewController(
         _ controller: SelectLocationViewController,
         didSelectRelayLocation relayLocation: RelayLocation
@@ -795,21 +782,17 @@ extension SceneDelegate: SelectLocationViewControllerDelegate {
             TunnelManager.shared.startTunnel()
         }
     }
-}
 
-// MARK: - RevokedDeviceViewControllerDelegate
+    // MARK: - RevokedDeviceViewControllerDelegate
 
-extension SceneDelegate: RevokedDeviceViewControllerDelegate {
     func revokedDeviceControllerDidRequestLogout(_ controller: RevokedDeviceViewController) {
         TunnelManager.shared.unsetAccount { [weak self] in
             self?.showLoginViewAfterLogout(dismissController: nil)
         }
     }
-}
 
-// MARK: - UIAdaptivePresentationControllerDelegate
+    // MARK: - UIAdaptivePresentationControllerDelegate
 
-extension SceneDelegate: UIAdaptivePresentationControllerDelegate {
     func adaptivePresentationStyle(
         for controller: UIPresentationController,
         traitCollection: UITraitCollection
@@ -865,11 +848,9 @@ extension SceneDelegate: UIAdaptivePresentationControllerDelegate {
             )
         }
     }
-}
 
-// MARK: - TunnelObserver
+    // MARK: - TunnelObserver
 
-extension SceneDelegate: TunnelObserver {
     func tunnelManagerDidLoadConfiguration(_ manager: TunnelManager) {
         configureScene()
     }
@@ -907,22 +888,18 @@ extension SceneDelegate: TunnelObserver {
     func tunnelManager(_ manager: TunnelManager, didFailWithError error: Error) {
         // no-op
     }
-}
 
-// MARK: - RelayCacheTrackerObserver
+    // MARK: - RelayCacheTrackerObserver
 
-extension SceneDelegate: RelayCacheTrackerObserver {
     func relayCacheTracker(
         _ tracker: RelayCacheTracker,
         didUpdateCachedRelays cachedRelays: CachedRelays
     ) {
         selectLocationViewController?.setCachedRelays(cachedRelays)
     }
-}
 
-// MARK: - UISplitViewControllerDelegate
+    // MARK: - UISplitViewControllerDelegate
 
-extension SceneDelegate: UISplitViewControllerDelegate {
     func primaryViewController(forExpanding splitViewController: UISplitViewController)
         -> UIViewController?
     {


### PR DESCRIPTION
This PR moves protocol conformance declaration to the class declaration itself and removes excessive use of extensions in `AppDelegate` and `SceneDelegate`. 

As I mentioned earlier, I think many engineers abuse extensions for the sake of code organization. However the lack of stored properties in extensions introduces unnecessary fragmentation where extension is not complete without variables stored inside of class, especially when extension is the only consumer of those variables.

Perhaps subjective, but I think that keeping implementation within the class definition is probably cleaner and `MARK` comments can be used to separate sections of class. It's also easy to glance at what protocols the class implements by looking at the class declaration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4121)
<!-- Reviewable:end -->
