### PR TITLE
Fix app stuck problem after upgrading target sdk to 33

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/SdkUtils.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/SdkUtils.kt
@@ -10,7 +10,7 @@ import android.service.quicksettings.Tile
 
 object SdkUtils {
     fun getSupportedPendingIntentFlags(): Int {
-        return if (Build.VERSION.SDK_INT > Build.VERSION_CODES.S) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
         } else {
             PendingIntent.FLAG_UPDATE_CURRENT


### PR DESCRIPTION
after upgrading build target sdk version from 30 to 33 app stuck on first page on android 12 devices(tested of official builds like https://releases.mullvad.net/builds/2022.2-beta2-dev-169121/), this tiny pr fix this issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4165)
<!-- Reviewable:end -->
