### PR TITLE
Ignore RUSTSEC-2021-0145

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -26,6 +26,11 @@ jobs:
                   version: latest
 
             - name: Audit
-              # TEMP: Ignore the time segfault CVE since there are no known
+              # RUSTSEC-2020-0071: Ignore the time segfault CVE since there are no known
               # good workarounds, and we want logs etc to be in local time.
-              run: cargo audit --ignore RUSTSEC-2020-0071
+              # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
+              # so it should be safe to ignore it. Stop ignoring the warning once
+              # atty has been replaced in clap and env_logger:
+              # https://github.com/clap-rs/clap/pull/4249
+              # https://github.com/rust-cli/env_logger/pull/246
+              run: cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0145


### PR DESCRIPTION
This vulnerability in `atty` (https://rustsec.org/advisories/RUSTSEC-2021-0145) only affects custom global allocators on Windows, so we can ignore it for now.

`atty` is a dependency due to `clap` and `env_logger`. Stop ignoring the issue once they've moved away from using it:
https://github.com/clap-rs/clap/pull/4249
https://github.com/rust-cli/env_logger/pull/246

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4164)
<!-- Reviewable:end -->
