### PR TITLE
Fix double header row in filter view

### DIFF
--- a/gui/src/renderer/components/cell/Selector.tsx
+++ b/gui/src/renderer/components/cell/Selector.tsx
@@ -86,9 +86,7 @@ export default function Selector<T, U>(props: SelectorProps<T, U>) {
         </AriaDetails>
       )}
     </>
-  ) : (
-    <></>
-  );
+  ) : undefined;
 
   // Add potential additional items to the list. Used for custom entry.
   const children = (


### PR DESCRIPTION
Thi PR fixes the ownership title in the filter view. It previously showed an empty row below the actual title.
