### PR TITLE
Exclude outbound obfuscation socket from the tunnel on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -888,15 +888,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -905,18 +905,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -924,23 +922,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -950,8 +947,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -2346,12 +2341,6 @@ name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -3855,7 +3844,7 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 [[package]]
 name = "udp-over-tcp"
 version = "0.2.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=d03e67b1a082982981626b5cbf49b29bb9663d63#d03e67b1a082982981626b5cbf49b29bb9663d63"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=4d52f93cd9962562cb52d66e36771d5f5c70e25a#4d52f93cd9962562cb52d66e36771d5f5c70e25a"
 dependencies = [
  "err-context",
  "futures",

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -12,4 +12,4 @@ async-trait = "0.1"
 err-derive = "0.3.0"
 futures = "0.3.5"
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "net", "io-util"] }
-udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "d03e67b1a082982981626b5cbf49b29bb9663d63" }
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "4d52f93cd9962562cb52d66e36771d5f5c70e25a" }

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -18,8 +18,14 @@ pub enum Error {
 
 #[async_trait]
 pub trait Obfuscator: Send {
-    fn endpoint(&self) -> SocketAddr;
     async fn run(self: Box<Self>) -> Result<()>;
+
+    /// Returns the address of the local socket.
+    fn endpoint(&self) -> SocketAddr;
+
+    /// Returns the file descriptor of the outbound socket.
+    #[cfg(target_os = "android")]
+    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd;
 }
 
 pub enum Settings {

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -78,6 +78,11 @@ impl Obfuscator for Udp2Tcp {
             .map_err(Error::RunObfuscator)
             .map_err(crate::Error::RunUdp2TcpObfuscator)
     }
+
+    #[cfg(target_os = "android")]
+    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd {
+        self.instance.remote_tcp_fd()
+    }
 }
 
 pub async fn create_obfuscator(settings: &Udp2TcpSettings) -> Result<Box<dyn Obfuscator>> {

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -2,7 +2,7 @@ use crate::Obfuscator;
 use async_trait::async_trait;
 use std::net::SocketAddr;
 use udp_over_tcp::{
-    udp2tcp::{ConnectError, ForwardError, Udp2Tcp as Udp2TcpImpl},
+    udp2tcp::{self, Udp2Tcp as Udp2TcpImpl},
     TcpOptions,
 };
 
@@ -19,7 +19,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// Failed to create obfuscator
     #[error(display = "Failed to create obfuscator")]
-    CreateObfuscator(#[error(source)] ConnectError),
+    CreateObfuscator(#[error(source)] udp2tcp::Error),
 
     /// Failed to determine UDP socket details
     #[error(display = "Failed to determine UDP socket details")]
@@ -27,7 +27,7 @@ pub enum Error {
 
     /// Failed to run obfuscator
     #[error(display = "Failed to run obfuscator")]
-    RunObfuscator(#[error(source)] ForwardError),
+    RunObfuscator(#[error(source)] udp2tcp::Error),
 }
 
 struct Udp2Tcp {
@@ -47,7 +47,6 @@ impl Udp2Tcp {
             listen_addr,
             settings.peer,
             TcpOptions {
-                lazy_connect: true,
                 #[cfg(target_os = "linux")]
                 fwmark: settings.fwmark,
                 ..TcpOptions::default()


### PR DESCRIPTION
Changes:
* Update `udp-over-tcp`. Lets us obtain the TCP socket file descriptor.
* Protect the remote TCP socket from going inside the tunnel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4168)
<!-- Reviewable:end -->
