### PR TITLE
Add transition on auth failed caused by account expiry

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -44,6 +44,7 @@ import net.mullvad.mullvadvpn.util.JobTracker
 import net.mullvad.mullvadvpn.util.appVersionCallbackFlow
 import net.mullvad.mullvadvpn.util.callbackFlowFromNotifier
 import net.mullvad.mullvadvpn.viewmodel.ConnectViewModel
+import net.mullvad.talpid.tunnel.ErrorStateCause
 import org.joda.time.DateTime
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -235,6 +236,10 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
 
         actionButton.tunnelState = uiState
         switchLocationButton.tunnelState = uiState
+
+        if (realState.isTunnelErrorStateDueToExpiredAccount()) {
+            openOutOfTimeScreen()
+        }
     }
 
     private fun openSwitchLocationScreen() {
@@ -274,5 +279,10 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
             delay(5_000)
             openOutOfTimeScreen()
         }
+    }
+
+    private fun TunnelState.isTunnelErrorStateDueToExpiredAccount(): Boolean {
+        return ((this as? TunnelState.Error)?.errorState?.cause as? ErrorStateCause.AuthFailed)
+            ?.isCausedByExpiredAccount() ?: false
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectFragment.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collect
@@ -20,7 +19,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
@@ -45,7 +43,6 @@ import net.mullvad.mullvadvpn.util.appVersionCallbackFlow
 import net.mullvad.mullvadvpn.util.callbackFlowFromNotifier
 import net.mullvad.mullvadvpn.viewmodel.ConnectViewModel
 import net.mullvad.talpid.tunnel.ErrorStateCause
-import org.joda.time.DateTime
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -146,7 +143,6 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
 
     private fun CoroutineScope.launchUiSubscriptionsOnResume() = launch {
         repeatOnLifecycle(Lifecycle.State.RESUMED) {
-            launchScheduledExpiryCheck()
             launchLocationSubscription()
             launchRelayLocationSubscription()
             launchTunnelStateSubscription()
@@ -154,17 +150,6 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
             launchAccountExpirySubscription()
             launchTunnelInfoExpansionSubscription()
         }
-    }
-
-    private fun CoroutineScope.launchScheduledExpiryCheck() = launch {
-        accountRepository.accountExpiryState
-            .map { state -> state.date() }
-            .collect { expiryDate ->
-                if (expiryDate?.isBeforeNow == true) {
-                    openOutOfTimeScreen()
-                } else if (expiryDate != null)
-                    scheduleNextAccountExpiryCheck(expiryDate)
-            }
     }
 
     private fun CoroutineScope.launchLocationSubscription() = launch {
@@ -262,22 +247,6 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
                 replace(R.id.main_fragment, OutOfTimeFragment())
                 commitAllowingStateLoss()
             }
-        }
-    }
-
-    private fun scheduleNextAccountExpiryCheck(expiration: DateTime) {
-        jobTracker.newBackgroundJob("refetchAccountExpiry") {
-            val millisUntilExpiration = expiration.millis - DateTime.now().millis
-
-            delay(millisUntilExpiration)
-            accountRepository.fetchAccountExpiry()
-
-            // If the account ran out of time but is still connected, fetching the expiry again will
-            // fail. Therefore, after a timeout of 5 seconds the app will assume the account time
-            // really expired and move to the out of time screen. However, if fetching the expiry
-            // succeeds, this job is cancelled and replaced with a new scheduled check.
-            delay(5_000)
-            openOutOfTimeScreen()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
+++ b/android/app/src/main/kotlin/net/mullvad/talpid/tunnel/ErrorStateCause.kt
@@ -4,9 +4,15 @@ import android.os.Parcelable
 import java.net.InetAddress
 import kotlinx.parcelize.Parcelize
 
+private const val AUTH_FAILED_REASON_EXPIRED_ACCOUNT = "[EXPIRED_ACCOUNT]"
+
 sealed class ErrorStateCause : Parcelable {
     @Parcelize
-    class AuthFailed(val reason: String?) : ErrorStateCause()
+    class AuthFailed(private val reason: String?) : ErrorStateCause() {
+        fun isCausedByExpiredAccount(): Boolean {
+            return reason == AUTH_FAILED_REASON_EXPIRED_ACCOUNT
+        }
+    }
 
     @Parcelize
     object Ipv6Unavailable : ErrorStateCause()


### PR DESCRIPTION
This PR aims to adds an automatic transition to the out-of-time view if there's a tunnel state error caused by the account being expired. It also removes the expiry check scheduling in the connect view.

Depends on: #3971

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4162)
<!-- Reviewable:end -->
