### PR TITLE
Ignore misconfigured network adapters in the installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Remove last filesystem dependency of early boot blocking unit.
 
+#### Windows
+- Ignore adapters that have no valid GUID when removing obsolete Wintun interfaces during install.
+  Previously, the installer would abort.
+
 
 ### Changed
 - Update Electron from 19.0.13 to 21.1.1.

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -796,11 +796,6 @@
 	${ExtractDriverlogic}
 	${RemoveAbandonedWintunAdapter}
 
-	${If} $R0 != 0
-		MessageBox MB_OK "$R0"
-		Goto customInstall_abort_installation
-	${EndIf}
-
 	${RemoveSplitTunnelDriver}
 
 	${If} $R0 != 0

--- a/windows/driverlogic/src/driverlogic.cpp
+++ b/windows/driverlogic/src/driverlogic.cpp
@@ -186,9 +186,17 @@ ReturnCode CommandWintunDeleteAbandonedDevice(const std::vector<std::wstring> &a
 	{
 		static wchar_t WintunMullvadAdapter[] = L"{AFE43773-E1F8-4EBB-8536-576AB86AFE9A}";
 
-		auto candidateAdapterGuid = GetDeviceNetCfgInstanceId(deviceInfoSet, deviceInfo);
+		try
+		{
+			auto candidateAdapterGuid = GetDeviceNetCfgInstanceId(deviceInfoSet, deviceInfo);
 
-		return 0 == _wcsicmp(candidateAdapterGuid.c_str(), WintunMullvadAdapter);
+			return 0 == _wcsicmp(candidateAdapterGuid.c_str(), WintunMullvadAdapter);
+		}
+		catch (...)
+		{
+			// Skip adapters for which we cannot obtain NetCfgInstanceId.
+			return false;
+		}
 	});
 
 	EnumeratedDevice device;


### PR DESCRIPTION
This PR updates the installer on Windows to ignore errors that occur while attempting to clean up old Wintun interfaces in `RemoveAbandonedWintunAdapter`. It also makes `driverlogic` skip adapters that appear to have no valid GUID.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4136)
<!-- Reviewable:end -->
