### PR TITLE
Use fwmark for routing in openvpn

### DIFF
--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -182,6 +182,8 @@ impl InnerParametersGenerator {
                     options: self.tunnel_options.openvpn.clone(),
                     generic_options: self.tunnel_options.generic.clone(),
                     proxy: bridge_settings,
+                    #[cfg(target_os = "linux")]
+                    fwmark: mullvad_types::TUNNEL_FWMARK,
                 }
                 .into())
             }

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -54,6 +54,8 @@ impl CustomTunnelEndpoint {
                 options: tunnel_options.openvpn.clone(),
                 generic_options: tunnel_options.generic,
                 proxy,
+                #[cfg(target_os = "linux")]
+                fwmark: crate::TUNNEL_FWMARK,
             }
             .into(),
             ConnectionConfig::Wireguard(connection) => wireguard::TunnelParameters {

--- a/talpid-types/src/net/openvpn.rs
+++ b/talpid-types/src/net/openvpn.rs
@@ -13,6 +13,8 @@ pub struct TunnelParameters {
     pub options: TunnelOptions,
     pub generic_options: GenericTunnelOptions,
     pub proxy: Option<ProxySettings>,
+    #[cfg(target_os = "linux")]
+    pub fwmark: u32,
 }
 
 /// Connection configuration used by [`TunnelParameters`].


### PR DESCRIPTION
In the latest changes of splitting up `talpid-core`, the firewall mark was no longer being passed to the OpenVPN tunnel when it's being set up, which results in the tunnel not working on Linux. These changes _fix_ that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4135)
<!-- Reviewable:end -->
