### PR TITLE
Fix "any tunnel type" relay matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - When a country is selected, and the constraints only match relays that are not included on the
   country level, select those relays anyway.
+- Fix regression where WireGuard relays were connected to over OpenVPN after a couple of failed
+  attempts, when the tunnel type was set to `any`.
 
 #### macOS
 - Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.


### PR DESCRIPTION
Removing per-relay endpoints caused `AnyTunnelMatcher` to sometimes use the wrong tunnel protocol. This was only noticeable after a couple of attempts since "preferred" constraints are used at first.

This PR fixes this and simplifies the relay filtering.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4130)
<!-- Reviewable:end -->
