### PR TITLE
Allow settings removal during silent uninstall on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Add privacy policy link in settings.
 
+#### Windows
+- Remove all settings when the app is uninstalled silently.
 
 ### Fixed
 - When a country is selected, and the constraints only match relays that are not included on the

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -1030,7 +1030,7 @@
 	${ExtractDriverlogic}
 	${ExtractMullvadSetup}
 
-	${If} $Silent == 1
+	${If} ${isUpdated}
 		ReadRegStr $NewVersion HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APP_GUID}" "NewVersion"
 
 		nsExec::ExecToStack '"$PLUGINSDIR\mullvad-setup.exe" is-older-version $0'
@@ -1122,10 +1122,13 @@
 		${RemoveLogsAndCache}
 		${If} $Silent != 1
 			MessageBox MB_ICONQUESTION|MB_YESNO "Would you like to remove settings files as well?" IDNO customRemoveFiles_after_remove_settings
-			${RemoveSettings}
-
-			DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "net.mullvad.vpn"
+		${ElseIf} ${isUpdated}
+			Goto customRemoveFiles_after_remove_settings
 		${EndIf}
+
+		${RemoveSettings}
+		DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "net.mullvad.vpn"
+
 		customRemoveFiles_after_remove_settings:
 	${Else}
 		log::SetLogTarget ${LOG_VOID}


### PR DESCRIPTION
The script previously could not distinguish between upgrades and normal silent uninstalls. This change is useful for removing the app in scripts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4146)
<!-- Reviewable:end -->
