### PR TITLE
trusted DNS servers option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Changed
 - Update Electron from 19.0.13 to 21.1.1.
+- Add a trusted DNS option
 
 ### Security
 #### Windows

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -45,7 +45,7 @@ use mullvad_types::{
     location::GeoIpLocation,
     relay_constraints::{BridgeSettings, BridgeState, ObfuscationSettings, RelaySettingsUpdate},
     relay_list::RelayList,
-    settings::{DnsOptions, Settings},
+    settings::{DnsOptions, TrustedDnsOptions, Settings},
     states::{TargetState, TunnelState},
     version::{AppVersion, AppVersionInfo},
     wireguard::{PublicKey, RotationInterval},
@@ -228,6 +228,8 @@ pub enum DaemonCommand {
     SetQuantumResistantTunnel(ResponseTx<(), settings::Error>, bool),
     /// Set DNS options or servers to use
     SetDnsOptions(ResponseTx<(), settings::Error>, DnsOptions),
+    /// Set trusted DNS servers
+    SetTrustedDnsOptions(ResponseTx<(), settings::Error>, TrustedDnsOptions),
     /// Toggle macOS network check leak
     /// Set MTU for wireguard tunnels
     SetWireguardMtu(ResponseTx<(), settings::Error>, Option<u16>),
@@ -676,6 +678,7 @@ where
                 allow_lan: settings.allow_lan,
                 block_when_disconnected: settings.block_when_disconnected,
                 dns_servers: dns::addresses_from_options(&settings.tunnel_options.dns_options),
+                trusted_dns_servers: Vec::new(),
                 allowed_endpoint: initial_api_endpoint,
                 reset_firewall: *target_state != TargetState::Secured,
                 #[cfg(windows)]
@@ -1008,6 +1011,7 @@ where
                 self.on_set_quantum_resistant_tunnel(tx, enable_pq).await
             }
             SetDnsOptions(tx, dns_servers) => self.on_set_dns_options(tx, dns_servers).await,
+            SetTrustedDnsOptions(tx, dns_servers) => self.on_set_trusted_dns_options(tx, dns_servers).await,
             SetWireguardMtu(tx, mtu) => self.on_set_wireguard_mtu(tx, mtu).await,
             SetWireguardRotationInterval(tx, interval) => {
                 self.on_set_wireguard_rotation_interval(tx, interval).await
@@ -2073,6 +2077,33 @@ where
             }
         }
     }
+
+    async fn on_set_trusted_dns_options(
+        &mut self,
+        tx: ResponseTx<(), settings::Error>,
+        trusted_dns_options: TrustedDnsOptions,
+    ) {
+        let save_result = self.settings.set_trusted_dns_options(trusted_dns_options.clone()).await;
+        match save_result {
+            Ok(settings_changed) => {
+                Self::oneshot_send(tx, Ok(()), "set_trusted_dns_options response");
+                if settings_changed {
+                    let settings = self.settings.to_settings();
+                    let resolvers = settings.tunnel_options.trusted_dns_options.addresses.clone();
+                    self.parameters_generator
+                        .set_tunnel_options(&settings.tunnel_options)
+                        .await;
+                    self.event_listener.notify_settings(settings);
+                    self.send_tunnel_command(TunnelCommand::DnsTrust(resolvers));
+                }
+            }
+            Err(e) => {
+                log::error!("{}", e.display_chain_with_msg("Unable to save settings"));
+                Self::oneshot_send(tx, Err(e), "set_dns_options response");
+            }
+        }
+    }
+
 
     async fn on_set_wireguard_mtu(
         &mut self,

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -2,7 +2,7 @@
 use futures::TryFutureExt;
 use mullvad_types::{
     relay_constraints::{BridgeSettings, BridgeState, ObfuscationSettings, RelaySettingsUpdate},
-    settings::{DnsOptions, Settings},
+    settings::{DnsOptions, TrustedDnsOptions, Settings},
     wireguard::RotationInterval,
 };
 use rand::Rng;
@@ -266,6 +266,12 @@ impl SettingsPersister {
     pub async fn set_dns_options(&mut self, options: DnsOptions) -> Result<bool, Error> {
         let should_save =
             Self::update_field(&mut self.settings.tunnel_options.dns_options, options);
+        self.update(should_save).await
+    }
+
+    pub async fn set_trusted_dns_options(&mut self, options: TrustedDnsOptions) -> Result<bool, Error> {
+        let should_save =
+            Self::update_field(&mut self.settings.tunnel_options.trusted_dns_options, options);
         self.update(should_save).await
     }
 

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -282,6 +282,16 @@ impl DaemonInterface {
             .map_err(|_| Error::SettingsError)
     }
 
+    pub fn set_trusted_dns_options(&self, trusted_dns_options: TrustedDnsOptions) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(DaemonCommand::SetTrustedDnsOptions(tx, dns_options))?;
+
+        block_on(rx)
+            .map_err(|_| Error::NoResponse)?
+            .map_err(|_| Error::SettingsError)
+    }
+
     pub fn set_wireguard_mtu(&self, wireguard_mtu: Option<u16>) -> Result<()> {
         let (tx, rx) = oneshot::channel();
 

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -45,6 +45,7 @@ service ManagementService {
 	rpc SetEnableIpv6(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
 	rpc SetQuantumResistantTunnel(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
 	rpc SetDnsOptions(DnsOptions) returns (google.protobuf.Empty) {}
+	rpc SetTrustedDnsOptions(TrustedDnsOptions) returns (google.protobuf.Empty) {}
 
 	// Account management
 	rpc CreateNewAccount(google.protobuf.Empty) returns (google.protobuf.StringValue) {}
@@ -448,6 +449,7 @@ message TunnelOptions {
 	WireguardOptions wireguard = 2;
 	GenericOptions generic = 3;
 	DnsOptions dns_options = 4;
+	TrustedDnsOptions trusted_dns_options = 5;
 }
 
 message DefaultDnsOptions {
@@ -470,6 +472,10 @@ message DnsOptions {
 	DnsState state = 1;
 	DefaultDnsOptions default_options = 2;
 	CustomDnsOptions custom_options = 3;
+}
+
+message TrustedDnsOptions {
+	repeated string addresses = 1;
 }
 
 message PublicKey {

--- a/mullvad-types/src/settings/dns.rs
+++ b/mullvad-types/src/settings/dns.rs
@@ -82,3 +82,9 @@ pub struct DefaultDnsOptions {
 pub struct CustomDnsOptions {
     pub addresses: Vec<IpAddr>,
 }
+
+/// Trusted DNS config
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct TrustedDnsOptions {
+    pub addresses: Vec<IpAddr>,
+}

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -204,9 +204,10 @@ pub struct TunnelOptions {
     pub generic: GenericTunnelOptions,
     /// DNS options.
     pub dns_options: DnsOptions,
+    pub trusted_dns_options: TrustedDnsOptions,
 }
 
-pub use dns::{CustomDnsOptions, DefaultDnsOptions, DnsOptions, DnsState};
+pub use dns::{CustomDnsOptions, DefaultDnsOptions, DnsOptions, TrustedDnsOptions, DnsState};
 
 #[cfg(target_os = "android")]
 pub use dns::AndroidDnsOptions;
@@ -224,6 +225,7 @@ impl Default for TunnelOptions {
                 enable_ipv6: cfg!(target_os = "android"),
             },
             dns_options: DnsOptions::default(),
+            trusted_dns_options: TrustedDnsOptions::default(),
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -85,12 +85,15 @@ impl ConnectedState {
     fn get_dns_servers(&self, shared_values: &SharedTunnelStateValues) -> Vec<IpAddr> {
         #[cfg(not(target_os = "android"))]
         if let Some(ref servers) = shared_values.dns_servers {
-            servers.clone()
+            let mut server_list = servers.clone();
+            server_list.append(&mut shared_values.trusted_dns_servers.clone());
+            server_list
         } else {
             let mut dns_ips = vec![self.metadata.ipv4_gateway.into()];
             if let Some(ipv6_gateway) = self.metadata.ipv6_gateway {
                 dns_ips.push(ipv6_gateway.into());
             };
+            dns_ips.append(&mut shared_values.trusted_dns_servers.clone());
             dns_ips
         }
         #[cfg(target_os = "android")]
@@ -100,6 +103,7 @@ impl ConnectedState {
             if let Some(ipv6_gateway) = self.metadata.ipv6_gateway {
                 dns_ips.push(ipv6_gateway.into());
             };
+            dns_ips.append(&mut shared_values.dns_servers_allowed.clone());
             dns_ips
         }
     }
@@ -235,6 +239,22 @@ impl ConnectedState {
                                 AfterDisconnect::Block(ErrorStateCause::SetDnsError),
                             )
                         }
+                    }
+                }
+                Ok(false) => SameState(self.into()),
+                Err(error_cause) => {
+                    self.disconnect(shared_values, AfterDisconnect::Block(error_cause))
+                }
+            },
+            Some(TunnelCommand::DnsTrust(servers)) => match shared_values.set_trusted_dns_servers(servers) {
+                Ok(true) => {
+                    if let Err(error) = self.set_firewall_policy(shared_values) {
+                        return self.disconnect(
+                            shared_values,
+                            AfterDisconnect::Block(ErrorStateCause::SetFirewallPolicyError(error)),
+                        );
+                    } else {
+                        SameState(self.into())
                     }
                 }
                 Ok(false) => SameState(self.into()),

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -354,6 +354,12 @@ impl ConnectingState {
                 Ok(_) => SameState(self.into()),
                 Err(cause) => self.disconnect(shared_values, AfterDisconnect::Block(cause)),
             },
+            Some(TunnelCommand::DnsTrust(servers)) => match shared_values.set_trusted_dns_servers(servers) {
+                #[cfg(target_os = "android")]
+                Ok(true) => self.disconnect(shared_values, AfterDisconnect::Reconnect(0)),
+                Ok(_) => SameState(self.into()),
+                Err(cause) => self.disconnect(shared_values, AfterDisconnect::Block(cause)),
+            },
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 shared_values.block_when_disconnected = block_when_disconnected;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -36,6 +36,10 @@ impl DisconnectingState {
                     let _ = shared_values.set_dns_servers(servers);
                     AfterDisconnect::Nothing
                 }
+                Some(TunnelCommand::DnsTrust(servers)) => {
+                    let _ = shared_values.set_trusted_dns_servers(servers);
+                    AfterDisconnect::Nothing
+                }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                     shared_values.block_when_disconnected = block_when_disconnected;
                     AfterDisconnect::Nothing
@@ -70,6 +74,10 @@ impl DisconnectingState {
                 }
                 Some(TunnelCommand::Dns(servers)) => {
                     let _ = shared_values.set_dns_servers(servers);
+                    AfterDisconnect::Block(reason)
+                }
+                Some(TunnelCommand::DnsTrust(servers)) => {
+                    let _ = shared_values.set_trusted_dns_servers(servers);
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
@@ -111,6 +119,10 @@ impl DisconnectingState {
                 }
                 Some(TunnelCommand::Dns(servers)) => {
                     let _ = shared_values.set_dns_servers(servers);
+                    AfterDisconnect::Reconnect(retry_attempt)
+                }
+                Some(TunnelCommand::DnsTrust(servers)) => {
+                    let _ = shared_values.set_trusted_dns_servers(servers);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -172,6 +172,13 @@ impl TunnelState for ErrorState {
                     SameState(self.into())
                 }
             }
+            Some(TunnelCommand::DnsTrust(servers)) => {
+                if let Err(error_state_cause) = shared_values.set_trusted_dns_servers(servers) {
+                    NewState(Self::enter(shared_values, error_state_cause))
+                } else {
+                    SameState(self.into())
+                }
+            }
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
                 shared_values.block_when_disconnected = block_when_disconnected;
                 SameState(self.into())

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -95,6 +95,12 @@ pub struct InitialTunnelState {
     pub block_when_disconnected: bool,
     /// DNS servers to use. If `None`, the tunnel gateway is used.
     pub dns_servers: Option<Vec<IpAddr>>,
+    /// DNS servers that will not be blocked by the firewall, but will not be
+    /// used as in the above dns_servers list. So for instance the dns_servers
+    /// list could be None to use the default, but the trusted_dns_servers
+    /// list could include another trusted DNS server that is used for a
+    /// particular domain.
+    pub trusted_dns_servers: Vec<IpAddr>,
     /// A single endpoint that is allowed to communicate outside the tunnel, i.e.
     /// in any of the blocking states.
     pub allowed_endpoint: AllowedEndpoint,
@@ -200,6 +206,9 @@ pub enum TunnelCommand {
     AllowEndpoint(AllowedEndpoint, oneshot::Sender<()>),
     /// Set DNS servers to use.
     Dns(Option<Vec<IpAddr>>),
+    /// Set extra DNS servers to allow to be used (but they are not added to
+    /// the resolver).
+    DnsTrust(Vec<IpAddr>),
     /// Enable or disable the block_when_disconnected feature.
     BlockWhenDisconnected(bool),
     /// Notify the state machine of the connectivity of the device.
@@ -378,6 +387,7 @@ impl TunnelStateMachine {
             block_when_disconnected: args.settings.block_when_disconnected,
             is_offline,
             dns_servers: args.settings.dns_servers,
+            trusted_dns_servers: args.settings.trusted_dns_servers,
             allowed_endpoint: args.settings.allowed_endpoint,
             tunnel_parameters_generator: Box::new(args.tunnel_parameters_generator),
             tun_provider: Arc::new(Mutex::new(args.tun_provider)),
@@ -466,6 +476,12 @@ struct SharedTunnelStateValues {
     is_offline: bool,
     /// DNS servers to use (overriding default).
     dns_servers: Option<Vec<IpAddr>>,
+    /// DNS servers that will not be blocked by the firewall, but will not be
+    /// used as in the above dns_servers list. So for instance the dns_servers
+    /// list could be None to use the default, but the trusted_dns_servers
+    /// list could include another trusted DNS server that is used for a
+    /// particular domain.
+    trusted_dns_servers: Vec<IpAddr>,
     /// Endpoint that should not be blocked by the firewall.
     allowed_endpoint: AllowedEndpoint,
     /// The generator of new `TunnelParameter`s
@@ -515,7 +531,7 @@ impl SharedTunnelStateValues {
 
     pub fn set_dns_servers(
         &mut self,
-        dns_servers: Option<Vec<IpAddr>>,
+        dns_servers: Option<Vec<IpAddr>>
     ) -> Result<bool, ErrorStateCause> {
         if self.dns_servers != dns_servers {
             self.dns_servers = dns_servers;
@@ -542,6 +558,19 @@ impl SharedTunnelStateValues {
         } else {
             Ok(false)
         }
+    }
+
+    pub fn set_trusted_dns_servers(
+        &mut self,
+        addresses: Vec<IpAddr>
+    ) -> Result<bool, ErrorStateCause> {
+        if self.trusted_dns_servers != addresses {
+            self.trusted_dns_servers = addresses;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+
     }
 
     /// NetworkManager's connectivity check can get hung when DNS requests fail, thus the TSM


### PR DESCRIPTION
# Motivating use case

**This patch is intended to spark discussion about the feature.**

A user has a VPN connection for work which gives its own DNS server that is trusted by the user, and the local resolver is set up to only route requests for a particular domain to this server. They can now use `mullvad dns trusted set <address of resolver>` to make it work.

# What it does

Adds an option for trusted DNS servers. These will not be blocked on port 53 in the firewall.

# How it does it

Mostly copied and modified from the existing DNS settings.

# Remaining work

I don't believe it works properly when the trusted DNS is set while the tunnel is not in connected state. Will look into this.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4140)
<!-- Reviewable:end -->
