### PR TITLE
Return the correct settings path on Windows in `mullvad_paths`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,8 @@ dependencies = [
  "dirs-next",
  "err-derive",
  "log",
+ "widestring 1.0.2",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1786,8 +1788,6 @@ dependencies = [
  "talpid-core",
  "talpid-types",
  "tokio",
- "widestring 0.5.1",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "triggered",
  "uuid",
  "which",
- "widestring 0.5.1",
+ "widestring 1.0.2",
  "winapi",
  "windows-sys 0.42.0",
  "winreg",
@@ -3373,7 +3373,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tunnel-obfuscation",
- "widestring 0.5.1",
+ "widestring 1.0.2",
  "windows-sys 0.42.0",
  "zeroize",
 ]

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -13,3 +13,16 @@ log = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 dirs-next = "2.0"
+widestring = "1.0"
+
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.42.0"
+features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Com",
+    "Win32_System_ProcessStatus",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_UI_Shell",
+]

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -69,3 +69,6 @@ pub use crate::rpc_socket::{get_default_rpc_socket_path, get_rpc_socket_path};
 
 mod settings;
 pub use crate::settings::{get_default_settings_dir, settings_dir};
+
+#[cfg(windows)]
+mod windows;

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -24,7 +24,10 @@ pub fn get_default_settings_dir() -> Result<PathBuf> {
         }
         #[cfg(windows)]
         {
-            dir = dirs_next::data_local_dir().ok_or_else(|| crate::Error::FindDirError);
+            dir = crate::windows::get_system_service_appdata().map_err(|error| {
+                log::error!("Failed to obtain system app data path: {error}");
+                crate::Error::FindDirError
+            })
         }
         dir.map(|dir| dir.join(crate::PRODUCT_NAME))
     }

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -28,17 +28,3 @@ mullvad-types = { path = "../mullvad-types" }
 mullvad-version = { path = "../mullvad-version" }
 talpid-core = { path = "../talpid-core" }
 talpid-types = { path = "../talpid-types" }
-
-[target.'cfg(windows)'.dependencies]
-widestring = "0.5"
-
-[target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.42.0"
-features = [
-    "Win32_Foundation",
-    "Win32_Security",
-    "Win32_System_Com",
-    "Win32_System_ProcessStatus",
-    "Win32_System_Threading",
-    "Win32_UI_Shell",
-]

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -40,7 +40,7 @@ prost = "0.11"
 which = { version = "4.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-widestring = "0.5"
+widestring = "1.0"
 winreg = { version = "0.7", features = ["transactions"] }
 winapi = { version = "0.3.6", features = ["ws2def"] }
 talpid-windows-net = { path = "../talpid-windows-net" }

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -50,7 +50,7 @@ tokio-stream = { version = "0.1", features = ["io-util"] }
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.2"
 talpid-windows-net = { path = "../talpid-windows-net" }
-widestring = "0.5"
+widestring = "1.0"
 
 # Figure out which features are needed and which are not
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
Previously, the path was only correct if called from a system service. I've moved the code for impersonating `SYSTEM` from `mullvad_setup` to `mullvad_paths`, so that it always returns the correct result.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4150)
<!-- Reviewable:end -->
