### PR TITLE
Improve developer tools

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -18,11 +18,7 @@ import { SystemNotification } from '../shared/notifications/notification';
 import Account, { AccountDelegate, LocaleProvider } from './account';
 import { getOpenAtLogin } from './autostart';
 import { readChangelog } from './changelog';
-import {
-  SHOULD_DISABLE_RESET_NAVIGATION,
-  SHOULD_FORWARD_RENDERER_LOG,
-  SHOULD_SHOW_CHANGES,
-} from './command-line-options';
+import { SHOULD_DISABLE_RESET_NAVIGATION, SHOULD_SHOW_CHANGES } from './command-line-options';
 import { ConnectionObserver, DaemonRpc, SubscriptionListener } from './daemon-rpc';
 import Expectation from './expectation';
 import { IpcMainEventChannel } from './ipc-event-channel';
@@ -250,11 +246,7 @@ class ApplicationMain
     const mainLogPath = getMainLogPath();
     const rendererLogPath = getRendererLogPath();
 
-    if (process.env.NODE_ENV === 'development') {
-      if (SHOULD_FORWARD_RENDERER_LOG) {
-        log.addInput(new IpcInput());
-      }
-    } else {
+    if (process.env.NODE_ENV === 'production') {
       this.rendererLog = new Logger();
       this.rendererLog.addInput(new IpcInput());
 

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -8,9 +8,10 @@ import { IAccountData, ILocation, TunnelState } from '../shared/daemon-rpc-types
 import { messages, relayLocations } from '../shared/gettext';
 import log from '../shared/logging';
 import { Scheduler } from '../shared/scheduler';
-import { SHOULD_DISABLE_DEVTOOLS_OPEN } from './command-line-options';
+import { SHOULD_DISABLE_DEVTOOLS_OPEN, SHOULD_FORWARD_RENDERER_LOG } from './command-line-options';
 import { DaemonRpc } from './daemon-rpc';
 import { changeIpcWebContents, IpcMainEventChannel } from './ipc-event-channel';
+import { WebContentsConsoleInput } from './logging';
 import { isMacOs11OrNewer } from './platform-version';
 import TrayIconController, { TrayIconType } from './tray-icon-controller';
 import WindowController, { WindowControllerDelegate } from './window-controller';
@@ -95,6 +96,10 @@ export default class UserInterface implements WindowControllerDelegate {
       if (!SHOULD_DISABLE_DEVTOOLS_OPEN) {
         // The devtools doesn't open on Windows if openDevTools is called without a delay here.
         window.once('ready-to-show', () => window.webContents.openDevTools({ mode: 'detach' }));
+      }
+
+      if (SHOULD_FORWARD_RENDERER_LOG) {
+        log.addInput(new WebContentsConsoleInput(window.webContents));
       }
     }
 

--- a/gui/src/renderer/components/AppRouter.tsx
+++ b/gui/src/renderer/components/AppRouter.tsx
@@ -7,6 +7,7 @@ import { useAppContext } from '../context';
 import { ITransitionSpecification, transitions, useHistory } from '../lib/history';
 import { RoutePath } from '../lib/routes';
 import Account from './Account';
+import Debug from './Debug';
 import { DeviceRevokedView } from './DeviceRevokedView';
 import {
   SetupFinished,
@@ -79,6 +80,7 @@ export default function AppRouter() {
             <Route exact path={RoutePath.splitTunneling} component={SplitTunnelingSettings} />
             <Route exact path={RoutePath.support} component={Support} />
             <Route exact path={RoutePath.problemReport} component={ProblemReport} />
+            <Route exact path={RoutePath.debug} component={Debug} />
             <Route exact path={RoutePath.selectLocation} component={SelectLocationPage} />
             <Route exact path={RoutePath.filter} component={Filter} />
           </Switch>

--- a/gui/src/renderer/components/Debug.tsx
+++ b/gui/src/renderer/components/Debug.tsx
@@ -1,0 +1,90 @@
+import { useCallback } from 'react';
+import styled from 'styled-components';
+
+import { useHistory } from '../lib/history';
+import { useBoolean } from '../lib/utilityHooks';
+import * as AppButton from './AppButton';
+import { measurements } from './common-styles';
+import { BackAction } from './KeyboardNavigation';
+import { Layout, SettingsContainer } from './Layout';
+import {
+  NavigationBar,
+  NavigationContainer,
+  NavigationItems,
+  NavigationScrollbars,
+  TitleBarItem,
+} from './NavigationBar';
+import SettingsHeader, { HeaderTitle } from './SettingsHeader';
+
+const StyledContent = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  marginBottom: '2px',
+});
+
+const StyledButtonGroup = styled.div({
+  margin: measurements.viewMargin,
+});
+
+export default function Debug() {
+  const { pop } = useHistory();
+
+  return (
+    <BackAction action={pop}>
+      <Layout>
+        <SettingsContainer>
+          <NavigationContainer>
+            <NavigationBar>
+              <NavigationItems>
+                <TitleBarItem>Developer tools</TitleBarItem>
+              </NavigationItems>
+            </NavigationBar>
+
+            <NavigationScrollbars>
+              <SettingsHeader>
+                <HeaderTitle>Developer tools</HeaderTitle>
+              </SettingsHeader>
+
+              <StyledContent>
+                <StyledButtonGroup>
+                  <AppButton.ButtonGroup>
+                    <ThrowErrorButton />
+                    <UnhandledRejectionButton />
+                    <ErrorDuringRender />
+                  </AppButton.ButtonGroup>
+                </StyledButtonGroup>
+              </StyledContent>
+            </NavigationScrollbars>
+          </NavigationContainer>
+        </SettingsContainer>
+      </Layout>
+    </BackAction>
+  );
+}
+
+function ThrowErrorButton() {
+  const handleClick = useCallback(() => {
+    throw new Error('This is a test error');
+  }, []);
+
+  return <AppButton.RedButton onClick={handleClick}>Throw error</AppButton.RedButton>;
+}
+
+function UnhandledRejectionButton() {
+  const handleClick = useCallback(() => {
+    return new Promise((_resolve, reject) => setTimeout(reject, 100));
+  }, []);
+
+  return <AppButton.RedButton onClick={handleClick}>Unhandled rejection</AppButton.RedButton>;
+}
+
+function ErrorDuringRender() {
+  const [error, setError] = useBoolean(false);
+
+  if (error) {
+    throw new Error('This is a test error during render');
+  }
+
+  return <AppButton.RedButton onClick={setError}>Error next render</AppButton.RedButton>;
+}

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -84,6 +84,12 @@ export default function Support() {
                     <SupportButton />
                     <AppVersionButton />
                   </Cell.Group>
+
+                  {window.env.development && (
+                    <Cell.Group>
+                      <DebugButton />
+                    </Cell.Group>
+                  )}
                 </StyledSettingsContent>
               </StyledContent>
 
@@ -233,6 +239,17 @@ function SupportButton() {
   return (
     <Cell.CellNavigationButton onClick={navigate}>
       <Cell.Label>{messages.pgettext('settings-view', 'Support')}</Cell.Label>
+    </Cell.CellNavigationButton>
+  );
+}
+
+function DebugButton() {
+  const history = useHistory();
+  const navigate = useCallback(() => history.push(RoutePath.debug), [history]);
+
+  return (
+    <Cell.CellNavigationButton onClick={navigate}>
+      <Cell.Label>Developer tools</Cell.Label>
     </Cell.CellNavigationButton>
   );
 }

--- a/gui/src/renderer/lib/routes.ts
+++ b/gui/src/renderer/lib/routes.ts
@@ -22,6 +22,7 @@ export enum RoutePath {
   splitTunneling = '/settings/split-tunneling',
   support = '/settings/support',
   problemReport = '/settings/support/problem-report',
+  debug = '/settings/debug',
   selectLocation = '/select-location',
   filter = '/select-location/filter',
 }


### PR DESCRIPTION
This PR adds a few features to make development easier:
- When forwarding the renderer log to the main console it now uses the webcontents console event listener instead of the ipc input. This results in regular console.log, console.error and thrown errors to show up. It also prefixes all renderer messages with "[Renderer]" in either blue or red depending on log level. This is only applicable if the app is run with `--forward-renderer-log`.
- A new view which will be used to trigger varius things while testing the app. The currently available actions are to throw errors in multiple different situations. This view is only visible when running with `npm run develop`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4131)
<!-- Reviewable:end -->
