### PR TITLE
Set android build daemon stripping conditionally

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -21,6 +21,7 @@ CARGO_ARGS="--release"
 EXTRA_WGGO_ARGS=""
 BUILD_BUNDLE="no"
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"target"}
+SKIP_STRIPPING=${SKIP_STRIPPING:-"no"}
 
 while [ ! -z "${1:-""}" ]; do
     if [[ "${1:-""}" == "--dev-build" ]]; then
@@ -41,6 +42,8 @@ while [ ! -z "${1:-""}" ]; do
         BUILD_BUNDLE="yes"
     elif [[ "${1:-""}" == "--no-docker" ]]; then
         EXTRA_WGGO_ARGS="--no-docker"
+    elif [[ "${1:-""}" == "--skip-stripping" ]]; then
+        SKIP_STRIPPING="yes"
     fi
 
     shift 1
@@ -111,11 +114,10 @@ for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
     TARGET_LIB_PATH="$SCRIPT_DIR/android/app/build/extraJni/$ABI/libmullvad_jni.so"
     UNSTRIPPED_LIB_PATH="$CARGO_TARGET_DIR/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
 
-
-    if [[ "$BUILD_TYPE" != "debug" ]]; then
-        $STRIP_TOOL --strip-debug --strip-unneeded -o "$TARGET_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
-    else
+    if [[ "$SKIP_STRIPPING" == "yes" ]]; then
         cp "$UNSTRIPPED_LIB_PATH" "$TARGET_LIB_PATH"
+    else
+        $STRIP_TOOL --strip-debug --strip-unneeded -o "$TARGET_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
     fi
 done
 


### PR DESCRIPTION
The default behavior is to strip, but this can be set using either
the environment variable `SKIP_STRIPPING=yes` or by running the build
script with the skip stripping flag: `./build-apk.sh --skip-stripping`

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4172)
<!-- Reviewable:end -->
