### PR TITLE
Ensure RPM cleans up app's direcotires when removed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - Remove last filesystem dependency of early boot blocking unit.
+- Ensure RPM package removes all application directories when uninstalled.
 
 #### Windows
 - Ignore adapters that have no valid GUID when removing obsolete Wintun interfaces during install.

--- a/dist-assets/linux/after-remove.sh
+++ b/dist-assets/linux/after-remove.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-echo "Running after-remove.sh"
-
 function remove_logs_and_cache {
   rm -r --interactive=never /var/log/mullvad-vpn/ || \
     echo "Failed to remove mullvad-vpn logs"

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -202,6 +202,7 @@ const config = {
 
   rpm: {
     fpm: [
+      '--directories=/opt/Mullvad VPN/',
       '--before-install',
       distAssets('linux/before-install.sh'),
       '--before-remove',


### PR DESCRIPTION
RPM doesn't seem to remove our app's directories - they are left empty. This can be fixed by passing `--directories=/opt/Mullvad VPN` to `fpm` when building the package.

As a bonus, some obtuse logging is removed from the install scripts- these would normally pollute standard output during installation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4138)
<!-- Reviewable:end -->
