### PR TITLE
Add connect timeout for udp2tcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
   country level, select those relays anyway.
 - Fix regression where WireGuard relays were connected to over OpenVPN after a couple of failed
   attempts, when the tunnel type was set to `any`.
+- Fix missing connect timeout when connecting to a WireGuard relay over TCP.
 
 #### macOS
 - Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,7 +3855,7 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 [[package]]
 name = "udp-over-tcp"
 version = "0.2.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=3dae584677ed26aff08ab759f7799a55c0ff1aec#3dae584677ed26aff08ab759f7799a55c0ff1aec"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=d03e67b1a082982981626b5cbf49b29bb9663d63#d03e67b1a082982981626b5cbf49b29bb9663d63"
 dependencies = [
  "err-context",
  "futures",

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -482,6 +482,8 @@ fn should_retry(error: &tunnel::Error, retry_attempt: u32) -> bool {
     match error {
         tunnel::Error::WireguardTunnelMonitoringError(Error::CreateObfuscatorError(_)) => true,
 
+        tunnel::Error::WireguardTunnelMonitoringError(Error::ObfuscatorError(_)) => true,
+
         tunnel::Error::WireguardTunnelMonitoringError(Error::PskNegotiationError(
             talpid_tunnel_config_client::Error::GrpcConnectError(_),
         )) => true,

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -12,8 +12,4 @@ async-trait = "0.1"
 err-derive = "0.3.0"
 futures = "0.3.5"
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "net", "io-util"] }
-
-[dependencies.udp-over-tcp]
-git = "https://github.com/mullvad/udp-over-tcp"
-rev = "3dae584677ed26aff08ab759f7799a55c0ff1aec"
-version = "0.2"
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "d03e67b1a082982981626b5cbf49b29bb9663d63" }

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -47,6 +47,7 @@ impl Udp2Tcp {
             listen_addr,
             settings.peer,
             TcpOptions {
+                lazy_connect: true,
                 #[cfg(target_os = "linux")]
                 fwmark: settings.fwmark,
                 ..TcpOptions::default()


### PR DESCRIPTION
This PR ensures that connecting times out when the connectivity monitor times out, and also that the user can immediately cancel it by disconnecting. See https://github.com/mullvad/udp-over-tcp/pull/32.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4147)
<!-- Reviewable:end -->
