### PR TITLE
Fix race condition when updating IPC target when recreating window

### DIFF
--- a/gui/src/main/ipc-event-channel.ts
+++ b/gui/src/main/ipc-event-channel.ts
@@ -10,3 +10,7 @@ export let IpcMainEventChannel = createIpcMain(ipcSchema, ipcMain, undefined);
 export function changeIpcWebContents(webContents: WebContents | undefined) {
   IpcMainEventChannel = createIpcMain(ipcSchema, ipcMain, webContents);
 }
+
+export function unsetIpcWebContents() {
+  changeIpcWebContents(undefined);
+}


### PR DESCRIPTION
This PR fixes a race condition which caused the `IpcMainEventChannel` to not have a `webContents` after toggling "Unpinned window". The issue was that the `webContents` `destroyed` event was received after the new `webContents` had been set up and therefore removing it from `IpcMainEventChannel`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4167)
<!-- Reviewable:end -->
