### PR TITLE
Add quit button to tray context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Add quit button to tray context menu on Linux and Window.
+
 #### Windows
 - Remove all settings when the app is uninstalled silently.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
 #### Windows
 - Remove all settings when the app is uninstalled silently.
 
@@ -43,7 +44,6 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Ignore adapters that have no valid GUID when removing obsolete Wintun interfaces during install.
   Previously, the installer would abort.
-
 
 ### Changed
 - Update Electron from 19.0.13 to 21.1.1.

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -126,6 +126,12 @@ msgstr ""
 msgid "Disconnect"
 msgstr ""
 
+msgid "Disconnect & quit"
+msgstr ""
+
+msgid "Disconnect and quit"
+msgstr ""
+
 msgid "Disconnected"
 msgstr ""
 
@@ -179,6 +185,9 @@ msgid "Open URL"
 msgstr ""
 
 msgid "QUANTUM SECURE CONNECTION"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Reconnect"
@@ -1004,10 +1013,6 @@ msgstr ""
 
 msgctxt "settings-view"
 msgid "OUT OF TIME"
-msgstr ""
-
-msgctxt "settings-view"
-msgid "Quit app"
 msgstr ""
 
 #. Navigation button to the 'Split tunneling' view

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -211,6 +211,22 @@ class ApplicationMain
     );
   };
 
+  public disconnectAndQuit = async () => {
+    if (this.daemonRpc.isConnected) {
+      try {
+        await this.daemonRpc.disconnectTunnel();
+        log.info('Disconnected the tunnel');
+      } catch (e) {
+        const error = e as Error;
+        log.error(`Failed to disconnect the tunnel: ${error.message}`);
+      }
+    } else {
+      log.info('Cannot close the tunnel because there is no active connection to daemon.');
+    }
+
+    app.quit();
+  };
+
   private addSecondInstanceEventHandler() {
     app.on('second-instance', (_event, _argv, _workingDirectory) => {
       this.userInterface?.showWindow();
@@ -269,22 +285,6 @@ class ApplicationMain
   }
 
   private onActivate = () => this.userInterface?.showWindow();
-
-  private async disconnectAndQuit() {
-    if (this.daemonRpc.isConnected) {
-      try {
-        await this.daemonRpc.disconnectTunnel();
-        log.info('Disconnected the tunnel');
-      } catch (e) {
-        const error = e as Error;
-        log.error(`Failed to disconnect the tunnel: ${error.message}`);
-      }
-    } else {
-      log.info('Cannot close the tunnel because there is no active connection to daemon.');
-    }
-
-    app.quit();
-  }
 
   // This is a last try to disconnect and quit gracefully if the app quits without having received
   // the before-quit event.

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -23,6 +23,7 @@ export interface UserInterfaceDelegate {
   connectTunnel(): void;
   reconnectTunnel(): void;
   disconnectTunnel(): void;
+  disconnectAndQuit(): void;
   isUnpinnedWindow(): boolean;
   isLoggedIn(): boolean;
   getAccountData(): IAccountData | undefined;
@@ -617,6 +618,15 @@ export default class UserInterface implements WindowControllerDelegate {
         label: messages.gettext('Disconnect'),
         enabled: disconnectEnabled(connectedToDaemon, tunnelState.state),
         click: this.delegate.disconnectTunnel,
+      },
+      { type: 'separator' },
+      {
+        id: 'disconnect',
+        label:
+          tunnelState.state === 'disconnected'
+            ? messages.gettext('Quit')
+            : messages.gettext('Disconnect and quit'),
+        click: this.delegate.disconnectAndQuit,
       },
     ];
 

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -256,10 +256,13 @@ function DebugButton() {
 
 function QuitButton() {
   const { quit } = useAppContext();
+  const tunnelState = useSelector((state) => state.connection.status);
 
   return (
     <StyledQuitButton onClick={quit}>
-      {messages.pgettext('settings-view', 'Quit app')}
+      {tunnelState.state === 'disconnected'
+        ? messages.gettext('Quit')
+        : messages.gettext('Disconnect & quit')}
     </StyledQuitButton>
   );
 }


### PR DESCRIPTION
This PR adds a quit button to the tray context menu. The text of the in-app quit button has also
been changed. It's now either "Quit" or "Disconnect & quit".

I've also added the missing "Added" title in the changelog.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
